### PR TITLE
performance upgrade: Rc-wrapped atomic digested objects

### DIFF
--- a/rtx/src/converter.rs
+++ b/rtx/src/converter.rs
@@ -165,7 +165,7 @@ impl Converter {
       Err(e) => {
         // TODO digestion failed, report
         e.log_fatal();
-        Digested::List(Box::new(List::new(Vec::new())))
+        Digested::List(List::new(Vec::new()))
       },
       Ok(d) => d,
     };

--- a/rtx/src/package/binding_macros.rs
+++ b/rtx/src/package/binding_macros.rs
@@ -225,7 +225,7 @@ macro_rules! prop_digested {
   ($props:ident, $key:expr) => {
     match $props.get($key) {
       Some(Stored::VecDigested(vd)) => vd.clone(),
-      Some(Stored::Digested(d)) => vec![(**d).clone()],
+      Some(Stored::Digested(d)) => vec![(*d).clone()],
       Some(Stored::String(s)) => vec![s.into()],
       _ => Vec::new(),
     }
@@ -257,8 +257,8 @@ macro_rules! prop_whatsit {
   ($props:ident, $key:expr) => {
     match $props.get($key) {
       // TODO: Cloning here ought to be terribly inefficient and should be avoided. How?
-      Some(&Stored::Digested(ref rc)) => (**rc).clone(),
-      _ => Digested::Whatsit(Box::new(Whatsit::default())),
+      Some(&Stored::Digested(ref rc)) => (*rc).clone(),
+      _ => Digested::Whatsit(Rc::new(RefCell::new(Whatsit::default()))),
     };
   };
 }

--- a/rtx/src/package/functions.rs
+++ b/rtx/src/package/functions.rs
@@ -1081,7 +1081,7 @@ pub fn ref_step_counter(
   state.activate_scope(&scope);
 
   Ok(map!(
-    "tags" => Stored::Digested(Rc::new(tags)),
+    "tags" => Stored::Digested(tags),
     "id" => Stored::String(id)
   ))
 }

--- a/rtx/src/package/mod.rs
+++ b/rtx/src/package/mod.rs
@@ -1,5 +1,7 @@
 pub use libxml::tree::{Namespace, Node};
 pub use regex::Regex;
+pub use std::borrow::Cow;
+pub use std::cell::RefCell;
 pub use std::collections::HashMap;
 pub use std::collections::VecDeque;
 pub use std::rc::Rc;

--- a/rtx/src/package/pool/latex.rs
+++ b/rtx/src/package/pool/latex.rs
@@ -292,7 +292,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
         //   e.g. unlist()-ing a digested List will have to produce box references, rather than provide the owned boxes directly.
         //   would have to experiment with this - as it is of course much lighter on performance
         if let Some(Stored::Digested(tags)) = props.get("tags") {
-          document.absorb((**tags).clone(), state)?;
+          document.absorb(tags.clone(), state)?;
         }
         let title = prop_digested!(props, "title");
         document.insert_element("ltx:title", title, None, state)?;

--- a/rtx/src/package/pool/tex_ch24_primitives.rs
+++ b/rtx/src/package/pool/tex_ch24_primitives.rs
@@ -34,7 +34,7 @@ pub fn load_definitions(outer_state: &mut State) -> Result<()> {
         Some(TexMode::Text)
       };
       let body = stomach.digest_next_body(false, state)?;
-      let mut boxes = vec![Digested::TBox(Box::new(open))];
+      let mut boxes = vec![Digested::TBox(Rc::new(open))];
       boxes.extend(body);
       let return_list = List {
         boxes,
@@ -42,7 +42,7 @@ pub fn load_definitions(outer_state: &mut State) -> Result<()> {
         font: None,
       };
 
-      Ok(vec![Digested::List(Box::new(return_list))])
+      Ok(vec![Digested::List(return_list)])
     })
   );
 
