### PR TITLE
TeX.pool coverage 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 dist: trusty
 language: rust
 rust:
+  - stable 
   - nightly
 addons:
   apt:

--- a/rtx_codegen/src/constructable.rs
+++ b/rtx_codegen/src/constructable.rs
@@ -112,11 +112,10 @@ pub fn compile_replacement(input: DeriveInput) -> TokenStream {
   // mechanism. Once the new procedural macro scheme lands, this begs to be
   // refactored.
   quote!(
-  impl _Dummy {
-    fn replacement() -> Option<ReplacementClosure> {
-      #compiled_replacement_closure
+    macro_rules! this_replacement {
+      () => {#compiled_replacement_closure}
     }
-  })
+  )
   .into()
 }
 
@@ -150,11 +149,10 @@ pub fn compile_expansion(input: DeriveInput) -> TokenStream {
   // mechanism. Once the new procedural macro scheme lands, this begs to be
   // refactored.
   quote!(
-  impl _DummyE {
-    fn expansion() -> Option<ExpansionBody> {
-      #compiled_expansion
+    macro_rules! this_expansion {
+      () => {#compiled_expansion}
     }
-  })
+  )
   .into()
 }
 

--- a/rtx_codegen/src/lib.rs
+++ b/rtx_codegen/src/lib.rs
@@ -85,3 +85,10 @@ pub fn end_state_frame(_input: TokenStream) -> TokenStream {
   unsafe { CONTEXT_DEPTH -=1 };
   TokenStream::new()
 }
+
+
+#[proc_macro]
+pub fn def_environment(input: TokenStream) -> TokenStream {
+  dbg!(input);
+  TokenStream::new()
+}

--- a/rtx_core/src/common/store.rs
+++ b/rtx_core/src/common/store.rs
@@ -11,6 +11,7 @@ use crate::common::font::Font;
 use crate::common::glue::{Glue, MuGlue};
 use crate::common::ligature::Ligature;
 use crate::common::number::Number;
+use crate::definition::register::NumericOps;
 use crate::definition::conditional::{Conditional, IfFrame};
 use crate::definition::constructor::Constructor;
 use crate::definition::expandable::Expandable;
@@ -184,6 +185,11 @@ impl<'a> From<&'a str> for Stored {
 impl From<i32> for Stored {
   fn from(value: i32) -> Self { Stored::Int(value) }
 }
+
+impl From<f32> for Stored {
+  fn from(value: f32) -> Self { Stored::Number(Number::new(value)) }
+}
+
 
 impl From<Catcode> for Stored {
   fn from(value: Catcode) -> Self { Stored::Catcode(value) }

--- a/rtx_core/src/definition/conditional.rs
+++ b/rtx_core/src/definition/conditional.rs
@@ -125,7 +125,6 @@ impl Definition for Conditional {
   fn get_cs(&self) -> Cow<Token> { Cow::Borrowed(&self.cs) }
   fn get_cs_name(&self) -> Cow<str> { Cow::Borrowed(self.cs.get_cs_name()) }
   fn get_alias(&self) -> Option<String> { None }
-
   fn get_locator(&self) -> String { String::from("Locator is TODO") }
 
   // Not implemented for expandable

--- a/rtx_core/src/definition/conditional.rs
+++ b/rtx_core/src/definition/conditional.rs
@@ -116,7 +116,12 @@ impl Definition for Conditional {
     }
   }
 
-  fn get_parameters(&self) -> &Option<Parameters> { &self.paramlist }
+  fn get_parameters(&self) -> Option<&Parameters> {
+    match self.paramlist {
+      None => None,
+      Some(ref ps) => Some(ps)
+    }
+  }
   fn get_cs(&self) -> Cow<Token> { Cow::Borrowed(&self.cs) }
   fn get_cs_name(&self) -> Cow<str> { Cow::Borrowed(self.cs.get_cs_name()) }
   fn get_alias(&self) -> Option<String> { None }

--- a/rtx_core/src/definition/conditional.rs
+++ b/rtx_core/src/definition/conditional.rs
@@ -118,8 +118,8 @@ impl Definition for Conditional {
 
   fn get_parameters(&self) -> &Option<Parameters> { &self.paramlist }
   fn get_cs(&self) -> Cow<Token> { Cow::Borrowed(&self.cs) }
-
   fn get_cs_name(&self) -> Cow<str> { Cow::Borrowed(self.cs.get_cs_name()) }
+  fn get_alias(&self) -> Option<String> { None }
 
   fn get_locator(&self) -> String { String::from("Locator is TODO") }
 

--- a/rtx_core/src/definition/constructor.rs
+++ b/rtx_core/src/definition/constructor.rs
@@ -199,6 +199,7 @@ impl Definition for Constructor {
 
   fn get_cs(&self) -> Cow<Token> { Cow::Borrowed(&self.cs) }
   fn get_cs_name(&self) -> Cow<str> { Cow::Borrowed(self.cs.get_cs_name()) }
+  fn get_alias(&self) -> Option<String> { self.alias.clone() }
   fn get_locator(&self) -> String { unimplemented!() }
   fn get_parameters(&self) -> &Option<Parameters> { &self.paramlist }
   fn get_num_args(&self) -> usize {

--- a/rtx_core/src/definition/constructor.rs
+++ b/rtx_core/src/definition/constructor.rs
@@ -217,7 +217,7 @@ impl Definition for Constructor {
     }
     // self.nargs = Some(nargs);
   }
-
+  
   fn do_absorbtion(&self, document: &mut Document, whatsit: &Whatsit, state: &mut State) -> Result<()> {
     for pre_closure in &self.before_construct {
       pre_closure(document, whatsit, state)?;

--- a/rtx_core/src/definition/constructor.rs
+++ b/rtx_core/src/definition/constructor.rs
@@ -137,7 +137,7 @@ impl Definition for Constructor {
     let ismath = state.lookup_bool("IN_MATH");
     // info!(target: "constructor", "invoke for {:?} ({:?})", self.get_cs(), ismath);
     // Parse AND digest the arguments to the Constructor
-    let mut args: Vec<Option<Digested>> = match *self.get_parameters() {
+    let mut args: Vec<Option<Digested>> = match self.get_parameters() {
       None => Vec::new(),
       Some(ref params) => params.read_arguments_and_digest(stomach, self, state)?,
     };
@@ -201,7 +201,12 @@ impl Definition for Constructor {
   fn get_cs_name(&self) -> Cow<str> { Cow::Borrowed(self.cs.get_cs_name()) }
   fn get_alias(&self) -> Option<String> { self.alias.clone() }
   fn get_locator(&self) -> String { unimplemented!() }
-  fn get_parameters(&self) -> &Option<Parameters> { &self.paramlist }
+  fn get_parameters(&self) -> Option<&Parameters> {
+    match self.paramlist {
+      None => None,
+      Some(ref ps) => Some(ps)
+    }
+  }
   fn get_num_args(&self) -> usize {
     match self.nargs {
       Some(n) => n,

--- a/rtx_core/src/definition/expandable.rs
+++ b/rtx_core/src/definition/expandable.rs
@@ -88,7 +88,6 @@ impl Definition for Expandable {
     })
   }
   fn get_alias(&self) -> Option<String> { self.alias.clone() }
-
   fn get_locator(&self) -> String { self.locator.clone() }
 
   fn invoke(&self, gullet: &mut Gullet, state: &mut State) -> Result<Tokens> {

--- a/rtx_core/src/definition/expandable.rs
+++ b/rtx_core/src/definition/expandable.rs
@@ -76,13 +76,13 @@ impl Definition for Expandable {
   fn is_protected(&self) -> bool { self.is_protected }
   fn get_parameters(&self) -> &Option<Parameters> { &self.paramlist }
   fn get_cs(&self) -> Cow<Token> { Cow::Borrowed(&self.cs) }
-
   fn get_cs_name(&self) -> Cow<str> {
     Cow::Borrowed(match self.alias {
       Some(ref alias) => alias,
       None => self.cs.get_cs_name(),
     })
   }
+  fn get_alias(&self) -> Option<String> { self.alias.clone() }
 
   fn get_locator(&self) -> String { self.locator.clone() }
 

--- a/rtx_core/src/definition/expandable.rs
+++ b/rtx_core/src/definition/expandable.rs
@@ -74,7 +74,12 @@ impl Object for Expandable {
 }
 impl Definition for Expandable {
   fn is_protected(&self) -> bool { self.is_protected }
-  fn get_parameters(&self) -> &Option<Parameters> { &self.paramlist }
+  fn get_parameters(&self) -> Option<&Parameters> { 
+    match self.paramlist {
+      None => None,
+      Some(ref ps) => Some(ps)
+    }
+  }
   fn get_cs(&self) -> Cow<Token> { Cow::Borrowed(&self.cs) }
   fn get_cs_name(&self) -> Cow<str> {
     Cow::Borrowed(match self.alias {
@@ -158,6 +163,13 @@ impl Expandable {
       },
       // empty if no expansion
       None => Ok(Tokens!()),
+    }
+  }
+
+  pub fn get_expansion(&self) -> Option<&ExpansionBody> {
+    match self.expansion {
+      None => None,
+      Some(ref exp) => Some(exp)
     }
   }
 }

--- a/rtx_core/src/definition/math_primitive.rs
+++ b/rtx_core/src/definition/math_primitive.rs
@@ -121,6 +121,7 @@ pub struct MathPrimitive {
   pub nargs: Option<usize>,
   pub replacement: Option<PrimitiveClosure>,
   pub options: MathPrimitiveOptions,
+  pub alias: Option<String>
 }
 impl Default for MathPrimitive {
   fn default() -> Self {
@@ -130,6 +131,7 @@ impl Default for MathPrimitive {
       nargs: None,
       replacement: None,
       options: MathPrimitiveOptions::default(),
+      alias:None,
     }
   }
 }
@@ -171,6 +173,7 @@ impl Definition for MathPrimitive {
 
   fn get_cs(&self) -> Cow<Token> { Cow::Borrowed(&self.cs) }
   fn get_cs_name(&self) -> Cow<str> { Cow::Borrowed(self.cs.get_cs_name()) }
+  fn get_alias(&self) -> Option<String> { self.alias.clone() }
   fn get_locator(&self) -> String { unimplemented!() }
   fn get_parameters(&self) -> &Option<Parameters> { &self.paramlist }
   fn get_num_args(&self) -> usize {

--- a/rtx_core/src/definition/math_primitive.rs
+++ b/rtx_core/src/definition/math_primitive.rs
@@ -175,7 +175,12 @@ impl Definition for MathPrimitive {
   fn get_cs_name(&self) -> Cow<str> { Cow::Borrowed(self.cs.get_cs_name()) }
   fn get_alias(&self) -> Option<String> { self.alias.clone() }
   fn get_locator(&self) -> String { unimplemented!() }
-  fn get_parameters(&self) -> &Option<Parameters> { &self.paramlist }
+  fn get_parameters(&self) -> Option<&Parameters> {
+    match self.paramlist {
+      None => None,
+      Some(ref ps) => Some(ps)
+    }
+  }
   fn get_num_args(&self) -> usize {
     match self.nargs {
       Some(n) => n,

--- a/rtx_core/src/definition/mod.rs
+++ b/rtx_core/src/definition/mod.rs
@@ -21,7 +21,7 @@ use crate::mouth;
 use crate::parameter::Parameters;
 use crate::state::State;
 use crate::stomach::Stomach;
-use crate::token::Token;
+use crate::token::{Catcode, Token};
 use crate::tokens::Tokens;
 use crate::whatsit::Whatsit;
 use crate::Digested;
@@ -73,7 +73,13 @@ pub trait Definition: Object {
   /// forced to clone
   fn get_cs(&self) -> Cow<Token>;
   fn get_cs_name(&self) -> Cow<str>;
-
+  fn get_cs_or_alias(&self) -> Cow<Token> {
+    match self.get_alias() {
+      Some(alias) => Cow::Owned(T_CS!(alias)),
+      None => self.get_cs()
+    }
+  }
+  fn get_alias(&self) -> Option<String>;
   fn is_protected(&self) -> bool { false }
   fn is_register(&self) -> bool { false }
   fn is_prefix(&self) -> bool { false }

--- a/rtx_core/src/definition/mod.rs
+++ b/rtx_core/src/definition/mod.rs
@@ -100,7 +100,13 @@ pub trait Definition: Object {
   // Overriding methods
   fn stringify(&self) -> String { unimplemented!() }
 
-  fn to_string(&self) -> String { unimplemented!() }
+  fn to_string(&self) -> String {
+    if let Some(params) = self.get_parameters() {
+      s!("{} {}", self.get_cs_name(), params.to_string())
+    } else {
+      self.get_cs_name().to_string()
+    }
+  }
 
   // Return the Tokens that would invoke the given definition with arguments.
   fn invocation(&mut self, args: Vec<Tokens>, gullet: &mut Gullet, state: &mut State) -> Result<Tokens> {
@@ -166,4 +172,13 @@ pub trait Definition: Object {
   fn value_of(&self, args: Vec<Token>, state: &State) -> Option<RegisterValue> { unimplemented!() }
   fn register_type(&self) -> Option<RegisterType> { None }
   fn get_reversion_spec(&self) -> Option<Reversion> { unimplemented!() }
+}
+
+impl ExpansionBody {
+  pub fn to_string(&self) -> String {
+    match self {
+      ExpansionBody::Tokens(ref t) => t.to_string(),
+      ExpansionBody::Closure(_) => unimplemented!(), // what is the right way to serialize this, e.g. for the \meaning macro
+    }
+  }
 }

--- a/rtx_core/src/definition/mod.rs
+++ b/rtx_core/src/definition/mod.rs
@@ -94,7 +94,7 @@ pub trait Definition: Object {
       Some(ref params) => params.read_arguments(gullet, self, state),
     }
   }
-  fn get_parameters(&self) -> &Option<Parameters>;
+  fn get_parameters(&self) -> Option<&Parameters>;
 
   // ======================================================================
   // Overriding methods
@@ -107,7 +107,7 @@ pub trait Definition: Object {
     let mut invocation_result: Vec<Token> = Vec::new();
     invocation_result.push(self.get_cs().into_owned());
 
-    match *self.get_parameters() {
+    match self.get_parameters() {
       None => {},
       Some(ref params) => {
         for result_token in params.revert_arguments(args, gullet, state)? {

--- a/rtx_core/src/definition/primitive.rs
+++ b/rtx_core/src/definition/primitive.rs
@@ -114,7 +114,13 @@ impl Definition for Primitive {
   fn get_cs_name(&self) -> Cow<str> { Cow::Borrowed(self.cs.get_cs_name()) }
   fn get_alias(&self) -> Option<String> { self.alias.clone() }
   fn get_locator(&self) -> String { unimplemented!() }
-  fn get_parameters(&self) -> &Option<Parameters> { &self.paramlist }
+  fn get_parameters(&self) -> Option<&Parameters> {
+    match self.paramlist {
+      None => None,
+      Some(ref ps) => Some(ps)
+    }
+  }
+    
   fn get_num_args(&self) -> usize {
     match self.nargs {
       Some(n) => n,

--- a/rtx_core/src/definition/primitive.rs
+++ b/rtx_core/src/definition/primitive.rs
@@ -56,7 +56,10 @@ pub struct Primitive {
   pub cs: Token,
   pub paramlist: Option<Parameters>,
   pub replacement: Option<PrimitiveClosure>,
-  pub options: PrimitiveOptions,
+  pub before_digest: Vec<BeforeDigestClosure>,
+  pub after_digest: Vec<DigestionClosure>,
+  pub alias: Option<String>,
+  pub nargs: Option<usize>,
 }
 impl Default for Primitive {
   fn default() -> Self {
@@ -64,7 +67,10 @@ impl Default for Primitive {
       cs: T_CS!("Primitive"),
       paramlist: None,
       replacement: None,
-      options: PrimitiveOptions::default(),
+      alias: None,
+      before_digest: Vec::new(),
+      after_digest: Vec::new(),
+      nargs: None,
     }
   }
 }
@@ -74,8 +80,8 @@ impl PartialEq for Primitive {
 
 impl Object for Primitive {}
 impl Definition for Primitive {
-  fn before_digest(&self) -> Option<&Vec<BeforeDigestClosure>> { Some(&self.options.before_digest) }
-  fn after_digest(&self) -> Option<&Vec<DigestionClosure>> { Some(&self.options.after_digest) }
+  fn before_digest(&self) -> Option<&Vec<BeforeDigestClosure>> { Some(&self.before_digest) }
+  fn after_digest(&self) -> Option<&Vec<DigestionClosure>> { Some(&self.after_digest) }
 
   fn invoke(&self, _gullet: &mut Gullet, _state: &mut State) -> Result<Tokens> { Ok(Tokens!()) }
   fn invoke_primitive(&self, stomach: &mut Stomach, _caller: Rc<Definition>, state: &mut State) -> Result<Vec<Digested>> {
@@ -106,10 +112,11 @@ impl Definition for Primitive {
 
   fn get_cs(&self) -> Cow<Token> { Cow::Borrowed(&self.cs) }
   fn get_cs_name(&self) -> Cow<str> { Cow::Borrowed(self.cs.get_cs_name()) }
+  fn get_alias(&self) -> Option<String> { self.alias.clone() }
   fn get_locator(&self) -> String { unimplemented!() }
   fn get_parameters(&self) -> &Option<Parameters> { &self.paramlist }
   fn get_num_args(&self) -> usize {
-    match self.options.nargs {
+    match self.nargs {
       Some(n) => n,
       None => match self.paramlist {
         Some(ref params) => params.get_num_args(),

--- a/rtx_core/src/definition/register.rs
+++ b/rtx_core/src/definition/register.rs
@@ -254,7 +254,7 @@ impl Definition for RefCell<Register> {
   fn is_readonly(&self) -> bool { self.borrow().readonly }
   // not implemented for primitives
   fn invoke(&self, gullet: &mut Gullet, state: &mut State) -> Result<Tokens> { unimplemented!() }
-  fn get_parameters(&self) -> &Option<Parameters> { unimplemented!() } // TODO: How do we do this with a RefCell ?!
+  fn get_parameters(&self) -> Option<&Parameters> { unimplemented!() } // TODO: How do we do this with a RefCell ?!
   fn get_cs(&self) -> Cow<Token> { Cow::Owned(self.borrow().cs.clone()) }
   fn get_cs_name(&self) -> Cow<str> { Cow::Owned(self.borrow().cs.get_cs_name().to_owned()) }
   fn get_alias(&self) -> Option<String> { None }

--- a/rtx_core/src/definition/register.rs
+++ b/rtx_core/src/definition/register.rs
@@ -258,7 +258,6 @@ impl Definition for RefCell<Register> {
   fn get_cs(&self) -> Cow<Token> { Cow::Owned(self.borrow().cs.clone()) }
   fn get_cs_name(&self) -> Cow<str> { Cow::Owned(self.borrow().cs.get_cs_name().to_owned()) }
   fn get_alias(&self) -> Option<String> { None }
-
   fn get_locator(&self) -> String { String::from("Locator is TODO") }
 
   // No before/after daemons ???

--- a/rtx_core/src/definition/register.rs
+++ b/rtx_core/src/definition/register.rs
@@ -256,8 +256,8 @@ impl Definition for RefCell<Register> {
   fn invoke(&self, gullet: &mut Gullet, state: &mut State) -> Result<Tokens> { unimplemented!() }
   fn get_parameters(&self) -> &Option<Parameters> { unimplemented!() } // TODO: How do we do this with a RefCell ?!
   fn get_cs(&self) -> Cow<Token> { Cow::Owned(self.borrow().cs.clone()) }
-
   fn get_cs_name(&self) -> Cow<str> { Cow::Owned(self.borrow().cs.get_cs_name().to_owned()) }
+  fn get_alias(&self) -> Option<String> { None }
 
   fn get_locator(&self) -> String { String::from("Locator is TODO") }
 

--- a/rtx_core/src/document/mod.rs
+++ b/rtx_core/src/document/mod.rs
@@ -330,28 +330,20 @@ impl Document {
       self.absorb(digested, state)?;
     }
 
-    let mut needs_close = self.node == node;
-    {
-      // In obscure situations, `node` may have already gotten closed?
-      // close it if it is still open.
-      let self_node = self.node.get_parent().unwrap();
-      let mut c = Some(self_node);
-
-      while c.is_some() && c.as_ref().unwrap().get_type() != Some(NodeType::DocumentNode) && c.as_ref().unwrap() != &node {
-        let parent = c.unwrap().get_parent().unwrap();
-        if parent.get_type() != Some(NodeType::DocumentNode) {
-          c = Some(parent);
-        } else {
-          c = None;
-        }
-      }
-      if let Some(ref c_node) = c {
-        if c_node == &node {
-          needs_close = true;
-        }
-      }
+    let self_node = self.node.get_parent().unwrap();
+    let mut c = Some(self_node);
+    while c.is_some() && c.as_ref() != Some(&node) && c.as_ref().unwrap().get_type() != Some(NodeType::DocumentNode) {
+      let parent = c.unwrap().get_parent().unwrap();
+      c = match parent.get_type() {
+        Some(NodeType::DocumentNode) => None,
+        None => None,
+        Some(_) => Some(parent),
+      };
     }
-    if needs_close {
+
+    // In obscure situations, `node` may have already gotten closed?
+    // close it if it is still open.    
+    if (self.node == node) || (c.as_ref() == Some(&node)) {
       self.close_element(qname, state)?;
     }
     Ok(node)

--- a/rtx_core/src/gullet.rs
+++ b/rtx_core/src/gullet.rs
@@ -969,56 +969,49 @@ impl Gullet {
 
   pub fn reading_from_mouth<R>(&mut self, mouth: Mouth, state: &mut State, mut reader: Box<FnMut(&mut Gullet, &mut State) -> R>) -> R {
     let mouth_source = mouth.source.clone();
-    {
-      self.open_mouth(mouth, false); // only allow mouth to be explicitly closed here.
-    }
+    self.open_mouth(mouth, false); // only allow mouth to be explicitly closed here.
     let results: R = reader(self, state);
     // `mouth` must still be open, with (at worst) empty autoclosable mouths in front of it
     loop {
       let mut is_mouth = false;
-      {
-        if let Some(ref mut runtime) = self.mouth {
-          if runtime.mouth.source == mouth_source {
-            is_mouth = true;
-          }
-        } else {
-          error!(target: "unexpected:runtime", "TODO: gullet had no active runtime");
+      if let Some(ref mut runtime) = self.mouth {
+        if runtime.mouth.source == mouth_source {
+          self.close_mouth(true, state);
+          break;  
+        } else if self.mouthstack.is_empty() {
+          error!(target: "unexpected:<closed>", "TODO: Mouth is unexpectedly already closed");
+          // Error('unexpected', '<closed>', $gullet, "Mouth is unexpectedly already closed",
+          //   "Reading from " . Stringify($mouth) . ", but it has already been closed.");
           break;
-        }
-      }
-      if is_mouth {
-        self.close_mouth(true, state);
-        break;
-      } else if self.mouthstack.is_empty() {
-        error!(target: "unexpected:<closed>", "TODO: Mouth is unexpectedly already closed");
-        // Error('unexpected', '<closed>', $gullet, "Mouth is unexpectedly already closed",
-        //   "Reading from " . Stringify($mouth) . ", but it has already been closed.");
-        break;
-      } else {
-        let mut ready_to_read = false;
-        {
-          if let Some(ref mut runtime) = self.mouth {
-            if !runtime.autoclose || !runtime.pushback.is_empty() || runtime.mouth.has_more_input() {
-              ready_to_read = true;
-            }
-          }
-        }
-        if ready_to_read {
-          let _next = self.read_token(state); // stringify( ?
-          error!(target: "unexpected:next", "TODO: unexpected input remaining");
-          // Error('unexpected', $next, $gullet, "Unexpected input remaining: '$next'",
-          //   "Finished reading from " . Stringify($mouth) . ", but it still has input.");
+        } else {
+          let mut ready_to_read = false;
           {
             if let Some(ref mut runtime) = self.mouth {
-              runtime.mouth.finish(state);
+              if !runtime.autoclose || !runtime.pushback.is_empty() || runtime.mouth.has_more_input() {
+                ready_to_read = true;
+              }
             }
           }
-          self.close_mouth(true, state);
+          if ready_to_read {
+            let _next = self.read_token(state); // stringify( ?
+            error!(target: "unexpected:next", "TODO: unexpected input remaining");
+            // Error('unexpected', $next, $gullet, "Unexpected input remaining: '$next'",
+            //   "Finished reading from " . Stringify($mouth) . ", but it still has input.");
+            {
+              if let Some(ref mut runtime) = self.mouth {
+                runtime.mouth.finish(state);
+              }
+            }
+            self.close_mouth(true, state);
+          }
+          // ?? if we continue?
+          else {
+            self.close_mouth(false, state);
+          }
         }
-        // ?? if we continue?
-        else {
-          self.close_mouth(false, state);
-        }
+      } else {
+        error!(target: "unexpected:runtime", "TODO: gullet had no active runtime");
+        break;
       }
     }
     results

--- a/rtx_core/src/parameter.rs
+++ b/rtx_core/src/parameter.rs
@@ -24,6 +24,11 @@ pub type ReaderPredigestClosure = Rc<ReaderPredigestFn>;
 pub type ReaderClosure = Rc<ReaderFn>;
 pub type ReversionClosure = Rc<Fn(&mut Gullet, Vec<Token>, Vec<ParameterExtra>, &mut State) -> Result<Tokens>>;
 
+lazy_static! {
+  static ref LAST_WCHAR_RE : Regex = Regex::new(r"\w$").unwrap();
+  static ref FIRST_WCHAR_RE : Regex = Regex::new(r"^\w").unwrap();
+}
+
 #[derive(Clone, Debug)]
 pub enum ParameterExtra {
   Token(Token),
@@ -325,6 +330,10 @@ impl Parameter {
       Ok(Tokens::new(value.revert()))
     }
   }
+
+  pub fn to_string(&self) -> String {
+    self.spec.clone()
+  }
 }
 
 #[derive(Clone, Debug)]
@@ -334,7 +343,7 @@ pub struct Parameters {
 
 impl Parameters {
   pub fn get_num_args(&self) -> usize { self.params.iter().filter(|&p| !p.novalue).count() }
-
+  pub fn get_parameters(&self) -> Vec<&Parameter> { self.params.iter().map(|p| p).collect() }
   pub fn revert_arguments(&self, args: Vec<Tokens>, gullet: &mut Gullet, state: &mut State) -> Result<Vec<Token>> {
     let mut tokens = Vec::new();
     for (parameter, arg) in self.params.iter().zip(args.into_iter()) {
@@ -375,4 +384,15 @@ impl Parameters {
   }
 
   pub fn reparse_argument(&self, _gullet: &mut Gullet, _value: Tokens, _state: &mut State) -> Tokens { Tokens!() }
+  pub fn to_string(&self) -> String {
+    let mut content = String::new();
+    for parameter in &self.params {
+      let param_content = parameter.to_string();
+      if LAST_WCHAR_RE.is_match(&content) && FIRST_WCHAR_RE.is_match(&param_content) {
+        content.push(' '); 
+      }
+      content.push_str(&param_content);
+    }
+    content
+  }
 }

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -1,5 +1,5 @@
 use lazy_static::lazy_static;
-use log::{debug, error, warn};
+use log::*;
 use regex::Regex;
 use std::borrow::Cow;
 use std::cell::RefCell;
@@ -479,65 +479,57 @@ impl State {
       // We are going to change the model, where we first count the total number of definitions to
       // pop, and then pop them, in order to never mutably morrow more than once at a time.
       let mut undo_count = 0;
-      {
-        // Remove bindings made in all frames down-to & including the next lower locked frame
-        let mut frame_table: &mut AssignmentCount = &mut HashMap::new();
 
-        for frame in &mut self.undo {
-          let is_locked = frame.locked;
-          frame_table = frame.table_mut(table_name);
-          if let Some(n) = frame_table.remove(key) {
-            undo_count += n;
-          }
+      // Remove bindings made in all frames down-to & including the next lower locked frame
+      let mut frame_table: &mut AssignmentCount = &mut HashMap::new();
 
-          if is_locked {
-            break;
-          }
+      for frame in &mut self.undo {
+        let is_locked = frame.locked;
+        frame_table = frame.table_mut(table_name);
+        if let Some(n) = frame_table.remove(key) {
+          undo_count += n;
         }
-        // whatever is left -- if anything -- should be bindings below the locked frame.
-        frame_table.insert(key.to_string(), 1); // Note that there's only one value in the stack, now
-      }
-      {
-        // Undo the bindings, if `key` was bound in this frame
-        let state_table = self.table_mut(table_name);
-        if let Some(defs) = state_table.get_mut(key) {
-          for _ in 1..=undo_count {
-            defs.pop_front();
-          }
+        if is_locked {
+          break;
         }
-
-        let table_entry = state_table.entry(key.to_string()).or_insert_with(VecDeque::new);
-        table_entry.push_front(value);
       }
+      // whatever is left -- if anything -- should be bindings below the locked frame.
+      frame_table.insert(key.to_string(), 1); // Note that there's only one value in the stack, now
+
+      // Undo the bindings, if `key` was bound in this frame
+      let state_table = self.table_mut(table_name);
+      if let Some(defs) = state_table.get_mut(key) {
+        for _ in 1..=undo_count {
+          defs.pop_front();
+        }
+      }
+
+      let table_entry = state_table.entry(key.to_string()).or_insert_with(VecDeque::new);
+      table_entry.push_front(value);
     } else if scope == Scope::Local {
       // Again, split the logic as 1) bookkeeping in undo, then 2) operations in state tables
       let mut is_replace = false;
-      {
-        // 1. Undo mutable logic
-        if let Some(current_frame) = self.undo.front_mut() {
-          let current_frame_table = current_frame.table_mut(table_name);
-
-          // If the value was previously assigned in this frame
-          if current_frame_table.get(key).is_some() {
-            is_replace = true;
-          } else {
-            // Otherwise, push new value & set 1 to be undone
-            current_frame_table.insert(key.to_string(), 1);
-            //  And push new binding.
-            is_replace = false;
-          }
+      // 1. Undo mutable logic
+      if let Some(current_frame) = self.undo.front_mut() {
+        let current_frame_table = current_frame.table_mut(table_name);
+        // If the value was previously assigned in this frame
+        if current_frame_table.get(key).is_some() {
+          is_replace = true;
+        } else {
+          // Otherwise, push new value & set 1 to be undone
+          current_frame_table.insert(key.to_string(), 1);
+          //  And push new binding.
+          is_replace = false;
         }
       }
-      {
-        // 2. State table mutable logic
-        let state_table = self.table_mut(table_name);
-        let defs = state_table.entry(key.to_string()).or_insert_with(VecDeque::new);
-        if is_replace {
-          // Replace the value
-          defs.pop_front();
-        }
-        defs.push_front(value)
+      // 2. State table mutable logic
+      let state_table = self.table_mut(table_name);
+      let defs = state_table.entry(key.to_string()).or_insert_with(VecDeque::new);
+      if is_replace {
+        // Replace the value
+        defs.pop_front();
       }
+      defs.push_front(value)
     }
     // TODO: stash cases
   }
@@ -1156,30 +1148,38 @@ impl State {
 
   // #======================================================================
 
-  pub fn activate_scope(&mut self, scope: &str) {}
-  //   if (!$$self{stash_active}{$scope}[0]) {
-  //     assign_internal($self, 'stash_active', $scope, 1, 'local');
-  //     if (defined(my $defns = $$self{stash}{$scope}[0])) {
-  //       # Now make local assignments for all those in the stash.
-  //       my $frame = $$self{undo}[0];
-  //       foreach my $entry (@$defns) {
-  //         # Here we ALWAYS push the stashed values into the table
-  //         # since they may be popped off by deactivateScope
-  //         my ($table, $key, $value) = @$entry;
-  //         $$frame{$table}{$key}++;    # Note that this many values must be undone
-  //         unshift(@{ $$self{$table}{$key} }, $value); } } }    # And push new binding.
-  //   return; }
+  pub fn activate_scope(&mut self, scope: &str) {
+    info!("TODO: implement State::activate_scope");
+    if let Some(scope_entry) = self.stash_active.get(scope) {
+      if let Some(count) = scope_entry.front() {
+        self.assign_internal(TableName::StashActive, scope, Stored::Bool(true), Some(Scope::Local));
+        if let Some(stash_entry) = self.stash.get(scope) {
+          // if let Some(defns) = stash_entry.front() {
+            // Now make local assignments for all those in the stash.
+            // let frame = self.undo.front();
+            
+            // for entry in defns.iter() {
+              // Here we ALWAYS push the stashed values into the table
+              // since they may be popped off by deactivateScope
+              //         my ($table, $key, $value) = @$entry;
+              //         $$frame{$table}{$key}++;    # Note that this many values must be undone
+              //         unshift(@{ $$self{$table}{$key} }, $value); } } }    # And push new binding.
+            // }
+          // }
+        }
+      }
+    }
+  }
 
   // # Probably, in most cases, the assignments made by activateScope
   // # will be undone by egroup or popping frames.
   // # But they can also be undone explicitly
 
-  pub fn deactivate_scope(&mut self, scope: &str) {}
-  //   my ($self, $scope) = @_;
-  //   if ($$self{stash_active}{$scope}[0]) {
+  pub fn deactivate_scope(&self, scope: &str) {  info!("TODO: implement State::deactivate_scope"); }
+    // if self{stash_active}{$scope}[0]) {
   //     assign_internal($self, 'stash_active', $scope, 0, 'global');
   //     if (defined(my $defns = $$self{stash}{$scope}[0])) {
-  //       my $frame = $$self{undo}[0];
+  //       let frame = $$self{undo}[0];
   //       foreach my $entry (@$defns) {
   //         my ($table, $key, $value) = @$entry;
   //         if ($$self{$table}{$key}[0] eq $value) {
@@ -1192,8 +1192,7 @@ impl State {
   //             "Unassigning wrong value for $key from table $table in deactivateScope",
   //             "value is $value but stack is " . join(', ', @{ $$self{$table}{$key} })); } } } }
   //   return; }
-  pub fn deactivate_counter_scope(&mut self, scope: &str) {} // ???
-
+  
   // sub getKnownScopes {
   //   my ($self) = @_;
   //   my @scopes = sort keys %{ $$self{stash} };
@@ -1403,39 +1402,19 @@ impl State {
   }
   /// `XEquals` check for two token arguments
   pub fn x_equals(&mut self, token1: &Token, token2: &Token) -> bool {
-    let def1_opt: Option<Stored>;
-    {
-      // mutability guard
-      def1_opt = match self.lookup_meaning(token1) {
-        // token, definition object or undef
-        None => None,
-        Some(ref obj) => Some((*obj).clone()), /* TODO: Can this code pattern be reworked
-                                                * without a clone? What is the idiomatic Rust
-                                                * for this? */
-      };
-    }
+    let def1_opt = self.lookup_meaning(token1);
     let def2_opt = self.lookup_meaning(token2); // ditto
-    if def1_opt.is_none() && def2_opt.is_none() {
-      // true if both undefined
-      true
-    } else if let Some(def1) = def1_opt {
-      if let Some(def2) = def2_opt {
-        def1 == def2 // If both have defns, must be same defn!
-      } else {
-        // False, if only one has 'meaning'
-        false
-      }
-    } else {
-      false // False, if only one has 'meaning'
+    match (def1_opt, def2_opt) {
+      (None, None) => true, // true if both undefined
+      (Some(def1), Some(def2)) => def1 == def2, // If both have defns, must be same defn!
+      _ => false // False, if only one has 'meaning'
     }
   }
 
   pub fn load_font_map(&self, encoding: &str) -> Option<&Fontmap> {
     let fontmap_key = s!("{}_fontmap", encoding);
-    {
-      if let Some(map) = self.lookup_value(&fontmap_key) {
-        return map.into();
-      }
+    if let Some(map) = self.lookup_value(&fontmap_key) {
+      return map.into();
     }
 
     // TODO: Once we try to load font maps via require package we will have some serious mutability

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -551,8 +551,9 @@ impl State {
     }
   }
 
-  pub fn assign_value<'av, T: Into<Stored>>(&'av mut self, key: &'av str, value: T, scope: Option<Scope>) {
+  pub fn assign_value<'av, T: Into<Stored>, S: Into<Option<Scope>>>(&'av mut self, key: &'av str, value: T, scope: S) {
     let value = value.into();
+    let scope = scope.into();
     self.assign_internal(TableName::Value, key, value, scope);
   }
 

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -54,13 +54,12 @@ pub enum TableName {
   Lccode,
   Uccode,
   Delcode,
-  Stash,
   StashActive,
 }
 impl TableName {
   pub fn variants() -> Vec<TableName> {
     use self::TableName::*;
-    vec![Meaning, Value, Catcode, Sfcode, Lccode, Uccode, Delcode, Stash, StashActive]
+    vec![Meaning, Value, Catcode, Sfcode, Lccode, Uccode, Delcode, StashActive]
   }
 }
 
@@ -74,6 +73,7 @@ pub enum Catcodes {
 
 /// Ledger for stacked assignments
 pub type AssignmentCount = HashMap<String, usize>;
+pub type StashStore = HashMap<String, Vec<(TableName, String, Stored)>>;
 #[derive(Debug, Clone)]
 pub struct UndoFrame {
   locked: bool,
@@ -85,7 +85,6 @@ pub struct UndoFrame {
   lccode: AssignmentCount,
   uccode: AssignmentCount,
   delcode: AssignmentCount,
-  stash: AssignmentCount,
   stash_active: AssignmentCount,
 }
 
@@ -101,7 +100,6 @@ impl Default for UndoFrame {
       lccode: HashMap::new(),
       uccode: HashMap::new(),
       delcode: HashMap::new(),
-      stash: HashMap::new(),
       stash_active: HashMap::new(),
     }
   }
@@ -118,7 +116,6 @@ impl UndoFrame {
       Lccode => &self.lccode,
       Uccode => &self.uccode,
       Delcode => &self.delcode,
-      Stash => &self.stash,
       StashActive => &self.stash_active,
     }
   }
@@ -133,7 +130,6 @@ impl UndoFrame {
       Lccode => &mut self.lccode,
       Uccode => &mut self.uccode,
       Delcode => &mut self.delcode,
-      Stash => &mut self.stash,
       StashActive => &mut self.stash_active,
     }
   }
@@ -200,7 +196,7 @@ pub struct State {
   // Tables
   pub value: Table,
   pub meaning: Table,
-  pub stash: Table,
+  pub stash: StashStore,
   pub stash_active: Table,
   pub catcode: Table,
   pub mathcode: Table,
@@ -443,7 +439,6 @@ impl State {
       Lccode => &self.lccode,
       Uccode => &self.uccode,
       Delcode => &self.delcode,
-      Stash => &self.stash,
       StashActive => &self.stash_active,
     }
   }
@@ -458,7 +453,6 @@ impl State {
       Lccode => &mut self.lccode,
       Uccode => &mut self.uccode,
       Delcode => &mut self.delcode,
-      Stash => &mut self.stash,
       StashActive => &mut self.stash_active,
     }
   }
@@ -1149,23 +1143,38 @@ impl State {
   // #======================================================================
 
   pub fn activate_scope(&mut self, scope: &str) {
-    info!("TODO: implement State::activate_scope");
     if let Some(scope_entry) = self.stash_active.get(scope) {
       if let Some(count) = scope_entry.front() {
         self.assign_internal(TableName::StashActive, scope, Stored::Bool(true), Some(Scope::Local));
-        if let Some(stash_entry) = self.stash.get(scope) {
-          // if let Some(defns) = stash_entry.front() {
-            // Now make local assignments for all those in the stash.
-            // let frame = self.undo.front();
-            
-            // for entry in defns.iter() {
-              // Here we ALWAYS push the stashed values into the table
-              // since they may be popped off by deactivateScope
-              //         my ($table, $key, $value) = @$entry;
-              //         $$frame{$table}{$key}++;    # Note that this many values must be undone
-              //         unshift(@{ $$self{$table}{$key} }, $value); } } }    # And push new binding.
-            // }
-          // }
+        // For now we modify a bit the latexml implementation of stash.
+        // The Perl code seems to consistently and exlcusively use the value
+        //  $$self{stash}{$scope}[0]
+        // which suggests that we are really looking at an array-ref stored as a single value of $$self{stash}{$scope}
+        // so let's just do that for simplicity's sake and assume
+        // defns = $$self{stash}{$scope}
+
+        // Also, we need to take ownership of the stashed data, so that we can assign it. TODO: Potential to optimize?
+        let defns : Vec<(TableName, String, Stored)> = if let Some(defns) = self.stash.get(scope) {
+          defns.iter().map(|(table_name, key, value)| (*table_name, key.to_string(), value.clone())).collect()
+        } else {
+          Vec::new()
+        };
+         
+        // Now make local assignments for all those in the stash.
+        if let Some(frame) = self.undo.front_mut() {
+          for (table_name, key, _value) in defns.iter() {
+            // Here we ALWAYS push the stashed values into the table
+            // since they may be popped off by deactivateScope
+            let mut frame_table = frame.table_mut(*table_name);
+            let mut frame_count = frame_table.entry(key.to_string()).or_default();
+            *frame_count += 1;  // Note that this many values must be undone
+          }
+        }
+        if !self.undo.is_empty() { // avoid borrowing mutably twice, by iterating a separate time for inserting the defs
+          for (table_name, key, value) in defns.iter() {
+            let mut table_entry = self.table_mut(*table_name).entry(key.to_string()).or_insert_with(VecDeque::new);
+            table_entry.push_front(value.clone()); // And push new binding.
+          }
         }
       }
     }
@@ -1175,23 +1184,39 @@ impl State {
   // # will be undone by egroup or popping frames.
   // # But they can also be undone explicitly
 
-  pub fn deactivate_scope(&self, scope: &str) {  info!("TODO: implement State::deactivate_scope"); }
-    // if self{stash_active}{$scope}[0]) {
-  //     assign_internal($self, 'stash_active', $scope, 0, 'global');
-  //     if (defined(my $defns = $$self{stash}{$scope}[0])) {
-  //       let frame = $$self{undo}[0];
-  //       foreach my $entry (@$defns) {
-  //         my ($table, $key, $value) = @$entry;
-  //         if ($$self{$table}{$key}[0] eq $value) {
-  //           # Here we're popping off the values pushed by activateScope
-  //           # to (possibly) reveal a local assignment in the same frame, preceding activateScope.
-  //           shift(@{ $$self{$table}{$key} });
-  //           $$frame{$table}{$key}--; }
-  //         else {
-  //           Warn('internal', $key, $self->getStomach,
-  //             "Unassigning wrong value for $key from table $table in deactivateScope",
-  //             "value is $value but stack is " . join(', ', @{ $$self{$table}{$key} })); } } } }
-  //   return; }
+  pub fn deactivate_scope(&mut self, scope: &str) {  
+    if let Some(scope_entry) = self.stash_active.get(scope) {
+      self.assign_internal(TableName::StashActive, scope, Stored::Bool(false), Some(Scope::Global));
+      let defns : Vec<(TableName, String, Stored)> = if let Some(defns) = self.stash.get(scope) {
+        defns.iter().map(|(table_name, key, value)| (*table_name, key.to_string(), value.clone())).collect()
+      } else {
+        Vec::new()
+      };
+      
+      let mut countdown_keys = Vec::new();
+      for (table_name, key, value) in defns.iter() {
+        let table_entry = self.table_mut(*table_name).entry(key.to_string()).or_default();
+        if (*table_entry).front() == Some(&value) {
+          // Here we're popping off the values pushed by activateScope
+          // to (possibly) reveal a local assignment in the same frame, preceding activateScope.
+          (*table_entry).pop_front();
+          countdown_keys.push((table_name, key));
+        } else {
+          warn!(target: &s!("internal:{}",key),// $self->getStomach,
+            "Unassigning wrong value for $key from table $table in deactivateScope\
+            value is {:?} but stack is {:?}",value, table_entry.iter().map(|x| x.to_string()).collect::<Vec<String>>().join(", "));
+        }
+      }
+
+      if let Some(mut frame) = self.undo.front_mut() {
+        for (table_name, key) in countdown_keys {
+          let mut frame_table = frame.table_mut(*table_name);
+          let mut frame_count = frame_table.entry(key.to_string()).or_default();
+          *frame_count -= 1;  
+        }
+      }
+    }
+  }
   
   // sub getKnownScopes {
   //   my ($self) = @_;

--- a/rtx_core/src/stomach.rs
+++ b/rtx_core/src/stomach.rs
@@ -143,17 +143,14 @@ impl<'t> Stomach {
     //  Digest(TokenizeInternal($text));
     let savedcc = state.lookup_catcode('@').unwrap_or(Catcode::OTHER);
     state.assign_catcode('@', Catcode::LETTER, None);
-    let raw_tex_mouth;
-    {
-      raw_tex_mouth = Mouth::new(
-        text,
-        Some(MouthOptions {
-          fordefinitions: true,
-          ..MouthOptions::default()
-        }),
-        state,
-      )?;
-    }
+    let raw_tex_mouth = Mouth::new(
+      text,
+      Some(MouthOptions {
+        fordefinitions: true,
+        ..MouthOptions::default()
+      }),
+      state,
+    )?;
     self.reading_from_mouth(
       raw_tex_mouth,
       state,

--- a/rtx_package/Cargo.toml
+++ b/rtx_package/Cargo.toml
@@ -19,6 +19,6 @@ regex = "0.2.5"
 log = "0.4"
 libxml = "0.2.6"
 unidecode = "0.3.0"
-chrono="*"
+chrono = "0.4.6"
 rtx_codegen = {path = "../rtx_codegen"}
 rtx_core = {path = "../rtx_core"}

--- a/rtx_package/src/macros/mod.rs
+++ b/rtx_package/src/macros/mod.rs
@@ -8,7 +8,8 @@ macro_rules! compile_replacement {
     #[derive(CompileReplacement)]
     #[replacement=$replacement]
     struct _Dummy;
-    $var = _Dummy::replacement();
+    let tmp : Option<ReplacementClosure> = this_replacement!();
+    $var = tmp;
   }};
 }
 
@@ -23,7 +24,8 @@ macro_rules! compile_expansion {
     #[derive(CompileExpansion)]
     #[expansion=$expansion]
     struct _DummyE;
-    $var = _DummyE::expansion();
+    let tmp : Option<ExpansionBody> = this_expansion!();
+    $var = tmp;
   }};
 }
 

--- a/rtx_package/src/package/binding_macros.rs
+++ b/rtx_package/src/package/binding_macros.rs
@@ -214,6 +214,32 @@ macro_rules! reader_predigest {
 }
 
 #[macro_export]
+macro_rules! getter {
+  ($body:block) => { getter!(args, state, $body) };
+  ($args: ident, $body:block) => { getter!($args, state, $body) };
+  ($args: ident, $state:ident, $body:block) => {
+    Some(Rc::new(
+      move |$args: Vec<Token>, $state: &State| -> Option<RegisterValue> {
+        WithInnerState!($body, $state).into_register_value_option()
+      },
+    ))
+  };
+}
+
+#[macro_export]
+macro_rules! setter {
+  ($body:block) => { setter!(value, args, state, $body) };
+  ($value:ident, $args: ident, $body:block) => { setter!($value, $args, state, $body) };
+  ($value:ident, $args: ident, $state:ident, $body:block) => {
+    Some(Rc::new(
+      move |$value: RegisterValue, $args: Vec<Tokens>, $state: &mut State| {
+        WithInnerState!($body, $state)
+      },
+    ))
+  };
+}
+
+#[macro_export]
 macro_rules! undigested {
   () => {
     Some(Rc::new(

--- a/rtx_package/src/package/binding_macros.rs
+++ b/rtx_package/src/package/binding_macros.rs
@@ -81,32 +81,21 @@ macro_rules! primitiveproc {
 }
 
 #[macro_export]
-macro_rules! beforesub {
+macro_rules! before_digest {
   ($stomach:ident, $state:ident, $body:block) => {
-    vec![Rc::new(|$stomach: &mut Stomach, $state: &mut State| {
+    vec![before_digest_single!($stomach, $state, $body)]
+  };
+}
+
+
+#[macro_export]
+macro_rules! before_digest_single {
+  ($stomach:ident, $state:ident, $body:block) => {
+    Rc::new(move |$stomach: &mut Stomach, $state: &mut State| {
       BindInnerState!($state, $stomach);
       let macro_out = $body;
       end_state_frame!();
-      macro_out
-    })]
-  };
-}
-#[macro_export]
-macro_rules! beforeproc {
-  // just as beforesub! but with a default return value
-  ($stomach:ident, $state:ident, $body:expr) => {
-    vec![beforeproc_single!($stomach, $state, $body)]
-  };
-}
-#[macro_export]
-macro_rules! beforeproc_single {
-  // just as beforesub! but with a default return value
-  ($stomach:ident, $state:ident, $body:expr) => {
-    Rc::new(move |$stomach: &mut Stomach, $state: &mut State| {
-      BindInnerState!($state, $stomach);
-      $body
-      end_state_frame!();
-      Ok(Vec::new())
+      macro_out.into_digested_result()
     })
   };
 }

--- a/rtx_package/src/package/functions.rs
+++ b/rtx_package/src/package/functions.rs
@@ -140,6 +140,28 @@ impl IntoDigestedResult<Result<Vec<Digested>>> for Result<Vec<Digested>> {
   fn into_digested_result(self) -> Result<Vec<Digested>> { self }
 }
 
+pub trait IntoRegisterValueOption<T>: Sized {
+  fn into_register_value_option(self) -> Option<RegisterValue>;
+}
+impl IntoRegisterValueOption<Option<RegisterValue>> for () {
+  fn into_register_value_option(self) -> Option<RegisterValue> { None }
+}
+impl IntoRegisterValueOption<Option<RegisterValue>> for Option<RegisterValue> {
+  fn into_register_value_option(self) -> Option<RegisterValue> { self }
+}
+impl IntoRegisterValueOption<Option<RegisterValue>> for Number {
+  fn into_register_value_option(self) -> Option<RegisterValue> { Some(RegisterValue::Number(self)) }
+}
+
+impl IntoRegisterValueOption<Option<RegisterValue>> for Option<Number> {
+  fn into_register_value_option(self) -> Option<RegisterValue> { 
+    match self {
+      Some(n) => Some(RegisterValue::Number(n)),
+      None => None
+    }
+  }
+}
+
 
 //**********************************************************************
 //   Initially, I thought LaTeXML Packages should try to be like perl modules:
@@ -283,6 +305,10 @@ pub fn input_content(core: &mut Core, request: &str) -> Result<()> {
      * Error("missing_file", request, state.get_stomach().get_gullet(),
      * "Can't find TeX file "+request, maybeReportSearchPaths(state))) */
   }
+}
+
+pub fn input(file: String, gullet: &mut Gullet, state: &mut State) {
+  unimplemented!();
 }
 
 pub fn load_tex_content(core: &mut Core, path: &str) -> Result<()> {

--- a/rtx_package/src/package/functions.rs
+++ b/rtx_package/src/package/functions.rs
@@ -991,11 +991,10 @@ pub fn def_primitive(cs: Token, paramlist: Option<Parameters>, compiled_replacem
       cs: cs.clone(),
       paramlist,
       replacement: Some(compiled_replacement),
-      options: PrimitiveOptions {
-        before_digest: before_digest_env,
-        after_digest: after_digest_env,
-        ..PrimitiveOptions::default()
-      },
+      before_digest: before_digest_env,
+      after_digest: after_digest_env,
+      alias: options.alias,
+      nargs: options.nargs,
     },
     scope,
   );

--- a/rtx_package/src/package/functions.rs
+++ b/rtx_package/src/package/functions.rs
@@ -942,29 +942,29 @@ pub fn def_primitive(cs: Token, paramlist: Option<Parameters>, compiled_replacem
 
   if options.require_math {
     let cs_name_cloned = cs_name.clone();
-    let require_math_closure = beforeproc_single!(stomach, state, { requireMath!(cs_name_cloned, state) });
+    let require_math_closure = before_digest_single!(stomach, state, { requireMath!(cs_name_cloned, state) });
     before_digest_env.push(require_math_closure);
   }
 
   if options.forbid_math {
     let cs_name_cloned = cs_name.clone();
-    let forbid_math_closure = beforeproc_single!(stomach, state, { forbidMath!(cs_name_cloned, state) });
+    let forbid_math_closure = before_digest_single!(stomach, state, { forbidMath!(cs_name_cloned, state) });
     before_digest_env.push(forbid_math_closure);
   }
   if let Some(ref mode) = options.mode {
     let mode_clone = mode.clone();
-    let begin_mode_closure = beforeproc_single!(stomach, state, {
+    let begin_mode_closure = before_digest_single!(stomach, state, {
       stomach.begin_mode(&mode_clone, state)?;
     });
     before_digest_env.push(begin_mode_closure);
   } else if options.bounded {
-    let bgroup_closure = beforeproc_single!(stomach, state, {
+    let bgroup_closure = before_digest_single!(stomach, state, {
       stomach.bgroup(state);
     });
     before_digest_env.push(bgroup_closure);
   }
   if let Some(chosen_font) = options.font {
-    let merge_font_closure = beforeproc_single!(stomach, state, {
+    let merge_font_closure = before_digest_single!(stomach, state, {
       MergeFont!(&chosen_font, state);
     });
     before_digest_env.push(merge_font_closure);
@@ -1065,28 +1065,28 @@ pub fn def_constructor(
 
   if options.require_math {
     let cs_name_cloned = cs_name.clone();
-    let require_math_closure = beforeproc_single!(stomach, state, { requireMath!(cs_name_cloned, state) });
+    let require_math_closure = before_digest_single!(stomach, state, { requireMath!(cs_name_cloned, state) });
     before_digest_closures.push(require_math_closure);
   }
   if options.forbid_math {
     let cs_name_cloned = cs_name.clone();
-    let forbid_math_closure = beforeproc_single!(stomach, state, { forbidMath!(cs_name_cloned, state) });
+    let forbid_math_closure = before_digest_single!(stomach, state, { forbidMath!(cs_name_cloned, state) });
     before_digest_closures.push(forbid_math_closure);
   }
   if let Some(ref mode) = options.mode {
     let mode_clone = mode.clone();
-    let begin_mode_closure = beforeproc_single!(stomach, state, {
+    let begin_mode_closure = before_digest_single!(stomach, state, {
       stomach.begin_mode(&mode_clone, state)?;
     });
     before_digest_closures.push(begin_mode_closure);
   } else if options.bounded {
-    let bgroup_closure = beforeproc_single!(stomach, state, {
+    let bgroup_closure = before_digest_single!(stomach, state, {
       stomach.bgroup(state);
     });
     before_digest_closures.push(bgroup_closure);
   }
   if let Some(chosen_font) = options.font {
-    let merge_font_closure = beforeproc_single!(stomach, state, {
+    let merge_font_closure = before_digest_single!(stomach, state, {
       MergeFont!(&chosen_font, state);
     });
     before_digest_closures.push(merge_font_closure);
@@ -1156,7 +1156,7 @@ pub fn def_environment(
       before_digest_env.push(mode_closure);
     },
     None => {
-      let bgroup_closure = beforeproc_single!(stomach, state, {
+      let bgroup_closure = before_digest_single!(stomach, state, {
         stomach.bgroup(state);
       });
       before_digest_env.push(bgroup_closure);
@@ -1164,17 +1164,17 @@ pub fn def_environment(
   };
   if options.require_math {
     let require_name = begin_name.clone();
-    let require_math_closure = beforeproc_single!(stomach, state, { requireMath!(require_name, state) });
+    let require_math_closure = before_digest_single!(stomach, state, { requireMath!(require_name, state) });
     before_digest_env.push(require_math_closure);
   }
   if options.forbid_math {
     let forbid_name = begin_name.clone();
-    let forbid_math_closure = beforeproc_single!(stomach, state, { forbidMath!(forbid_name, state) });
+    let forbid_math_closure = before_digest_single!(stomach, state, { forbidMath!(forbid_name, state) });
     before_digest_env.push(forbid_math_closure);
   }
 
   let env_name = name.clone();
-  let current_environment_closure = beforeproc_single!(stomach, state, {
+  let current_environment_closure = before_digest_single!(stomach, state, {
     AssignValue!("current_environment", env_name.clone(), None, state);
     let body = T_LETTER!(env_name.clone());
     DefMacroI!(T_CS!("\\@currenvir"), None, body.clone(), state);
@@ -1182,7 +1182,7 @@ pub fn def_environment(
   before_digest_env.push(current_environment_closure);
 
   if let Some(chosen_font) = options.font {
-    let merge_font_closure = beforeproc_single!(stomach, state, {
+    let merge_font_closure = before_digest_single!(stomach, state, {
       MergeFont!(&chosen_font.clone(), state);
     });
     before_digest_env.push(merge_font_closure);

--- a/rtx_package/src/package/functions.rs
+++ b/rtx_package/src/package/functions.rs
@@ -1621,25 +1621,17 @@ pub fn ref_step_counter(ctype: &str, noreset: bool, stomach: &mut Stomach, state
 
 fn deactivate_counter_scope(ctr: &str, state: &mut State) {
   //  print STDERR "Unusing scopes for $ctr\n";
-  let scopes = if let Some(Stored::VecString(stored_scopes)) = state.lookup_value(&s!("scopes_for_counter:{}", ctr)) {
-    stored_scopes.clone()
-  } else {
-    Vec::new()
-  };
-  for scope in &scopes {
-    state.deactivate_scope(scope);
+  if let Some(Stored::VecString(stored_scopes)) = state.lookup_value(&s!("scopes_for_counter:{}", ctr)) {
+    for scope in stored_scopes.clone() {
+      state.deactivate_scope(&scope);
+    }
   }
 
-  let counters = if let Some(Stored::VecString(stored_counters)) = state.lookup_value(&s!("nested_counters_{}", ctr)) {
-    stored_counters.clone()
-  } else {
-    Vec::new()
-  };
-  for inner_ctr in &counters {
-    state.deactivate_counter_scope(inner_ctr);
+  if let Some(Stored::VecString(stored_counters)) = state.lookup_value(&s!("nested_counters_{}", ctr)) {
+    for inner_ctr in stored_counters.clone() {
+      deactivate_counter_scope(&inner_ctr, state);
+    }
   }
-
-  return;
 }
 
 // For UN-numbered units

--- a/rtx_package/src/package/pool/alltt_sty.rs
+++ b/rtx_package/src/package/pool/alltt_sty.rs
@@ -3,7 +3,7 @@ use crate::package::*;
 LoadDefinitions!(state, {
   DefEnvironment!("{alltt}", "<ltx:verbatim font='#font'>#body</ltx:verbatim>",
   font => Font!(family => "typewriter", series => "medium", shape => "upright"),
-  before_digest => beforeproc!(stomach, inner_state, {
+  before_digest => before_digest!(stomach, inner_state, {
     for c in &['$', '&', '#', '^', '_', '%', '~'] {
      AssignCatcode!(*c, Catcode::OTHER);
     }

--- a/rtx_package/src/package/pool/latex.rs
+++ b/rtx_package/src/package/pool/latex.rs
@@ -152,7 +152,7 @@ LoadDefinitions!(state, {
   //     AssignValue('@at@end@document', []) unless LookupValue('@at@end@document');
   //     PushValue('@at@end@document', $_[1]->unlist); });
 
-  DefEnvironmentC!("{document}",
+  DefEnvironmentI!("{document}",
     Some(Rc::new(|document: &mut Document, args: &Vec<Option<Digested>>, props: &HashMap<String, Stored>, state: &mut State| {
       let id = prop_str!(props,"id");
       let body = prop_whatsit!(props,"body");

--- a/rtx_package/src/package/pool/latex.rs
+++ b/rtx_package/src/package/pool/latex.rs
@@ -167,7 +167,7 @@ LoadDefinitions!(state, {
       }
       Ok(())
     })),
-    before_digest => beforeproc!(_stomach, state, { AssignValue!("inPreamble", false); }),
+    before_digest => before_digest!(_stomach, state, { AssignValue!("inPreamble", false); }),
     // after_digest_begin => vec![|stomach, whatsit, state| {
     //   whatsit.set_property("id", Expand!(T_CS!("\\thedocument@ID"), state));
     //   if let Some(ops) = LookupValue!("@at@begin@document", state) {
@@ -178,7 +178,7 @@ LoadDefinitions!(state, {
     //     return Vec::new()
     //   }
     // }],
-    before_digest_end => beforesub!(stomach, state, {
+    before_digest_end => before_digest!(stomach, state, {
       stomach.get_gullet_mut().flush(state);
       if let Some(Stored::Tokens(ops)) = RemoveValue!("@at@end@document") {
         Ok(vec![stomach.digest(ops, state)?]) // TODO: Can we improve to the regular Digest!(ops) syntax?
@@ -460,7 +460,7 @@ LoadDefinitions!(state, {
 
   DefConstructor!("\\usepackage OptionalSemiverbatim Semiverbatim []",
                   "<?latexml package='#2' ?#1(options='#1')?>",
-      before_digest => beforeproc!(_stomach, state, { only_preamble("\\usepackage", state); }),
+      before_digest => before_digest!(_stomach, state, { only_preamble("\\usepackage", state); }),
       after_digest => sub!(|_stomach: &mut Stomach, whatsit: &mut Whatsit, state: &mut State| -> Result<Vec<Digested>> {
         let options: Option<&Digested> = whatsit.get_arg(1);
         let packages: Option<&Digested> = whatsit.get_arg(2);

--- a/rtx_package/src/package/pool/latex_ch11_moving_information.rs
+++ b/rtx_package/src/package/pool/latex_ch11_moving_information.rs
@@ -152,7 +152,7 @@ LoadDefinitions!(state, {
   // Should be an environment, but people seem to want to misuse it.
   DefConstructor!("\\thebibliography",
     "<ltx:bibliography xml:id='#id'><ltx:title font='#titlefont' _force_font='true'>#title</ltx:title><ltx:biblist>",
-     before_digest => beforesub!(stomach, state, {
+     before_digest => before_digest!(stomach, state, {
         AssignValue!("inPreamble", false);
         Ok(vec![stomach.digest(Tokens!(T_CS!("\\@lx@inbibliographytrue")), state)?])
     }),

--- a/rtx_package/src/package/pool/latex_ch13_boxes.rs
+++ b/rtx_package/src/package/pool/latex_ch13_boxes.rs
@@ -108,7 +108,7 @@ LoadDefinitions!(state, {
     mode => "text".into_option(),
     bounded => true,
     // sizer => "#1", // TODO
-    before_digest => beforeproc!(stomach, state, { reenter_text_mode(false, state); })
+    before_digest => before_digest!(stomach, state, { reenter_text_mode(false, state); })
   );
 
   // our %makebox_alignment = (l => 'left', r => 'right', s => 'justified');

--- a/rtx_package/src/package/pool/latex_ch3_sentences_and_paragraphs.rs
+++ b/rtx_package/src/package/pool/latex_ch3_sentences_and_paragraphs.rs
@@ -32,7 +32,7 @@ LoadDefinitions!(state, {
   // more like a font switch.
   DefConstructor!("\\emph{}", "#1", mode => "text".into_option(),
     bounded        => true, font=>Some(fontmap!(emph => true)), alias => "\\emph".into_option(),
-    before_digest   => beforeproc!(stomach, inner_state, { DefMacroI!(T_CS!("\\f@shape"), None, T_LETTER!("i")); }),
+    before_digest   => before_digest!(stomach, inner_state, { DefMacroI!(T_CS!("\\f@shape"), None, T_LETTER!("i")); }),
     after_construct => construct!(doc,args,inner_state, { doc.add_class(&mut doc.get_element().unwrap(), "ltx_emph")?; })
   );
 

--- a/rtx_package/src/package/pool/latex_math_mode_environments.rs
+++ b/rtx_package/src/package/pool/latex_math_mode_environments.rs
@@ -85,7 +85,7 @@ LoadDefinitions!(state, {
   );
   // TODO: Caution -- very strange 30+ min infinite loop in rustc if used as-is
   // mode => Some(s!("display_math")),
-  // before_digest => beforeproc!(stomach, state, {
+  // before_digest => before_digest!(stomach, state, {
   //   prepare_equation_counter(map!(numbered => true, preset => true).into(), state);
   //   before_equation(state);
   // }),
@@ -105,10 +105,10 @@ LoadDefinitions!(state, {
     </ltx:XMath>\
     </ltx:Math>\
     </ltx:equation>",
-  before_digest => beforeproc!(stomach, state, {stomach.begin_mode("display_math", state)?; }),
+  before_digest => before_digest!(stomach, state, {stomach.begin_mode("display_math", state)?; }),
   capture_body  => true,
   properties   => properties!(sub[stomach, args, state] { ref_step_id("equation", stomach, state) })
   );
 
-  DefConstructor!("\\]", "", before_digest => beforeproc!(gullet, state, { gullet.end_mode("display_math", state)?; }));
+  DefConstructor!("\\]", "", before_digest => before_digest!(gullet, state, { gullet.end_mode("display_math", state)?; }));
 });

--- a/rtx_package/src/package/pool/latex_verbatim.rs
+++ b/rtx_package/src/package/pool/latex_verbatim.rs
@@ -20,7 +20,7 @@ LoadDefinitions!(outer_state, {
   // and also the usual environment capture.
 
   DefConstructor!(cs["\\begin{verbatim}"], None, "<ltx:verbatim font='#font'>#body</ltx:verbatim>",
-    before_digest => beforesub!(stomach, state, {
+    before_digest => before_digest!(stomach, state, {
       stomach.bgroup(state);
       let mut stuff = Vec::new();
       if let Some(b) = state.lookup_tokens("@environment@verbatim@atbegin") {
@@ -103,7 +103,7 @@ LoadDefinitions!(outer_state, {
   });
 
   DefConstructor!("\\@text@verb{}{}", "<ltx:verbatim font='#font'>#2</ltx:verbatim>",
-    before_digest => beforeproc!(stomach, state, {
+    before_digest => before_digest!(stomach, state, {
       stomach.bgroup(state);
       MergeFont!(family => "typewriter");
     }),
@@ -116,7 +116,7 @@ LoadDefinitions!(outer_state, {
     reversion => Some("\\verb#1#2#1".into())
   );
   DefConstructor!("\\@math@verb{}{}", "#2",
-   before_digest => beforeproc!(stomach, state, {
+   before_digest => before_digest!(stomach, state, {
      stomach.bgroup(state);
      MergeFont!(family => "typewriter");
    }),

--- a/rtx_package/src/package/pool/tex.rs
+++ b/rtx_package/src/package/pool/tex.rs
@@ -16,11 +16,19 @@ LoadDefinitions!(state, {
 
   //**********************************************************************
   // Primitives
+  // See The TeXBook, Chapter 24, Summary of Vertical Mode
+  //  and Chapter 25, Summary of Horizontal Mode.
+  // Parsing of basic types (pp.268--271) is (mostly) handled in Gullet.pm
+  //**********************************************************************
 
-  // lines 950-1102
+  // lines 960-1102
   // Dimen registers; TeXBook p. 274
   InnerPool!(tex_registers);
-  // <--- updated upto here --->
+  
+  // <----------------------------------------->
+  // <--- updated upto (and including) here --->
+  // <----------------------------------------->
+
   // lines 1102-1278
   InnerPool!(tex_assignment);
 

--- a/rtx_package/src/package/pool/tex.rs
+++ b/rtx_package/src/package/pool/tex.rs
@@ -21,7 +21,7 @@ LoadDefinitions!(state, {
   // Parsing of basic types (pp.268--271) is (mostly) handled in Gullet.pm
   //**********************************************************************
 
-  // lines 960-1102
+  // lines 950-1102
   // Dimen registers; TeXBook p. 274
   InnerPool!(tex_registers);
   

--- a/rtx_package/src/package/pool/tex_assignment.rs
+++ b/rtx_package/src/package/pool/tex_assignment.rs
@@ -67,43 +67,43 @@ LoadDefinitions!(state, {
     let count = s!("\\count{}", num.to_number().value_of());
     let setter_count = count.clone();
     DefRegisterI!(cs, None, Number::new(0.0),
-      getter => Some(Rc::new(move |args, state| { Some(state.lookup_number(&count).unwrap_or_default().into()) })),
-      setter => Some(Rc::new(move |value, args, state| { state.assign_value(&setter_count, value, None); })));
+      getter => getter!(args, state, { state.lookup_number(&count).unwrap_or_default() }),
+      setter => setter!(value, args, state, { state.assign_value(&setter_count, value, None); }));
     AfterAssignment!();
     Ok(vec![])
   });
 
   DefRegister!("\\catcode Number", Number::new(0.0),
-    getter => Some(Rc::new(|args, state| {
+    getter => getter!(args, state, {
       let num : f32 = args[0].to_number().value_of();
       let refchar = (num as u8) as char;
       let code : Catcode = state.lookup_catcode(refchar).unwrap_or(Catcode::OTHER);
       let code : u8 = code.into();
-      Number::new(code).into()
-    })),
-    setter => Some(Rc::new(|value, args, state| {
+      Number::new(code)
+    }),
+    setter => setter!(value, args, state, {
       let c_char = (args[0].to_number().value_of() as u8) as char;
       let c_code = From::from(value.value_of() as u8);
       state.assign_catcode(c_char, c_code, None);
-    }))
+    })
   );
 
   // Only used for active math characters, so far
   DefRegister!("\\mathcode Number", Number::new(0.0),
-    getter => Some(Rc::new(|args, state| {
+    getter => getter!(args, state, {
       let ch_code   = args[0].to_number().value_of() as u8;
       let ch : char = ch_code as char;
       let code = match state.lookup_mathcode(&ch.to_string()) {
         None => ch_code,
         Some(code) => code as u8
       };
-      Some(Number::new(f32::from(code)).into())
-    })),    // defaults to the char's code itself(?)
-    setter => Some(Rc::new(|value, args, state| {
+      Number::new(f32::from(code))
+    }),    // defaults to the char's code itself(?)
+    setter => setter!(value, args, state, {
       let ch = args[0].to_number().value_of() as u8;
       let ch : char = ch as char;
       state.assign_mathcode(ch, value.value_of() as usize, None);
-    }))
+    })
   );
 
   // Stub definitions ???

--- a/rtx_package/src/package/pool/tex_boxes.rs
+++ b/rtx_package/src/package/pool/tex_boxes.rs
@@ -151,7 +151,7 @@ LoadDefinitions!(state, {
     // sizer => "#2",
     //   # Workaround for $ in alignment; an explicit \hbox gives us a normal $.
     //   # And also things like \centerline that will end up bumping up to block level!
-    before_digest => beforeproc!(stomach, state, {reenter_text_mode(false, state)}),
+    before_digest => before_digest!(stomach, state, {reenter_text_mode(false, state)}),
     after_digest => afterproc!(stomach, whatsit, state, {
       let mut width : Option<RegisterValue>= None;
       {

--- a/rtx_package/src/package/pool/tex_expandable_primitives.rs
+++ b/rtx_package/src/package/pool/tex_expandable_primitives.rs
@@ -248,7 +248,7 @@ LoadDefinitions!(outer_state, {
   DefMacroI!(T_CS!("\\splitfirstmark"), None, Tokens!());
   DefMacroI!(T_CS!("\\splitbotmark"), None, Tokens!());
 
-  // DefMacro('\input TeXFileName', sub { Input($_[1]); });
+  DefMacro!("\\input TeXFileName", sub[gullet,args,state] { input(args[0].to_string(), gullet, state); });
 
   // Note that TeX doesn't actually close the mouth;
   // it just flushes it so that it will close the next time it's read!

--- a/rtx_package/src/package/pool/tex_expandable_primitives.rs
+++ b/rtx_package/src/package/pool/tex_expandable_primitives.rs
@@ -102,47 +102,54 @@ LoadDefinitions!(outer_state, {
     };
     if let Some(definition) = definition_opt {
        // First, if this definition is a primitive or constructor, check to see if it has an alias, which would allow us to work with a token
-     //         $definition = $definition->getCSorAlias;
-      //         $type       = ref $definition;
-      //         $type =~ s/^LaTeXML:://; }
-      //       if ($type =~ /con(ditional|structor)/i) {
-      //         $definition = $definition->getCSorAlias;
-      //         $type       = ref $definition;
-      //         $type =~ s/^LaTeXML:://; }
+       let definition = match definition {
+         Stored::Primitive(primitive) => Stored::Token(primitive.get_cs_or_alias().into_owned()),
+         Stored::Constructor(constructor) => Stored::Token(constructor.get_cs_or_alias().into_owned()),
+         other => other
+       };
+      // Now that we've tried to obtain an expandable definition, do the TeX dance:
       match definition {
         Stored::Token(t) => {
           let cc = t.get_catcode();
           let text = if cc == Catcode::SPACE {
             " "
-          }else {
+          } else {
             t.get_string()
           };
           meaning = s!("{} {}", cc.meaning(), text);
         },
         Stored::Register(register) => {      
-          //         my $value = $definition->valueOf;
-          //         my $register_type = lc(ref $value);
-          //         my $prefix = '\count';
-          //         if ($register_type && $register_type =~ /glue/) {
-          //             $prefix = '\skip'; }
-          //         elsif ($register_type && $register_type =~ /dimension/) {
-          //             $prefix = '\dimen'; }
-          //         my $literal_value = $value->valueOf if $register_type;
-          //         # Should we be more careful to distinguish between latex and tex counters?
-          //         $meaning = $prefix . $literal_value; }
+          let value = register.value_of(vec![],state);
+          let register_type = register.register_type().unwrap();
+          let prefix = match register_type {
+            RegisterType::Glue | RegisterType::MuGlue =>  "\\skip",
+            RegisterType::Dimension => "\\dimen",
+            _ => "\\count"
+          };
+          let literal_value : String = if register_type != RegisterType::Any {
+            if let Some(v) = value {
+              v.value_of().to_string()
+            } else {
+              String::new()
+            }
+          } else {
+            String::new()
+          };
+          // Should we be more careful to distinguish between latex and tex counters?
+          meaning = s!("{}{}",prefix, literal_value);
         },
         Stored::Expandable(expandable) => {
-          //         my $expansion = $definition->getExpansion;
-          //         my $ltxps     = $definition->getParameters;
-          //         my @params;
-          //         my $argcount = 0;
+          let expansion = expandable.get_expansion();
+          let ltxps     = expandable.get_parameters();
+          // let mut params = Vec::new();
+          let mut argcount = 0;
           //         if (defined $ltxps) {
           //           @params   = $ltxps->getParameters;
           //           $argcount = $ltxps->getNumArgs;
           //         }
-          //         my $sp;
+          // let sp;
           //         my @specparts = map { (($sp = $_->{spec}) =~ s/^(\w+):// ? $sp : $sp) } @params;
-          //         my $arg = 1;
+          // let arg = 1;
           //         foreach (@specparts) {
           //           last if ($arg > $argcount);
           //           $_ .= "#$arg";
@@ -150,12 +157,22 @@ LoadDefinitions!(outer_state, {
           //         my $spec = join("", @specparts);
           //         $spec =~ s/\{\}//g;
           //         $spec =~ s/Token//g;
-          //         my $prefixes = join('',
-          //           ($definition->isProtected ? '\protected' : ()),
-          //           ($definition->isLong      ? '\long'      : ()),
-          //           ($definition->isOuter     ? '\outer'     : ()),
-          //         );
-          //         $meaning = ($prefixes ? $prefixes . ' ' : '') . "macro:" . ToString($spec) . "->" . ToString($expansion); 
+          let mut prefixes = String::new();
+          if expandable.is_protected {
+            prefixes.push_str("\\protected");
+          }
+          if expandable.is_long {
+            prefixes.push_str("\\long");
+          }
+          if expandable.is_outer {
+            prefixes.push_str("\\outer");
+          }
+          if !prefixes.is_empty() {
+            prefixes.push(' ');
+          }
+          let spec_str = String::new(); // spec.to_string();
+          let expandable_str = expandable.to_string();
+          meaning = s!("{}macro:{}->{}",prefixes, spec_str, expandable_str); 
         },
         _ => {}
       }

--- a/rtx_package/src/package/pool/tex_expandable_primitives.rs
+++ b/rtx_package/src/package/pool/tex_expandable_primitives.rs
@@ -19,9 +19,9 @@ LoadDefinitions!(outer_state, {
     compare(u, rel, v)
   });
   DefConditional!("\\ifodd Number", sub[gullet, args, state] {
-    unimplemented!();
-    false
-    // $_[1]->valueOf % 2
+    unpack_to_token!(args => u);
+    let uint = u.to_number().value_of() as i64;
+    uint % 2 == 1
   });
 
   // NOTE: We don't KNOW if we're in vertical, horizontal or inner mode!!!!!!!
@@ -31,10 +31,13 @@ LoadDefinitions!(outer_state, {
   DefConditional!("\\ifmmode", sub { LookupBool!("IN_MATH") });
 
   DefConditional!("\\if XToken XToken", sub[gullet, args, state] {
-    unpack!(args=>tokens1, tokens2);
-    let token1 : Token = tokens1.into();
-    let token2 : Token = tokens2.into();
-    Ok(token1.get_charcode() == token2.get_charcode())
+    unpack_to_token!(args=>token1, token2);
+    token1.get_charcode() == token2.get_charcode()
+  });
+
+  DefConditional!("\\ifcat XToken XToken", sub[gullet, args, state] {
+    unpack_to_token!(args=>token1, token2);
+    token1.get_catcode() == token2.get_catcode()
   });
 
   DefConditional!("\\ifx Token Token", sub[gullet, args, state] {
@@ -44,6 +47,10 @@ LoadDefinitions!(outer_state, {
     let xequals = XEquals!(&token1, &token2);
     Ok(xequals)
   });
+
+  DefConditional!("\\ifvoid Number", sub[_g, args, state] {unpack_to_token!(args=>arg); classify_box(arg, state).is_empty() });
+  DefConditional!("\\ifhbox Number", sub[_g, args, state] {unpack_to_token!(args=>arg); classify_box(arg, state) == "hbox" });
+  DefConditional!("\\ifvbox Number", sub[_g, args, state] {unpack_to_token!(args=>arg); classify_box(arg, state) == "vbox" });
 
   DefConditional!("\\iftrue",  sub { true });
   DefConditional!("\\iffalse", sub { false });
@@ -86,12 +93,22 @@ LoadDefinitions!(outer_state, {
   DefMacroI!(T_CS!("\\fontname"), None, Tokens::new(Explode!("fontname not implemented")));
 
   DefMacro!("\\meaning Token", sub[gullet, args, state] {
-    unpack!(args => token);
-    let token : Token = token.into();
+    unpack_to_token!(args => token);
     let mut meaning = String::from("undefined");
-
-    if let Some(definition) = state.lookup_meaning(&token) {
-      //     if (my $definition = (Equals($tok, T_ALIGN) ? $tok : LookupMeaning($tok))) {
+    let definition_opt = if token == T_ALIGN!() {
+      Some(Stored::Token(token))
+    } else {
+      state.lookup_meaning(&token)
+    };
+    if let Some(definition) = definition_opt {
+       // First, if this definition is a primitive or constructor, check to see if it has an alias, which would allow us to work with a token
+     //         $definition = $definition->getCSorAlias;
+      //         $type       = ref $definition;
+      //         $type =~ s/^LaTeXML:://; }
+      //       if ($type =~ /con(ditional|structor)/i) {
+      //         $definition = $definition->getCSorAlias;
+      //         $type       = ref $definition;
+      //         $type =~ s/^LaTeXML:://; }
       match definition {
         Stored::Token(t) => {
           let cc = t.get_catcode();
@@ -100,64 +117,50 @@ LoadDefinitions!(outer_state, {
           }else {
             t.get_string()
           };
-          let meaning = s!("{} {}", cc.meaning(), text);
-          Ok(Explode!(meaning).into())
+          meaning = s!("{} {}", cc.meaning(), text);
         },
-        _ => Ok(Explode!("meaning").into())
-        // TODO: Continue implementing ...
-      // Stored::Expandable(meaning)
-      // Stored::Conditional(meaning)
-      // }
-      //       if ($type =~ /primitive/i) {
-      //         $definition = $definition->getCSorAlias;
-      //         $type       = ref $definition;
-      //         $type =~ s/^LaTeXML:://; }
-      //       if ($type =~ /con(ditional|structor)/i) {
-      //         $definition = $definition->getCSorAlias;
-      //         $type       = ref $definition;
-      //         $type =~ s/^LaTeXML:://; }
-
-      //       elsif ($type =~ /register/i) {
-      //         my $value = $definition->valueOf;
-      //         my $register_type = lc(ref $value);
-      //         my $prefix = '\count';
-      //         if ($register_type && $register_type =~ /glue/) {
-      //             $prefix = '\skip'; }
-      //         elsif ($register_type && $register_type =~ /dimension/) {
-      //             $prefix = '\dimen'; }
-      //         my $literal_value = $value->valueOf if $register_type;
-      //         # Should we be more careful to distinguish between latex and tex counters?
-      //         $meaning = $prefix . $literal_value; }
-      //       elsif ($type =~ /expandable/i) {
-      //         my $expansion = $definition->getExpansion;
-      //         my $ltxps     = $definition->getParameters;
-      //         my @params;
-      //         my $argcount = 0;
-      //         if (defined $ltxps) {
-      //           @params   = $ltxps->getParameters;
-      //           $argcount = $ltxps->getNumArgs;
-      //         }
-      //         my $sp;
-      //         my @specparts = map { (($sp = $_->{spec}) =~ s/^(\w+):// ? $sp : $sp) } @params;
-      //         my $arg = 1;
-      //         foreach (@specparts) {
-      //           last if ($arg > $argcount);
-      //           $_ .= "#$arg";
-      //           $arg++; }
-      //         my $spec = join("", @specparts);
-      //         $spec =~ s/\{\}//g;
-      //         $spec =~ s/Token//g;
-      //         my $prefixes = join('',
-      //           ($definition->isProtected ? '\protected' : ()),
-      //           ($definition->isLong      ? '\long'      : ()),
-      //           ($definition->isOuter     ? '\outer'     : ()),
-      //         );
-      //         $meaning = ($prefixes ? $prefixes . ' ' : '') . "macro:" . ToString($spec) . "->" . ToString($expansion); }
-      //       Explode($meaning); }
+        Stored::Register(register) => {      
+          //         my $value = $definition->valueOf;
+          //         my $register_type = lc(ref $value);
+          //         my $prefix = '\count';
+          //         if ($register_type && $register_type =~ /glue/) {
+          //             $prefix = '\skip'; }
+          //         elsif ($register_type && $register_type =~ /dimension/) {
+          //             $prefix = '\dimen'; }
+          //         my $literal_value = $value->valueOf if $register_type;
+          //         # Should we be more careful to distinguish between latex and tex counters?
+          //         $meaning = $prefix . $literal_value; }
+        },
+        Stored::Expandable(expandable) => {
+          //         my $expansion = $definition->getExpansion;
+          //         my $ltxps     = $definition->getParameters;
+          //         my @params;
+          //         my $argcount = 0;
+          //         if (defined $ltxps) {
+          //           @params   = $ltxps->getParameters;
+          //           $argcount = $ltxps->getNumArgs;
+          //         }
+          //         my $sp;
+          //         my @specparts = map { (($sp = $_->{spec}) =~ s/^(\w+):// ? $sp : $sp) } @params;
+          //         my $arg = 1;
+          //         foreach (@specparts) {
+          //           last if ($arg > $argcount);
+          //           $_ .= "#$arg";
+          //           $arg++; }
+          //         my $spec = join("", @specparts);
+          //         $spec =~ s/\{\}//g;
+          //         $spec =~ s/Token//g;
+          //         my $prefixes = join('',
+          //           ($definition->isProtected ? '\protected' : ()),
+          //           ($definition->isLong      ? '\long'      : ()),
+          //           ($definition->isOuter     ? '\outer'     : ()),
+          //         );
+          //         $meaning = ($prefixes ? $prefixes . ' ' : '') . "macro:" . ToString($spec) . "->" . ToString($expansion); 
+        },
+        _ => {}
       }
-    } else {
-      Ok(Explode!("undefined").into())
     }
+    Explode!(meaning)
   });
 
   //======================================================================

--- a/rtx_package/src/package/pool/tex_expandable_primitives.rs
+++ b/rtx_package/src/package/pool/tex_expandable_primitives.rs
@@ -1,5 +1,7 @@
 use crate::package::*;
-
+lazy_static! {
+  static ref LEAD_W_COLON_RE : Regex = Regex::new(r"^(\w+):").unwrap();
+}
 //=======================
 // -- Main Definitions --
 //=======================
@@ -102,7 +104,7 @@ LoadDefinitions!(outer_state, {
     };
     if let Some(definition) = definition_opt {
        // First, if this definition is a primitive or constructor, check to see if it has an alias, which would allow us to work with a token
-       let definition = match definition {
+       let definition : Stored = match definition {
          Stored::Primitive(primitive) => Stored::Token(primitive.get_cs_or_alias().into_owned()),
          Stored::Constructor(constructor) => Stored::Token(constructor.get_cs_or_alias().into_owned()),
          other => other
@@ -139,24 +141,22 @@ LoadDefinitions!(outer_state, {
           meaning = s!("{}{}",prefix, literal_value);
         },
         Stored::Expandable(expandable) => {
-          let expansion = expandable.get_expansion();
-          let ltxps     = expandable.get_parameters();
-          // let mut params = Vec::new();
+          let mut params = Vec::new();
           let mut argcount = 0;
-          //         if (defined $ltxps) {
-          //           @params   = $ltxps->getParameters;
-          //           $argcount = $ltxps->getNumArgs;
-          //         }
-          // let sp;
-          //         my @specparts = map { (($sp = $_->{spec}) =~ s/^(\w+):// ? $sp : $sp) } @params;
-          // let arg = 1;
-          //         foreach (@specparts) {
-          //           last if ($arg > $argcount);
-          //           $_ .= "#$arg";
-          //           $arg++; }
-          //         my $spec = join("", @specparts);
-          //         $spec =~ s/\{\}//g;
-          //         $spec =~ s/Token//g;
+          
+          if let Some(ltxps) = expandable.get_parameters() {
+            params   = ltxps.get_parameters();
+            argcount = ltxps.get_num_args();
+          }
+          let specparts : Vec<Cow<str>> = params.iter().map(|param| LEAD_W_COLON_RE.replace(&param.spec,"") ).collect();
+          let mut spec = String::new();  
+          for (index, part) in specparts.iter().take(argcount).enumerate() {
+            spec.push_str(part);
+            spec.push('#');
+            spec.push_str(&(index+1).to_string());
+            spec = spec.replace("{}","");
+            spec = spec.replace("Token",""); 
+          }
           let mut prefixes = String::new();
           if expandable.is_protected {
             prefixes.push_str("\\protected");
@@ -170,11 +170,16 @@ LoadDefinitions!(outer_state, {
           if !prefixes.is_empty() {
             prefixes.push(' ');
           }
-          let spec_str = String::new(); // spec.to_string();
-          let expandable_str = expandable.to_string();
-          meaning = s!("{}macro:{}->{}",prefixes, spec_str, expandable_str); 
+          let expansion = match expandable.get_expansion() {
+            None => String::new(),
+            Some(exp) => exp.to_string()
+          };
+          meaning = s!("{}macro:{}->{}",prefixes, spec, expansion); 
         },
-        _ => {}
+        e => { // are there other cases that could occur here? should we handle them?
+          dbg!(e);
+          unimplemented!();
+        }
       }
     }
     Explode!(meaning)

--- a/rtx_package/src/package/pool/tex_functions.rs
+++ b/rtx_package/src/package/pool/tex_functions.rs
@@ -165,3 +165,18 @@ pub fn do_def(globally: bool, expanded: bool, stomach: &mut Stomach, args: Vec<T
   AfterAssignment!(state);
   Ok(Vec::new())
 }
+
+
+// Kinda rough: We don't really keep track of modes as carefully as TeX does.
+// We'll assume that a box is horizontal if there's anything at all,
+// but it's not a vbox (!?!?)
+pub fn classify_box(boxnum: Token, state: &State) -> &'static str {
+  let boxnum : Number = boxnum.to_number();
+  match state.lookup_value(&s!("box{}", boxnum.value_of())) {
+    Some(Stored::Digested(ref d)) => match **d {
+      Digested::Whatsit(ref w) if Rc::ptr_eq(&w.borrow().definition, &state.lookup_definition(&T_CS!("\\vbox")).unwrap()) => "vbox" ,
+      _ => "hbox"
+    },
+    _ => "",
+  }
+}

--- a/rtx_package/src/package/pool/tex_math_mode.rs
+++ b/rtx_package/src/package/pool/tex_math_mode.rs
@@ -64,22 +64,22 @@ LoadDefinitions!(state, {
     </ltx:Math>
   </ltx:equation>",
     alias         => Some(s!("$$")),
-    before_digest => beforeproc!(stomach, state, { stomach.begin_mode("display_math", state)?; }),
+    before_digest => before_digest!(stomach, state, { stomach.begin_mode("display_math", state)?; }),
     capture_body  => true
   );
 
   DefConstructorI!(T_CS!("\\@@ENDDISPLAYMATH"), None, None, alias => Some(s!("$$")),
-    before_digest => beforeproc!(stomach, state, { stomach.end_mode("display_math", state)?; }));
+    before_digest => before_digest!(stomach, state, { stomach.end_mode("display_math", state)?; }));
 
   DefConstructor!("\\@@BEGININLINEMATH",
     "<ltx:Math mode=\"inline\"><ltx:XMath>#body</ltx:XMath></ltx:Math>",
     alias => Some(s!("$")),
-    before_digest => beforeproc!(stomach, state, {
+    before_digest => before_digest!(stomach, state, {
       stomach.begin_mode("inline_math", state)?; }),
     capture_body => true);
 
   DefConstructorI!(T_CS!("\\@@ENDINLINEMATH"), None, None, alias => Some(s!("$")),
-    before_digest => beforeproc!(stomach, state, { stomach.end_mode("inline_math", state)?; }));
+    before_digest => before_digest!(stomach, state, { stomach.end_mode("inline_math", state)?; }));
 
   // Same as add_TeX, but add the code from the body of the object.
   let add_body_tex_closure: Vec<TagConstructionClosure> = tagsub!(document, node, state, {

--- a/rtx_package/src/package/pool/tex_math_style.rs
+++ b/rtx_package/src/package/pool/tex_math_style.rs
@@ -13,7 +13,7 @@ LoadDefinitions!(state, {
   // This could still be made to work, but merge font would
   // need to look at any open <ltx:emph>, and then somehow close it!
   DefPrimitiveI!("\\em", noprimitive!(),
-  before_digest => beforeproc!(_stomach, state, {
+  before_digest => before_digest!(_stomach, state, {
     let font = LookupFont!().unwrap();
     let shape = font.get_shape().unwrap_or(Cow::Borrowed(""));
     let shapevariant = if shape == "italic" { "normal" } else { "italic" };

--- a/rtx_package/src/package/pool/tex_registers.rs
+++ b/rtx_package/src/package/pool/tex_registers.rs
@@ -1,4 +1,5 @@
 use crate::package::*;
+use chrono::prelude::*;
 
 //======================================================================
 // Registers & Parameters
@@ -9,7 +10,6 @@ use crate::package::*;
 LoadDefinitions!(state, {
   //======================================================================
   // Integer registers; TeXBook p. 272-273
-
   DefRegister!("\\tracingmacros", Number!(0.0),
     getter => getter!({ LookupNumber!("TRACINGMACROS") }),
     setter => setter!(value, args, state, { AssignValue!("TRACINGMACROS" => value.value_of()); }));
@@ -72,47 +72,116 @@ LoadDefinitions!(state, {
     ("showboxbreadth", 5),
     ("showboxdepth", 3),
     ("errorcontextlines", 5),
-  ]
-  .iter()
+  ].iter()
   {
     DefRegister!(&s!("\\{}", key), Number!(*val));
   }
 
-  // # Most of these are ignored, but...
-  // DefMacro('\tracingall',
-  //   '\tracingonline=1 \tracingcommands=2 \tracingstats=2'
-  // . ' \tracingpages=1 \tracingoutput=1 \tracinglostchars=1'
-  // . ' \tracingmacros=2 \tracingparagraphs=1 \tracingrestores=1'
-  //     . ' \showboxbreadth=\maxdimen \showboxdepth=\maxdimen \errorstopmode');
+  // Most of these are ignored, but...
+  DefMacro!("\\tracingall",
+    "\\tracingonline=1 \\tracingcommands=2 \\tracingstats=2\
+    \\tracingpages=1 \\tracingoutput=1 \\tracinglostchars=1\
+    \\tracingmacros=2 \\tracingparagraphs=1 \\tracingrestores=1\
+    \\showboxbreadth=\\maxdimen \\showboxdepth=\\maxdimen \\errorstopmode");
 
-  // # This may mess up Daemon state?
-  // { my ($sec, $min, $hour, $mday, $mon, $year) = localtime();
-  //   AssignValue('\day'   => Number($mday),             'global');
-  //   AssignValue('\month' => Number($mon + 1),          'global');
-  //   AssignValue('\year'  => Number(1900 + $year),      'global');
-  //   AssignValue('\time'  => Number(60 * $hour + $min), 'global'); }
+  let dt = Local::now();
 
-  // our @MonthNames = (qw( January February March April May June
-  //     July August September October November December));
+  AssignValue!("\\day"  , Number!(dt.day()),            Scope::Global);
+  AssignValue!("\\month", Number!(dt.month()),          Scope::Global);
+  AssignValue!("\\year" , Number!(dt.year()),           Scope::Global);
+  AssignValue!("\\time" , Number!(60*dt.hour() + dt.minute()), Scope::Global);
 
-  // # Return a string for today's date.
-  // sub today {
-  //   return $MonthNames[LookupValue('\month')->valueOf - 1]
-  //     . " " . LookupValue('\day')->valueOf
-  //     . ', ' . LookupValue('\year')->valueOf; }
+  
+  // Read-only Integer registers
+  for name in &["lastpenalty", "inputlineno", "badness"] {
+    DefRegister!(&s!("\\{}",name), Number!(0.0), readonly => true); 
+  }
+  
+  // Special integer registers (?)
+  // <special integer> = \spacefactor | \prevgraf | \deadcycles | \insertpenalties
+  for name in &["spacefactor", "prevgraf", "deadcycles", "insertpenalties"] {
+    DefRegister!(&s!("\\{}",name), Number!(0.0)); 
+  }
 
-  // # Read-only Integer registers
-  // {
-  //   my %ro_iparms = (lastpenalty => 0, inputlineno => 0, badness => 0);
-  //   foreach my $p (keys %ro_iparms) {
-  //     DefRegister("\\$p", Number($ro_iparms{$p}), readonly => 1); }
-  // }
+  // ======================================================================
+  // Dimen registers; TeXBook p. 274
+  let dparms = [
+    ("hfuzz", "0.1pt"),
+    ("vfuzz", "0.1pt"),
+    ("overfullrule", "5pt"),
+    ("emergencystretch", "0"),
+    ("hsize", "6.5in"),
+    ("vsize", "8.9in"),
+    ("maxdepth", "4pt"),
+    ("splitmaxdepth", "16383.99999pt"),
+    ("boxmaxdepth", "16383.99999pt"),
+    ("lineskiplimit", "0"),
+    ("delimitershortfall", "5pt"),
+    ("nulldelimiterspace", "1.2pt"),
+    ("scriptspace", "0.5pt"),
+    ("mathsurround", "0"),
+    ("predisplaysize", "0"),
+    ("displaywidth", "0"),
+    ("displayindent", "0"),
+    ("parindent", "20pt"),
+    ("hangindent", "0"),
+    ("hoffset", "0"),
+    ("voffset", "0")
+  ];
+  for (name, value) in &dparms {
+    DefRegister!(&s!("\\{}", name), Dimension!(value));
+  }
+  // Read-only dimension registers.
+  for name in &["lastkern"] {
+    DefRegister!(&s!("\\{}",name), Dimension::new(0.0), readonly => true);
+  }
+  // Special dimension registers (?)
+  // <special dimen> = \prevdepth | \pagegoal | \pagetotal | \pagestretch | \pagefilstretch
+  //    | \pagefillstretch | \pagefilllstretch | pageshrink | \pagedepth
+  for name in &["prevdepth", "pagegoal", "pagetotal", "pagestretch", "pagefilstretch", 
+                "pagefillstretch", "pagefilllstretch", "pageshrink", "pagedepth"] {
+    DefRegister!(&s!("\\{}", name), Dimension::new(0.0));
+  }
 
-  // # Special integer registers (?)
-  // # <special integer> = \spacefactor | \prevgraf | \deadcycles | \insertpenalties
-  // {
-  //   my %sp_iparms = (spacefactor => 0, prevgraf => 0, deadcycles => 0, insertpenalties => 0);
-  //   foreach my $p (keys %sp_iparms) {
-  //     DefRegister("\\$p", Number($sp_iparms{$p})); }
-  // }
+  // ======================================================================
+  //  Glue registers; TeXBook p.274
+  let gparms = &[
+    ("baselineskip", "12pt"),
+    ("lineskip", "1pt"),
+    ("parskip", "0pt plus 1pt"),
+    ("abovedisplayskip", "12pt plus 3pt minus 9pt"),
+    ("abovedisplayshortskip", "0pt plus 3pt"),
+    ("belowdisplayskip", "12pt plus 3pt minus 9pt"),
+    ("belowdisplayshortskip", "0pt plus 3pt"),
+    ("leftskip", "0"),
+    ("rightskip", "0"),
+    ("topskip", "10pt"),
+    ("splittopskip", "10pt"),
+    ("tabskip", "0"),
+    ("spaceskip", "0"),
+    ("xspaceskip", "0"),
+    ("parfillskip", "0pt plus 1fil")
+  ];
+  for (name, value) in gparms {
+    DefRegister!(&s!("\\{}",name), Glue!(value));
+  }
+
+  //======================================================================
+  // MuGlue registers; TeXBook p.274
+
+  let mparms = &[
+    ("thinmuskip","3mu"),
+    ("medmuskip","4mu plus 2mu minus 4mu"),
+    ("thickmuskip","5mu plus 5mu") ];
+  for (name, value) in mparms {
+    DefRegister!(&s!("\\{}",name), Glue!(value));
+  }
+
+  //======================================================================
+  // Token registers; TeXBook p.275
+
+  let tparms = &["output", "everypar", "everymath", "everydisplay", "everyhbox", "everyvbox", "everyjob", "everycr", "everyhelp"];
+  for name in tparms {
+    DefRegister!(&s!("\\{}",name), Tokens!());
+  }
 });

--- a/rtx_package/src/package/pool/tex_registers.rs
+++ b/rtx_package/src/package/pool/tex_registers.rs
@@ -10,12 +10,12 @@ LoadDefinitions!(state, {
   //======================================================================
   // Integer registers; TeXBook p. 272-273
 
-  // DefRegister('\tracingmacros', Number(0),
-  //   getter => sub { Number(LookupValue('TRACINGMACROS') || 0); },
-  //   setter => sub { AssignValue(TRACINGMACROS => $_[0]->valueOf); });
-  // DefRegister('\tracingcommands', Number(0),
-  //   getter => sub { Number(LookupValue('TRACINGCOMMANDS')); },
-  //   setter => sub { AssignValue(TRACINGCOMMANDS => $_[0]->valueOf); });
+  DefRegister!("\\tracingmacros", Number!(0.0),
+    getter => getter!({ LookupNumber!("TRACINGMACROS") }),
+    setter => setter!(value, args, state, { AssignValue!("TRACINGMACROS" => value.value_of()); }));
+  DefRegister!("\\tracingcommands", Number!(0.0),
+    getter => getter!({ LookupNumber!("TRACINGCOMMANDS") }),
+    setter => setter!(value, args, state, { AssignValue!("TRACINGCOMMANDS" => value.value_of()); }));
 
   for (key, val) in [
     ("pretolerance", 100),

--- a/rtx_package/src/package/pool/tex_setup.rs
+++ b/rtx_package/src/package/pool/tex_setup.rs
@@ -435,7 +435,7 @@ LoadDefinitions!(state, {
       state.end_semiverbatim()?;
       Ok(arg)
     },
-    before_digest => beforeproc!(stomach, state, {
+    before_digest => before_digest!(stomach, state, {
       stomach.bgroup(state);
       MergeFont!(family => "typewriter", state);
     }),

--- a/rtx_package/src/package/pool/verbatim_sty.rs
+++ b/rtx_package/src/package/pool/verbatim_sty.rs
@@ -37,7 +37,7 @@ LoadDefinitions!(state, {
   );
 
   DefConstructor!("\\lx@verbatim@", "<ltx:verbatim font='#font'>",
-    before_digest => beforeproc!(stomach, inner_state, { LetI!(&T_CS!("\\par"), T_CR!()); }),
+    before_digest => before_digest!(stomach, inner_state, { LetI!(&T_CS!("\\par"), T_CR!()); }),
     before_construct => construct!(document, whatsit, inner_state, { document.maybe_close_element("ltx:p", inner_state)?; })
   );
 

--- a/rtx_package/src/package/setup.rs
+++ b/rtx_package/src/package/setup.rs
@@ -545,7 +545,6 @@ macro_rules! DefEnvironmentWO (
   use rtx_core::util::text::*;
   let mut proto = $proto_raw.to_string().trim_start().to_string();
   let name = extract_bracketed(&mut proto, Some(&Delimiter::Brace));
-
   let compiled_replacement;
   compile_replacement!(compiled_replacement, $replacement);
 

--- a/rtx_package/src/package/setup.rs
+++ b/rtx_package/src/package/setup.rs
@@ -553,10 +553,10 @@ macro_rules! DefEnvironmentWO (
 }));
 
 #[macro_export]
-macro_rules! DefEnvironmentCWO (
+macro_rules! DefEnvironmentIWO (
   ($proto_raw:expr, $compiled_replacement:expr, $options:expr) => {{
     bind_state!(st);
-    DefEnvironmentCWO!($proto_raw, $compiled_replacement, $options, st)
+    DefEnvironmentIWO!($proto_raw, $compiled_replacement, $options, st)
   }};
   ($proto_raw:expr, $compiled_replacement:expr, $options:expr, $state_arg:ident) => ({
   use rtx_core::util::text::*;
@@ -1413,22 +1413,22 @@ macro_rules! DefEnvironment(
   ($proto_raw:expr, $replacement:expr, $($key:ident => $val:expr),*) =>
     (DefEnvironmentWO!($proto_raw, $replacement, NewDefault!(ConstructorOptions, $($key => $val),*)));
   // explicit state
-  ($proto_raw:expr, $replacement:expr, $state_arg:ident) => (DefEnvironmentWO!($proto_raw, $replacement, ConstructorOptions::default(), $state_arg));
-  ($proto_raw:expr, $replacement:expr, $($key:ident => $val:expr),*, $state_arg:ident) =>
-    (DefEnvironmentWO!($proto_raw, $replacement, NewDefault!(ConstructorOptions, $($key => $val),*, $state_arg)));
+  // ($proto_raw:expr, $replacement:expr, $state_arg:ident) => (DefEnvironmentWO!($proto_raw, $replacement, ConstructorOptions::default(), $state_arg));
+  // ($proto_raw:expr, $replacement:expr, $($key:ident => $val:expr),*, $state_arg:ident) =>
+  //   (DefEnvironmentWO!($proto_raw, $replacement, NewDefault!(ConstructorOptions, $($key => $val),*, $state_arg)));
 );
 
 #[macro_export]
-macro_rules! DefEnvironmentC(
+macro_rules! DefEnvironmentI(
   // implicit state
-  ($proto_raw:expr, $compiled_replacement:expr) => (DefEnvironmentCWO!($proto_raw, $paramlist, $compiled_replacement, ConstructorOptions::default()));
+  ($proto_raw:expr, $compiled_replacement:expr) => (DefEnvironmentIWO!($proto_raw, $paramlist, $compiled_replacement, ConstructorOptions::default()));
   ($proto_raw:expr, $compiled_replacement:expr, $($key:ident=>$val:expr),*) =>
-    (DefEnvironmentCWO!($proto_raw, $compiled_replacement, NewDefault!(ConstructorOptions, $($key => $val),*)));
+    (DefEnvironmentIWO!($proto_raw, $compiled_replacement, NewDefault!(ConstructorOptions, $($key => $val),*)));
   // explicit state
-  ($proto_raw:expr, $compiled_replacement:expr, $state_arg:ident) =>
-    (DefEnvironmentCWO!($proto_raw, $paramlist, $compiled_replacement, ConstructorOptions::default(), $state_arg));
-  ($proto_raw:expr, $compiled_replacement:expr, $($key:ident=>$val:expr),*, $state_arg:ident) =>
-    (DefEnvironmentCWO!($proto_raw, $compiled_replacement, NewDefault!(ConstructorOptions, $($key => $val),*), $state_arg));
+  // ($proto_raw:expr, $compiled_replacement:expr, $state_arg:ident) =>
+  //   (DefEnvironmentIWO!($proto_raw, $paramlist, $compiled_replacement, ConstructorOptions::default(), $state_arg));
+  // ($proto_raw:expr, $compiled_replacement:expr, $($key:ident=>$val:expr),*, $state_arg:ident) =>
+  //   (DefEnvironmentIWO!($proto_raw, $compiled_replacement, NewDefault!(ConstructorOptions, $($key => $val),*), $state_arg));
 );
 
 #[macro_export]

--- a/rtx_package/src/package/setup.rs
+++ b/rtx_package/src/package/setup.rs
@@ -1017,6 +1017,7 @@ macro_rules! LookupTokens {
 #[macro_export]
 macro_rules! AssignValue {
   ($name:expr => $value:expr) => {AssignValue!($name, $value)};
+  ($name:expr => $value:expr, $scope:expr) => {AssignValue!($name, $value, $scope)};
   ($name:expr, $value:expr) => {{
     bind_state_mut!(st);
     st.assign_value($name, $value, None)

--- a/rtx_package/src/package/setup.rs
+++ b/rtx_package/src/package/setup.rs
@@ -87,6 +87,17 @@ macro_rules! WithInnerState {
 #[macro_export]
 macro_rules! bind_state {
   ($st:ident) => {
+    let $st: &State = {
+      #[derive(BoundState)]
+      struct _Bound;
+      state!()
+    };
+  };
+}
+
+#[macro_export]
+macro_rules! bind_state_mut {
+  ($st:ident) => {
     let $st: &mut State = {
       #[derive(BoundState)]
       struct _Bound;
@@ -95,13 +106,14 @@ macro_rules! bind_state {
   };
 }
 
+
 //======================================================================
 // Defining new Control-sequence Parameter types.
 //======================================================================
 #[macro_export]
 macro_rules! DefParameterTypeWO {
   ($name:expr, $param:expr) => {
-    bind_state!(st);
+    bind_state_mut!(st);
     st.assign_mapping("PARAMETER_TYPES", $name, Some(Stored::Parameter($param)))
   };
   ($name:expr, $param:expr, $state_arg:ident) => {
@@ -112,7 +124,7 @@ macro_rules! DefParameterTypeWO {
 #[macro_export]
 macro_rules! LoadPool {
   ($name:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     LoadPool!($name, st)
   }};
   ($name:expr, $state_arg:ident) => {{
@@ -135,7 +147,7 @@ macro_rules! LoadPool {
 #[macro_export]
 macro_rules! InnerPool {
   ($name:ident) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     InnerPool!($name, st, outer_stomach!())
   }};
   ($name:ident, $state_arg:ident) => {
@@ -152,7 +164,7 @@ macro_rules! InnerPool {
 #[macro_export]
 macro_rules! RequirePackage {
   ($package:expr, $options:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     RequirePackage!($package, $options, st)
   }};
   ($package:expr, $options:expr, $state_arg:ident) => {
@@ -161,7 +173,7 @@ macro_rules! RequirePackage {
 }
 macro_rules! LoadClass {
   ($class:expr, $options:expr, $after:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     load_class($class, $options, $after, st)
   }};
   ($class:expr, $options:expr, $after:expr, $state_arg:ident) => {
@@ -182,11 +194,11 @@ macro_rules! DeclareFontMap {
     $state_arg.assign_value(&mapname, map, Some(Scope::Global));
   }};
   ($name:expr, $map:expr, $family:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DeclareFontMap!($name, $map, $family, st)
   }};
   ($name:expr, $map:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DeclareFontMap!($name, $map, st)
   }};
 }
@@ -195,7 +207,7 @@ macro_rules! DeclareFontMap {
 macro_rules! DefMacroIWO {
   // closure stub
   ($cs:expr, $paramlist:expr, sub [ $gullet:ident, $args:ident, $inner_state:ident ] $body:block, $options:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefMacroIWO!($cs, $paramlist, sub [ $gullet, $args, $inner_state ] $body, $options, st)
   }};
   // with explicit state
@@ -208,7 +220,7 @@ macro_rules! DefMacroIWO {
   // precompiled
   ($cs:expr, $paramlist:expr, $expansion:expr, $options:expr) => {{
     let expansion = {{ $expansion }}; // ensure we can do multiple mutable borrows of state
-    bind_state!(st);
+    bind_state_mut!(st);
     def_macro($cs, $paramlist, expansion, $options, st)
   }};
   // with explicit state
@@ -231,12 +243,12 @@ macro_rules! DefMacroWO {
     def_macro(cs, paramlist, expansion_body, $options, $state_arg);
   }};
   ($proto:expr, sub [ $gullet:ident, $args:ident, $inner_state:ident ] $body:block, $options:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefMacroWO!($proto, sub [ $gullet, $args, $inner_state ] $body, $options, st)
   }};
   // String expansion forms
   ($proto:expr, $expansion:expr, $options:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefMacroWO!($proto, $expansion, $options, st);
   }};
   ($proto:expr, $expansion:expr, $options:expr, $state_arg:ident) => ({
@@ -251,11 +263,11 @@ macro_rules! DefMacroWO {
 macro_rules! DefConditional(
   // test is always a rust closure
   ($proto:expr, sub [$gullet:ident, $args:ident, $inner_state:ident] $body:block) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefConditional!($proto, sub[$gullet, $args, $inner_state] $body, st);
   }};
   ($proto:expr, sub $body:block) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefConditional!($proto, sub[gullet, args, inner_state] $body, st);
   }};
   ($proto:expr, sub [$gullet:ident, $args:ident, $inner_state:ident] $body:block, $state_arg:ident) => ({
@@ -264,11 +276,11 @@ macro_rules! DefConditional(
   });
   // or None
   ($proto:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefConditional!($proto, None, st)
   }};
   ($proto:expr, None) => ({
-    bind_state!(st);
+    bind_state_mut!(st);
     DefConditional!($proto, None, st)
   });
   ($proto:expr, None, $state_arg:ident) => ({
@@ -281,7 +293,7 @@ macro_rules! DefConditional(
 macro_rules! DefConditionalI(
   // test is always a rust closure
   ($cs:expr, $paramlist:expr, sub[$gullet:ident, $args:ident, $inner_state:ident] $body:block) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefConditionalI!($cs, $paramlist, $gullet, $args, $inner_state, $body, st)
   }};
   ($cs:expr, $paramlist:expr, sub[$gullet:ident, $args:ident, $inner_state:ident] $body:block, $state_arg:ident) => ({
@@ -290,7 +302,7 @@ macro_rules! DefConditionalI(
   });
   // or None
   ($cs:expr, $paramlist:expr, None) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefConditionalI!($cs, $paramlist, None, st)
   }};
   ($cs:expr, $paramlist:expr, None, $state_arg:ident) => ({
@@ -340,18 +352,18 @@ macro_rules! DefConditionalI(
 #[macro_export]
 macro_rules! DefPrimitiveII {
   ($cs:expr, $paramlist:expr, sub[$stomach:ident,$args:ident,$inner_state:ident] $body:block) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefPrimitiveII!($cs, $paramlist, sub[$stomach, $args, $inner_state] $body, st)
   }};
   ($cs:expr, $paramlist:expr, sub[$stomach:ident,$args:ident,$inner_state:ident] $body:block, $state_arg:ident) => {
     DefPrimitiveII!($cs, $paramlist, move |$stomach, $args, $inner_state| {WithInnerState!($body, $inner_state, $stomach)}, PrimitiveOptions::default(), $state_arg)
   };
   ($cs:expr, $paramlist:expr, sub $body:block) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefPrimitiveII!($cs, $paramlist, sub[stomach, args, inner_state] $body, st)
   }};
   ($cs:expr, $paramlist:expr, $compiled_replacement:expr, $options:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefPrimitiveII!($cs, $paramlist, $compiled_replacement, $options, st)
   }};
   ($cs:expr, $paramlist:expr, $compiled_replacement:expr, $options:expr, $state_arg:ident) => {{
@@ -362,7 +374,7 @@ macro_rules! DefPrimitiveII {
 #[macro_export]
 macro_rules! DefPrimitiveIWO(
   ($proto:expr, $compiled_replacement:expr, $options:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefPrimitiveIWO!($proto, $compiled_replacement, $options, st)
   }};
   ($proto:expr, $compiled_replacement:expr, $options:expr, $state_arg:ident) => {{
@@ -375,7 +387,7 @@ macro_rules! DefPrimitiveIWO(
 macro_rules! DefRegisterWO {
   ($proto:expr, $value:expr, $options:expr) => {{
     let value = { $value }; // allow to re-borrow state in value macros
-    bind_state!(st);
+    bind_state_mut!(st);
     DefRegisterWO!($proto, value, $options, st)
   }};
   ($proto:expr, $value:expr, $options:expr, $state_arg:ident) => {{
@@ -394,7 +406,7 @@ macro_rules! DefRegisterI {
     (DefRegisterI!($cs, $paramlist, $value, Some(NewDefault!(RegisterOptions, $($key=>$val),*)), $state_arg));
   ($cs:expr, $paramlist:expr, $value:expr, $options:expr) => {{
     let value = { $value };
-    bind_state!(st);
+    bind_state_mut!(st);
     DefRegisterI!($cs, $paramlist, value, $options, st)
   }};
   ($cs:expr, $paramlist:expr, $value:expr, $options:expr, $state_arg:ident) => {
@@ -408,7 +420,7 @@ macro_rules! LookupRegister {
     LookupRegister!($cs, Vec::new())
   };
   ($cs:expr, $parameters:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     LookupRegister!($cs, $parameters, st)
   }};
   ($cs:expr, $parameters:expr, $state_arg: ident) => {
@@ -473,7 +485,7 @@ macro_rules! LookupRegister {
 #[macro_export]
 macro_rules! DefConstructorIWO {
   ($cs:expr, $paramlist:expr, $compiled_replacement:expr, $options:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefConstructorIWO!($cs, $paramlist, $compiled_replacement, $options, st)
   }};
   ($cs:expr, $paramlist:expr, $compiled_replacement:expr, $options:expr, $state_arg:ident) => {{
@@ -484,7 +496,7 @@ macro_rules! DefConstructorIWO {
 #[macro_export]
 macro_rules! DefConstructorWO(
   ($proto:expr, $replacement:expr, $options:expr) => ({
-    bind_state!(st);
+    bind_state_mut!(st);
     DefConstructorWO!($proto, $replacement, $options, st)
   });
   ($proto:expr, $replacement:expr, $options:expr, $state_arg:ident) => ({
@@ -495,7 +507,7 @@ macro_rules! DefConstructorWO(
     DefConstructorIWO!(cs, paramlist, compiled_replacement, $options, $state_arg);
   });
   ($proto:expr, $document:ident, $args:ident, $props:ident, $inner_state:ident, $body:block, $options:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefConstructorWO!($proto, $document, $args, $props, $inner_state, $body, $options, st)
   }};
 
@@ -506,7 +518,7 @@ macro_rules! DefConstructorWO(
   });
   // pre-compiled CS with to-be-compiled replacement (see \begin{verbatim})
   (cs [ $cs:expr ], $paramlist:expr, $replacement:expr, $options:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefConstructorWO!(cs[$cs], $paramlist, $replacement, $options, st)
   }};
   (cs [ $cs:expr ], $paramlist:expr, $replacement:expr, $options:expr, $state_arg:ident) => ({
@@ -520,7 +532,7 @@ macro_rules! DefConstructorWO(
 #[macro_export]
 macro_rules! TagWO {
   ($tag:expr, $properties:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     TagWO!($tag, $properties, st)
   }};
   ($tag:expr, $properties:expr, $state_arg:ident) => {
@@ -538,7 +550,7 @@ macro_rules! TagWO {
 #[macro_export]
 macro_rules! DefEnvironmentWO (
   ($proto_raw:expr, $replacement:expr, $options:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefEnvironmentWO!($proto_raw, $replacement, $options, st)
   }};
   ($proto_raw:expr, $replacement:expr, $options:expr, $state_arg:ident) => ({
@@ -555,7 +567,7 @@ macro_rules! DefEnvironmentWO (
 #[macro_export]
 macro_rules! DefEnvironmentIWO (
   ($proto_raw:expr, $compiled_replacement:expr, $options:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefEnvironmentIWO!($proto_raw, $compiled_replacement, $options, st)
   }};
   ($proto_raw:expr, $compiled_replacement:expr, $options:expr, $state_arg:ident) => ({
@@ -570,7 +582,7 @@ macro_rules! DefEnvironmentIWO (
 #[macro_export]
 macro_rules! RelaxNGSchema {
   ($name:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     RelaxNGSchema!($name, st)
   }};
   ($name:expr,$state_arg:ident) => {
@@ -581,7 +593,7 @@ macro_rules! RelaxNGSchema {
 #[macro_export]
 macro_rules! RegisterNamespace(
   ($prefix:expr, $namespace:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     RegisterNamespace!($prefix, $namespace, st)
   }};
   ($prefix:expr, $namespace:expr,$state_arg:ident) =>
@@ -590,7 +602,7 @@ macro_rules! RegisterNamespace(
 #[macro_export]
 macro_rules! RegisterDocumentNamespace(
   ($prefix:expr, $namespace:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     RegisterDocumentNamespace!($prefix, $namespace, st)
   }};
   ($prefix:expr, $namespace:expr,$state_arg:ident) =>
@@ -599,7 +611,7 @@ macro_rules! RegisterDocumentNamespace(
 #[macro_export]
 macro_rules! RequireResource(
   ($resource:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     RequireResource!($resource, st)
   }};
   ($resource:expr,$state_arg:ident) =>
@@ -615,7 +627,7 @@ macro_rules! RequireResource(
 #[macro_export]
 macro_rules! DefMathWO {
   ($cstext:expr, $paramlist:expr, $presentation:expr, $options:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefMathWO!($cstext, $paramlist, $presentation, $options, st)
   }};
   ($cstext:expr, $paramlist:expr, $presentation:expr, $options:expr, $state_arg:ident) => {{
@@ -695,7 +707,7 @@ macro_rules! DefMathWO {
 #[macro_export]
 macro_rules! requireMath {
   ($cs_name:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     requireMath!($cs_name, st)
   }};
   ($cs_name:expr, $state_arg:ident) => (
@@ -707,7 +719,7 @@ macro_rules! requireMath {
 #[macro_export]
 macro_rules! forbidMath {
   ($cs_name:expr) => ({
-    bind_state!(st);
+    bind_state_mut!(st);
     forbidMath!($cs_name, st)
   });
   ($cs_name:expr, $state_arg:ident) => (
@@ -743,14 +755,14 @@ macro_rules! forbidMath {
 #[macro_export]
 macro_rules! NewCounterWO {
   ($ctr:expr, $within:expr, None) => {
-    bind_state!(st);
+    bind_state_mut!(st);
     new_counter($ctr, $within, None, st)?
   };
   ($ctr:expr, $within:expr, None, $state_arg:ident) => {
     new_counter($ctr, $within, None, $state_arg)?
   };
   ($ctr:expr, $within:expr, Some($opts:expr)) => {
-    bind_state!(st);
+    bind_state_mut!(st);
     new_counter($ctr, $within, Some($opts), st)?
   };
   ($ctr:expr, $within:expr, Some($opts:expr), $state_arg:ident) => {
@@ -760,7 +772,7 @@ macro_rules! NewCounterWO {
 #[macro_export]
 macro_rules! CounterValue {
   ($ctr:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     counter_value($ctr, st)
   }};
   ($ctr:expr, $state_arg:ident) => {
@@ -786,7 +798,7 @@ macro_rules! SetCounter {
 #[macro_export]
 macro_rules! AddToCounter {
   ($ctr:expr, $value:expr, $gullet:ident) => {
-    bind_state!(st);
+    bind_state_mut!(st);
     add_to_counter($ctr, $value, $gullet, st)
   };
   ($ctr:expr, $value:expr, $gullet:ident, $state_arg:ident) => {
@@ -796,7 +808,7 @@ macro_rules! AddToCounter {
 #[macro_export]
 macro_rules! StepCounter {
   ($ctr:expr, $noreset:expr, $gullet:ident) => {
-    bind_state!(st);
+    bind_state_mut!(st);
     step_counter($ctr, $noreset, $gullet, st)
   };
   ($ctr:expr, $noreset:expr, $gullet:ident, $state_arg:ident) => {
@@ -806,7 +818,7 @@ macro_rules! StepCounter {
 #[macro_export]
 macro_rules! RefStepCounter {
   ($ctr:expr, $noreset:expr, $stomach:ident) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     ref_step_counter($ctr, $noreset, $stomach, st)
   }};
   ($ctr:expr, $noreset:expr, $stomach:ident, $state_arg:ident) => {
@@ -816,7 +828,7 @@ macro_rules! RefStepCounter {
 #[macro_export]
 macro_rules! RefStepID {
   ($ctr:expr, $stomach:ident) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     ref_step_id($ctr, $stomach, st)
   }};
   ($ctr:expr, $stomach:ident, $state_arg:ident) => {
@@ -826,7 +838,7 @@ macro_rules! RefStepID {
 #[macro_export]
 macro_rules! ResetCounter {
   ($ctr:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     reset_counter($ctr, st)
   }};
   ($ctr:expr, $state_arg: ident) => {
@@ -838,7 +850,7 @@ macro_rules! ResetCounter {
 #[macro_export]
 macro_rules! Expand {
   ($tokens:expr, $gullet:ident) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     do_expand($tokens, $gullet, st)?
   }};
   ($tokens:expr, $gullet:ident, $state_arg:ident) => {
@@ -851,14 +863,14 @@ macro_rules! Expand {
 #[macro_export]
 macro_rules! Invocation {
   ($csname:literal, $args:expr, $gullet:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     Invocation!(T_CS!($csname), $args, $gullet, st)
   }};
   ($csname:literal, $args:expr, $gullet:expr, $state_arg:ident) => {
     Invocation!(T_CS!($csname), $args, $gullet, $state_arg)
   };
   ($token:expr, $args:expr, $gullet:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     Invocation!($token, $args, $gullet, st)
   }};
   ($token:expr, $args:expr, $gullet:expr, $state_arg:ident) => {
@@ -868,7 +880,7 @@ macro_rules! Invocation {
 #[macro_export]
 macro_rules! DefLigature {
   ($regex:expr, $replacement:expr, fontTest => sub[$font:ident] $body:block) => {
-    bind_state!(st);
+    bind_state_mut!(st);
     DefLigature!($regex, $replacement, fontTest => sub[$font]{$body}, st)
   };
   ($regex:expr, $replacement:expr, fontTest => sub[$font:ident] $body:block, $state_arg:ident) => {
@@ -885,7 +897,7 @@ macro_rules! DefLigature {
     );
   };
   ($regex:expr, $replacement:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefLigature!($regex, $replacement, st)
   }};
   ($regex:expr, $replacement:expr, $state_arg:ident) => {
@@ -907,15 +919,15 @@ macro_rules! DefLigature {
 macro_rules! DefAccent {
   ($accent:expr, $combiningchar:expr, $standalonechar:expr) => {
     let mut empty_opts : HashMap<String, Stored> = HashMap::new();
-    bind_state!(st);
+    bind_state_mut!(st);
     DefAccent!($accent, $combiningchar, $standalonechar, empty_opts, st)
   };
   ($accent:expr, $combiningchar:expr, $standalonechar:expr, below => true) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefAccent!($accent, $combiningchar, $standalonechar, map!("below"=>Stored::Bool(true)), st)
   }};
   ($accent:expr, $combiningchar:expr, $standalonechar:expr, $options:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DefAccent!($accent, $combiningchar, $standalonechar, $options, st)
   }};
   ($accent:expr, $combiningchar:expr, $standalonechar:expr, $options:expr, $state_arg: ident) => {{
@@ -1006,11 +1018,11 @@ macro_rules! LookupTokens {
 macro_rules! AssignValue {
   ($name:expr => $value:expr) => {AssignValue!($name, $value)};
   ($name:expr, $value:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     st.assign_value($name, $value, None)
   }};
   ($name:expr, $value:expr, $scope:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     st.assign_value($name, $value, $scope)
   }};
   ($name:expr, $value:expr, $scope:expr, $state_arg:ident) => {
@@ -1020,7 +1032,7 @@ macro_rules! AssignValue {
 #[macro_export]
 macro_rules! RemoveValue {
   ($name:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     st.remove_value($name)
   }};
   ($name:expr, $state_arg:ident) => {
@@ -1030,7 +1042,7 @@ macro_rules! RemoveValue {
 #[macro_export]
 macro_rules! PushValue {
   ($name:expr, $values:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     st.push_value($name, $values)
   }};
   ($name:expr, $values:expr, $state_arg:ident) => {
@@ -1040,7 +1052,7 @@ macro_rules! PushValue {
 #[macro_export]
 macro_rules! PopValue {
   ($name:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     st.pop_value($name)
   }};
   ($name:expr, $state_arg:ident) => {
@@ -1050,7 +1062,7 @@ macro_rules! PopValue {
 #[macro_export]
 macro_rules! UnshiftValue {
   ($name:expr, $values:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     st.unshift_value($name, $values)
   }};
   ($name:expr, $values:expr,$state_arg:ident) => {
@@ -1060,7 +1072,7 @@ macro_rules! UnshiftValue {
 #[macro_export]
 macro_rules! ShiftValue {
   ($name:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     st.shift_value($name)
   }};
   ($name:expr,$state_arg:ident) => {
@@ -1070,7 +1082,7 @@ macro_rules! ShiftValue {
 #[macro_export]
 macro_rules! LookupMapping {
   ($map:expr, $key:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     st.lookup_mapping($map, $key)
   }};
   ($map:expr, $key:expr, $state_arg:ident) => {
@@ -1080,7 +1092,7 @@ macro_rules! LookupMapping {
 #[macro_export]
 macro_rules! AssignMapping {
   ($map:expr, $key:expr => $value:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     AssignMapping!($map, $key => $value, st)
   }};
   ($map:expr, $key:expr => $value:expr, $state_arg:ident) => {
@@ -1091,7 +1103,7 @@ macro_rules! AssignMapping {
 macro_rules! AssignMeaning {
   ($key:expr, $val:expr) => { AssignMeaning!($key, $val, None) };
   ($key:expr, $val:expr, $scope: expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     st.assign_meaning($key, $val, $scope)
   }};
   ($key:expr, $val:expr, $scope: expr, $state_arg:ident) => {
@@ -1102,7 +1114,7 @@ macro_rules! AssignMeaning {
 #[macro_export]
 macro_rules! LookupMappingKeys {
   ($map:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     LookupMappingKeys!($map, st)
   }};
   ($map:expr, $state_arg:ident) => {
@@ -1112,7 +1124,7 @@ macro_rules! LookupMappingKeys {
 #[macro_export]
 macro_rules! LookupCatcode {
   ($c:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     st.lookup_catcode($c)
   }};
   ($c:expr, $state_arg:ident) => {
@@ -1123,11 +1135,11 @@ macro_rules! LookupCatcode {
 macro_rules! AssignCatcode {
   ($name:expr => $value:expr) => {AssignCatcode!($name, $value)};
   ($c:expr, $catcode:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     AssignCatcode!($c, $catcode, None, st)
   }};
   ($c:expr, $catcode:expr, $scope:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     AssignCatcode!($c, $catcode, $scope, st)
   }};
   ($c:expr, $catcode:expr, $scope:expr, $state_arg:ident) => {
@@ -1137,7 +1149,7 @@ macro_rules! AssignCatcode {
 #[macro_export]
 macro_rules! LookupMeaning {
   ($name:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     LookupMeaning!($name, st)
   }};
   ($name:expr, $state_arg:ident) => {
@@ -1147,7 +1159,7 @@ macro_rules! LookupMeaning {
 #[macro_export]
 macro_rules! LookupDefinition {
   ($name:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     LookupDefinition!($name, st)
   }};
   ($name:expr, $state_arg:ident) => {
@@ -1157,7 +1169,7 @@ macro_rules! LookupDefinition {
 #[macro_export]
 macro_rules! InstallDefinition {
   ($name:expr, $definition:expr, $scope:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     InstallDefinition!($name, $definition, $scope, st)
   }};
   ($name:expr, $definition:expr, $scope:expr, $state_arg:ident) => {
@@ -1167,7 +1179,7 @@ macro_rules! InstallDefinition {
 #[macro_export]
 macro_rules! XEquals {
   ($token1:expr, $token2:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     XEquals!($token1, $token2, st)
   }};
   ($token1:expr, $token2:expr, $state_arg:ident) => {
@@ -1177,7 +1189,7 @@ macro_rules! XEquals {
 #[macro_export]
 macro_rules! IsDefined {
   ($name:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     IsDefined!($name, st)
   }};
   ($name:expr, $state_arg:ident) => {
@@ -1187,18 +1199,18 @@ macro_rules! IsDefined {
 #[macro_export]
 macro_rules! IsDefinedToken {
   ($name:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     is_defined_token($name, st)
   }};
 }
 #[macro_export]
 macro_rules! Let {
   ($token1:literal, $token2:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     Let!($token1, $token2, st)
   }};
   ($token1:ident, $token2:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     Let!($token1, $token2, st)
   }};
   ($token1:expr, $token2:expr, $state_arg:ident) => {{
@@ -1211,7 +1223,7 @@ macro_rules! Let {
 #[macro_export]
 macro_rules! LetI {
   ($token1:expr, $token2:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     LetI!($token1, $token2, st)
   }};
   ($token1:expr, $token2:expr, $state_arg:ident) => {
@@ -1224,14 +1236,14 @@ macro_rules! LetI {
 #[macro_export]
 macro_rules! DigestIf {
   ($token:literal, $stomach:ident) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DigestIf!(T_CS!($token), $stomach, st)
   }};
   ($token:literal, $stomach:ident, $state_arg:ident) => {
     digest_if(T_CS!($token), $stomach, $state_arg)
   };
   ($token:expr, $stomach:ident) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     DigestIf!($token, $stomach, st)
   }};
   ($token:expr, $stomach:ident, $state_arg: ident) => {
@@ -1241,7 +1253,7 @@ macro_rules! DigestIf {
 #[macro_export]
 macro_rules! AfterAssignment {
   () => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     st.after_assignment()
   }};
   ($state_arg: ident) => {
@@ -1253,14 +1265,14 @@ macro_rules! AfterAssignment {
 #[macro_export]
 macro_rules! MergeFont {
   ($kv:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     MergeFont!($kv, st)
   }};
   ($kv:expr, $state_arg:ident) => {
     merge_font($kv, $state_arg)
   };
   ($key:ident => $val:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     MergeFont!($key => $val, st)
   }};
   ($key:ident => $val:expr, $state_arg:ident) => {
@@ -1550,7 +1562,7 @@ macro_rules! GetKeyVals {
 #[macro_export]
 macro_rules! Digest {
   ($tokens:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     Digest!($tokens, st)
   }};
   ($tokens:expr, $state_arg:ident) => {{
@@ -1565,7 +1577,7 @@ macro_rules! Digest {
 #[macro_export]
 macro_rules! DigestText {
   ($tokens:expr) => {
-    bind_state!(st);
+    bind_state_mut!(st);
     let mut state_stomach = st.stomach.clone();
     match outer_stomach!().as_mut() {
       Some(st) => digest_text($tokens, *st, st),
@@ -1573,7 +1585,7 @@ macro_rules! DigestText {
     }
   };
   ($tokens:expr, $stomach:ident) => {
-    bind_state!(st);
+    bind_state_mut!(st);
     DigestText!($tokens, $stomach, st)
   };
   ($tokens:expr, $stomach:ident, $state_arg:ident) => {
@@ -1615,7 +1627,7 @@ macro_rules! TokenizeInternal {
 #[macro_export]
 macro_rules! RawTeX {
   ($text:expr) => {
-    bind_state!(st);
+    bind_state_mut!(st);
     RawTeX!($text, st)
   };
   ($text:expr, $state_arg:ident) => {{
@@ -1630,7 +1642,7 @@ macro_rules! RawTeX {
 #[macro_export]
 macro_rules! Dimension {
   ($number:expr) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     Dimension!($number, st)
   }};
   ($number:expr, $state_arg:ident) => {
@@ -1641,7 +1653,7 @@ macro_rules! Dimension {
 #[macro_export]
 macro_rules! DocType {
   ($rootelement:expr, $pubid:expr, $sysid:expr) => {
-    bind_state!(st);
+    bind_state_mut!(st);
     let mut namespaces: HashMap<String, String> = HashMap::new();
     DocType!($rootelement, $pubid, $sysid, namespaces, st)
   };
@@ -1657,7 +1669,7 @@ macro_rules! DocType {
 #[macro_export]
 macro_rules! Today {
   () => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     today(st)
   }};
 }
@@ -1665,7 +1677,7 @@ macro_rules! Today {
 #[macro_export]
 macro_rules! SetPrefix {
   ($prefix:literal) => {{
-    bind_state!(st);
+    bind_state_mut!(st);
     st.set_prefix($prefix);
   }}
 }


### PR DESCRIPTION
So far here:
 * added `\meaning` macro and flesh out related stringifying infrastructure and type interfaces. Pretty good macro for stress-testing parameters.
 * exhaustively covering TeX.pool line-by-line, reached end of `\meaning` macro, so nearing line 900 in the original file