### PR TITLE
Comment-related part of tokenize/comment.tex test

### DIFF
--- a/rtx_core/src/definition/primitive.rs
+++ b/rtx_core/src/definition/primitive.rs
@@ -1,8 +1,11 @@
 use std::rc::Rc;
-use state::{State, Scope};
-use Digested;
-use common::object::Object;
+
 use common::error::*;
+use common::font::Font;
+use common::object::Object;
+use state::{State, Scope};
+
+use Digested;
 use token::*;
 use gullet::Gullet;
 use stomach::Stomach;
@@ -19,7 +22,7 @@ pub struct PrimitiveOptions {
   pub after_digest: Vec<DigestionClosure>,
   pub is_prefix: bool,
   pub scope: Option<Scope>,
-  // font : TODO
+  pub font: Option<Font>,
   pub require_math: bool,
   pub forbid_math: bool,
   pub locked: bool,
@@ -32,6 +35,7 @@ impl Default for PrimitiveOptions {
       before_digest: Vec::new(),
       after_digest: Vec::new(),
       mode: None,
+      font: None,
       is_prefix: false,
       scope: None,
       require_math: false,

--- a/rtx_core/src/document/mod.rs
+++ b/rtx_core/src/document/mod.rs
@@ -177,7 +177,7 @@ impl Document {
       //   box_node.set_content(&tbox.text);
     }
     if self.debug {
-      info!("Document absorbed {:?} nodes", results.len());
+      debug!("Document absorbed {:?} nodes", results.len());
     }
     Ok(results)
   }
@@ -258,7 +258,7 @@ impl Document {
   /// This is kinda risky! Maybe we should try to request closing of specific nodes.
   pub fn close_element(&mut self, qname: &str, state: &mut State) -> Result<Option<Node>> {
     if self.debug {
-      info!("Close element {:?} at {:?}", qname, self.node.get_name());
+      debug!("Close element {:?} at {:?}", qname, self.node.get_name());
     }
     self.close_text_internal();
     let mut node = self.node.clone();
@@ -697,7 +697,7 @@ impl Document {
     //   return;
     // }
     // if self.debug {
-    //   info!("Insert text {:?} at {:?}", text, self.document.node_to_string(&self.node));
+    //   debug!("Insert text {:?} at {:?}", text, self.document.node_to_string(&self.node));
     // }
 
     // if node_type != Some(NodeType::DocumentNode) // If not at document begin
@@ -821,7 +821,7 @@ impl Document {
     if self.node.get_type() == Some(NodeType::TextNode) {
       // current node already is a text node.
       // if self.debug {
-      //   info!("Appending text \"{:?}\" to {:?}",
+      //   debug!("Appending text \"{:?}\" to {:?}",
       //                   text,
       //                   self.document.node_to_string(&self.node));
       // }
@@ -831,7 +831,7 @@ impl Document {
       let mut point = try!(self.find_insertion_point("#PCDATA", state));
       let node = Node::new_text(text, &self.document).unwrap();
       if self.debug {
-        info!("Inserting text node for {:?} into {:?}",
+        debug!("Inserting text node for {:?} into {:?}",
                         text,
                         self.document.node_to_string(&point));
       }
@@ -1070,6 +1070,7 @@ impl Document {
 
     // If this will be the document root node, things are slightly more involved.
     if point.get_type() == Some(NodeType::DocumentNode) {    // First node! (?)
+      info!("adding schema declaration, new node will be : {}", tag);
       state.model.add_schema_declaration(self);
       newnode = Node::new(&tag, None, &self.document).unwrap();
       self.document.set_root_element(&newnode);
@@ -1123,7 +1124,7 @@ impl Document {
     }
 
     if self.debug {
-      info!("Inserting {:?} into {:?}",newnode.get_name(), point.get_name());// if $LaTeXML::Core::Document::DEBUG;
+      debug!("Inserting {:?} into {:?}",newnode.get_name(), point.get_name());// if $LaTeXML::Core::Document::DEBUG;
     }
 
     // Run afterOpen operations

--- a/rtx_core/src/document/mod.rs
+++ b/rtx_core/src/document/mod.rs
@@ -190,7 +190,7 @@ impl Document {
     // TODO: Quickly hacked together, needs a careful refactor with all .clone() calls removed
     let node = try!(self.open_element(qname, attrib, state));
     if self.debug {
-      info!("Inserting element {:?} with body: {:?}", qname, content);
+      debug!("Inserting element {:?} with body: {:?}", qname, content);
     }
     for digested in content {
       try!(self.absorb(digested, state));
@@ -240,7 +240,7 @@ impl Document {
   pub fn open_element(&mut self, qname: &str, attributes: Option<HashMap<String, String>>, state: &mut State) -> Result<Node> {
     // NoteProgress('.') if (self.progress}++ % 25) == 0;
     if self.debug {
-      info!("Open element {:?} at {:?}", qname, self.node.get_name());
+      debug!("Open element {:?} at {:?}", qname, self.node.get_name());
     }
     let point = try!(self.find_insertion_point(qname, state));
     // attributes.entry("_box").or_insert(state.locals.box);

--- a/rtx_core/src/gullet.rs
+++ b/rtx_core/src/gullet.rs
@@ -262,6 +262,26 @@ impl Gullet {
     }
   }
 
+  /// Read the next raw line (string);
+  /// primarily to read from the Mouth, but keep any unread input!
+  pub fn read_raw_line(&mut self) {
+    // // If we've got unread tokens, they presumably should come before the Mouth's raw data
+    // // but we'll convert them back to string.
+    // my @tokens = @{ $$self{pushback} };
+    // my @markers = grep { $_->getCatcode == CC_MARKER } @tokens;
+    // if (@markers) {    // Whoops, profiling markers!
+    //   @tokens = grep { $_->getCatcode != CC_MARKER } @tokens;    // Remove
+    //   map { LaTeXML::Core::Definition::stopProfiling($_, 'expand') } @markers; }
+    // $$self{pushback} = [];
+    // // If we still have peeked tokens, we ONLY want to combine it with the remainder
+    // // of the current line from the Mouth (NOT reading a new line)
+    // if (@tokens) {
+    //   return ToString(Tokens(@tokens)) . $$self{mouth}->readRawLine(1); }
+    // // Otherwise, read the next line from the Mouth.
+    // else {
+    //   return $$self{mouth}->readRawLine; } }
+  }
+
   pub fn unread(&mut self, tokens: Vec<Token>) {
     if let Some(ref mut runtime) = self.mouth {
       for token in tokens.into_iter().rev() {
@@ -468,7 +488,6 @@ impl Gullet {
     // TODO
     Ok(Vec::new())
   }
-
 
   pub fn skip_spaces(&mut self, state: &mut State) {
     match self.read_non_space(state) {

--- a/rtx_core/src/gullet.rs
+++ b/rtx_core/src/gullet.rs
@@ -6,7 +6,7 @@ use common::error::*;
 use definition::Definition;
 use mouth::Mouth;
 use token::{Token, Catcode};
-// use stomach::Stomach;
+use tokens::Tokens;
 
 #[derive(PartialEq, Clone)]
 pub struct MouthRuntime {
@@ -264,22 +264,30 @@ impl Gullet {
 
   /// Read the next raw line (string);
   /// primarily to read from the Mouth, but keep any unread input!
-  pub fn read_raw_line(&mut self) {
-    // // If we've got unread tokens, they presumably should come before the Mouth's raw data
-    // // but we'll convert them back to string.
-    // my @tokens = @{ $$self{pushback} };
-    // my @markers = grep { $_->getCatcode == CC_MARKER } @tokens;
-    // if (@markers) {    // Whoops, profiling markers!
-    //   @tokens = grep { $_->getCatcode != CC_MARKER } @tokens;    // Remove
-    //   map { LaTeXML::Core::Definition::stopProfiling($_, 'expand') } @markers; }
-    // $$self{pushback} = [];
-    // // If we still have peeked tokens, we ONLY want to combine it with the remainder
-    // // of the current line from the Mouth (NOT reading a new line)
-    // if (@tokens) {
-    //   return ToString(Tokens(@tokens)) . $$self{mouth}->readRawLine(1); }
-    // // Otherwise, read the next line from the Mouth.
-    // else {
-    //   return $$self{mouth}->readRawLine; } }
+  pub fn read_raw_line(&mut self) -> Option<String> {
+    // If we've got unread tokens, they presumably should come before the Mouth's raw data
+    // but we'll convert them back to string.
+    if let Some(ref mut runtime) = self.mouth {
+      let tokens : Vec<Token> = runtime.pushback.drain(..).collect();
+
+      // TODO
+      // let markers : Vec<&Token> = tokens.iter().filter(|t:Token| t.get_catcode() == Catcode::MARKER).collect();
+      // if !markers.is_empty() {    // Whoops, profiling markers!
+
+        // @tokens = grep { $_->getCatcode != CC_MARKER } @tokens;    // Remove
+        // map { LaTeXML::Core::Definition::stopProfiling($_, 'expand') } @markers;
+      // }
+
+      // If we still have peeked tokens, we ONLY want to combine it with the remainder
+      // of the current line from the Mouth (NOT reading a new line)
+      if !tokens.is_empty() {
+        Some(Tokens{tokens: tokens}.to_string() + &runtime.mouth.read_raw_line(true).unwrap_or_default())
+      } else { // Otherwise, read the next line from the Mouth.
+        runtime.mouth.read_raw_line(false)
+      }
+    } else {
+      None
+    }
   }
 
   pub fn unread(&mut self, tokens: Vec<Token>) {

--- a/rtx_core/src/gullet.rs
+++ b/rtx_core/src/gullet.rs
@@ -32,6 +32,16 @@ impl Default for Gullet {
 }
 
 impl Gullet {
+  /// This flushes a mouth so that it will be automatically closed, next time it's read
+  /// Corresponds (I think) to TeX's \endinput
+  pub fn flush_mouth(&mut self, state: &mut State) {
+    if let Some(ref mut runtime) = self.mouth {
+      runtime.mouth.finish(state);  // but not close!
+      runtime.pushback.drain(..);    // And don't read anytyhing more from it.
+      runtime.autoclose = true;
+    }
+    return;
+  }
 
   /// Obscure, but the only way I can think of to End!! (see \bye or \end{document})
   /// Flush all sources (close all pending mouth's)

--- a/rtx_core/src/mouth.rs
+++ b/rtx_core/src/mouth.rs
@@ -8,6 +8,7 @@ use regex::Regex;
 use common::error::*;
 use state::{State, Scope, ObjectStore};
 use token::*;
+use tokens::Tokens;
 
 #[derive(PartialEq, Clone)]
 pub enum FoodType {
@@ -317,6 +318,74 @@ impl Mouth {
       }
     }
   }
+
+  //**********************************************************************
+  /// Read all tokens until a token equal to $until (if given), or until exhausted.
+  /// Returns an empty Tokens list, if there is no input
+  pub fn read_tokens(&mut self, until: Option<Token>, state: &mut State) -> Tokens {
+    let mut tokens = Vec::new();
+    let has_until = until.is_some();
+    let until_string = if let Some(until_token) = until {
+      until_token.get_string().to_owned()
+    } else {
+      String::new()
+    };
+    while let Some(token) = self.read_token(state) {
+      if has_until && token.get_string() == until_string {
+        tokens.push(token);
+      }
+    }
+    while !tokens.is_empty() && tokens.last().unwrap().get_catcode() == Catcode::SPACE {    // Remove trailing space
+      tokens.pop();
+    }
+    Tokens{ tokens: tokens }
+  }
+
+  //**********************************************************************
+  // Read a raw lines; there are so many variants of how it should end,
+  // that the Mouth API is left as simple as possible.
+  // Alas: $noread true means NOT to read a new line, but only return
+  // the remainder of the current line, if any. This is useful when combining
+  // with previously peeked tokens from the Gullet.
+  pub fn read_raw_line(&mut self, noread: bool) -> Option<String> {
+    let mut line = String::new();
+    if self.colno < self.nchars {
+      // DG: Can't slice a VecDeque really? Oh well...
+      // Please refactor if you know a better way!
+      for (index, c) in self.chars.iter().enumerate() {
+        if self.colno <= index && index < self.nchars {
+          line.push(*c);
+        }
+      }
+      // End lines with \n, not CR, since the result will be treated as strings
+      self.colno = self.nchars;
+    } else if noread {
+      line = String::new();
+    } else {
+      match self.get_next_line() {
+        None => {
+          line = String::new();
+          self.chars = VecDeque::new();
+          self.nchars = 0;
+          self.colno = 0;
+        },
+        Some(next_line) => {
+          line = next_line;
+          self.lineno += 1;
+          self.chars  = line.chars().collect();
+          self.nchars = self.chars.len();
+          self.colno  = self.nchars;
+        }
+      }
+    }
+    line = line.trim_right().to_owned(); // Is this right?
+    if line.is_empty() {
+      None
+    } else {
+      Some(line)
+    }
+  }
+
 
   fn dispatch_char(&mut self, ch: char, cc: Catcode, state: &mut State) -> Option<Token> {
     // Possibly want to think about caching (common) letters, etc to keep from

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -56,6 +56,7 @@ pub enum ObjectStore {
   Bool(bool),
   String(String),
   Mathcode(usize),
+  Int(i32),
   // LaTeXML objects
   Catcode(Catcode),
   Token(Token),
@@ -82,6 +83,7 @@ impl fmt::Debug for ObjectStore {
     use state::ObjectStore::*;
     match *self {
       String(ref s) => write!(f, "{}", s),
+      Int(ref num) => write!(f, "{}", num),
       VecChar(ref vs) => write!(f, "{:?}",vs),
       VecString(ref vs) => write!(f, "{:?}", vs),
       Bool(ref b) => write!(f, "{:?}", b),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //
 
 //! # The `LaTeXML` converter, reimplemented in Rust
-#![allow(unused_variables, unused_macros, unused_mut)]
+#![allow(unused_variables, unused_mut)]
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 

--- a/src/math_parser.rs
+++ b/src/math_parser.rs
@@ -641,7 +641,7 @@ pub fn realize_xmnode(&self, node: &Node, document: &Document) -> Node {
   fn parse_single(&self, mathnode: &mut Node, document: &mut Document, rule: String, state: &mut State) -> Result<Option<Node>> {
     //   my @nodes = $self->filter_hints($document, $mathnode->childNodes);
     let nodes = mathnode.get_child_nodes();
-    let mut result = None;
+    let mut result;
     //   my ($punct, $result, $unparsed);
     //   my @punct = ();
     //   # Extract trailing punctuation, if rule allows it.
@@ -676,7 +676,7 @@ pub fn realize_xmnode(&self, node: &Node, document: &Document) -> Node {
         None => None
       };
     } else { // Now do the actual parse.
-      let (result_internal, unparsed)  = self.parse_internal(&rule, nodes, document);
+      let (result_internal, unparsed)  = try!(self.parse_internal(&rule, nodes, document));
       result = result_internal;
     }
 
@@ -698,7 +698,7 @@ pub fn realize_xmnode(&self, node: &Node, document: &Document) -> Node {
     Ok(result)
   }
 
-fn parse_internal(&self, rule: &str, nodes: Vec<Node>, document: &mut Document) -> (Option<Node>,Option<Node>) {
+fn parse_internal(&self, rule: &str, nodes: Vec<Node>, document: &mut Document) -> Result<(Option<Node>,Option<Node>)> {
   // Generate a textual token for each node; The parser operates on this encoded string.
 //   local $LaTeXML::MathParser::LEXEMES = {};
 //   my $i       = 0;
@@ -757,9 +757,9 @@ fn parse_internal(&self, rule: &str, nodes: Vec<Node>, document: &mut Document) 
 
     let mut new_app_node = Node::new("XMApp", None, &mut document.document).unwrap();
     new_app_node.set_namespace(left_arg.get_namespace().unwrap());
-    new_app_node.add_child(infix_op);
-    new_app_node.add_child(left_arg);
-    new_app_node.add_child(right_arg);
+    try!(new_app_node.add_child(infix_op));
+    try!(new_app_node.add_child(left_arg));
+    try!(new_app_node.add_child(right_arg));
 
     let new_app_child = parent.add_child(new_app_node).unwrap();
 
@@ -767,7 +767,7 @@ fn parse_internal(&self, rule: &str, nodes: Vec<Node>, document: &mut Document) 
   }
   // If still failed, try other strategies?
 
-  return (result, None)
+  return Ok((result, None))
 }
 
 // sub getGrammaticalRole {

--- a/src/package/mod.rs
+++ b/src/package/mod.rs
@@ -838,12 +838,13 @@ macro_rules! DefMacroI_F(
 );
 
 macro_rules! DefMacroT_F {
-    ($cs:expr, $paramlist:expr, None, $state:ident) => ({
-      DefMacroI_F!($cs, $paramlist, move |_gullet, _args, state| {Ok(vec![])}, $state)
-    });
     ($cs:expr, $paramlist:expr, $body:expr, $state:ident) => ({
       DefMacroI_F!($cs, $paramlist, move |_gullet, _args, state| {Ok(vec![$body])}, $state)
     });
+    ($cs:expr, $paramlist:expr, $state:ident) => ({
+      DefMacroI_F!($cs, $paramlist, move |_gullet, _args, state| {Ok(vec![])}, $state)
+    });
+
 }
 
 macro_rules! DefMacro_F(
@@ -1072,12 +1073,8 @@ macro_rules! DefConstructorIWO_F(
 
 macro_rules! DefConstructor_F {
   ($cs:expr, $replacement:expr, $state:ident) => (DefConstructorWO_F!($cs, $replacement, ConstructorOptions::default(), $state));
-  ($cs:expr, $replacement:expr,
-    $key1:ident=>$val1:expr,
-  , $state:ident) => (DefConstructorWO_F!($cs, $replacement, NewDefault!(ConstructorOptions,
-    $key1 => $val1
-  ), $state));
-
+  ($cs:expr, $replacement:expr, $key1:ident=>$val1:expr, $state:ident) =>
+    (DefConstructorWO_F!($cs, $replacement, NewDefault!(ConstructorOptions, $key1 => $val1), $state));
   ($cs:expr, $replacement:expr,
     $key1:ident=>$val1:expr,
     $key2:ident=>$val2:expr, $state:ident
@@ -1710,7 +1707,7 @@ macro_rules! SetupBindingMacros {($state:ident) => (
   macro_rules! AssignMapping {($map:expr, $key:expr, $value:expr) => (AssignMapping_F!($map, $key, $value, $state))}
   macro_rules! LookupMappingKeys {($map:expr) => (LookupMappingKeys_F!($map, $state))}
   macro_rules! LookupCatcode {($char:expr) => (LookupCatcode_F!($char, $state))}
-  macro_rules! AssignCatcode {($char:expr, $catcode:expr, $scope:expr) => (AssignCatcode_F!($char, $catcode, $scope, $state))};
+  macro_rules! AssignCatcode {($char:expr, $catcode:expr, $scope:expr) => (AssignCatcode_F!($char, $catcode, $scope, $state))}
   macro_rules! LookupMeaning {($name:expr) => (LookupMeaning_F!($name, $state))}
   macro_rules! LookupDefinition {($name:expr) => (LookupDefinition_F!($name, $state))}
   macro_rules! InstallDefinition {($name:expr, $definition:expr, $scope:expr) => (InstallDefinition_F!($name, $definition, $scope, $state))}
@@ -1750,7 +1747,10 @@ macro_rules! SetupBindingMacros {($state:ident) => (
   macro_rules! RequirePackage(($package:expr, $options:expr) => (RequirePackage_F!($package, $options, $state)));
   macro_rules! LoadClass(($class:expr, $options:expr, $after:expr) => (LoadClass_F!($class, $options, $after, $state)));
   macro_rules! DefMacroI(($cs:expr, $paramlist:expr, $expansion:expr) => (DefMacroI_F!($cs, $paramlist, $expansion, $state)));
-  macro_rules! DefMacroT(($cs:expr, $paramlist:expr, $arg:expr) => (DefMacroT_F!($cs, $paramlist, $arg, $state)));
+  macro_rules! DefMacroT(
+    ($cs:expr, $paramlist:expr) => (DefMacroT_F!($cs, $paramlist, $state));
+    ($cs:expr, $paramlist:expr, $arg:expr) => (DefMacroT_F!($cs, $paramlist, $arg, $state));
+  );
   macro_rules! DefMacro(($proto:expr, $expansion:expr) => (DefMacro_F!($proto, $expansion, $state)));
   macro_rules! DefPrimitive(($proto:expr, $replacement:expr, $options:expr) => (DefPrimitive_F!($proto, $replacement, $options, $state)));
 
@@ -1830,8 +1830,52 @@ macro_rules! SetupBindingMacros {($state:ident) => (
   );
 
 
-  macro_rules! DefEnvironment(($proto_raw:expr, $replacement:expr) => (DefEnvironment_F!($proto_raw, $replacement, $state)));
-  macro_rules! DefEnvironmentC(($proto_raw:expr, $compiled_replacement:expr) => (DefEnvironmentC_F!($proto_raw, $compiled_replacement, $state)));
+  macro_rules! DefEnvironment(
+    ($proto_raw:expr, $replacement:expr) => (DefEnvironment_F!($proto_raw, $replacement, $state));
+    ($proto_raw:expr, $replacement:expr,
+      $key1:ident=>$val1:expr) => (DefEnvironment_F!($proto_raw, $replacement, $key1=>$val1, $state));
+    ($proto_raw:expr, $replacement:expr,
+      $key1:ident=>$val1:expr,
+      $key2:ident=>$val2:expr) => (DefEnvironment_F!($proto_raw, $replacement, $key1=>$val1, $key2=>$val2, $state));
+    ($proto_raw:expr, $replacement:expr,
+      $key1:ident=>$val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr) => (DefEnvironment_F!($proto_raw, $replacement, $key1=>$val1, $key2=>$val2, $key3=>$val3, $state));
+    ($proto_raw:expr, $replacement:expr,
+      $key1:ident=>$val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr,
+      $key4:ident=>$val4:expr) => (DefEnvironment_F!($proto_raw, $replacement, $key1=>$val1, $key2=>$val2, $key3=>$val3, $key4=>$val4, $state));
+    ($proto_raw:expr, $replacement:expr,
+      $key1:ident=>$val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr,
+      $key4:ident=>$val4:expr,
+      $key5:ident=>$val5:expr) => (DefEnvironment_F!($proto_raw, $replacement, $key1=>$val1, $key2=>$val2, $key3=>$val3, $key4=>$val4, $key5=>$val5, $state));
+  );
+  macro_rules! DefEnvironmentC(
+    ($proto_raw:expr, $compiled_replacement:expr) => (DefEnvironmentC_F!($proto_raw, $compiled_replacement, $state));
+    ($proto_raw:expr, $compiled_replacement:expr,
+      $key1:ident=>$val1:expr) => (DefEnvironmentC_F!($proto_raw, $compiled_replacement, $key1=>$val1, $state));
+    ($proto_raw:expr, $compiled_replacement:expr,
+      $key1:ident=>$val1:expr,
+      $key2:ident=>$val2:expr) => (DefEnvironmentC_F!($proto_raw, $compiled_replacement, $key1=>$val1, $key2=>$val2, $state));
+    ($proto_raw:expr, $compiled_replacement:expr,
+      $key1:ident=>$val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr) => (DefEnvironmentC_F!($proto_raw, $compiled_replacement, $key1=>$val1, $key2=>$val2, $key3=>$val3, $state));
+    ($proto_raw:expr, $compiled_replacement:expr,
+      $key1:ident=>$val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr,
+      $key4:ident=>$val4:expr) => (DefEnvironmentC_F!($proto_raw, $compiled_replacement, $key1=>$val1, $key2=>$val2, $key3=>$val3, $key4=>$val4, $state));
+    ($proto_raw:expr, $compiled_replacement:expr,
+      $key1:ident=>$val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr,
+      $key4:ident=>$val4:expr,
+      $key5:ident=>$val5:expr) => (DefEnvironmentC_F!($proto_raw, $compiled_replacement, $key1=>$val1, $key2=>$val2, $key3=>$val3, $key4=>$val4, $key5=>$val5, $state));
+  );
   macro_rules! DefEnvironmentI(($name_raw:expr, $paramlist:expr, $compiled_replacement:expr, $cc_copy:expr, $options:expr) =>
     (DefEnvironmentI_F!($name_raw, $paramlist, $compiled_replacement, $cc_copy, $options, $state)));
   macro_rules! Tag(

--- a/src/package/mod.rs
+++ b/src/package/mod.rs
@@ -582,6 +582,19 @@ macro_rules! replacement {
   })
 }
 
+#[macro_export]
+macro_rules! noprimitive {
+  () => ( |stomach:&mut Stomach, args : Vec<Tokens>, state:&mut State| {Ok(Vec::new())})
+}
+
+#[macro_export]
+macro_rules! primitivesub {
+  ($stomach:ident, $args:ident, $state:ident, $body:expr) => (
+    |$stomach:&mut Stomach, $args : Vec<Tokens>, $state:&mut State| {
+      $body
+    }
+  )
+}
 
 // Discussion: It is unclear what the best authoring syntax is for our family of latexml binding macros.
 // One idea is to keep them very close to the Rust internals, but we suffer from a variety of boilerplate, such as
@@ -596,1070 +609,1276 @@ macro_rules! v {
   ($val:expr) => (Some($val.to_string()))
 }
 
-#[macro_export]
-macro_rules! SetupBindingMacros {($state:ident) => (
-  //======================================================================
-  // Convenience macros for writing definitions.
-  //======================================================================
-
-  macro_rules! LookupValue {
-    ($name:expr, $inner_state:ident) => ($inner_state.lookup_value($name));
-    ($name:expr) => {$state.lookup_value($name)}
-  }
-  macro_rules! LookupBool {
-    ($name:expr, $inner_state:ident) => ($inner_state.lookup_bool($name));
-    ($name:expr) => {$state.lookup_bool($name)}
-  }
-  macro_rules! LookupString {
-    ($name:expr, $inner_state:ident) => ($inner_state.lookup_string($name));
-    ($name:expr) => {$state.lookup_string($name)}
-  }
-
-  macro_rules! AssignValue {
-    ($name:expr, $value:expr, $scope:expr, $inner_state:ident) => ($inner_state.assign_value($name, $value, $scope));
-    ($name:expr, $value:expr, $scope:expr) => ($state.assign_value($name, $value, $scope))
-  }
-
-  macro_rules! RemoveValue {
-    ($name:expr) => ($state.remove_value($name))
-  }
-
-  macro_rules! PushValue {
-    ($name:expr, $values:expr) => ($state.pushValue($name, $values))
-  }
-
-  macro_rules! PopValue {
-    ($name:expr) => ($state.pop_value($name))
-  }
-
-  macro_rules! UnshiftValue {
-    ($name:expr, $values:expr) => ($state.unshift_value($name, $values))
-  }
-
-  macro_rules! ShiftValue {
-    ($name:expr) => ($state.shift_value($name))
-  }
-
-  macro_rules! LookupMapping {
-    ($map:expr, $key:expr) => ($state.lookup_mapping($map, $key))
-  }
-
-  macro_rules! AssignMapping {
-    ($map:expr, $key:expr, $value:expr) => ($state.assign_mapping($map, $key, $value))
-  }
-
-  macro_rules! LookupMappingKeys {
-    ($map:expr) => ($state.lookup_mapping_keys($map))
-  }
-
-  macro_rules! LookupCatcode {
-    ($char:expr) => ($state.lookup_catcode($char))
-  }
-
-  macro_rules! AssignCatcode {
-    ($char:expr, $catcode:expr, $scope:expr, $inner_state:ident) => ($inner_state.assign_catcode($char, $catcode, $scope));
-    ($char:expr, $catcode:expr, $scope:expr) => ($state.assign_catcode($char, $catcode, $scope))
-  }
-
-  macro_rules! LookupMeaning {
-    ($name:expr) => ($state.lookup_meaning($name))
-  }
-
-  macro_rules! LookupDefinition {
-    ($name:expr) => ($state.lookup_definition($name))
-  }
-
-  macro_rules! InstallDefinition {
-    ($name:expr, $definition:expr, $scope:expr) => ($state.install_definition($name, $definition, $scope))
-  }
-
-  // // macro_rules! XEquals {
-  //   ($token1:expr, $token2) => (
-  //   let def1 = LookupMeaning($token1);    # token, definition object or undef
-  //   let def2 = LookupMeaning($token2);    # ditto
-  //   if (defined $def1 != defined $def2) { # False, if only one has 'meaning'
-  //     return; }
-  //   elsif (!defined $def1 && !defined $def2) {    # true if both undefined
-  //     return 1; }
-  //   elsif ($def1->equals($def2)) {                # If both have defns, must be same defn!
-  //     return 1; }
-  //   return; }
+// We need to invoke constructors withing constructors. This is only possible with locally passed State arguments,
+// IF we have a macro form that explicitly accepts state and has no pseudo-global $state in its initialization.
+// For this we have to surrender to a verbose and redundant exercise. State needs to be explicitly passed down the call chain
+// of all *Factory macros, abbreviated for convenience with a trailing "_F"
+// We will first define the factories, and then the explicit SetupBindingMacros activation recipe that instantiates concrete
+// contextual versions.
 
 
-  macro_rules! IsDefined {
-    ($name:expr) => (is_defined($name, $state))
-  }
-  macro_rules! IsDefinedToken {
-    ($name:expr) => (is_defined_token($name, $state))
-  }
+//=============================================================================
+// Convenience macros for writing definitions. Factory form with explicit state
+//=============================================================================
 
-  macro_rules! Let {
-    ($token1:expr, $token2:expr) => ({
-      LetI!(&T_CS!($token1), T_CS!($token2))
+macro_rules! LookupValue_F {
+  ($name:expr, $state:ident) => ($state.lookup_value($name));
+}
+macro_rules! LookupBool_F {
+  ($name:expr, $state:ident) => ($state.lookup_bool($name));
+}
+macro_rules! LookupString_F {
+  ($name:expr, $state:ident) => ($state.lookup_string($name));
+}
+
+macro_rules! AssignValue_F {
+  ($name:expr, $value:expr, $scope:expr, $state:ident) => ($state.assign_value($name, $value, $scope));
+}
+
+macro_rules! RemoveValue_F {
+  ($name:expr, $state:ident) => ($state.remove_value($name))
+}
+
+macro_rules! PushValue_F {
+  ($name:expr, $values:expr, $state:ident) => ($state.pushValue($name, $values))
+}
+
+macro_rules! PopValue_F {
+  ($name:expr, $state:ident) => ($state.pop_value($name))
+}
+
+macro_rules! UnshiftValue_F {
+  ($name:expr, $values:expr,$state:ident) => ($state.unshift_value($name, $values))
+}
+
+macro_rules! ShiftValue_F {
+  ($name:expr,$state:ident) => ($state.shift_value($name))
+}
+
+macro_rules! LookupMapping_F {
+  ($map:expr, $key:expr, $state:ident) => ($state.lookup_mapping($map, $key))
+}
+
+macro_rules! AssignMapping_F {
+  ($map:expr, $key:expr, $value:expr, $state:ident) => ($state.assign_mapping($map, $key, $value))
+}
+
+macro_rules! LookupMappingKeys_F {
+  ($map:expr, $state:ident) => ($state.lookup_mapping_keys($map))
+}
+
+macro_rules! LookupCatcode_F {
+  ($char:expr, $state:ident) => ($state.lookup_catcode($char))
+}
+
+macro_rules! AssignCatcode_F {
+  ($char:expr, $catcode:expr, $scope:expr, $state:ident) => ($state.assign_catcode($char, $catcode, $scope));
+}
+
+macro_rules! LookupMeaning_F {
+  ($name:expr, $state:ident) => ($state.lookup_meaning($name))
+}
+
+macro_rules! LookupDefinition_F {
+  ($name:expr, $state:ident) => ($state.lookup_definition($name))
+}
+
+macro_rules! InstallDefinition_F {
+  ($name:expr, $definition:expr, $scope:expr, $state:ident) => ($state.install_definition($name, $definition, $scope))
+}
+
+// // macro_rules! XEquals {
+//   ($token1:expr, $token2) => (
+//   let def1 = LookupMeaning($token1);    # token, definition object or undef
+//   let def2 = LookupMeaning($token2);    # ditto
+//   if (defined $def1 != defined $def2) { # False, if only one has 'meaning'
+//     return; }
+//   elsif (!defined $def1 && !defined $def2) {    # true if both undefined
+//     return 1; }
+//   elsif ($def1->equals($def2)) {                # If both have defns, must be same defn!
+//     return 1; }
+//   return; }
+
+
+macro_rules! IsDefined_F {
+  ($name:expr, $state:ident) => (is_defined($name, $state))
+}
+macro_rules! IsDefinedToken_F {
+  ($name:expr, $state:ident) => (is_defined_token($name, $state))
+}
+
+macro_rules! Let_F {
+  ($token1:expr, $token2:expr, $state:ident) => ({
+    LetI_F!(&T_CS!($token1), T_CS!($token2), $state)
+  });
+  ($token1:expr, $token2:expr, $scope:expr, $state:ident) => ({
+    LetI_F!(&T_CS!($token1), T_CS!($token2), $scope, $state)
+  });
+}
+
+macro_rules! LetI_F {
+  ($token1:expr, $token2:expr, $state:ident) => (let_i($token1, $token2, None, $state));
+  ($token1:expr, $token2:expr, $scope:expr, $state:ident) => (let_i($token1, $token2, $scope, $state));
+}
+
+macro_rules! AfterAssignment_F {
+  ($state:ident) => ({
+    // TODO
+  })
+}
+
+// Merge the current font with the style specifications
+macro_rules! MergeFont_F {
+  ($kv:expr, $state:ident) => (merge_font($kv, $state))
+}
+
+
+//======================================================================
+// Defining new Control-sequence Parameter types.
+//======================================================================
+
+macro_rules! DefParameterType_F (
+  ($name:expr, $state:ident) => (DefParameterTypeWO_F!($name, Parameter::default(), $state));
+
+  ($name:expr,
+   $key1:ident => $val1:expr, $state:ident
+  ) => (DefParameterTypeWO_F!($name, NewDefault!(Parameter,
+   $key1 => $val1), $state));
+
+  ($name:expr,
+   $key1:ident => $val1:expr,
+   $key2:ident => $val2:expr, $state:ident
+  ) => (DefParameterTypeWO_F!($name, NewDefault!(Parameter,
+   $key1 => $val1,
+   $key2 => $val2
+  ), $state));
+
+  ($name:expr,
+   $key1:ident => $val1:expr,
+   $key2:ident => $val2:expr,
+   $key3:ident => $val3:expr, $state:ident
+  ) => (DefParameterTypeWO_F!($name, NewDefault!(Parameter,
+   $key1 => $val1,
+   $key2 => $val2,
+   $key3 => $val3
+  ), $state));
+
+  ($name:expr,
+   $key1:ident => $val1:expr,
+   $key2:ident => $val2:expr,
+   $key3:ident => $val3:expr,
+   $key4:ident => $val4:expr, $state:ident
+  ) => (DefParameterTypeWO_F!($name, NewDefault!(Parameter,
+   $key1 => $val1,
+   $key2 => $val2,
+   $key3 => $val3,
+   $key4 => $val4
+  ), $state));
+
+  ($name:expr,
+   $key1:ident => $val1:expr,
+   $key2:ident => $val2:expr,
+   $key3:ident => $val3:expr,
+   $key4:ident => $val4:expr,
+   $key5:ident => $val5:expr, $state:ident
+  ) => (DefParameterTypeWO_F!($name, NewDefault!(Parameter,
+   $key1 => $val1,
+   $key2 => $val2,
+   $key3 => $val3,
+   $key4 => $val4,
+   $key5 => $val5,
+  ), $state));
+
+  ($name:expr,
+   $key1:ident => $val1:expr,
+   $key2:ident => $val2:expr,
+   $key3:ident => $val3:expr,
+   $key4:ident => $val4:expr,
+   $key6:ident => $val6:expr, $state:ident
+  ) => (DefParameterTypeWO_F!($name, NewDefault!(Parameter,
+   $key1 => $val1,
+   $key2 => $val2,
+   $key3 => $val3,
+   $key4 => $val4,
+   $key5 => $val5,
+   $key6 => $val6
+  ), $state));
+);
+macro_rules! DefParameterTypeWO_F {
+  ($name:expr, $param:expr, $state:ident) => ($state.assign_mapping("PARAMETER_TYPES", $name, Some(ObjectStore::Parameter($param))))
+}
+
+macro_rules! LoadPool_F(
+  ($name: expr, $state:ident) => (try!(input_definitions($name.to_string(),
+    InputDefinitionOptions {
+      extension: Some("pool"),
+      ..InputDefinitionOptions::default()
+    }, $state)))
+);
+
+macro_rules! RequirePackage_F(
+  ($package:expr, $options:expr, $state:ident) => (
+  {
+    require_package($package, $options, $state);
+  }
+));
+
+macro_rules! LoadClass_F(
+  ($class:expr, $options:expr, $after:expr, $state:ident) => (
+  {
+    load_class($class, $options, $after , $state);
+  }
+));
+
+
+/// Macros and pool come at the end, so that they load seamlessly
+// TODO: package::coerce_cs on $cs
+macro_rules! DefMacroI_F(
+  ($cs:expr, $paramlist:expr, $expansion:expr, $state:expr) => (def_macro_i($cs, $paramlist, Rc::new($expansion), $state))
+);
+
+macro_rules! DefMacroT_F {
+    ($cs:expr, $paramlist:expr, None, $state:ident) => ({
+      DefMacroI_F!($cs, $paramlist, move |_gullet, _args, state| {Ok(vec![])}, $state)
     });
-    ($token1:expr, $token2:expr, $scope:expr) => ({
-      LetI!(&T_CS!($token1), T_CS!($token2), $scope)
+    ($cs:expr, $paramlist:expr, $body:expr, $state:ident) => ({
+      DefMacroI_F!($cs, $paramlist, move |_gullet, _args, state| {Ok(vec![$body])}, $state)
     });
+}
+
+macro_rules! DefMacro_F(
+  ($proto:expr, $expansion:expr, $state:ident) => ({
+    let (cs, paramlist) = try!(parse_prototype($proto, $state));
+    DefMacroI_F!(cs, paramlist, $expansion, $state);
+  })
+);
+
+
+///======================================================================
+/// Define a primitive control sequence.
+///======================================================================
+/// Primitives are executed in the Stomach.
+/// The $replacement should be a sub which returns nothing, or a list of `Box`'s or `Whatsit`'s.
+/// The options are:
+///    isPrefix  : 1 for things like \global, \long, etc.
+///    registerType : for parameters (but needs to be worked into `DefParameter`, below).
+
+macro_rules! DefPrimitive_F(
+  ($proto:expr, $replacement:expr, $options:expr, $state:ident) => ({
+    // TODO:
+    // let compiled_replacement = || Tbox{text: $replacement, Invocation($options{alias} || $cs, @_[1 .. $#_])); }
+    let compiled_replacement = $replacement;
+
+    DefPrimitiveIWO_F!($proto, compiled_replacement, $options, $state);
+  })
+);
+
+
+macro_rules! DefPrimitiveI_F(
+  ($proto:expr, $compiled_replacement:expr, $state:ident) => (DefPrimitiveIWO_F!($proto,$compiled_replacement, PrimitiveOptions::default(), $state));
+
+  ($proto:expr, $compiled_replacement:expr,
+    $key1:ident=>$val1:expr, $state:ident
+  ) => (DefPrimitiveIWO_F!($proto, $compiled_replacement, NewDefault!(PrimitiveOptions,
+    $key1 => $val1
+  ), $state));
+
+  ($proto:expr, $compiled_replacement:expr,
+    $key1:ident=>$val1:expr,
+    $key2:ident=>$val2:expr, $state:ident
+  ) => (DefPrimitiveIWO_F!($proto, $compiled_replacement, NewDefault!(PrimitiveOptions,
+    $key1 => $key2,
+    $key2 => $val2
+  ), $state));
+
+  ($proto:expr, $compiled_replacement:expr,
+    $key1:ident=>$val1:expr,
+    $key2:ident=>$val2:expr,
+    $key3:ident=>$val3:expr, $state:ident
+  ) => (DefPrimitiveIWO_F!($proto, $compiled_replacement, NewDefault!(PrimitiveOptions,
+    $key1 => $key2,
+    $key2 => $val2,
+    $key3 => $val3
+  ), $state));
+
+  ($proto:expr, $compiled_replacement:expr,
+    $key1:ident=>$val1:expr,
+    $key2:ident=>$val2:expr,
+    $key3:ident=>$val3:expr,
+    $key4:ident=>$val4:expr, $state:ident
+  ) => (DefPrimitiveIWO_F!($proto, $compiled_replacement, NewDefault!(PrimitiveOptions,
+    $key1 => $key2,
+    $key2 => $val2,
+    $key3 => $val3,
+    $key4 => $val4
+  ), $state));
+
+  ($proto:expr, $compiled_replacement:expr,
+    $key1:ident=>$val1:expr,
+    $key2:ident=>$val2:expr,
+    $key3:ident=>$val3:expr,
+    $key4:ident=>$val4:expr,
+    $key5:ident=>$val5:expr, $state:ident
+  ) => (DefPrimitiveIWO_F!($proto, $compiled_replacement, NewDefault!(PrimitiveOptions,
+    $key1 => $val1,
+    $key2 => $val2,
+    $key3 => $val3,
+    $key4 => $val4,
+    $key5 => $val5
+  ), $state));
+
+);
+
+
+macro_rules! DefPrimitiveIWO_F(
+  ($proto:expr, $compiled_replacement:expr, $options:expr, $state:ident) => ({
+    let (cs, paramlist) = try!(parse_prototype($proto, $state));
+    // let compiled_replacement = || Tbox{text: $replacement, Invocation($options{alias} || $cs, @_[1 .. $#_])); }
+    DefPrimitiveII_F!(cs, paramlist, $compiled_replacement, $options, $state);
+  })
+);
+
+macro_rules! DefPrimitiveII_F(
+  ($cs:expr, $paramlist:expr, $compiled_replacement:expr, $options:expr, $state:ident) => ({
+  let options = $options;
+  let options_locked = options.locked;
+  let scope = options.scope.clone();
+  // let mode    = options.mode;
+  // let bounded = options.bounded;
+  $state.install_definition(ObjectStore::Primitive(Rc::new(Primitive{
+      cs: $cs.clone(),
+      paramlist: $paramlist,
+      replacement: Some(Rc::new($compiled_replacement)),
+      // beforeDigest => flatten((options{requireMath} ? (sub { requireMath($cs); }) : ()),
+      //   (options{forbidMath} ? (sub { forbidMath($cs); }) : ()),
+      //   ($mode ? (sub { $_[0]->beginMode($mode); })
+      //     : ($bounded ? (sub { $_[0]->bgroup; }) : ())),
+      //   (options{font} ? (sub { MergeFont(%{ options{font} }); }) : ()),
+      //   options{beforeDigest}),
+      // afterDigest => flatten(options{afterDigest},
+      //   ($mode ? (sub { $_[0]->endMode($mode) })
+      //     : ($bounded ? (sub { $_[0]->egroup; }) : ()))),
+      options: options,
+      ..Primitive::default()
+    })),
+    scope);
+  if options_locked {
+    AssignValue_F!(&($cs.to_string()+":locked"), ObjectStore::Bool(true), None, $state);
   }
+}));
 
-  macro_rules! LetI {
-    ($token1:expr, $token2:expr) => (let_i($token1, $token2, None, $state));
-    ($token1:expr, $token2:expr, $scope:expr) => (let_i($token1, $token2, $scope, $state));
-    ($token1:expr, $token2:expr, $scope:expr, $inner_state:ident) => (let_i($token1, $token2, $scope, $inner_state));
+macro_rules! DefConstructorI_F {
+  ($cs:expr, $paramlist:expr, $compiled_replacement:expr, $state:ident) => (DefConstructorIWO_F!($cs, $paramlist, Some(Rc::new($compiled_replacement)), ConstructorOptions::default(), $state));
+  ($cs:expr, $paramlist:expr, $compiled_replacement:expr,
+    $key1:ident => $val1:expr,
+    $state:ident
+  ) => (DefConstructorIWO_F!($cs, $paramlist, Some(Rc::new($compiled_replacement)), NewDefault!(ConstructorOptions,
+    $key1 => $val1
+  ),$state));
+
+  ($cs:expr, $paramlist:expr, $compiled_replacement:expr,
+    $key1:ident => $val1:expr,
+    $key2:ident => $val2:expr,
+    $state:ident
+  ) => (DefConstructorIWO_F!($cs, $paramlist, Some(Rc::new($compiled_replacement)), NewDefault!(ConstructorOptions,
+    $key1 => $val1,
+    $key2 => $val2
+  ), $state));
+
+  ($cs:expr, $paramlist:expr, $compiled_replacement:expr,
+    $key1:ident => $val1:expr,
+    $key2:ident => $val2:expr,
+    $key3:ident => $val3:expr,
+    $state:ident
+  ) => (DefConstructorIWO_F!($cs, $paramlist, Some(Rc::new($compiled_replacement)), NewDefault!(ConstructorOptions,
+    $key1 => $val1,
+    $key2 => $val2,
+    $key3 => $val3
+  ), $state));
+
+  ($cs:expr, $paramlist:expr, $compiled_replacement:expr,
+    $key1:ident=>$val1:expr,
+    $key2:ident=>$val2:expr,
+    $key3:ident=>$val3:expr,
+    $key4:ident=>$val4:expr,
+    $state:ident
+  ) => (DefConstructorIWO_F!($cs, $paramlist, Some(Rc::new($compiled_replacement)), NewDefault!(ConstructorOptions,
+    $key1 => $val1,
+    $key2 => $val2,
+    $key3 => $val3,
+    $key4 => $val4
+  ), $state));
+
+  ($cs:expr, $paramlist:expr, $compiled_replacement:expr,
+    $key1:ident=>$val1:expr,
+    $key2:ident=>$val2:expr,
+    $key3:ident=>$val3:expr,
+    $key4:ident=>$val4:expr,
+    $key5:ident=>$val5:expr,
+    $state:ident
+  ) => (DefConstructorIWO_F!($cs, $paramlist, Some(Rc::new($compiled_replacement)), NewDefault!(ConstructorOptions,
+    $key1 => $val1,
+    $key2 => $val2,
+    $key3 => $val3,
+    $key4 => $val4,
+    $key5 => $val5
+  ), $state));
+}
+macro_rules! DefConstructorIWO_F(
+  ($cs:expr, $paramlist:expr, $compiled_replacement:expr, $options:expr, $state:ident) => (
+  {
+    use rtx_core::definition::constructor::Constructor;
+    // use libxml::tree::Node;
+    let options = $options;
+// let mode    = $options.mode;
+// let bounded = $options.bounded;
+
+    // TODO: This won't work, as we can only invoke method calls on paramlist in runtime
+    //*rtx_codegen::constructable::NARGS = $paramlist.get_num_args();
+    let constructor = Constructor {
+      cs: $cs,
+      paramlist: $paramlist,
+      replacement: $compiled_replacement,
+      options: options};
+
+    $state.install_definition(::rtx_core::state::ObjectStore::Constructor(Rc::new(constructor)), None);
+
+//   before_digest => flatten(($options{requireMath} ? (sub { requireMath($cs); }) : ()),
+//     ($options{forbidMath} ? (sub { forbidMath($cs); }) : ()),
+//     ($mode ? (sub { $_[0]->beginMode($mode); })
+//       : ($bounded ? (sub { $_[0]->bgroup; }) : ())),
+//     ($options{font} ? (sub { MergeFont(%{ $options{font} }); }) : ()),
+//     $options{before_digest}),
+//   after_digest => flatten($options{after_digest},
+//     ($mode ? (sub { $_[0]->endMode($mode) })
+//       : ($bounded ? (sub { $_[0]->egroup; }) : ()))),
+//   beforeConstruct => flatten($options{beforeConstruct}),
+//   afterConstruct  => flatten($options{afterConstruct}),
+//   nargs           => $options{nargs},
+//   alias           => $options{alias},
+//   reversion       => $options{reversion},
+//   sizer           => inferSizer($options{sizer}, $options{reversion}),
+//   captureBody     => $options{captureBody},
+//   properties      => $options{properties} || {}),
+// $options{scope});
+
+// if options.locked {
+//   $state.assign_value(ToString($cs) + ":locked", Box::new(true))
+// }
+// return;
   }
-
-  macro_rules! AfterAssignment {
-    () => ({
-      // TODO
-    })
-  }
-
-  // Merge the current font with the style specifications
-  macro_rules! MergeFont {
-    (kv:expr) => (merge_font(kv, $state))
-  }
-
-
-  //======================================================================
-  // Defining new Control-sequence Parameter types.
-  //======================================================================
-
-  macro_rules! DefParameterType (
-    ($name:expr) => (DefParameterTypeWO!($name, Parameter::default()));
-
-    ($name:expr,
-     $key1:ident => $val1:expr
-    ) => (DefParameterTypeWO!($name, NewDefault!(Parameter,
-     $key1 => $val1)));
-
-    ($name:expr,
-     $key1:ident => $val1:expr,
-     $key2:ident => $val2:expr
-    ) => (DefParameterTypeWO!($name, NewDefault!(Parameter,
-     $key1 => $val1,
-     $key2 => $val2
-    )));
-
-    ($name:expr,
-     $key1:ident => $val1:expr,
-     $key2:ident => $val2:expr,
-     $key3:ident => $val3:expr
-    ) => (DefParameterTypeWO!($name, NewDefault!(Parameter,
-     $key1 => $val1,
-     $key2 => $val2,
-     $key3 => $val3
-    )));
-
-    ($name:expr,
-     $key1:ident => $val1:expr,
-     $key2:ident => $val2:expr,
-     $key3:ident => $val3:expr,
-     $key4:ident => $val4:expr
-    ) => (DefParameterTypeWO!($name, NewDefault!(Parameter,
-     $key1 => $val1,
-     $key2 => $val2,
-     $key3 => $val3,
-     $key4 => $val4
-    )));
-
-    ($name:expr,
-     $key1:ident => $val1:expr,
-     $key2:ident => $val2:expr,
-     $key3:ident => $val3:expr,
-     $key4:ident => $val4:expr,
-     $key5:ident => $val5:expr
-    ) => (DefParameterTypeWO!($name, NewDefault!(Parameter,
-     $key1 => $val1,
-     $key2 => $val2,
-     $key3 => $val3,
-     $key4 => $val4,
-     $key5 => $val5,
-    )));
-
-    ($name:expr,
-     $key1:ident => $val1:expr,
-     $key2:ident => $val2:expr,
-     $key3:ident => $val3:expr,
-     $key4:ident => $val4:expr,
-     $key6:ident => $val6:expr
-    ) => (DefParameterTypeWO!($name, NewDefault!(Parameter,
-     $key1 => $val1,
-     $key2 => $val2,
-     $key3 => $val3,
-     $key4 => $val4,
-     $key5 => $val5,
-     $key6 => $val6
-    )));
   );
-  macro_rules! DefParameterTypeWO {
-    ($name:expr, $param:expr) => ($state.assign_mapping("PARAMETER_TYPES", $name, Some(ObjectStore::Parameter($param))))
-  }
+);
 
-  macro_rules! LoadPool(
-    ($name: expr) => (try!(input_definitions($name.to_string(),
-      InputDefinitionOptions {
-        extension: Some("pool"),
-        ..InputDefinitionOptions::default()
-      }, $state)))
-  );
+macro_rules! DefConstructor_F {
+  ($cs:expr, $replacement:expr, $state:ident) => (DefConstructorWO_F!($cs, $replacement, ConstructorOptions::default(), $state));
+  ($cs:expr, $replacement:expr,
+    $key1:ident=>$val1:expr,
+  , $state:ident) => (DefConstructorWO_F!($cs, $replacement, NewDefault!(ConstructorOptions,
+    $key1 => $val1
+  ), $state));
 
-  macro_rules! RequirePackage(
-    ($package:expr, $options:expr) => (
-    {
-      require_package($package, $options, $state);
-    }
-  ));
+  ($cs:expr, $replacement:expr,
+    $key1:ident=>$val1:expr,
+    $key2:ident=>$val2:expr, $state:ident
+  ) => (DefConstructorWO_F!($cs, $replacement, NewDefault!(ConstructorOptions,
+    $key1 => $val1,
+    $key2 => $val2
+  ), $state));
 
-  macro_rules! LoadClass(
-    ($class:expr, $options:expr, $after:expr) => (
-    {
-      load_class($class, $options, $after , $state);
-    }
-  ));
+  ($cs:expr, $replacement:expr,
+    $key1:ident=>$val1:expr,
+    $key2:ident=>$val2:expr,
+    $key3:ident=>$val3:expr, $state:ident
+  ) => (DefConstructorWO_F!($cs, $replacement, NewDefault!(ConstructorOptions,
+    $key1 => $val1,
+    $key2 => $val2,
+    $key3 => $val3
+  ), $state));
 
+  ($cs:expr, $replacement:expr,
+    $key1:ident=>$val1:expr,
+    $key2:ident=>$val2:expr,
+    $key3:ident=>$val3:expr,
+    $key4:ident=>$val4:expr, $state:ident
+  ) => (DefConstructorWO_F!($cs, $replacement, NewDefault!(ConstructorOptions,
+    $key1 => $val1,
+    $key2 => $val2,
+    $key3 => $val3,
+    $key4 => $val4
+  ), $state));
 
-  /// Macros and pool come at the end, so that they load seamlessly
-  // TODO: package::coerce_cs on $cs
-  macro_rules! DefMacroI(
-    ($cs:expr, $paramlist:expr, $expansion:expr) => (def_macro_i($cs, $paramlist, Rc::new($expansion), $state));
-    ($cs:expr, $paramlist:expr, $expansion:expr, $inner_state:expr) => (def_macro_i($cs, $paramlist, Rc::new($expansion), $inner_state))
-  );
+  ($cs:expr, $replacement:expr,
+    $key1:ident=>$val1:expr,
+    $key2:ident=>$val2:expr,
+    $key3:ident=>$val3:expr,
+    $key4:ident=>$val4:expr,
+    $key5:ident=>$val5:expr, $state:ident
+  ) => (DefConstructorWO_F!($cs, $replacement, NewDefault!(ConstructorOptions,
+    $key1 => $val1,
+    $key2 => $val2,
+    $key3 => $val3,
+    $key4 => $val4,
+    $key5 => $val5
+  ), $state));
+}
 
-  macro_rules! DefMacroT {
-      ($cs:expr, $paramlist:expr, None) => ({
-        DefMacroI!($cs, $paramlist, move |_gullet, _args, state| {Ok(vec![])})
-      });
-      ($cs:expr, $paramlist:expr, $body:expr) => ({
-        DefMacroI!($cs, $paramlist, move |_gullet, _args, state| {Ok(vec![$body])})
-      });
-  }
-
-  macro_rules! DefMacro(
-    ($proto:expr, $expansion:expr) => (
-    {
-      let (cs, paramlist) = try!(parse_prototype($proto, $state));
-      DefMacroI!(cs, paramlist, $expansion);
-    }
-    )
-  );
-
-
-  ///======================================================================
-  /// Define a primitive control sequence.
-  ///======================================================================
-  /// Primitives are executed in the Stomach.
-  /// The $replacement should be a sub which returns nothing, or a list of `Box`'s or `Whatsit`'s.
-  /// The options are:
-  ///    isPrefix  : 1 for things like \global, \long, etc.
-  ///    registerType : for parameters (but needs to be worked into `DefParameter`, below).
-
-  macro_rules! DefPrimitive(
-    ($proto:expr, $replacement:expr, $options:expr) => ({
-      // TODO:
-      // let compiled_replacement = || Tbox{text: $replacement, Invocation($options{alias} || $cs, @_[1 .. $#_])); }
-      let compiled_replacement = $replacement;
-
-      DefPrimitiveIWO!($proto, compiled_replacement, $options, $state);
-    })
-  );
-
-
-  macro_rules! DefPrimitiveI(
-    ($proto:expr, $compiled_replacement:expr) => (DefPrimitiveIWO!($proto,$compiled_replacement, PrimitiveOptions::default()));
-
-    ($proto:expr, $compiled_replacement:expr,
-      $key1:ident=>$val1:expr
-    ) => (DefPrimitiveIWO!($proto, $compiled_replacement, NewDefault!(PrimitiveOptions,
-      $key1 => $val1
-    )));
-
-    ($proto:expr, $compiled_replacement:expr,
-      $key1:ident=>$val1:expr,
-      $key2:ident=>$val2:expr
-    ) => (DefPrimitiveIWO!($proto, $compiled_replacement, NewDefault!(PrimitiveOptions,
-      $key1 => $key2,
-      $key2 => $val2
-    )));
-
-    ($proto:expr, $compiled_replacement:expr,
-      $key1:ident=>$val1:expr,
-      $key2:ident=>$val2:expr,
-      $key3:ident=>$val3:expr
-    ) => (DefPrimitiveIWO!($proto, $compiled_replacement, NewDefault!(PrimitiveOptions,
-      $key1 => $key2,
-      $key2 => $val2,
-      $key3 => $val3
-    )));
-
-    ($proto:expr, $compiled_replacement:expr,
-      $key1:ident=>$val1:expr,
-      $key2:ident=>$val2:expr,
-      $key3:ident=>$val3:expr,
-      $key4:ident=>$val4:expr
-    ) => (DefPrimitiveIWO!($proto, $compiled_replacement, NewDefault!(PrimitiveOptions,
-      $key1 => $key2,
-      $key2 => $val2,
-      $key3 => $val3,
-      $key4 => $val4
-    )));
-
-    ($proto:expr, $compiled_replacement:expr,
-      $key1:ident=>$val1:expr,
-      $key2:ident=>$val2:expr,
-      $key3:ident=>$val3:expr,
-      $key4:ident=>$val4:expr,
-      $key5:ident=>$val5:expr
-    ) => (DefPrimitiveIWO!($proto, $compiled_replacement, NewDefault!(PrimitiveOptions,
-      $key1 => $val1,
-      $key2 => $val2,
-      $key3 => $val3,
-      $key4 => $val4,
-      $key5 => $val5
-    )));
-
-  );
-
-
-  macro_rules! DefPrimitiveIWO(
-    ($proto:expr, $compiled_replacement:expr, $options:expr) => ({
-      let (cs, paramlist) = try!(parse_prototype($proto, $state));
-      // let compiled_replacement = || Tbox{text: $replacement, Invocation($options{alias} || $cs, @_[1 .. $#_])); }
-      DefPrimitiveII!(cs, paramlist, $compiled_replacement, $options);
-    })
-  );
-
-  macro_rules! DefPrimitiveII(
-    ($cs:expr, $paramlist:expr, $compiled_replacement:expr, $options:expr) => ({
-
-    let mode    = $options.mode;
-    let bounded = $options.bounded;
-    $state.install_definition(ObjectStore::Primitive(Rc::new(Primitive{
-        cs: $cs.clone(),
-        paramlist: $paramlist,
-        replacement: Some(Rc::new($compiled_replacement)),
-        // beforeDigest => flatten(($options{requireMath} ? (sub { requireMath($cs); }) : ()),
-        //   ($options{forbidMath} ? (sub { forbidMath($cs); }) : ()),
-        //   ($mode ? (sub { $_[0]->beginMode($mode); })
-        //     : ($bounded ? (sub { $_[0]->bgroup; }) : ())),
-        //   ($options{font} ? (sub { MergeFont(%{ $options{font} }); }) : ()),
-        //   $options{beforeDigest}),
-        // afterDigest => flatten($options{afterDigest},
-        //   ($mode ? (sub { $_[0]->endMode($mode) })
-        //     : ($bounded ? (sub { $_[0]->egroup; }) : ()))),
-        options: $options,
-        ..Primitive::default()
-      })),
-      $options.scope);
-    if $options.locked {
-      AssignValue!(&($cs.to_string()+":locked"), ObjectStore::Bool(true), None);
-    }
-  }));
-
-  macro_rules! DefConstructorI {
-    ($cs:expr, $paramlist:expr, $compiled_replacement:expr) => (DefConstructorIWO!($cs, $paramlist, Some(Rc::new($compiled_replacement)), ConstructorOptions::default()));
-    ($cs:expr, $paramlist:expr, $compiled_replacement:expr,
-      $key1:ident => $val1:expr
-    ) => (DefConstructorIWO!($cs, $paramlist, Some(Rc::new($compiled_replacement)), NewDefault!(ConstructorOptions,
-      $key1 => $val1
-    )));
-
-    ($cs:expr, $paramlist:expr, $compiled_replacement:expr,
-      $key1:ident => $val1:expr,
-      $key2:ident => $val2:expr
-    ) => (DefConstructorIWO!($cs, $paramlist, Some(Rc::new($compiled_replacement)), NewDefault!(ConstructorOptions,
-      $key1 => $val1,
-      $key2 => $val2
-    )));
-
-    ($cs:expr, $paramlist:expr, $compiled_replacement:expr,
-      $key1:ident => $val1:expr,
-      $key2:ident => $val2:expr,
-      $key3:ident => $val3:expr
-    ) => (DefConstructorIWO!($cs, $paramlist, Some(Rc::new($compiled_replacement)), NewDefault!(ConstructorOptions,
-      $key1 => $val1,
-      $key2 => $val2,
-      $key3 => $val3
-    )));
-
-    ($cs:expr, $paramlist:expr, $compiled_replacement:expr,
-      $key1:ident=>$val1:expr,
-      $key2:ident=>$val2:expr,
-      $key3:ident=>$val3:expr,
-      $key4:ident=>$val4:expr
-    ) => (DefConstructorIWO!($cs, $paramlist, Some(Rc::new($compiled_replacement)), NewDefault!(ConstructorOptions,
-      $key1 => $val1,
-      $key2 => $val2,
-      $key3 => $val3,
-      $key4 => $val4
-    )));
-
-    ($cs:expr, $paramlist:expr, $compiled_replacement:expr,
-      $key1:ident=>$val1:expr,
-      $key2:ident=>$val2:expr,
-      $key3:ident=>$val3:expr,
-      $key4:ident=>$val4:expr,
-      $key5:ident=>$val5:expr
-    ) => (DefConstructorIWO!($cs, $paramlist, Some(Rc::new($compiled_replacement)), NewDefault!(ConstructorOptions,
-      $key1 => $val1,
-      $key2 => $val2,
-      $key3 => $val3,
-      $key4 => $val4,
-      $key5 => $val5
-    )));
-  }
-  macro_rules! DefConstructorIWO(
-    ($cs:expr, $paramlist:expr, $compiled_replacement:expr, $options:expr) => (
-    {
-      use rtx_core::definition::constructor::Constructor;
-      // use libxml::tree::Node;
-
-  // let mode    = $options.mode;
-  // let bounded = $options.bounded;
-
-      // TODO: This won't work, as we can only invoke method calls on paramlist in runtime
-      //*rtx_codegen::constructable::NARGS = $paramlist.get_num_args();
-      let constructor = Constructor {
-        cs: $cs,
-        paramlist: $paramlist,
-        replacement: $compiled_replacement,
-        options: $options};
-
-      $state.install_definition(::rtx_core::state::ObjectStore::Constructor(Rc::new(constructor)), None);
-
-  //   before_digest => flatten(($options{requireMath} ? (sub { requireMath($cs); }) : ()),
-  //     ($options{forbidMath} ? (sub { forbidMath($cs); }) : ()),
-  //     ($mode ? (sub { $_[0]->beginMode($mode); })
-  //       : ($bounded ? (sub { $_[0]->bgroup; }) : ())),
-  //     ($options{font} ? (sub { MergeFont(%{ $options{font} }); }) : ()),
-  //     $options{before_digest}),
-  //   after_digest => flatten($options{after_digest},
-  //     ($mode ? (sub { $_[0]->endMode($mode) })
-  //       : ($bounded ? (sub { $_[0]->egroup; }) : ()))),
-  //   beforeConstruct => flatten($options{beforeConstruct}),
-  //   afterConstruct  => flatten($options{afterConstruct}),
-  //   nargs           => $options{nargs},
-  //   alias           => $options{alias},
-  //   reversion       => $options{reversion},
-  //   sizer           => inferSizer($options{sizer}, $options{reversion}),
-  //   captureBody     => $options{captureBody},
-  //   properties      => $options{properties} || {}),
-  // $options{scope});
-
-  // if options.locked {
-  //   $state.assign_value(ToString($cs) + ":locked", Box::new(true))
-  // }
-  // return;
-    }
-    );
-  );
-
-  macro_rules! DefConstructor {
-    ($cs:expr, $replacement:expr) => (DefConstructorWO!($cs, $replacement, ConstructorOptions::default()));
-    ($cs:expr, $replacement:expr,
-      $key1:ident=>$val1:expr
-    ) => (DefConstructorWO!($cs, $replacement, NewDefault!(ConstructorOptions,
-      $key1 => $val1
-    )));
-
-    ($cs:expr, $replacement:expr,
-      $key1:ident=>$val1:expr,
-      $key2:ident=>$val2:expr
-    ) => (DefConstructorWO!($cs, $replacement, NewDefault!(ConstructorOptions,
-      $key1 => $val1,
-      $key2 => $val2
-    )));
-
-    ($cs:expr, $replacement:expr,
-      $key1:ident=>$val1:expr,
-      $key2:ident=>$val2:expr,
-      $key3:ident=>$val3:expr
-    ) => (DefConstructorWO!($cs, $replacement, NewDefault!(ConstructorOptions,
-      $key1 => $val1,
-      $key2 => $val2,
-      $key3 => $val3
-    )));
-
-    ($cs:expr, $replacement:expr,
-      $key1:ident=>$val1:expr,
-      $key2:ident=>$val2:expr,
-      $key3:ident=>$val3:expr,
-      $key4:ident=>$val4:expr
-    ) => (DefConstructorWO!($cs, $replacement, NewDefault!(ConstructorOptions,
-      $key1 => $val1,
-      $key2 => $val2,
-      $key3 => $val3,
-      $key4 => $val4
-    )));
-
-    ($cs:expr, $replacement:expr,
-      $key1:ident=>$val1:expr,
-      $key2:ident=>$val2:expr,
-      $key3:ident=>$val3:expr,
-      $key4:ident=>$val4:expr,
-      $key5:ident=>$val5:expr
-    ) => (DefConstructorWO!($cs, $replacement, NewDefault!(ConstructorOptions,
-      $key1 => $val1,
-      $key2 => $val2,
-      $key3 => $val3,
-      $key4 => $val4,
-      $key5 => $val5
-    )));
-  }
-
-  macro_rules! DefConstructorWO(
-    ($proto:expr, $replacement:expr, $options:expr) => (
-    {
-  // check_options("DefConstructor (prototype)", $constructor_options, %options);
-      let (cs, paramlist) = try!(parse_prototype($proto, $state));
-      let compiled_replacement;
-      compile_replacement!(compiled_replacement, $replacement);
-      DefConstructorIWO!(cs, paramlist, compiled_replacement, $options);
-    }
-    )
-  );
-
-  //=====================================================================
-  // Define a LaTeX environment
-  // Note that the body of the environment is treated is the 'body' parameter in the constructor.
-  macro_rules! DefEnvironment ( // repetition isn't allowed here, so we have to do silly hackish signature magic
-    ($proto_raw:expr, $replacement:expr) => (DefEnvironmentWO!($proto_raw, $replacement, ConstructorOptions::default()));
-
-    ($proto_raw:expr, $replacement:expr,
-     $key1:ident => $val1:expr
-    ) => (DefEnvironmentWO!($proto_raw, $replacement, NewDefault!(ConstructorOptions,
-     $key1 => $val1)));
-
-    ($proto_raw:expr, $replacement:expr,
-     $key1:ident => $val1:expr,
-     $key2:ident => $val2:expr
-    ) => (DefEnvironmentWO!($proto_raw, $replacement, NewDefault!(ConstructorOptions,
-     $key1 => $val1,
-     $key2 => $val2
-    )));
-
-    ($proto_raw:expr, $replacement:expr,
-     $key1:ident => $val1:expr,
-     $key2:ident => $val2:expr,
-     $key3:ident => $val3:expr
-    ) => (DefEnvironmentWO!($proto_raw, $replacement, NewDefault!(ConstructorOptions,
-     $key1 => $val1,
-     $key2 => $val2,
-     $key3 => $val3
-    )));
-
-    ($proto_raw:expr, $replacement:expr,
-     $key1:ident => $val1:expr,
-     $key2:ident => $val2:expr,
-     $key3:ident => $val3:expr,
-     $key4:ident => $val4:expr
-    ) => (DefEnvironmentWO!($proto_raw, $replacement, NewDefault!(ConstructorOptions,
-     $key1 => $val1,
-     $key2 => $val2,
-     $key3 => $val3,
-     $key4 => $val4
-    )));
-
-    ($proto_raw:expr, $replacement:expr,
-     $key1:ident => $val1:expr,
-     $key2:ident => $val2:expr,
-     $key3:ident => $val3:expr,
-     $key4:ident => $val4:expr,
-     $key5:ident => $val5:expr,
-    ) => (DefEnvironmentWO!($proto_raw, $replacement, NewDefault!(ConstructorOptions,
-     $key1 => $val1,
-     $key2 => $val2,
-     $key3 => $val3,
-     $key4 => $val4,
-     $key5 => $val5
-    )));
-  );
-  macro_rules! DefEnvironmentWO (
-    ($proto_raw:expr, $replacement:expr, $options:expr) => ({
-    use rtx_core::util::text::*;
-    let mut proto = $proto_raw.to_string().trim_left().to_string();
-    let name = extract_bracketed(&mut proto, Some(&Delimiter::Brace));
-
+macro_rules! DefConstructorWO_F(
+  ($proto:expr, $replacement:expr, $options:expr, $state:ident) => (
+  {
+// check_options("DefConstructor (prototype)", $constructor_options, %options);
+    let (cs, paramlist) = try!(parse_prototype($proto, $state));
     let compiled_replacement;
     compile_replacement!(compiled_replacement, $replacement);
-    let cc_copy;
-    compile_replacement!(cc_copy, $replacement);
-
-    let options = $options;
-
-    DefEnvironmentI!(name, None, compiled_replacement, cc_copy, options);
-  }));
-
-  macro_rules! DefEnvironmentC {
-    ($proto_raw:expr, $compiled_replacement:expr) => (DefEnvironmentCWO!($proto_raw, $paramlist, $compiled_replacement, ConstructorOptions::default()));
-    ($proto_raw:expr, $compiled_replacement:expr,
-      $key1:ident=>$val1:expr
-    ) => (DefEnvironmentCWO!($proto_raw, $compiled_replacement, NewDefault!(ConstructorOptions,
-      $key1 => $val1
-    )));
-
-    ($proto_raw:expr, $compiled_replacement:expr,
-      $key1:ident=>$val1:expr,
-      $key2:ident=>$val2:expr
-    ) => (DefEnvironmentCWO!($proto_raw, $compiled_replacement, NewDefault!(ConstructorOptions,
-      $key1 => $val1,
-      $key2 => $val2
-    )));
-
-    ($proto_raw:expr, $compiled_replacement:expr,
-      $key1:ident=>$val1:expr,
-      $key2:ident=>$val2:expr,
-      $key3:ident=>$val3:expr
-    ) => (DefEnvironmentCWO!($proto_raw, $compiled_replacement, NewDefault!(ConstructorOptions,
-      $key1 => $val1,
-      $key2 => $val2,
-      $key3 => $val3
-    )));
-
-    ($proto_raw:expr, $compiled_replacement:expr,
-      $key1:ident=>$val1:expr,
-      $key2:ident=>$val2:expr,
-      $key3:ident=>$val3:expr,
-      $key4:ident=>$val4:expr
-    ) => (DefEnvironmentCWO!($proto_raw, $compiled_replacement, NewDefault!(ConstructorOptions,
-      $key1 => $val1,
-      $key2 => $val2,
-      $key3 => $val3,
-      $key4 => $val4
-    )));
-
-    ($proto_raw:expr, $compiled_replacement:expr,
-      $key1:ident=>$val1:expr,
-      $key2:ident=>$val2:expr,
-      $key3:ident=>$val3:expr,
-      $key4:ident=>$val4:expr,
-      $key5:ident=>$val5:expr
-    ) => (DefEnvironmentCWO!($proto_raw, $compiled_replacement, NewDefault!(ConstructorOptions,
-      $key1 => $val1,
-      $key2 => $val2,
-      $key3 => $val3,
-      $key4 => $val4,
-      $key5 => $val5
-    )));
+    DefConstructorIWO_F!(cs, paramlist, compiled_replacement, $options, $state);
   }
+  )
+);
 
-  macro_rules! DefEnvironmentCWO (
-    ($proto_raw:expr, $compiled_replacement:expr, $options:expr) => ({
-    use rtx_core::util::text::*;
-    let mut proto = $proto_raw.to_string().trim_left().to_string();
-    let name = extract_bracketed(&mut proto, Some(&Delimiter::Brace));
-    // TODO: What do we do with param lists?
-    //let paramlist_str = proto.trim_left().to_string();
-    DefEnvironmentI!(name, None, $compiled_replacement, $compiled_replacement, $options);
-  }));
+//=====================================================================
+// Define a LaTeX environment
+// Note that the body of the environment is treated is the 'body' parameter in the constructor.
+macro_rules! DefEnvironment_F ( // repetition isn't allowed here, so we have to do silly hackish signature magic
+  ($proto_raw:expr, $replacement:expr, $state:ident) => (DefEnvironmentWO_F!($proto_raw, $replacement, ConstructorOptions::default(), $state));
 
-  macro_rules! DefEnvironmentI (
-    ($name_raw:expr, $paramlist:expr, $compiled_replacement:expr, $cc_copy:expr, $options:expr) => ({
-    use rtx_core::stomach::Stomach;
-    use rtx_core::whatsit::Whatsit;
-    use rtx_core::definition::constructor::Constructor;
-    let name = $name_raw.to_string();
-    let options = $options;
-    // This is for the common case where the environment is opened by \begin{env}
-    // let sizer = inferSizer($options.sizer, $options.reversion);
-    let mut before_digest_env : Vec<BeforeDigestClosure> = Vec::new();
-    match &options.mode {
-      &Some(ref mode) => {
-        let bmode = mode.clone();
-        let mode_closure = Rc::new(move |stomach: &mut Stomach, state: &mut State| {
-          try!(stomach.begin_mode(&bmode, state));
-          Ok(Vec::new())
-        });
-        before_digest_env.push(mode_closure);
-      },
-      &None => {
-        let bgroup_closure = Rc::new(|stomach: &mut Stomach, state: &mut State| {stomach.bgroup(state); Ok(Vec::new())});
-        before_digest_env.push(bgroup_closure);
-      }
-    };
-    before_digest_env.extend(options.before_digest);
+  ($proto_raw:expr, $replacement:expr,
+   $key1:ident => $val1:expr, $state:ident
+  ) => (DefEnvironmentWO_F!($proto_raw, $replacement, NewDefault!(ConstructorOptions,
+   $key1 => $val1), $state));
 
-    let push_frame_closure = Rc::new(|_document: &mut Document, _whatsit: &Whatsit, state: &mut State| {
-      state.push_frame();
-    });
-    let mut before_construct_with_frame : Vec<ConstructionClosure> = vec![push_frame_closure];
-    before_construct_with_frame.extend(options.before_construct);
+  ($proto_raw:expr, $replacement:expr,
+   $key1:ident => $val1:expr,
+   $key2:ident => $val2:expr, $state:ident
+  ) => (DefEnvironmentWO_F!($proto_raw, $replacement, NewDefault!(ConstructorOptions,
+   $key1 => $val1,
+   $key2 => $val2
+  ), $state));
 
-    let mut after_construct_with_frame : Vec<ConstructionClosure> = options.after_construct;
+  ($proto_raw:expr, $replacement:expr,
+   $key1:ident => $val1:expr,
+   $key2:ident => $val2:expr,
+   $key3:ident => $val3:expr, $state:ident
+  ) => (DefEnvironmentWO_F!($proto_raw, $replacement, NewDefault!(ConstructorOptions,
+   $key1 => $val1,
+   $key2 => $val2,
+   $key3 => $val3
+  ), $state));
 
-    let pop_frame_closure = Rc::new(|_document: &mut Document, _whatsit: &Whatsit, state: &mut State| {
-      state.pop_frame();
-    });
-    after_construct_with_frame.push(pop_frame_closure);
+  ($proto_raw:expr, $replacement:expr,
+   $key1:ident => $val1:expr,
+   $key2:ident => $val2:expr,
+   $key3:ident => $val3:expr,
+   $key4:ident => $val4:expr, $state:ident
+  ) => (DefEnvironmentWO_F!($proto_raw, $replacement, NewDefault!(ConstructorOptions,
+   $key1 => $val1,
+   $key2 => $val2,
+   $key3 => $val3,
+   $key4 => $val4
+  ), $state));
 
-    let begin_name_constructor = Rc::new(Constructor {
-        cs: T_CS!("\\begin{".to_string()+&name+"}"),
-        paramlist: $paramlist,
-        replacement: $compiled_replacement,
-        options: ConstructorOptions {
-          nargs: options.nargs,
-          before_digest: before_digest_env,
-          // beforeDigest => flatten(($options{requireMath} ? (sub { requireMath($name); }) : ()),
-          //   ($options{forbidMath} ? (sub { forbidMath($name); }) : ()),
-          //   sub { AssignValue(current_environment => $name);
-          //     DefMacroI('\@currenvir', undef, $name); },
-          //   ($options{font} ? (sub { MergeFont(%{ $options{font} }); }) : ()),
-          font: options.font.clone(), // TODO
-          //   $options{beforeDigest}),
-          after_digest: options.after_digest_begin,
-          after_digest_body: options.after_digest_body,
-          before_construct: before_construct_with_frame,
-          // Curiously, it's the \begin whose afterConstruct gets called.
-          after_construct: after_construct_with_frame,
-          capture_body: true,
-          properties: options.properties.clone(),
-          // (defined $options{reversion} ? (reversion => $options{reversion}) : ()),
-          // (defined $sizer ? (sizer => $sizer) : ()),
-          // ), $options{scope});
-          ..ConstructorOptions::default()
-        }});
-    $state.install_definition(ObjectStore::Constructor(begin_name_constructor), options.scope.clone());
+  ($proto_raw:expr, $replacement:expr,
+   $key1:ident => $val1:expr,
+   $key2:ident => $val2:expr,
+   $key3:ident => $val3:expr,
+   $key4:ident => $val4:expr,
+   $key5:ident => $val5:expr, $state:ident
+  ) => (DefEnvironmentWO_F!($proto_raw, $replacement, NewDefault!(ConstructorOptions,
+   $key1 => $val1,
+   $key2 => $val2,
+   $key3 => $val3,
+   $key4 => $val4,
+   $key5 => $val5
+  ), $state));
+);
+macro_rules! DefEnvironmentWO_F (
+  ($proto_raw:expr, $replacement:expr, $options:expr, $state:ident) => ({
+  use rtx_core::util::text::*;
+  let mut proto = $proto_raw.to_string().trim_left().to_string();
+  let name = extract_bracketed(&mut proto, Some(&Delimiter::Brace));
 
+  let compiled_replacement;
+  compile_replacement!(compiled_replacement, $replacement);
+  let cc_copy;
+  compile_replacement!(cc_copy, $replacement);
 
-    let mut after_digest_env = options.after_digest;
-    let unexpected_end_closure = Rc::new(|_stomach: &mut Stomach, _whatsit: &mut Whatsit, state: &mut State| {
-      // let env = LookupValue!("current_environment", $state);
-      //     Error('unexpected', "\\end{$name}", $_[0],
-      //       "Can't close environment $name",
-      //       "Current are "
-      //         . join(', ', state->lookupStackedValues('current_environment')))
-      //       unless $env && $name eq $env;
-      //     return; },
-      Ok(Vec::new())
-    });
-    after_digest_env.push(unexpected_end_closure);
+  let options = $options;
 
-    match options.mode {
-      Some(mode) => {
-        let emode = mode.clone();
-        let emode_closure = Rc::new(move |stomach: &mut Stomach, _whatsit: &mut Whatsit, state: &mut State| {
-          try!(stomach.end_mode(&emode, state));
-          Ok(Vec::new())
-        });
-        after_digest_env.push(emode_closure);
-      },
-      None => {
-        let egroup_closure = Rc::new(|stomach: &mut Stomach, _whatsit: &mut Whatsit, state: &mut State| {
-          try!(stomach.egroup(state));
-          Ok(Vec::new())
-        });
-        after_digest_env.push(egroup_closure);
-      }
-    };
+  DefEnvironmentI_F!(name, None, compiled_replacement, cc_copy, options, $state);
+}));
 
-    let end_envname_constructor = Rc::new(Constructor {
-      cs: T_CS!("\\end{".to_string()+&name+"}"),
-      replacement: None,
-      paramlist: None,
-      options: ConstructorOptions {
-        before_digest: options.before_digest_end,
-        after_digest: after_digest_env,
-        ..ConstructorOptions::default()
-      }
-    });
-    $state.install_definition(ObjectStore::Constructor(end_envname_constructor), options.scope.clone());
+macro_rules! DefEnvironmentC_F {
+  ($proto_raw:expr, $compiled_replacement:expr, $state:ident) => (DefEnvironmentCWO_F!($proto_raw, $paramlist, $compiled_replacement, ConstructorOptions::default()));
+  ($proto_raw:expr, $compiled_replacement:expr,
+    $key1:ident=>$val1:expr,
+    $state:ident
+  ) => (DefEnvironmentCWO_F!($proto_raw, $compiled_replacement, NewDefault!(ConstructorOptions,
+    $key1 => $val1
+  ), $state));
 
-    // For the uncommon case opened by \csname env\endcsname
-    let name_constructor = Rc::new(Constructor{
-      cs: T_CS!("\\".to_string() +&name),
+  ($proto_raw:expr, $compiled_replacement:expr,
+    $key1:ident=>$val1:expr,
+    $key2:ident=>$val2:expr,
+    $state:ident
+  ) => (DefEnvironmentCWO_F!($proto_raw, $compiled_replacement, NewDefault!(ConstructorOptions,
+    $key1 => $val1,
+    $key2 => $val2
+  ), $state));
+
+  ($proto_raw:expr, $compiled_replacement:expr,
+    $key1:ident=>$val1:expr,
+    $key2:ident=>$val2:expr,
+    $key3:ident=>$val3:expr,
+    $state:ident
+  ) => (DefEnvironmentCWO_F!($proto_raw, $compiled_replacement, NewDefault!(ConstructorOptions,
+    $key1 => $val1,
+    $key2 => $val2,
+    $key3 => $val3
+  ), $state));
+
+  ($proto_raw:expr, $compiled_replacement:expr,
+    $key1:ident=>$val1:expr,
+    $key2:ident=>$val2:expr,
+    $key3:ident=>$val3:expr,
+    $key4:ident=>$val4:expr,
+    $state:ident
+  ) => (DefEnvironmentCWO_F!($proto_raw, $compiled_replacement, NewDefault!(ConstructorOptions,
+    $key1 => $val1,
+    $key2 => $val2,
+    $key3 => $val3,
+    $key4 => $val4
+  ), $state));
+
+  ($proto_raw:expr, $compiled_replacement:expr,
+    $key1:ident=>$val1:expr,
+    $key2:ident=>$val2:expr,
+    $key3:ident=>$val3:expr,
+    $key4:ident=>$val4:expr,
+    $key5:ident=>$val5:expr,
+    $state:ident
+  ) => (DefEnvironmentCWO_F!($proto_raw, $compiled_replacement, NewDefault!(ConstructorOptions,
+    $key1 => $val1,
+    $key2 => $val2,
+    $key3 => $val3,
+    $key4 => $val4,
+    $key5 => $val5
+  ), $state));
+}
+
+macro_rules! DefEnvironmentCWO_F (
+  ($proto_raw:expr, $compiled_replacement:expr, $options:expr, $state:ident) => ({
+  use rtx_core::util::text::*;
+  let mut proto = $proto_raw.to_string().trim_left().to_string();
+  let name = extract_bracketed(&mut proto, Some(&Delimiter::Brace));
+  // TODO: What do we do with param lists?
+  //let paramlist_str = proto.trim_left().to_string();
+  DefEnvironmentI_F!(name, None, $compiled_replacement, $compiled_replacement, $options, $state);
+}));
+
+macro_rules! DefEnvironmentI_F (
+  ($name_raw:expr, $paramlist:expr, $compiled_replacement:expr, $cc_copy:expr, $options:expr, $state:ident) => ({
+  use rtx_core::stomach::Stomach;
+  use rtx_core::whatsit::Whatsit;
+  use rtx_core::definition::constructor::Constructor;
+  let name = $name_raw.to_string();
+  let options = $options;
+  // This is for the common case where the environment is opened by \begin{env}
+  // let sizer = inferSizer($options.sizer, $options.reversion);
+  let mut before_digest_env : Vec<BeforeDigestClosure> = Vec::new();
+  match &options.mode {
+    &Some(ref mode) => {
+      let bmode = mode.clone();
+      let mode_closure = Rc::new(move |stomach: &mut Stomach, state: &mut State| {
+        try!(stomach.begin_mode(&bmode, state));
+        Ok(Vec::new())
+      });
+      before_digest_env.push(mode_closure);
+    },
+    &None => {
+      let bgroup_closure = Rc::new(|stomach: &mut Stomach, state: &mut State| {stomach.bgroup(state); Ok(Vec::new())});
+      before_digest_env.push(bgroup_closure);
+    }
+  };
+  before_digest_env.extend(options.before_digest);
+
+  let push_frame_closure = Rc::new(|_document: &mut Document, _whatsit: &Whatsit, state: &mut State| {
+    state.push_frame();
+  });
+  let mut before_construct_with_frame : Vec<ConstructionClosure> = vec![push_frame_closure];
+  before_construct_with_frame.extend(options.before_construct);
+
+  let mut after_construct_with_frame : Vec<ConstructionClosure> = options.after_construct;
+
+  let pop_frame_closure = Rc::new(|_document: &mut Document, _whatsit: &Whatsit, state: &mut State| {
+    state.pop_frame();
+  });
+  after_construct_with_frame.push(pop_frame_closure);
+
+  let begin_name_constructor = Rc::new(Constructor {
+      cs: T_CS!("\\begin{".to_string()+&name+"}"),
       paramlist: $paramlist,
-      replacement: $cc_copy,
-      // beforeDigest => flatten(($options{requireMath} ? (sub { requireMath($name); }) : ()),
-      //   ($options{forbidMath} ? (sub { forbidMath($name); })              : ()),
-      //   ($mode                ? (sub { $_[0]->beginMode($mode); })        : ()),
-      //   ($options{font}       ? (sub { MergeFont(%{ $options{font} }); }) : ()),
-      //   $options{beforeDigest}),
-      // afterDigest     => flatten($options{afterDigestBegin}),
-      // afterDigestBody => flatten($options{afterDigestBody}),
-      // beforeConstruct => flatten(sub { state->pushFrame; }, $options{beforeConstruct}),
-      // Curiously, it's the \begin whose afterConstruct gets called.
-      // afterConstruct => flatten($options{afterConstruct}, sub { state->popFrame; }),
+      replacement: $compiled_replacement,
       options: ConstructorOptions {
         nargs: options.nargs,
+        before_digest: before_digest_env,
+        // beforeDigest => flatten(($options{requireMath} ? (sub { requireMath($name); }) : ()),
+        //   ($options{forbidMath} ? (sub { forbidMath($name); }) : ()),
+        //   sub { AssignValue(current_environment => $name);
+        //     DefMacroI('\@currenvir', undef, $name); },
+        //   ($options{font} ? (sub { MergeFont(%{ $options{font} }); }) : ()),
+        font: options.font.clone(), // TODO
+        //   $options{beforeDigest}),
+        after_digest: options.after_digest_begin,
+        after_digest_body: options.after_digest_body,
+        before_construct: before_construct_with_frame,
+        // Curiously, it's the \begin whose afterConstruct gets called.
+        after_construct: after_construct_with_frame,
         capture_body: true,
         properties: options.properties.clone(),
-        font: options.font, // TODO
         // (defined $options{reversion} ? (reversion => $options{reversion}) : ()),
         // (defined $sizer ? (sizer => $sizer) : ()),
         // ), $options{scope});
         ..ConstructorOptions::default()
-      }
-    });
-    $state.install_definition(ObjectStore::Constructor(name_constructor), options.scope.clone());
+      }});
+  $state.install_definition(ObjectStore::Constructor(begin_name_constructor), options.scope.clone());
 
-    let end_name_constructor = Rc::new(Constructor {
-      cs: T_CS!("\\end".to_string() + &name),
-      paramlist: None,
-      replacement: Some(Rc::new(|document, whatsit, properties, state|{
-        let env = state.lookup_value("current_environment");
-        // Error('unexpected', "\\end{$name}", $_[0],
-        //   "Can't close environment $name",
-        //   "Current are "
-        //     . join(', ', state->lookupStackedValues('current_environment')))
-        //   unless $env && $name eq $env;
-        Ok(()) })),
-      // beforeDigest => flatten($options{beforeDigestEnd}),
-      // afterDigest  => flatten($options{afterDigest},
-      //   ($mode ? (sub { $_[0]->endMode($mode); }) : ())),
+
+  let mut after_digest_env = options.after_digest;
+  let unexpected_end_closure = Rc::new(|_stomach: &mut Stomach, _whatsit: &mut Whatsit, state: &mut State| {
+    // let env = LookupValue!("current_environment", $state);
+    //     Error('unexpected', "\\end{$name}", $_[0],
+    //       "Can't close environment $name",
+    //       "Current are "
+    //         . join(', ', state->lookupStackedValues('current_environment')))
+    //       unless $env && $name eq $env;
+    //     return; },
+    Ok(Vec::new())
+  });
+  after_digest_env.push(unexpected_end_closure);
+
+  match options.mode {
+    Some(mode) => {
+      let emode = mode.clone();
+      let emode_closure = Rc::new(move |stomach: &mut Stomach, _whatsit: &mut Whatsit, state: &mut State| {
+        try!(stomach.end_mode(&emode, state));
+        Ok(Vec::new())
+      });
+      after_digest_env.push(emode_closure);
+    },
+    None => {
+      let egroup_closure = Rc::new(|stomach: &mut Stomach, _whatsit: &mut Whatsit, state: &mut State| {
+        try!(stomach.egroup(state));
+        Ok(Vec::new())
+      });
+      after_digest_env.push(egroup_closure);
+    }
+  };
+
+  let end_envname_constructor = Rc::new(Constructor {
+    cs: T_CS!("\\end{".to_string()+&name+"}"),
+    replacement: None,
+    paramlist: None,
+    options: ConstructorOptions {
+      before_digest: options.before_digest_end,
+      after_digest: after_digest_env,
+      ..ConstructorOptions::default()
+    }
+  });
+  $state.install_definition(ObjectStore::Constructor(end_envname_constructor), options.scope.clone());
+
+  // For the uncommon case opened by \csname env\endcsname
+  let name_constructor = Rc::new(Constructor{
+    cs: T_CS!("\\".to_string() +&name),
+    paramlist: $paramlist,
+    replacement: $cc_copy,
+    // beforeDigest => flatten(($options{requireMath} ? (sub { requireMath($name); }) : ()),
+    //   ($options{forbidMath} ? (sub { forbidMath($name); })              : ()),
+    //   ($mode                ? (sub { $_[0]->beginMode($mode); })        : ()),
+    //   ($options{font}       ? (sub { MergeFont(%{ $options{font} }); }) : ()),
+    //   $options{beforeDigest}),
+    // afterDigest     => flatten($options{afterDigestBegin}),
+    // afterDigestBody => flatten($options{afterDigestBody}),
+    // beforeConstruct => flatten(sub { state->pushFrame; }, $options{beforeConstruct}),
+    // Curiously, it's the \begin whose afterConstruct gets called.
+    // afterConstruct => flatten($options{afterConstruct}, sub { state->popFrame; }),
+    options: ConstructorOptions {
+      nargs: options.nargs,
+      capture_body: true,
+      properties: options.properties.clone(),
+      font: options.font, // TODO
+      // (defined $options{reversion} ? (reversion => $options{reversion}) : ()),
+      // (defined $sizer ? (sizer => $sizer) : ()),
       // ), $options{scope});
-      options: ConstructorOptions::default()
-    });
-    $state.install_definition(ObjectStore::Constructor(end_name_constructor), options.scope);
-
-    if options.locked {
-      AssignValue!(&("\\begin{".to_string() + &name+"}:locked"), ObjectStore::Bool(true), None);
-      AssignValue!(&("\\end{".to_string()+&name+"}:locked")  , ObjectStore::Bool(true), None);
-      AssignValue!(&("\\".to_string()+&name+":locked")       , ObjectStore::Bool(true), None);
-      AssignValue!(&("\\end".to_string()+&name+":locked")    , ObjectStore::Bool(true), None);
+      ..ConstructorOptions::default()
     }
-  }));
+  });
+  $state.install_definition(ObjectStore::Constructor(name_constructor), options.scope.clone());
 
-  macro_rules! Tag (
-    ($tag:expr,
-     $key1:ident => $val1:expr
-    ) => (TagWO!($tag, NewDefault!(TagOptions,
-     $key1 => $val1)));
+  let end_name_constructor = Rc::new(Constructor {
+    cs: T_CS!("\\end".to_string() + &name),
+    paramlist: None,
+    replacement: Some(Rc::new(|document, whatsit, properties, state|{
+      let env = state.lookup_value("current_environment");
+      // Error('unexpected', "\\end{$name}", $_[0],
+      //   "Can't close environment $name",
+      //   "Current are "
+      //     . join(', ', state->lookupStackedValues('current_environment')))
+      //   unless $env && $name eq $env;
+      Ok(()) })),
+    // beforeDigest => flatten($options{beforeDigestEnd}),
+    // afterDigest  => flatten($options{afterDigest},
+    //   ($mode ? (sub { $_[0]->endMode($mode); }) : ())),
+    // ), $options{scope});
+    options: ConstructorOptions::default()
+  });
+  $state.install_definition(ObjectStore::Constructor(end_name_constructor), options.scope);
 
-    ($tag:expr,
-     $key1:ident => $val1:expr,
-     $key2:ident => $val2:expr
-    ) => (TagWO!($tag, NewDefault!(TagOptions,
-     $key1 => $val1,
-     $key2 => $val2
-    )));
+  if options.locked {
+    AssignValue_F!(&("\\begin{".to_string() + &name+"}:locked"), ObjectStore::Bool(true), None, $state);
+    AssignValue_F!(&("\\end{".to_string()+&name+"}:locked")  , ObjectStore::Bool(true), None, $state);
+    AssignValue_F!(&("\\".to_string()+&name+":locked")       , ObjectStore::Bool(true), None, $state);
+    AssignValue_F!(&("\\end".to_string()+&name+":locked")    , ObjectStore::Bool(true), None, $state);
+  }
+}));
 
-    ($tag:expr,
-     $key1:ident => $val1:expr,
-     $key2:ident => $val2:expr,
-     $key3:ident => $val3:expr
-    ) => (TagWO!($tag, NewDefault!(TagOptions,
-     $key1 => $val1,
-     $key2 => $val2,
-     $key3 => $val3
-    )));
+macro_rules! Tag_F (
+  ($tag:expr,
+   $key1:ident => $val1:expr,
+   $state:ident
+  ) => (TagWO_F!($tag, NewDefault!(TagOptions,
+   $key1 => $val1), $state));
 
-    ($tag:expr,
-     $key1:ident => $val1:expr,
-     $key2:ident => $val2:expr,
-     $key3:ident => $val3:expr,
-     $key4:ident => $val4:expr
-    ) => (TagWO!($tag, NewDefault!(TagOptions,
-     $key1 => $val1,
-     $key2 => $val2,
-     $key3 => $val3,
-     $key4 => $val4
-    )));
+  ($tag:expr,
+   $key1:ident => $val1:expr,
+   $key2:ident => $val2:expr,
+   $state:ident
+  ) => (TagWO_F!($tag, NewDefault!(TagOptions,
+   $key1 => $val1,
+   $key2 => $val2
+  ), $state));
 
-    ($tag:expr,
-     $key1:ident => $val1:expr,
-     $key2:ident => $val2:expr,
-     $key3:ident => $val3:expr,
-     $key4:ident => $val4:expr,
-     $key5:ident => $val5:expr,
-    ) => (TagWO!($tag, NewDefault!(TagOptions,
-     $key1 => $val1,
-     $key2 => $val2,
-     $key3 => $val3,
-     $key4 => $val4,
-     $key5 => $val5
-    )));
-  );
-  macro_rules! TagWO {
-    ($tag:expr, $properties:expr) => (install_tag($tag, $properties, $state))
+  ($tag:expr,
+   $key1:ident => $val1:expr,
+   $key2:ident => $val2:expr,
+   $key3:ident => $val3:expr,
+   $state:ident
+  ) => (TagWO_F!($tag, NewDefault!(TagOptions,
+   $key1 => $val1,
+   $key2 => $val2,
+   $key3 => $val3
+  ), $state));
+
+  ($tag:expr,
+   $key1:ident => $val1:expr,
+   $key2:ident => $val2:expr,
+   $key3:ident => $val3:expr,
+   $key4:ident => $val4:expr,
+   $state:ident
+  ) => (TagWO_F!($tag, NewDefault!(TagOptions,
+   $key1 => $val1,
+   $key2 => $val2,
+   $key3 => $val3,
+   $key4 => $val4
+  ),$state));
+
+  ($tag:expr,
+   $key1:ident => $val1:expr,
+   $key2:ident => $val2:expr,
+   $key3:ident => $val3:expr,
+   $key4:ident => $val4:expr,
+   $key5:ident => $val5:expr,
+   $state:ident
+  ) => (TagWO_F!($tag, NewDefault!(TagOptions,
+   $key1 => $val1,
+   $key2 => $val2,
+   $key3 => $val3,
+   $key4 => $val4,
+   $key5 => $val5
+  ),$state));
+);
+macro_rules! TagWO_F {
+  ($tag:expr, $properties:expr, $state:ident) => (install_tag($tag, $properties, $state))
+}
+
+// sub DocType {
+//   my ($rootelement, $pubid, $sysid, %namespaces) = @_;
+//   let model = state->getModel;
+//   $model->setDocType($rootelement, $pubid, $sysid);
+//   foreach let prefix (keys %namespaces) {
+//     $model->registerDocumentNamespace($prefix => $namespaces{$prefix}); }
+//   return; }
+
+macro_rules! RelaxNGSchema_F(
+  ($name:expr,$state:ident) => (select_relaxng_schema($name.to_string(), None, $state))
+);
+
+macro_rules! RegisterNamespace_F(
+  ($prefix:expr, $namespace:expr,$state:ident) => ($state.model.register_namespace($prefix, Some($namespace.to_string())))
+);
+
+macro_rules! RegisterDocumentNamespace_F(
+  ($prefix:expr, $namespace:expr,$state:ident) => ($state.model.register_document_namespace($prefix, Some($namespace.to_string())))
+);
+
+macro_rules! RequireResource_F(
+  ($resource:expr,$state:ident) => (require_resource(Resource{name: $resource.to_string(), ..Resource::default()}, $state))
+);
+
+// sub DefMath {
+//   my ($proto,
+//     $presentation, %options) = @_;
+//   CheckOptions("DefMath ($proto)", $math_options, %options);
+//   DefMathI(parsePrototype($proto), $presentation, %options);
+//   return; }
+
+macro_rules! DefMathI_F {
+  ($text:expr,$paramlist:expr,$presentation:expr,
+   $key1:ident => $val1:expr,
+   $state:ident
+  ) => (DefMathWO_F!($text,$paramlist, $presentation, NewDefault!(MathPrimitiveOptions,
+   $key1 => $val1),$state));
+
+  ($text:expr,$paramlist:expr,$presentation:expr,
+   $key1:ident => $val1:expr,
+   $key2:ident => $val2:expr,
+   $state:ident
+  ) => (DefMathWO_F!($text,$paramlist, $presentation, NewDefault!(MathPrimitiveOptions,
+   $key1 => $val1,
+   $key2 => $val2
+  ), $state));
+
+  ($text:expr,$paramlist:expr,$presentation:expr,
+   $key1:ident => $val1:expr,
+   $key2:ident => $val2:expr,
+   $key3:ident => $val3:expr,
+   $state:ident
+  ) => (DefMathWO_F!($text,$paramlist, $presentation, NewDefault!(MathPrimitiveOptions,
+   $key1 => $val1,
+   $key2 => $val2,
+   $key3 => $val3
+  ),$state));
+
+  ($text:expr,$paramlist:expr,$presentation:expr,
+   $key1:ident => $val1:expr,
+   $key2:ident => $val2:expr,
+   $key3:ident => $val3:expr,
+   $key4:ident => $val4:expr,
+   $state:ident
+  ) => (DefMathWO_F!($text,$paramlist, $presentation, NewDefault!(MathPrimitiveOptions,
+   $key1 => $val1,
+   $key2 => $val2,
+   $key3 => $val3,
+   $key4 => $val4
+  ), $state));
+
+  ($text:expr,$paramlist:expr,$presentation:expr,
+   $key1:ident => $val1:expr,
+   $key2:ident => $val2:expr,
+   $key3:ident => $val3:expr,
+   $key4:ident => $val4:expr,
+   $key5:ident => $val5:expr,
+   $state:ident
+  ) => (DefMathWO_F!($text,$paramlist, $presentation, NewDefault!(MathPrimitiveOptions,
+   $key1 => $val1,
+   $key2 => $val2,
+   $key3 => $val3,
+   $key4 => $val4,
+   $key5 => $val5
+  ), $state));
+}
+
+macro_rules! DefMathWO_F {
+  ($cstext:expr, $paramlist:expr, $presentation:expr, $options:expr, $state:ident) => ({
+  let mut options = $options;
+  let cs = T_CS!($cstext.to_string());
+  let presentation = $presentation.to_string();
+  // Can't defer parsing parameters since we need to know number of args!
+  // $paramlist = parseParameters($paramlist, $cs) if defined $paramlist && !ref $paramlist;
+  let paramlist : Option<Parameters> = $paramlist;
+  let nargs = match paramlist {
+    Some(plist) => plist.get_num_args(),
+    None => 0
+  };
+  let csname = cs.get_string().to_string();
+  let mut name = options.alias.clone().unwrap_or_else(|| csname.clone());
+  if name.starts_with('\\') {
+    name = name.replacen('\\', "", 1)
+  }
+  if let Some(options_name) = options.name {
+    name = options_name;
+  }
+  let name_opt = if (name == presentation) || (name.is_empty()) || (options.meaning == Some(name.clone())) {
+    None
+  } else {
+    Some(name)
+  };
+  options.name = name_opt;
+  if nargs == 0 && options.role.is_none() {
+    options.role = Some("UNKNOWN".to_string())
+  }
+  if nargs > 0 && options.operator_role.is_none() {
+    options.operator_role = Some("UNKNOWN".to_string())
   }
 
-  // sub DocType {
-  //   my ($rootelement, $pubid, $sysid, %namespaces) = @_;
-  //   let model = state->getModel;
-  //   $model->setDocType($rootelement, $pubid, $sysid);
-  //   foreach let prefix (keys %namespaces) {
-  //     $model->registerDocumentNamespace($prefix => $namespaces{$prefix}); }
-  //   return; }
+  // Store some data for introspection
+  // defmath_introspective(cs, $paramlist, presentation, %options);
 
-  macro_rules! RelaxNGSchema(
-    ($name:expr) => (select_relaxng_schema($name.to_string(), None, $state))
-  );
+  // If single character, handle with a rewrite rule
+  if csname.len() == 1 {
+    // WAS: defmath_rewrite!($cs, options);
+    // No, do NOT make mathactive; screws up things like babel french, or... ?
+    // EXPERIMENT: store XMTok attributes for if this char ends up a Math Token.
+    // But only some DefMath options make sense!
+    // let rw_options = { name => 1, meaning => 1, omcd => 1, role => 1, mathstyle => 1, stretchy => 1 }; # (well, mathstyle?)
+    // CheckOptions("DefMath reimplemented as DefRewrite ($csname)", $rw_options, %options);
+    let mut math_attr_hash : HashMap<String, String> = HashMap::new();
+    transfer_opt_default!(name, options, math_attr_hash);
+    transfer_opt_default!(meaning, options, math_attr_hash);
+    transfer_opt_default!(omcd, options, math_attr_hash);
+    transfer_opt_default!(role, options, math_attr_hash);
+    transfer_opt_default!(mathstyle, options, math_attr_hash);
+    transfer_default!(stretchy, options, math_attr_hash);
 
-  macro_rules! RegisterNamespace(
-    ($prefix:expr, $namespace:expr) => ($state.model.register_namespace($prefix, Some($namespace.to_string())))
-  );
+    $state.assign_value(&format!("math_token_attributes_{}",csname), ObjectStore::HashStr(math_attr_hash), Some(Scope::Global));
+  }
+  // TODO:
+  // // If the presentation is complex, and involves arguments,
+  // // we will create an XMDual to separate content & presentation.
+  // elsif ((ref presentation eq "CODE")
+  //   || ((ref presentation) && grep { $_->equals(T_PARAM) } presentation->unlist)
+  //   || (!(ref presentation) && (presentation =~ /\//\d|\\./))
+  //   || ((ref presentation) && (grep { $_->isExecutable } presentation->unlist))) {
+  //   defmath_dual($cs, $paramlist, presentation, %options); }
 
-  macro_rules! RegisterDocumentNamespace(
-    ($prefix:expr, $namespace:expr) => ($state.model.register_document_namespace($prefix, Some($namespace.to_string())))
-  );
-
-  macro_rules! RequireResource(
-    ($resource:expr) => (require_resource(Resource{name: $resource.to_string(), ..Resource::default()}, $state))
-  );
-
-  // sub DefMath {
-  //   my ($proto,
-  //     $presentation, %options) = @_;
-  //   CheckOptions("DefMath ($proto)", $math_options, %options);
-  //   DefMathI(parsePrototype($proto), $presentation, %options);
-  //   return; }
-
-  macro_rules! DefMathI {
-    ($text:expr,$paramlist:expr,$presentation:expr,
-     $key1:ident => $val1:expr
-    ) => (DefMathWO!($text,$paramlist, $presentation, NewDefault!(MathPrimitiveOptions,
-     $key1 => $val1)));
-
-    ($text:expr,$paramlist:expr,$presentation:expr,
-     $key1:ident => $val1:expr,
-     $key2:ident => $val2:expr
-    ) => (DefMathWO!($text,$paramlist, $presentation, NewDefault!(MathPrimitiveOptions,
-     $key1 => $val1,
-     $key2 => $val2
-    )));
-
-    ($text:expr,$paramlist:expr,$presentation:expr,
-     $key1:ident => $val1:expr,
-     $key2:ident => $val2:expr,
-     $key3:ident => $val3:expr
-    ) => (DefMathWO!($text,$paramlist, $presentation, NewDefault!(MathPrimitiveOptions,
-     $key1 => $val1,
-     $key2 => $val2,
-     $key3 => $val3
-    )));
-
-    ($text:expr,$paramlist:expr,$presentation:expr,
-     $key1:ident => $val1:expr,
-     $key2:ident => $val2:expr,
-     $key3:ident => $val3:expr,
-     $key4:ident => $val4:expr
-    ) => (DefMathWO!($text,$paramlist, $presentation, NewDefault!(MathPrimitiveOptions,
-     $key1 => $val1,
-     $key2 => $val2,
-     $key3 => $val3,
-     $key4 => $val4
-    )));
-
-    ($text:expr,$paramlist:expr,$presentation:expr,
-     $key1:ident => $val1:expr,
-     $key2:ident => $val2:expr,
-     $key3:ident => $val3:expr,
-     $key4:ident => $val4:expr,
-     $key5:ident => $val5:expr,
-    ) => (DefMathWO!($text,$paramlist, $presentation, NewDefault!(MathPrimitiveOptions,
-     $key1 => $val1,
-     $key2 => $val2,
-     $key3 => $val3,
-     $key4 => $val4,
-     $key5 => $val5
-    )));
+  // EXPERIMENT: Introduce an intermediate case for simple symbols
+  // Define a primitive that will create a Box with the appropriate set of XMTok attributes.
+  if nargs == 0 {// && !grep { !$$simpletoken_options{$_} } keys %options) {
+    defmath_prim!(cs, paramlist, $presentation.clone(), options, $state);
   }
 
-  macro_rules! DefMathWO {
-    ($cstext:expr, $paramlist:expr, $presentation:expr, $options:expr) => ({
-    let mut options = $options;
-    let cs = T_CS!($cstext.to_string());
-    let presentation = $presentation.to_string();
-    // Can't defer parsing parameters since we need to know number of args!
-    // $paramlist = parseParameters($paramlist, $cs) if defined $paramlist && !ref $paramlist;
-    let paramlist : Option<Parameters> = $paramlist;
-    let nargs = match paramlist {
-      Some(plist) => plist.get_num_args(),
-      None => 0
-    };
-    let csname = cs.get_string().to_string();
-    let mut name = options.alias.clone().unwrap_or_else(|| csname.clone());
-    if name.starts_with('\\') {
-      name = name.replacen('\\', "", 1)
-    }
-    if let Some(options_name) = options.name {
-      name = options_name;
-    }
-    let name_opt = if (name == presentation) || (name.is_empty()) || (options.meaning == Some(name.clone())) {
-      None
-    } else {
-      Some(name)
-    };
-    options.name = name_opt;
-    if nargs == 0 && options.role.is_none() {
-      options.role = Some("UNKNOWN".to_string())
-    }
-    if nargs > 0 && options.operator_role.is_none() {
-      options.operator_role = Some("UNKNOWN".to_string())
-    }
+  // else {
+  //   defmath_cons($cs, $paramlist, $presentation, %options); }
+  // AssignValue($csname . ":locked" => 1) if $options{locked};
+})}
 
-    // Store some data for introspection
-    // defmath_introspective(cs, $paramlist, presentation, %options);
+macro_rules! defmath_prim {
+  ($cs:expr, $_paramlist:expr, $presentation:expr, $options:expr, $state:ident) => ({
+  let mut prim_options = $options;
+  let reqfont = prim_options.font.clone();
+  prim_options.locked = false;
+  prim_options.font = None;
+  let scope = prim_options.scope.clone();
 
-    // If single character, handle with a rewrite rule
-    if csname.len() == 1 {
-      // WAS: defmath_rewrite!($cs, options);
-      // No, do NOT make mathactive; screws up things like babel french, or... ?
-      // EXPERIMENT: store XMTok attributes for if this char ends up a Math Token.
-      // But only some DefMath options make sense!
-      // let rw_options = { name => 1, meaning => 1, omcd => 1, role => 1, mathstyle => 1, stretchy => 1 }; # (well, mathstyle?)
-      // CheckOptions("DefMath reimplemented as DefRewrite ($csname)", $rw_options, %options);
-      let mut math_attr_hash : HashMap<String, String> = HashMap::new();
-      transfer_opt_default!(name, options, math_attr_hash);
-      transfer_opt_default!(meaning, options, math_attr_hash);
-      transfer_opt_default!(omcd, options, math_attr_hash);
-      transfer_opt_default!(role, options, math_attr_hash);
-      transfer_opt_default!(mathstyle, options, math_attr_hash);
-      transfer_default!(stretchy, options, math_attr_hash);
+  $state.install_definition(ObjectStore::MathPrimitive(Rc::new(MathPrimitive{
+    cs: $cs.clone(),
+    paramlist: None, // never any parameters, this is intentional
+    replacement: Some(Rc::new(move |stomach, args, state| {
+      // let locator    = $stomach->getGullet->getLocator;
+      let mut properties = HashMap::new(); // TODO: sync with perl master here
+      properties.insert("mode".to_owned(), "math".to_owned());
+      // let font       = LookupValue('font')->merge(%$reqfont)->specialize($string);
+      // foreach my $key (keys %properties) {
+      //   my $value = $properties{$key};
+      //   if (ref $value eq 'CODE') {
+      //     $properties{$key} = &$value(); } }
+      info!("defmath_prim: {}, tokens: {:?}", $presentation, $cs);
+      Ok(vec![Digested::Box( // TODO: Can we reduce boilerplate?
+        Tbox{ text: $presentation.to_string(), tokens: vec![$cs.clone()], properties: properties, ..Tbox::default()}
+      )])
+    })),
+    options: prim_options,
+    ..MathPrimitive::default()
+    })), scope);
+  })
+}
 
-      $state.assign_value(&format!("math_token_attributes_{}",csname), ObjectStore::HashStr(math_attr_hash), Some(Scope::Global));
-    }
-    // TODO:
-    // // If the presentation is complex, and involves arguments,
-    // // we will create an XMDual to separate content & presentation.
-    // elsif ((ref presentation eq "CODE")
-    //   || ((ref presentation) && grep { $_->equals(T_PARAM) } presentation->unlist)
-    //   || (!(ref presentation) && (presentation =~ /\//\d|\\./))
-    //   || ((ref presentation) && (grep { $_->isExecutable } presentation->unlist))) {
-    //   defmath_dual($cs, $paramlist, presentation, %options); }
 
-    // EXPERIMENT: Introduce an intermediate case for simple symbols
-    // Define a primitive that will create a Box with the appropriate set of XMTok attributes.
-    if nargs == 0 {// && !grep { !$$simpletoken_options{$_} } keys %options) {
-      defmath_prim!(cs, paramlist, $presentation.clone(), options);
-    }
+#[macro_export]
+macro_rules! SetupBindingMacros {($state:ident) => (
+  //=============================================================================
+  // Convenience macros for writing definitions. User-facing form with implicit state
+  //=============================================================================
+  macro_rules! LookupValue {($name:expr) => (LookupValue!($name, $state))}
+  macro_rules! LookupBool {($name:expr) => (LookupBool_F!($name, $state))}
+  macro_rules! LookupString {($name:expr) => (LookupString_F!($name, $state))}
+  macro_rules! AssignValue {($name:expr, $value:expr, $scope:expr) => (AssignValue_F!($name, $value, $scope, $state))}
+  macro_rules! RemoveValue {($name:expr) => (RemoveValue_F!($name, $state))}
+  macro_rules! PushValue {($name:expr, $values:expr) => (PushValue_F!($name, $values, $state))}
+  macro_rules! PopValue  {($name:expr) => (PopValue_F!($name, $state))}
+  macro_rules! UnshiftValue {($name:expr, $values:expr) => (UnshiftValue_F!($name, $values, $state))}
+  macro_rules! ShiftValue {($name:expr) => (ShiftValue_F!($name, $state))}
+  macro_rules! LookupMapping {($map:expr, $key:expr) => (LookupValue_F!($map, $key, $state))}
+  macro_rules! AssignMapping {($map:expr, $key:expr, $value:expr) => (AssignMapping_F!($map, $key, $value, $state))}
+  macro_rules! LookupMappingKeys {($map:expr) => (LookupMappingKeys_F!($map, $state))}
+  macro_rules! LookupCatcode {($char:expr) => (LookupCatcode_F!($char, $state))}
+  macro_rules! AssignCatcode {($char:expr, $catcode:expr, $scope:expr) => (AssignCatcode_F!($char, $catcode, $scope, $state))};
+  macro_rules! LookupMeaning {($name:expr) => (LookupMeaning_F!($name, $state))}
+  macro_rules! LookupDefinition {($name:expr) => (LookupDefinition_F!($name, $state))}
+  macro_rules! InstallDefinition {($name:expr, $definition:expr, $scope:expr) => (InstallDefinition_F!($name, $definition, $scope, $state))}
+  macro_rules! IsDefined {($name:expr) => (IsDefined_F!($name, $state))}
+  macro_rules! IsDefinedToken {($name:expr) => (IsDefinedToken_F!($name, $state))}
+  macro_rules! Let {($token1:expr, $token2:expr) => (Let_F!($token1, $token2, $state))}
+  macro_rules! LetI {($token1:expr, $token2:expr) => (LetI_F!($token1, $token2, $state))}
+  macro_rules! AfterAssignment {() => (AfterAssignment_F!($state))}
+  macro_rules! MergeFont {($kv:expr) => (MergeFont_F!($kv, $state))}
 
-    // else {
-    //   defmath_cons($cs, $paramlist, $presentation, %options); }
-    // AssignValue($csname . ":locked" => 1) if $options{locked};
-  })}
-
-  macro_rules! defmath_prim {
-    ($cs:expr, $_paramlist:expr, $presentation:expr, $options:expr) => ({
-    let mut prim_options = $options;
-    let reqfont = prim_options.font.clone();
-    prim_options.locked = false;
-    prim_options.font = None;
-    let scope = prim_options.scope.clone();
-
-    $state.install_definition(ObjectStore::MathPrimitive(Rc::new(MathPrimitive{
-      cs: $cs.clone(),
-      paramlist: None, // never any parameters, this is intentional
-      replacement: Some(Rc::new(move |stomach, args, state| {
-        // let locator    = $stomach->getGullet->getLocator;
-        let mut properties = HashMap::new(); // TODO: sync with perl master here
-        properties.insert("mode".to_owned(), "math".to_owned());
-        // let font       = LookupValue('font')->merge(%$reqfont)->specialize($string);
-        // foreach my $key (keys %properties) {
-        //   my $value = $properties{$key};
-        //   if (ref $value eq 'CODE') {
-        //     $properties{$key} = &$value(); } }
-        info!("defmath_prim: {}, tokens: {:?}", $presentation, $cs);
-        Ok(vec![Digested::Box( // TODO: Can we reduce boilerplate?
-          Tbox{ text: $presentation.to_string(), tokens: vec![$cs.clone()], properties: properties, ..Tbox::default()}
-        )])
-      })),
-      options: prim_options,
-      ..MathPrimitive::default()
-      })), scope);
-    })
+  macro_rules! DefParameterType{
+    ($name:expr) => (DefParameterType_F!($name, $state));
+    ($name:expr, $key1:ident => $val1:expr)=>(DefParameterType_F!($name, $key1=>$val1, $state));
+    ($name:expr, $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr)=>(DefParameterType_F!($name, $key1=>$val1, $key2=>$val2, $state));
+    ($name:expr, $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr)=>(DefParameterType_F!($name, $key1=>$val1, $key2=>$val2, $key3=>$val3, $state));
+    ($name:expr, $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr,
+      $key4:ident=>$val4:expr)=>(DefParameterType_F!($name, $key1=>$val1, $key2=>$val2, $key3=>$val3, $key4=>$val4, $state));
+    ($name:expr, $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr,
+      $key4:ident=>$val4:expr,
+      $key5:ident=>$val5:expr)=>(DefParameterType_F!($name, $key1=>$val1, $key2=>$val2, $key3=>$val3, $key4=>$val4, $key5=>$val5, $state));
+    ($name:expr, $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr,
+      $key4:ident=>$val4:expr,
+      $key5:ident=>$val5:expr,
+      $key6:ident=>$val6:expr)=>(DefParameterType_F!($name, $key1=>$val1, $key2=>$val2, $key3=>$val3, $key4=>$val4, $key5=>$val5, $key6=>$val6, $state));
   }
+
+  macro_rules! LoadPool{($name:expr) => (LoadPool_F!($name, $state))}
+  macro_rules! RequirePackage(($package:expr, $options:expr) => (RequirePackage_F!($package, $options, $state)));
+  macro_rules! LoadClass(($class:expr, $options:expr, $after:expr) => (LoadClass_F!($class, $options, $after, $state)));
+  macro_rules! DefMacroI(($cs:expr, $paramlist:expr, $expansion:expr) => (DefMacroI_F!($cs, $paramlist, $expansion, $state)));
+  macro_rules! DefMacroT(($cs:expr, $paramlist:expr, $arg:expr) => (DefMacroT_F!($cs, $paramlist, $arg, $state)));
+  macro_rules! DefMacro(($proto:expr, $expansion:expr) => (DefMacro_F!($proto, $expansion, $state)));
+  macro_rules! DefPrimitive(($proto:expr, $replacement:expr, $options:expr) => (DefPrimitive_F!($proto, $replacement, $options, $state)));
+
+  macro_rules! DefPrimitiveI(
+    ($proto:expr, $compiled_replacement:expr) => (DefPrimitiveI_F!($proto, $compiled_replacement, $state));
+    ($proto:expr, $compiled_replacement:expr,
+      $key1:ident => $val1:expr)=>(DefPrimitiveI_F!($proto, $compiled_replacement, $key1=>$val1, $state));
+    ($proto:expr, $compiled_replacement:expr,
+      $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr)=>(DefPrimitiveI_F!($proto, $compiled_replacement, $key1=>$val1, $key2=>$val2, $state));
+    ($proto:expr, $compiled_replacement:expr,
+      $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr)=>(DefPrimitiveI_F!($proto, $compiled_replacement, $key1=>$val1, $key2=>$val2, $key3=>$val3, $state));
+    ($proto:expr, $compiled_replacement:expr,
+      $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr,
+      $key4:ident=>$val4:expr)=>(DefPrimitiveI_F!($proto, $compiled_replacement, $key1=>$val1, $key2=>$val2, $key3=>$val3, $key4=>$val4, $state));
+    ($proto:expr, $compiled_replacement:expr,
+      $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr,
+      $key4:ident=>$val4:expr,
+      $key5:ident=>$val5:expr)=>(DefPrimitiveI_F!($proto, $compiled_replacement, $key1=>$val1, $key2=>$val2, $key3=>$val3, $key4=>$val4, $key5=>$val5, $state));
+
+  );
+
+  macro_rules! DefPrimitiveII(($cs:expr, $paramlist:expr, $compiled_replacement:expr, $options:expr) => (DefPrimitiveII_F!($cs, $paramlist, $compiled_replacement, $options, $state)));
+
+  macro_rules! DefConstructorI(
+    ($cs:expr, $paramlist:expr, $compiled_replacement:expr) => (DefConstructorI_F!($cs, $paramlist, $compiled_replacement, $state));
+    ($cs:expr, $paramlist:expr, $compiled_replacement:expr,
+      $key1:ident => $val1:expr)=>(DefConstructorI_F!($cs, $paramlist, $compiled_replacement, $key1=>$val1, $state));
+    ($cs:expr, $paramlist:expr, $compiled_replacement:expr,
+      $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr)=>(DefConstructorI_F!($cs, $paramlist, $compiled_replacement, $key1=>$val1, $key2=>$val2, $state));
+    ($cs:expr, $paramlist:expr, $compiled_replacement:expr,
+      $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr)=>(DefConstructorI_F!($cs, $paramlist, $compiled_replacement, $key1=>$val1, $key2=>$val2, $key3=>$val3, $state));
+    ($cs:expr, $paramlist:expr, $compiled_replacement:expr,
+      $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr,
+      $key4:ident=>$val4:expr)=>(DefConstructorI_F!($cs, $paramlist, $compiled_replacement, $key1=>$val1, $key2=>$val2, $key3=>$val3, $key4=>$val4, $state));
+    ($cs:expr, $paramlist:expr, $compiled_replacement:expr,
+      $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr,
+      $key4:ident=>$val4:expr,
+      $key5:ident=>$val5:expr)=>(DefConstructorI_F!($cs, $paramlist, $compiled_replacement, $key1=>$val1, $key2=>$val2, $key3=>$val3, $key4=>$val4, $key5=>$val5, $state));
+  );
+
+  macro_rules! DefConstructor(
+    ($cs:expr, $replacement:expr) => (DefConstructor_F!($cs, $replacement, $state));
+    ($cs:expr, $replacement:expr,
+      $key1:ident => $val1:expr)=>(DefConstructor_F!($cs, $replacement, $key1=>$val1, $state));
+    ($cs:expr, $replacement:expr,
+      $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr)=>(DefConstructor_F!($cs, $replacement, $key1=>$val1, $key2=>$val2, $state));
+    ($cs:expr, $replacement:expr,
+      $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr)=>(DefConstructor_F!($cs, $replacement, $key1=>$val1, $key2=>$val2, $key3=>$val3, $state));
+    ($cs:expr, $replacement:expr,
+      $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr,
+      $key4:ident=>$val4:expr)=>(DefConstructor_F!($cs, $replacement, $key1=>$val1, $key2=>$val2, $key3=>$val3, $key4=>$val4, $state));
+    ($cs:expr, $replacement:expr,
+      $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr,
+      $key4:ident=>$val4:expr,
+      $key5:ident=>$val5:expr)=>(DefConstructor_F!($cs, $replacement, $key1=>$val1, $key2=>$val2, $key3=>$val3, $key4=>$val4, $key5=>$val5, $state));
+  );
+
+
+  macro_rules! DefEnvironment(($proto_raw:expr, $replacement:expr) => (DefEnvironment_F!($proto_raw, $replacement, $state)));
+  macro_rules! DefEnvironmentC(($proto_raw:expr, $compiled_replacement:expr) => (DefEnvironmentC_F!($proto_raw, $compiled_replacement, $state)));
+  macro_rules! DefEnvironmentI(($name_raw:expr, $paramlist:expr, $compiled_replacement:expr, $cc_copy:expr, $options:expr) =>
+    (DefEnvironmentI_F!($name_raw, $paramlist, $compiled_replacement, $cc_copy, $options, $state)));
+  macro_rules! Tag(
+    ($tag:expr, $key1:ident => $val1:expr)=>(Tag_F!($tag, $key1=>$val1, $state));
+    ($tag:expr, $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr)=>(Tag_F!($tag, $key1=>$val1, $key2=>$val2, $state));
+    ($tag:expr, $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr)=>(Tag_F!($tag, $key1=>$val1, $key2=>$val2, $key3=>$val3, $state));
+    ($tag:expr, $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr,
+      $key4:ident=>$val4:expr)=>(Tag_F!($tag, $key1=>$val1, $key2=>$val2, $key3=>$val3, $key4=>$val4, $state));
+    ($tag:expr, $key1:ident => $val1:expr,
+      $key2:ident=>$val2:expr,
+      $key3:ident=>$val3:expr,
+      $key4:ident=>$val4:expr,
+      $key5:ident=>$val5:expr)=>(Tag_F!($tag, $key1=>$val1, $key2=>$val2, $key3=>$val3, $key4=>$val4, $key5=>$val5, $state));
+  );
+  macro_rules! RelaxNGSchema(($name:expr) => (RelaxNGSchema_F!($name, $state)));
+  macro_rules! RegisterNamespace(($prefix:expr, $namespace:expr) => (RegisterNamespace_F!($prefix, $namespace, $state)));
+  macro_rules! RegisterDocumentNamespace(($prefix:expr, $namespace:expr) => (RegisterDocumentNamespace_F!($prefix, $namespace, $state)));
+  macro_rules! RequireResource(($resource:expr) => (RequireResource_F!($resource, $state)));
+
+  macro_rules! DefMathI(
+    ($text:expr,$paramlist:expr,$presentation:expr,
+      $key1:ident => $val1:expr)=>(DefMathI_F!($text, $paramlist, $presentation, $key1=>$val1, $state));
+    ($text:expr,$paramlist:expr,$presentation:expr,
+      $key1:ident => $val1:expr,
+      $key2:ident => $val2:expr)=>(DefMathI_F!($text, $paramlist, $presentation, $key1=>$val1, $key2=>$val2, $state));
+    ($text:expr,$paramlist:expr,$presentation:expr,
+      $key1:ident => $val1:expr,
+      $key2:ident => $val2:expr,
+      $key3:ident => $val3:expr)=>(DefMathI_F!($text, $paramlist, $presentation, $key1=>$val1, $key2=>$val2, $key3=>$val3, $state));
+    ($text:expr,$paramlist:expr,$presentation:expr,
+      $key1:ident => $val1:expr,
+      $key2:ident => $val2:expr,
+      $key3:ident => $val3:expr,
+      $key4:ident => $val4:expr)=>(DefMathI_F!($text, $paramlist, $presentation, $key1=>$val1, $key2=>$val2, $key3=>$val3, $key4=>$val4, $state));
+    ($text:expr,$paramlist:expr,$presentation:expr,
+      $key1:ident => $val1:expr,
+      $key2:ident => $val2:expr,
+      $key3:ident => $val3:expr,
+      $key4:ident => $val4:expr,
+      $key5:ident => $val5:expr)=>(DefMathI_F!($text, $paramlist, $presentation, $key1=>$val1, $key2=>$val2, $key3=>$val3, $key4=>$val4, $key5=>$val5, $state));
+  );
 
 )}
-
 
 pub mod pool;

--- a/src/package/mod.rs
+++ b/src/package/mod.rs
@@ -591,7 +591,7 @@ macro_rules! noprimitive {
 #[macro_export]
 macro_rules! primitivesub {
   ($stomach:ident, $args:ident, $state:ident, $body:expr) => (
-    |$stomach:&mut Stomach, $args : Vec<Tokens>, $state:&mut State| {
+    |$stomach:&mut Stomach, mut $args : Vec<Tokens>, $state:&mut State| {
       $body
     }
   )

--- a/src/package/mod.rs
+++ b/src/package/mod.rs
@@ -97,6 +97,7 @@ pub fn input_definitions(raw_file: String, options: InputDefinitionOptions, mut 
     "LaTeX.pool" => try!(pool::latex::load_definitions(&mut state)),
     "article.cls" => try!(pool::article_cls::load_definitions(&mut state)),
     "alltt.sty" => try!(pool::alltt_sty::load_definitions(&mut state)),
+    "comment.sty" => try!(pool::comment_sty::load_definitions(&mut state)),
     other => { fatal!(Package, Unknown, format!("TODO: unknown binding {:?}, can't load", other)) }
   };
 

--- a/src/package/mod.rs
+++ b/src/package/mod.rs
@@ -532,6 +532,11 @@ pub fn merge_font(font_hash: HashMap<String, String>, state: &mut State) {
 // Macros requiring repetitions need to be handled outside of the main setup macro, as nested macros currently don't support repetition
 // Details at: https://github.com/rust-lang/rust/issues/35853
 
+macro_rules! Font {
+  ($($key:ident => $value:expr),*) => (
+    Some(Font { $($key: $value.to_string(),)* .. Font::default() })
+)}
+
 #[macro_export]
 macro_rules! NewDefault {
   ($name:ident, $($key:ident => $value:expr),*) => ($name {

--- a/src/package/pool/alltt_sty.rs
+++ b/src/package/pool/alltt_sty.rs
@@ -8,11 +8,11 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
     font => "typewriter".to_string(), // TODO
     before_digest => sub!(|stomach, state| {
       for c in &['$', '&', '#', '^', '_', '%', '~'] {
-       AssignCatcode!(*c, Catcode::OTHER, None, state);
+       AssignCatcode_F!(*c, Catcode::OTHER, None, state);
       }
-      AssignCatcode!(' ', Catcode::ACTIVE, None, state);
-      LetI!(&T_ACTIVE!(" "), T_CS!("\\space"), None, state);
-      AssignValue!("PRESERVE_NEWLINES", ObjectStore::Bool(true), None, state);
+      AssignCatcode_F!(' ', Catcode::ACTIVE, None, state);
+      LetI_F!(&T_ACTIVE!(" "), T_CS!("\\space"), None, state);
+      AssignValue_F!("PRESERVE_NEWLINES", ObjectStore::Bool(true), None, state);
       Ok(Vec::new())
     }));
 

--- a/src/package/pool/comment_sty.rs
+++ b/src/package/pool/comment_sty.rs
@@ -31,22 +31,34 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
   });
 
   let define_included = primitivesub!(stomach, args, state,{
-    // let name = args[0].to_string();
-    // let before = args[1];
-    // let after = args[2];
-    // let mut before_tokens = before.unlist();
-    // before_tokens.push(T_CS!("\\ignorespaces"));
-    // let mut after_tokens = after.unlist();
-    // after_tokens.push(T_CS!("\\ignorespaces"));
+    args.reverse(); // we'll be poppint from the front
+    let name = if let Some(name_token) = args.pop() {
+      name_token.to_string()
+    } else {
+      String::new()
+    };
+    // TODO: All instances of `.clone` here look like Rust memory waste, consider improving
+    let mut before_tokens = if let Some(before) = args.pop() {
+      before.unlist()
+    } else {
+      Vec::new()
+    };
+    before_tokens.push(T_CS!("\\ignorespaces"));
+    let mut after_tokens = if let Some(after) = args.pop() {
+      after.unlist()
+    } else {
+      Vec::new()
+    };
+    after_tokens.push(T_CS!("\\ignorespaces"));
     // Note that we define the `magic' environment control sequences,
     // but DO NOT do any of the normal environ things, like \begingroup \endgroup!
-    // DefMacroI!(T_CS!(format!("\\begin{{{}}}",name)), None, move |gullet, _args, _state| {
-    //     gullet.read_raw_line();    // IGNORE 1st line (after the \begin{$name} !!!
-    //     Ok(before_tokens)
-    //   });
-    // DefMacroI!(T_CS!(format!("\\end{{{}}}",name)), None, move |_gullet, _args, _state| {
-    //   Ok(after_tokens)
-    // });
+    DefMacroI_F!(T_CS!(format!("\\begin{{{}}}",name)), None, move |gullet, _args, _state| {
+        gullet.read_raw_line();    // IGNORE 1st line (after the \begin{$name} !!!
+        Ok(before_tokens.clone())
+      }, state);
+    DefMacroI_F!(T_CS!(format!("\\end{{{}}}",name)), None, move |_gullet, _args, _state| {
+      Ok(after_tokens.clone())
+    }, state);
 
     Ok(Vec::new())
   });

--- a/src/package/pool/comment_sty.rs
+++ b/src/package/pool/comment_sty.rs
@@ -6,56 +6,75 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
   //**********************************************************************
   // Define \name and \begin{name} to start an ignored section
   // until \endname or \end{name}, respectively
-  let define_excluded = |stomach, args, state| {
+  let define_excluded = primitivesub!(stomach, args, state,{
     let name = args[0].to_string();
     let endmark = format!("\\end{{{}}}", name);
-    DefConstructorI!(T_CS!(format!("\\begin{{{}}}",name)), None, noreplacement!()
-      // after_Digest => [sub {
-      //     my ($istomach, $whatsit) = @_;
-      //     let nlines = 0;
-      //     my ($line);
-      //     let gullet = $istomach->getGullet;
-      //     $gullet->readRawLine;    // IGNORE 1st line (after the \begin{$name} !!!
-      //     while (defined($line = $gullet->readRawLine) && ($line ne $endmark)) {
-      //       $nlines++; }
-      //     NoteProgress("[Skipped $name ($nlines lines)]");
-      // }]
-    );
-    Ok(())
-  };
+    {
+      DefConstructorI!(T_CS!(format!("\\begin{{{}}}",name)), None, noreplacement!()
+        // after_Digest => [sub {
+        //     my ($istomach, $whatsit) = @_;
+        //     let nlines = 0;
+        //     my ($line);
+        //     let gullet = $istomach->getGullet;
+        //     $gullet->readRawLine;    // IGNORE 1st line (after the \begin{$name} !!!
+        //     while (defined($line = $gullet->readRawLine) && ($line ne $endmark)) {
+        //       $nlines++; }
+        //     NoteProgress("[Skipped $name ($nlines lines)]");
+        // }]
+      );
+    }
+    Ok(Vec::new())
+  });
 
-  let define_included = |stomach, args, state| {
-    let name = args[0].to_string();
-    let before = args[1];
-    let after = args[2];
-    let mut before_tokens = match before {
-      Some(toks) => toks.unlist(),
-      None => Vec::new()
-    };
-    before_tokens.push(T_CS!("\\ignorespaces"));
-    let mut after_tokens = match after {
-      Some(toks) => toks.unlist(),
-      None => Vec::new()
-    };
-    after_tokens.push(T_CS!("\\ignorespaces"));
+  let define_included = primitivesub!(stomach, args, state,{
+    // let name = args[0].to_string();
+    // let before = args[1];
+    // let after = args[2];
+    // let mut before_tokens = before.unlist();
+    // before_tokens.push(T_CS!("\\ignorespaces"));
+    // let mut after_tokens = after.unlist();
+    // after_tokens.push(T_CS!("\\ignorespaces"));
     // Note that we define the `magic' environment control sequences,
     // but DO NOT do any of the normal environ things, like \begingroup \endgroup!
-    DefMacroI!(T_CS!(format!("\\begin{{{}}}",name)), None, move |gullet, _args, _state| {
-        gullet.read_raw_line();    // IGNORE 1st line (after the \begin{$name} !!!
-        Ok(before_tokens)
-      });
-    DefMacroI!(T_CS!(format!("\\end{{{}}}",name)), None, move |_gullet, _args, _state| {
-      Ok(after_tokens)
-    });
+    // DefMacroI!(T_CS!(format!("\\begin{{{}}}",name)), None, move |gullet, _args, _state| {
+    //     gullet.read_raw_line();    // IGNORE 1st line (after the \begin{$name} !!!
+    //     Ok(before_tokens)
+    //   });
+    // DefMacroI!(T_CS!(format!("\\end{{{}}}",name)), None, move |_gullet, _args, _state| {
+    //   Ok(after_tokens)
+    // });
 
-    Ok(())
-  };
+    Ok(Vec::new())
+  });
 
-  define_excluded(None, "comment", state);
+  let define_special_included = primitivesub!(stomach, args, state,{
+    // let name = args[0].to_string();
+    // let before = args[1];
+    // let after = args[2];
+    // let mut before_tokens = before.unlist();
+    // before_tokens.push(T_CS!("\\ignorespaces"));
+    // let mut after_tokens = after.unlist();
+    // after_tokens.push(T_CS!("\\ignorespaces"));
+    // Note that we define the `magic' environment control sequences,
+    // but DO NOT do any of the normal environ things, like \begingroup \endgroup!
+    // DefMacroI!(T_CS!(format!("\\begin{{{}}}",name)), None, move |gullet, _args, _state| {
+    //     gullet.read_raw_line();    // IGNORE 1st line (after the \begin{$name} !!!
+    //     Ok(before_tokens)
+    //   });
+    // DefMacroI!(T_CS!(format!("\\end{{{}}}",name)), None, move |_gullet, _args, _state| {
+    //   Ok(after_tokens)
+    // });
+
+    Ok(Vec::new())
+  });
+
+
+  let mut mock_stomach = Stomach::default();
+  define_excluded(&mut mock_stomach, vec![Tokens{tokens: vec![T_OTHER!("comment")]}], state);
 
   DefPrimitiveI!("\\includecomment{}",     define_included);
   DefPrimitiveI!("\\excludecomment{}",     define_excluded);
-  DefPrimitiveI!("\\specialcomment{}{}{}", define_included);
+  DefPrimitiveI!("\\specialcomment{}{}{}", define_special_included);
   //DefPrimitive("\processcomment{}{}{}{}",);
 
   Ok(())

--- a/src/package/pool/comment_sty.rs
+++ b/src/package/pool/comment_sty.rs
@@ -75,7 +75,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
   DefPrimitiveI!("\\includecomment{}",     define_included);
   DefPrimitiveI!("\\excludecomment{}",     define_excluded);
   DefPrimitiveI!("\\specialcomment{}{}{}", define_special_included);
-  //DefPrimitive("\processcomment{}{}{}{}",);
+  DefPrimitiveI!("\\processcomment{}{}{}{}", noprimitive!());
 
   Ok(())
 }

--- a/src/package/pool/comment_sty.rs
+++ b/src/package/pool/comment_sty.rs
@@ -10,7 +10,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
     let name = args[0].to_string();
     let endmark = format!("\\end{{{}}}", name);
     {
-      DefConstructorI!(T_CS!(format!("\\begin{{{}}}",name)), None, noreplacement!()
+      DefConstructorI_F!(T_CS!(format!("\\begin{{{}}}",name)), None, noreplacement!()
         // after_Digest => [sub {
         //     my ($istomach, $whatsit) = @_;
         //     let nlines = 0;
@@ -21,7 +21,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
         //       $nlines++; }
         //     NoteProgress("[Skipped $name ($nlines lines)]");
         // }]
-      );
+      ,state);
     }
     Ok(Vec::new())
   });

--- a/src/package/pool/comment_sty.rs
+++ b/src/package/pool/comment_sty.rs
@@ -30,8 +30,9 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
     Ok(Vec::new())
   });
 
-  let define_included = primitivesub!(stomach, args, state,{
-    args.reverse(); // we'll be poppint from the front
+  // I don't understand Rust closures enough to figure out how to clone one, so instantiating it twice instead, via a macro
+  macro_rules! define_included {() =>(primitivesub!(stomach, args, state,{
+    args.reverse(); // we'll be popping from the front
     let name = if let Some(name_token) = args.pop() {
       name_token.to_string()
     } else {
@@ -61,36 +62,14 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
     }, state);
 
     Ok(Vec::new())
-  });
-
-  let define_special_included = primitivesub!(stomach, args, state,{
-    // let name = args[0].to_string();
-    // let before = args[1];
-    // let after = args[2];
-    // let mut before_tokens = before.unlist();
-    // before_tokens.push(T_CS!("\\ignorespaces"));
-    // let mut after_tokens = after.unlist();
-    // after_tokens.push(T_CS!("\\ignorespaces"));
-    // Note that we define the `magic' environment control sequences,
-    // but DO NOT do any of the normal environ things, like \begingroup \endgroup!
-    // DefMacroI!(T_CS!(format!("\\begin{{{}}}",name)), None, move |gullet, _args, _state| {
-    //     gullet.read_raw_line();    // IGNORE 1st line (after the \begin{$name} !!!
-    //     Ok(before_tokens)
-    //   });
-    // DefMacroI!(T_CS!(format!("\\end{{{}}}",name)), None, move |_gullet, _args, _state| {
-    //   Ok(after_tokens)
-    // });
-
-    Ok(Vec::new())
-  });
-
+  });)}
 
   let mut mock_stomach = Stomach::default();
-  define_excluded(&mut mock_stomach, vec![Tokens{tokens: vec![T_OTHER!("comment")]}], state);
+  try!(define_excluded(&mut mock_stomach, vec![Tokens{tokens: vec![T_OTHER!("comment")]}], state));
 
-  DefPrimitiveI!("\\includecomment{}",     define_included);
+  DefPrimitiveI!("\\includecomment{}",     define_included!());
   DefPrimitiveI!("\\excludecomment{}",     define_excluded);
-  DefPrimitiveI!("\\specialcomment{}{}{}", define_special_included);
+  DefPrimitiveI!("\\specialcomment{}{}{}", define_included!());
   DefPrimitiveI!("\\processcomment{}{}{}{}", noprimitive!());
 
   Ok(())

--- a/src/package/pool/comment_sty.rs
+++ b/src/package/pool/comment_sty.rs
@@ -8,19 +8,23 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
   // until \endname or \end{name}, respectively
   let define_excluded = primitivesub!(stomach, args, state,{
     let name = args[0].to_string();
-    let endmark = format!("\\end{{{}}}", name);
+    let begin_mark = format!("\\begin{{{}}}",name);
+    let end_mark = format!("\\end{{{}}}", name);
     {
-      DefConstructorI_F!(T_CS!(format!("\\begin{{{}}}",name)), None, noreplacement!()
-        // after_Digest => [sub {
-        //     my ($istomach, $whatsit) = @_;
-        //     let nlines = 0;
-        //     my ($line);
-        //     let gullet = $istomach->getGullet;
-        //     $gullet->readRawLine;    // IGNORE 1st line (after the \begin{$name} !!!
-        //     while (defined($line = $gullet->readRawLine) && ($line ne $endmark)) {
-        //       $nlines++; }
-        //     NoteProgress("[Skipped $name ($nlines lines)]");
-        // }]
+      DefConstructorI_F!(T_CS!(begin_mark), None, noreplacement!(),
+        after_digest => sub!(move |stomach: &mut Stomach, whatsit: &mut Whatsit, _state: &mut State| {
+          let mut nlines = 0;
+          let gullet = &mut stomach.gullet;
+          gullet.read_raw_line();    // IGNORE 1st line (after the \begin{$name} !!!
+          while let Some(line) = gullet.read_raw_line() {
+            if line == end_mark {
+              break;
+            }
+            nlines += 1;
+          }
+          note_progress(&format!("[Skipped {} ({} lines)]",name,nlines));
+          Ok(Vec::new())
+        })
       ,state);
     }
     Ok(Vec::new())

--- a/src/package/pool/comment_sty.rs
+++ b/src/package/pool/comment_sty.rs
@@ -1,0 +1,62 @@
+use package::*;
+
+pub fn load_definitions(state: &mut State) -> Result<()> {
+  SetupBindingMacros!(state);
+
+  //**********************************************************************
+  // Define \name and \begin{name} to start an ignored section
+  // until \endname or \end{name}, respectively
+  let define_excluded = |stomach, args, state| {
+    let name = args[0].to_string();
+    let endmark = format!("\\end{{{}}}", name);
+    DefConstructorI!(T_CS!(format!("\\begin{{{}}}",name)), None, noreplacement!()
+      // after_Digest => [sub {
+      //     my ($istomach, $whatsit) = @_;
+      //     let nlines = 0;
+      //     my ($line);
+      //     let gullet = $istomach->getGullet;
+      //     $gullet->readRawLine;    // IGNORE 1st line (after the \begin{$name} !!!
+      //     while (defined($line = $gullet->readRawLine) && ($line ne $endmark)) {
+      //       $nlines++; }
+      //     NoteProgress("[Skipped $name ($nlines lines)]");
+      // }]
+    );
+    Ok(())
+  };
+
+  let define_included = |stomach, args, state| {
+    let name = args[0].to_string();
+    let before = args[1];
+    let after = args[2];
+    let mut before_tokens = match before {
+      Some(toks) => toks.unlist(),
+      None => Vec::new()
+    };
+    before_tokens.push(T_CS!("\\ignorespaces"));
+    let mut after_tokens = match after {
+      Some(toks) => toks.unlist(),
+      None => Vec::new()
+    };
+    after_tokens.push(T_CS!("\\ignorespaces"));
+    // Note that we define the `magic' environment control sequences,
+    // but DO NOT do any of the normal environ things, like \begingroup \endgroup!
+    DefMacroI!(T_CS!(format!("\\begin{{{}}}",name)), None, move |gullet, _args, _state| {
+        gullet.read_raw_line();    // IGNORE 1st line (after the \begin{$name} !!!
+        Ok(before_tokens)
+      });
+    DefMacroI!(T_CS!(format!("\\end{{{}}}",name)), None, move |_gullet, _args, _state| {
+      Ok(after_tokens)
+    });
+
+    Ok(())
+  };
+
+  define_excluded(None, "comment", state);
+
+  DefPrimitiveI!("\\includecomment{}",     define_included);
+  DefPrimitiveI!("\\excludecomment{}",     define_excluded);
+  DefPrimitiveI!("\\specialcomment{}{}{}", define_included);
+  //DefPrimitive("\processcomment{}{}{}{}",);
+
+  Ok(())
+}

--- a/src/package/pool/latex.rs
+++ b/src/package/pool/latex.rs
@@ -289,7 +289,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
 
       // TODO: convertLaTeXArgs($nargs, $opt)
       let body_closure = move |gullet:&mut Gullet, args:Vec<Tokens>, state:&mut State|{ Ok(body.clone()) };
-      DefMacroI!(cs.clone(), None, body_closure, state);
+      DefMacroI_F!(cs.clone(), None, body_closure, state);
       Ok(Vec::new())
   });
 

--- a/src/package/pool/latex.rs
+++ b/src/package/pool/latex.rs
@@ -166,14 +166,16 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
     //     return Vec::new()
     //   }
     // },
-    // before_digest_end => |stomach, whatsit, state| {
-    //   stomach.get_gullet().flush();
-    //   if let Some(ops) = LookupValue!("@at@end@document", state) {
-    //     return Digest!(Tokens!(ops));
-    //   } else {
-    //     return Vec::new();
-    //   }
-    // },
+    before_digest_end => sub!(|stomach, state| {
+      stomach.get_gullet_mut().flush(state);
+      if let Some(ops) = LookupValue_F!("@at@end@document", state) {
+        // TODO:
+        // Ok(Digest!(Tokens!(ops)))
+        Ok(Vec::new())
+      } else {
+        Ok(Vec::new())
+      }
+    }),
     mode => Some("text".to_string())
   );
 

--- a/src/package/pool/mod.rs
+++ b/src/package/pool/mod.rs
@@ -5,5 +5,8 @@ pub mod tex_math;
 pub mod tex_appendix_b;
 
 pub mod latex;
+// Supported package bindings
 pub mod article_cls;
 pub mod alltt_sty;
+pub mod comment_sty;
+

--- a/src/package/pool/mod.rs
+++ b/src/package/pool/mod.rs
@@ -3,6 +3,7 @@ pub mod tex_setup;
 pub mod tex_structure;
 pub mod tex_math;
 pub mod tex_appendix_b;
+pub mod tex_chapter_24;
 
 pub mod latex;
 // Supported package bindings

--- a/src/package/pool/tex.rs
+++ b/src/package/pool/tex.rs
@@ -8,5 +8,7 @@ pub fn load_definitions(mut state: &mut State) -> Result<()> {
   try!(pool::tex_math::load_definitions(&mut state));
 
   try!(pool::tex_appendix_b::load_definitions(&mut state));
+
+  try!(pool::tex_chapter_24::load_definitions(&mut state));
   Ok(())
 }

--- a/src/package/pool/tex_appendix_b.rs
+++ b/src/package/pool/tex_appendix_b.rs
@@ -66,8 +66,8 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
   //   font => { family => 'serif', series => 'medium', shape => 'upright' });
   // DefPrimitiveI!("\\sf", undef, undef,
   //   font => { family => 'sansserif', series => 'medium', shape => 'upright' });
-  // DefPrimitiveI!("\\bf", undef, undef,
-  //   font => { series => 'bold', family => 'serif', shape => 'upright' });
+  DefPrimitiveI!("\\bf", noprimitive!(),
+    font => Font!(series => "bold", family => "serif", shape => "upright"));
   // DefPrimitiveI!("\\it", undef, undef,
   //   font => { shape => 'italic', family => 'serif', series => 'medium' });
   // DefPrimitiveI!("\\tt", undef, undef,

--- a/src/package/pool/tex_appendix_b.rs
+++ b/src/package/pool/tex_appendix_b.rs
@@ -52,5 +52,68 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
   DefMathI!('<', None, '<', role => v!("RELOP"), meaning => v!("less-than"));
   DefMathI!('>', None, '>', role => v!("RELOP"), meaning => v!("greater-than"));
 
+  //======================================================================
+  // TeX Book, Appendix B, p. 351
+
+  // Old style font styles.
+  // The trick is to create an empty Whatsit preserved till assimilation (for reversion'ing)
+  // but to change the current font used in boxes.
+  // (some of these were defined on different pages? or even latex...)
+  Tag!("ltx:text", auto_open => true, auto_close => true);
+
+  // // Note that these, unlike \rmfamily, should set the other attributes to the defaults!
+  // DefPrimitiveI!("\\rm", undef, undef,
+  //   font => { family => 'serif', series => 'medium', shape => 'upright' });
+  // DefPrimitiveI!("\\sf", undef, undef,
+  //   font => { family => 'sansserif', series => 'medium', shape => 'upright' });
+  // DefPrimitiveI!("\\bf", undef, undef,
+  //   font => { series => 'bold', family => 'serif', shape => 'upright' });
+  // DefPrimitiveI!("\\it", undef, undef,
+  //   font => { shape => 'italic', family => 'serif', series => 'medium' });
+  // DefPrimitiveI!("\\tt", undef, undef,
+  //   font => { family => 'typewriter', series => 'medium', shape => 'upright' });
+  // // No effect in math for the following 2 ?
+  // DefPrimitiveI!("\\sl", undef, undef,
+  //   font => { shape => 'slanted', family => 'serif', series => 'medium' });
+  // DefPrimitiveI!("\\sc", undef, undef,
+  //   font => { shape => 'smallcaps', family => 'serif', series => 'medium' });
+
+  // // Ideally, we should set these sizes from class files
+  // AssignValue!("NOMINAL_FONT_SIZE", ObjectStore::Int(10));
+  // DefPrimitiveI!("\\tiny",         undef, undef, font => { size => 5 });
+  // DefPrimitiveI!("\\scriptsize",   undef, undef, font => { size => 7 });
+  // DefPrimitiveI!("\\footnotesize", undef, undef, font => { size => 8 });
+  // DefPrimitiveI!("\\small",        undef, undef, font => { size => 9 });
+  // DefPrimitiveI!("\\normalsize",   undef, undef, font => { size => 10 });
+  // DefPrimitiveI!("\\large",        undef, undef, font => { size => 12 });
+  // DefPrimitiveI!("\\Large",        undef, undef, font => { size => 14.4 });
+  // DefPrimitiveI!("\\LARGE",        undef, undef, font => { size => 17.28 });
+  // DefPrimitiveI!("\\huge",         undef, undef, font => { size => 20.74 });
+  // DefPrimitiveI!("\\Huge",         undef, undef, font => { size => 29.8 });
+
+  // DefPrimitiveI!("\\mit", undef, undef, requireMath => 1, font => { family => 'italic' });
+
+  // DefPrimitiveI!("\\frenchspacing",    undef, undef);
+  // DefPrimitiveI!("\\nonfrenchspacing", undef, undef);
+  // DefMacroI!("\\normalbaselines", undef,
+  //   '\lineskip=\normallineskip\baselineskip=\normalbaselineskip\lineskiplimit=\normallineskiplimit');
+  // DefMacroI!("\\space", undef, Tokens(T_SPACE));
+  // DefMacroI!("\\lq",    undef, "`");
+  // DefMacroI!("\\rq",    undef, "'");
+  // Let!("\\empty", "\\@empty");
+  // DefMacroI!("\\null", undef, '\hbox{}');
+  // Let!("\\bgroup",  T_BEGIN!());
+  // Let!("\\egroup",  T_END!());
+  // Let!("\\endgraf", "\\par");
+  // Let!("\\endline", "\\cr");
+
+  // DefPrimitiveI!("\\endline", undef, undef);
+
+  // // Use \r for the newline from TeX!!!
+  // DefMacroI!("\\\r", undef, "\\ ");    // \<cr> == \<space> Interesting (see latex.ltx)
+  // Let!(T_ACTIVE("\r"), "\\par");       // (or is this just LaTeX?)
+
+  // Let!("\\\t", "\\\r");               // \<tab> == \<space>, also
+
   Ok(())
 }

--- a/src/package/pool/tex_chapter_24.rs
+++ b/src/package/pool/tex_chapter_24.rs
@@ -1,6 +1,4 @@
 use package::*;
-use rtx_core::{BoxOps};
-use rtx_core::document::tag::TagConstructionClosure;
 
 pub fn load_definitions(state: &mut State) -> Result<()> {
   SetupBindingMacros!(state);
@@ -34,8 +32,8 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
   // DefConstructor('\@hidden@egroup', '', afterDigest => sub { $_[0]->egroup; },
   //   reversion => '');
 
-  // DefPrimitive('\begingroup', sub { $_[0]->begingroup; });
-  // DefPrimitive('\endgroup',   sub { $_[0]->endgroup; });
+  DefPrimitiveI!("\\begingroup", primitivesub!(stomach, _args, inner_state, {stomach.begingroup(inner_state);Ok((Vec::new()))}));
+  DefPrimitiveI!("\\endgroup",   primitivesub!(stomach, _args, inner_state, {stomach.endgroup(inner_state);Ok((Vec::new()))}));
 
   // // Debugging aids; Ignored!
   // DefPrimitive('\show Token',     undef);

--- a/src/package/pool/tex_chapter_24.rs
+++ b/src/package/pool/tex_chapter_24.rs
@@ -1,0 +1,85 @@
+use package::*;
+use rtx_core::{BoxOps};
+use rtx_core::document::tag::TagConstructionClosure;
+
+pub fn load_definitions(state: &mut State) -> Result<()> {
+  SetupBindingMacros!(state);
+
+  // //======================================================================
+  // // Remaining Mode independent primitives in Ch.24, pp.279-280
+  // // \relax was done as expandable (isn't that right?)
+  // // }
+  // // Note, we don't bother making sure begingroup is ended by endgroup.
+
+  // // These define the handler for { } (or anything of catcode BEGIN, END)
+
+  // // These are actually TeX primitives, but we treat them as a Whatsit so they
+  // // remain in the constructed tree.
+  // //DefConstructor('{','//body', beforeDigest=>sub{$_[0]->bgroup;}, captureBody=>1);
+  // DefPrimitive('{', sub {
+  //     my ($stomach) = @_;
+  //     $stomach->bgroup;
+  //     my $open   = Box(undef, undef, undef, T_BEGIN);
+  //     my $ismath = $STATE->lookupValue('IN_MATH');
+  //     my @body   = $stomach->digestNextBody();
+  //     List($open, @body, mode => ($ismath ? 'math' : 'text')); });
+  // //DefConstructor('}',  '',    beforeDigest=>sub{$_[0]->egroup;});
+  // DefPrimitive('}', sub { my $f = LookupValue('font'); $_[0]->egroup; Box(undef, $f, undef, T_END); });
+
+  // // These are for those screwy cases where you need to create a group like box,
+  // // more than just bgroup, egroup,
+  // // BUT you DON'T want extra {, } showing up in any untex-ing.
+  // DefConstructor('\@hidden@bgroup', '//body', beforeDigest => sub { $_[0]->bgroup; }, captureBody => 1,
+  //   reversion => sub { Revert($_[0]->getProperty('body')); });
+  // DefConstructor('\@hidden@egroup', '', afterDigest => sub { $_[0]->egroup; },
+  //   reversion => '');
+
+  // DefPrimitive('\begingroup', sub { $_[0]->begingroup; });
+  // DefPrimitive('\endgroup',   sub { $_[0]->endgroup; });
+
+  // // Debugging aids; Ignored!
+  // DefPrimitive('\show Token',     undef);
+  // DefPrimitive('\showbox Number', undef);
+  // DefPrimitive('\showlists',      undef);
+  // DefPrimitive('\showthe Token',  undef);
+
+  // // DefPrimitive('\shipout ??
+  DefPrimitiveI!("\\ignorespaces SkipSpaces", noprimitive!());
+
+  // // \afterassignment saves ONE token (globally!) to execute after the next assignment
+  // DefPrimitive('\afterassignment Token', sub { AssignValue(afterAssignment => $_[1], 'global'); });
+  // // \aftergroup saves ALL tokens (from repeated calls) to be executed IN ORDER after the next egroup or }
+  // DefPrimitive('\aftergroup Token', sub { PushValue(afterGroup => $_[1]); });
+
+  // // \uppercase<general text>, \lowercase<general text>
+  // sub ucToken {
+  //   my ($token) = @_;
+  //   my $code = $STATE->lookupUCcode($token->getString);
+  //   return ((defined $code) && ($code != 0) ? Token(chr($code), $token->getCatcode) : $token); }
+
+  // sub lcToken {
+  //   my ($token) = @_;
+  //   my $code = $STATE->lookupLCcode($token->getString);
+  //   return ((defined $code) && ($code != 0) ? Token(chr($code), $token->getCatcode) : $token); }
+
+  // DefMacro('\uppercase GeneralText', sub {
+  //     my ($gullet, $tokens) = @_;
+  //     return map { ucToken($_) } $tokens->unlist; });
+
+  // DefMacro('\lowercase GeneralText', sub {
+  //     my ($gullet, $tokens) = @_;
+  //     return map { lcToken($_) } $tokens->unlist; });
+
+  // DefPrimitive('\message{}', sub {
+  //     my ($stomach, $stuff) = @_;
+  //     print STDERR ToString(Expand($stuff)) . "\n" if LookupValue('VERBOSITY') > -1;
+  //     return; });
+
+  // DefRegister('\errhelp' => Tokens());
+  // DefPrimitive('\errmessage{}', sub {
+  //     my ($stomach, $stuff) = @_;
+  //     print STDERR ToString(Expand($stuff)) . ": " . ToString(Expand(Tokens(T_CS('\the'), T_CS('\errhelp')))) . "\n";
+  //     return; });
+
+  Ok(())
+}

--- a/src/package/pool/tex_math.rs
+++ b/src/package/pool/tex_math.rs
@@ -20,7 +20,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
     let mut op        = "\\@@BEGININLINEMATH";
   {
     let mut gullet = stomach.get_gullet_mut();
-    let mode      = LookupString!("MODE", state);
+    let mode      = LookupString_F!("MODE", state);
     info!("T_MATH primitive current mode: {:?}", mode);
     if mode == "display_math" {
       if try!(gullet.if_next(T_MATH!(), state)) {

--- a/src/package/pool/tex_setup.rs
+++ b/src/package/pool/tex_setup.rs
@@ -9,7 +9,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
   RegisterNamespace!("m"    , "http://www.w3.org/1998/Math/MathML");
   RegisterNamespace!("xhtml", "http://www.w3.org/1999/xhtml");
 
-  DefMacroT!(T_CS!("\\@empty"), None, None);
+  DefMacroT!(T_CS!("\\@empty"), None);
 
 
   //======================================================================

--- a/src/package/pool/tex_structure.rs
+++ b/src/package/pool/tex_structure.rs
@@ -57,7 +57,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
         _ => false
       };
       if !in_preamble {
-        document.maybe_close_element("ltx:p", state);
+        try!(document.maybe_close_element("ltx:p", state));
         if let Some(c) = props.get("class") {
           let element = document.get_element();
           if let Some(mut node) = element {
@@ -70,7 +70,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
             }
           }
         }
-        document.maybe_close_element("ltx:para", state);
+        try!(document.maybe_close_element("ltx:para", state));
      }
     }),
     after_digest => sub!(|stomach, whatsit, state| {


### PR DESCRIPTION
Done:
 * Def factories
 * various macros
 * flushing gullet at end of document
 * reading raw lines
 * basic placeholder for font-change via `\bf`

Remaining:
 * Font-related infrastructure needs to be implemented (in basic) and activated, so that comment tests passes