### PR TITLE
Allow for perl-brevity in binding definitions

### DIFF
--- a/rtx_core/src/common/store.rs
+++ b/rtx_core/src/common/store.rs
@@ -486,28 +486,3 @@ impl<'a> From<&'a Stored> for Token {
     }
   }
 }
-
-pub trait IntoOption<T>: Sized {
-  /// Performs the conversion.
-  fn into_option(self) -> T;
-}
-
-impl<'a> IntoOption<Option<String>> for &'a str {
-  fn into_option(self) -> Option<String> { Some(self.to_string()) }
-}
-
-impl<T> IntoOption<Option<T>> for Option<T> {
-  fn into_option(self) -> Option<T> { self }
-}
-
-impl IntoOption<bool> for bool {
-  fn into_option(self) -> bool { self }
-}
-
-impl<T> IntoOption<Option<Vec<T>>> for Vec<T> {
-  fn into_option(self) -> Option<Vec<T>> { Some(self) }
-}
-
-impl<T> IntoOption<Option<VecDeque<T>>> for VecDeque<T> {
-  fn into_option(self) -> Option<VecDeque<T>> { Some(self) }
-}

--- a/rtx_package/src/package/functions.rs
+++ b/rtx_package/src/package/functions.rs
@@ -86,12 +86,16 @@ impl<T> IntoOption<Option<VecDeque<T>>> for VecDeque<T> {
 }
 
 pub trait IntoTokensResult<T>: Sized {
-  /// Performs the conversion.
+  /// Performs the conversion, used for DefMacro return values etc
   fn into_tokens_result(self) -> Result<Tokens>;
 }
 
 impl IntoTokensResult<Result<Tokens>> for Token {
   fn into_tokens_result(self) -> Result<Tokens> { Ok(Tokens!(self)) }
+}
+
+impl IntoTokensResult<Result<Tokens>> for Vec<Token> {
+  fn into_tokens_result(self) -> Result<Tokens> { Ok(Tokens(self)) }
 }
 
 impl IntoTokensResult<Result<Tokens>> for Tokens {
@@ -105,6 +109,37 @@ impl IntoTokensResult<Result<Tokens>> for Result<Tokens> {
 impl IntoTokensResult<Result<Tokens>> for () {
   fn into_tokens_result(self) -> Result<Tokens> { Ok(Tokens!()) }
 }
+
+pub trait IntoBoolResult<T>:Sized {
+  /// Performs the conversion, used for DefConditional return values etc
+  fn into_bool_result(self) -> Result<bool>;
+}
+impl IntoBoolResult<Result<bool>> for bool {
+  fn into_bool_result(self) -> Result<bool> { Ok(self) }
+}
+impl IntoBoolResult<Result<bool>> for Result<bool> {
+  fn into_bool_result(self) -> Result<bool> { self }
+}
+
+pub trait IntoDigestedResult<T>: Sized {
+  /// Performs the conversion, used for DefPrimitive return values etc
+  fn into_digested_result(self) -> Result<Vec<Digested>>;
+}
+impl IntoDigestedResult<Result<Vec<Digested>>> for () {
+  fn into_digested_result(self) -> Result<Vec<Digested>> { Ok(Vec::new()) }
+}
+impl IntoDigestedResult<Result<Vec<Digested>>> for Tbox {
+  fn into_digested_result(self) -> Result<Vec<Digested>> { Ok(vec![self.into()]) }
+}
+
+impl IntoDigestedResult<Result<Vec<Digested>>> for Digested {
+  fn into_digested_result(self) -> Result<Vec<Digested>> { Ok(vec![self]) }
+}
+
+impl IntoDigestedResult<Result<Vec<Digested>>> for Result<Vec<Digested>> {
+  fn into_digested_result(self) -> Result<Vec<Digested>> { self }
+}
+
 
 //**********************************************************************
 //   Initially, I thought LaTeXML Packages should try to be like perl modules:

--- a/rtx_package/src/package/functions.rs
+++ b/rtx_package/src/package/functions.rs
@@ -3,7 +3,7 @@ use libxml::tree::Node;
 use log::*;
 use regex::Regex;
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{VecDeque, HashMap};
 use std::path::Path;
 use std::rc::Rc;
 use unidecode::unidecode;
@@ -11,7 +11,6 @@ use unidecode::unidecode;
 use rtx_core::common::error::*;
 use rtx_core::common::font::Font;
 use rtx_core::common::number::Number;
-use rtx_core::common::store::IntoOption;
 use rtx_core::common::xml::XML_NS;
 use rtx_core::definition::conditional::{Conditional, ConditionalOptions, ConditionalType};
 use rtx_core::definition::constructor::{Constructor, ConstructorOptions};
@@ -59,6 +58,52 @@ lazy_static! {
   static ref PARAMSPECT_CHECK_RE: Regex = Regex::new(r"^((\w*)(:([^\s\{\[]*))?)\s*").unwrap();
   static ref NON_ID_CHARSET_RE: Regex = Regex::new(r"[^\w_\-.]+").unwrap();
   static ref TILDE_NOISE_RE: Regex = Regex::new(r"\\~\{\}").unwrap();
+}
+
+pub trait IntoOption<T>: Sized {
+  /// Performs the conversion.
+  fn into_option(self) -> T;
+}
+
+impl<'a> IntoOption<Option<String>> for &'a str {
+  fn into_option(self) -> Option<String> { Some(self.to_string()) }
+}
+
+impl<T> IntoOption<Option<T>> for Option<T> {
+  fn into_option(self) -> Option<T> { self }
+}
+
+impl IntoOption<bool> for bool {
+  fn into_option(self) -> bool { self }
+}
+
+impl<T> IntoOption<Option<Vec<T>>> for Vec<T> {
+  fn into_option(self) -> Option<Vec<T>> { Some(self) }
+}
+
+impl<T> IntoOption<Option<VecDeque<T>>> for VecDeque<T> {
+  fn into_option(self) -> Option<VecDeque<T>> { Some(self) }
+}
+
+pub trait IntoTokensResult<T>: Sized {
+  /// Performs the conversion.
+  fn into_tokens_result(self) -> Result<Tokens>;
+}
+
+impl IntoTokensResult<Result<Tokens>> for Token {
+  fn into_tokens_result(self) -> Result<Tokens> { Ok(Tokens!(self)) }
+}
+
+impl IntoTokensResult<Result<Tokens>> for Tokens {
+  fn into_tokens_result(self) -> Result<Tokens> { Ok(self) }
+}
+
+impl IntoTokensResult<Result<Tokens>> for Result<Tokens> {
+  fn into_tokens_result(self) -> Result<Tokens> { self }
+}
+
+impl IntoTokensResult<Result<Tokens>> for () {
+  fn into_tokens_result(self) -> Result<Tokens> { Ok(Tokens!()) }
 }
 
 //**********************************************************************

--- a/rtx_package/src/package/mod.rs
+++ b/rtx_package/src/package/mod.rs
@@ -16,7 +16,6 @@ pub use rtx_core::common::font::Font;
 pub use rtx_core::common::glue::{Glue, MuGlue};
 pub use rtx_core::common::ligature::{FontTestClosure, Ligature};
 pub use rtx_core::common::number::Number;
-pub use rtx_core::common::store::IntoOption;
 pub use rtx_core::definition::conditional::{Conditional, ConditionalOptions, ConditionalType};
 pub use rtx_core::definition::constructor::ConstructorOptions;
 pub use rtx_core::definition::expandable::{Expandable, ExpandableOptions};

--- a/rtx_package/src/package/pool/latex.rs
+++ b/rtx_package/src/package/pool/latex.rs
@@ -82,7 +82,6 @@ LoadDefinitions!(state, {
     let env_string = env.to_string();
     DefMacroI!(T_CS!("\\@currenvir"), None, env);
     AssignValue!("current_environment", env_string);
-    Ok(vec![])
   });
 
   DefPrimitive!(
@@ -91,11 +90,10 @@ LoadDefinitions!(state, {
     let env_string = env.to_string();
     DefMacroI!(T_CS!("\\@currenvir"), None, env);
     AssignValue!("current_environment", env_string);
-    Ok(vec![])
   });
   Let!("\\@currenvline", "\\@empty");
 
-  DefMacro!("\\begin{}", sub [gullet, args, state] {
+  DefMacro!("\\begin{}", sub[gullet, args, state] {
     unpack!(args => env);
     let name = Expand!(env, gullet).to_string();
     let begin_name = s!("\\begin{{{}}}", name);
@@ -608,9 +606,7 @@ LoadDefinitions!(state, {
     unpack!(args => value);
     let ctr_expansion = Expand!(value, gullet, inner_state).to_string();
     let ctr_value = CounterValue!(&ctr_expansion, inner_state).value_of();
-    Ok(Tokens::new(
-      ExplodeText!(ctr_value)
-    ))
+    ExplodeText!(ctr_value)
   });
 
   // DefMacro('\@arabic{Number}', sub {
@@ -619,9 +615,7 @@ LoadDefinitions!(state, {
     unpack!(args => value);
     let ctr_expansion = Expand!(value, gullet, inner_state).to_string();
     let ctr_value = CounterValue!(&ctr_expansion, inner_state).value_of();
-    Ok(Tokens::new(
-      ExplodeText!(ctr_value)
-    ))
+    ExplodeText!(ctr_value)
   });
 
   // DefMacro('\@roman{Number}', sub {
@@ -664,8 +658,8 @@ LoadDefinitions!(state, {
 
   //======================================================================
   // Hair
-  DefPrimitive!("\\makeatletter", sub[stomach, whatsit, state] { state.assign_catcode('@', Catcode::LETTER, Some(Scope::Local)); Ok(vec![]) });
-  DefPrimitive!("\\makeatother",  sub[stomach, whatsit, state] { state.assign_catcode('@', Catcode::OTHER, Some(Scope::Local)); Ok(vec![]) });
+  DefPrimitive!("\\makeatletter", sub { AssignCatcode!('@', Catcode::LETTER, Some(Scope::Local)); });
+  DefPrimitive!("\\makeatother",  sub { AssignCatcode!('@', Catcode::OTHER, Some(Scope::Local)); });
 
   //**********************************************************************
   // Sundry (is this ams ?)

--- a/rtx_package/src/package/pool/latex_ch3_sentences_and_paragraphs.rs
+++ b/rtx_package/src/package/pool/latex_ch3_sentences_and_paragraphs.rs
@@ -25,7 +25,7 @@ LoadDefinitions!(state, {
   DefMacro!("\\fmtname", "LaTeX2e");
   DefMacro!("\\fmtversion", "XXXX/XX/XX");
 
-  DefMacro!("\\today", sub[gullet,args,state] { Ok(Tokens::new(ExplodeText!(today(state)))) });
+  DefMacro!("\\today", sub { ExplodeText!(Today!()) });
 
   // Previously, we used ltx:emph, to preserve the semantic intent,
   // but some folks wrap it around arbitrary blocks of material,

--- a/rtx_package/src/package/pool/latex_hook.rs
+++ b/rtx_package/src/package/pool/latex_hook.rs
@@ -40,8 +40,8 @@ LoadDefinitions!(state, {
   .map(|s| s.to_string())
   {
     let inner_ltxtrigger = ltxtrigger.clone();
-    DefMacroI!(T_CS!(ltxtrigger), None, sub[ _gullet, _args, inner_state] {
-      Ok(Tokens!(T_CS!("\\@load@latex@pool"), T_CS!(inner_ltxtrigger)))
+    DefMacroI!(T_CS!(ltxtrigger), None, sub {
+       Tokens!(T_CS!("\\@load@latex@pool"), T_CS!(inner_ltxtrigger))
     });
   }
 
@@ -55,6 +55,5 @@ LoadDefinitions!(state, {
       },
       state,
     )?;
-    Ok(vec![])
   });
 });

--- a/rtx_package/src/package/pool/tex_appendix_b.rs
+++ b/rtx_package/src/package/pool/tex_appendix_b.rs
@@ -171,7 +171,7 @@ LoadDefinitions!(state, {
   DefMacro!("\\magstephalf", "1095");
   DefMacro!("\\magstep{}", sub[gullet, args, state] {
     unpack_to_string!(args => mag);
-    Ok(Tokens::new(Explode!(match mag.as_str() {
+    Explode!(match mag.as_str() {
       "0" => "1000",
       "1" => "1200",
       "2" => "1440",
@@ -179,7 +179,7 @@ LoadDefinitions!(state, {
       "4" => "2074",
       "5" => "2488",
       _ => ""
-    })))
+    })
   });
 
   // #======================================================================
@@ -280,19 +280,17 @@ LoadDefinitions!(state, {
   //======================================================================
   // TeX Book, Appendix B, p. 352
 
-  DefPrimitive!("\\obeyspaces", sub[stomach, whatsit, state] {
+  DefPrimitive!("\\obeyspaces", sub {
      AssignCatcode!(' ', Catcode::ACTIVE);
      LetI!(&T_ACTIVE!(" "), T_CS!("\\space"));
-     Ok(vec![])
   });
   // Curiously enough, " " (a space) is ALREADY defined to be the same as "\space"
   // EVEN before it is made active. (see p.380)
   LetI!(&T_ACTIVE!(" "), T_CS!("\\space"));
 
-  DefPrimitive!("\\obeylines", sub[stomach, whatsit, state] {
+  DefPrimitive!("\\obeylines", sub {
       AssignCatcode!('\r', Catcode::ACTIVE);
       LetI!(&T_ACTIVE!("\r"), T_CS!("\\@break")); // More appropriate than \par, I think?
-      Ok(vec![])
   });
 
   DefConstructor!("\\@break", "<ltx:break/>");
@@ -366,7 +364,7 @@ LoadDefinitions!(state, {
   DefMacro!("\\nobreakspace", "\\ifmmode\\math@nobreakspace\\else\\text@nobreakspace\\fi");
 
   DefPrimitive!("\\text@nobreakspace", sub[stomach, whatsit, state] {
-    Tbox::new(String::from("\u{00A0}"), None, None, Tokens!(T_CS!("~")), map!("isSpace" => Stored::Bool(true)), state).into()
+    Tbox::new(String::from("\u{00A0}"), None, None, Tokens!(T_CS!("~")), map!("isSpace" => Stored::Bool(true)), state)
   });
 
   // DefConstructor!("\\math@nobreakspace", "<ltx:XMHint name='nobreakspace' width='#width'/>",

--- a/rtx_package/src/package/pool/tex_assignment.rs
+++ b/rtx_package/src/package/pool/tex_assignment.rs
@@ -37,9 +37,9 @@ LoadDefinitions!(state, {
   
   // <prefix> = \global | \long | \outer
   // See Stomach.pm & Stomach.pm
-  DefPrimitive!("\\global",sub[stomach, args, state] { state.set_prefix("global");  Ok(vec![])}, is_prefix => true);
-  DefPrimitive!("\\long",  sub[stomach, args, state] { state.set_prefix("long");    Ok(vec![])}, is_prefix => true);
-  DefPrimitive!("\\outer", sub[stomach, args, state] { state.set_prefix("outer");   Ok(vec![])}, is_prefix => true);
+  DefPrimitive!("\\global",sub { SetPrefix!("global"); }, is_prefix => true);
+  DefPrimitive!("\\long",  sub { SetPrefix!("long");   }, is_prefix => true);
+  DefPrimitive!("\\outer", sub { SetPrefix!("outer");  }, is_prefix => true);
 
   // <let assignment> = \futurelet <control sequence><token><token>
   //  | \let<control sequence><equals><one optional space><token>

--- a/rtx_package/src/package/pool/tex_expandable_primitives.rs
+++ b/rtx_package/src/package/pool/tex_expandable_primitives.rs
@@ -67,7 +67,7 @@ LoadDefinitions!(outer_state, {
   // define it here (only approxmiately), since it's already useful.
   Let!("\\protect", "\\relax");
 
-  DefMacro!("\\romannumeral Number", sub[gullet, args, state] { roman!(args[0].to_number().value_of()).into() });
+  DefMacro!("\\romannumeral Number", sub[gullet, args, state] { roman!(args[0].to_number().value_of()) });
 
   // # 1) Knuth, The TeXBook, page 40, paragraph 1, Chapter 7: How TEX Reads What You Type.
   // # suggests all characters except spaces are returned in category code Other, i.e. Explode()
@@ -192,7 +192,7 @@ LoadDefinitions!(outer_state, {
     if LookupMeaning!(&token).is_none() {
       Let!(token, "\\relax");
     }
-    token.into()
+    token
   });
 
   DefPrimitive!("\\endcsname", sub[stomach, whatsit, state] {

--- a/rtx_package/src/package/pool/tex_expandable_primitives.rs
+++ b/rtx_package/src/package/pool/tex_expandable_primitives.rs
@@ -20,15 +20,15 @@ LoadDefinitions!(outer_state, {
   });
   DefConditional!("\\ifodd Number", sub[gullet, args, state] {
     unimplemented!();
+    false
     // $_[1]->valueOf % 2
   });
 
   // NOTE: We don't KNOW if we're in vertical, horizontal or inner mode!!!!!!!
-  DefConditional!("\\ifvmode", sub[gullet,args,state] {Ok(false)});
-  DefConditional!("\\ifhmode", sub[gullet,args,state] {Ok(false)});
-  DefConditional!("\\ifinner", sub[gullet,args,state] {Ok(false)});
-
-  DefConditional!("\\ifmmode", sub[gullet,args,state] {Ok(LookupBool!("IN_MATH"))});
+  DefConditional!("\\ifvmode", sub { false });
+  DefConditional!("\\ifhmode", sub { false });
+  DefConditional!("\\ifinner", sub { false });
+  DefConditional!("\\ifmmode", sub { LookupBool!("IN_MATH") });
 
   DefConditional!("\\if XToken XToken", sub[gullet, args, state] {
     unpack!(args=>tokens1, tokens2);
@@ -45,8 +45,8 @@ LoadDefinitions!(outer_state, {
     Ok(xequals)
   });
 
-  DefConditional!("\\iftrue",  sub[gullet, args, state] { Ok(true) });
-  DefConditional!("\\iffalse", sub[gullet, args, state] { Ok(false) });
+  DefConditional!("\\iftrue",  sub { true });
+  DefConditional!("\\iffalse", sub { false });
 
   //======================================================================
   // This makes \relax disappear completely after digestion
@@ -195,9 +195,8 @@ LoadDefinitions!(outer_state, {
     token
   });
 
-  DefPrimitive!("\\endcsname", sub[stomach, whatsit, state] {
+  DefPrimitive!("\\endcsname", sub {
     error!(target: "unexpected:\\endcsname", "Extra \\endcsname");
-    Ok(Vec::new())
   });
 
   DefMacro!("\\expandafter Token Token", sub[gullet, args, state] {
@@ -239,7 +238,6 @@ LoadDefinitions!(outer_state, {
     if let Some(line) = line_opt {
       gullet.unread(&Tokenize!(&line));
     }
-    Ok(Tokens!())
   });
 
   // \the<internal quantity>
@@ -247,28 +245,25 @@ LoadDefinitions!(outer_state, {
     unpack!(args => variable);
     let mut args = variable.unlist();
     let defn = args.remove(0).to_register(state);
-    match defn {
-      None => {
-        error!(target:"expected:<register>", "a register was expected to be here");
-        Ok(Tokens!())
-      },
-      Some(defn) => {
-        let register_type = defn.borrow().register_type;
-        //     if (!$type) {
-        //       my $cs = ToString($defn->getCS);
-        //       Error('unexpected', "\\the$cs", $gullet, "You can't use $cs after \\the"); return (); }
-        let value = defn.value_of(args, state).unwrap_or_else(|| RegisterValue::Tokens(Tokens!()));
-        // In all cases, these should be OTHER, except for space. (!?)
-        let mut tokens : Vec<Token> = match value {
-          RegisterValue::Tokens(ts) => ts.unlist(),
-          RegisterValue::Token(t) => vec![t],
-          rv => Explode!(rv.to_string()),
-        };
-        if state.noexpand_the { // See \the for the sense in this.
-          tokens = gullet.neutralize_tokens(&tokens, state);
-        }
-        Ok(Tokens::new(tokens))
+    if let Some(defn) = defn {
+      let register_type = defn.borrow().register_type;
+      //     if (!$type) {
+      //       my $cs = ToString($defn->getCS);
+      //       Error('unexpected', "\\the$cs", $gullet, "You can't use $cs after \\the"); return (); }
+      let value = defn.value_of(args, state).unwrap_or_else(|| RegisterValue::Tokens(Tokens!()));
+      // In all cases, these should be OTHER, except for space. (!?)
+      let mut tokens : Vec<Token> = match value {
+        RegisterValue::Tokens(ts) => ts.unlist(),
+        RegisterValue::Token(t) => vec![t],
+        rv => Explode!(rv.to_string()),
+      };
+      if state.noexpand_the { // See \the for the sense in this.
+        tokens = gullet.neutralize_tokens(&tokens, state);
       }
+      tokens
+    } else {
+      error!(target:"expected:<register>", "a register was expected to be here");
+      Vec::new()
     }
   });
 });

--- a/rtx_package/src/package/pool/tex_fonts.rs
+++ b/rtx_package/src/package/pool/tex_fonts.rs
@@ -283,7 +283,7 @@ LoadDefinitions!(state, {
      None,
      invoked,
      HashMap::new(),
-     p_state).into()
+     p_state)
   });
 
   // Almost like a register, but different...

--- a/rtx_package/src/package/pool/tex_frontmatter.rs
+++ b/rtx_package/src/package/pool/tex_frontmatter.rs
@@ -252,9 +252,9 @@ LoadDefinitions!(state, {
     unpack!(args => ctr_type);
     let ctr_opt = LookupMapping!("counter_for_type", &ctr_type.to_string());
     if let Some(ctr) = ctr_opt {
-      T_OTHER!(ctr).into()
+      Tokens!(T_OTHER!(ctr))
     } else {
-      ctr_type.into()
+      ctr_type
     }
   });
   DefMacro!("\\lx@the@@{}", "\\expandafter\\lx@@the@@\\expandafter{\\lx@counterfor{#1}}");

--- a/rtx_package/src/package/pool/tex_para.rs
+++ b/rtx_package/src/package/pool/tex_para.rs
@@ -69,7 +69,7 @@ LoadDefinitions!(state, {
   Tag!("ltx:p", auto_close => true, auto_open => true, after_close => trim_node_whitespace_closure);
 
   // \dump ???
-  DefPrimitive!("\\end", sub[stomach, args, state] { stomach.get_gullet_mut().flush(state); Ok(vec![]) });
+  DefPrimitive!("\\end", sub[stomach, args, state] { stomach.get_gullet_mut().flush(state); });
 
   // TODO: Move to the right place in the pool definitions (maybe split out individual sub-pools by
   // chapter?)

--- a/rtx_package/src/package/setup.rs
+++ b/rtx_package/src/package/setup.rs
@@ -80,7 +80,7 @@ macro_rules! WithInnerState {
     BindInnerState!($inner_state, $stomach);
     let macro_out = $body;
     end_state_frame!();
-    return macro_out;
+    macro_out
   }}
 }
 
@@ -201,7 +201,7 @@ macro_rules! DefMacroIWO {
   // with explicit state
   ($cs:expr, $paramlist:expr, sub [ $gullet:ident, $args:ident, $inner_state:ident ] $body:block, $options:expr, $state_arg:ident) => {{
     let expansion_closure: Option<ExpansionBody> = Some(ExpansionBody::Closure(Rc::new(
-      move |$gullet, $args, $inner_state| WithInnerState!($body, $inner_state)
+      move |$gullet, $args, $inner_state| WithInnerState!($body, $inner_state).into_tokens_result()
     )));
     def_macro($cs, $paramlist, expansion_closure, $options, $state_arg);
   }};
@@ -225,7 +225,7 @@ macro_rules! DefMacroWO {
     let (cs, paramlist) = parse_prototype($proto, $state_arg)?;
     let expansion_body : Option<ExpansionBody> =
       Some(ExpansionBody::Closure(Rc::new(
-        move |$gullet: &mut Gullet, $args: Vec<Tokens>, $inner_state:&mut State| WithInnerState!($body, $inner_state)
+        move |$gullet: &mut Gullet, $args: Vec<Tokens>, $inner_state:&mut State| WithInnerState!($body, $inner_state).into_tokens_result()
       )));
     // TODO: Also pass in options
     def_macro(cs, paramlist, expansion_body, $options, $state_arg);
@@ -1294,6 +1294,8 @@ macro_rules! DefMacro {
     (DefMacroWO!($proto, sub[$gullet, $args, $inner_state] $body, None));
   ($proto:expr, sub [ $gullet:ident, $args:ident, $inner_state:ident ] $body:block, $($key:ident=>$val:expr),*) =>
     (DefMacroWO!($proto, sub[$gullet, $args, $inner_state] $body, Some(NewDefaultV!(ExpandableOptions, $($key=>$val),*))));
+  ($proto:expr, sub $body:block) =>
+    (DefMacroWO!($proto, sub[gullet, args, inner_state] $body, None));
   // String form
   ($proto:expr, $expansion:expr) => (DefMacroWO!($proto, $expansion, None));
   ($proto:expr, $expansion:expr, $($key:ident=>$val:expr),*) =>

--- a/rtx_package/src/package/setup.rs
+++ b/rtx_package/src/package/setup.rs
@@ -254,6 +254,10 @@ macro_rules! DefConditional(
     bind_state!(st);
     DefConditional!($proto, sub[$gullet, $args, $inner_state] $body, st);
   }};
+  ($proto:expr, sub $body:block) => {{
+    bind_state!(st);
+    DefConditional!($proto, sub[gullet, args, inner_state] $body, st);
+  }};
   ($proto:expr, sub [$gullet:ident, $args:ident, $inner_state:ident] $body:block, $state_arg:ident) => ({
     let (cs, paramlist) = parse_prototype($proto, $state_arg)?;
     DefConditionalI!(cs, paramlist, sub[$gullet, $args, $inner_state] $body, $state_arg)
@@ -281,7 +285,7 @@ macro_rules! DefConditionalI(
     DefConditionalI!($cs, $paramlist, $gullet, $args, $inner_state, $body, st)
   }};
   ($cs:expr, $paramlist:expr, sub[$gullet:ident, $args:ident, $inner_state:ident] $body:block, $state_arg:ident) => ({
-    let test : ConditionalClosure = Rc::new(move |$gullet, $args, $inner_state| { WithInnerState!($body, $inner_state) });
+    let test : ConditionalClosure = Rc::new(move |$gullet, $args, $inner_state| { WithInnerState!($body, $inner_state).into_bool_result() });
     def_conditional($cs, $paramlist, Some(test), ConditionalOptions::default(), $state_arg);
   });
   // or None
@@ -342,6 +346,10 @@ macro_rules! DefPrimitiveII {
   ($cs:expr, $paramlist:expr, sub[$stomach:ident,$args:ident,$inner_state:ident] $body:block, $state_arg:ident) => {
     DefPrimitiveII!($cs, $paramlist, move |$stomach, $args, $inner_state| {WithInnerState!($body, $inner_state, $stomach)}, PrimitiveOptions::default(), $state_arg)
   };
+  ($cs:expr, $paramlist:expr, sub $body:block) => {{
+    bind_state!(st);
+    DefPrimitiveII!($cs, $paramlist, sub[stomach, args, inner_state] $body, st)
+  }};
   ($cs:expr, $paramlist:expr, $compiled_replacement:expr, $options:expr) => {{
     bind_state!(st);
     DefPrimitiveII!($cs, $paramlist, $compiled_replacement, $options, st)
@@ -1271,6 +1279,8 @@ macro_rules! DefMacroI(
   // Expansion closure syntax
   ($cs:expr, $paramlist:expr, sub [ $gullet:ident, $args:ident, $inner_state:ident ] $body:block) =>
     (DefMacroIWO!($cs, $paramlist, sub [ $gullet, $args, $inner_state ] $body, None));
+  ($cs:expr, $paramlist:expr, sub $body:block) =>
+    (DefMacroIWO!($cs, $paramlist, sub [ gullet, args, inner_state ] $body, None));
   // With explicit state
   ($cs:expr, $paramlist:expr, sub [ $gullet:ident, $args:ident, $inner_state:ident ] $body:block, $state_arg:ident) =>
     (DefMacroIWO!($cs, $paramlist, sub [ $gullet, $args, $inner_state ] $body, None, $state_arg));
@@ -1426,10 +1436,17 @@ macro_rules! DefEnvironmentC(
 macro_rules! DefPrimitive{
   ($proto:expr, sub[$stomach:ident, $whatsit:ident, $inner_state:ident] $body:block) =>
     (DefPrimitiveIWO!($proto, |$stomach, $whatsit, $inner_state| {
-      WithInnerState!($body, $inner_state, $stomach) }, PrimitiveOptions::default())); 
+      WithInnerState!($body, $inner_state, $stomach).into_digested_result() }, PrimitiveOptions::default())); 
   ($proto:expr, sub[$stomach:ident, $whatsit:ident, $inner_state:ident] $body:block, $($key:ident=>$val:expr),*) =>
     (DefPrimitiveIWO!($proto, |$stomach, $whatsit, $inner_state| {
-      WithInnerState!($body, $inner_state, $stomach) }, NewDefault!(PrimitiveOptions, $($key=>$val),*))); 
+      WithInnerState!($body, $inner_state, $stomach).into_digested_result() }, NewDefault!(PrimitiveOptions, $($key=>$val),*))); 
+  ($proto:expr, sub $body:block) =>
+    (DefPrimitiveIWO!($proto, |stomach, whatsit, inner_state| {
+      WithInnerState!($body, inner_state, stomach).into_digested_result() }, PrimitiveOptions::default())); 
+  ($proto:expr, sub $body:block, $($key:ident=>$val:expr),*) =>
+    (DefPrimitiveIWO!($proto, |stomach, whatsit, inner_state| {
+      WithInnerState!($body, inner_state, stomach).into_digested_result() }, NewDefault!(PrimitiveOptions, $($key=>$val),*))); 
+
   ($proto:expr, $replacement:expr, $options:expr) => ({
     // TODO:
     // let compiled_replacement = || Tbox{text: $replacement, Invocation($options{alias} || $cs, @_[1 .. $#_])); }
@@ -1439,9 +1456,9 @@ macro_rules! DefPrimitive{
 
   // explicit state
   ($proto:expr, sub[$stomach:ident, $whatsit:ident, $inner_state:ident] $body:block, $state_arg:ident) =>
-    (DefPrimitiveIWO!($proto, |$stomach, $whatsit, $inner_state| {WithInnerState!($body, $inner_state, $stomach)}, PrimitiveOptions::default(), $state_arg));
+    (DefPrimitiveIWO!($proto, |$stomach, $whatsit, $inner_state| {WithInnerState!($body, $inner_state, $stomach).into_digested_result()}, PrimitiveOptions::default(), $state_arg));
   ($proto:expr, sub[$stomach:ident, $whatsit:ident, $inner_state:ident] $body:block, $state_arg:ident, $($key:ident=>$val:expr),*) =>
-    (DefPrimitiveIWO!($proto, |$stomach, $whatsit, $inner_state| {WithInnerState!($body, $inner_state, $stomach)}, NewDefault!(PrimitiveOptions, $($key=>$val),*), $state_arg));
+    (DefPrimitiveIWO!($proto, |$stomach, $whatsit, $inner_state| {WithInnerState!($body, $inner_state, $stomach).into_digested_result()}, NewDefault!(PrimitiveOptions, $($key=>$val),*), $state_arg));
 
   ($proto:expr, $replacement:expr, $options:expr, $state_arg:ident) => ({
     // TODO:
@@ -1636,4 +1653,20 @@ macro_rules! DocType {
       model.register_document_namespace(prefix, Some(value.to_string()));
     }
   }};
+}
+
+#[macro_export]
+macro_rules! Today {
+  () => {{
+    bind_state!(st);
+    today(st)
+  }};
+}
+
+#[macro_export]
+macro_rules! SetPrefix {
+  ($prefix:literal) => {{
+    bind_state!(st);
+    st.set_prefix($prefix);
+  }}
 }


### PR DESCRIPTION
Only augmented for DefMacro at the start of this PR, but even so! This is now valid Rust code in rtx:

```rust
DefMacro!("\\a", sub{ DefMacro!("\\b", "c"); });
```

I would like to upgrade the rest of the bindings that support the `sub[]` notations, and ensure that there is a proper `.into_*_result` trait for each of them, at which point this brevity can become the expected norm in rtx.