@@ -103,8 +103,12 @@ pub fn load_definitions(outer_state: &mut State) -> Result<()> {
       while !boxes.is_empty() {
         let is_space : bool;
         {
-          is_space = if let Some(Stored::Bool(space_bool)) = boxes[0].get_property("isSpace", state) {
-            *space_bool 
+          is_space = if let Some(space_val) = boxes[0].get_property("isSpace", state) {
+            match space_val {
+              Cow::Borrowed(Stored::Bool(space_bool)) => *space_bool,
+              Cow::Owned(Stored::Bool(ref space_bool))  => *space_bool, // TODO : is there match syntax for Cow ?
+              _ => false
+            }
           } else {
             false
           };

--- a/rtx/src/package/pool/tex_math_mode.rs
+++ b/rtx/src/package/pool/tex_math_mode.rs
@@ -90,7 +90,7 @@ pub fn load_definitions(state: &mut State) -> Result<()> {
 
       let tex_opt = if let Some(ref tbox) = document.get_node_box(&node) {
         if let Some(body) = tbox.get_body() {
-          Some(untex(body, state))
+          Some(untex(&body, state))
         // local $LaTeXML::DUAL_BRANCH = 'presentation';
         // let tex = untex(body, state);
         // $LaTeXML::DUAL_BRANCH = 'content';

--- a/rtx/src/package/setup.rs
+++ b/rtx/src/package/setup.rs
@@ -1672,7 +1672,7 @@ macro_rules! SetupBindingMacros {($state:ident) => (
         //   if (ref $value eq 'CODE') {
         //     $properties{$key} = &$value(); } }
         info!("defmath_prim: {}, tokens: {:?}", &$presentation, $cs);
-        Ok(vec![Digested::TBox(Box::new( // TODO: Can we reduce boilerplate?
+        Ok(vec![Digested::TBox(Rc::new( // TODO: Can we reduce boilerplate?
           Tbox{ text: $presentation, tokens: Tokens!($cs.clone()), font, properties, ..Tbox::default()}
         ))])
       })),

--- a/rtx_codegen/src/constructable.rs
+++ b/rtx_codegen/src/constructable.rs
@@ -316,7 +316,7 @@ fn compile_replacement_tokens(mut replacement: String) -> Vec<quote::Tokens> {
           if let Some(text_match) = refs.get(1) {
             let escaped_match = &slashify(&unquote(text_match.as_str()));
             operations.push(quote!(
-            let content_box = Digested::TBox(Box::new(Tbox{text: #escaped_match.to_string(), ..Tbox::default()}));
+            let content_box = Digested::TBox(Rc::new(Tbox{text: #escaped_match.to_string(), ..Tbox::default()}));
             document.absorb(content_box, state)?;
           ));
             is_match = true;

--- a/rtx_core/src/common/store.rs
+++ b/rtx_core/src/common/store.rs
@@ -78,7 +78,7 @@ pub enum Stored {
   IfFrame(Rc<RefCell<IfFrame>>),
   /////// MathPrimitiveOptions(MathPrimitiveOptions), // Maybe later
   Constructor(Rc<Constructor>),
-  Digested(Rc<::Digested>),
+  Digested(::Digested),
   Parameter(Parameter),
   Font(Rc<Font>),
   Ligature(Box<Ligature>),
@@ -217,11 +217,8 @@ impl From<Constructor> for Stored {
   fn from(value: Constructor) -> Self { Rc::new(value).into() }
 }
 
-impl From<Rc<::Digested>> for Stored {
-  fn from(definition: Rc<::Digested>) -> Self { Stored::Digested(definition) }
-}
 impl From<::Digested> for Stored {
-  fn from(value: ::Digested) -> Self { Rc::new(value).into() }
+  fn from(value: ::Digested) -> Self { Stored::Digested(value) }
 }
 
 impl From<Parameter> for Stored {
@@ -427,7 +424,7 @@ impl<'a> From<&'a Stored> for Option<RegisterValue> {
 impl<'a> From<&'a Stored> for Option<::Digested> {
   fn from(value: &'a Stored) -> Option<::Digested> {
     match value {
-      Stored::Digested(digested) => Some((**digested).clone()),
+      Stored::Digested(digested) => Some((*digested).clone()),
       _ => None,
     }
   }

--- a/rtx_core/src/document/mod.rs
+++ b/rtx_core/src/document/mod.rs
@@ -31,18 +31,16 @@ lazy_static! {
 static FONT_ELEMENT_NAME: &'static str = "ltx:text";
 static MATH_TOKEN_NAME: &'static str = "ltx:XMTok";
 
-pub type DigestedRef = Rc<Digested>;
-
 pub struct Document {
   pub document: XmlDoc,
   pub pending: Vec<Node>,
   pub node: Node,
-  pub node_boxes: HashMap<usize, DigestedRef>, // used to be _box attribute
-  pub node_fonts: HashMap<usize, Font>,        // used to be _font attribute
+  pub node_boxes: HashMap<usize, Digested>, // used to be _box attribute
+  pub node_fonts: HashMap<usize, Font>,     // used to be _font attribute
   pub debug: bool,
   pub constructed_nodes: Vec<Node>,
-  box_to_absorb: Option<DigestedRef>, // local $LaTeXML::BOX;
-  localized_boxes: Vec<Option<DigestedRef>>,
+  box_to_absorb: Option<Digested>, // local $LaTeXML::BOX;
+  localized_boxes: Vec<Option<Digested>>,
 }
 impl Default for Document {
   fn default() -> Self { Self::new() }
@@ -256,7 +254,7 @@ impl Document {
     let mut boxes = VecDeque::new();
     boxes.push_front(object);
     while let Some(front_box) = boxes.pop_front() {
-      if let Digested::List(list) = front_box {
+      if let Digested::List(ref list) = front_box {
         // Simply unwind Lists to avoid unneccessary recursion; This occurs quite frequently!
         for tbox in list.unlist().into_iter().rev() {
           boxes.push_front(tbox);
@@ -264,12 +262,11 @@ impl Document {
       } else {
         // info!(target: "document:absorb", "front box: {:?}", front_box);
         // self.constructed_nodes = Vec::new();
-        let front_box = Rc::new(front_box);
         self.set_box_to_absorb(Some(front_box.clone()));
-        match *front_box {
+        match front_box {
           // A Proper Box or Whatsit? Absorb it.
           Digested::TBox(ref digested) => digested.be_absorbed(self, state)?,
-          Digested::Whatsit(ref digested) => digested.be_absorbed(self, state)?,
+          Digested::Whatsit(ref digested) => digested.borrow().be_absorbed(self, state)?,
           _ => unimplemented!(),
         };
         self.localize_box_to_absorb();
@@ -875,7 +872,7 @@ impl Document {
       Some(f) => f.clone(),
       None => match &self.box_to_absorb {
         &Some(ref tbox) => match tbox.get_font() {
-          Some(f) => f.clone(),
+          Some(f) => f.into_owned(),
           None => Font::math_default(), // should never happen?
         },
         &None => Font::math_default(), // should never happen?
@@ -1337,12 +1334,12 @@ impl Document {
 
   //**********************************************************************
   /// Record the Box that created this node.
-  pub fn set_node_box(&mut self, node: &Node, digested: DigestedRef) {
+  pub fn set_node_box(&mut self, node: &Node, digested: Digested) {
     let nodeid = node.to_hashable();
     self.node_boxes.insert(nodeid, digested);
   }
 
-  pub fn get_node_box(&self, node: &Node) -> Option<&DigestedRef> {
+  pub fn get_node_box(&self, node: &Node) -> Option<&Digested> {
     if node.get_type() == Some(NodeType::ElementNode) {
       let nodeid = node.to_hashable();
       self.node_boxes.get(&nodeid)
@@ -1371,7 +1368,7 @@ impl Document {
           .unwrap()
           .get_font()
           .unwrap()
-          .clone(),
+          .into_owned(),
       );
     }
   }
@@ -1659,7 +1656,7 @@ impl Document {
     attrib.insert(s!("src"), resource.name);
     attrib.insert(s!("type"), resource.mimetype);
     attrib.insert(s!("media"), resource.media);
-    let content_box = Digested::TBox(Box::new(Tbox {
+    let content_box = Digested::TBox(Rc::new(Tbox {
       text: resource.content,
       ..Tbox::default()
     }));
@@ -1701,7 +1698,7 @@ impl Document {
   // TODO!
   fn float_to_element(&mut self, element: &str, flag: bool) -> Option<Node> { None }
 
-  pub fn set_box_to_absorb(&mut self, arg: Option<DigestedRef>) {
+  pub fn set_box_to_absorb(&mut self, arg: Option<Digested>) {
     self.localized_boxes.push(self.box_to_absorb.take());
     self.box_to_absorb = arg;
   }

--- a/rtx_core/src/lib.rs
+++ b/rtx_core/src/lib.rs
@@ -35,6 +35,7 @@ pub mod tbox;
 pub mod util;
 pub mod whatsit;
 
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::fmt;
 use std::rc::Rc;
@@ -138,20 +139,20 @@ impl Core {
 }
 
 pub trait BoxOps {
-  fn unlist(self) -> Vec<Digested>;
+  fn unlist(&self) -> Vec<Digested>;
   fn be_absorbed(&self, document: &mut Document, state: &mut State) -> Result<()>;
   fn to_string(&self) -> String;
   fn stringify(&self) -> String { s!("Vec<Tbox> for now ") }
   fn set_property<T: Into<Stored>>(&mut self, _key: &str, _value: T) {}
-  fn get_property(&self, _key: &str, _state: &mut State) -> Option<&Stored> {
+  fn get_property(&self, _key: &str, _state: &mut State) -> Option<Cow<Stored>> {
     error!(target: "boxops:get_property", "Generic BoxOps::get_property should never be called!");
     None
   }
-  fn get_body(&self) -> Option<&Digested> {
+  fn get_body(&self) -> Option<Digested> {
     error!(target: "boxops:get_body", "Generic BoxOps::get_body should never be called!");
     None
   }
-  fn get_font(&self) -> Option<&Font>;
+  fn get_font(&self) -> Option<Cow<Font>>;
   fn revert(&self) -> Tokens;
 }
 
@@ -163,10 +164,10 @@ pub enum TexMode {
 
 #[derive(Clone, PartialEq)]
 pub enum Digested {
-  TBox(Box<Tbox>),
-  List(Box<List>),
-  Whatsit(Box<Whatsit>),
-  Postponed(Tokens),
+  TBox(Rc<Tbox>),
+  Whatsit(Rc<RefCell<Whatsit>>),
+  List(List),
+  Postponed(Rc<Tokens>),
 }
 impl fmt::Debug for Digested {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -181,7 +182,7 @@ impl fmt::Debug for Digested {
 
 impl<'a> From<&'a String> for Digested {
   fn from(value: &'a String) -> Digested {
-    Digested::TBox(Box::new(Tbox {
+    Digested::TBox(Rc::new(Tbox {
       text: value.to_string(),
       ..Tbox::default()
     }))
@@ -199,15 +200,15 @@ impl<'a> From<Digested> for Tokens {
 }
 
 impl Default for Digested {
-  fn default() -> Self { Digested::TBox(Box::new(Tbox::default())) }
+  fn default() -> Self { Digested::TBox(Rc::new(Tbox::default())) }
 }
 
 impl BoxOps for Digested {
-  fn unlist(self) -> Vec<Digested> {
+  fn unlist(&self) -> Vec<Digested> {
     match self {
-      Digested::TBox(b) => b.unlist(),
-      Digested::List(l) => l.unlist(),
-      Digested::Whatsit(w) => w.unlist(),
+      Digested::TBox(ref b) => b.unlist(),
+      Digested::List(ref l) => l.unlist(),
+      Digested::Whatsit(ref w) => w.borrow().unlist(),
       Digested::Postponed(ref _t) => unimplemented!(),
     }
   }
@@ -216,7 +217,7 @@ impl BoxOps for Digested {
     match self {
       Digested::TBox(b) => b.be_absorbed(document, state),
       Digested::List(l) => l.be_absorbed(document, state),
-      Digested::Whatsit(w) => w.be_absorbed(document, state),
+      Digested::Whatsit(w) => w.borrow().be_absorbed(document, state),
       Digested::Postponed(_) => unimplemented!(),
     }
   }
@@ -225,7 +226,7 @@ impl BoxOps for Digested {
     match *self {
       Digested::TBox(ref b) => b.to_string(),
       Digested::List(ref l) => l.to_string(),
-      Digested::Whatsit(ref w) => w.to_string(),
+      Digested::Whatsit(ref w) => w.borrow().to_string(),
       Digested::Postponed(ref t) => t.to_string(),
     }
   }
@@ -234,8 +235,8 @@ impl BoxOps for Digested {
     match *self {
       Digested::TBox(ref b) => b.stringify(),
       Digested::List(ref l) => l.stringify(),
-      Digested::Whatsit(ref w) => w.stringify(),
-      Digested::Postponed(ref t) => t.clone().stringify(),
+      Digested::Whatsit(ref w) => w.borrow().stringify(),
+      Digested::Postponed(ref t) => (*t).stringify(),
     }
   }
 
@@ -247,23 +248,26 @@ impl BoxOps for Digested {
       Digested::List(ref l) => {
         error!(target: "digested:set_property", "Called set_property on List: {:?}", l)
       },
-      Digested::Whatsit(ref mut w) => w.set_property(key, value),
+      Digested::Whatsit(ref w) => w.borrow_mut().set_property(key, value), // TODO
       Digested::Postponed(ref _t) => unimplemented!(),
     }
   }
 
-  fn get_property(&self, key: &str, state: &mut State) -> Option<&Stored> {
+  fn get_property(&self, key: &str, state: &mut State) -> Option<Cow<Stored>> {
     match *self {
       Digested::TBox(ref b) => b.get_property(key, state),
       Digested::List(ref l) => {
         error!(target: "digested:get_property", "Called get_property on List: {:?}", l);
         None
       },
-      Digested::Whatsit(ref w) => w.get_property(key, state),
+      Digested::Whatsit(ref w) => match w.borrow().get_property(key, state) {
+        None => None,
+        Some(v) => Some(Cow::Owned(v.into_owned())),
+      },
       Digested::Postponed(ref _t) => unimplemented!(),
     }
   }
-  fn get_body(&self) -> Option<&Digested> {
+  fn get_body(&self) -> Option<Digested> {
     match *self {
       Digested::TBox(ref b) => {
         error!(target: "digested:get_body", "Called get_body on Box: {:?}", b);
@@ -273,16 +277,19 @@ impl BoxOps for Digested {
         error!(target: "digested:get_body", "Called get_body on List: {:?}", l);
         None
       },
-      Digested::Whatsit(ref w) => w.get_body(),
+      Digested::Whatsit(ref w) => w.borrow().get_body(),
       Digested::Postponed(ref _t) => unimplemented!(),
     }
   }
 
-  fn get_font(&self) -> Option<&Font> {
+  fn get_font(&self) -> Option<Cow<Font>> {
     match *self {
       Digested::TBox(ref b) => b.get_font(),
       Digested::List(ref l) => l.get_font(),
-      Digested::Whatsit(ref w) => w.get_font(),
+      Digested::Whatsit(ref w) => match w.borrow().get_font() {
+        None => None,
+        Some(t) => Some(Cow::Owned(t.into_owned())),
+      },
       Digested::Postponed(ref _t) => unimplemented!(),
     }
   }
@@ -291,8 +298,8 @@ impl BoxOps for Digested {
     match *self {
       Digested::TBox(ref b) => b.revert(),
       Digested::List(ref l) => l.revert(),
-      Digested::Whatsit(ref w) => w.revert(),
-      Digested::Postponed(ref t) => t.clone(),
+      Digested::Whatsit(ref w) => w.borrow().revert(),
+      Digested::Postponed(ref t) => (**t).clone(),
     }
   }
 }

--- a/rtx_core/src/list.rs
+++ b/rtx_core/src/list.rs
@@ -1,8 +1,11 @@
+use std::borrow::Cow;
+use std::fmt;
+
 use common::error::*;
 use common::font::Font;
 use document::Document;
 use state::State;
-use std::fmt;
+
 use token::Token;
 use tokens::Tokens;
 use {BoxOps, Digested, TexMode};
@@ -26,7 +29,7 @@ impl fmt::Debug for List {
 }
 
 impl BoxOps for List {
-  fn unlist(self) -> Vec<Digested> { self.boxes.into_iter().collect::<Vec<_>>() }
+  fn unlist(&self) -> Vec<Digested> { self.boxes.clone() }
 
   fn to_string(&self) -> String {
     self
@@ -53,7 +56,12 @@ impl BoxOps for List {
     Tokens::new(reverted)
   }
 
-  fn get_font(&self) -> Option<&Font> { self.font.as_ref() }
+  fn get_font(&self) -> Option<Cow<Font>> {
+    match self.font {
+      None => None,
+      Some(ref f) => Some(Cow::Borrowed(&f)),
+    }
+  }
 }
 
 impl List {
@@ -66,7 +74,7 @@ impl List {
     let mut font: Option<Font> = None;
     for bx in boxes.iter().rev() {
       if let Some(bx_font) = bx.get_font() {
-        font = Some(bx_font.clone());
+        font = Some(bx_font.into_owned());
         break;
       }
     }
@@ -83,5 +91,5 @@ impl From<List> for Result<Vec<Digested>> {
 }
 
 impl From<List> for Result<Digested> {
-  fn from(list: List) -> Result<Digested> { Ok(Digested::List(Box::new(list))) }
+  fn from(list: List) -> Result<Digested> { Ok(Digested::List(list)) }
 }

--- a/rtx_core/src/parameter.rs
+++ b/rtx_core/src/parameter.rs
@@ -295,7 +295,7 @@ impl Parameter {
       if !self.undigested {
         Some(value_to_digest.be_digested(stomach, state)?)
       } else {
-        Some(Digested::Postponed(value_to_digest))
+        Some(Digested::Postponed(Rc::new(value_to_digest)))
       }
     } else {
       None

--- a/rtx_core/src/stomach.rs
+++ b/rtx_core/src/stomach.rs
@@ -58,7 +58,7 @@ impl Stomach {
         None => {
           // Wer ran out, terminate,
           // and add a Dummy `trailer' if none explicit.
-          box_list.push(Digested::TBox(Box::new(Tbox::default())));
+          box_list.push(Digested::TBox(Rc::new(Tbox::default())));
           // info!(target:"digest_next_body","no_token");
           break;
         },
@@ -131,7 +131,7 @@ impl Stomach {
         // let list = STOMACH_LIST.lock()
         let mut digested_list = List::new(digested_boxes);
         digested_list.mode = Some(mode);
-        Ok(Digested::List(Box::new(digested_list)))
+        digested_list.into()
       }),
     )
   }
@@ -360,7 +360,7 @@ impl Stomach {
       if in_math || in_preamble {
         Ok(Vec::new())
       } else {
-        Ok(vec![Digested::TBox(Box::new(Tbox::new(
+        Ok(vec![Digested::TBox(Rc::new(Tbox::new(
           meaning.get_string().to_string(), //text
           font,
           Some(self.gullet.get_locator()), //locator
@@ -386,7 +386,7 @@ impl Stomach {
     // return; }
     else {
       let text = font::decode_string(meaning.get_string().to_string(), None, true, state);
-      Ok(vec![Digested::TBox(Box::new(Tbox::new(
+      Ok(vec![Digested::TBox(Rc::new(Tbox::new(
         text,
         font,
         None,             // locator

--- a/rtx_core/src/tbox.rs
+++ b/rtx_core/src/tbox.rs
@@ -1,6 +1,7 @@
+use std::borrow::Cow;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::cell::RefCell;
 
 use common::error::*;
 use common::font::Font;
@@ -97,7 +98,7 @@ impl Tbox {
 
 impl BoxOps for Tbox {
   fn to_string(&self) -> String { self.text.clone() }
-  fn unlist(self) -> Vec<Digested> { Vec::new() }
+  fn unlist(&self) -> Vec<Digested> { Vec::new() }
 
   fn be_absorbed(&self, document: &mut Document, state: &mut State) -> Result<()> {
     let text = &self.text;
@@ -124,30 +125,35 @@ impl BoxOps for Tbox {
 
   fn revert(&self) -> Tokens { self.tokens.clone() }
 
-  fn get_font(&self) -> Option<&Font> { Some(&self.font) }
+  fn get_font(&self) -> Option<Cow<Font>> { Some(Cow::Borrowed(&self.font)) }
 
-  fn get_property(&self, key: &str, state: &mut State) -> Option<&Stored> {
+  fn get_property(&self, key: &str, state: &mut State) -> Option<Cow<Stored>> {
     if key == "isSpace" {
       match self.properties.get(key) {
-        Some(value) => Some(value),
+        Some(value) => Some(Cow::Borrowed(value)),
         None => {
           let tex = self.tokens.untex(state); // !
           let property_bool = !tex.is_empty() && tex.chars().all(|c| c.is_whitespace()); // Check the TeX code, not (just) the string!
-          Some(property_bool.into())
+          Some(Cow::Borrowed(property_bool.into()))
         },
       }
     } else {
-      self.properties.get(key)
+      match self.properties.get(key) {
+        None => None,
+        Some(v) => Some(Cow::Borrowed(v)),
+      }
     }
   }
 }
 
 impl From<Tbox> for Result<Vec<Digested>> {
-  fn from(tbox: Tbox) -> Result<Vec<Digested>> { Ok(vec![Digested::TBox(Box::new(tbox))]) }
+  fn from(tbox: Tbox) -> Result<Vec<Digested>> { Ok(vec![Digested::TBox(Rc::new(tbox))]) }
 }
-impl From<Tbox> for Option<Rc<Digested>> {
-  fn from(tbox: Tbox) -> Option<Rc<Digested>> { Some(Rc::new(Digested::TBox(Box::new(tbox)))) }
+impl From<Tbox> for Option<Digested> {
+  fn from(tbox: Tbox) -> Option<Digested> { Some(Digested::TBox(Rc::new(tbox))) }
 }
 impl From<Tbox> for Option<Rc<RefCell<Digested>>> {
-  fn from(tbox: Tbox) -> Option<Rc<RefCell<Digested>>> { Some(Rc::new(RefCell::new(Digested::TBox(Box::new(tbox))))) }
+  fn from(tbox: Tbox) -> Option<Rc<RefCell<Digested>>> {
+    Some(Rc::new(RefCell::new(Digested::TBox(Rc::new(tbox)))))
+  }
 }

--- a/rtx_core/src/tokens.rs
+++ b/rtx_core/src/tokens.rs
@@ -125,7 +125,7 @@ impl Tokens {
   // should we unify the interfaces so that Options are always used? Could be cumbursome...
   pub fn unwrap_or_default(self) -> Tokens { self }
 
-  pub fn stringify(self) -> String {
+  pub fn stringify(&self) -> String {
     s!(
       "Tokens[{}]",
       &self

--- a/rtx_core/src/whatsit.rs
+++ b/rtx_core/src/whatsit.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt;
 use std::rc::Rc;
@@ -77,10 +79,10 @@ impl Whatsit {
     }
     self
       .properties
-      .insert(s!("body"), Digested::List(Box::new(list)).into());
-    if let Some(Digested::Whatsit(trailer)) = trailer_opt {
+      .insert(s!("body"), Digested::List(list).into());
+    if let Some(Digested::Whatsit(ref trailer)) = trailer_opt {
       // And copy any otherwise undefined properties from the trailer
-      for (prop, value) in trailer.get_properties() {
+      for (prop, value) in trailer.borrow().get_properties() {
         self
           .properties
           .entry(prop.to_string())
@@ -88,7 +90,7 @@ impl Whatsit {
       }
       self
         .properties
-        .insert(s!("trailer"), Digested::Whatsit(trailer).into());
+        .insert(s!("trailer"), trailer_opt.as_ref().unwrap().clone().into());
     }
   }
 }
@@ -108,7 +110,7 @@ impl BoxOps for Whatsit {
     self.revert().to_string() // What else??
   }
 
-  fn unlist(self) -> Vec<Digested> { Vec::new() }
+  fn unlist(&self) -> Vec<Digested> { Vec::new() }
 
   fn be_absorbed(&self, document: &mut Document, state: &mut State) -> Result<()> {
     // Significant time is consumed here, and associated with a specific CS,
@@ -119,24 +121,25 @@ impl BoxOps for Whatsit {
     // LaTeXML::Definition::startProfiling($profiled, 'absorb') if $profiled;
     // info!(target:"whatsit:be_absorbed", "{:?}", self);
 
-    self
-      .definition
-      .do_absorbtion(document, self, state)?;
+    self.definition.do_absorbtion(document, self, state)?;
     // LaTeXML::Definition::stopProfiling($profiled, 'absorb') if $profiled;
     Ok(())
   }
 
-  fn get_property(&self, key: &str, _state: &mut State) -> Option<&Stored> {
-    self.properties.get(key)
+  fn get_property(&self, key: &str, _state: &mut State) -> Option<Cow<Stored>> {
+    match self.properties.get(key) {
+      None => None,
+      Some(v) => Some(Cow::Borrowed(v)),
+    }
   }
 
   fn set_property<T: Into<Stored>>(&mut self, key: &str, value: T) {
     self.properties.insert(key.to_string(), value.into());
   }
 
-  fn get_body(&self) -> Option<&Digested> {
+  fn get_body(&self) -> Option<Digested> {
     match self.properties.get("body") {
-      Some(&Stored::Digested(ref body)) => Some(body),
+      Some(&Stored::Digested(ref body)) => Some(body.clone()),
       _ => None,
     }
   }
@@ -146,14 +149,14 @@ impl BoxOps for Whatsit {
     Tokens!()
   }
 
-  fn get_font(&self) -> Option<&Font> {
+  fn get_font(&self) -> Option<Cow<Font>> {
     match self.properties.get("font") {
-      Some(&Stored::Font(ref font)) => Some(font),
+      Some(&Stored::Font(ref font)) => Some(Cow::Owned((**font).clone())),
       _ => None,
     }
   }
 }
 
 impl From<Whatsit> for Digested {
-  fn from(w: Whatsit) -> Digested { Digested::Whatsit(Box::new(w)) }
+  fn from(w: Whatsit) -> Digested { Digested::Whatsit(Rc::new(RefCell::new(w))) }
 }


### PR DESCRIPTION
Base idea: 
 * Avoid deep clones on `Digested` objects, but resign to needing clones for at least the atoms, as they cohabitate all of 1) state storage, 2) main application flow, 3) `node_boxes` map that associates constructed nodes to their digested boxes.
 * Also, use as lightweight wrappers as possible to improve performance,
 * So Digested has now evolved into a Rc-pointer for Tbox and Whatsit, where Whatsit also requires a RefCell as we still want to allow mutability.

```rust
pub enum Digested {
  TBox(Rc<Tbox>),
  Whatsit(Rc<RefCell<Whatsit>>),
  List(List),
  Postponed(Rc<Tokens>),
}
```

Also, using Rc internally to the digested variants that end up cloned frequently allows to more freely store digested objects as-is (similarly to the rust-libxml Node objects), as the underlying data remains shared between multiple Digested enum instances.