### PR TITLE
Auto localized state in closures

### DIFF
--- a/rtx_codegen/src/lib.rs
+++ b/rtx_codegen/src/lib.rs
@@ -87,10 +87,7 @@ pub fn bound_state(input: TokenStream) -> TokenStream {
       let options = get_options_from_input("bound_options", &item.attrs, bug);
       let location_opt = options.as_ref().map(|o| get_option(&o, "location", bug));
       let location = match location_opt {
-        Some(n) => {
-          println!("loc opt: {:?}", location_opt);
-          n
-        },
+        Some(n) => n,
         None => "outer",
       };
 

--- a/rtx_codegen/src/lib.rs
+++ b/rtx_codegen/src/lib.rs
@@ -8,9 +8,8 @@ extern crate rtx_core;
 extern crate proc_macro;
 #[macro_use]
 extern crate quote;
-extern crate regex;
-extern crate syn;
 
+use crate::util::{get_option, get_options_from_input};
 use proc_macro::TokenStream;
 use syn::parse_macro_input;
 
@@ -63,5 +62,60 @@ pub fn derive_load_indirect_model(input: TokenStream) -> TokenStream {
       Err(e) => panic!("Failed to load indirect model: {:?}", e),
     },
     Err(e) => panic!("Failed to parse macro input: {:?}", e),
+  }
+}
+
+// May be good to track: https://github.com/rust-lang/rust/issues/54727
+// to see if it becomes possible one day to use this type of technique,
+// which would allow declarations such as:
+//     #[bound_state(outer)]
+//     pub fn load_definitions($state: &mut State, mut outer_stomach: Option<&mut Stomach>) -> Result<()> {
+//
+//     and
+//
+//     #[bound_state(inner)]
+//     | ... | { before digest closure here...}
+//
+//    making it possible to use the simple DefMacro("\\a","\\b") form in any context, while auto-binding the nearest state
+
+fn bug() -> ! { panic!("bug") }
+
+#[proc_macro_derive(BoundState, attributes(bind_options))]
+pub fn bound_state(input: TokenStream) -> TokenStream {
+  match parse_macro_input(&input.to_string()) {
+    Ok(item) => {
+      let options = get_options_from_input("bound_options", &item.attrs, bug);
+      let location_opt = options.as_ref().map(|o| get_option(&o, "location", bug));
+      let location = match location_opt {
+        Some(n) => {
+          println!("loc opt: {:?}", location_opt);
+          n
+        },
+        None => "outer",
+      };
+
+      let state_declaration = if location == "outer" {
+        quote!(
+          macro_rules! state {
+            () => {
+              outer_state!()
+            };
+          }
+        )
+      } else if location == "inner" {
+        quote!(
+          macro_rules! state {
+            () => {
+              inner_state!()
+            };
+          }
+        )
+      } else {
+        panic!("Unsupported bound state location: {:?}", location);
+      };
+
+      state_declaration.to_string().parse().unwrap()
+    },
+    Err(e) => panic!("Binding state failed: {:?}", e),
   }
 }

