### PR TITLE
Upgrades to DefConstructor, properties

### DIFF
--- a/rtx/src/lib.rs
+++ b/rtx/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(unused_variables, unused_mut, unused_macros)]
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
+#![feature(macro_literal_matcher)]
 
 #[macro_use]
 extern crate lazy_static;

--- a/rtx/src/lib.rs
+++ b/rtx/src/lib.rs
@@ -6,7 +6,6 @@
 #![allow(unused_variables, unused_mut, unused_macros)]
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
-#![feature(macro_literal_matcher)]
 
 #[macro_use]
 extern crate lazy_static;

--- a/rtx/src/package/binding_macros.rs
+++ b/rtx/src/package/binding_macros.rs
@@ -104,13 +104,13 @@ macro_rules! noprimitive {
 
 #[macro_export]
 macro_rules! primitivesub {
-  ($stomach:ident, $args:ident, $state:ident, $body:expr) => {
+  ($stomach:ident, $args:ident, $state:ident, $body:block) => {
     |$stomach: &mut Stomach, mut $args: Vec<Tokens>, $state: &mut State| $body
   };
 }
 #[macro_export]
 macro_rules! primitiveproc {
-  ($stomach:ident, $args:ident, $state:ident, $body:expr) => (
+  ($stomach:ident, $args:ident, $state:ident, $body:block) => (
     |$stomach:&mut Stomach, mut $args : Vec<Tokens>, $state:&mut State| {
       $body
       Ok(Vec::new())
@@ -120,7 +120,7 @@ macro_rules! primitiveproc {
 
 #[macro_export]
 macro_rules! beforesub {
-  ($stomach:ident, $state:ident, $body:expr) => {
+  ($stomach:ident, $state:ident, $body:block) => {
     |$stomach: &mut Stomach, $state: &mut State| $body
   };
 }

--- a/rtx/src/package/binding_macros.rs
+++ b/rtx/src/package/binding_macros.rs
@@ -137,8 +137,21 @@ macro_rules! beforeproc {
 
 #[macro_export]
 macro_rules! properties {
-  ($stomach:ident, $args:ident, $state:ident, $body:expr) => {
-    |$stomach: &mut Stomach, mut $args: Vec<Tokens>, $state: &mut State| $body
+  (sub [ $stomach:ident, $args:ident, $inner_state:ident ] $body:block) => {
+    Rc::new(
+      move |$stomach: &mut Stomach,
+            mut $args: &Vec<Option<Digested>>,
+            $inner_state: &mut State|
+            -> Result<HashMap<String, Stored>> { $body },
+    )
+  };
+  ($value:expr) => {
+    Rc::new(
+      move |_stomach: &mut Stomach,
+            _args: &Vec<Option<Digested>>,
+            _state: &mut State|
+            -> Result<HashMap<String, Stored>> { Ok($value.clone()) },
+    )
   };
 }
 

--- a/rtx/src/package/binding_macros.rs
+++ b/rtx/src/package/binding_macros.rs
@@ -136,6 +136,13 @@ macro_rules! beforeproc {
 }
 
 #[macro_export]
+macro_rules! properties {
+  ($stomach:ident, $args:ident, $state:ident, $body:expr) => {
+    |$stomach: &mut Stomach, mut $args: Vec<Tokens>, $state: &mut State| $body
+  };
+}
+
+#[macro_export]
 macro_rules! aftersub {
   ($stomach:ident, $whatsit:ident, $state:ident, $body:expr) => {
     vec![Rc::new(
@@ -146,6 +153,7 @@ macro_rules! aftersub {
     )]
   };
 }
+
 #[macro_export]
 macro_rules! afterproc {
   ($stomach:ident, $whatsit:ident, $state:ident, $body:expr) => (

--- a/rtx/src/package/functions.rs
+++ b/rtx/src/package/functions.rs
@@ -1018,11 +1018,9 @@ fn deactivate_counter_scope(ctr: &str, state: &mut State) {
 fn reset_counter(ctr: &str, state: &mut State) {
   state.assign_value(&s!("\\c@{}", ctr), Number!(0), Some(Scope::Global));
   // and reset any within counters!
-  let nested = if let Some(Stored::Tokens(nested)) = state.lookup_value(&s!("\\cl@{}", ctr)) {
-    nested.clone()
-  } else {
-    Tokens!()
-  };
+  let nested = state
+    .lookup_tokens(&s!("\\cl@{}", ctr))
+    .unwrap_or_else(|| Tokens!());
 
   for c in &(nested.unlist()) {
     reset_counter(&c.to_string(), state);

--- a/rtx/src/package/functions.rs
+++ b/rtx/src/package/functions.rs
@@ -922,7 +922,7 @@ pub fn ref_step_counter(
   noreset: bool,
   stomach: &mut Stomach,
   state: &mut State,
-) -> Result<RefStepValue>
+) -> Result<HashMap<String, Stored>>
 {
   let ctr = match state.lookup_mapping("counter_for_type", ctype) {
     Some(Stored::String(ctr)) => ctr.to_string(),
@@ -930,13 +930,14 @@ pub fn ref_step_counter(
   };
   step_counter(&ctr, noreset, stomach, state)?;
 
-  let iddef_opt = state.lookup_definition(&T_CS!(s!("\\the{}@ID", ctr)));
-  let has_id: bool = match iddef_opt {
-    Some(Stored::Expandable(iddef)) => match iddef.get_parameters() {
-      Some(params) => params.get_num_args() == 0,
-      None => false,
-    },
-    _ => false,
+  let has_id: bool = if let Some(iddef) = state.lookup_definition(&T_CS!(s!("\\the{}@ID", ctr))) {
+    if let Some(params) = iddef.get_parameters() {
+      params.get_num_args() == 0
+    } else {
+      false
+    }
+  } else {
+    false
   };
 
   SetupBindingMacros!(state);
@@ -971,11 +972,11 @@ pub fn ref_step_counter(
   );
   state.activate_scope(&scope);
 
-  Ok(RefStepValue {
+  Ok(map!(
     //   ($tags   ? (tags => $tags) : ()),
-    tags: None,
-    id: if has_id { Some(id) } else { None },
-  })
+    "tags" => Stored::VecString(Vec::new()),
+    "id" => Stored::String(id)
+  ))
 }
 
 fn deactivate_counter_scope(ctr: &str, state: &mut State) {
@@ -1034,5 +1035,39 @@ fn reset_counter(ctr: &str, state: &mut State) {
 fn after_assignment(gullet: &mut Gullet, state: &mut State) {
   if let Some(Stored::Tokens(after)) = state.remove_value("afterAssignment") {
     gullet.unread(after); // primitive returns boxes, so these need to be digested!
+  }
+}
+
+pub fn build_invocation(token: Token, args: Vec<Tokens>, state: &mut State) -> Tokens {
+  // Note: token may have been \let to another defn!
+  if let Some(defn) = state.lookup_definition(&token) {
+    let mut invoked_tokens = vec![token];
+    let mut reverted_args = if let Some(params) = defn.get_parameters() {
+      params.revert_arguments(args, state).unlist()
+    } else {
+      Vec::new()
+    };
+    invoked_tokens.append(&mut reverted_args);
+    Tokens::new(invoked_tokens)
+  } else {
+    let mut invoked_tokens = vec![token];
+    // error!(
+    //   "undefined",
+    //   token,
+    //   None,
+    //   format!("Can't invoke {:?}; it is undefined", token)
+    // );
+    // DefConstructorI!(token, convert_latex_args(args.len(), 0),
+    // sub { LaTeXML::Core::Stomach::makeError($_[0], 'undefined', token); });
+    let mut wrapped_args: Vec<Token> = args
+      .into_iter()
+      .flat_map(|arg| {
+        let mut wrapped = vec![T_BEGIN!()];
+        wrapped.append(&mut arg.unlist());
+        wrapped.push(T_END!());
+        wrapped
+      }).collect();
+    invoked_tokens.append(&mut wrapped_args);
+    Tokens::new(invoked_tokens)
   }
 }

--- a/rtx/src/package/functions.rs
+++ b/rtx/src/package/functions.rs
@@ -499,10 +499,10 @@ pub fn select_relaxng_schema(
   return;
 }
 
-pub fn def_macro(
+pub fn def_macro<T: Into<Option<ExpansionClosure>>>(
   cs: Token,
   paramlist: Option<Parameters>,
-  expansion: Option<ExpansionClosure>,
+  expansion: T,
   state: &mut State,
 )
 {
@@ -513,6 +513,7 @@ pub fn def_macro(
   // expansion: $expansion});//, %options), $options{scope});       // if $options{locked} {
   //       //   $state.assign_value(ToString($cs)+":locked", true, "global")
   //       // }
+  let expansion = expansion.into();
 
   state.install_definition(
     Expandable {
@@ -578,14 +579,14 @@ pub fn def_conditional(
           // second, each invocation of the conditional macro needs to create new tokens to
           // return,       hence a clone is required on each call.
           let cs_c1 = cs.clone();
-          DefMacroTS!(
+          DefMacroI!(
             T_CS!(s!("\\{}true", name)),
             None,
             Tokens!(T_CS!("\\let"), cs_c1.clone(), T_CS!("\\iftrue")),
             state
           );
           let cs_c2 = cs.clone();
-          DefMacroTS!(
+          DefMacroI!(
             T_CS!(s!("\\{}false", name)),
             None,
             Tokens!(T_CS!("\\let"), cs_c2.clone(), T_CS!("\\iffalse")),
@@ -695,7 +696,8 @@ pub fn generate_id(
     let id = match ancestor_id {
       Some(aid) => aid + ".",
       None => String::new(),
-    } + prefix + &ctr;
+    } + prefix
+      + &ctr;
 
     ancestor.set_attribute(&ctrkey, &ctr)?;
     node.set_attribute("xml:id", &id)?;
@@ -872,7 +874,7 @@ pub fn add_to_counter(ctr: &str, value: Number, gullet: &mut Gullet, state: &mut
   after_assignment(gullet, state);
   SetupBindingMacros!(state);
   let id_cs = T_CS!(s!("\\@{}@ID", ctr));
-  DefMacroTS!(id_cs.clone(), None, Tokens::new(Explode!(v.value_of())),
+  DefMacroI!(id_cs.clone(), None, Tokens::new(Explode!(v.value_of())),
     scope => Some(Scope::Global));
 }
 
@@ -895,7 +897,7 @@ pub fn step_counter(
     after_assignment(gullet, state);
   }
   let token_value = Tokens::new(Explode!(counter_value(ctr, state).value_of()));
-  DefMacroTS!(T_CS!(s!("\\@{}@ID",ctr)), None, 
+  DefMacroI!(T_CS!(s!("\\@{}@ID",ctr)), None, 
               token_value.clone(), scope => Some(Scope::Global));
 
   // and reset any within counters!
@@ -940,9 +942,9 @@ pub fn ref_step_counter(
   SetupBindingMacros!(state);
   let the_cs = T_CS!(s!("\\the{}", ctr));
   let the_id_cs = T_CS!(s!("\\the{}@ID", ctr));
-  DefMacroT!(T_CS!("\\@currentlabel"), None, the_cs.clone(), scope => Some(Scope::Global));
+  DefMacroI!(T_CS!("\\@currentlabel"), None, the_cs.clone(), scope => Some(Scope::Global));
   if has_id {
-    DefMacroT!(T_CS!("\\@currentID"), None, the_id_cs.clone(), scope => Some(Scope::Global))
+    DefMacroI!(T_CS!("\\@currentID"), None, the_id_cs.clone(), scope => Some(Scope::Global))
   }
 
   let id = if has_id {

--- a/rtx/src/package/pool/comment_sty.rs
+++ b/rtx/src/package/pool/comment_sty.rs
@@ -10,23 +10,22 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
     unpack_to_string!(args => name);
     let begin_mark = s!("\\begin{{{}}}", name);
     let end_mark = s!("\\end{{{}}}", name);
-    {
-      DefConstructorI!(T_CS!(begin_mark), None, noreplacement!(),
-        after_digest => sub!(move |stomach: &mut Stomach, whatsit: &mut Whatsit, _state: &mut State| {
-          let mut nlines = 0;
-          let gullet = &mut stomach.gullet;
-          gullet.read_raw_line();    // IGNORE 1st line (after the \begin{$name} !!!
-          while let Some(line) = gullet.read_raw_line() {
-            if line == end_mark {
-              break;
-            }
-            nlines += 1;
+    DefConstructorI!(T_CS!(begin_mark), None, noreplacement!(),
+      after_digest => sub!(move |stomach: &mut Stomach, whatsit: &mut Whatsit, _state: &mut State| {
+        let mut nlines = 0;
+        let gullet = &mut stomach.gullet;
+        gullet.read_raw_line();    // IGNORE 1st line (after the \begin{$name} !!!
+        while let Some(line) = gullet.read_raw_line() {
+          if line == end_mark {
+            break;
           }
-          note_progress(&s!("[Skipped {} ({} lines)]",name,nlines));
-          Ok(Vec::new())
-        })
-      ,state);
-    }
+          nlines += 1;
+        }
+        note_progress(&s!("[Skipped {} ({} lines)]",name,nlines));
+        Ok(Vec::new())
+      })
+    ,state);
+
     Ok(Vec::new())
   });
 
@@ -35,36 +34,26 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
   macro_rules! define_included {
     () => {
       primitivesub!(stomach, args, state, {
-        args.reverse(); // we'll be popping from the front
-        let name = if let Some(name_token) = args.pop() {
-          name_token.to_string()
-        } else {
-          String::new()
-        };
-        // TODO: All instances of `.clone` here look like Rust memory waste, consider improving
-        let mut before_tokens = if let Some(before) = args.pop() {
-          before.unlist()
-        } else {
-          Vec::new()
-        };
+        args.reverse(); // we'll be using .pop() from the front
+        let name = args.pop().unwrap_or(Tokens!()).to_string();
+        let mut before_tokens = args.pop().unwrap_or(Tokens!()).unlist();
         before_tokens.push(T_CS!("\\ignorespaces"));
-        let mut after_tokens = if let Some(after) = args.pop() {
-          after.unlist()
-        } else {
-          Vec::new()
-        };
+        let mut after_tokens = args.pop().unwrap_or(Tokens!()).unlist();
         after_tokens.push(T_CS!("\\ignorespaces"));
         // Note that we define the `magic' environment control sequences,
         // but DO NOT do any of the normal environ things, like \begingroup \endgroup!
         DefMacroI!(T_CS!(s!("\\begin{{{}}}", name)),
-                      None,
-                      sub[gullet, _args, _state] {
-                        gullet.read_raw_line(); // IGNORE 1st line (after the \begin{$name} !!!
-                        Ok(Tokens::new(before_tokens.clone()))
-                      },
-                      state
-                    );
-        DefMacroI!(T_CS!(s!("\\end{{{}}}", name)), None, Tokens{tokens: after_tokens}, state);
+                          None,
+                          sub[gullet, _args, _state] {
+                            gullet.read_raw_line(); // IGNORE 1st line (after the \begin{$name} !!!
+                            Ok(before_tokens.clone().into())
+                          },
+                          state
+                        );
+        DefMacroI!(T_CS!(s!("\\end{{{}}}", name)),None,
+          Tokens::new(after_tokens),
+          state
+        );
 
         Ok(Vec::new())
       });

--- a/rtx/src/package/pool/comment_sty.rs
+++ b/rtx/src/package/pool/comment_sty.rs
@@ -56,21 +56,15 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
         after_tokens.push(T_CS!("\\ignorespaces"));
         // Note that we define the `magic' environment control sequences,
         // but DO NOT do any of the normal environ things, like \begingroup \endgroup!
-        DefMacroI!(
-          T_CS!(s!("\\begin{{{}}}", name)),
-          None,
-          move |gullet, _args, _state| {
-            gullet.read_raw_line(); // IGNORE 1st line (after the \begin{$name} !!!
-            Ok(Tokens::new(before_tokens.clone()))
-          },
-          state
-        );
-        DefMacroI!(
-          T_CS!(s!("\\end{{{}}}", name)),
-          None,
-          move |_gullet, _args, _state| Ok(Tokens::new(after_tokens.clone())),
-          state
-        );
+        DefMacroI!(T_CS!(s!("\\begin{{{}}}", name)),
+                      None,
+                      sub[gullet, _args, _state] {
+                        gullet.read_raw_line(); // IGNORE 1st line (after the \begin{$name} !!!
+                        Ok(Tokens::new(before_tokens.clone()))
+                      },
+                      state
+                    );
+        DefMacroI!(T_CS!(s!("\\end{{{}}}", name)), None, Tokens{tokens: after_tokens}, state);
 
         Ok(Vec::new())
       });

--- a/rtx/src/package/pool/latex.rs
+++ b/rtx/src/package/pool/latex.rs
@@ -266,53 +266,56 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
     }
   );
 
-  //   DefConstructorI!(
-  //     "\\@@numbered@section{} Undigested OptionalUndigested Undigested",
-  //      replacement!(document, args, props, state,
-  //     {
-  //       // TODO: This bizarre argument API interaction needs to be simplified down to Perl's
-  //       // intuitive level of:       let (x,y,z, ...) = @args;
-  //       unpack_to_string!(args => stype, inlist, toctitle, title);
-  //       let clean_id = prop_str!(props,"id"); // TODO: CleanID($id);
-  //       document.open_element(&s!("ltx:{}", stype),
-  //         Some(string_map!("xml:id" => clean_id, "inlist" => inlist)),
-  //         None,
-  //         state,
-  //       )?;
-  //       // TODO: Another instance where the immutability of props causes endless cloning
-  //       //       which is slow and wasteful.
-  //       // The big problem is that for props to be mutable, the entire parent whatsit needs to
-  //       // be mutable, and Rust hits a mutability conflict between the parent, and the
-  //       // "args" and "props" children ... will come back here after performance becomes
-  //       // an issue again
-  //       if let Some(Stored::Digested(tags)) = props.get("tags") {
-  //         document.absorb((**tags).clone(), state)?;
-  //       }
-  //       let title = prop_digested!(props, "title");
-  //       document.insert_element("ltx:title", title, None, state)?;
+  DefConstructor!(
+      "\\@@numbered@section{} Undigested OptionalUndigested Undigested",
+       sub[document, args, props, state] {
+        // TODO: This bizarre argument API interaction needs to be simplified down to Perl's
+        // intuitive level of:       let (x,y,z, ...) = @args;
+        unpack_to_string!(args => stype, inlist, toctitle, title);
+        let clean_id = prop_str!(props,"id"); // TODO: CleanID($id);
+        document.open_element(&s!("ltx:{}", stype),
+          Some(string_map!("xml:id" => clean_id, "inlist" => inlist)),
+          None,
+          state,
+        )?;
+        // TODO: Another instance where the immutability of props causes endless cloning
+        //       which is slow and wasteful.
+        // The big problem is that for props to be mutable, the entire parent whatsit needs to
+        // be mutable, and Rust hits a mutability conflict between the parent, and the
+        // "args" and "props" children ... will come back here after performance becomes
+        // an issue again
+        if let Some(Stored::Digested(tags)) = props.get("tags") {
+          document.absorb((**tags).clone(), state)?;
+        }
+        let title = prop_digested!(props, "title");
+        document.insert_element("ltx:title", title, None, state)?;
 
-  //       let toctitle = prop_digested!(props, "toctitle");
-  //       if !toctitle.is_empty() {
-  //         document.insert_element("ltx:toctitle", toctitle, None, state)?;
-  //       }
-  //     }),
-  //     properties => properties!(stomach, args, state, {
-  //       unpack!(args => stype, inlist, toctitle_arg, title);
-  //       let mut props = ref_step_counter(stype.to_string(), state);
-  //       let toctitle = if toctitle_arg.to_string().is_empty() {
-  //         toctitle_arg
-  //       } else {
-  //         title
-  //       };
-  //       let xtitle    = stomach.digest(Invocation!(T_CS!("\\lx@format@title@@"), stype, title))?;
-  // let xtoctitle = stomach.digest(Invocation!(T_CS!("\\lx@format@toctitle@@"), stype,
-  // toctitle))?;       props.set(s!("title"), xtitle.into());
-  //       if xtoctitle.to_string() != xtitle.to_string() {
-  //         props.set(s!("toctitle"), xtoctitle.int());
-  //       }
-  //       props
-  //     })
-  //  );
+        let toctitle = prop_digested!(props, "toctitle");
+        if !toctitle.is_empty() {
+          document.insert_element("ltx:toctitle", toctitle, None, state)?;
+        }
+      },
+      properties => properties!(sub[stomach, args, state] {
+        unpack!(args => stype, inlist, toctitle_arg, title);
+        let mut props = ref_step_counter(&stype.to_string(), false, stomach, state)?;
+        let toctitle = if toctitle_arg.to_string().is_empty() {
+          toctitle_arg
+        } else {
+          title
+        };
+        // TODO!
+        // let xtitle    = stomach.digest(Invocation!(T_CS!("\\lx@format@title@@"), vec![stype, title]), state)?;
+        // let xtoctitle = stomach.digest(Invocation!(T_CS!("\\lx@format@toctitle@@"), vec![stype, toctitle]), state)?;
+        let xtitle = Stored::String("xtitle".into());
+        let xtoctitle = Stored::String("xtoctitle".into());
+        
+        if xtoctitle.to_string() != xtitle.to_string() {
+          props.insert(s!("toctitle"), xtoctitle);
+        }
+        props.insert(s!("title"), xtitle);
+        Ok(props)
+      })
+   );
 
   // # No tags, at all? Consider...
   // DefConstructor('\@@unnumbered@section{} Undigested OptionalUndigested Undigested', sub {

--- a/rtx/src/package/pool/latex.rs
+++ b/rtx/src/package/pool/latex.rs
@@ -270,56 +270,53 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
     }
   );
 
-  DefConstructor!(
-    "\\@@numbered@section{} Undigested OptionalUndigested Undigested",
-    document,
-    args,
-    props,
-    state,
-    {
-      // TODO: This bizarre argument API interaction needs to be simplified down to Perl's
-      // intuitive level of:       let (x,y,z, ...) = @args;
-      unpack_to_string!(args => stype, inlist, toctitle, title);
-      let clean_id = prop_str!(props,"id"); // TODO: CleanID($id);
-      document.open_element(&s!("ltx:{}", stype),
-        Some(string_map!("xml:id" => clean_id, "inlist" => inlist)),
-        None,
-        state,
-      )?;
-      // TODO: Another instance where the immutability of props causes endless cloning
-      //       which is slow and wasteful.
-      // The big problem is that for props to be mutable, the entire parent whatsit needs to
-      // be mutable, and Rust hits a mutability conflict between the parent, and the
-      // "args" and "props" children ... will come back here after performance becomes
-      // an issue again
-      if let Some(Stored::Digested(tags)) = props.get("tags") {
-        document.absorb((**tags).clone(), state)?;
-      }
-      let title = prop_digested!(props, "title");
-      document.insert_element("ltx:title", title, None, state)?;
+  //   DefConstructorI!(
+  //     "\\@@numbered@section{} Undigested OptionalUndigested Undigested",
+  //      replacement!(document, args, props, state,
+  //     {
+  //       // TODO: This bizarre argument API interaction needs to be simplified down to Perl's
+  //       // intuitive level of:       let (x,y,z, ...) = @args;
+  //       unpack_to_string!(args => stype, inlist, toctitle, title);
+  //       let clean_id = prop_str!(props,"id"); // TODO: CleanID($id);
+  //       document.open_element(&s!("ltx:{}", stype),
+  //         Some(string_map!("xml:id" => clean_id, "inlist" => inlist)),
+  //         None,
+  //         state,
+  //       )?;
+  //       // TODO: Another instance where the immutability of props causes endless cloning
+  //       //       which is slow and wasteful.
+  //       // The big problem is that for props to be mutable, the entire parent whatsit needs to
+  //       // be mutable, and Rust hits a mutability conflict between the parent, and the
+  //       // "args" and "props" children ... will come back here after performance becomes
+  //       // an issue again
+  //       if let Some(Stored::Digested(tags)) = props.get("tags") {
+  //         document.absorb((**tags).clone(), state)?;
+  //       }
+  //       let title = prop_digested!(props, "title");
+  //       document.insert_element("ltx:title", title, None, state)?;
 
-      let toctitle = prop_digested!(props, "toctitle");
-      if !toctitle.is_empty() {
-        document.insert_element("ltx:toctitle", toctitle, None, state)?;
-      }
-    },
-    properties => properties!(stomach, args, state, {
-      unpack!(args => stype, inlist, toctitle_arg, title);
-      let mut props = ref_step_counter(stype.to_string(), state);
-      let toctitle = if toctitle_arg.to_string().is_empty() {
-        toctitle_arg
-      } else {
-        title
-      };
-      let xtitle    = stomach.digest(Invocation!(T_CS!("\\lx@format@title@@"), stype, title))?;
-      let xtoctitle = stomach.digest(Invocation!(T_CS!("\\lx@format@toctitle@@"), stype, toctitle))?;
-      props.set(s!("title"), xtitle.into());
-      if xtoctitle.to_string() != xtitle.to_string() {
-        props.set(s!("toctitle"), xtoctitle.int());
-      }
-      props
-    })
- );
+  //       let toctitle = prop_digested!(props, "toctitle");
+  //       if !toctitle.is_empty() {
+  //         document.insert_element("ltx:toctitle", toctitle, None, state)?;
+  //       }
+  //     }),
+  //     properties => properties!(stomach, args, state, {
+  //       unpack!(args => stype, inlist, toctitle_arg, title);
+  //       let mut props = ref_step_counter(stype.to_string(), state);
+  //       let toctitle = if toctitle_arg.to_string().is_empty() {
+  //         toctitle_arg
+  //       } else {
+  //         title
+  //       };
+  //       let xtitle    = stomach.digest(Invocation!(T_CS!("\\lx@format@title@@"), stype, title))?;
+  // let xtoctitle = stomach.digest(Invocation!(T_CS!("\\lx@format@toctitle@@"), stype,
+  // toctitle))?;       props.set(s!("title"), xtitle.into());
+  //       if xtoctitle.to_string() != xtitle.to_string() {
+  //         props.set(s!("toctitle"), xtoctitle.int());
+  //       }
+  //       props
+  //     })
+  //  );
 
   // # No tags, at all? Consider...
   // DefConstructor('\@@unnumbered@section{} Undigested OptionalUndigested Undigested', sub {
@@ -373,35 +370,33 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
   //// However, I hate setting up even more machinery & options and dragging yet another form
   //// around....
   // \@@section{type}{id}{refnum}{formattedrefnum}{toctitle}{title}
-  DefConstructor!(
-    "\\@@section{}{}{}{}{}{}",
-    document,
-    args,
-    props,
-    inner_state,
-    {
-      unpack!(args => stype, id, refnum_arg, frefnum_arg, toctitle, title);
-      let refnum = refnum_arg.to_string();
-      let mut frefnum = frefnum_arg.to_string();
-      if frefnum == refnum {
-        frefnum = String::new();
-      }
 
-      let clean_id = id; // TODO: CleanID($id);
-      let has_toctitle =
-        !toctitle.to_string().is_empty() && (toctitle.to_string() != title.to_string());
-      document.open_element(
-        &s!("ltx:{}", stype.to_string()),
-        Some(string_map!("xml:id" => clean_id, "refnum" => refnum, "frefnum" => frefnum)),
-        None,
-        inner_state,
-      )?;
-      document.insert_element("ltx:title", vec![title], None, inner_state)?;
-      if has_toctitle {
-        document.insert_element("ltx:toctitle", vec![toctitle], None, inner_state)?;
-      }
-    }
-  );
+  // DefConstructorI!(
+  //   "\\@@section{}{}{}{}{}{}",
+  //   replacement!(document, args, props, inner_state, {
+  //     unpack!(args => stype, id, refnum_arg, frefnum_arg, toctitle, title);
+  //     let refnum = refnum_arg.to_string();
+  //     let mut frefnum = frefnum_arg.to_string();
+  //     if frefnum == refnum {
+  //       frefnum = String::new();
+  //     }
+
+  //     let clean_id = id; // TODO: CleanID($id);
+  //     let has_toctitle =
+  //       !toctitle.to_string().is_empty() && (toctitle.to_string() != title.to_string());
+  //     document.open_element(
+  //       &s!("ltx:{}", stype.to_string()),
+  //       Some(string_map!("xml:id" => clean_id, "refnum" => refnum, "frefnum" => frefnum)),
+  //       None,
+  //       inner_state,
+  //     )?;
+  //     document.insert_element("ltx:title", vec![title], None, inner_state)?;
+  //     if has_toctitle {
+  //       document.insert_element("ltx:toctitle", vec![toctitle], None, inner_state)?;
+  //     }
+  //   }),
+  //   state
+  // );
 
   // Not sure if this is best, but if no explicit \section'ing...
   //### Tag('ltx:section',autoOpen=>1);

--- a/rtx/src/package/pool/latex.rs
+++ b/rtx/src/package/pool/latex.rs
@@ -71,7 +71,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
   //     state.assign_value(current_environment => ToString($_[1])); });
   // Let("\@currenvline", "\@empty");
 
-  DefMacro!("\\begin{}", gullet, args, state, {
+  DefMacro!("\\begin{}", sub [gullet, args, state] {
     unpack!(args => name);
     let begin_name = s!("\\begin{{{}}}", name);
     if is_defined(&begin_name, state) {
@@ -92,7 +92,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
     }
   });
 
-  DefMacro!("\\end{}", gullet, args, state, {
+  DefMacro!("\\end{}", sub[gullet, args, state]{
     let name: String = args[0].to_string();
     let mut t = T_CS!(s!("\\end{{{}}}", name));
     if is_defined_token(&t, state) {
@@ -207,7 +207,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
     Tag!(&s!("ltx:{}",tag), auto_close => true);
   }
 
-  DefMacro!("\\secdef {}{} OptionalMatch:*", gullet, args, state, {
+  DefMacro!("\\secdef {}{} OptionalMatch:*", sub[gullet, args, state] {
     if args.len() == 3 {
       Ok(args[1].clone()) // can't move out without clone, how to circumvent?
     } else {
@@ -220,11 +220,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
   NewCounter!("secnumdepth");
   SetCounter!("secnumdepth", Number!(3), None);
   DefMacro!(
-    "\\@startsection{}{}{}{}{}{} OptionalMatch:*",
-    gullet,
-    args,
-    state,
-    {
+    "\\@startsection{}{}{}{}{}{} OptionalMatch:*", sub[gullet,args,state] {
       unpack!(args => type_tokens, level_arg, ignore3, ignore4, ignore5, ignore6, flag);
 
       let stype = type_tokens.to_string();
@@ -470,12 +466,11 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
     "\\makeatother",
     "\\typeout",
     "\\listfiles",
-  ].into_iter()
+  ]
+    .into_iter()
     .map(|s| s.to_string())
   {
-    DefMacroI!(T_CS!(ltxtrigger), None, move |_gullet, _args, _state| {
-      Ok(Tokens!())
-    });
+    DefMacroI!(T_CS!(ltxtrigger), None, Tokens!());
   }
 
   //======================================================================
@@ -535,9 +530,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
       //   return; }
 
       // TODO: convertLaTeXArgs($nargs, $opt)
-      let body_closure =
-        move |gullet: &mut Gullet, args: Vec<Tokens>, state: &mut State| Ok(body.clone());
-      DefMacroI!(cs.clone(), None, body_closure, state);
+      DefMacroI!(cs.clone(), None, body, state);
     })
   );
 

--- a/rtx/src/package/pool/latex.rs
+++ b/rtx/src/package/pool/latex.rs
@@ -225,58 +225,48 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
     args,
     state,
     {
-      let type_tokens = args[0].clone();
+      unpack!(args => type_tokens, level_arg, ignore3, ignore4, ignore5, ignore6, flag);
+
       let stype = type_tokens.to_string();
+      let level = level_arg.to_string();
+
       let mut ctr = state.lookup_string(&s!("counter_for_{}", stype));
       if ctr.is_empty() {
         ctr = stype
       };
-      let level = args[1].to_string();
-      let flag = args[6].to_string();
+      let mut tokens: Vec<Token> = Vec::new();
       if !flag.is_empty() {
         // No number, not in TOC
-        //|| (!level.is_empty() && (level > CounterValue!("secnumdepth").value_of())) {
-        // RefStepID!(ctr);
-        let mut tokens: Vec<Token> = vec![
+        tokens = vec![
           T_CS!("\\@startsection@hook"),
           T_CS!("\\@@unnumbered@section"),
           T_BEGIN!(),
         ];
         tokens.append(&mut type_tokens.unlist());
-        tokens.push(T_END!());
-        tokens.push(T_BEGIN!());
-        tokens.push(T_END!());
-        Ok(Tokens::new(tokens))
+        tokens.append(&mut vec![T_END!(), T_BEGIN!(), T_END!()]);
       } else if !level.is_empty()
         && (level.parse::<i32>().unwrap() > CounterValue!("secnumdepth", state).value_of())
         || LookupBool!("no_number_sections", state)
       {
         // No number, but in TOC
-        let mut tokens: Vec<Token> = vec![
+        tokens = vec![
           T_CS!("\\@startsection@hook"),
           T_CS!("\\@@unnumbered@section"),
           T_BEGIN!(),
         ];
         tokens.append(&mut type_tokens.unlist());
-        tokens.push(T_END!());
-        tokens.push(T_BEGIN!());
-        tokens.push(T_OTHER!("toc"));
-        tokens.push(T_END!());
-        Ok(Tokens::new(tokens))
+        tokens.append(&mut vec![T_END!(), T_BEGIN!(), T_OTHER!("toc"), T_END!()]);
       } else {
         // Number and in TOC
-        let mut tokens: Vec<Token> = vec![
+        tokens = vec![
           T_CS!("\\@startsection@hook"),
           T_CS!("\\@@numbered@section"),
           T_BEGIN!(),
         ];
         tokens.append(&mut type_tokens.unlist());
-        tokens.push(T_END!());
-        tokens.push(T_BEGIN!());
-        tokens.push(T_OTHER!("toc"));
-        tokens.push(T_END!());
-        Ok(Tokens::new(tokens))
+        tokens.append(&mut vec![T_END!(), T_BEGIN!(), T_OTHER!("toc"), T_END!()]);
       }
+      Ok(Tokens::new(tokens))
     }
   );
 
@@ -290,10 +280,8 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
       // TODO: This bizarre argument API interaction needs to be simplified down to Perl's
       // intuitive level of:       let (x,y,z, ...) = @args;
       unpack_to_string!(args => stype, inlist, toctitle, title);
-      let id = prop_str!(props, "id");
-      let clean_id = id; // TODO: CleanID($id);
-      document.open_element(
-        &s!("ltx:{}", stype),
+      let clean_id = prop_str!(props,"id"); // TODO: CleanID($id);
+      document.open_element(&s!("ltx:{}", stype),
         Some(string_map!("xml:id" => clean_id, "inlist" => inlist)),
         None,
         state,
@@ -314,17 +302,24 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
       if !toctitle.is_empty() {
         document.insert_element("ltx:toctitle", toctitle, None, state)?;
       }
-    }
-  );
-  //   properties => sub {
-  //     my ($stomach, $type, $inlist, $toctitle, $title) = @_;
-  //     my %props     = RefStepCounter(ToString($type));
-  //     my $xtitle    = Digest(Invocation(T_CS('\lx@format@title@@'), $type, $title));
-  // my $xtoctitle = Digest(Invocation(T_CS('\lx@format@toctitle@@'), $type, $toctitle ||
-  // $title));     $props{title}    = $xtitle;
-  //     $props{toctitle} = $xtoctitle
-  //       if $xtoctitle && $xtoctitle->unlist && (ToString($xtoctitle) ne ToString($xtitle));
-  //     return %props; });
+    },
+    properties => properties!(stomach, args, state, {
+      unpack!(args => stype, inlist, toctitle_arg, title);
+      let mut props = ref_step_counter(stype.to_string(), state);
+      let toctitle = if toctitle_arg.to_string().is_empty() {
+        toctitle_arg
+      } else {
+        title
+      };
+      let xtitle    = stomach.digest(Invocation!(T_CS!("\\lx@format@title@@"), stype, title))?;
+      let xtoctitle = stomach.digest(Invocation!(T_CS!("\\lx@format@toctitle@@"), stype, toctitle))?;
+      props.set(s!("title"), xtitle.into());
+      if xtoctitle.to_string() != xtitle.to_string() {
+        props.set(s!("toctitle"), xtoctitle.int());
+      }
+      props
+    })
+ );
 
   // # No tags, at all? Consider...
   // DefConstructor('\@@unnumbered@section{} Undigested OptionalUndigested Undigested', sub {

--- a/rtx/src/package/pool/latex_hook.rs
+++ b/rtx/src/package/pool/latex_hook.rs
@@ -37,10 +37,12 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
     "\\typeout",
     "\\begin",
     "\\listfiles",
-  ].into_iter()
+  ]
+    .into_iter()
     .map(|s| s.to_string())
   {
-    DefMacroI!(T_CS!(ltxtrigger), None, move |_gullet, _args, state| {
+    let inner_ltxtrigger = ltxtrigger.clone();
+    DefMacroI!(T_CS!(ltxtrigger), None, sub[ _gullet, _args, state] {
       input_definitions(
         "LaTeX",
         InputDefinitionOptions {
@@ -49,7 +51,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
         },
         state,
       )?;
-      Ok(Tokens!(T_CS!(ltxtrigger)))
+      Ok(Tokens!(T_CS!(inner_ltxtrigger)))
     });
   }
 

--- a/rtx/src/package/pool/tex_appendix_b.rs
+++ b/rtx/src/package/pool/tex_appendix_b.rs
@@ -96,11 +96,11 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
   DefPrimitiveI!("\\nonfrenchspacing", noprimitive!());
   // DefMacroI!("\\normalbaselines", undef,
   //   '\lineskip=\normallineskip\baselineskip=\normalbaselineskip\lineskiplimit=\normallineskiplimit');
-  DefMacroT!(T_CS!("\\space"), None, T_SPACE!());
-  DefMacroT!(T_CS!("\\lq"), None, T_OTHER!("`"));
-  DefMacroT!(T_CS!("\\rq"), None, T_OTHER!("'"));
+  DefMacroI!(T_CS!("\\space"), None, T_SPACE!());
+  DefMacroI!(T_CS!("\\lq"), None, T_OTHER!("`"));
+  DefMacroI!(T_CS!("\\rq"), None, T_OTHER!("'"));
   Let!("\\empty", "\\@empty");
-  // DefMacroT!(T_CS!("\\null"), None, "\hbox{}");
+  //DefMacro!("\\null", "\hbox{}");
   Let!("\\bgroup", T_BEGIN!());
   Let!("\\egroup", T_END!());
   Let!("\\endgraf", "\\par");
@@ -109,7 +109,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
   DefPrimitiveI!("\\endline", noprimitive!());
 
   // Use \r for the newline from TeX!!!
-  DefMacroT!(T_CS!("\\\r"), None, T_CS!("\\ ")); // \<cr> == \<space> Interesting (see latex.ltx)
+  DefMacroI!(T_CS!("\\\r"), None, T_CS!("\\ ")); // \<cr> == \<space> Interesting (see latex.ltx)
   Let!(T_ACTIVE!("\r"), "\\par"); // (or is this just LaTeX?)
 
   Let!("\\\t", "\\\r"); // \<tab> == \<space>, also

--- a/rtx/src/package/pool/tex_expandable_primitives.rs
+++ b/rtx/src/package/pool/tex_expandable_primitives.rs
@@ -3,7 +3,7 @@ use package::*;
 pub fn load_definitions(state: &mut State) -> Result<()> {
   SetupBindingMacros!(state);
 
-  DefConditional!("\\ifx Token Token", gullet, args, inner_state, {
+  DefConditional!("\\ifx Token Token", sub[gullet, args, inner_state] {
     if let Some(token1) = args[0].tokens.first() {
       if let Some(token2) = args[1].tokens.first() {
         let xequals = XEquals!(token1, token2, inner_state);

--- a/rtx/src/package/pool/tex_para.rs
+++ b/rtx/src/package/pool/tex_para.rs
@@ -46,7 +46,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
       }
       Ok(Vec::new())
     }),
-    properties => skippable_props,
+    properties => properties!(skippable_props),
     alias => Some(s!("\\par\n"))
   );
 

--- a/rtx/src/package/pool/tex_para.rs
+++ b/rtx/src/package/pool/tex_para.rs
@@ -133,7 +133,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
 
   // TODO: Move to the right place in the pool definitions (maybe split out individual sub-pools by
   // chapter?)
-  DefMacroT!(T_CS!("\\space"), None, T_SPACE!());
+  DefMacroI!(T_CS!("\\space"), None, T_SPACE!());
 
   Ok(())
 }

--- a/rtx/src/package/pool/tex_para.rs
+++ b/rtx/src/package/pool/tex_para.rs
@@ -1,5 +1,4 @@
 use package::*;
-use rtx_core::document::tag::TagConstructionClosure;
 
 pub fn load_definitions(state: &mut State) -> Result<()> {
   SetupBindingMacros!(state);
@@ -18,7 +17,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
   let mut skippable_props: HashMap<String, Stored> = HashMap::new();
   skippable_props.insert(s!("alignmentSkippable"), true.into());
 
-  DefConstructorI!(T_CS!("\\par"), None, replacement!(document, args, props, state, {
+  DefConstructor!("\\par", sub[document, args, props, state] {
       let in_preamble = prop_bool!(props, "inPreamble");
       if !in_preamble {
         document.maybe_close_element("ltx:p", state)?;
@@ -33,7 +32,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
         }
         document.maybe_close_element("ltx:para", state)?;
      }
-    }),
+    },
     after_digest => aftersub!(stomach, whatsit, state, {
       let in_preamble = state.lookup_bool("inPreamble");
       if in_preamble {
@@ -53,16 +52,12 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
 
   // OTOH, sometimes \par is just a minimalistic "start a new line"
   // This should be closer for those cases.
-  DefConstructorI!(
-    T_CS!("\\inner@par"),
-    None,
-    replacement!(document, args, props, state, {
+  DefConstructor!("\\inner@par", sub[document, args, props, state] {
       if document.maybe_close_element("ltx:p", state)?.is_some() {
       } else if document.can_contain(document.get_node(), "ltx:break", state) {
         document.insert_element("ltx:break", Vec::new(), None, state)?;
       }
-    })
-  );
+    });
 
   fn do_def(
     globally: bool,
@@ -130,7 +125,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
   );
 
   Tag!("ltx:para", auto_close => true, auto_open => true);
-
+  use rtx_core::document::tag::TagConstructionClosure;
   let trim_node_whitespace_closure: Vec<TagConstructionClosure> = tagsub!(document, node, state, {
     document.trim_node_whitespace(node)?;
   });

--- a/rtx/src/package/pool/tex_setup.rs
+++ b/rtx/src/package/pool/tex_setup.rs
@@ -19,7 +19,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
   if !state.documentid.is_empty() {
     let docid = state.documentid.clone();
     // Wrap in T_OTHER so funny chars don't screw up (no space!)
-    DefMacroT!(T_CS!("\\thedocument@ID"), None, T_OTHER!(docid));
+    DefMacroI!(T_CS!("\\thedocument@ID"), None, T_OTHER!(docid));
   } else {
     Let!("\\thedocument@ID", "\\@empty");
   }

--- a/rtx/src/package/setup.rs
+++ b/rtx/src/package/setup.rs
@@ -759,7 +759,7 @@ macro_rules! SetupBindingMacros {($state:ident) => (
    })
   }
 
-  macro_rules! DefConstructor(
+  macro_rules! DefConstructor (
     // Code replacement flavors
    ($proto:expr, sub [ $document:ident, $args:ident, $props:ident, $inner_state:ident ] $body:block) => (DefConstructor!($proto, sub [ $document, $args, $props, $inner_state ] $body, $state));
    ($proto:expr, sub [ $document:ident, $args:ident, $props:ident, $inner_state:ident ] $body:block,
@@ -1717,6 +1717,14 @@ macro_rules! SetupBindingMacros {($state:ident) => (
   macro_rules! RefStepCounter {
     ($ctr:expr, $noreset:expr, $gullet:ident) => (RefStepCounter!($ctr, $noreset, $gullet, $state));
     ($ctr:expr, $noreset:expr, $gullet:ident, $state_arg:ident) => (ref_step_counter($ctr, $noreset, $gullet, $state_arg));
+  }
+
+  /// Invocation(<list of Token>); builds a representation of a command sequence invoked on its
+  /// arguments
+  macro_rules! Invocation {
+    ($token:expr, $args:expr) => {
+      build_invocation($token, $args, $state)
+    };
   }
 
 )}

--- a/rtx/src/package/setup.rs
+++ b/rtx/src/package/setup.rs
@@ -766,6 +766,33 @@ macro_rules! SetupBindingMacros {($state:ident) => (
   }
 
   macro_rules! DefConstructor(
+    // Code replacement flavors
+   ($proto:expr, sub [ $document:ident, $args:ident, $props:ident, $inner_state:ident ] $body:block) => (DefConstructor!($proto, sub [ $document, $args, $props, $inner_state ] $body, $state));
+   ($proto:expr, sub [ $document:ident, $args:ident, $props:ident, $inner_state:ident ] $body:block,
+      $key1:ident => $val1:expr) => (DefConstructor!($proto, sub [ $document, $args, $props, $inner_state ] $body, $key1 => $val1, $state));
+    ($proto:expr, sub [ $document:ident, $args:ident, $props:ident, $inner_state:ident ] $body:block,
+      $key1:ident => $val1:expr,
+      $key2:ident => $val2:expr) => (DefConstructor!($proto, sub [ $document, $args, $props, $inner_state ] $body, $key1 => $val1, $key2=>$val2, $state));
+    ($proto:expr, sub [ $document:ident, $args:ident, $props:ident, $inner_state:ident ] $body:block,
+      $key1:ident => $val1:expr,
+      $key2:ident => $val2:expr,
+      $key3:ident => $val3:expr) => (DefConstructor!($proto, sub [ $document, $args, $props, $inner_state ] $body, $key1 => $val1, $key2=>$val2, $key3=>$val3, $state));
+    // with explicit state
+    ($proto:expr, sub [ $document:ident, $args:ident, $props:ident, $inner_state:ident ] $body:block, $state_arg:ident) => (
+      DefConstructorWO!($proto, $document, $args, $props, $inner_state, $body, ConstructorOptions::default(), $state_arg));
+    ($proto:expr, sub [ $document:ident, $args:ident, $props:ident, $inner_state:ident ] $body:block,
+      $key1:ident => $val1:expr, $state_arg:ident ) => (
+      DefConstructorWO!($proto, $document, $args, $props, $inner_state, $body, NewDefault!(ConstructorOptions,$key1=>$val1), $state_arg));
+    ($proto:expr, sub [ $document:ident, $args:ident, $props:ident, $inner_state:ident ] $body:block,
+      $key1:ident => $val1:expr,
+      $key2:ident => $val2:expr, $state_arg:ident ) => (
+      DefConstructorWO!($proto, $document, $args, $props, $inner_state, $body, NewDefault!(ConstructorOptions,$key1=>$val1, $key2=>$val2), $state_arg));
+    ($proto:expr, sub [ $document:ident, $args:ident, $props:ident, $inner_state:ident ] $body:block,
+      $key1:ident => $val1:expr,
+      $key2:ident => $val2:expr,
+      $key3:ident => $val3:expr, $state_arg:ident ) => (
+      DefConstructorWO!($proto, $document, $args, $props, $inner_state, $body, NewDefault!(ConstructorOptions,$key1=>$val1, $key2=>$val2, $key3=>$val3), $state_arg));
+
     // String replacement flavors
     ($cs:expr, $replacement:expr) => (DefConstructor!($cs, $replacement, $state));
     ($cs:expr, $replacement:expr,

--- a/rtx/src/package/setup.rs
+++ b/rtx/src/package/setup.rs
@@ -271,64 +271,66 @@ macro_rules! SetupBindingMacros {($state:ident) => (
     ($class:expr, $options:expr, $after:expr, $state_arg:ident) => (load_class($class, $options, $after, $state_arg))
   }
   macro_rules! DefMacroI(
+    // With explicit state
+    // TODO: Propagate options, such as "locked", etc
+    // Expansion closure syntax + explicit state
+    ($cs:expr, $paramlist:expr, sub [ $gullet:ident, $args:ident, $inner_state:ident ] $body:block, $state_arg:ident) => {
+      let expansion_closure : Option<ExpansionClosure> = Some(Rc::new(move |$gullet, $args, $inner_state| $body));
+      def_macro($cs, $paramlist, expansion_closure, $state_arg); };
+    ($cs:expr, $paramlist:expr, sub [ $gullet:ident, $args:ident, $inner_state:ident ] $body:block, $key1:ident=>$val1:expr, $state_arg:ident) => {
+      let expansion_closure : Option<ExpansionClosure> = Some(Rc::new(move |$gullet, $args, $inner_state| $body));
+      def_macro($cs, $paramlist, expansion_closure, $state_arg); };
+    // Without explicit state
+    // Expansion closure syntax
+    ($cs:expr, $paramlist:expr, sub [$gullet:ident, $args:ident, $inner_state:ident ] $body:block) =>
+        (DefMacroI!($cs, $paramlist, sub [$gullet, $args, $inner_state] $body, $state));
+    ($cs:expr, $paramlist:expr, sub [$gullet:ident, $args:ident, $inner_state:ident ] $body:block, $key1:ident=>$val1:expr) =>
+        (DefMacroI!($cs, $paramlist, sub [ $gullet, $args, $inner_state ] $body, $key1=>$val1, $state));
+
+    // With explicit state
+    // TODO: Propagate options, such as "locked", etc
+    // Simple Expression syntax + explicit state
+    ($cs:expr, $paramlist:expr, None, $state_arg:ident) => (def_macro($cs, $paramlist, None, $state_arg));
+    ($cs:expr, $paramlist:expr, $expansion:expr, $state_arg:ident) => (def_macro($cs, $paramlist, $expansion, $state_arg));
+    ($cs:expr, $paramlist:expr, $expansion:expr, $key1:ident=>$val1:expr, $state_arg:ident) => (def_macro($cs, $paramlist, $expansion, $state_arg));
+
+    // Simple Expression syntax
+    ($cs:expr, $paramlist:expr, None) => (DefMacroI!($cs, $paramlist, None, $state));
     ($cs:expr, $paramlist:expr, $expansion:expr) => (DefMacroI!($cs, $paramlist, $expansion, $state));
     ($cs:expr, $paramlist:expr, $expansion:expr, $key1:ident=>$val1:expr) => (DefMacroI!($cs, $paramlist, $expansion, $key1=>$val1, $state));
 
-    // With explicit state
-    // TODO: package::coerce_cs on $cs
-    ($cs:expr, $paramlist:expr, None, $state_arg:expr) => (def_macro($cs, $paramlist, None, $state_arg));
-    ($cs:expr, $paramlist:expr, $expansion:expr, $state_arg:expr) => (def_macro($cs, $paramlist, Some(Rc::new($expansion)), $state_arg));
-    // TODO: Use the definitional options such as "locked"
-    ($cs:expr, $paramlist:expr, $expansion:expr, $key1:ident=>$val1:expr, $state_arg:expr) => (def_macro($cs, $paramlist, Some(Rc::new($expansion)), $state_arg));
-  );
-
-  macro_rules! DefMacroT(
-    // $body is an ungrouped stream of Token literals, which will be then grouped by Tokens!
-    ($cs:expr, $paramlist:expr, $arg:expr) => (DefMacroT!($cs, $paramlist, $arg, $state));
-    ($cs:expr, $paramlist:expr, $body:expr, $state_arg:ident) => ({
-      DefMacroI!($cs, $paramlist, move |_gullet, _args, _state| {Ok(Tokens!($body))}, $state_arg)
-    });
-    // with 1 key=>val param
-    ($cs:expr, $paramlist:expr, $arg:expr, $key1:ident => $val1:expr) => (DefMacroT!($cs, $paramlist, $arg, $key1=>$val1, $state));
-    ($cs:expr, $paramlist:expr, $body:expr,$key1:ident => $val1:expr, $state_arg:ident) => ({
-      DefMacroI!($cs, $paramlist, move |_gullet, _args, _state| {Ok(Tokens!($body))}, $key1=>$val1, $state_arg)
-    });
-  );
-
-  macro_rules! DefMacroTS(
-    // $body is a Tokens-typed expression | TODO: Ideally we want to improve the Tokens! macro to be a no-op when nothing to do
-    ($cs:expr, $paramlist:expr, $arg:expr) => (DefMacroTS!($cs, $paramlist, $arg, $state));
-    ($cs:expr, $paramlist:expr, $body:expr, $state_arg:ident) => ({
-      DefMacroI!($cs, $paramlist, move |_gullet, _args, _state| {Ok($body)}, $state_arg)
-    });
-    // with 1 key=>val param
-    ($cs:expr, $paramlist:expr, $arg:expr, $key1:ident=>$val1:expr) => (DefMacroTS!($cs, $paramlist, $arg, $key1=>$val1,$state));
-    ($cs:expr, $paramlist:expr, $body:expr, $key1:ident=>$val1:expr, $state_arg:ident) => ({
-      DefMacroI!($cs, $paramlist, move |_gullet, _args, _state| {Ok($body)}, $key1=>$val1, $state_arg)
-    });
   );
 
   macro_rules! DefMacro {
-    // String form
-    ($proto:expr, $expansion:expr) => (DefMacroWO!($proto, $expansion, ExpandableOptions::default()));
-    ($proto:expr, $expansion:expr, $key1:ident=>$val1:expr) => (
-      DefMacroWO!($proto, $expansion, NewDefault!(ExpandableOptions, $key1=>$val1)));
-    // string; explicit state
-    ($proto:expr, $expansion:expr,$state_arg:ident) => (DefMacroWO!($proto, $expansion, ExpandableOptions::default(), $state_arg));
     // Closure form
-    ($proto:expr, $gullet:ident, $args:ident, $inner_state:ident, $block:expr) => (
-      DefMacroWO!($proto, $gullet, $args, $inner_state, $block, None)
+    ($proto:expr, sub [ $gullet:ident, $args:ident, $inner_state:ident ] $body:block) => (
+      DefMacroWO!($proto, sub [$gullet, $args, $inner_state] $body, ExpandableOptions::default(), $state)
     );
-    ($proto:expr, $gullet:ident, $args:ident, $inner_state:ident, $block:expr, $key1:ident=>$val1:expr) => (
-      DefMacroWO!($proto, $gullet, $args, $inner_state, $block, NewDefault!(ExpandableOptions, $key1=>$val1))
+    ($proto:expr, sub [ $gullet:ident, $args:ident, $inner_state:ident ] $body:block, $key1:ident=>$val1:expr) => (
+      DefMacroWO!($proto, sub[$gullet, $args, $inner_state] $body, NewDefault!(ExpandableOptions, $key1=>$val1))
     );
     // closure; explicit state
-    ($proto:expr, $gullet:ident, $args:ident, $inner_state:ident, $block:expr, $state_arg:ident) => (
-      DefMacroWO!($proto, $gullet, $args, $inner_state, $block, None, $state_arg);
+    ($proto:expr, sub [ $gullet:ident, $args:ident, $inner_state:ident ] $body:block, $state_arg:ident) => (
+      DefMacroWO!($proto, sub[$gullet, $args, $inner_state] $body, ExpandableOptions::default(), $state_arg);
     );
+    // String form
+    ($proto:expr, $expansion:expr) => (DefMacroWO!($proto, $expansion, ExpandableOptions::default()));
+    ($proto:expr, $expansion:expr, $key1:ident=>$val1:expr) =>
+      (DefMacroWO!($proto, $expansion, NewDefault!(ExpandableOptions, $key1=>$val1)));
+    // string; explicit state
+    ($proto:expr, $expansion:expr,$state_arg:ident) => (DefMacroWO!($proto, $expansion, ExpandableOptions::default(), $state_arg));
   }
 
   macro_rules! DefMacroWO(
+    // Rust closure expansion form
+    ($proto:expr, sub [ $gullet:ident, $args:ident, $inner_state:ident ] $body:block, $options:expr, $state_arg:ident) => {
+      let (cs, paramlist) = parse_prototype($proto, $state_arg)?;
+      let expansion_closure : Option<ExpansionClosure> = Some(Rc::new(|$gullet: &mut Gullet, $args: Vec<Tokens>, $inner_state:&mut State| $body));
+      // TODO: Also pass in options
+      def_macro(cs, paramlist, expansion_closure, $state_arg);
+    };
+    ($proto:expr, sub [ $gullet:ident, $args:ident, $inner_state:ident ] $body:block, $options:expr) => (
+      DefMacroWO!($proto, sub [ $gullet, $args, $inner_state ] $body, $options, $state));
     // String expansion forms
     ($proto:expr, $expansion:expr, $options:expr) => (DefMacroWO!($proto, $expansion, $options, $state));
     ($proto:expr, $expansion:expr, $options:expr, $state_arg:ident) => ({
@@ -338,31 +340,23 @@ macro_rules! SetupBindingMacros {($state:ident) => (
       // TODO: Also pass in options
       def_macro(cs, paramlist, expansion, $state_arg);
     });
-    // Rust closure expansion form
-    ($proto:expr, $gullet:ident, $args:ident, $inner_state:ident, $block:expr, $options:expr) => (
-      DefMacroWO!($proto, $gullet, $args, $inner_state, $block, $options, $state));
-    ($proto:expr, $gullet:ident, $args:ident, $inner_state:ident, $block:expr, $options:expr, $state_arg:ident) => ({
-      let (cs, paramlist) = parse_prototype($proto, $state_arg)?;
-      // TODO: Also pass in options
-      def_macro(cs, paramlist, Some(Rc::new(|$gullet, $args, $inner_state| {$block})), $state_arg);
-    })
   );
 
   macro_rules! DefConditional(
     // test is always a rust closure
-    ($proto:expr, $gullet:ident, $args:ident, $inner_state:ident, $block:expr) => (DefConditional!($proto, $gullet, $args, $inner_state, $block, $state));
-    ($proto:expr, $gullet:ident, $args:ident, $inner_state:ident, $block:expr, $state_arg:ident) => ({
+    ($proto:expr, $gullet:ident, $args:ident, $inner_state:ident, $body:block) => (DefConditional!($proto, $gullet, $args, $inner_state, $body, $state));
+    ($proto:expr, $gullet:ident, $args:ident, $inner_state:ident, $body:block, $state_arg:ident) => ({
       let (cs, paramlist) = parse_prototype($proto, $state_arg)?;
-      DefConditionalI!(cs, paramlist, $gullet, $args, $inner_state, $block, $state_arg)
+      DefConditionalI!(cs, paramlist, $gullet, $args, $inner_state, $body, $state_arg)
     })
   );
 
   macro_rules! DefConditionalI(
     // test is always a rust closure
-    ($cs:expr, $paramlist:expr, $gullet:ident, $args:ident, $inner_state:ident, $block:expr) =>
-      (DefConditionalI!($cs, $paramlist, $gullet, $args, $inner_state, $block, $state));
-    ($cs:expr, $paramlist:expr, $gullet:ident, $args:ident, $inner_state:ident, $block:expr, $state_arg:ident) => ({
-      let test : ConditionalClosure = Rc::new(|$gullet, $args, $inner_state| {$block});
+    ($cs:expr, $paramlist:expr, $gullet:ident, $args:ident, $inner_state:ident, $body:block) =>
+      (DefConditionalI!($cs, $paramlist, $gullet, $args, $inner_state, $body, $state));
+    ($cs:expr, $paramlist:expr, $gullet:ident, $args:ident, $inner_state:ident, $body:block, $state_arg:ident) => ({
+      let test : ConditionalClosure = Rc::new(|$gullet, $args, $inner_state| {$body});
       def_conditional($cs, $paramlist, Some(test), ConditionalOptions::default(), $state_arg);
     });
   );
@@ -963,7 +957,7 @@ macro_rules! SetupBindingMacros {($state:ident) => (
       compile_replacement!(compiled_replacement, $replacement);
       DefConstructorIWO!(cs, paramlist, compiled_replacement, $options, $state_arg);
     });
-    ($proto:expr, $document:ident, $args:ident, $props:ident, $inner_state:ident, $body:expr, $options:expr, $state_arg:ident) => ({
+    ($proto:expr, $document:ident, $args:ident, $props:ident, $inner_state:ident, $body:block, $options:expr, $state_arg:ident) => ({
       let compiled_replacement : Option<ReplacementClosure> = Some(Rc::new(replacement!($document, $args, $props, $inner_state, $body)));
       let (cs, paramlist) = parse_prototype($proto, $state_arg)?;
       DefConstructorIWO!(cs, paramlist, compiled_replacement, $options, $state_arg);
@@ -1171,7 +1165,7 @@ macro_rules! SetupBindingMacros {($state:ident) => (
       let current_environment_closure = beforeproc!(stomach, state, {
         AssignValue!("current_environment", env_name.clone(), None, state);
         let body = T_LETTER!(env_name.clone());
-        DefMacroT!(T_CS!("\\@currenvir"), None, body.clone(), state);
+        DefMacroI!(T_CS!("\\@currenvir"), None, body.clone(), state);
       });
       before_digest_env.push(current_environment_closure);
 
@@ -1697,14 +1691,14 @@ macro_rules! SetupBindingMacros {($state:ident) => (
   macro_rules! SetCounter {
     ($ctr:expr, $value:expr, None) => {
       AssignValue!(&s!("\\c@{}",$ctr), $value, Some(Scope::Global));
-      DefMacroTS!(T_CS!(s!("\\@{}@ID",$ctr)), None, Tokens::new(Explode!($value.value_of())),
+      DefMacroI!(T_CS!(s!("\\@{}@ID",$ctr)), None, Tokens::new(Explode!($value.value_of())),
                   scope => Some(Scope::Global)
       );
     };
     ($ctr:expr, $value:expr, $gullet:ident) => {
       AssignValue!(&s!("\\c@{}",$ctr), $value, Some(Scope::Global));
       AfterAssignment!($gullet);
-      DefMacroTS!(T_CS!(s!("\\@{}@ID",$ctr)), None, Tokens::new(Explode!($value.value_of())),
+      DefMacroI!(T_CS!(s!("\\@{}@ID",$ctr)), None, Tokens::new(Explode!($value.value_of())),
                   scope => Some(Scope::Global)
       );
     }

--- a/rtx/src/package/setup.rs
+++ b/rtx/src/package/setup.rs
@@ -344,18 +344,18 @@ macro_rules! SetupBindingMacros {($state:ident) => (
 
   macro_rules! DefConditional(
     // test is always a rust closure
-    ($proto:expr, $gullet:ident, $args:ident, $inner_state:ident, $body:block) => (DefConditional!($proto, $gullet, $args, $inner_state, $body, $state));
-    ($proto:expr, $gullet:ident, $args:ident, $inner_state:ident, $body:block, $state_arg:ident) => ({
+    ($proto:expr, sub [$gullet:ident, $args:ident, $inner_state:ident] $body:block) => (DefConditional!($proto, sub[$gullet, $args, $inner_state] $body, $state));
+    ($proto:expr, sub [$gullet:ident, $args:ident, $inner_state:ident] $body:block, $state_arg:ident) => ({
       let (cs, paramlist) = parse_prototype($proto, $state_arg)?;
-      DefConditionalI!(cs, paramlist, $gullet, $args, $inner_state, $body, $state_arg)
+      DefConditionalI!(cs, paramlist, sub[$gullet, $args, $inner_state] $body, $state_arg)
     })
   );
 
   macro_rules! DefConditionalI(
     // test is always a rust closure
-    ($cs:expr, $paramlist:expr, $gullet:ident, $args:ident, $inner_state:ident, $body:block) =>
+    ($cs:expr, $paramlist:expr, sub[$gullet:ident, $args:ident, $inner_state:ident] $body:block) =>
       (DefConditionalI!($cs, $paramlist, $gullet, $args, $inner_state, $body, $state));
-    ($cs:expr, $paramlist:expr, $gullet:ident, $args:ident, $inner_state:ident, $body:block, $state_arg:ident) => ({
+    ($cs:expr, $paramlist:expr, sub[$gullet:ident, $args:ident, $inner_state:ident] $body:block, $state_arg:ident) => ({
       let test : ConditionalClosure = Rc::new(|$gullet, $args, $inner_state| {$body});
       def_conditional($cs, $paramlist, Some(test), ConditionalOptions::default(), $state_arg);
     });

--- a/rtx/tests/000_unit_state.rs
+++ b/rtx/tests/000_unit_state.rs
@@ -248,9 +248,8 @@ fn install_definition_and_meaning() {
   };
   // Install a Definition
   state.install_definition(job_definition.clone(), None);
-  if let Some(Stored::Expandable(stored_definition)) = state.lookup_definition(&T_CS!("\\jobname"))
-  {
-    assert_eq!(stored_definition.cs, T_CS!("\\jobname"));
+  if let Some(stored_definition) = state.lookup_definition(&T_CS!("\\jobname")) {
+    assert_eq!(stored_definition.get_cs(), T_CS!("\\jobname"));
   } else {
     panic!("Failed to lookup installed definition!");
   }

--- a/rtx_core/src/common/number.rs
+++ b/rtx_core/src/common/number.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Number {
   number: i32,
 }

--- a/rtx_core/src/common/store.rs
+++ b/rtx_core/src/common/store.rs
@@ -9,6 +9,7 @@ use definition::constructor::Constructor;
 use definition::expandable::Expandable;
 use definition::math_primitive::MathPrimitive; //MathPrimitiveOptions
 use definition::primitive::Primitive;
+use definition::register::Register;
 use document::tag::TagData;
 use parameter::Parameter;
 use token::{Catcode, Token};
@@ -61,6 +62,7 @@ pub enum Stored {
   Conditional(Rc<Conditional>),
   Primitive(Rc<Primitive>),
   MathPrimitive(Rc<MathPrimitive>),
+  Register(Rc<Register>),
   // MathPrimitiveOptions(MathPrimitiveOptions), // Maybe later
   Constructor(Rc<Constructor>),
   Digested(Rc<::Digested>),
@@ -89,6 +91,7 @@ impl fmt::Debug for Stored {
       Constructor(ref _constructor) => write!(f, "<closure for constructor definition>"),
       Digested(ref digested) => write!(f, "{:?}", digested),
       Parameter(ref parameter) => write!(f, "{:?}", parameter),
+      Register(ref register) => write!(f, "{:?}", register),
       Font(ref font) => write!(f, "{:?}", font),
       Number(ref number) => write!(f, "{:?}", number),
       VecToken(ref token_vec) => write!(f, "{:?}", token_vec),

--- a/rtx_core/src/common/store.rs
+++ b/rtx_core/src/common/store.rs
@@ -289,3 +289,12 @@ impl<'a> From<&'a Stored> for Option<Catcode> {
     }
   }
 }
+
+impl<'a> From<&'a Stored> for Option<&'a Vec<char>> {
+  fn from(value: &'a Stored) -> Option<&'a Vec<char>> {
+    match value {
+      Stored::VecChar(ref cc) => Some(cc),
+      _ => None,
+    }
+  }
+}

--- a/rtx_core/src/common/store.rs
+++ b/rtx_core/src/common/store.rs
@@ -28,17 +28,35 @@ use tokens::Tokens;
 //    rather than requiring writing Stored::Primitive(Rc::new(p)) each time
 //    and equally importantly for unwrapping.
 
+// Basic principles:
+// 1. If the type is `Copy`, store directly
+// 2. If the type is intended as State-exclusive, store in a Box
+//      (or directly if any already Boxed datatype such as Vec, VecDeque)
+// 3. If the struct is intended for reuse/(mutation?!) in digestion components, store it in an Rc,
+//    e.g. Rc<Font>
+
 #[derive(Clone, PartialEq)]
 pub enum Stored {
-  // Primitives
+  // Primitives (Copy types, or cheap Clone)
   Bool(bool),
   String(String),
   Mathcode(usize),
   Int(i32),
-  // LaTeXML objects
+  // Collections (boxed)
+  VecChar(Vec<char>),
+  VecString(Vec<String>),
+  VecToken(Vec<Token>),
+  VecDigested(Vec<::Digested>),
+  HashStr(HashMap<String, String>),
+  VecDequeStored(VecDeque<Stored>),
+  HashStored(HashMap<String, Stored>),
+  HashTagData(HashMap<String, Vec<TagData>>),
+  // LaTeXML primitives (Copy types)
   Catcode(Catcode),
   Token(Token),
   Tokens(Tokens),
+  Number(Number),
+  // LaTeXML objects (Rc-wrapped)
   Expandable(Rc<Expandable>),
   Conditional(Rc<Conditional>),
   Primitive(Rc<Primitive>),
@@ -48,16 +66,6 @@ pub enum Stored {
   Digested(Rc<::Digested>),
   Parameter(Parameter),
   Font(Rc<Font>),
-  Number(Number),
-  // Collections
-  VecChar(Vec<char>),
-  VecString(Vec<String>),
-  VecToken(Vec<Token>),
-  VecDigested(Vec<::Digested>),
-  HashStr(HashMap<String, String>),
-  VecDequeStored(VecDeque<Stored>),
-  HashStored(HashMap<String, Stored>),
-  HashTagData(HashMap<String, Vec<TagData>>),
 }
 
 impl fmt::Debug for Stored {
@@ -116,11 +124,12 @@ impl From<Token> for Stored {
   fn from(value: Token) -> Self { Stored::Token(value) }
 }
 
+// Storing all definitions is expected - Rc<Expandable> case
+
 impl From<Tokens> for Stored {
   fn from(value: Tokens) -> Self { Stored::Tokens(value) }
 }
 
-/// Storing all definitions is expected - Rc<Expandable> case
 impl From<Rc<Expandable>> for Stored {
   fn from(definition: Rc<Expandable>) -> Self { Stored::Expandable(definition) }
 }
@@ -179,6 +188,10 @@ impl From<Number> for Stored {
   fn from(value: Number) -> Self { Stored::Number(value) }
 }
 
+impl<'a> From<&'a Token> for Stored {
+  fn from(value: &'a Token) -> Self { Stored::Token(value.clone()) }
+}
+
 impl From<Vec<char>> for Stored {
   fn from(value: Vec<char>) -> Self { Stored::VecChar(value) }
 }
@@ -209,4 +222,70 @@ impl From<HashMap<String, Stored>> for Stored {
 
 impl From<HashMap<String, Vec<TagData>>> for Stored {
   fn from(value: HashMap<String, Vec<TagData>>) -> Self { Stored::HashTagData(value) }
+}
+
+// Reverse direction -- cast Stored back into concrete types, with meaningfull fallbacks where
+// impossible
+
+impl<'a> From<&'a Stored> for bool {
+  fn from(value: &Stored) -> bool {
+    match value {
+      Stored::Bool(b) => *b,
+      _ => true,
+    }
+  }
+}
+
+impl<'a> From<&'a Stored> for String {
+  fn from(value: &Stored) -> String {
+    match value {
+      &Stored::String(ref v) => v.to_owned(),
+      v => s!("{:?}", v),
+    }
+  }
+}
+
+impl<'a> From<&'a Stored> for Option<&'a VecDeque<Stored>> {
+  fn from(value: &'a Stored) -> Option<&'a VecDeque<Stored>> {
+    match value {
+      Stored::VecDequeStored(ref v) => Some(v),
+      _ => None,
+    }
+  }
+}
+
+impl<'a> From<&'a Stored> for Option<Rc<Font>> {
+  fn from(value: &'a Stored) -> Option<Rc<Font>> {
+    match value {
+      Stored::Font(ref f) => Some(f.clone()),
+      _ => None,
+    }
+  }
+}
+
+impl<'a> From<&'a Stored> for Option<Number> {
+  fn from(value: &'a Stored) -> Option<Number> {
+    match value {
+      Stored::Number(ref n) => Some(*n),
+      _ => None,
+    }
+  }
+}
+
+impl<'a> From<&'a Stored> for Option<Tokens> {
+  fn from(value: &'a Stored) -> Option<Tokens> {
+    match value {
+      Stored::Tokens(ref ts) => Some(ts.clone()),
+      _ => None,
+    }
+  }
+}
+
+impl<'a> From<&'a Stored> for Option<Catcode> {
+  fn from(value: &'a Stored) -> Option<Catcode> {
+    match value {
+      Stored::Catcode(ref cc) => Some(*cc),
+      _ => None,
+    }
+  }
 }

--- a/rtx_core/src/definition/constructor.rs
+++ b/rtx_core/src/definition/constructor.rs
@@ -7,7 +7,8 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use definition::{
-  BeforeDigestClosure, ConstructionClosure, Definition, DigestionClosure, ReplacementClosure,
+  BeforeDigestClosure, ConstructionClosure, Definition, DigestionClosure, PropertiesClosure,
+  ReplacementClosure,
 };
 use document::Document;
 use gullet::Gullet;
@@ -31,7 +32,7 @@ pub struct ConstructorOptions {
   // environment-specific
   pub require_math: bool,
   pub forbid_math: bool,
-  pub properties: HashMap<String, Stored>,
+  pub properties: PropertiesClosure,
   pub capture_body: bool,
   pub font: Option<Font>,
 
@@ -57,7 +58,7 @@ impl Default for ConstructorOptions {
       // environment-specific
       require_math: false,
       forbid_math: false,
-      properties: HashMap::new(),
+      properties: Rc::new(|stomach, whatsit, state| Ok(HashMap::new())),
       capture_body: false,
       font: None,
       after_digest_begin: vec![],
@@ -134,7 +135,7 @@ impl Definition for Constructor {
 
     // Compute any extra Whatsit properties (many end up as element attributes)
 
-    let mut props = self.options.properties.clone();
+    let mut props = (self.options.properties)(stomach, &args, state)?;
     // for (key, value) in props.iter() {
     //   if (ref $value eq 'CODE') {
     //     $props{$key} = &$value($stomach, @args); } }

--- a/rtx_core/src/definition/expandable.rs
+++ b/rtx_core/src/definition/expandable.rs
@@ -59,7 +59,6 @@ impl Object for Expandable {
   fn is_definition(&self) -> bool { true }
   fn is_expandable(&self) -> bool { true }
 }
-
 impl Definition for Expandable {
   fn is_protected(&self) -> bool { self.is_protected }
   fn get_parameters(&self) -> &Option<Parameters> { &self.paramlist }

--- a/rtx_core/src/definition/mod.rs
+++ b/rtx_core/src/definition/mod.rs
@@ -25,6 +25,7 @@ pub type ExpansionClosure = Rc<Fn(&mut Gullet, Vec<Tokens>, &mut State) -> Resul
 pub type ConditionalClosure = Rc<Fn(&mut Gullet, Vec<Tokens>, &mut State) -> Result<bool>>;
 pub type PrimitiveClosure = Rc<Fn(&mut Stomach, Vec<Tokens>, &mut State) -> Result<Vec<Digested>>>;
 pub type BeforeDigestClosure = Rc<Fn(&mut Stomach, &mut State) -> Result<Vec<Digested>>>;
+pub type PropertiesClosure = Rc<Fn(&mut Stomach, Vec<Tokens>, &mut State) -> Result<HashMap<String, ObjectStore>>>;
 pub type DigestionClosure = Rc<Fn(&mut Stomach, &mut Whatsit, &mut State) -> Result<Vec<Digested>>>;
 pub type ReplacementClosure =
   Rc<Fn(&mut Document, &Vec<Option<Digested>>, &HashMap<String, Stored>, &mut State) -> Result<()>>;

--- a/rtx_core/src/definition/mod.rs
+++ b/rtx_core/src/definition/mod.rs
@@ -25,7 +25,8 @@ pub type ExpansionClosure = Rc<Fn(&mut Gullet, Vec<Tokens>, &mut State) -> Resul
 pub type ConditionalClosure = Rc<Fn(&mut Gullet, Vec<Tokens>, &mut State) -> Result<bool>>;
 pub type PrimitiveClosure = Rc<Fn(&mut Stomach, Vec<Tokens>, &mut State) -> Result<Vec<Digested>>>;
 pub type BeforeDigestClosure = Rc<Fn(&mut Stomach, &mut State) -> Result<Vec<Digested>>>;
-pub type PropertiesClosure = Rc<Fn(&mut Stomach, Vec<Tokens>, &mut State) -> Result<HashMap<String, ObjectStore>>>;
+pub type PropertiesClosure =
+  Rc<Fn(&mut Stomach, Vec<Tokens>, &mut State) -> Result<HashMap<String, Stored>>>;
 pub type DigestionClosure = Rc<Fn(&mut Stomach, &mut Whatsit, &mut State) -> Result<Vec<Digested>>>;
 pub type ReplacementClosure =
   Rc<Fn(&mut Document, &Vec<Option<Digested>>, &HashMap<String, Stored>, &mut State) -> Result<()>>;

--- a/rtx_core/src/definition/mod.rs
+++ b/rtx_core/src/definition/mod.rs
@@ -4,12 +4,15 @@ pub mod conditional;
 pub mod constructor;
 pub mod math_primitive;
 pub mod primitive;
+pub mod register;
 
 use std::collections::HashMap;
 use std::rc::Rc;
 
 use common::error::*;
+use common::object::Object;
 use common::store::Stored;
+
 use gullet::Gullet;
 use stomach::Stomach;
 use token::Token;
@@ -27,7 +30,7 @@ pub type PrimitiveFn = Fn(&mut Stomach, Vec<Tokens>, &mut State) -> Result<Vec<D
 pub type PrimitiveClosure = Rc<PrimitiveFn>;
 pub type BeforeDigestClosure = Rc<Fn(&mut Stomach, &mut State) -> Result<Vec<Digested>>>;
 pub type PropertiesClosure =
-  Rc<Fn(&mut Stomach, Vec<Tokens>, &mut State) -> Result<HashMap<String, Stored>>>;
+  Rc<Fn(&mut Stomach, &Vec<Option<Digested>>, &mut State) -> Result<HashMap<String, Stored>>>;
 pub type DigestionClosure = Rc<Fn(&mut Stomach, &mut Whatsit, &mut State) -> Result<Vec<Digested>>>;
 pub type ReplacementClosure =
   Rc<Fn(&mut Document, &Vec<Option<Digested>>, &HashMap<String, Stored>, &mut State) -> Result<()>>;
@@ -43,7 +46,7 @@ impl From<Tokens> for Option<ExpansionClosure> {
   }
 }
 
-pub trait Definition {
+pub trait Definition: Object {
   fn invoke(&self, gullet: &mut Gullet, state: &mut State) -> Result<Tokens>;
   fn invoke_primitive(
     &self,
@@ -77,7 +80,7 @@ pub trait Definition {
   fn to_string(&self) -> String { unimplemented!() }
 
   // Return the Tokens that would invoke the given definition with arguments.
-  fn invocation(&mut self, args: Vec<Token>, state: &mut State) -> Tokens {
+  fn invocation(&mut self, args: Vec<Tokens>, state: &mut State) -> Tokens {
     let mut invocation_result = Vec::new();
     invocation_result.push(self.get_cs());
 

--- a/rtx_core/src/definition/mod.rs
+++ b/rtx_core/src/definition/mod.rs
@@ -23,7 +23,8 @@ use whatsit::Whatsit;
 
 pub type ExpansionClosure = Rc<Fn(&mut Gullet, Vec<Tokens>, &mut State) -> Result<Tokens>>;
 pub type ConditionalClosure = Rc<Fn(&mut Gullet, Vec<Tokens>, &mut State) -> Result<bool>>;
-pub type PrimitiveClosure = Rc<Fn(&mut Stomach, Vec<Tokens>, &mut State) -> Result<Vec<Digested>>>;
+pub type PrimitiveFn = Fn(&mut Stomach, Vec<Tokens>, &mut State) -> Result<Vec<Digested>>;
+pub type PrimitiveClosure = Rc<PrimitiveFn>;
 pub type BeforeDigestClosure = Rc<Fn(&mut Stomach, &mut State) -> Result<Vec<Digested>>>;
 pub type PropertiesClosure =
   Rc<Fn(&mut Stomach, Vec<Tokens>, &mut State) -> Result<HashMap<String, Stored>>>;
@@ -31,6 +32,16 @@ pub type DigestionClosure = Rc<Fn(&mut Stomach, &mut Whatsit, &mut State) -> Res
 pub type ReplacementClosure =
   Rc<Fn(&mut Document, &Vec<Option<Digested>>, &HashMap<String, Stored>, &mut State) -> Result<()>>;
 pub type ConstructionClosure = Rc<Fn(&mut Document, &Whatsit, &mut State)>;
+
+impl From<Token> for Option<ExpansionClosure> {
+  fn from(t: Token) -> Option<ExpansionClosure> { Tokens!(t).into() }
+}
+
+impl From<Tokens> for Option<ExpansionClosure> {
+  fn from(t: Tokens) -> Option<ExpansionClosure> {
+    Some(Rc::new(move |gullet, args, state| Ok(t.clone())))
+  }
+}
 
 pub trait Definition {
   fn invoke(&self, gullet: &mut Gullet, state: &mut State) -> Result<Tokens>;

--- a/rtx_core/src/definition/register.rs
+++ b/rtx_core/src/definition/register.rs
@@ -12,7 +12,7 @@ use tokens::Tokens;
 use whatsit::Whatsit;
 use Digested;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Register {
   pub cs: Token,
   pub parameters: Option<Parameters>,
@@ -30,6 +30,9 @@ impl Default for Register {
     }
   }
 }
+impl PartialEq for Register {
+  fn eq(&self, other: &Register) -> bool { self.cs == other.cs }
+}
 
 impl Register {
   // `is_register` begs to be refactored into a better naming scheme
@@ -44,7 +47,7 @@ impl Definition for Register {
   // (other than afterassign)
   fn invoke(&self, gullet: &mut Gullet, state: &mut State) -> Result<Tokens> { Ok(Tokens!()) }
   // TODO:
-  fn get_parameters(&self) -> &Option<Parameters> { &self.paramlist }
+  fn get_parameters(&self) -> &Option<Parameters> { &self.parameters }
   fn get_cs(&self) -> Token { self.cs.clone() }
 
   fn get_cs_name(&self) -> String { self.cs.get_cs_name() }
@@ -70,6 +73,7 @@ impl Definition for Register {
     _state: &mut State,
   ) -> Result<()>
   {
+    Ok(())
   }
 }
 

--- a/rtx_core/src/gullet.rs
+++ b/rtx_core/src/gullet.rs
@@ -1,5 +1,4 @@
 use common::error::*;
-use common::object::Object;
 use common::store::Stored;
 use definition::Definition;
 use mouth::Mouth;
@@ -221,25 +220,20 @@ impl Gullet {
                 //   LaTeXML::Definition::stopProfiling($token, 'expand'); }
                 // }
                 _ => {
-                  let looked_up_definition: Option<Stored> = state.lookup_definition(&token);
-                  match looked_up_definition {
-                    Some(defn_store) => {
-                      match defn_store {
-                        Stored::Expandable(defn) => {
-                          if (*defn).is_expandable() && (toplevel || !(*defn).is_protected()) {
-                            // is this the right logic here? don't expand unless digesting?
-                            state.current_token = Some(token);
-                            defn_next = Some(defn.clone());
-                            expand_next = true;
-                          } else {
-                            return Ok(Some(token));
-                          }
-                        },
-                        _ => return Ok(Some(token)),
-                      }
-                    },
-                    None => return Ok(Some(token)),
-                  };
+                  let looked_up_definition: Option<Rc<Definition>> =
+                    state.lookup_definition(&token);
+                  if let Some(defn) = looked_up_definition {
+                    if (*defn).is_expandable() && (toplevel || !(*defn).is_protected()) {
+                      // is this the right logic here? don't expand unless digesting?
+                      state.current_token = Some(token);
+                      defn_next = Some(defn.clone());
+                      expand_next = true;
+                    } else {
+                      return Ok(Some(token));
+                    }
+                  } else {
+                    return Ok(Some(token));
+                  }
                 },
               };
             },

--- a/rtx_core/src/parameter.rs
+++ b/rtx_core/src/parameter.rs
@@ -268,7 +268,7 @@ pub struct Parameters {
 impl Parameters {
   pub fn get_num_args(&self) -> usize { self.params.iter().filter(|&p| !p.novalue).count() }
 
-  pub fn revert_arguments(&self, _args: Vec<Token>, _state: &mut State) -> Tokens {
+  pub fn revert_arguments(&self, _args: Vec<Tokens>, _state: &mut State) -> Tokens {
     // TODO
     Tokens!()
   }

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -618,53 +618,49 @@ impl State {
   /// A bit of Perl "existence as truth" semantics mixed in with proper boolean lookup
   pub fn lookup_bool(&self, key: &str) -> bool {
     match self.lookup_value(key) {
-      Some(&Stored::Bool(ref v)) => *v,
-      Some(_) => true,
+      Some(v) => v.into(),
       None => false,
     }
   }
 
   pub fn lookup_string(&self, key: &str) -> String {
     match self.lookup_value(key) {
-      Some(&Stored::String(ref v)) => v.to_owned(),
-      _ => String::new(),
+      Some(v) => v.into(),
+      None => String::new(),
     }
   }
 
   pub fn lookup_vecdeque<'lvdq>(&'lvdq self, key: &'lvdq str) -> Option<&VecDeque<Stored>> {
     match self.lookup_value(key) {
-      Some(&Stored::VecDequeStored(ref v)) => Some(v),
+      Some(v) => v.into(),
       _ => None,
     }
   }
 
   pub fn lookup_font(&self) -> Option<Rc<Font>> {
     match self.lookup_value("font") {
-      Some(&Stored::Font(ref f)) => Some(f.clone()), /* TODO: is this clone heavy/slow?
-                                                             * We can refactor into refs */
+      Some(f) => f.into(),
       _ => None,
     }
   }
+
   pub fn lookup_mathfont(&self) -> Option<Rc<Font>> {
     match self.lookup_value("mathfont") {
-      Some(&Stored::Font(ref f)) => Some(f.clone()), /* TODO: is this clone heavy/slow?
-                                                             * We can refactor into refs */
+      Some(v) => v.into(),
       _ => None,
     }
   }
 
   pub fn lookup_number(&self, key: &str) -> Option<Number> {
     match self.lookup_value(key) {
-      Some(&Stored::Number(ref n)) => Some(n.clone()), /* TODO: is this clone heavy/slow?
-                                                             * We can refactor into refs */
+      Some(v) => v.into(),
       _ => None,
     }
   }
 
   pub fn lookup_tokens(&self, key: &str) -> Option<Tokens> {
     match self.lookup_value(key) {
-      Some(&Stored::Tokens(ref ts)) => Some(ts.clone()), /* TODO: is this clone heavy/slow?
-                                                             * We can refactor into refs */
+      Some(v) => v.into(),
       _ => None,
     }
   }
@@ -802,7 +798,7 @@ impl State {
     match self.catcode.get(&c.to_string()) {
       None => None,
       Some(cvec) => match cvec.front() {
-        Some(&Stored::Catcode(ref cc)) => Some(*cc),
+        Some(cc) => cc.into(),
         _ => None,
       },
     }
@@ -921,7 +917,7 @@ impl State {
       // $defn = $$entry[0]; }
       Some(defn.front().unwrap().clone())
     } else {
-      Some(Stored::Token(token.clone()))
+      Some(token.into())
     }
   }
 
@@ -931,6 +927,7 @@ impl State {
     _definition: T,
   )
   {
+    unimplemented!()
   }
 
   /// And a shorthand for installing definitions
@@ -954,14 +951,9 @@ impl State {
 
     let cs_locked = cs.clone() + ":locked";
     // TODO, .is_none() should be a real false check
-    let is_cs_locked = match self.lookup_value(&cs_locked) {
-      Some(&Stored::Bool(ref x)) => *x,
-      _ => false,
-    };
-    let is_state_unlocked: bool = match self.lookup_value("UNLOCKED") {
-      Some(&Stored::Bool(ref x)) => *x,
-      _ => false,
-    };
+    let is_cs_locked = self.lookup_bool(&cs_locked);
+    let is_state_unlocked = self.lookup_bool("UNLOCKED");
+
     if is_cs_locked && !is_state_unlocked {
       if let Some(&Stored::String(ref s)) = self.lookup_value("SOURCEFILE") {
         // report if the redefinition seems to come from document source

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -865,7 +865,7 @@ impl State {
   /// Since we're not doing digestion here, we don't need to handle mathactive,
   /// nor cs let to executable tokens
   /// This returns a definition object, or undef
-  pub fn lookup_definition<'def>(&'def self, key: &'def Token) -> Option<Stored> {
+  pub fn lookup_definition<'def>(&'def self, key: &'def Token) -> Option<Rc<Definition>> {
     let cc = &key.code;
     let name = &key.text;
     let lookupname: String = if (cc == &Catcode::ACTIVE) || (cc == &Catcode::CS) {
@@ -879,8 +879,13 @@ impl State {
     } else {
       match self.meaning.get(&lookupname) {
         Some(defs) => match defs.front() {
-          Some(entry) => Some(entry.clone()),
-          None => None,
+          Some(Stored::Conditional(entry)) => Some(entry.clone()),
+          Some(Stored::Constructor(entry)) => Some(entry.clone()),
+          Some(Stored::Expandable(entry)) => Some(entry.clone()),
+          Some(Stored::MathPrimitive(entry)) => Some(entry.clone()),
+          Some(Stored::Primitive(entry)) => Some(entry.clone()),
+          Some(Stored::Register(entry)) => Some(entry.clone()),
+          _ => None,
         },
         _ => None,
       }
@@ -893,7 +898,8 @@ impl State {
     if name.is_empty() {
       return None;
     }
-    let lookupname = if (cc == &Catcode::ACTIVE) || (cc == &Catcode::CS)
+    let lookupname = if (cc == &Catcode::ACTIVE)
+      || (cc == &Catcode::CS)
       || ((cc == &Catcode::LETTER)
         || (cc == &Catcode::OTHER)
           && self.lookup_bool("IN_MATH")

--- a/rtx_core/src/tokens.rs
+++ b/rtx_core/src/tokens.rs
@@ -10,9 +10,6 @@ use stomach::Stomach;
 use token::*;
 use Digested;
 
-// Form a Tokens list of Token's
-// Flatten the arguments Token's and Tokens's into plain Token's
-// .... Efficiently! since this seems to be called MANY times.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Tokens {
   pub tokens: Vec<Token>,
@@ -26,6 +23,11 @@ impl ToTokens for Tokens {
     self.tokens.to_tokens(tokens);
     tokens.append("}");
   }
+}
+
+// We also need convenient auxiliaries, including auto-casting
+impl From<Vec<Token>> for Tokens {
+  fn from(ts: Vec<Token>) -> Tokens { Tokens::new(ts) }
 }
 
 #[macro_export]


### PR DESCRIPTION
(while fleshing out sectioning infrastructure)

This is a work in progress and may not even compile on individual commits, as there are too many moving pieces.

Key goals (for my own memory):
 * Allow dual-typed signatures for `DefConstructor!` replacements, where strings are compiled and closures are accepted as-is.
 * Similarly allow a dual-typed HashMap vs closure for properties.

After this the PR can be merged and the sectioning support flesh-out can continue on a new branch.