### PR TITLE
AfterAssignment and DefRegister support

### DIFF
--- a/rtx/src/converter.rs
+++ b/rtx/src/converter.rs
@@ -44,7 +44,7 @@ impl Converter {
     self.ready = true;
     Ok(())
   }
-  pub fn state_mut(&mut self) -> &mut State { self.core.state_mut() }
+  pub fn state_mut(&mut self) -> &mut State { self.core.get_state_mut() }
   pub fn bind_log(&mut self) {
     // TODO
   }

--- a/rtx/src/core.rs
+++ b/rtx/src/core.rs
@@ -204,13 +204,13 @@ impl DigestionAPI for Core {
     let mut boxes = Vec::new();
     let mut state = &mut self.state;
 
-    while self.stomach.get_gullet().has_more_input() {
-      let next_bodies: Vec<Digested> = self.stomach.digest_next_body(false, state)?;
+    while self.stomach.borrow().get_gullet().has_more_input() {
+      let next_bodies: Vec<Digested> = self.stomach.borrow_mut().digest_next_body(false, state)?;
       for body in next_bodies {
         boxes.push(body);
       }
     }
-    self.stomach.get_gullet_mut().flush(state);
+    self.stomach.borrow_mut().get_gullet_mut().flush(state);
     Ok(Digested::List(Box::new(List::new(boxes))))
   }
 

--- a/rtx/src/macros/mod.rs
+++ b/rtx/src/macros/mod.rs
@@ -21,6 +21,7 @@ macro_rules! compile_replacement {
 macro_rules! compile_expansion {
   ($var:ident, $expansion:expr) => {{
     use rtx_core::definition::ExpansionClosure;
+    use rtx_core::token::Catcode;
     #[derive(CompileExpansion)]
     #[compile_expansion_options(expansion=$expansion)]
     struct _DummyE;

--- a/rtx/src/macros/mod.rs
+++ b/rtx/src/macros/mod.rs
@@ -21,7 +21,9 @@ macro_rules! compile_replacement {
 macro_rules! compile_expansion {
   ($var:ident, $expansion:expr) => {{
     use rtx_core::definition::ExpansionClosure;
+    #[allow(unused_imports)]
     use rtx_core::token::Catcode;
+
     #[derive(CompileExpansion)]
     #[compile_expansion_options(expansion=$expansion)]
     struct _DummyE;

--- a/rtx/src/package/functions.rs
+++ b/rtx/src/package/functions.rs
@@ -1102,3 +1102,25 @@ pub fn build_invocation(token: Token, args: Vec<Tokens>, state: &mut State) -> T
     Tokens::new(invoked_tokens)
   }
 }
+
+pub fn do_expand(
+  tokens: Tokens,
+  outer_gullet: &mut Gullet,
+  outer_state: &mut State,
+) -> Result<Tokens>
+{
+  outer_gullet.reading_from_mouth(
+    Mouth::default(),
+    outer_state,
+    Box::new(
+      move |expand_gullet: &mut Gullet, expand_state: &mut State| -> Result<Tokens> {
+        expand_gullet.unread(tokens.clone());
+        let mut expanded = Vec::new();
+        while let Some(t) = expand_gullet.read_x_token(false, false, expand_state)? {
+          expanded.push(t);
+        }
+        Ok(Tokens::new(expanded))
+      },
+    ),
+  )
+}

--- a/rtx/src/package/functions.rs
+++ b/rtx/src/package/functions.rs
@@ -871,7 +871,7 @@ pub fn counter_value(ctr: &str, state: &mut State) -> Number {
 pub fn add_to_counter(ctr: &str, value: Number, gullet: &mut Gullet, state: &mut State) {
   let v = counter_value(ctr, state).add(value);
   state.assign_value(&s!("\\c@{}", ctr), v.clone(), Some(Scope::Global));
-  after_assignment(gullet, state);
+  gullet.after_assignment(state);
   SetupBindingMacros!(state);
   let id_cs = T_CS!(s!("\\@{}@ID", ctr));
   DefMacroI!(id_cs.clone(), None, Tokens::new(Explode!(v.value_of())),
@@ -894,7 +894,7 @@ pub fn step_counter(
   );
   {
     let gullet = stomach.get_gullet_mut();
-    after_assignment(gullet, state);
+    gullet.after_assignment(state);
   }
   let token_value = Tokens::new(Explode!(counter_value(ctr, state).value_of()));
   DefMacroI!(T_CS!(s!("\\@{}@ID",ctr)), None, 
@@ -1030,12 +1030,6 @@ fn reset_counter(ctr: &str, state: &mut State) {
   }
 
   return;
-}
-
-fn after_assignment(gullet: &mut Gullet, state: &mut State) {
-  if let Some(Stored::Tokens(after)) = state.remove_value("afterAssignment") {
-    gullet.unread(after); // primitive returns boxes, so these need to be digested!
-  }
 }
 
 pub fn build_invocation(token: Token, args: Vec<Tokens>, state: &mut State) -> Tokens {

--- a/rtx/src/package/functions.rs
+++ b/rtx/src/package/functions.rs
@@ -535,12 +535,14 @@ pub fn def_macro<T: Into<Option<ExpansionClosure>>>(
 pub struct RegisterOptions {
   pub getter: Option<RegisterGetterClosure>,
   pub setter: Option<RegisterSetterClosure>,
+  pub readonly: bool,
 }
 impl Default for RegisterOptions {
   fn default() -> Self {
     RegisterOptions {
       getter: None,
       setter: None,
+      readonly: false,
     }
   }
 }
@@ -639,16 +641,20 @@ pub fn def_conditional(
 
 pub fn def_register<T: Into<RegisterValue>>(
   cs: Token,
-  paramlist: Option<Parameters>,
+  parameters: Option<Parameters>,
   value: T,
   options: Option<RegisterOptions>,
   state: &mut State,
 )
 {
+  let options: RegisterOptions = options.unwrap_or_else(|| RegisterOptions::default());
   let value: RegisterValue = value.into();
   let name = cs.to_string();
-  let rtype: RegisterType = (&value).into();
-  let options = options.unwrap_or(RegisterOptions::default());
+  let register_type: RegisterType = (&value).into();
+  // Prepare clones to move into closures
+  let getter_value = value.clone();
+  let setter_name = name.clone();
+
   let getter: RegisterGetterClosure = match options.getter {
     Some(getter) => getter.clone(),
     None => Rc::new(move |args: Vec<Token>, state: &mut State| -> Stored {
@@ -659,25 +665,48 @@ pub fn def_register<T: Into<RegisterValue>>(
         .join("");
       match state.lookup_value(&(name.clone() + &args_string)) {
         Some(v) => v.clone(),
-        None => value.clone().into(),
+        None => getter_value.clone().into(),
       }
     }),
   };
+  let readonly = options.readonly;
 
-  //   my $setter = $options{setter}
-  //     || ($options{readonly}
-  //     ? sub { my ($v, @args) = @_;
-  //       Warn('unexpected', $name, $STATE->getStomach,
-  //         "Can't assign to register $name"); return; }
-  //     : sub { my ($v, @args) = @_;
-  //       AssignValue(join('', $name, map { ToString($_) } @args) => $v); });
-  //   # Not really right to set the value!
-  //   AssignValue(ToString($cs) => $value) if defined $value;
-  //   $STATE->installDefinition(LaTeXML::Core::Definition::Register->new($cs, $paramlist,
-  //       registerType => $type,
-  //       getter       => $getter, setter => $setter,
-  //       readonly     => $options{readonly}),
-  //     'global');
+  let setter: RegisterSetterClosure = match options.setter {
+    Some(setter) => setter.clone(),
+    None => if readonly {
+      Rc::new(move |value, args, state| {
+        warn!(
+          target: &s!("unexpected:{}", setter_name),
+          "Can't assign to register {}",
+          setter_name
+        );
+      })
+    } else {
+      Rc::new(move |value, args, state| {
+        let args_string: String = args
+          .iter()
+          .map(|arg: &Token| arg.to_string())
+          .collect::<Vec<String>>()
+          .join("");
+
+        state.assign_value(&(setter_name.clone() + &args_string), value, None);
+      })
+    },
+  };
+
+  // Not really right to set the value!
+  state.assign_value(&cs.to_string(), value, None);
+  state.install_definition(
+    Register {
+      cs,
+      parameters,
+      register_type,
+      readonly,
+      getter,
+      setter,
+    },
+    Some(Scope::Global),
+  );
   return;
 }
 

--- a/rtx/src/package/functions.rs
+++ b/rtx/src/package/functions.rs
@@ -141,8 +141,11 @@ pub fn load_tex_content(core: &mut Core, path: &str) -> Result<()> {
   // content => LookupValue($pathname . '_contents')
 
   // Open a mouth for that TeX content
-  let gullet = core.stomach.get_gullet_mut();
-  gullet.open_mouth(mouth, true);
+  core
+    .stomach
+    .borrow_mut()
+    .get_gullet_mut()
+    .open_mouth(mouth, true);
   Ok(())
 }
 
@@ -779,18 +782,18 @@ pub fn new_counter(ctr: &str, within: &str, options: Option<NewCounterOptions>, 
   let clunctr = s!("\\cl@{}", unctr);
 
   def_register(T_CS!(cctr), None, Some(Number::new(0)), None, state);
-  // state.assign_value(cctr, Number!(0), Some(Scope::Global));
-  // // TODO:
-  // // AfterAssignment!();
-  // if !state.lookup_bool(&clctr) {
-  //   state.assign_value(clctr, Tokens!(), Some(Scope::Global));
-  // }
-  // // TODO:
-  // // DefRegisterI!(T_CS!(cunctr), None, Number!(0));
-  // state.assign_value(cunctr, Number!(0), Some(Scope::Global));
-  // if !state.lookup_bool(clunctr) {
-  //   state.assign_value(clunctr, Tokens!(), Some(Scope::Global));
-  // }
+  state.assign_value(&cctr, Number!(0), Some(Scope::Global));
+  state.after_assignment();
+  if !state.lookup_bool(&clctr) {
+    state.assign_value(&clctr, Tokens!(), Some(Scope::Global));
+  }
+  SetupBindingMacros!(state);
+
+  DefRegisterI!(T_CS!(cunctr), None, Some(Number!(0)), None);
+  state.assign_value(&cunctr, Number!(0), Some(Scope::Global));
+  if !state.lookup_bool(&clunctr) {
+    state.assign_value(&clunctr, Tokens!(), Some(Scope::Global));
+  }
 
   // if !within.is_empty() {
   //   let clwithin = s!("\\cl@{}",within);
@@ -871,7 +874,7 @@ pub fn counter_value(ctr: &str, state: &mut State) -> Number {
 pub fn add_to_counter(ctr: &str, value: Number, gullet: &mut Gullet, state: &mut State) {
   let v = counter_value(ctr, state).add(value);
   state.assign_value(&s!("\\c@{}", ctr), v.clone(), Some(Scope::Global));
-  gullet.after_assignment(state);
+  state.after_assignment();
   SetupBindingMacros!(state);
   let id_cs = T_CS!(s!("\\@{}@ID", ctr));
   DefMacroI!(id_cs.clone(), None, Tokens::new(Explode!(v.value_of())),
@@ -892,10 +895,7 @@ pub fn step_counter(
     value.add(Number!(1)),
     Some(Scope::Global),
   );
-  {
-    let gullet = stomach.get_gullet_mut();
-    gullet.after_assignment(state);
-  }
+  state.after_assignment();
   let token_value = Tokens::new(Explode!(counter_value(ctr, state).value_of()));
   DefMacroI!(T_CS!(s!("\\@{}@ID",ctr)), None, 
               token_value.clone(), scope => Some(Scope::Global));

--- a/rtx/src/package/functions.rs
+++ b/rtx/src/package/functions.rs
@@ -8,6 +8,7 @@ use rtx_core::common::font::Font;
 use rtx_core::common::number::Number;
 use rtx_core::definition::conditional::{Conditional, ConditionalOptions, ConditionalType};
 use rtx_core::definition::expandable::Expandable;
+use rtx_core::definition::register::{Register, RegisterType, RegisterValue};
 use rtx_core::definition::{ConditionalClosure, Definition, ExpansionClosure};
 use rtx_core::document::resource::*;
 use rtx_core::document::tag::{TagOptionName, TagOptions};
@@ -530,8 +531,8 @@ pub fn def_macro<T: Into<Option<ExpansionClosure>>>(
 }
 
 pub struct RegisterOptions {
-  pub getter: bool,
-  pub setter: bool,
+  pub getter: Option<Rc<Fn(Vec<Token>) -> Result<Tokens>>>,
+  pub setter: Option<Rc<Fn(Stored, Vec<Token>)>>,
 }
 
 //======================================================================
@@ -626,17 +627,17 @@ pub fn def_conditional(
   return;
 }
 
-pub fn def_register(
+pub fn def_register<T: Into<RegisterValue>>(
   cs: Token,
   paramlist: Option<Parameters>,
-  value_opt: Option<Number>,
+  value: T,
   options: Option<RegisterOptions>,
   state: &mut State,
 )
 {
-  // TODO:
-  //   my $type   = $register_types{ ref $value };
-  //   my $name   = ToString($cs);
+  let value: RegisterValue = value.into();
+  let name = cs.to_string();
+  let rtype: RegisterType = value.into();
   //   my $getter = $options{getter}
   //     || sub { LookupValue(join('', $name, map { ToString($_) } @_)) || $value; };
   //   my $setter = $options{setter}
@@ -788,14 +789,14 @@ pub fn new_counter(
   let cunctr = s!("\\c@{}", unctr);
   let clunctr = s!("\\cl@{}", unctr);
 
-  def_register(T_CS!(cctr), None, Some(Number::new(0)), None, state);
+  def_register(T_CS!(cctr), None, Number::new(0), None, state);
   state.assign_value(&cctr, Number!(0), Some(Scope::Global));
   AfterAssignment!();
   if !state.lookup_bool(&clctr) {
     state.assign_value(&clctr, Tokens!(), Some(Scope::Global));
   }
 
-  DefRegisterI!(T_CS!(cunctr), None, Some(Number!(0)), None);
+  DefRegisterI!(T_CS!(cunctr), None, Number::new(0), None);
   state.assign_value(&cunctr, Number!(0), Some(Scope::Global));
   if !state.lookup_bool(&clunctr) {
     state.assign_value(&clunctr, Tokens!(), Some(Scope::Global));

--- a/rtx/src/package/functions.rs
+++ b/rtx/src/package/functions.rs
@@ -8,7 +8,9 @@ use rtx_core::common::font::Font;
 use rtx_core::common::number::Number;
 use rtx_core::definition::conditional::{Conditional, ConditionalOptions, ConditionalType};
 use rtx_core::definition::expandable::Expandable;
-use rtx_core::definition::register::{Register, RegisterType, RegisterValue};
+use rtx_core::definition::register::{
+  Register, RegisterGetterClosure, RegisterSetterClosure, RegisterType, RegisterValue,
+};
 use rtx_core::definition::{ConditionalClosure, Definition, ExpansionClosure};
 use rtx_core::document::resource::*;
 use rtx_core::document::tag::{TagOptionName, TagOptions};
@@ -531,8 +533,16 @@ pub fn def_macro<T: Into<Option<ExpansionClosure>>>(
 }
 
 pub struct RegisterOptions {
-  pub getter: Option<Rc<Fn(Vec<Token>) -> Result<Tokens>>>,
-  pub setter: Option<Rc<Fn(Stored, Vec<Token>)>>,
+  pub getter: Option<RegisterGetterClosure>,
+  pub setter: Option<RegisterSetterClosure>,
+}
+impl Default for RegisterOptions {
+  fn default() -> Self {
+    RegisterOptions {
+      getter: None,
+      setter: None,
+    }
+  }
 }
 
 //======================================================================
@@ -637,9 +647,23 @@ pub fn def_register<T: Into<RegisterValue>>(
 {
   let value: RegisterValue = value.into();
   let name = cs.to_string();
-  let rtype: RegisterType = value.into();
-  //   my $getter = $options{getter}
-  //     || sub { LookupValue(join('', $name, map { ToString($_) } @_)) || $value; };
+  let rtype: RegisterType = (&value).into();
+  let options = options.unwrap_or(RegisterOptions::default());
+  let getter: RegisterGetterClosure = match options.getter {
+    Some(getter) => getter.clone(),
+    None => Rc::new(move |args: Vec<Token>, state: &mut State| -> Stored {
+      let args_string: String = args
+        .iter()
+        .map(|arg: &Token| arg.to_string())
+        .collect::<Vec<String>>()
+        .join("");
+      match state.lookup_value(&(name.clone() + &args_string)) {
+        Some(v) => v.clone(),
+        None => value.clone().into(),
+      }
+    }),
+  };
+
   //   my $setter = $options{setter}
   //     || ($options{readonly}
   //     ? sub { my ($v, @args) = @_;
@@ -789,7 +813,7 @@ pub fn new_counter(
   let cunctr = s!("\\c@{}", unctr);
   let clunctr = s!("\\cl@{}", unctr);
 
-  def_register(T_CS!(cctr), None, Number::new(0), None, state);
+  DefRegisterI!(T_CS!(cctr), None, Number::new(0), None);
   state.assign_value(&cctr, Number!(0), Some(Scope::Global));
   AfterAssignment!();
   if !state.lookup_bool(&clctr) {

--- a/rtx/src/package/functions.rs
+++ b/rtx/src/package/functions.rs
@@ -795,33 +795,44 @@ pub fn new_counter(ctr: &str, within: &str, options: Option<NewCounterOptions>, 
     state.assign_value(&clunctr, Tokens!(), Some(Scope::Global));
   }
 
-  // if !within.is_empty() {
-  //   let clwithin = s!("\\cl@{}",within);
-  //   let clunwithin = s!("\\cl@UN{}",within);
-  //   let x = if let Some(Stored::Tokens(cl)) = state.lookup_value(clwithin) {
-  //    cl.unlist()
-  //   } else {
-  //     Vec::new()
-  //   };
-  //   let mut clwithin_tokens = vec![T_CS!(ctr), T_CS!(unctr)];
-  //   clwithin_tokens.append(x);
-  // state.assign_value(clwithin, Stored::Tokens(Tokens{tokens: clwithin_tokens}),
-  // Some(Scope::Global));
+  if !within.is_empty() {
+    let clwithin = s!("\\cl@{}", within);
+    let clunwithin = s!("\\cl@UN{}", within);
+    let mut x = if let Some(Stored::Tokens(cl)) = state.remove_value(&clwithin) {
+      cl.unlist()
+    } else {
+      Vec::new()
+    };
+    let mut clwithin_tokens = vec![T_CS!(ctr), T_CS!(unctr)];
+    clwithin_tokens.append(&mut x);
+    state.assign_value(
+      &clwithin,
+      Stored::Tokens(Tokens::new(clwithin_tokens)),
+      Some(Scope::Global),
+    );
 
-  //   let unx = if let Some(Stored::Tokens(clun)) = state.lookup_value(clunwithin) {
-  //     clun.unlist()
-  //   } else {
-  //    Vec::new()
-  //   };
-  //   let mut clunwithin_tokens = T_CS!(unctr);
-  //   clunwithin_tokens.append(unx);
+    let mut unx = if let Some(Stored::Tokens(clun)) = state.remove_value(&clunwithin) {
+      clun.unlist()
+    } else {
+      Vec::new()
+    };
+    let mut clunwithin_tokens = vec![T_CS!(unctr)];
+    clunwithin_tokens.append(&mut unx);
 
-  // state.assign_value(clunwithin, Stored::Tokens(Tokens{tokens: clunwithin_tokens}),
-  // Some(Scope::Global)) }
+    state.assign_value(
+      &clunwithin,
+      Stored::Tokens(Tokens::new(clunwithin_tokens)),
+      Some(Scope::Global),
+    )
+  }
 
   // if let Some(nested_val) = options.get("nested") {
-  // state.assign_value(s!("nested_counters_{}", ctr), Stored::String(nested_val),
-  // Some(Scope::Global)) }
+  //   state.assign_value(
+  //     &s!("nested_counters_{}", ctr),
+  //     Stored::String(nested_val),
+  //     Some(Scope::Global),
+  //   )
+  // }
 
   // // default is equivalent to \arabic{ctr}, but w/o using the LaTeX macro!
   // DefMacroI!(T_CS!(s!("\\the{}",ctr)), None, move |gullet, args, inner_state| {

--- a/rtx/src/package/functions.rs
+++ b/rtx/src/package/functions.rs
@@ -774,7 +774,14 @@ impl<'ct> Default for NewCounterOptions<'ct> {
   }
 }
 
-pub fn new_counter(ctr: &str, within: &str, options: Option<NewCounterOptions>, state: &mut State) {
+pub fn new_counter(
+  ctr: &str,
+  within: &str,
+  options_opt: Option<NewCounterOptions>,
+  state: &mut State,
+) -> Result<()>
+{
+  SetupBindingMacros!(state);
   let unctr = s!("UN{}", ctr); // UNctr is counter for generating ID's for UN-numbered items.
   let cctr = s!("\\c@{}", ctr);
   let clctr = s!("\\cl@{}", ctr);
@@ -783,11 +790,10 @@ pub fn new_counter(ctr: &str, within: &str, options: Option<NewCounterOptions>, 
 
   def_register(T_CS!(cctr), None, Some(Number::new(0)), None, state);
   state.assign_value(&cctr, Number!(0), Some(Scope::Global));
-  state.after_assignment();
+  AfterAssignment!();
   if !state.lookup_bool(&clctr) {
     state.assign_value(&clctr, Tokens!(), Some(Scope::Global));
   }
-  SetupBindingMacros!(state);
 
   DefRegisterI!(T_CS!(cunctr), None, Some(Number!(0)), None);
   state.assign_value(&cunctr, Number!(0), Some(Scope::Global));
@@ -826,46 +832,66 @@ pub fn new_counter(ctr: &str, within: &str, options: Option<NewCounterOptions>, 
     )
   }
 
-  // if let Some(nested_val) = options.get("nested") {
-  //   state.assign_value(
-  //     &s!("nested_counters_{}", ctr),
-  //     Stored::String(nested_val),
-  //     Some(Scope::Global),
-  //   )
-  // }
+  if let Some(ref options) = options_opt {
+    if !options.nested.is_empty() {
+      state.assign_value(
+        &s!("nested_counters_{}", ctr),
+        options.nested.clone(),
+        Some(Scope::Global),
+      )
+    }
+  }
 
-  // // default is equivalent to \arabic{ctr}, but w/o using the LaTeX macro!
-  // DefMacroI!(T_CS!(s!("\\the{}",ctr)), None, move |gullet, args, inner_state| {
-  //   let counter_value = CounterValue!(ctr, inner_state).value_of();
-  //   Ok(ExplodeText!(counter_value))
-  // },
-  // scope => Some(Scope::Global));
+  // default is equivalent to \arabic{ctr}, but w/o using the LaTeX macro!
+  let ctr_string = ctr.to_string();
+  DefMacro!(&s!("\\the{}",ctr), sub[gullet, args, inner_state] {
+    let counter_value = CounterValue!(&ctr_string, inner_state).value_of();
+    Ok(Tokens::new(ExplodeText!(counter_value)))
+  }, scope => Some(Scope::Global));
 
-  // let mut prefix = options.get("idprefix").unwrap_or(String::new());
-  // if !prefix.is_empty() {
-  // state.assign_value(s!("@ID@prefix@{}",ctr), Stored::String(prefix),
-  // Some(Scope::Global)); } else {
-  //   prefix = state.lookup_string(s!("@ID@prefix@{}",ctr));
-  //   if prefix.is_empty() {
-  //     prefix = clean_id(ctr);
-  //   }
-  // }
-  // if !prefix.is_empty() {
-  //   let idwithin = options.get("idwithin").unwrap_or(within.clone());
-  //   if !idwithin.is_empty() {
-  //     DefMacro!(s!("\\the{}@ID",ctr),
-  //       concat!(s!("\\expandafter\\ifx\\csname the{}@ID\\endcsname\\@empty",idwithin),
-  //               s!("\\else\\csname the{}@ID\\endcsname.\\fi",idwithin),
-  //               s!(" {}\\csname @{}@ID\\endcsname",prefix,ctr)),
-  //       scope => Some(Scope::Global));
-  //   }
-  //   else {
-  //     DefMacro!(s!("\\the{}@ID",ctr), s!("{}\\csname @{}@ID\\endcsname",prefix,ctr),
-  //       scope => Some(Scope::Global));
-  //   }
-  //   DefMacro!(s!("\\@{}@ID",ctr), "0", scope => Some(Scope::Global));
-  // }
-  return;
+  if let Some(options) = options_opt {
+    let mut prefix = options.idprefix.to_string();
+    if !prefix.is_empty() {
+      state.assign_value(
+        &s!("@ID@prefix@{}", ctr),
+        prefix.clone(),
+        Some(Scope::Global),
+      );
+    } else {
+      prefix = state.lookup_string(&s!("@ID@prefix@{}", ctr));
+      if prefix.is_empty() {
+        // TODO:
+        prefix = "clean_id(ctr)".to_string();
+      }
+    }
+    if !prefix.is_empty() {
+      let mut idwithin = if !options.idwithin.is_empty() {
+        options.idwithin.to_string()
+      } else {
+        within.to_string()
+      };
+      if !idwithin.is_empty() {
+        let ctr_string = ctr.to_string();
+        DefMacro!(&s!("\\the{}@ID",ctr), sub[gullet, args, inner_state] {
+          Ok(TokenizeInternal!(
+            &s!("\\expandafter\\ifx\\csname the{}@ID\\endcsname\\@empty\\else\\csname the{}@ID\\endcsname.\\fi {}\\csname @{}@ID\\endcsname",
+          idwithin,idwithin,prefix,ctr_string)
+          ))
+        },
+        scope => Some(Scope::Global));
+      } else {
+        let ctr_string = ctr.to_string();
+        DefMacro!(&s!("\\the{}@ID",ctr), sub[gullet,args, inner_state] {
+          Ok(TokenizeInternal!(
+              &s!("{}\\csname @{}@ID\\endcsname",prefix,ctr_string)
+          ))},
+          scope => Some(Scope::Global));
+      }
+      DefMacro!(&s!("\\@{}@ID",ctr), "0", scope => Some(Scope::Global));
+    }
+  }
+
+  Ok(())
 }
 
 pub fn counter_value(ctr: &str, state: &mut State) -> Number {

--- a/rtx/src/package/pool/article_cls.rs
+++ b/rtx/src/package/pool/article_cls.rs
@@ -26,7 +26,8 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
     "twocolumn",
     "notitlepage",
     "titlepage",
-  ].into_iter()
+  ]
+    .into_iter()
     .map(|s| s.to_string())
   {
     // DeclareOption!(option, None);

--- a/rtx/src/package/pool/latex.rs
+++ b/rtx/src/package/pool/latex.rs
@@ -547,5 +547,78 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
     generate_id(document, node, "p", state)?;
   }));
 
+  // DefPrimitive('\newcounter{}[]', sub {
+  //     NewCounter(ToString(Expand($_[1])), $_[2] && ToString(Expand($_[2])));
+  //     return; });
+  // DefPrimitive('\setcounter{}{Number}', sub { SetCounter(ToString(Expand($_[1])), $_[2]); });
+  // DefPrimitive('\addtocounter{}{Number}', sub { AddToCounter(ToString(Expand($_[1])), $_[2]); });
+  // DefPrimitive('\stepcounter{}',    sub { StepCounter(ToString(Expand($_[1])));    return; });
+  // DefPrimitive('\refstepcounter{}', sub { RefStepCounter(ToString(Expand($_[1]))); return; });
+
+  // DefPrimitive('\@addtoreset{}{}', sub {
+  //     my ($stomach, $ctr, $within) = @_;
+  //     $ctr    = ToString(Expand($ctr));
+  //     $within = ToString(Expand($within));
+  //     my $unctr = "UN$ctr";    # UNctr is counter for generating ID's for UN-numbered items.
+  //     AssignValue("\\cl\@$within" =>
+  //         Tokens(T_CS($ctr), T_CS($unctr),
+  //         (LookupValue("\\cl\@$within") ? LookupValue("\\cl\@$within")->unlist : ())),
+  //       'global');
+  //     # This counter might be doing double duty generating ID's as well, so we may need to patch up.
+  //     my $prefix = LookupValue('@ID@prefix@' . $ctr);
+  //     if (defined $prefix) {
+  //       DefMacroI(T_CS("\\the$ctr\@ID"), undef,
+  //         "\\expandafter\\ifx\\csname the$within\@ID\\endcsname\\\@empty"
+  //           . "\\else\\csname the$within\@ID\\endcsname.\\fi"
+  //           . " $prefix\\csname \@$ctr\@ID\\endcsname",
+  //         scope => 'global');
+  //       DefMacroI(T_CS("\\\@$ctr\@ID"), undef, "0", scope => 'global'); }
+  //     return; });
+
+  DefMacro!("\\value{}", sub[gullet, args, inner_state] {
+    unpack!(args => value);
+    let ctr_expansion = Expand!(value, gullet, inner_state)?.to_string();
+    let ctr_value = CounterValue!(&ctr_expansion, inner_state).value_of();
+    Ok(Tokens::new(
+      ExplodeText!(ctr_value)
+    ))
+  });
+
+  // DefMacro('\@arabic{Number}', sub {
+  //     ExplodeText(ToString($_[1]->valueOf)); });
+  DefMacro!("\\arabic{}", sub[gullet, args, inner_state] {
+    unpack!(args => value);
+    let ctr_expansion = Expand!(value, gullet, inner_state)?.to_string();
+    let ctr_value = CounterValue!(&ctr_expansion, inner_state).value_of();
+    Ok(Tokens::new(
+      ExplodeText!(ctr_value)
+    ))
+  });
+
+  // DefMacro('\@roman{Number}', sub {
+  //     ExplodeText(radix_roman(ToString($_[1]->valueOf))); });
+  // DefMacro('\roman{}', sub {
+  //     ExplodeText(radix_roman(CounterValue(ToString(Expand($_[1])))->valueOf)); });
+  // DefMacro('\@Roman{Number}', sub {
+  //     ExplodeText(radix_Roman(ToString($_[1]->valueOf))); });
+  // DefMacro('\Roman{}', sub {
+  //     ExplodeText(radix_Roman(CounterValue(ToString(Expand($_[1])))->valueOf)); });
+  // DefMacro('\@alph{Number}', sub {
+  //     ExplodeText(radix_alpha($_[1]->valueOf)); });
+  // DefMacro('\alph{}', sub {
+  //     ExplodeText(radix_alpha(CounterValue(ToString(Expand($_[1])))->valueOf)); });
+  // DefMacro('\@Alph{Number}', sub {
+  //     ExplodeText(radix_Alpha($_[1]->valueOf)); });
+  // DefMacro('\Alph{}', sub {
+  //     ExplodeText(radix_Alpha(CounterValue(ToString(Expand($_[1])))->valueOf)); });
+
+  // our @fnsymbols = ("*", "\x{2020}", "\x{2021}", UTF(0xA7), UTF(0xB6),
+  //   "\x{2225}", "**", "\x{2020}\x{2020}", "\x{2021}\x{2021}");
+  // DefMacro('\@fnsymbol{Number}', sub {
+  //     ExplodeText(radix_format($_[1]->valueOf, @fnsymbols)); });
+  // DefMacro('\fnsymbol{}', sub {
+  //     ExplodeText(radix_format(CounterValue(ToString(Expand($_[1])))->valueOf, @fnsymbols)); });
+
+
   Ok(())
 }

--- a/rtx/src/package/pool/tex_para.rs
+++ b/rtx/src/package/pool/tex_para.rs
@@ -99,7 +99,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
       },
       scope,
     );
-    stomach.get_gullet_mut().after_assignment(state);
+    state.after_assignment();
     Ok(Vec::new())
   }
 

--- a/rtx/src/package/pool/tex_para.rs
+++ b/rtx/src/package/pool/tex_para.rs
@@ -99,7 +99,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
       },
       scope,
     );
-    state.after_assignment();
+    AfterAssignment!(state);
     Ok(Vec::new())
   }
 

--- a/rtx/src/package/pool/tex_para.rs
+++ b/rtx/src/package/pool/tex_para.rs
@@ -99,7 +99,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
       },
       scope,
     );
-    //TODO: AfterAssignment!(state);
+    stomach.get_gullet_mut().after_assignment(state);
     Ok(Vec::new())
   }
 

--- a/rtx/src/package/setup.rs
+++ b/rtx/src/package/setup.rs
@@ -141,7 +141,7 @@ macro_rules! SetupBindingMacros {($state:ident) => (
 
   macro_rules! AfterAssignment {
     ($gullet: ident) => (AfterAssignment!($gullet, $state));
-    ($gullet:ident, $state_arg: ident) => (after_assignment($gullet, $state));
+    ($gullet:ident, $state_arg: ident) => (after_assignment($gullet, $state_arg));
   }
 
   // Merge the current font with the style specifications

--- a/rtx/src/package/setup.rs
+++ b/rtx/src/package/setup.rs
@@ -140,8 +140,8 @@ macro_rules! SetupBindingMacros {($state:ident) => (
   }
 
   macro_rules! AfterAssignment {
-    ($gullet: ident) => (AfterAssignment!($gullet, $state));
-    ($gullet:ident, $state_arg: ident) => (after_assignment($gullet, $state_arg));
+    () => (AfterAssignment!($state));
+    ($state_arg: ident) => ($state_arg.after_assignment());
   }
 
   // Merge the current font with the style specifications
@@ -325,7 +325,7 @@ macro_rules! SetupBindingMacros {($state:ident) => (
     // Rust closure expansion form
     ($proto:expr, sub [ $gullet:ident, $args:ident, $inner_state:ident ] $body:block, $options:expr, $state_arg:ident) => {
       let (cs, paramlist) = parse_prototype($proto, $state_arg)?;
-      let expansion_closure : Option<ExpansionClosure> = Some(Rc::new(|$gullet: &mut Gullet, $args: Vec<Tokens>, $inner_state:&mut State| $body));
+      let expansion_closure : Option<ExpansionClosure> = Some(Rc::new(move |$gullet: &mut Gullet, $args: Vec<Tokens>, $inner_state:&mut State| $body));
       // TODO: Also pass in options
       def_macro(cs, paramlist, expansion_closure, $state_arg);
     };
@@ -356,7 +356,7 @@ macro_rules! SetupBindingMacros {($state:ident) => (
     ($cs:expr, $paramlist:expr, sub[$gullet:ident, $args:ident, $inner_state:ident] $body:block) =>
       (DefConditionalI!($cs, $paramlist, $gullet, $args, $inner_state, $body, $state));
     ($cs:expr, $paramlist:expr, sub[$gullet:ident, $args:ident, $inner_state:ident] $body:block, $state_arg:ident) => ({
-      let test : ConditionalClosure = Rc::new(|$gullet, $args, $inner_state| {$body});
+      let test : ConditionalClosure = Rc::new(move |$gullet, $args, $inner_state| {$body});
       def_conditional($cs, $paramlist, Some(test), ConditionalOptions::default(), $state_arg);
     });
   );
@@ -1672,15 +1672,15 @@ macro_rules! SetupBindingMacros {($state:ident) => (
   macro_rules! NewCounter {
     ($ctr:expr) => (NewCounter!($ctr, "", None, $state));
     ($ctr:expr, $within:expr) => (NewCounter!($ctr, $within, None, $state));
-    ($ctr:expr, $within:expr, None, $state_arg:ident) => (new_counter($ctr, $within, None, $state_arg));
+    ($ctr:expr, $within:expr, None, $state_arg:ident) => (new_counter($ctr, $within, None, $state_arg)?);
 
     // with options
     ($ctr:expr, $within:expr, $key1:ident => $val1:expr) => (NewCounter!($ctr, $within, $key1 => $val1, $state));
     ($ctr:expr, $within:expr, $key1:ident => $val1:expr, $state_arg: ident) =>
-     (new_counter($ctr, $within, Some(NewDefault!(NewCounterOptions, $key1=>$val1)), $state_arg));
+     (new_counter($ctr, $within, Some(NewDefault!(NewCounterOptions, $key1=>$val1)), $state_arg)?);
     ($ctr:expr, $within:expr, $key1:ident => $val1:expr, $key2:ident => $val2:expr) => (NewCounter!($ctr, $within, $key1=>$val1, $key2=>$val2, $state));
     ($ctr:expr, $within:expr, $key1:ident => $val1:expr, $key2:ident => $val2:expr, $state_arg: ident) =>
-     (new_counter($ctr, $within, Some(NewDefault!(NewCounterOptions, $key1=>$val1, $key2=>$val2)), $state_arg));
+     (new_counter($ctr, $within, Some(NewDefault!(NewCounterOptions, $key1=>$val1, $key2=>$val2)), $state_arg)?);
   }
 
   macro_rules! CounterValue {
@@ -1697,7 +1697,7 @@ macro_rules! SetupBindingMacros {($state:ident) => (
     };
     ($ctr:expr, $value:expr, $gullet:ident) => {
       AssignValue!(&s!("\\c@{}",$ctr), $value, Some(Scope::Global));
-      AfterAssignment!($gullet);
+      AfterAssignment!();
       DefMacroI!(T_CS!(s!("\\@{}@ID",$ctr)), None, Tokens::new(Explode!($value.value_of())),
                   scope => Some(Scope::Global)
       );

--- a/rtx/src/package/setup.rs
+++ b/rtx/src/package/setup.rs
@@ -1719,6 +1719,12 @@ macro_rules! SetupBindingMacros {($state:ident) => (
     ($ctr:expr, $noreset:expr, $gullet:ident, $state_arg:ident) => (ref_step_counter($ctr, $noreset, $gullet, $state_arg));
   }
 
+  /// Return $tokens with all tokens expanded
+  macro_rules! Expand {
+    ($tokens:expr, $gullet:ident) => (Expand!($tokens, $gullet, $state));
+    ($tokens:expr, $gullet:ident, $state_arg:ident) => (do_expand($tokens, $gullet, $state_arg));
+  }
+
   /// Invocation(<list of Token>); builds a representation of a command sequence invoked on its
   /// arguments
   macro_rules! Invocation {

--- a/rtx/src/util/test.rs
+++ b/rtx/src/util/test.rs
@@ -72,7 +72,7 @@ fn process_texfile(tex_path: &str, name: &str) -> Vec<String> {
 
   match latexml.convert_file(tex_path.to_owned()) {
     Err(e) => panic!("{:?}: Couldn't convert {:?}; {:?}", name, tex_path, e),
-    Ok(doc) => process_ltx_doc(doc, name, latexml.state_mut()),
+    Ok(doc) => process_ltx_doc(doc, name, latexml.get_state_mut()),
   }
 }
 

--- a/rtx_codegen/src/constructable.rs
+++ b/rtx_codegen/src/constructable.rs
@@ -161,8 +161,7 @@ fn compile_replacement_tokens(mut replacement: String) -> Vec<quote::Tokens> {
       floats = refs.get(1).map_or("", |m| m.as_str()).to_string();
       has_floats = true;
       String::new()
-    })
-    .to_string();
+    }).to_string();
   let mut operations = Vec::new();
 
   while !replacement.is_empty() {
@@ -194,8 +193,7 @@ fn compile_replacement_tokens(mut replacement: String) -> Vec<quote::Tokens> {
           current_tag = refs.get(1).map_or("", |m| m.as_str()).to_string();
           is_match = true;
           String::new()
-        })
-        .to_string();
+        }).to_string();
 
       if is_match {
         // println!("-- matched a PI ");
@@ -214,8 +212,7 @@ fn compile_replacement_tokens(mut replacement: String) -> Vec<quote::Tokens> {
           .replace(&replacement, |_: &Captures| -> String {
             pi_closed = true;
             String::new()
-          })
-          .to_string();
+          }).to_string();
 
         if !pi_closed {
           panic!("Missing '?>' at '{:?}'\n", replacement);
@@ -231,8 +228,7 @@ fn compile_replacement_tokens(mut replacement: String) -> Vec<quote::Tokens> {
           current_tag = refs.get(1).map_or("", |m| m.as_str()).to_string();
           // println!("-- open tag {:?}", current_tag);
           String::new()
-        })
-        .to_string();
+        }).to_string();
 
       // handle open tag
       if is_match {
@@ -275,8 +271,7 @@ fn compile_replacement_tokens(mut replacement: String) -> Vec<quote::Tokens> {
           current_tag = refs.get(1).map_or("", |m| m.as_str()).to_string();
           // println!("-- close tag {:?}", current_tag);
           String::new()
-        })
-        .to_string();
+        }).to_string();
       // handle close tag
       if is_match {
         operations.push(quote!(document.close_element(#current_tag, state)?;));
@@ -363,8 +358,7 @@ fn translate_string(mut text: &mut String) -> quote::Tokens {
             quoted_match = refs.get(1).map_or("", |m| m.as_str()).to_string();
             is_quoted_match = true;
             String::new()
-          })
-          .to_string();
+          }).to_string();
         if is_quoted_match {
           let escaped_match = &slashify(&unquote(&quoted_match));
           values.push(quote!(#escaped_match));
@@ -393,8 +387,7 @@ fn translate_string(mut text: &mut String) -> quote::Tokens {
         None => String::new()
       })
       }
-    })
-    .collect::<Vec<_>>();
+    }).collect::<Vec<_>>();
   quote!(#(#token_values)+*)
 }
 
@@ -429,8 +422,7 @@ fn translate_avpairs(mut text: &mut String) -> Vec<quote::Tokens> {
           key = refs.get(1).map_or("", |m| m.as_str()).to_string();
           is_match = true;
           String::new()
-        })
-        .to_string();
+        }).to_string();
       if is_match {
         let val = translate_string(&mut text);
         avs.push(quote!(av_props.insert(#key.to_string(), #val);));
@@ -457,8 +449,7 @@ fn translate_value(exclude_chars: &str, mut text: &mut String) -> quote::Tokens 
       fcn = refs.get(1).map_or("", |m| m.as_str()).to_owned();
       is_match = true;
       String::new()
-    })
-    .to_string();
+    }).to_string();
   if is_match {
     let mut args = Vec::new();
     while !LEAD_CPAREN_RE.is_match(text) {
@@ -478,8 +469,7 @@ fn translate_value(exclude_chars: &str, mut text: &mut String) -> quote::Tokens 
         .replace(text, |_: &Captures| {
           intermediate_kv = true;
           String::new()
-        })
-        .to_string();
+        }).to_string();
       if !intermediate_kv {
         break;
       }
@@ -509,8 +499,7 @@ fn translate_value(exclude_chars: &str, mut text: &mut String) -> quote::Tokens 
           val = quote!(args[#n_usize])
         }
         String::new()
-      })
-      .to_string();
+      }).to_string();
   }
   if !is_match {
     *text = PROP_HOLE_RE
@@ -523,8 +512,7 @@ fn translate_value(exclude_chars: &str, mut text: &mut String) -> quote::Tokens 
         // meaningfully ?
         val = quote!(props.get(#prop_name));
         String::new()
-      })
-      .to_string();
+      }).to_string();
   }
   if !is_match {
     // Build the exclusion regex
@@ -540,8 +528,7 @@ fn translate_value(exclude_chars: &str, mut text: &mut String) -> quote::Tokens 
         let normalized_val = &slashify(&unquote(&quoted));
         val = quote!(#normalized_val);
         String::new()
-      })
-      .to_string();
+      }).to_string();
   }
   if !is_match {
     panic!("Missing value at '{:?}'\n", text);
@@ -572,7 +559,6 @@ fn unquote(text: &str) -> String {
   ESCAPED_OP
     .replace_all(text, |escaped_refs: &Captures| -> String {
       escaped_refs.get(1).map_or("", |m| m.as_str()).to_string()
-    })
-    .replace("##", "#")
+    }).replace("##", "#")
     .replace("&amp;", "&")
 }

--- a/rtx_core/src/common/dimension.rs
+++ b/rtx_core/src/common/dimension.rs
@@ -1,0 +1,4 @@
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Dimension {
+  number: i32,
+}

--- a/rtx_core/src/common/glue.rs
+++ b/rtx_core/src/common/glue.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Glue {
+  number: i32,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct MuGlue {
+  number: i32,
+}

--- a/rtx_core/src/common/mod.rs
+++ b/rtx_core/src/common/mod.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 pub mod error;
+pub mod dimension;
 pub mod font;
+pub mod glue;
 pub mod model;
 pub mod number;
 pub mod object;

--- a/rtx_core/src/common/store.rs
+++ b/rtx_core/src/common/store.rs
@@ -203,6 +203,12 @@ impl From<Vec<String>> for Stored {
   fn from(value: Vec<String>) -> Self { Stored::VecString(value) }
 }
 
+impl<'a> From<Vec<&'a str>> for Stored {
+  fn from(value: Vec<&'a str>) -> Self {
+    Stored::VecString(value.iter().map(|x| x.to_string()).collect::<Vec<String>>())
+  }
+}
+
 impl From<Vec<Token>> for Stored {
   fn from(value: Vec<Token>) -> Self { Stored::VecToken(value) }
 }

--- a/rtx_core/src/common/store.rs
+++ b/rtx_core/src/common/store.rs
@@ -2,14 +2,16 @@ use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::rc::Rc;
 
+use common::dimension::Dimension;
 use common::font::Font;
+use common::glue::{Glue, MuGlue};
 use common::number::Number;
 use definition::conditional::Conditional;
 use definition::constructor::Constructor;
 use definition::expandable::Expandable;
 use definition::math_primitive::MathPrimitive; //MathPrimitiveOptions
 use definition::primitive::Primitive;
-use definition::register::Register;
+use definition::register::{Register, RegisterValue};
 use document::tag::TagData;
 use parameter::Parameter;
 use token::{Catcode, Token};
@@ -57,6 +59,9 @@ pub enum Stored {
   Token(Token),
   Tokens(Tokens),
   Number(Number),
+  Glue(Glue),
+  MuGlue(MuGlue),
+  Dimension(Dimension),
   // LaTeXML objects (Rc-wrapped)
   Expandable(Rc<Expandable>),
   Conditional(Rc<Conditional>),
@@ -91,9 +96,12 @@ impl fmt::Debug for Stored {
       Constructor(ref _constructor) => write!(f, "<closure for constructor definition>"),
       Digested(ref digested) => write!(f, "{:?}", digested),
       Parameter(ref parameter) => write!(f, "{:?}", parameter),
-      Register(ref register) => write!(f, "{:?}", register),
+      Register(ref register) => write!(f, "<register {:?}>", register.cs),
       Font(ref font) => write!(f, "{:?}", font),
       Number(ref number) => write!(f, "{:?}", number),
+      Glue(ref glue) => write!(f, "{:?}", glue),
+      MuGlue(ref glue) => write!(f, "{:?}", glue),
+      Dimension(ref dimension) => write!(f, "{:?}", dimension),
       VecToken(ref token_vec) => write!(f, "{:?}", token_vec),
       VecDigested(ref digested_vec) => write!(f, "{:?}", digested_vec),
       VecDequeStored(ref vec) => write!(f, "VecDequeStored({:?})", vec),
@@ -231,6 +239,19 @@ impl From<HashMap<String, Stored>> for Stored {
 
 impl From<HashMap<String, Vec<TagData>>> for Stored {
   fn from(value: HashMap<String, Vec<TagData>>) -> Self { Stored::HashTagData(value) }
+}
+
+impl From<RegisterValue> for Stored {
+  fn from(rv: RegisterValue) -> Self {
+    match rv {
+      RegisterValue::Number(v) => Stored::Number(v),
+      RegisterValue::Dimension(v) => Stored::Dimension(v),
+      RegisterValue::Glue(v) => Stored::Glue(v),
+      RegisterValue::MuGlue(v) => Stored::MuGlue(v),
+      RegisterValue::Token(v) => Stored::Token(v),
+      RegisterValue::Tokens(v) => Stored::Tokens(v),
+    }
+  }
 }
 
 // Reverse direction -- cast Stored back into concrete types, with meaningfull fallbacks where

--- a/rtx_core/src/common/store.rs
+++ b/rtx_core/src/common/store.rs
@@ -189,8 +189,16 @@ impl From<Parameter> for Stored {
 }
 
 impl From<Rc<Font>> for Stored {
-  fn from(definition: Rc<Font>) -> Self { Stored::Font(definition) }
+  fn from(font: Rc<Font>) -> Self { Stored::Font(font) }
 }
+
+impl From<Rc<Register>> for Stored {
+  fn from(register: Rc<Register>) -> Self { Stored::Register(register) }
+}
+impl From<Register> for Stored {
+  fn from(register: Register) -> Self { Rc::new(register).into() }
+}
+
 impl From<Font> for Stored {
   fn from(value: Font) -> Self { Rc::new(value).into() }
 }

--- a/rtx_core/src/definition/register.rs
+++ b/rtx_core/src/definition/register.rs
@@ -68,7 +68,7 @@ pub enum RegisterType {
 }
 
 pub type RegisterGetterClosure = Rc<Fn(Vec<Token>, &mut State) -> Stored>;
-pub type RegisterSetterClosure = Rc<Fn(RegisterValue, &mut State)>;
+pub type RegisterSetterClosure = Rc<Fn(RegisterValue, Vec<Token>, &mut State)>;
 
 #[derive(Clone)]
 pub struct Register {
@@ -87,7 +87,7 @@ impl Default for Register {
       parameters: None,
       register_type: RegisterType::Number,
       getter: Rc::new(|_: Vec<Token>, _: &mut State| Stored::Number(Number::new(0))),
-      setter: Rc::new(|_: RegisterValue, _: &mut State| {}),
+      setter: Rc::new(|_: RegisterValue, _: Vec<Token>, _: &mut State| {}),
       readonly: false,
     }
   }

--- a/rtx_core/src/definition/register.rs
+++ b/rtx_core/src/definition/register.rs
@@ -1,11 +1,15 @@
+use std::rc::Rc;
+
+use common::dimension::Dimension;
 use common::error::*;
+use common::glue::{Glue, MuGlue};
+use common::number::Number;
 use common::object::Object;
 use definition::{BeforeDigestClosure, ConditionalClosure, Definition, DigestionClosure};
 use document::Document;
 use gullet::Gullet;
 use parameter::Parameters;
 use state::State;
-use std::rc::Rc;
 use stomach::Stomach;
 use token::*;
 use tokens::Tokens;
@@ -13,10 +17,45 @@ use whatsit::Whatsit;
 use Digested;
 
 #[derive(Debug, Clone)]
+pub enum RegisterValue {
+  Number(Number),
+  Dimension(Dimension),
+  Glue(Glue),
+  MuGlue(MuGlue),
+  Token(Token),
+  Tokens(Tokens),
+}
+impl From<Number> for RegisterValue {
+  fn from(n: Number) -> RegisterValue { RegisterValue::Number(n) }
+}
+impl From<RegisterValue> for RegisterType {
+  fn from(v: RegisterValue) -> RegisterType {
+    match v {
+      RegisterValue::Number(_) => RegisterType::Number,
+      RegisterValue::Dimension(_) => RegisterType::Dimension,
+      RegisterValue::Glue(_) => RegisterType::Glue,
+      RegisterValue::MuGlue(_) => RegisterType::MuGlue,
+      RegisterValue::Token(_) => RegisterType::Token,
+      RegisterValue::Tokens(_) => RegisterType::Tokens,
+    }
+  }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum RegisterType {
+  Number,
+  Dimension,
+  Glue,
+  MuGlue,
+  Token,
+  Tokens,
+}
+
+#[derive(Debug, Clone)]
 pub struct Register {
   pub cs: Token,
   pub parameters: Option<Parameters>,
-  pub register_type: Option<String>,
+  pub register_type: RegisterType,
   pub readonly: bool,
   // pub traits: PrimitiveOptions,
 }
@@ -25,7 +64,7 @@ impl Default for Register {
     Register {
       cs: T_CS!(s!("Register")),
       parameters: None,
-      register_type: None,
+      register_type: RegisterType::Number,
       readonly: false,
     }
   }
@@ -35,14 +74,13 @@ impl PartialEq for Register {
 }
 
 impl Register {
-  // `is_register` begs to be refactored into a better naming scheme
-  fn is_register(&self) -> Option<String> { self.register_type.clone() }
   fn is_readonly(&self) -> bool { self.readonly }
-  fn is_prefix(&self) -> bool { false }
 }
 
 impl Object for Register {}
 impl Definition for Register {
+  fn is_register(&self) -> bool { true }
+  fn is_prefix(&self) -> bool { false }
   // No before/after daemons ???
   // (other than afterassign)
   fn invoke(&self, gullet: &mut Gullet, state: &mut State) -> Result<Tokens> { Ok(Tokens!()) }

--- a/rtx_core/src/definition/register.rs
+++ b/rtx_core/src/definition/register.rs
@@ -5,6 +5,7 @@ use common::error::*;
 use common::glue::{Glue, MuGlue};
 use common::number::Number;
 use common::object::Object;
+use common::store::Stored;
 use definition::{BeforeDigestClosure, ConditionalClosure, Definition, DigestionClosure};
 use document::Document;
 use gullet::Gullet;
@@ -16,7 +17,7 @@ use tokens::Tokens;
 use whatsit::Whatsit;
 use Digested;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum RegisterValue {
   Number(Number),
   Dimension(Dimension),
@@ -28,9 +29,24 @@ pub enum RegisterValue {
 impl From<Number> for RegisterValue {
   fn from(n: Number) -> RegisterValue { RegisterValue::Number(n) }
 }
-impl From<RegisterValue> for RegisterType {
-  fn from(v: RegisterValue) -> RegisterType {
-    match v {
+impl From<Dimension> for RegisterValue {
+  fn from(n: Dimension) -> RegisterValue { RegisterValue::Dimension(n) }
+}
+impl From<Glue> for RegisterValue {
+  fn from(n: Glue) -> RegisterValue { RegisterValue::Glue(n) }
+}
+impl From<MuGlue> for RegisterValue {
+  fn from(n: MuGlue) -> RegisterValue { RegisterValue::MuGlue(n) }
+}
+impl From<Token> for RegisterValue {
+  fn from(n: Token) -> RegisterValue { RegisterValue::Token(n) }
+}
+impl From<Tokens> for RegisterValue {
+  fn from(n: Tokens) -> RegisterValue { RegisterValue::Tokens(n) }
+}
+impl<'a> From<&'a RegisterValue> for RegisterType {
+  fn from(v: &RegisterValue) -> RegisterType {
+    match *v {
       RegisterValue::Number(_) => RegisterType::Number,
       RegisterValue::Dimension(_) => RegisterType::Dimension,
       RegisterValue::Glue(_) => RegisterType::Glue,
@@ -51,12 +67,17 @@ pub enum RegisterType {
   Tokens,
 }
 
-#[derive(Debug, Clone)]
+pub type RegisterGetterClosure = Rc<Fn(Vec<Token>, &mut State) -> Stored>;
+pub type RegisterSetterClosure = Rc<Fn(RegisterValue, &mut State)>;
+
+#[derive(Clone)]
 pub struct Register {
   pub cs: Token,
   pub parameters: Option<Parameters>,
   pub register_type: RegisterType,
   pub readonly: bool,
+  pub getter: RegisterGetterClosure,
+  pub setter: RegisterSetterClosure,
   // pub traits: PrimitiveOptions,
 }
 impl Default for Register {
@@ -65,6 +86,8 @@ impl Default for Register {
       cs: T_CS!(s!("Register")),
       parameters: None,
       register_type: RegisterType::Number,
+      getter: Rc::new(|_: Vec<Token>, _: &mut State| Stored::Number(Number::new(0))),
+      setter: Rc::new(|_: RegisterValue, _: &mut State| {}),
       readonly: false,
     }
   }

--- a/rtx_core/src/gullet.rs
+++ b/rtx_core/src/gullet.rs
@@ -2,7 +2,7 @@ use common::error::*;
 use common::store::Stored;
 use definition::Definition;
 use mouth::Mouth;
-use state::State;
+use state::{Scope, State};
 use std::collections::VecDeque;
 use std::rc::Rc;
 use token::{Catcode, Token};
@@ -512,12 +512,6 @@ impl Gullet {
       Some(t) => {
         self.unread(Tokens!(t));
       },
-    }
-  }
-
-  pub fn after_assignment(&mut self, state: &mut State) {
-    if let Some(Stored::Tokens(after)) = state.remove_value("afterAssignment") {
-      self.unread(after); // primitive returns boxes, so these need to be digested!
     }
   }
 }

--- a/rtx_core/src/gullet.rs
+++ b/rtx_core/src/gullet.rs
@@ -514,4 +514,68 @@ impl Gullet {
       },
     }
   }
+
+  pub fn reading_from_mouth<R>(
+    &mut self,
+    mouth: Mouth,
+    state: &mut State,
+    reader: Box<Fn(&mut Gullet, &mut State) -> R>,
+  ) -> R
+  {
+    let mouth_source = mouth.source.clone();
+    {
+      self.open_mouth(mouth, false); // only allow mouth to be explicitly closed here.
+    }
+    let results: R = reader(self, state);
+    // `mouth` must still be open, with (at worst) empty autoclosable mouths in front of it
+    loop {
+      let mut is_mouth = false;
+      {
+        if let Some(ref mut runtime) = self.mouth {
+          if runtime.mouth.source == mouth_source {
+            is_mouth = true;
+          }
+        } else {
+          error!(target: "unexpected:runtime", "TODO: gullet had no active runtime");
+          break;
+        }
+      }
+      if is_mouth {
+        self.close_mouth(true, state);
+        break;
+      } else if self.mouthstack.is_empty() {
+        error!(target: "unexpected:<closed>", "TODO: Mouth is unexpectedly already closed");
+        // Error('unexpected', '<closed>', $gullet, "Mouth is unexpectedly already closed",
+        //   "Reading from " . Stringify($mouth) . ", but it has already been closed.");
+        break;
+      } else {
+        let mut ready_to_read = false;
+        {
+          if let Some(ref mut runtime) = self.mouth {
+            if !runtime.autoclose || !runtime.pushback.is_empty() || runtime.mouth.has_more_input()
+            {
+              ready_to_read = true;
+            }
+          }
+        }
+        if ready_to_read {
+          let _next = self.read_token(state); // stringify( ?
+          error!(target: "unexpected:next", "TODO: unexpected input remaining");
+          // Error('unexpected', $next, $gullet, "Unexpected input remaining: '$next'",
+          //   "Finished reading from " . Stringify($mouth) . ", but it still has input.");
+          {
+            if let Some(ref mut runtime) = self.mouth {
+              runtime.mouth.finish(state);
+            }
+          }
+          self.close_mouth(true, state);
+        }
+        // ?? if we continue?
+        else {
+          self.close_mouth(false, state);
+        }
+      }
+    }
+    results
+  }
 }

--- a/rtx_core/src/gullet.rs
+++ b/rtx_core/src/gullet.rs
@@ -514,4 +514,10 @@ impl Gullet {
       },
     }
   }
+
+  pub fn after_assignment(&mut self, state: &mut State) {
+    if let Some(Stored::Tokens(after)) = state.remove_value("afterAssignment") {
+      self.unread(after); // primitive returns boxes, so these need to be digested!
+    }
+  }
 }

--- a/rtx_core/src/lib.rs
+++ b/rtx_core/src/lib.rs
@@ -32,14 +32,18 @@ pub mod tbox;
 pub mod util;
 pub mod whatsit;
 
+use std::cell::RefCell;
+use std::fmt;
+use std::rc::Rc;
+
 use common::error::*;
 use common::font::Font;
 use common::model::Model;
 use common::store::Stored;
 use document::Document;
+use gullet::Gullet;
 use list::List;
 use state::{State, StateOptions};
-use std::fmt;
 use stomach::Stomach;
 use tbox::Tbox;
 use tokens::Tokens;
@@ -47,7 +51,7 @@ use whatsit::Whatsit;
 
 pub struct Core {
   pub state: State,
-  pub stomach: Stomach,
+  pub stomach: Rc<RefCell<Stomach>>,
   pub preload: Vec<String>,
 }
 pub struct CoreOptions {
@@ -85,10 +89,13 @@ impl Default for CoreOptions {
 
 impl Default for Core {
   fn default() -> Self {
+    let stomach = Rc::new(RefCell::new(Stomach::default()));
+    let mut state = State::new(StateOptions::default());
+    state.stomach = stomach.clone();
     Core {
       preload: Vec::new(),
-      stomach: Stomach::default(),
-      state: State::new(StateOptions::default()),
+      stomach: stomach,
+      state: state,
     }
   }
 }
@@ -113,17 +120,20 @@ impl Core {
       nomathparse: options.nomathparse,
       ..StateOptions::default()
     };
-
-    let state = State::new(state_options);
+    let stomach = Rc::new(RefCell::new(Stomach::default()));
+    let mut state = State::new(state_options);
+    state.stomach = stomach.clone();
 
     Core {
       state,
       preload,
+      stomach,
       ..Core::default()
     }
   }
 
-  pub fn state_mut(&mut self) -> &mut State { &mut self.state }
+  pub fn get_state(&self) -> &State { &self.state }
+  pub fn get_state_mut(&mut self) -> &mut State { &mut self.state }
 }
 
 pub trait BoxOps {

--- a/rtx_core/src/lib.rs
+++ b/rtx_core/src/lib.rs
@@ -128,7 +128,6 @@ impl Core {
       state,
       preload,
       stomach,
-      ..Core::default()
     }
   }
 

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -13,6 +13,7 @@ use document::resource::Resource;
 use document::tag::TagOptions;
 use document::Document;
 
+use mouth::Mouth;
 use stomach::Stomach;
 use token::{Catcode, Token};
 use tokens::Tokens;
@@ -1447,6 +1448,9 @@ impl State {
     }
   }
 
+  // WALL OF SHAME
+  // HACKY functions that violate Rust's mutability guards, to succeed in emulating the most
+  // arbitrary uses of Global scope in latexml
   pub fn after_assignment(&mut self) {
     if let Some(Stored::Tokens(after)) = self.remove_value("afterAssignment") {
       self.stomach.borrow_mut().get_gullet_mut().unread(after); // primitive returns boxes, so these need to be digested!

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -1,4 +1,5 @@
 use regex::Regex;
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::hash::Hash;
 use std::rc::Rc;
@@ -12,6 +13,7 @@ use document::resource::Resource;
 use document::tag::TagOptions;
 use document::Document;
 
+use stomach::Stomach;
 use token::{Catcode, Token};
 use tokens::Tokens;
 use util::pathname;
@@ -191,7 +193,7 @@ impl UndoFrame {
 ///      (see also activateScope & deactivateScope)
 pub type Table = HashMap<String, VecDeque<Stored>>;
 pub struct State {
-  /// Tables
+  // Tables
   pub value: Table,
   pub meaning: Table,
   pub stash: Table,
@@ -202,9 +204,9 @@ pub struct State {
   pub lccode: Table,
   pub uccode: Table,
   pub delcode: Table,
-  /// Table bookkeeping
+  // Table bookkeeping
   pub undo: VecDeque<UndoFrame>,
-  /// Stateful runtime - data structures
+  // Stateful runtime - data structures
   pub model: Model,
   pub document: Option<Document>,
   pub prefixes: HashMap<String, bool>, // ?
@@ -213,7 +215,7 @@ pub struct State {
   pub tag_properties: HashMap<String, TagOptions>,
   pub indirect_model: Option<IndirectModel>,
   pub pending_resources: Vec<Resource>,
-  /// Stateful runtime - simple fields
+  // Stateful runtime - simple fields
   pub verbosity: i32,
   pub status_code: usize,
   pub unlocked: bool,
@@ -227,6 +229,9 @@ pub struct State {
   pub graphics_paths: VecDeque<String>,
   pub include_styles: bool,
   pub nomathparse: bool,
+  // Circular dependency and global $STATE in Perl requires a bad
+  // style use of interior mutability...
+  pub stomach: Rc<RefCell<Stomach>>,
 }
 
 impl Default for State {
@@ -275,6 +280,8 @@ impl Default for State {
       graphics_paths: VecDeque::new(),
       include_styles: false,
       nomathparse: false,
+      // interiorly mutable
+      stomach: Rc::new(RefCell::new(Stomach::default())),
     }
   }
 }
@@ -1409,7 +1416,7 @@ impl State {
       None => Stored::Token(token2),
     };
     self.assign_meaning(token1, meaning, scope);
-    // TODO: AfterAssignment!();
+    self.after_assignment();
   }
   /// `XEquals` check for two token arguments
   pub fn x_equals(&mut self, token1: &Token, token2: &Token) -> bool {
@@ -1437,6 +1444,12 @@ impl State {
       }
     } else {
       false // False, if only one has 'meaning'
+    }
+  }
+
+  pub fn after_assignment(&mut self) {
+    if let Some(Stored::Tokens(after)) = self.remove_value("afterAssignment") {
+      self.stomach.borrow_mut().get_gullet_mut().unread(after); // primitive returns boxes, so these need to be digested!
     }
   }
 }

--- a/rtx_core/src/stomach.rs
+++ b/rtx_core/src/stomach.rs
@@ -283,8 +283,9 @@ impl Stomach {
         None,
       );
 
+      let gullet = self.get_gullet_mut();
       state.let_i(token, T_CS!("\\iffalse"), None);
-      self.get_gullet_mut().unread(Tokens!(token.clone())); // Retry
+      gullet.unread(Tokens!(token.clone())); // Retry
       Ok(Vec::new())
     } else {
       error!(


### PR DESCRIPTION
Added: 
 * basic boilerplate for registers: Glue, MuGlue, Dimension
 * more auto-casting between Register and Stored
 * fleshed out Register API (RegisterGetterClosure, RegisterSetterClosure, RegisterOptions)

Finalized: 
 * support for DefRegister, NewCounter 

Hacked: 
 * Added a `Rc<RefCell<Stomach>>` in the `State`, as the after-assignment flow violates any separation of concerns principles. The worst examples are in e.g. `Let` which invokes afterassignment from arbitrary  locations - both top-level definitions in bindings, as well as any closure in the expansion/digestion flow. 

Unless we make a Gullet/Stomach object accessible everywhere (e.g. via passing around the `Core` object), there is no way to allow for that technique. But since this is a design requirement coming all the way back from core-TeX, it needs to be supported. Working with any higher-level object than State (= Core) leads to mutability conflicts in Rust immediately, and there is no clean way to untangle them without redesigning everything from the ground up.

So, after a lot of back-and-forth, I've come to reintroduce the dependency between State and Stomach, using the trick of interior mutability to keep Rust's compliance checks silent. It is hard and dirty to use, which I like, as it should be an absolute last-ditch mechanism for pathological cases such as AfterAssignment. Any better behaved binding constructs can still fully rely on the "typed closure hygiene" Rust brings along.