--- a/rtx_core/src/definition/conditional.rs
+++ b/rtx_core/src/definition/conditional.rs
@@ -209,7 +209,7 @@ impl Conditional {
   // # Return the token we've skipped to, and the frame that this applies to.
   fn skip_conditional_body(&self, nskips: f32, gullet: &mut Gullet, state: &mut State) -> Tokens {
     let mut level = 1;
-    let mut n_ors: f32 = 0.0;
+    let mut n_ors = 0;
     let _start = gullet.get_locator();
     // NOTE: Open-coded manipulation of if_stack!
     // [we're only reading tokens & looking up, so State shouldn't change behind our backs]
@@ -248,8 +248,8 @@ impl Conditional {
           if level <= 1 {
             // Ignore \else,\or nested in the body.
             if cond_type == Some(ConditionalType::Or) {
-              n_ors += 1.0;
-              if n_ors == nskips {
+              n_ors += 1;
+              if n_ors == nskips as i32 {
                 return t;
               }
             } else if cond_type == Some(ConditionalType::Else) && nskips != 0.0 {

--- a/rtx_package/src/lib.rs
+++ b/rtx_package/src/lib.rs
@@ -4,6 +4,7 @@
 
 //! Binding infrastructure for the `LaTeXML` converter, reimplemented in Rust
 #![feature(custom_attribute)]
+#![feature(stmt_expr_attributes)]
 #![allow(dead_code, unused_variables, unused_mut, unused_macros)]
 
 #[macro_use]

--- a/rtx_package/src/package/binding_macros.rs
+++ b/rtx_package/src/package/binding_macros.rs
@@ -91,6 +91,7 @@ macro_rules! primitivesub {
 macro_rules! primitiveproc {
   ($stomach:ident, $args:ident, $inner_state:ident, $body:block) => (
     |$stomach:&mut Stomach, mut $args : Vec<Tokens>, $inner_state:&mut State| {
+      // BindState!($inner_state, $stomach);
       $body
       Ok(Vec::new())
     }

--- a/rtx_package/src/package/binding_macros.rs
+++ b/rtx_package/src/package/binding_macros.rs
@@ -84,14 +84,17 @@ macro_rules! noprimitive {
 #[macro_export]
 macro_rules! primitivesub {
   ($stomach:ident, $args:ident, $inner_state:ident, $body:block) => {
-    move |$stomach: &mut Stomach, mut $args: Vec<Tokens>, $inner_state: &mut State| $body
+    move |$stomach: &mut Stomach, mut $args: Vec<Tokens>, $inner_state: &mut State| {
+      BindInnerState!($inner_state, $stomach);
+      $body
+    }
   };
 }
 #[macro_export]
 macro_rules! primitiveproc {
   ($stomach:ident, $args:ident, $inner_state:ident, $body:block) => (
     |$stomach:&mut Stomach, mut $args : Vec<Tokens>, $inner_state:&mut State| {
-      // BindState!($inner_state, $stomach);
+      BindInnerState!($inner_state, $stomach);
       $body
       Ok(Vec::new())
     }
@@ -101,7 +104,10 @@ macro_rules! primitiveproc {
 #[macro_export]
 macro_rules! beforesub {
   ($stomach:ident, $state:ident, $body:block) => {
-    vec![Rc::new(|$stomach: &mut Stomach, $state: &mut State| $body)]
+    vec![Rc::new(|$stomach: &mut Stomach, $state: &mut State| {
+      BindInnerState!($state, $stomach);
+      $body
+    })]
   };
 }
 #[macro_export]
@@ -116,6 +122,7 @@ macro_rules! beforeproc_single {
   // just as beforesub! but with a default return value
   ($stomach:ident, $state:ident, $body:expr) => {
     Rc::new(move |$stomach: &mut Stomach, $state: &mut State| {
+      BindInnerState!($state, $stomach);
       $body;
       Ok(Vec::new())
     })
@@ -127,6 +134,7 @@ macro_rules! tagsub {
   ($document:ident, $node:ident, $state:ident, $body:expr) => {
     vec![Rc::new(
       |$document: &mut Document, mut $node: &mut Node, $state: &mut State| -> Result<()> {
+        BindInnerState!($state);
         $body;
         Ok(())
       },
@@ -145,6 +153,7 @@ macro_rules! noreplacement {
 macro_rules! replacement {
   ($doc:ident, $args:ident, $props:ident, $state:ident, $body:expr) => (
     |$doc:&mut Document,$args: &Vec<Option<Digested>>,$props: &HashMap<String, Stored>, $state: &mut State| -> Result<()> {
+    BindInnerState!($state);
     $body
     Ok(())
   })
@@ -155,6 +164,7 @@ macro_rules! construct {
   ($doc:ident, $whatsit:ident, $state:ident, $body:expr) => {
   vec![Rc::new(
     move |$doc: &mut Document, $whatsit: &Whatsit, $state: &mut State| -> Result<()> {
+      BindInnerState!($state);
       $body
       Ok(())
     }
@@ -164,7 +174,12 @@ macro_rules! construct {
 #[macro_export]
 macro_rules! properties {
   (sub [ $stomach:ident, $args:ident, $inner_state:ident ] $body:block) => {
-    Rc::new(move |$stomach: &mut Stomach, mut $args: &Vec<Option<Digested>>, $inner_state: &mut State| -> Result<HashMap<String, Stored>> { $body })
+    Rc::new(
+      move |$stomach: &mut Stomach, mut $args: &Vec<Option<Digested>>, $inner_state: &mut State| -> Result<HashMap<String, Stored>> {
+        BindInnerState!($inner_state, $stomach);
+        $body
+      },
+    )
   };
   ($value:expr) => {
     Rc::new(move |_stomach: &mut Stomach, _args: &Vec<Option<Digested>>, _state: &mut State| -> Result<HashMap<String, Stored>> { Ok($value.clone()) })
@@ -175,7 +190,10 @@ macro_rules! properties {
 macro_rules! aftersub {
   ($stomach:ident, $whatsit:ident, $state:ident, $body:expr) => {
     vec![Rc::new(
-      move |$stomach: &mut Stomach, $whatsit: &mut Whatsit, $state: &mut State| -> Result<Vec<Digested>> { $body },
+      move |$stomach: &mut Stomach, $whatsit: &mut Whatsit, $state: &mut State| -> Result<Vec<Digested>> {
+        BindInnerState!($state, $stomach);
+        $body
+      },
     )]
   };
 }
@@ -184,6 +202,7 @@ macro_rules! aftersub {
 macro_rules! afterproc {
   ($stomach:ident, $whatsit:ident, $state:ident, $body:expr) => (
     vec![Rc::new(move |$stomach:&mut Stomach, $whatsit:&mut Whatsit, $state:&mut State| -> Result<Vec<Digested>> {
+      BindInnerState!($state, $stomach);
       $body
       Ok(Vec::new())
     }
@@ -193,7 +212,12 @@ macro_rules! afterproc {
 #[macro_export]
 macro_rules! reader {
   ($gullet:ident, $inner:ident, $extra:ident, $state:ident, $body:block) => {
-    Rc::new(|$gullet: &mut Gullet, $inner: Vec<Option<Parameters>>, $extra: Vec<ParameterExtra>, $state: &mut State| -> Result<Tokens> { $body })
+    Rc::new(
+      |$gullet: &mut Gullet, $inner: Vec<Option<Parameters>>, $extra: Vec<ParameterExtra>, $state: &mut State| -> Result<Tokens> {
+        BindInnerState!($state);
+        $body
+      },
+    )
   };
 }
 
@@ -201,7 +225,10 @@ macro_rules! reader {
 macro_rules! reader_predigest {
   ($stomach:ident, $arg:ident, $state:ident, $body:block) => {
     Some(Rc::new(
-      |$stomach: &mut Stomach, $arg: Tokens, $state: &mut State| -> Result<Option<Digested>> { $body },
+      |$stomach: &mut Stomach, $arg: Tokens, $state: &mut State| -> Result<Option<Digested>> {
+        BindInnerState!($state, $stomach);
+        $body
+      },
     ))
   };
 }
@@ -219,7 +246,10 @@ macro_rules! undigested {
 macro_rules! reversion {
   ($gullet:ident, $arg:ident, $inner:ident, $state:ident, $body:block) => {
     Some(Rc::new(
-      |$gullet: &mut Gullet, mut $arg: Vec<Token>, $inner: Vec<ParameterExtra>, $state: &mut State| -> Result<Tokens> { $body },
+      |$gullet: &mut Gullet, mut $arg: Vec<Token>, $inner: Vec<ParameterExtra>, $state: &mut State| -> Result<Tokens> {
+        BindInnerState!($state);
+        $body
+      },
     ))
   };
 }

--- a/rtx_package/src/package/functions.rs
+++ b/rtx_package/src/package/functions.rs
@@ -13,9 +13,14 @@ use rtx_core::common::number::Number;
 use rtx_core::common::store::IntoOption;
 use rtx_core::common::xml::XML_NS;
 use rtx_core::definition::conditional::{Conditional, ConditionalOptions, ConditionalType};
+use rtx_core::definition::constructor::{Constructor, ConstructorOptions};
 use rtx_core::definition::expandable::{Expandable, ExpandableOptions};
+use rtx_core::definition::math_primitive::{MathPrimitive, MathPrimitiveOptions};
+use rtx_core::definition::primitive::{Primitive, PrimitiveOptions};
 use rtx_core::definition::register::{NumericOps, Register, RegisterGetterClosure, RegisterSetterClosure, RegisterType, RegisterValue};
-use rtx_core::definition::{ConditionalClosure, Definition, ExpansionClosure};
+use rtx_core::definition::{
+  BeforeDigestClosure, ConditionalClosure, ConstructionClosure, Definition, DigestionClosure, ExpansionClosure, PrimitiveClosure, ReplacementClosure,
+};
 use rtx_core::document::resource::*;
 use rtx_core::document::tag::{TagOptionName, TagOptions};
 use rtx_core::document::Document;
@@ -25,10 +30,12 @@ use rtx_core::mouth::Mouth;
 use rtx_core::parameter::{Parameter, ParameterExtra, Parameters};
 use rtx_core::state::{Scope, State, Stored};
 use rtx_core::stomach::Stomach;
+use rtx_core::tbox::Tbox;
 use rtx_core::token::{Catcode, Token};
 use rtx_core::tokens::Tokens;
 use rtx_core::util::pathname;
 use rtx_core::util::pathname::PathnameFindOptions;
+use rtx_core::whatsit::Whatsit;
 use rtx_core::BoxOps;
 use rtx_core::{Core, Digested};
 
@@ -805,6 +812,393 @@ pub fn def_register<T: Into<RegisterValue>>(cs: Token, parameters: Option<Parame
     Some(Scope::Global),
   );
   return;
+}
+
+pub fn def_primitive(cs: Token, paramlist: Option<Parameters>, compiled_replacement: PrimitiveClosure, options: PrimitiveOptions, state: &mut State) {
+  let options_locked = options.locked;
+  let scope = options.scope.clone();
+  let mut before_digest_env: Vec<BeforeDigestClosure> = Vec::new();
+  let cs_name = cs.get_cs_name().to_owned();
+
+  if options.require_math {
+    let cs_name_cloned = cs_name.clone();
+    let require_math_closure = beforeproc_single!(stomach, state, { requireMath!(cs_name_cloned, state) });
+    before_digest_env.push(require_math_closure);
+  }
+
+  if options.forbid_math {
+    let cs_name_cloned = cs_name.clone();
+    let forbid_math_closure = beforeproc_single!(stomach, state, { forbidMath!(cs_name_cloned, state) });
+    before_digest_env.push(forbid_math_closure);
+  }
+  if let Some(ref mode) = options.mode {
+    let mode_clone = mode.clone();
+    let begin_mode_closure = beforeproc_single!(stomach, state, {
+      stomach.begin_mode(&mode_clone, state)?;
+    });
+    before_digest_env.push(begin_mode_closure);
+  } else if options.bounded {
+    let bgroup_closure = beforeproc_single!(stomach, state, {
+      stomach.bgroup(state);
+    });
+    before_digest_env.push(bgroup_closure);
+  }
+  if let Some(chosen_font) = options.font {
+    let merge_font_closure = beforeproc_single!(stomach, state, {
+      MergeFont!(&chosen_font, state);
+    });
+    before_digest_env.push(merge_font_closure);
+  }
+  before_digest_env.extend(options.before_digest);
+
+  let mut after_digest_env: Vec<DigestionClosure> = Vec::new();
+  after_digest_env.extend(options.after_digest);
+  if let Some(ref mode) = options.mode {
+    let mode_clone = mode.clone();
+    let end_mode_closure: Vec<DigestionClosure> = afterproc!(stomach, whatsit, state, {
+      stomach.end_mode(&mode_clone, state)?;
+    });
+    after_digest_env.extend(end_mode_closure);
+  } else if options.bounded {
+    let egroup_closure: Vec<DigestionClosure> = afterproc!(stomach, whatsit, state, {
+      stomach.egroup(state)?;
+    });
+    after_digest_env.extend(egroup_closure);
+  }
+
+  state.install_definition(
+    Primitive {
+      cs: cs.clone(),
+      paramlist,
+      replacement: Some(compiled_replacement),
+      options: PrimitiveOptions {
+        before_digest: before_digest_env,
+        after_digest: after_digest_env,
+        ..PrimitiveOptions::default()
+      },
+    },
+    scope,
+  );
+  if options_locked {
+    state.assign_value(&s!("{}:locked", cs_name), true, None);
+  }
+}
+
+pub fn def_math_primitive(cs: Token, paramlist: Option<Parameters>, presentation: String, mut options: MathPrimitiveOptions, state: &mut State) {
+  options.locked = false;
+  options.font = None;
+  let scope = options.scope.clone();
+  let reqfont = options.font.clone().unwrap_or_else(Font::default);
+  state.install_definition(
+    MathPrimitive {
+      cs: cs.clone(),
+      paramlist: None, // never any parameters, this is intentional
+      replacement: Some(Rc::new(move |stomach, args, state| {
+        // let locator    = $stomach->getGullet->getLocator;
+        let mut properties = HashMap::new(); // TODO: sync with perl master here
+        properties.insert(s!("mode"), Stored::String(String::from("math")));
+        // TODO: Improve font precision here, the defaults may not belong in this lookup
+        let font = state
+          .lookup_font()
+          .unwrap_or_else(|| Rc::new(Font::default()))
+          .merge(&reqfont)
+          .specialize(&presentation);
+        let font = Rc::new(font);
+        // foreach my $key (keys %properties) {
+        //   my $value = $properties{$key};
+        //   if (ref $value eq 'CODE') {
+        //     $properties{$key} = &$value(); } }
+        // info!("defmath_prim: {}, tokens: {:?}", &$presentation, $cs);
+        Ok(vec![Digested::TBox(Rc::new(
+          // TODO: Can we reduce boilerplate?
+          Tbox {
+            text: presentation.clone(),
+            tokens: Tokens!(cs.clone()),
+            font,
+            properties,
+            ..Tbox::default()
+          },
+        ))])
+      })),
+      options,
+      ..MathPrimitive::default()
+    },
+    scope,
+  );
+}
+
+pub fn def_constructor(
+  cs: Token,
+  paramlist: Option<Parameters>,
+  compiled_replacement: Option<ReplacementClosure>,
+  options: ConstructorOptions,
+  state: &mut State,
+)
+{
+  // TODO: This won't work, as we can only invoke method calls on paramlist in runtime
+  //*rtx_codegen::constructable::NARGS = $paramlist.get_num_args();
+  let scope = options.scope.clone();
+  let is_locked = options.locked.clone();
+  let cs_name = cs.get_cs_name().to_owned();
+  let locked_key = if is_locked { s!("{}:locked", cs_name) } else { String::new() };
+
+  let mut before_digest_closures: Vec<BeforeDigestClosure> = Vec::new();
+
+  if options.require_math {
+    let cs_name_cloned = cs_name.clone();
+    let require_math_closure = beforeproc_single!(stomach, state, { requireMath!(cs_name_cloned, state) });
+    before_digest_closures.push(require_math_closure);
+  }
+  if options.forbid_math {
+    let cs_name_cloned = cs_name.clone();
+    let forbid_math_closure = beforeproc_single!(stomach, state, { forbidMath!(cs_name_cloned, state) });
+    before_digest_closures.push(forbid_math_closure);
+  }
+  if let Some(ref mode) = options.mode {
+    let mode_clone = mode.clone();
+    let begin_mode_closure = beforeproc_single!(stomach, state, {
+      stomach.begin_mode(&mode_clone, state)?;
+    });
+    before_digest_closures.push(begin_mode_closure);
+  } else if options.bounded {
+    let bgroup_closure = beforeproc_single!(stomach, state, {
+      stomach.bgroup(state);
+    });
+    before_digest_closures.push(bgroup_closure);
+  }
+  if let Some(chosen_font) = options.font {
+    let merge_font_closure = beforeproc_single!(stomach, state, {
+      MergeFont!(&chosen_font, state);
+    });
+    before_digest_closures.push(merge_font_closure);
+  }
+  before_digest_closures.extend(options.before_digest);
+
+  let mut after_digest_closures: Vec<DigestionClosure> = Vec::new();
+  after_digest_closures.extend(options.after_digest);
+  if let Some(ref mode) = options.mode {
+    let mode_clone = mode.clone();
+    let end_mode_closure: Vec<DigestionClosure> = afterproc!(stomach, whatsit, state, {
+      stomach.end_mode(&mode_clone, state)?;
+    });
+    after_digest_closures.extend(end_mode_closure);
+  } else if options.bounded {
+    let egroup_closure: Vec<DigestionClosure> = afterproc!(stomach, whatsit, state, {
+      stomach.egroup(state)?;
+    });
+    after_digest_closures.extend(egroup_closure);
+  }
+
+  let constructor = Constructor {
+    cs,
+    paramlist,
+    replacement: compiled_replacement,
+    before_digest: before_digest_closures,
+    after_digest: after_digest_closures,
+    before_construct: options.before_construct,
+    after_construct: options.after_construct,
+    nargs: options.nargs,
+    alias: options.alias,
+    reversion: options.reversion,
+    // sizer
+    capture_body: options.capture_body,
+    properties: options.properties,
+    // outer
+    // long
+    ..Constructor::default()
+  };
+  state.install_definition(constructor, scope);
+
+  if is_locked {
+    state.assign_value(&locked_key, true, None);
+  }
+}
+
+pub fn def_environment(
+  name: String,
+  paramlist: Option<Parameters>,
+  compiled_replacement: Option<ReplacementClosure>,
+  options: ConstructorOptions,
+  state: &mut State,
+)
+{
+  let begin_name = s!("\\begin{{{}}}", &name);
+  let end_name = s!("\\end{{{}}}", &name);
+  // This is for the common case where the environment is opened by \begin{env}
+  // let sizer = inferSizer($options.sizer, $options.reversion);
+  let mut before_digest_env: Vec<BeforeDigestClosure> = Vec::new();
+  match &options.mode {
+    Some(ref mode) => {
+      let bmode = mode.clone();
+      let mode_closure = Rc::new(move |stomach: &mut Stomach, state: &mut State| {
+        stomach.begin_mode(&bmode, state)?;
+        Ok(Vec::new())
+      });
+      before_digest_env.push(mode_closure);
+    },
+    None => {
+      let bgroup_closure = beforeproc_single!(stomach, state, {
+        stomach.bgroup(state);
+      });
+      before_digest_env.push(bgroup_closure);
+    },
+  };
+  if options.require_math {
+    let require_name = begin_name.clone();
+    let require_math_closure = beforeproc_single!(stomach, state, { requireMath!(require_name, state) });
+    before_digest_env.push(require_math_closure);
+  }
+  if options.forbid_math {
+    let forbid_name = begin_name.clone();
+    let forbid_math_closure = beforeproc_single!(stomach, state, { forbidMath!(forbid_name, state) });
+    before_digest_env.push(forbid_math_closure);
+  }
+
+  let env_name = name.clone();
+  let current_environment_closure = beforeproc_single!(stomach, state, {
+    AssignValue!("current_environment", env_name.clone(), None, state);
+    let body = T_LETTER!(env_name.clone());
+    DefMacroI!(T_CS!("\\@currenvir"), None, body.clone(), state);
+  });
+  before_digest_env.push(current_environment_closure);
+
+  if let Some(chosen_font) = options.font {
+    let merge_font_closure = beforeproc_single!(stomach, state, {
+      MergeFont!(&chosen_font.clone(), state);
+    });
+    before_digest_env.push(merge_font_closure);
+  }
+  before_digest_env.extend(options.before_digest);
+
+  let push_frame_closure = Rc::new(|_document: &mut Document, _whatsit: &Whatsit, state: &mut State| {
+    state.push_frame();
+    Ok(())
+  });
+  let mut before_construct_with_frame: Vec<ConstructionClosure> = vec![push_frame_closure];
+  before_construct_with_frame.extend(options.before_construct);
+
+  let mut after_construct_with_frame: Vec<ConstructionClosure> = options.after_construct;
+
+  let pop_frame_closure = Rc::new(|_document: &mut Document, _whatsit: &Whatsit, state: &mut State| {
+    state.pop_frame()?;
+    Ok(())
+  });
+  after_construct_with_frame.push(pop_frame_closure);
+
+  let begin_name_constructor = Rc::new(Constructor {
+    cs: T_CS!(begin_name),
+    paramlist: paramlist.clone(),
+    replacement: compiled_replacement.clone(),
+    nargs: options.nargs,
+    before_digest: before_digest_env,
+    after_digest: options.after_digest_begin,
+    after_digest_body: options.after_digest_body,
+    before_construct: before_construct_with_frame,
+    // Curiously, it's the \begin whose afterConstruct gets called.
+    after_construct: after_construct_with_frame,
+    capture_body: true,
+    properties: options.properties.clone(),
+    // (defined $options{reversion} ? (reversion => $options{reversion}) : ()),
+    // (defined $sizer ? (sizer => $sizer) : ()),
+    // ), $options{scope});
+    reversion: options.reversion,
+    alias: options.alias,
+    ..Constructor::default()
+  });
+  state.install_definition(begin_name_constructor, options.scope.clone());
+
+  let mut after_digest_env = options.after_digest;
+  let unexpected_end_closure = Rc::new(|_stomach: &mut Stomach, _whatsit: &mut Whatsit, state: &mut State| {
+    // let env = LookupValue!("current_environment", $state_arg);
+    //     Error('unexpected', "\\end{$name}", $_[0],
+    //       "Can't close environment $name",
+    //       "Current are "
+    //         . join(', ', state->lookupStackedValues('current_environment')))
+    //       unless $env && $name eq $env;
+    //     return; },
+    Ok(Vec::new())
+  });
+  after_digest_env.push(unexpected_end_closure);
+
+  match options.mode {
+    Some(mode) => {
+      let emode = mode.clone();
+      let emode_closure = Rc::new(move |stomach: &mut Stomach, _whatsit: &mut Whatsit, state: &mut State| {
+        stomach.end_mode(&emode, state)?;
+        Ok(Vec::new())
+      });
+      after_digest_env.push(emode_closure);
+    },
+    None => {
+      let egroup_closure = Rc::new(|stomach: &mut Stomach, _whatsit: &mut Whatsit, state: &mut State| {
+        stomach.egroup(state)?;
+        Ok(Vec::new())
+      });
+      after_digest_env.push(egroup_closure);
+    },
+  };
+
+  let end_envname_constructor = Rc::new(Constructor {
+    cs: T_CS!(end_name),
+    replacement: None,
+    paramlist: None,
+    before_digest: options.before_digest_end,
+    after_digest: after_digest_env,
+    ..Constructor::default() // TODO ? fill in missing ones
+  });
+  state.install_definition(end_envname_constructor, options.scope.clone());
+
+  // For the uncommon case opened by \csname env\endcsname
+  let name_constructor = Rc::new(Constructor {
+    cs: T_CS!(s!("\\{}", &name)),
+    paramlist,
+    replacement: compiled_replacement,
+    // beforeDigest => flatten(($options{requireMath} ? (sub { requireMath($name); }) : ()),
+    //   ($options{forbidMath} ? (sub { forbidMath($name); })              : ()),
+    //   ($mode                ? (sub { $_[0]->beginMode($mode); })        : ()),
+    //   ($options{font}       ? (sub { MergeFont(%{ $options{font} }); }) : ()),
+    //   $options{beforeDigest}),
+    // afterDigest     => flatten($options{afterDigestBegin}),
+    // afterDigestBody => flatten($options{afterDigestBody}),
+    // beforeConstruct => flatten(sub { state->pushFrame; }, $options{beforeConstruct}),
+    // Curiously, it's the \begin whose afterConstruct gets called.
+    // afterConstruct => flatten($options{afterConstruct}, sub { state->popFrame; }),
+    nargs: options.nargs,
+    capture_body: true,
+    properties: options.properties.clone(),
+    // (defined $options{reversion} ? (reversion => $options{reversion}) : ()),
+    // (defined $sizer ? (sizer => $sizer) : ()),
+    // ), $options{scope});
+    ..Constructor::default()
+  });
+  state.install_definition(name_constructor, options.scope.clone());
+
+  let end_name_constructor = Rc::new(Constructor {
+    cs: T_CS!(s!("\\end{}", &name)),
+    paramlist: None,
+    replacement: Some(Rc::new(|document, whatsit, properties, state| {
+      let env = state.lookup_value("current_environment");
+      // Error('unexpected', "\\end{$name}", $_[0],
+      //   "Can't close environment $name",
+      //   "Current are "
+      //     . join(', ', state->lookupStackedValues('current_environment')))
+      //   unless $env && $name eq $env;
+      Ok(())
+    })),
+    // beforeDigest => flatten($options{beforeDigestEnd}),
+    // afterDigest  => flatten($options{afterDigest},
+    //   ($mode ? (sub { $_[0]->endMode($mode); }) : ())),
+    // ), $options{scope});
+    ..Constructor::default()
+  });
+  state.install_definition(end_name_constructor, options.scope);
+
+  if options.locked {
+    state.assign_value(&s!("\\begin{{{}}}:locked", &name), true, None);
+    state.assign_value(&s!("\\end{{{}}}:locked", &name), true, None);
+    state.assign_value(&s!("\\{}:locked", &name), true, None);
+    state.assign_value(&s!("\\end{}:locked", &name), true, None);
+  }
 }
 
 //**********************************************************************

--- a/rtx_package/src/package/pool/latex_math_mode_environments.rs
+++ b/rtx_package/src/package/pool/latex_math_mode_environments.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::rc::Rc;
 
 use crate::package::*;

--- a/rtx_package/src/package/pool/tex_fonts.rs
+++ b/rtx_package/src/package/pool/tex_fonts.rs
@@ -293,7 +293,7 @@ LoadDefinitions!(state, {
     let number = value.to_number();
     let chardef_value = value.clone();
     let internalcs = T_CS!(&s!("\\@chardef@{}", csname));
-    DefPrimitiveII!(internalcs, None, sub[stomach,args,i_state] {
+    DefPrimitiveII!(internalcs.clone(), None, sub[stomach,args,i_state] {
       let gullet = stomach.get_gullet_mut();
       let decoded = match font::decode(number.value_of() as u8, None, false, i_state) {
         None => String::new(),

--- a/rtx_package/src/package/setup.rs
+++ b/rtx_package/src/package/setup.rs
@@ -13,9 +13,9 @@
 
 #[macro_export]
 macro_rules! LoadDefinitions {
-  ($state:ident, $body:block) => {
-    pub fn load_definitions($state: &mut State, mut outer_stomach: Option<&mut Stomach>) -> Result<()> {
-      BindState!($state, outer_stomach);
+  ($outer_state:ident, $body:block) => {
+    pub fn load_definitions($outer_state: &mut State, mut outer_stomach: Option<&mut Stomach>) -> Result<()> {
+      BindState!($outer_state, outer_stomach);
       {
         $body
       }
@@ -29,17 +29,16 @@ macro_rules! LoadDefinitions {
 //    into a set of convenience macros for brief syntax
 //
 //=================================================
+
 #[macro_export]
 macro_rules! BindState {
   ($state:ident) => {
     BindState!($state, None)
   };
-  ($state:ident, $outer_stomach: expr) => {
-    #[allow(unused_macros)]
-    let state_stomach = $state.stomach.clone();
-    macro_rules! state {
+  ($outer_state:ident, $outer_stomach: expr) => {
+    macro_rules! outer_state {
       () => {
-        $state
+        $outer_state
       };
     }
     macro_rules! outer_stomach {
@@ -47,45 +46,42 @@ macro_rules! BindState {
         $outer_stomach
       };
     }
-    macro_rules! Digest {
-      ($tokens:expr) => {{
-        let st: &mut State = state!();
-        Digest!($tokens, st)
-      }};
-      ($tokens:expr, $state_arg:ident) => {{
-        match $outer_stomach.as_mut() {
-          Some(st) => (*st).digest($tokens, $state_arg),
-          None => state_stomach.borrow_mut().digest($tokens, $state_arg),
-        }
-      }};
-    }
+  };
+}
 
-    macro_rules! DigestText {
-      ($tokens:expr) => {
-        match $outer_stomach.as_mut() {
-          Some(st) => digest_text($tokens, *st, $state),
-          None => digest_text($tokens, state_stomach.borrow_mut(), $state),
-        }
-      };
-      ($tokens:expr, $stomach:ident) => {
-        DigestText!($tokens, $stomach, $state)
-      };
-      ($tokens:expr, $stomach:ident, $state_arg:ident) => {
-        digest_text($tokens, $stomach, $state_arg)
+#[macro_export]
+macro_rules! BindInnerState {
+  ($state:ident) => {
+    BindInnerState!($state, None)
+  };
+  ($inner_state:ident, $inner_stomach: expr) => {
+    macro_rules! inner_state {
+      () => {
+        $inner_state
       };
     }
+    macro_rules! inner_stomach {
+      () => {
+        $inner_stomach
+      };
+    }
+  };
+}
 
-    macro_rules! RawTeX {
-      ($text:expr) => {
-        RawTeX!($text, $state)
-      };
-      ($text:expr, $state_arg:ident) => {{
-        match $outer_stomach.as_mut() {
-          Some(st) => (*st).raw_tex($text, $state_arg)?,
-          None => state_stomach.borrow_mut().raw_tex($text, $state_arg)?,
-        }
-      }};
-    }
+#[macro_export]
+macro_rules! bind_state {
+  ($st:ident) => {
+    let $st: &mut State = {
+      // TODO: If we can manage to make this attribute visible from **outside**,
+      // in particular in macros such as beforeproc!() and beforesub!(), we can automate the inner state use
+      // entirely
+      //
+      // #[bound_options(location = "inner")]
+      //
+      #[derive(BoundState)]
+      struct _Bound;
+      state!()
+    };
   };
 }
 
@@ -95,7 +91,8 @@ macro_rules! BindState {
 #[macro_export]
 macro_rules! DefParameterTypeWO {
   ($name:expr, $param:expr) => {
-    state!().assign_mapping("PARAMETER_TYPES", $name, Some(Stored::Parameter($param)))
+    bind_state!(st);
+    st.assign_mapping("PARAMETER_TYPES", $name, Some(Stored::Parameter($param)))
   };
   ($name:expr, $param:expr, $state_arg:ident) => {
     $state_arg.assign_mapping("PARAMETER_TYPES", $name, Some(Stored::Parameter($param)))
@@ -105,7 +102,7 @@ macro_rules! DefParameterTypeWO {
 #[macro_export]
 macro_rules! LoadPool {
   ($name:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     LoadPool!($name, st)
   }};
   ($name:expr, $state_arg:ident) => {{
@@ -128,7 +125,7 @@ macro_rules! LoadPool {
 #[macro_export]
 macro_rules! InnerPool {
   ($name:ident) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     InnerPool!($name, st, outer_stomach!())
   }};
   ($name:ident, $state_arg:ident) => {
@@ -145,7 +142,7 @@ macro_rules! InnerPool {
 #[macro_export]
 macro_rules! RequirePackage {
   ($package:expr, $options:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     RequirePackage!($package, $options, st)
   }};
   ($package:expr, $options:expr, $state_arg:ident) => {
@@ -174,11 +171,11 @@ macro_rules! DeclareFontMap {
     $state_arg.assign_value(&mapname, map, Some(Scope::Global));
   }};
   ($name:expr, $map:expr, $family:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     DeclareFontMap!($name, $map, $family, st)
   }};
   ($name:expr, $map:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     DeclareFontMap!($name, $map, st)
   }};
 }
@@ -187,7 +184,8 @@ macro_rules! DeclareFontMap {
 macro_rules! DefMacroIWO {
   // closure stub
   ($cs:expr, $paramlist:expr, sub [ $gullet:ident, $args:ident, $inner_state:ident ] $body:block, $options:expr) => {{
-    let st : &mut State = state!();
+
+    bind_state!(st);
     DefMacroIWO!($cs, $paramlist, sub [ $gullet, $args, $inner_state ] $body, $options, st)
   }};
   // with explicit state
@@ -197,7 +195,8 @@ macro_rules! DefMacroIWO {
   }};
   // precompiled
   ($cs:expr, $paramlist:expr, $expansion:expr, $options:expr) => {{
-    def_macro($cs, $paramlist, $expansion, $options, state!())
+    bind_state!(st);
+    def_macro($cs, $paramlist, $expansion, $options, st)
   }};
   // with explicit state
   ($cs:expr, $paramlist:expr, $expansion:expr, $options:expr, $state_arg:ident) => {{
@@ -216,12 +215,12 @@ macro_rules! DefMacroWO {
     def_macro(cs, paramlist, expansion_closure, $options, $state_arg);
   }};
   ($proto:expr, sub [ $gullet:ident, $args:ident, $inner_state:ident ] $body:block, $options:expr) => ({
-    let st : &mut State = state!();
+    bind_state!(st);
     DefMacroWO!($proto, sub [ $gullet, $args, $inner_state ] $body, $options, st)
   });
   // String expansion forms
   ($proto:expr, $expansion:expr, $options:expr) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     DefMacroWO!($proto, $expansion, $options, st);
   }};
   ($proto:expr, $expansion:expr, $options:expr, $state_arg:ident) => ({
@@ -236,7 +235,7 @@ macro_rules! DefMacroWO {
 macro_rules! DefConditional(
   // test is always a rust closure
   ($proto:expr, sub [$gullet:ident, $args:ident, $inner_state:ident] $body:block) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     DefConditional!($proto, sub[$gullet, $args, $inner_state] $body, st);
   }};
   ($proto:expr, sub [$gullet:ident, $args:ident, $inner_state:ident] $body:block, $state_arg:ident) => ({
@@ -245,11 +244,11 @@ macro_rules! DefConditional(
   });
   // or None
   ($proto:expr) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     DefConditional!($proto, None, st)
   }};
   ($proto:expr, None) => ({
-    let st : &mut State = state!();
+    bind_state!(st);
     DefConditional!($proto, None, st)
   });
   ($proto:expr, None, $state_arg:ident) => ({
@@ -262,7 +261,7 @@ macro_rules! DefConditional(
 macro_rules! DefConditionalI(
   // test is always a rust closure
   ($cs:expr, $paramlist:expr, sub[$gullet:ident, $args:ident, $inner_state:ident] $body:block) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     DefConditionalI!($cs, $paramlist, $gullet, $args, $inner_state, $body, st)
   }};
   ($cs:expr, $paramlist:expr, sub[$gullet:ident, $args:ident, $inner_state:ident] $body:block, $state_arg:ident) => ({
@@ -271,7 +270,7 @@ macro_rules! DefConditionalI(
   });
   // or None
   ($cs:expr, $paramlist:expr, None) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     DefConditionalI!($cs, $paramlist, None, st)
   }};
   ($cs:expr, $paramlist:expr, None, $state_arg:ident) => ({
@@ -321,14 +320,14 @@ macro_rules! DefConditionalI(
 #[macro_export]
 macro_rules! DefPrimitiveII {
   ($cs:expr, $paramlist:expr, sub[$stomach:ident,$args:ident,$inner_state:ident] $body:block) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     DefPrimitiveII!($cs, $paramlist, sub[$stomach, $args, $inner_state] $body, st)
   }};
   ($cs:expr, $paramlist:expr, sub[$stomach:ident,$args:ident,$inner_state:ident] $body:block, $state_arg:ident) => {
     DefPrimitiveII!($cs, $paramlist, move |$stomach, $args, $inner_state| $body, PrimitiveOptions::default(), $state_arg)
   };
   ($cs:expr, $paramlist:expr, $compiled_replacement:expr, $options:expr) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     DefPrimitiveII!($cs, $paramlist, $compiled_replacement, $options, st)
   }};
   ($cs:expr, $paramlist:expr, $compiled_replacement:expr, $options:expr, $state_arg:ident) => {{
@@ -339,7 +338,7 @@ macro_rules! DefPrimitiveII {
 #[macro_export]
 macro_rules! DefPrimitiveIWO(
   ($proto:expr, $compiled_replacement:expr, $options:expr) => ({
-    let st : &mut State = state!();
+    bind_state!(st);
     DefPrimitiveIWO!($proto, $compiled_replacement, $options, st)
   });
   ($proto:expr, $compiled_replacement:expr, $options:expr, $state_arg:ident) => ({
@@ -351,7 +350,7 @@ macro_rules! DefPrimitiveIWO(
 #[macro_export]
 macro_rules! DefRegisterWO {
   ($proto:expr, $value:expr, $options:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     DefRegisterWO!($proto, $value, $options, st)
   }};
   ($proto:expr, $value:expr, $options:expr, $state_arg:ident) => {{
@@ -363,7 +362,7 @@ macro_rules! DefRegisterWO {
 #[macro_export]
 macro_rules! DefRegisterI {
   ($cs:expr, $paramlist:expr, $value:expr, $options:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     DefRegisterI!($cs, $paramlist, $value, $options, st)
   }};
   ($cs:expr, $paramlist:expr, $value:expr, $options:expr, $state_arg:ident) => {
@@ -434,7 +433,7 @@ macro_rules! DefRegisterI {
 #[macro_export]
 macro_rules! DefConstructorIWO {
   ($cs:expr, $paramlist:expr, $compiled_replacement:expr, $options:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     DefConstructorIWO!($cs, $paramlist, $compiled_replacement, $options, st)
   }};
   ($cs:expr, $paramlist:expr, $compiled_replacement:expr, $options:expr, $state_arg:ident) => {{
@@ -445,7 +444,7 @@ macro_rules! DefConstructorIWO {
 #[macro_export]
 macro_rules! DefConstructorWO(
   ($proto:expr, $replacement:expr, $options:expr) => ({
-    let st : &mut State = state!();
+    bind_state!(st);
     DefConstructorWO!($proto, $replacement, $options, st)
   });
   ($proto:expr, $replacement:expr, $options:expr, $state_arg:ident) => ({
@@ -456,7 +455,7 @@ macro_rules! DefConstructorWO(
     DefConstructorIWO!(cs, paramlist, compiled_replacement, $options, $state_arg);
   });
   ($proto:expr, $document:ident, $args:ident, $props:ident, $inner_state:ident, $body:block, $options:expr) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     DefConstructorWO!($proto, $document, $args, $props, $inner_state, $body, $options, st)
   }};
 
@@ -467,7 +466,7 @@ macro_rules! DefConstructorWO(
   });
   // pre-compiled CS with to-be-compiled replacement (see \begin{verbatim})
   (cs [ $cs:expr ], $paramlist:expr, $replacement:expr, $options:expr) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     DefConstructorWO!(cs[$cs], $paramlist, $replacement, $options, st)
   }};
   (cs [ $cs:expr ], $paramlist:expr, $replacement:expr, $options:expr, $state_arg:ident) => ({
@@ -481,7 +480,7 @@ macro_rules! DefConstructorWO(
 #[macro_export]
 macro_rules! TagWO {
   ($tag:expr, $properties:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     TagWO!($tag, $properties, st)
   }};
   ($tag:expr, $properties:expr, $state_arg:ident) => {
@@ -499,7 +498,7 @@ macro_rules! TagWO {
 #[macro_export]
 macro_rules! DefEnvironmentWO (
   ($proto_raw:expr, $replacement:expr, $options:expr) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     DefEnvironmentWO!($proto_raw, $replacement, $options, st)
   }};
   ($proto_raw:expr, $replacement:expr, $options:expr, $state_arg:ident) => ({
@@ -517,7 +516,7 @@ macro_rules! DefEnvironmentWO (
 #[macro_export]
 macro_rules! DefEnvironmentCWO (
   ($proto_raw:expr, $compiled_replacement:expr, $options:expr) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     DefEnvironmentCWO!($proto_raw, $compiled_replacement, $options, st)
   }};
   ($proto_raw:expr, $compiled_replacement:expr, $options:expr, $state_arg:ident) => ({
@@ -532,7 +531,7 @@ macro_rules! DefEnvironmentCWO (
 #[macro_export]
 macro_rules! RelaxNGSchema {
   ($name:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     RelaxNGSchema!($name, st)
   }};
   ($name:expr,$state_arg:ident) => {
@@ -543,7 +542,7 @@ macro_rules! RelaxNGSchema {
 #[macro_export]
 macro_rules! RegisterNamespace(
   ($prefix:expr, $namespace:expr) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     RegisterNamespace!($prefix, $namespace, st)
   }};
   ($prefix:expr, $namespace:expr,$state_arg:ident) =>
@@ -552,7 +551,7 @@ macro_rules! RegisterNamespace(
 #[macro_export]
 macro_rules! RegisterDocumentNamespace(
   ($prefix:expr, $namespace:expr) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     RegisterDocumentNamespace!($prefix, $namespace, st)
   }};
   ($prefix:expr, $namespace:expr,$state_arg:ident) =>
@@ -561,7 +560,7 @@ macro_rules! RegisterDocumentNamespace(
 #[macro_export]
 macro_rules! RequireResource(
   ($resource:expr) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     RequireResource!($resource, st)
   }};
   ($resource:expr,$state_arg:ident) =>
@@ -577,7 +576,7 @@ macro_rules! RequireResource(
 #[macro_export]
 macro_rules! DefMathWO {
   ($cstext:expr, $paramlist:expr, $presentation:expr, $options:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     DefMathWO!($cstext, $paramlist, $presentation, $options, st)
   }};
   ($cstext:expr, $paramlist:expr, $presentation:expr, $options:expr, $state_arg:ident) => {{
@@ -657,7 +656,7 @@ macro_rules! DefMathWO {
 #[macro_export]
 macro_rules! requireMath {
   ($cs_name:expr) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     requireMath!($cs_name, st)
   }};
   ($cs_name:expr, $state_arg:ident) => (
@@ -669,7 +668,7 @@ macro_rules! requireMath {
 #[macro_export]
 macro_rules! forbidMath {
   ($cs_name:expr) => ({
-    let st : &mut State = state!();
+    bind_state!(st);
     forbidMath!($cs_name, st)
   });
   ($cs_name:expr, $state_arg:ident) => (
@@ -705,13 +704,15 @@ macro_rules! forbidMath {
 #[macro_export]
 macro_rules! NewCounterWO {
   ($ctr:expr, $within:expr, None) => {
-    new_counter($ctr, $within, None, state!())?
+    bind_state!(st);
+    new_counter($ctr, $within, None, st)?
   };
   ($ctr:expr, $within:expr, None, $state_arg:ident) => {
     new_counter($ctr, $within, None, $state_arg)?
   };
   ($ctr:expr, $within:expr, Some($opts:expr)) => {
-    new_counter($ctr, $within, Some($opts), state!())?
+    bind_state!(st);
+    new_counter($ctr, $within, Some($opts), st)?
   };
   ($ctr:expr, $within:expr, Some($opts:expr), $state_arg:ident) => {
     new_counter($ctr, $within, Some($opts), $state_arg)?
@@ -720,7 +721,8 @@ macro_rules! NewCounterWO {
 #[macro_export]
 macro_rules! CounterValue {
   ($ctr:expr) => {
-    counter_value($ctr, state!())
+    bind_state!(st);
+    counter_value($ctr, st)
   };
   ($ctr:expr, $state_arg:ident) => {
     counter_value($ctr, $state_arg)
@@ -745,7 +747,8 @@ macro_rules! SetCounter {
 #[macro_export]
 macro_rules! AddToCounter {
   ($ctr:expr, $value:expr, $gullet:ident) => {
-    add_to_counter($ctr, $value, $gullet, state!())
+    bind_state!(st);
+    add_to_counter($ctr, $value, $gullet, st)
   };
   ($ctr:expr, $value:expr, $gullet:ident, $state_arg:ident) => {
     add_to_counter($ctr, $value, $gullet, $state_arg)
@@ -754,7 +757,8 @@ macro_rules! AddToCounter {
 #[macro_export]
 macro_rules! StepCounter {
   ($ctr:expr, $noreset:expr, $gullet:ident) => {
-    step_counter($ctr, $noreset, $gullet, state!())
+    bind_state!(st);
+    step_counter($ctr, $noreset, $gullet, st)
   };
   ($ctr:expr, $noreset:expr, $gullet:ident, $state_arg:ident) => {
     step_counter($ctr, $noreset, $gullet, $state_arg)
@@ -804,14 +808,14 @@ macro_rules! Expand {
 #[macro_export]
 macro_rules! Invocation {
   ($csname:literal, $args:expr, $gullet:expr) => {
-    let st: &mut State = state!();
+    bind_state!(st);
     Invocation!(T_CS!($csname), $args, $gullet, st)
   };
   ($csname:literal, $args:expr, $gullet:expr, $state_arg:ident) => {
     Invocation!(T_CS!($csname), $args, $gullet, $state_arg)
   };
   ($token:expr, $args:expr, $gullet:expr) => {
-    let st: &mut State = state!();
+    bind_state!(st);
     Invocation!($token, $args, $gullet, st)
   };
   ($token:expr, $args:expr, $gullet:expr, $state_arg:ident) => {
@@ -821,7 +825,7 @@ macro_rules! Invocation {
 #[macro_export]
 macro_rules! DefLigature {
   ($regex:expr, $replacement:expr, fontTest => sub[$font:ident] $body:block) => {
-    let st : &mut State = state!();
+    bind_state!(st);
     DefLigature!($regex, $replacement, fontTest => sub[$font]{$body}, st)
   };
   ($regex:expr, $replacement:expr, fontTest => sub[$font:ident] $body:block, $state_arg:ident) => {
@@ -837,7 +841,7 @@ macro_rules! DefLigature {
     );
   };
   ($regex:expr, $replacement:expr) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     DefLigature!($regex, $replacement, st)
   }};
   ($regex:expr, $replacement:expr, $state_arg:ident) => {
@@ -859,15 +863,15 @@ macro_rules! DefLigature {
 macro_rules! DefAccent {
   ($accent:expr, $combiningchar:expr, $standalonechar:expr) => {
     let mut empty_opts : HashMap<String, Stored> = HashMap::new();
-    let st : &mut State = state!();
+    bind_state!(st);
     DefAccent!($accent, $combiningchar, $standalonechar, empty_opts, st)
   };
   ($accent:expr, $combiningchar:expr, $standalonechar:expr, below => true) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     DefAccent!($accent, $combiningchar, $standalonechar, map!("below"=>Stored::Bool(true)), st)
   }};
   ($accent:expr, $combiningchar:expr, $standalonechar:expr, $options:expr) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     DefAccent!($accent, $combiningchar, $standalonechar, $options, st)
   }};
   ($accent:expr, $combiningchar:expr, $standalonechar:expr, $options:expr, $state_arg: ident) => {{
@@ -897,7 +901,7 @@ macro_rules! DefAccent {
 #[macro_export]
 macro_rules! LookupValue {
   ($name:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     LookupValue!($name, st)
   }};
   ($name:expr, $state_arg:ident) => {
@@ -908,7 +912,7 @@ macro_rules! LookupValue {
 macro_rules! LookupBool {
   ($name:expr) => {{
     {
-      let st: &mut State = state!();
+      bind_state!(st);
       LookupBool!($name, st)
     }
   }};
@@ -919,7 +923,7 @@ macro_rules! LookupBool {
 #[macro_export]
 macro_rules! LookupString {
   ($name:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     LookupString!($name, st)
   }};
   ($name:expr, $state_arg:ident) => {
@@ -929,7 +933,7 @@ macro_rules! LookupString {
 #[macro_export]
 macro_rules! LookupNumber {
   ($name:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     LookupNumber!($name, st)
   }};
   ($name:expr, $state_arg:ident) => {
@@ -939,7 +943,7 @@ macro_rules! LookupNumber {
 #[macro_export]
 macro_rules! LookupTokens {
   ($name:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     LookupTokens!($name, st)
   }};
   ($name:expr, $state_arg:ident) => {
@@ -948,14 +952,14 @@ macro_rules! LookupTokens {
 }
 #[macro_export]
 macro_rules! AssignValue {
-  ($name:expr, $value:expr) => {{
-    let st: &mut State = state!();
+  ($name:expr, $value:expr) => {
+    bind_state!(st);
     AssignValue!($name, $value, None, st)
-  }};
-  ($name:expr, $value:expr, $scope:expr) => {{
-    let st: &mut State = state!();
+  };
+  ($name:expr, $value:expr, $scope:expr) => {
+    bind_state!(st);
     AssignValue!($name, $value, $scope, st)
-  }};
+  };
   ($name:expr, $value:expr, $scope:expr, $state_arg:ident) => {
     $state_arg.assign_value($name, $value, $scope)
   };
@@ -963,7 +967,7 @@ macro_rules! AssignValue {
 #[macro_export]
 macro_rules! RemoveValue {
   ($name:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     RemoveValue!($name, st)
   }};
   ($name:expr, $state_arg:ident) => {
@@ -973,7 +977,7 @@ macro_rules! RemoveValue {
 #[macro_export]
 macro_rules! PushValue {
   ($name:expr, $values:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     PushValue!($name, $values, st)
   }};
   ($name:expr, $values:expr, $state_arg:ident) => {
@@ -983,7 +987,7 @@ macro_rules! PushValue {
 #[macro_export]
 macro_rules! PopValue {
   ($name:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     PopValue!($name, st)
   }};
   ($name:expr, $state_arg:ident) => {
@@ -993,7 +997,7 @@ macro_rules! PopValue {
 #[macro_export]
 macro_rules! UnshiftValue {
   ($name:expr, $values:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     UnshiftValue!($name, $values, st)
   }};
   ($name:expr, $values:expr,$state_arg:ident) => {
@@ -1003,7 +1007,7 @@ macro_rules! UnshiftValue {
 #[macro_export]
 macro_rules! ShiftValue {
   ($name:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     ShiftValue!($name, st)
   }};
   ($name:expr,$state_arg:ident) => {
@@ -1013,7 +1017,7 @@ macro_rules! ShiftValue {
 #[macro_export]
 macro_rules! LookupMapping {
   ($map:expr, $key:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     LookupValue!($map, $key, st)
   }};
   ($map:expr, $key:expr, $state_arg:ident) => {
@@ -1023,7 +1027,7 @@ macro_rules! LookupMapping {
 #[macro_export]
 macro_rules! AssignMapping {
   ($map:expr, $key:expr => $value:expr) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     AssignMapping!($map, $key => $value, st)
   }};
   ($map:expr, $key:expr => $value:expr, $state_arg:ident) => {
@@ -1033,7 +1037,7 @@ macro_rules! AssignMapping {
 #[macro_export]
 macro_rules! LookupMappingKeys {
   ($map:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     LookupMappingKeys!($map, st)
   }};
   ($map:expr, $state_arg:ident) => {
@@ -1043,7 +1047,7 @@ macro_rules! LookupMappingKeys {
 #[macro_export]
 macro_rules! LookupCatcode {
   ($char:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     LookupCatcode!($char, st)
   }};
   ($char:expr, $state_arg:ident) => {
@@ -1053,7 +1057,7 @@ macro_rules! LookupCatcode {
 #[macro_export]
 macro_rules! AssignCatcode {
   ($char:expr, $catcode:expr, $scope:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     AssignCatcode!($char, $catcode, $scope, st)
   }};
   ($char:expr, $catcode:expr, $scope:expr, $state_arg:ident) => {
@@ -1063,7 +1067,7 @@ macro_rules! AssignCatcode {
 #[macro_export]
 macro_rules! LookupMeaning {
   ($name:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     LookupMeaning!($name, st)
   }};
   ($name:expr, $state_arg:ident) => {
@@ -1073,7 +1077,7 @@ macro_rules! LookupMeaning {
 #[macro_export]
 macro_rules! LookupDefinition {
   ($name:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     LookupDefinition!($name, st)
   }};
   ($name:expr, $state_arg:ident) => {
@@ -1083,7 +1087,7 @@ macro_rules! LookupDefinition {
 #[macro_export]
 macro_rules! InstallDefinition {
   ($name:expr, $definition:expr, $scope:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     InstallDefinition!($name, $definition, $scope, st)
   }};
   ($name:expr, $definition:expr, $scope:expr, $state_arg:ident) => {
@@ -1093,7 +1097,7 @@ macro_rules! InstallDefinition {
 #[macro_export]
 macro_rules! XEquals {
   ($token1:expr, $token2:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     XEquals!($token1, $token2, st)
   }};
   ($token1:expr, $token2:expr, $state_arg:ident) => {
@@ -1103,7 +1107,7 @@ macro_rules! XEquals {
 #[macro_export]
 macro_rules! IsDefined {
   ($name:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     IsDefined!($name, st)
   }};
   ($name:expr, $state_arg:ident) => {
@@ -1113,14 +1117,14 @@ macro_rules! IsDefined {
 #[macro_export]
 macro_rules! IsDefinedToken {
   ($name:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     is_defined_token($name, st)
   }};
 }
 #[macro_export]
 macro_rules! Let {
   ($token1:expr, $token2:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     Let!($token1, $token2, st)
   }};
   ($token1:expr, $token2:expr, $state_arg:ident) => {{
@@ -1133,7 +1137,7 @@ macro_rules! Let {
 #[macro_export]
 macro_rules! LetI {
   ($token1:expr, $token2:expr) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     LetI!($token1, $token2, st)
   }};
   ($token1:expr, $token2:expr, $state_arg:ident) => {
@@ -1146,14 +1150,14 @@ macro_rules! LetI {
 #[macro_export]
 macro_rules! DigestIf {
   ($token:literal, $stomach:ident) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     DigestIf!(T_CS!($token), $stomach, st)
   }};
   ($token:literal, $stomach:ident, $state_arg:ident) => {
     digest_if(T_CS!($token), $stomach, $state_arg)
   };
   ($token:expr, $stomach:ident) => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     DigestIf!($token, $stomach, st)
   }};
   ($token:expr, $stomach:ident, $state_arg: ident) => {
@@ -1163,7 +1167,7 @@ macro_rules! DigestIf {
 #[macro_export]
 macro_rules! AfterAssignment {
   () => {{
-    let st: &mut State = state!();
+    bind_state!(st);
     AfterAssignment!(st)
   }};
   ($state_arg: ident) => {
@@ -1175,14 +1179,14 @@ macro_rules! AfterAssignment {
 #[macro_export]
 macro_rules! MergeFont {
   ($kv:expr) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     MergeFont!($kv, st)
   }};
   ($kv:expr, $state_arg:ident) => {
     merge_font($kv, $state_arg)
   };
   ($key:ident => $val:expr) => {{
-    let st : &mut State = state!();
+    bind_state!(st);
     MergeFont!($key => $val, st)
   }};
   ($key:ident => $val:expr, $state_arg:ident) => {
@@ -1352,9 +1356,11 @@ macro_rules! DefEnvironmentC(
 #[macro_export]
 macro_rules! DefPrimitive{
   ($proto:expr, sub[$stomach:ident, $whatsit:ident, $inner_state:ident] $body:block) =>
-    (DefPrimitiveIWO!($proto, |$stomach, $whatsit, $inner_state| {$body}, PrimitiveOptions::default()));
+    (DefPrimitiveIWO!($proto, |$stomach, $whatsit, $inner_state| {
+      BindInnerState!($inner_state, $stomach); $body}, PrimitiveOptions::default()));
   ($proto:expr, sub[$stomach:ident, $whatsit:ident, $inner_state:ident] $body:block, $($key:ident=>$val:expr),*) =>
-    (DefPrimitiveIWO!($proto, |$stomach, $whatsit, $inner_state| {$body}, NewDefault!(PrimitiveOptions, $($key=>$val),*)));
+    (DefPrimitiveIWO!($proto, |$stomach, $whatsit, $inner_state| {
+      BindInnerState!($inner_state, $stomach); $body}, NewDefault!(PrimitiveOptions, $($key=>$val),*)));
   ($proto:expr, $replacement:expr, $options:expr) => ({
     // TODO:
     // let compiled_replacement = || Tbox{text: $replacement, Invocation($options{alias} || $cs, @_[1 .. $#_])); }
@@ -1445,4 +1451,50 @@ macro_rules! GetKeyVals {
       _ => None,
     }
   };
+}
+
+macro_rules! Digest {
+  ($tokens:expr) => {{
+    bind_state!(st);
+    Digest!($tokens, st)
+  }};
+  ($tokens:expr, $state_arg:ident) => {{
+    let mut state_stomach = $state_arg.stomach.clone();
+    match outer_stomach!().as_mut() {
+      Some(st) => (*st).digest($tokens, $state_arg),
+      None => state_stomach.borrow_mut().digest($tokens, $state_arg),
+    }
+  }};
+}
+
+macro_rules! DigestText {
+  ($tokens:expr) => {
+    bind_state!(st);
+    let mut state_stomach = st.stomach.clone();
+    match outer_stomach!().as_mut() {
+      Some(st) => digest_text($tokens, *st, st),
+      None => digest_text($tokens, state_stomach.borrow_mut(), st),
+    }
+  };
+  ($tokens:expr, $stomach:ident) => {
+    bind_state!(st);
+    DigestText!($tokens, $stomach, st)
+  };
+  ($tokens:expr, $stomach:ident, $state_arg:ident) => {
+    digest_text($tokens, $stomach, $state_arg)
+  };
+}
+
+macro_rules! RawTeX {
+  ($text:expr) => {
+    bind_state!(st);
+    RawTeX!($text, st)
+  };
+  ($text:expr, $state_arg:ident) => {{
+    let mut state_stomach = $state_arg.stomach.clone();
+    match outer_stomach!().as_mut() {
+      Some(st) => (*st).raw_tex($text, $state_arg)?,
+      None => state_stomach.borrow_mut().raw_tex($text, $state_arg)?,
+    }
+  }};
 }

--- a/rtx_package/src/package/setup.rs
+++ b/rtx_package/src/package/setup.rs
@@ -71,6 +71,9 @@ macro_rules! BindInnerState {
 #[macro_export]
 macro_rules! bind_state {
   ($st:ident) => {
+    bind_state!($st, "outer")
+  };
+  ($st:ident, $location:expr) => {
     let $st: &mut State = {
       // TODO: If we can manage to make this attribute visible from **outside**,
       // in particular in macros such as beforeproc!() and beforesub!(), we can automate the inner state use

--- a/rtx_package/src/package/setup.rs
+++ b/rtx_package/src/package/setup.rs
@@ -47,7 +47,6 @@ macro_rules! BindState {
         $outer_stomach
       };
     }
-
     macro_rules! Digest {
       ($tokens:expr) => {{
         let st: &mut State = state!();
@@ -62,20 +61,19 @@ macro_rules! BindState {
     }
 
     macro_rules! DigestText {
-                          ($stuff:expr) => {{
-                            digest_text($stuff, $state)
-                            match $outer_stomach.as_mut() {
-                              Some(st) => (*st).digest_text($stuff, $state_arg),
-                              None => state_stomach.borrow_mut().digest_text($stuff, $state_arg),
-                            }
-                          }};
-                          ($stuff:expr, $stomach:ident) => {{
-                            DigestText!($stuff, $stomach, $state)
-                          }};
-                          ($stuff:expr, $stomach:ident, $state_arg:ident) => {{
-                            digest_text($stuff, $stomach, $state_arg)
-                          }};
-                        }
+      ($tokens:expr) => {
+        match $outer_stomach.as_mut() {
+          Some(st) => digest_text($tokens, *st, $state),
+          None => digest_text($tokens, state_stomach.borrow_mut(), $state),
+        }
+      };
+      ($tokens:expr, $stomach:ident) => {
+        DigestText!($tokens, $stomach, $state)
+      };
+      ($tokens:expr, $stomach:ident, $state_arg:ident) => {
+        digest_text($tokens, $stomach, $state_arg)
+      };
+    }
 
     macro_rules! RawTeX {
       ($text:expr) => {
@@ -334,73 +332,7 @@ macro_rules! DefPrimitiveII {
     DefPrimitiveII!($cs, $paramlist, $compiled_replacement, $options, st)
   }};
   ($cs:expr, $paramlist:expr, $compiled_replacement:expr, $options:expr, $state_arg:ident) => {{
-    let options = $options;
-    let options_locked = options.locked;
-    let scope = options.scope.clone();
-    let mut before_digest_env: Vec<BeforeDigestClosure> = Vec::new();
-
-    if options.require_math {
-      let cs_name = $cs.get_cs_name().to_owned();
-      let require_math_closure = beforeproc_single!(stomach, state, { requireMath!(cs_name, state) });
-      before_digest_env.push(require_math_closure);
-    }
-
-    if options.forbid_math {
-      let cs_name = $cs.get_cs_name().to_owned();
-      let forbid_math_closure = beforeproc_single!(stomach, state, { forbidMath!(cs_name, state) });
-      before_digest_env.push(forbid_math_closure);
-    }
-    if let Some(ref mode) = options.mode {
-      let mode_clone = mode.clone();
-      let begin_mode_closure = beforeproc_single!(stomach, state, {
-        stomach.begin_mode(&mode_clone, state)?;
-      });
-      before_digest_env.push(begin_mode_closure);
-    } else if options.bounded {
-      let bgroup_closure = beforeproc_single!(stomach, state, {
-        stomach.bgroup(state);
-      });
-      before_digest_env.push(bgroup_closure);
-    }
-    if let Some(chosen_font) = options.font {
-      let merge_font_closure = beforeproc_single!(stomach, state, {
-        MergeFont!(&chosen_font, state);
-      });
-      before_digest_env.push(merge_font_closure);
-    }
-    before_digest_env.extend(options.before_digest);
-
-    let mut after_digest_env: Vec<DigestionClosure> = Vec::new();
-    after_digest_env.extend(options.after_digest);
-    if let Some(ref mode) = options.mode {
-      let mode_clone = mode.clone();
-      let end_mode_closure: Vec<DigestionClosure> = afterproc!(stomach, whatsit, state, {
-        stomach.end_mode(&mode_clone, state)?;
-      });
-      after_digest_env.extend(end_mode_closure);
-    } else if options.bounded {
-      let egroup_closure: Vec<DigestionClosure> = afterproc!(stomach, whatsit, state, {
-        stomach.egroup(state)?;
-      });
-      after_digest_env.extend(egroup_closure);
-    }
-
-    $state_arg.install_definition(
-      Primitive {
-        cs: $cs.clone(),
-        paramlist: $paramlist,
-        replacement: Some(Rc::new($compiled_replacement)),
-        options: PrimitiveOptions {
-          before_digest: before_digest_env,
-          after_digest: after_digest_env,
-          ..PrimitiveOptions::default()
-        },
-      },
-      scope,
-    );
-    if options_locked {
-      AssignValue!(&s!("{}:locked", $cs.get_cs_name()), true, None, $state_arg);
-    }
+    def_primitive($cs, $paramlist, Rc::new($compiled_replacement), $options, $state_arg);
   }};
 }
 
@@ -506,84 +438,7 @@ macro_rules! DefConstructorIWO {
     DefConstructorIWO!($cs, $paramlist, $compiled_replacement, $options, st)
   }};
   ($cs:expr, $paramlist:expr, $compiled_replacement:expr, $options:expr, $state_arg:ident) => {{
-    use rtx_core::definition::constructor::Constructor;
-    let options = $options;
-    // TODO: This won't work, as we can only invoke method calls on paramlist in runtime
-    //*rtx_codegen::constructable::NARGS = $paramlist.get_num_args();
-    let scope = options.scope.clone();
-    let is_locked = options.locked.clone();
-    let locked_key = if is_locked { s!("{}:locked", $cs.get_cs_name()) } else { String::new() };
-
-    let mut before_digest_closures: Vec<BeforeDigestClosure> = Vec::new();
-
-    if options.require_math {
-      let cs_name = $cs.get_cs_name().to_owned();
-      let require_math_closure = beforeproc_single!(stomach, state, { requireMath!(cs_name, state) });
-      before_digest_closures.push(require_math_closure);
-    }
-    if options.forbid_math {
-      let cs_name = $cs.get_cs_name().to_owned();
-      let forbid_math_closure = beforeproc_single!(stomach, state, { forbidMath!(cs_name, state) });
-      before_digest_closures.push(forbid_math_closure);
-    }
-    if let Some(ref mode) = options.mode {
-      let mode_clone = mode.clone();
-      let begin_mode_closure = beforeproc_single!(stomach, state, {
-        stomach.begin_mode(&mode_clone, state)?;
-      });
-      before_digest_closures.push(begin_mode_closure);
-    } else if options.bounded {
-      let bgroup_closure = beforeproc_single!(stomach, state, {
-        stomach.bgroup(state);
-      });
-      before_digest_closures.push(bgroup_closure);
-    }
-    if let Some(chosen_font) = options.font {
-      let merge_font_closure = beforeproc_single!(stomach, state, {
-        MergeFont!(&chosen_font, state);
-      });
-      before_digest_closures.push(merge_font_closure);
-    }
-    before_digest_closures.extend(options.before_digest);
-
-    let mut after_digest_closures: Vec<DigestionClosure> = Vec::new();
-    after_digest_closures.extend(options.after_digest);
-    if let Some(ref mode) = options.mode {
-      let mode_clone = mode.clone();
-      let end_mode_closure: Vec<DigestionClosure> = afterproc!(stomach, whatsit, state, {
-        stomach.end_mode(&mode_clone, state)?;
-      });
-      after_digest_closures.extend(end_mode_closure);
-    } else if options.bounded {
-      let egroup_closure: Vec<DigestionClosure> = afterproc!(stomach, whatsit, state, {
-        stomach.egroup(state)?;
-      });
-      after_digest_closures.extend(egroup_closure);
-    }
-
-    let constructor = Constructor {
-      cs: $cs,
-      paramlist: $paramlist,
-      replacement: $compiled_replacement,
-      before_digest: before_digest_closures,
-      after_digest: after_digest_closures,
-      before_construct: options.before_construct,
-      after_construct: options.after_construct,
-      nargs: options.nargs,
-      alias: options.alias,
-      reversion: options.reversion,
-      // sizer
-      capture_body: options.capture_body,
-      properties: options.properties,
-      // outer
-      // long
-      ..Constructor::default()
-    };
-    $state_arg.install_definition(constructor, scope);
-
-    if is_locked {
-      $state_arg.assign_value(&locked_key, true, None);
-    }
+    def_constructor($cs, $paramlist, $compiled_replacement, $options, $state_arg);
   }};
 }
 
@@ -623,201 +478,6 @@ macro_rules! DefConstructorWO(
   })
 );
 
-//=====================================================================
-// Define a LaTeX environment
-// Note that the body of the environment is treated is the 'body' parameter in the constructor.
-#[macro_export]
-macro_rules! DefEnvironmentI {
-  ($name_raw:expr, $paramlist:expr, $compiled_replacement:expr, $cc_copy:expr, $options:expr) => {{
-    let st: &mut State = state!();
-    DefEnvironmentI!($name_raw, $paramlist, $compiled_replacement, $cc_copy, $options, st)
-  }};
-  ($name_raw:expr, $paramlist:expr, $compiled_replacement:expr, $cc_copy:expr, $options:expr, $state_arg:ident) => {{
-    use rtx_core::definition::constructor::Constructor;
-    use rtx_core::stomach::Stomach;
-    use rtx_core::whatsit::Whatsit;
-    let name = $name_raw.to_string();
-    let options = $options;
-    let begin_name = s!("\\begin{{{}}}", &name);
-    let end_name = s!("\\end{{{}}}", &name);
-    // This is for the common case where the environment is opened by \begin{env}
-    // let sizer = inferSizer($options.sizer, $options.reversion);
-    let mut before_digest_env: Vec<BeforeDigestClosure> = Vec::new();
-    match &options.mode {
-      Some(ref mode) => {
-        let bmode = mode.clone();
-        let mode_closure = Rc::new(move |stomach: &mut Stomach, state: &mut State| {
-          stomach.begin_mode(&bmode, state)?;
-          Ok(Vec::new())
-        });
-        before_digest_env.push(mode_closure);
-      },
-      None => {
-        let bgroup_closure = beforeproc_single!(stomach, state, {
-          stomach.bgroup(state);
-        });
-        before_digest_env.push(bgroup_closure);
-      },
-    };
-    if options.require_math {
-      let require_name = begin_name.clone();
-      let require_math_closure = beforeproc_single!(stomach, state, { requireMath!(require_name, state) });
-      before_digest_env.push(require_math_closure);
-    }
-    if options.forbid_math {
-      let forbid_name = begin_name.clone();
-      let forbid_math_closure = beforeproc_single!(stomach, state, { forbidMath!(forbid_name, state) });
-      before_digest_env.push(forbid_math_closure);
-    }
-
-    let env_name = name.clone();
-    let current_environment_closure = beforeproc_single!(stomach, state, {
-      AssignValue!("current_environment", env_name.clone(), None, state);
-      let body = T_LETTER!(env_name.clone());
-      DefMacroI!(T_CS!("\\@currenvir"), None, body.clone(), state);
-    });
-    before_digest_env.push(current_environment_closure);
-
-    if let Some(chosen_font) = options.font {
-      let merge_font_closure = beforeproc_single!(stomach, state, {
-        MergeFont!(&chosen_font.clone(), state);
-      });
-      before_digest_env.push(merge_font_closure);
-    }
-    before_digest_env.extend(options.before_digest);
-
-    let push_frame_closure = Rc::new(|_document: &mut Document, _whatsit: &Whatsit, state: &mut State| {
-      state.push_frame();
-      Ok(())
-    });
-    let mut before_construct_with_frame: Vec<ConstructionClosure> = vec![push_frame_closure];
-    before_construct_with_frame.extend(options.before_construct);
-
-    let mut after_construct_with_frame: Vec<ConstructionClosure> = options.after_construct;
-
-    let pop_frame_closure = Rc::new(|_document: &mut Document, _whatsit: &Whatsit, state: &mut State| {
-      state.pop_frame()?;
-      Ok(())
-    });
-    after_construct_with_frame.push(pop_frame_closure);
-
-    let begin_name_constructor = Rc::new(Constructor {
-      cs: T_CS!(begin_name),
-      paramlist: $paramlist,
-      replacement: $compiled_replacement,
-      nargs: options.nargs,
-      before_digest: before_digest_env,
-      after_digest: options.after_digest_begin,
-      after_digest_body: options.after_digest_body,
-      before_construct: before_construct_with_frame,
-      // Curiously, it's the \begin whose afterConstruct gets called.
-      after_construct: after_construct_with_frame,
-      capture_body: true,
-      properties: options.properties.clone(),
-      // (defined $options{reversion} ? (reversion => $options{reversion}) : ()),
-      // (defined $sizer ? (sizer => $sizer) : ()),
-      // ), $options{scope});
-      reversion: options.reversion,
-      alias: options.alias,
-      ..Constructor::default()
-    });
-    $state_arg.install_definition(begin_name_constructor, options.scope.clone());
-
-    let mut after_digest_env = options.after_digest;
-    let unexpected_end_closure = Rc::new(|_stomach: &mut Stomach, _whatsit: &mut Whatsit, state: &mut State| {
-      // let env = LookupValue!("current_environment", $state_arg);
-      //     Error('unexpected', "\\end{$name}", $_[0],
-      //       "Can't close environment $name",
-      //       "Current are "
-      //         . join(', ', state->lookupStackedValues('current_environment')))
-      //       unless $env && $name eq $env;
-      //     return; },
-      Ok(Vec::new())
-    });
-    after_digest_env.push(unexpected_end_closure);
-
-    match options.mode {
-      Some(mode) => {
-        let emode = mode.clone();
-        let emode_closure = Rc::new(move |stomach: &mut Stomach, _whatsit: &mut Whatsit, state: &mut State| {
-          stomach.end_mode(&emode, state)?;
-          Ok(Vec::new())
-        });
-        after_digest_env.push(emode_closure);
-      },
-      None => {
-        let egroup_closure = Rc::new(|stomach: &mut Stomach, _whatsit: &mut Whatsit, state: &mut State| {
-          stomach.egroup(state)?;
-          Ok(Vec::new())
-        });
-        after_digest_env.push(egroup_closure);
-      },
-    };
-
-    let end_envname_constructor = Rc::new(Constructor {
-      cs: T_CS!(end_name),
-      replacement: None,
-      paramlist: None,
-      before_digest: options.before_digest_end,
-      after_digest: after_digest_env,
-      ..Constructor::default() // TODO ? fill in missing ones
-    });
-    $state_arg.install_definition(end_envname_constructor, options.scope.clone());
-
-    // For the uncommon case opened by \csname env\endcsname
-    let name_constructor = Rc::new(Constructor {
-      cs: T_CS!(s!("\\{}", &name)),
-      paramlist: $paramlist,
-      replacement: $cc_copy,
-      // beforeDigest => flatten(($options{requireMath} ? (sub { requireMath($name); }) : ()),
-      //   ($options{forbidMath} ? (sub { forbidMath($name); })              : ()),
-      //   ($mode                ? (sub { $_[0]->beginMode($mode); })        : ()),
-      //   ($options{font}       ? (sub { MergeFont(%{ $options{font} }); }) : ()),
-      //   $options{beforeDigest}),
-      // afterDigest     => flatten($options{afterDigestBegin}),
-      // afterDigestBody => flatten($options{afterDigestBody}),
-      // beforeConstruct => flatten(sub { state->pushFrame; }, $options{beforeConstruct}),
-      // Curiously, it's the \begin whose afterConstruct gets called.
-      // afterConstruct => flatten($options{afterConstruct}, sub { state->popFrame; }),
-      nargs: options.nargs,
-      capture_body: true,
-      properties: options.properties.clone(),
-      // (defined $options{reversion} ? (reversion => $options{reversion}) : ()),
-      // (defined $sizer ? (sizer => $sizer) : ()),
-      // ), $options{scope});
-      ..Constructor::default()
-    });
-    $state_arg.install_definition(name_constructor, options.scope.clone());
-
-    let end_name_constructor = Rc::new(Constructor {
-      cs: T_CS!(s!("\\end{}", &name)),
-      paramlist: None,
-      replacement: Some(Rc::new(|document, whatsit, properties, state| {
-        let env = state.lookup_value("current_environment");
-        // Error('unexpected', "\\end{$name}", $_[0],
-        //   "Can't close environment $name",
-        //   "Current are "
-        //     . join(', ', state->lookupStackedValues('current_environment')))
-        //   unless $env && $name eq $env;
-        Ok(())
-      })),
-      // beforeDigest => flatten($options{beforeDigestEnd}),
-      // afterDigest  => flatten($options{afterDigest},
-      //   ($mode ? (sub { $_[0]->endMode($mode); }) : ())),
-      // ), $options{scope});
-      ..Constructor::default()
-    });
-    $state_arg.install_definition(end_name_constructor, options.scope);
-
-    if options.locked {
-      AssignValue!(&s!("\\begin{{{}}}:locked", &name), true, None, $state_arg);
-      AssignValue!(&s!("\\end{{{}}}:locked", &name), true, None, $state_arg);
-      AssignValue!(&s!("\\{}:locked", &name), true, None, $state_arg);
-      AssignValue!(&s!("\\end{}:locked", &name), true, None, $state_arg);
-    }
-  }};
-}
-
 #[macro_export]
 macro_rules! TagWO {
   ($tag:expr, $properties:expr) => {{
@@ -849,11 +509,9 @@ macro_rules! DefEnvironmentWO (
 
   let compiled_replacement;
   compile_replacement!(compiled_replacement, $replacement);
-  let cc_copy;
-  compile_replacement!(cc_copy, $replacement);
 
   let options = $options;
-  DefEnvironmentI!(name, None, compiled_replacement, cc_copy, options, $state_arg);
+  def_environment(name, None, compiled_replacement, options, $state_arg);
 }));
 
 #[macro_export]
@@ -868,7 +526,7 @@ macro_rules! DefEnvironmentCWO (
   let name = extract_bracketed(&mut proto, Some(&Delimiter::Brace));
   // TODO: What do we do with param lists?
   //let paramlist_str = proto.trim_start().to_string();
-  DefEnvironmentI!(name, None, $compiled_replacement, $compiled_replacement, $options, $state_arg);
+  def_environment(name, None, $compiled_replacement, $options, $state_arg);
 }));
 
 #[macro_export]
@@ -930,7 +588,7 @@ macro_rules! DefMathWO {
     // $paramlist = parseParameters($paramlist, $cs) if defined $paramlist && !ref $paramlist;
     let paramlist: Option<Parameters> = $paramlist;
     let nargs = match paramlist {
-      Some(plist) => plist.get_num_args(),
+      Some(ref plist) => plist.get_num_args(),
       None => 0,
     };
     let csname = cs.get_string().to_string();
@@ -987,7 +645,7 @@ macro_rules! DefMathWO {
     // Define a primitive that will create a Box with the appropriate set of XMTok attributes.
     if nargs == 0 {
       // && !grep { !$$simpletoken_options{$_} } keys %options) {
-      defmath_prim!(cs, paramlist, $presentation.to_string(), options, $state_arg);
+      def_math_primitive(cs, paramlist, $presentation.to_string(), options, $state_arg);
     }
 
     // else {
@@ -996,52 +654,6 @@ macro_rules! DefMathWO {
   }};
 }
 
-#[macro_export]
-macro_rules! defmath_prim {
-  ($cs:expr, $_paramlist:expr, $presentation:expr, $options:expr, $state_arg:ident) => {{
-    let mut prim_options = $options;
-    prim_options.locked = false;
-    prim_options.font = None;
-    let scope = prim_options.scope.clone();
-    let reqfont = prim_options.font.clone().unwrap_or_else(Font::default);
-    $state_arg.install_definition(
-      MathPrimitive {
-        cs: $cs.clone(),
-        paramlist: None, // never any parameters, this is intentional
-        replacement: Some(Rc::new(move |stomach, args, state| {
-          // let locator    = $stomach->getGullet->getLocator;
-          let mut properties = HashMap::new(); // TODO: sync with perl master here
-          properties.insert(s!("mode"), Stored::String(String::from("math")));
-          // TODO: Improve font precision here, the defaults may not belong in this lookup
-          let font = state
-            .lookup_font()
-            .unwrap_or_else(|| Rc::new(Font::default()))
-            .merge(&reqfont)
-            .specialize(&$presentation);
-          let font = Rc::new(font);
-          // foreach my $key (keys %properties) {
-          //   my $value = $properties{$key};
-          //   if (ref $value eq 'CODE') {
-          //     $properties{$key} = &$value(); } }
-          // info!("defmath_prim: {}, tokens: {:?}", &$presentation, $cs);
-          Ok(vec![Digested::TBox(Rc::new(
-            // TODO: Can we reduce boilerplate?
-            Tbox {
-              text: $presentation,
-              tokens: Tokens!($cs.clone()),
-              font,
-              properties,
-              ..Tbox::default()
-            },
-          ))])
-        })),
-        options: prim_options,
-        ..MathPrimitive::default()
-      },
-      scope,
-    );
-  }};
-}
 #[macro_export]
 macro_rules! requireMath {
   ($cs_name:expr) => {{
@@ -1709,6 +1321,9 @@ macro_rules! NewCounter {
     (NewCounterWO!($ctr, $within, Some(NewDefault!(NewCounterOptions, $($key=>$val),*)), $state_arg))
 }
 
+//=====================================================================
+// Define a LaTeX environment
+// Note that the body of the environment is treated is the 'body' parameter in the constructor.
 #[macro_export]
 macro_rules! DefEnvironment(
   // implicit state


### PR DESCRIPTION
This PR *almost* manages to auto-localize the inner state of binding closures.

I'd rather merge it and move onto other tasks until a full solution reveals itself -- especially since the work on macros in Rust is still ongoing.

If I spot the exact method of passing an "inner" macro attribute to the `bind_state` macro, after this PR it should be very easy to plug in and refactor the inner closures.