### PR TITLE
Locator, Error, Object infrastructure; low-level encoding bindings

### DIFF
--- a/rtx/src/main.rs
+++ b/rtx/src/main.rs
@@ -1,4 +1,5 @@
-use log::*;
+#[macro_use]
+extern crate rtx_core;
 use rtx_core::common::{Config, DataSize, OutputFormat};
 use rtx_package::converter::Converter;
 use std::env;
@@ -7,7 +8,8 @@ use std::rc::Rc;
 
 fn main() {
   if rtx_core::util::logger::init(log::LevelFilter::Info).is_err() {
-    error!("Failed to load logger, aborting early. Please check rtx_core::util::logger installed correctly.")
+    Error!("rtx", "logger", None, None, 
+      "Failed to load logger, aborting early. Please check rtx_core::util::logger installed correctly.");
   }
   let mut argv = env::args();
   argv.next();
@@ -15,7 +17,7 @@ fn main() {
   let source = match argv.next() {
     Some(s) => s,
     None => {
-      error!("Please provide a source document! Exiting...");
+      Error!("rtx","", None, None, "Please provide a source document! Exiting...");
       process::exit(1);
     },
   };
@@ -32,7 +34,8 @@ fn main() {
   };
   let mut converter = Converter::from_config(opts.clone());
   if let Err(e) = converter.prepare_session(&opts) {
-    error!("Could not prepare converter session! : {}", e);
+    let message = s!("Could not prepare converter session! : {}", e);
+    Error!("rtx","session",None, None, message);
     process::exit(1);
   }
   // Perform the conversion:

--- a/rtx_core/src/common/dimension.rs
+++ b/rtx_core/src/common/dimension.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use crate::definition::register;
 use crate::definition::register::{NumericOps, RegisterType};
 
@@ -26,6 +27,18 @@ impl Default for MuDimension {
   fn default() -> Self { MuDimension(0.0) }
 }
 
+impl fmt::Display for Dimension {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(f, "{}", Dimension::point_format(self.0))
+  }
+}
+impl fmt::Display for MuDimension {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(f, "{}", Dimension::point_format(self.0))
+  }
+}
+
+
 impl Dimension {
   /// Utility for formatting scaled points sanely.
   pub fn point_format(num: f32) -> String {
@@ -46,8 +59,6 @@ impl Dimension {
   }
 
   fn attribute_format(self) -> String { s!("{:.1}pt", register::round_to(self.value_of() / 65536.0, Some(1))) }
-
-  pub fn to_string(self) -> String { Dimension::point_format(self.0) }
 
   pub fn to_attribute(self) -> String { self.attribute_format() }
 }

--- a/rtx_core/src/common/error.rs
+++ b/rtx_core/src/common/error.rs
@@ -55,6 +55,23 @@ pub enum ErrorTarget {
 }
 
 #[macro_export]
+macro_rules! Info {
+  ($category:literal, $object:expr, $where:ident, $message:literal, $details:expr, $state:ident) => {
+    $state.note_status("info");
+    info!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $details))
+  }
+}
+
+#[macro_export]
+macro_rules! Error {
+  ($category:literal, $object:expr, $where:ident, $message:expr, $state:ident) => {
+    $state.note_status("error");
+    error!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1))
+  }
+}
+
+
+#[macro_export]
 macro_rules! fatal {
   ($target:tt, $category:tt, $message:expr) => {{
     use $crate::common::error::Error as RtxError;
@@ -66,6 +83,16 @@ macro_rules! fatal {
       message: $message.to_string(),
     });
   }};
+}
+
+#[macro_export]
+macro_rules! generate_message {
+  ($where:ident, $message:expr, $level:literal) => {
+    s!("{}\n\t{}\n", $message, &$where.get_location())
+  };
+  ($where:ident, $message:expr, $level:literal, $detail:expr) => {
+    s!("{}\n\t{}\n\t{}\n", $message, &$where.get_location(),$detail)
+  }
 }
 
 pub type Result<T> = result::Result<T, Error>;

--- a/rtx_core/src/common/error.rs
+++ b/rtx_core/src/common/error.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use log::{debug, error, info, warn};
 use std::collections::HashMap;
 use std::error::Error as ErrorTrait;
 use std::fmt;
@@ -11,35 +10,86 @@ lazy_static! {
   static ref _NOTE_TIMERS: HashMap<String, String> = HashMap::new();
 }
 
+
 #[macro_export]
-macro_rules! Info {
-  ($category:literal, $object:expr, $where:ident, $state:ident, $message:expr) => {{
-    $state.note_status("info");
-    info!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1))
+macro_rules! Debug {
+  ($category:expr, $object:expr, $where:ident, None, $message:expr) => {{
+    // $state.note_status("debug"); // TODO: We're losing the info count this way...
+    use log::debug;
+    debug!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1))
   }};
-  ($category:literal, $object:expr, $where:ident, $state:ident, $message:expr, $($details:expr),*) => {{
-    $state.note_status("info");
-    info!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
-  }}
+ ($category:expr, $object:expr, $where:ident, None, $message:expr, $($details:expr),*) => {{
+    // $state.note_status("debug"); // TODO: We're losing the debug count this way...
+    use log::debug;
+    debug!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
+  }};
+  ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr) => {{
+    use log::debug;
+    $state.note_status("debug");
+    debug!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1))
+  }};
+ ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr, $($details:expr),*) => {{
+    use log::debug;
+    $state.note_status("debug");
+    debug!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
+  }};
+  ($($simple:expr),*) => {{
+    // $state.note_status("debug"); // TODO: We're losing the info count this way...
+    use log::debug;
+    debug!($($simple),*);
+  }};
+
 }
 
+#[macro_export]
+macro_rules! Info {
+  ($category:expr, $object:expr, $where:ident, None, $message:expr) => {{
+    use log::info;
+    // $state.note_status("info"); // TODO: We're losing the info count this way...
+    info!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1))
+  }};
+ ($category:expr, $object:expr, $where:ident, None, $message:expr, $($details:expr),*) => {{
+    // $state.note_status("info"); // TODO: We're losing the info count this way...
+    use log::info;
+    info!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
+  }};
+  ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr) => {{
+    $state.note_status("info");
+    use log::info;
+    info!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1))
+  }};
+ ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr, $($details:expr),*) => {{
+    $state.note_status("info");
+    use log::info;
+    info!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
+  }};
+  ($($simple:expr),*) => {{
+    // $state.note_status("debug"); // TODO: We're losing the info count this way...
+    use log::info;
+    info!($($simple),*);
+  }};
+}
 
 #[macro_export]
 macro_rules! Warn {
   ($category:expr, $object:expr, $where:ident, None, $message:expr) => {{
-    // $state.note_status("error"); // TODO: We're losing the error count this way...
+    // $state.note_status("warn"); // TODO: We're losing the warn count this way...
+    use log::warn;
     warn!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1))
   }};
  ($category:expr, $object:expr, $where:ident, None, $message:expr, $($details:expr),*) => {{
-    // $state.note_status("error"); // TODO: We're losing the error count this way...
+    // $state.note_status("warn"); // TODO: We're losing the warn count this way...
+    use log::warn;
     warn!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
   }};
   ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr) => {{
-    $state.note_status("error");
+    $state.note_status("warn");
+    use log::warn;
     warn!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1))
   }};
  ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr, $($details:expr),*) => {{
-    $state.note_status("error");
+    $state.note_status("warn");
+    use log::warn;
     warn!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
   }}
 }
@@ -48,18 +98,22 @@ macro_rules! Warn {
 macro_rules! Error {
   ($category:expr, $object:expr, $where:ident, None, $message:expr) => {{
     // $state.note_status("error"); // TODO: We're losing the error count this way...
+    use log::error;
     error!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1))
   }};
  ($category:expr, $object:expr, $where:ident, None, $message:expr, $($details:expr),*) => {{
     // $state.note_status("error"); // TODO: We're losing the error count this way...
+    use log::error;
     error!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
   }};
   ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr) => {{
     $state.note_status("error");
+    use log::error;
     error!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1))
   }};
  ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr, $($details:expr),*) => {{
     $state.note_status("error");
+    use log::error;
     error!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
   }}
 }
@@ -99,10 +153,10 @@ macro_rules! generate_message {
     s!("{}\n\t{}\n\tIn {}:{}:{}\n", $message, $detail, file!(), line!(), column!())
   };
   ($where:ident, $message:expr, $level:literal) => {
-    s!("{}\n\t{}\n\tIn {}:{}:{}\n", $message, &$where.get_location(), file!(), line!(), column!())
+    s!("{}\n\t{}\n\tIn {}:{}:{}\n", $message, $where.get_location(), file!(), line!(), column!())
   };
   ($where:ident, $message:expr, $level:literal, $detail:expr) => {
-    s!("{}\n\t{}\n\t{}\n\tIn {}:{}:{}\n", $message, &$where.get_location(),$detail, file!(), line!(), column!());
+    s!("{}\n\t{}\n\t{}\n\tIn {}:{}:{}\n", $message, $where.get_location(),$detail, file!(), line!(), column!());
   }
 }
 
@@ -220,6 +274,7 @@ impl ErrorTrait for Error {
 impl Error {
   pub fn log_fatal(&self) {
     let target_str = s!("Fatal:{:?}:{:?} ", self.target, self.category);
+    use log::error;
     error!(target: &target_str, "{}", self.message);
   }
 }
@@ -300,16 +355,19 @@ impl From<ParseFloatError> for Error {
 // Progress reporting.
 
 pub fn note_progress(stuff: &str) {
+  use log::info;
   info!(target: "note", "{}", stuff);
 }
 
 // TODO: Rethink this reporting
 pub fn note_progress_detailed(stuff: &str) {
+  use log::debug;
   debug!(target: "note", "{}", stuff);
 }
 
 pub fn note_begin(stage: &str) {
   // $state->assignMapping('NOTE_TIMERS', $stage, [Time::HiRes::gettimeofday]);
+  use log::info;
   info!(target: "note", "\n({}...", stage);
 }
 
@@ -319,5 +377,6 @@ pub fn note_end(_stage: &str) {
 
   // my $elapsed = Time::HiRes::tv_interval($start, [Time::HiRes::gettimeofday]);
   // info!(target: "note", " %.2f sec)", elapsed);
+  use log::info;
   info!(target: "note", " )");
 }

--- a/rtx_core/src/common/error.rs
+++ b/rtx_core/src/common/error.rs
@@ -1,5 +1,5 @@
 use lazy_static::lazy_static;
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use std::collections::HashMap;
 use std::error::Error as ErrorTrait;
 use std::fmt;
@@ -10,6 +10,103 @@ use std::result;
 lazy_static! {
   static ref _NOTE_TIMERS: HashMap<String, String> = HashMap::new();
 }
+
+#[macro_export]
+macro_rules! Info {
+  ($category:literal, $object:expr, $where:ident, $state:ident, $message:expr) => {{
+    $state.note_status("info");
+    info!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1))
+  }};
+  ($category:literal, $object:expr, $where:ident, $state:ident, $message:expr, $($details:expr),*) => {{
+    $state.note_status("info");
+    info!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
+  }}
+}
+
+
+#[macro_export]
+macro_rules! Warn {
+  ($category:expr, $object:expr, $where:ident, None, $message:expr) => {{
+    // $state.note_status("error"); // TODO: We're losing the error count this way...
+    warn!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1))
+  }};
+ ($category:expr, $object:expr, $where:ident, None, $message:expr, $($details:expr),*) => {{
+    // $state.note_status("error"); // TODO: We're losing the error count this way...
+    warn!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
+  }};
+  ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr) => {{
+    $state.note_status("error");
+    warn!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1))
+  }};
+ ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr, $($details:expr),*) => {{
+    $state.note_status("error");
+    warn!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
+  }}
+}
+
+#[macro_export]
+macro_rules! Error {
+  ($category:expr, $object:expr, $where:ident, None, $message:expr) => {{
+    // $state.note_status("error"); // TODO: We're losing the error count this way...
+    error!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1))
+  }};
+ ($category:expr, $object:expr, $where:ident, None, $message:expr, $($details:expr),*) => {{
+    // $state.note_status("error"); // TODO: We're losing the error count this way...
+    error!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
+  }};
+  ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr) => {{
+    $state.note_status("error");
+    error!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1))
+  }};
+ ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr, $($details:expr),*) => {{
+    $state.note_status("error");
+    error!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
+  }}
+}
+
+
+#[macro_export]
+macro_rules! fatal {
+  ($target:tt, $category:tt, $message:expr) => {{
+    use $crate::common::error::Error as RtxError;
+    use $crate::common::error::ErrorCategory::*;
+    use $crate::common::error::ErrorTarget::*;
+    return Err(RtxError {
+      target: $target,
+      category: $category,
+      message: $message.to_string(),
+    });
+  }};
+  ($target:tt, $category:expr, $where: ident, $state: ident, $message:expr) => {{
+    use $crate::common::error::Error as RtxError;
+    use $crate::common::error::ErrorCategory::*;
+    use $crate::common::error::ErrorTarget::*;
+    return Err(RtxError {
+      target: $target,
+      category: $category,
+      message: $message.to_string(),
+    });
+  }};
+
+}
+
+#[macro_export]
+macro_rules! generate_message {
+  (None, $message:expr, $level:literal) => {
+    s!("{}\n\tIn {}:{}:{}\n", $message, file!(), line!(), column!())
+  };
+  (None, $message:expr, $level:literal, $detail:expr) => {
+    s!("{}\n\t{}\n\tIn {}:{}:{}\n", $message, $detail, file!(), line!(), column!())
+  };
+  ($where:ident, $message:expr, $level:literal) => {
+    s!("{}\n\t{}\n\tIn {}:{}:{}\n", $message, &$where.get_location(), file!(), line!(), column!())
+  };
+  ($where:ident, $message:expr, $level:literal, $detail:expr) => {
+    s!("{}\n\t{}\n\t{}\n\tIn {}:{}:{}\n", $message, &$where.get_location(),$detail, file!(), line!(), column!());
+  }
+}
+
+pub type Result<T> = result::Result<T, Error>;
 
 #[derive(Debug)]
 pub struct Error {
@@ -30,10 +127,12 @@ pub enum ErrorCategory {
   MissingFile,
   Malformed,
   Libxml,
+  Convert,
   Recursion,
   EoF,
   Endgroup,
   Generic(Box<ErrorTrait>),
+  Filename(String)
 }
 
 #[derive(Debug)]
@@ -43,6 +142,8 @@ pub enum ErrorTarget {
   ParamSpec,
   Converter,
   Mouth,
+  Core,
+  State,
   Stomach,
   Codegen,
   Macro,
@@ -53,49 +154,6 @@ pub enum ErrorTarget {
   Internal,
   TargetUnexpected,
 }
-
-#[macro_export]
-macro_rules! Info {
-  ($category:literal, $object:expr, $where:ident, $message:literal, $details:expr, $state:ident) => {
-    $state.note_status("info");
-    info!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $details))
-  }
-}
-
-#[macro_export]
-macro_rules! Error {
-  ($category:literal, $object:expr, $where:ident, $message:expr, $state:ident) => {
-    $state.note_status("error");
-    error!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1))
-  }
-}
-
-
-#[macro_export]
-macro_rules! fatal {
-  ($target:tt, $category:tt, $message:expr) => {{
-    use $crate::common::error::Error as RtxError;
-    use $crate::common::error::ErrorCategory::*;
-    use $crate::common::error::ErrorTarget::*;
-    return Err(RtxError {
-      target: $target,
-      category: $category,
-      message: $message.to_string(),
-    });
-  }};
-}
-
-#[macro_export]
-macro_rules! generate_message {
-  ($where:ident, $message:expr, $level:literal) => {
-    s!("{}\n\t{}\n", $message, &$where.get_location())
-  };
-  ($where:ident, $message:expr, $level:literal, $detail:expr) => {
-    s!("{}\n\t{}\n\t{}\n", $message, &$where.get_location(),$detail)
-  }
-}
-
-pub type Result<T> = result::Result<T, Error>;
 
 impl fmt::Display for Error {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -117,8 +175,10 @@ impl fmt::Display for Error {
       Libxml => write!(f, "libxml error"),
       Recursion => write!(f, "<recursion>"),
       EoF => write!(f, "<EOF>"),
+      Convert => write!(f, "conversion"),
       Endgroup => write!(f, "<endgroup>"),
       Generic(ref err) => err.fmt(f),
+      Filename(ref name) => write!(f, "file:{}", name)
     }
   }
 }
@@ -129,6 +189,7 @@ impl ErrorTrait for Error {
     match self.category {
       Init => "initialization failed",
       Io(ref err) => err.description(),
+      Convert => "conversion",
       MissingFile => "missing file",
       NotFound => "not found",
       Misdefined => "misdefined",
@@ -141,6 +202,7 @@ impl ErrorTrait for Error {
       EoF => "<EOF>",
       Endgroup => "<endgroup>",
       Generic(ref err) => err.description(),
+      Filename(ref name) => name
     }
   }
 

--- a/rtx_core/src/common/glue.rs
+++ b/rtx_core/src/common/glue.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use lazy_static::lazy_static;
 use regex::Regex;
 
@@ -15,14 +16,13 @@ pub enum FillCode {
   Filll,
 }
 
-impl ToString for FillCode {
-  fn to_string(&self) -> String {
+impl fmt::Display for FillCode {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
-      FillCode::Fil => "fil",
-      FillCode::Fill => "fill",
-      FillCode::Filll => "filll",
+      FillCode::Fil => write!(f, "fil"),
+      FillCode::Fill => write!(f, "fill"),
+      FillCode::Filll => write!(f, "filll"),
     }
-    .to_string()
   }
 }
 
@@ -160,32 +160,31 @@ impl NumericOps for MuGlue {
   fn register_type(&self) -> RegisterType { RegisterType::MuGlue }
 }
 
-impl ToString for Glue {
-  fn to_string(&self) -> String {
+impl fmt::Display for Glue {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     // my ($sp, $plus, $pfill, $minus, $mfill) = @$self;
-    let mut formatted = Dimension::point_format(self.skip);
+    write!(f, "{}", Dimension::point_format(self.skip))?;
     if let Some(plus) = self.plus {
       if plus != 0.0 {
-        formatted += " plus ";
-        formatted += &(if let Some(pfill) = self.pfill {
-          plus.to_string() + &pfill.to_string()
+        write!(f, " plus ")?;
+        if let Some(pfill) = self.pfill {
+          write!(f, "{}{}", plus, pfill)?;
         } else {
-          Dimension::point_format(plus)
-        });
+          write!(f,"{}", Dimension::point_format(plus))?;
+        };
       }
     }
     if let Some(minus) = self.minus {
       if minus != 0.0 {
-        formatted += " minus ";
-        formatted += &(if let Some(mfill) = self.mfill {
-          minus.to_string() + &mfill.to_string()
+        write!(f, " minus ")?;
+        if let Some(mfill) = self.mfill {
+          write!(f,"{}{}", minus, mfill)?;
         } else {
-          Dimension::point_format(minus)
-        })
+          write!(f,"{}",Dimension::point_format(minus))?;
+        }
       }
     }
-
-    formatted
+    Ok(())
   }
 }
 

--- a/rtx_core/src/common/locator.rs
+++ b/rtx_core/src/common/locator.rs
@@ -1,14 +1,172 @@
+use crate::util::pathname;
+use crate::common::object::Object;
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Locator {
-  from: String,
-  to: String,
+  source: String,
+  from_line: usize,
+  to_line: usize,
+  from_column: usize,
+  to_column: usize
 }
 
 impl Default for Locator {
   fn default() -> Self {
     Locator {
-      from: String::new(),
-      to: String::new(),
+      source: String::new(),
+      from_line: 0,
+      to_line: 0,
+      from_column: 0,
+      to_column: 0,
     }
+  }
+}
+
+impl ToString for Locator {
+  fn to_string(&self) -> String {
+    let mut loc = self.get_short_source("");
+    if self.from_line > 0 {
+      loc.push_str(&s!("; line {}", self.from_line));
+      if self.from_column > 0 {
+        loc.push_str(&s!(" col {}",self.from_column));
+      }
+    }
+    if self.to_line > 0 {
+      loc.push_str(&s!(" - line {}", self.to_line));
+      if self.to_column > 0 {
+        loc.push_str(&s!(" col {}", self.to_column));
+      }
+    }
+    loc
+  }
+}
+
+impl Locator {
+  pub fn new(source: String, from_line: usize, from_column: usize, to_line: usize, to_column: usize) -> Self {
+    Locator {
+      source,
+      from_line,
+      from_column,
+      to_line,
+      to_column,
+    }
+  }
+
+  /// creates a new locator range from a given start and end
+  pub fn new_range(from: Locator, to: Locator) -> Option<Locator> {
+    // make sure that either parameters are defined
+    // bail if we have different sources
+    if from.source != to.source {
+      return None;
+    }
+    // the end coordinates depend on
+    let (to_line,to_column) = if to.is_range() {
+      (to.to_line, to.to_column)
+    } else {
+      (to.from_line, to.from_column)
+    };
+    Some(Locator::new(from.source, from.from_line, from.from_column, to_line, to_column))
+  }
+
+  pub fn is_range(&self) -> bool {
+    self.to_line > 0 || self.to_column > 0
+  }
+
+  pub fn get_short_source(&self, string_source: &str) -> String {
+    if self.source.is_empty() {
+      if string_source.is_empty() {
+        "String".to_string()
+      } else {
+        string_source.to_string()
+      }
+    } else {
+      if self.source.contains(":") {
+        let (base, ext) = pathname::url_split(&self.source);
+        s!("{}.{}",base,ext)
+      } else {
+        let (path, base, ext) = pathname::split(&self.source);
+        s!("{}.{}",base,ext)
+      }
+    }
+  }
+  pub fn get_source(&self) -> &str {
+    &self.source
+  }
+
+  pub fn get_from_locator(&self) -> Locator { 
+    Locator {
+      source: self.source.clone(),
+      from_line: self.from_line,
+      from_column: self.from_column,
+      .. Locator::default()
+    }
+  }
+
+  pub fn get_to_locator(&self) -> Locator { 
+    Locator {
+      source: self.source.clone(),
+      from_line: self.to_line,
+      from_column: self.to_column,
+      ..Locator::default()
+    }
+  }
+}
+impl Object for Locator {
+
+  fn stringify(&self) -> String {
+    let mut loc = if self.source.is_empty() { "Anonymous String".to_string() } else { self.source.to_string() };
+    let range_from = if self.is_range() {" from"} else {""};
+    if self.from_line > 0 {
+      loc.push_str(&s!(";{} line {}", range_from, self.from_line));
+      if self.from_column > 0 {
+        loc.push_str(&s!(" col {}", self.from_column));
+      }
+    }
+    if self.to_line > 0 {
+      loc.push_str(&s!(" to line {}", self.to_line));
+      if self.to_column > 0 {
+        loc.push_str(&s!(" col {}", self.to_column));
+      }
+    }
+    loc
+  }
+
+  fn to_attribute(&self) -> String {
+    let mut loc = self.get_short_source("anonymous_string") + "#text";
+    if self.is_range() {
+      loc.push_str(&s!("range(from='"));
+      // if self.from_line > 0 {
+        loc.push_str(&self.from_line.to_string());
+      // }
+      // if self.from_column > 0 {
+        loc.push(';');
+        loc.push_str(&self.from_column.to_string());
+      // }
+      loc.push_str(",to='");
+      // if self.to_line > 0 {
+        loc.push_str(&self.to_line.to_string());
+      // }
+      // if self.to_column > 0 {
+        loc.push(';');
+        loc.push_str(&self.to_column.to_string());
+      // }
+      loc.push_str(")'");
+   } else {
+      loc.push_str("point('");
+      // if self.from_line > 0 {
+      loc.push_str(&self.from_line.to_string());
+      // }
+      // if self.from_column > 0 {
+      loc.push(';');
+      loc.push_str(&self.from_column.to_string());
+      // }
+      loc.push_str(")'");
+   }
+   loc
+  }
+
+  /// getting the locator of a locator should return itself
+  fn get_locator(&self) -> &Locator {
+    &self
   }
 }

--- a/rtx_core/src/common/locator.rs
+++ b/rtx_core/src/common/locator.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::borrow::Cow;
+use log::warn;
 use crate::util::pathname;
 use crate::common::object::Object;
 
@@ -97,7 +98,7 @@ impl Locator {
         s!("{}.{}",base,ext)
       } else {
         let (path, base, ext) = pathname::split(&self.source);
-        s!("{}.{}",base,ext)
+        base
       }
     }
   }

--- a/rtx_core/src/common/locator.rs
+++ b/rtx_core/src/common/locator.rs
@@ -1,6 +1,5 @@
 use std::fmt;
 use std::borrow::Cow;
-use log::warn;
 use crate::util::pathname;
 use crate::common::object::Object;
 

--- a/rtx_core/src/common/locator.rs
+++ b/rtx_core/src/common/locator.rs
@@ -1,6 +1,17 @@
+use std::fmt;
 use std::borrow::Cow;
 use crate::util::pathname;
 use crate::common::object::Object;
+
+// TODO: This will require a large refactor, but 
+// switching the source from an owned String to a &str reference
+// could provide a noticeable performance (and memory allocation) boost
+// (and especially if we also start adding locators to tokens)
+// my current thoughts are that we can have the core/gullet own the sources of all mouths
+// so that we can borrow them with the lifetime of the main convert_document loop... 
+// that's harder than it sounds, I've already tried unsuccessfully with the Token contents,
+// but the mouth sources should be easier to manage.
+// definitely something that can be tried after test milestone is achieved.
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Locator {
@@ -23,22 +34,22 @@ impl Default for Locator {
   }
 }
 
-impl ToString for Locator {
-  fn to_string(&self) -> String {
-    let mut loc = self.get_short_source("");
+impl fmt::Display for Locator {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(f, "{}", self.get_short_source(""))?;
     if self.from_line > 0 {
-      loc.push_str(&s!("; line {}", self.from_line));
+      write!(f, "; line {}", self.from_line)?;
       if self.from_column > 0 {
-        loc.push_str(&s!(" col {}",self.from_column));
+        write!(f, " col {}",self.from_column)?;
       }
     }
     if self.to_line > 0 {
-      loc.push_str(&s!(" - line {}", self.to_line));
+      write!(f, " - line {}", self.to_line)?;
       if self.to_column > 0 {
-        loc.push_str(&s!(" col {}", self.to_column));
+        write!(f, " col {}", self.to_column)?;
       }
     }
-    loc
+    Ok(())
   }
 }
 

--- a/rtx_core/src/common/locator.rs
+++ b/rtx_core/src/common/locator.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use crate::util::pathname;
 use crate::common::object::Object;
 
@@ -166,7 +167,7 @@ impl Object for Locator {
   }
 
   /// getting the locator of a locator should return itself
-  fn get_locator(&self) -> &Locator {
-    &self
+  fn get_locator(&self) -> Cow<Locator> {
+    Cow::Borrowed(self)
   }
 }

--- a/rtx_core/src/common/model.rs
+++ b/rtx_core/src/common/model.rs
@@ -8,6 +8,7 @@ use std::io::BufReader;
 use std::string::ToString;
 
 use crate::common::error::*;
+use crate::common::object::Object;
 use crate::common::relaxng::Relaxng;
 use crate::common::xml::{XPath, XML_NS};
 use crate::document::Document;
@@ -78,6 +79,7 @@ impl Default for Model {
   }
 }
 
+impl Object for Model {}
 impl Model {
   pub fn new() -> Self {
     let mut model = Model::default();
@@ -106,7 +108,7 @@ impl Model {
     let mut name = String::new();
     if self.schema_data.is_none() {
       // TODO: Return this code path to normal once we properly load schemas
-      warn!(target: "expected:<model>", "TODO");
+      Warn!("expected", "<model>", None, None, "TODO");
       // Warn('expected', '<model>', undef, "No Schema Model has been declared; assuming LaTeXML");
       // // article ??? or what ? undef gives problems!
 
@@ -142,7 +144,10 @@ impl Model {
               ..Relaxng::default()
             });
           },
-          e => error!(target:"unknown:schematype", "Can't load a schema of type {:?}", e),
+          e => { 
+            let message = s!("Can't load a schema of type {:?}", e);
+            Error!("unknown", "schematype", self, None, message)
+          }
         };
       },
     };
@@ -278,10 +283,8 @@ impl Model {
       self.namespace_errors += 1;
       docprefix = Some(s!("namespace{}", &self.namespace_errors.to_string()));
       self.register_document_namespace(docprefix.as_ref().unwrap(), Some(namespace.to_string()));
-      warn!(target: &s!("malformed:{}", namespace), "No prefix has been registered for namespace.");
-      // Warn('malformed', $namespace, undef,
-      // "No prefix has been registered for namespace '$namespace' (in document)",
-      // "Using '$docprefix' instead"); }
+      let message2 = if let Some(ref dp) = docprefix { s!("Using '{}' instead", dp) } else { String::from("No prefix to fall back on.") };
+      Warn!("malformed", namespace, self, None, "No prefix has been registered for namespace (in document)", message2);
     }
     match docprefix {
       None => None,
@@ -314,10 +317,9 @@ impl Model {
       self.namespace_errors += 1;
       let ns_error = s!("http://example.com/namespace{}", &self.namespace_errors.to_string());
       self.register_document_namespace(docprefix, Some(ns_error));
-      error!(target: &s!("malformed:{}", docprefix), "No namespace has been registered for prefix.");
-      // Error('malformed', $docprefix, undef,
-      //   "No namespace has been registered for prefix '$docprefix' (in document)",
-      //   "Using '$ns' instead"); }
+      let msg1 = s!("No namespace has been registered for prefix '{}' (in document)", docprefix);
+      let msg2 = s!("Using '{}' instead", ns_str);
+      Error!("malformed", docprefix, self, None, msg1, msg2);
     }
     if ns_str.is_empty() {
       None
@@ -379,9 +381,9 @@ impl Model {
       let example_namespace = s!("http://example.com/namespace{}", &self.namespace_errors.to_string());
       ns = Some(example_namespace.clone());
       self.register_namespace(codeprefix, Some(example_namespace));
-      // Error!('malformed', $codeprefix, undef,
-      //   "No namespace has been registered for prefix '$codeprefix' (in code)",
-      //   "Using '$ns' isntead");
+      Error!("malformed", codeprefix, self, None,
+      "No namespace has been registered for prefix '$codeprefix' (in code)",
+      "Using '$ns' isntead");
     }
     match ns {
       None => None,

--- a/rtx_core/src/common/model.rs
+++ b/rtx_core/src/common/model.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use log::*;
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;

--- a/rtx_core/src/common/object.rs
+++ b/rtx_core/src/common/object.rs
@@ -1,6 +1,7 @@
 ///======================================================================
 /// Exported generic functions for dealing with `LaTeXML`'s objects
 ///======================================================================
+use std::borrow::Cow;
 use crate::common::error::*;
 use crate::common::locator::Locator;
 use crate::document::Document;
@@ -46,7 +47,7 @@ pub trait Object {
   fn be_digested(&self) -> Result<Tbox> { Ok(Tbox::default()) }
 
   fn be_absorbed(&self, _document: Document) { unimplemented!() }
-  fn get_locator(&self) -> &Locator { unimplemented!(); }
+  fn get_locator(&self) -> Cow<Locator> { unimplemented!(); }
 
   fn unlist<T>(&self) -> Vec<T>
   where Self: Sized {

--- a/rtx_core/src/common/object.rs
+++ b/rtx_core/src/common/object.rs
@@ -45,6 +45,14 @@ pub trait Object {
 
   // fn be_absorbed(&self, _document: Document) { unimplemented!() }
   fn get_locator(&self) -> Cow<Locator> { unimplemented!(); }
+  fn get_location(&self) -> String {
+    let loc = self.get_locator();
+    if *loc == Locator::default() {
+      String::new() 
+    } else {
+      s!("at {}", loc)
+    }
+  }
 
   // fn unlist<T>(&self) -> Vec<T>
   // where Self: Sized {

--- a/rtx_core/src/common/object.rs
+++ b/rtx_core/src/common/object.rs
@@ -4,7 +4,6 @@
 use std::borrow::Cow;
 use crate::common::error::*;
 use crate::common::locator::Locator;
-use crate::document::Document;
 use crate::tbox::Tbox;
 
 // ======================================================================
@@ -16,9 +15,7 @@ use crate::tbox::Tbox;
 // try to have stringify do too much.
 // ======================================================================
 pub trait Object {
-  fn stringify(&self) -> String { unimplemented!() }
-
-  fn to_string(&self) -> String { unimplemented!() }
+  fn stringify(&self) -> String;
 
   // Since the next two are used in debugging and error messages,
   // be careful to avoid recursive errors
@@ -46,11 +43,11 @@ pub trait Object {
   // Defaults (probably poor)
   fn be_digested(&self) -> Result<Tbox> { Ok(Tbox::default()) }
 
-  fn be_absorbed(&self, _document: Document) { unimplemented!() }
+  // fn be_absorbed(&self, _document: Document) { unimplemented!() }
   fn get_locator(&self) -> Cow<Locator> { unimplemented!(); }
 
-  fn unlist<T>(&self) -> Vec<T>
-  where Self: Sized {
-    unimplemented!()
-  }
+  // fn unlist<T>(&self) -> Vec<T>
+  // where Self: Sized {
+  //   unimplemented!()
+  // }
 }

--- a/rtx_core/src/common/object.rs
+++ b/rtx_core/src/common/object.rs
@@ -15,7 +15,7 @@ use crate::tbox::Tbox;
 // try to have stringify do too much.
 // ======================================================================
 pub trait Object {
-  fn stringify(&self) -> String;
+  fn stringify(&self) -> String { unimplemented!(); }
 
   // Since the next two are used in debugging and error messages,
   // be careful to avoid recursive errors

--- a/rtx_core/src/common/object.rs
+++ b/rtx_core/src/common/object.rs
@@ -2,6 +2,7 @@
 /// Exported generic functions for dealing with `LaTeXML`'s objects
 ///======================================================================
 use crate::common::error::*;
+use crate::common::locator::Locator;
 use crate::document::Document;
 use crate::tbox::Tbox;
 
@@ -45,6 +46,7 @@ pub trait Object {
   fn be_digested(&self) -> Result<Tbox> { Ok(Tbox::default()) }
 
   fn be_absorbed(&self, _document: Document) { unimplemented!() }
+  fn get_locator(&self) -> &Locator { unimplemented!(); }
 
   fn unlist<T>(&self) -> Vec<T>
   where Self: Sized {

--- a/rtx_core/src/common/store.rs
+++ b/rtx_core/src/common/store.rs
@@ -18,7 +18,7 @@ use crate::definition::expandable::Expandable;
 use crate::definition::math_primitive::MathPrimitive; //MathPrimitiveOptions
 use crate::definition::primitive::Primitive;
 use crate::definition::register::NumericOps;
-use crate::definition::register::{Register, RegisterValue};
+use crate::definition::register::{Register, RegisterValue, RegisterCell};
 use crate::document::tag::TagData;
 use crate::gullet::Gullet;
 use crate::list::List;
@@ -84,7 +84,7 @@ pub enum Stored {
   Primitive(Rc<Primitive>),
   MathPrimitive(Rc<MathPrimitive>),
   // WALL OF SHAME (interior mutability)
-  Register(Rc<RefCell<Register>>),
+  Register(Rc<RegisterCell>),
   IfFrame(Rc<RefCell<IfFrame>>),
   /////// MathPrimitiveOptions(MathPrimitiveOptions), // Maybe later
   Constructor(Rc<Constructor>),
@@ -270,11 +270,11 @@ impl From<Rc<Font>> for Stored {
   fn from(font: Rc<Font>) -> Self { Stored::Font(font) }
 }
 
-impl From<Rc<RefCell<Register>>> for Stored {
-  fn from(register: Rc<RefCell<Register>>) -> Self { Stored::Register(register) }
+impl From<Rc<RegisterCell>> for Stored {
+  fn from(register: Rc<RegisterCell>) -> Self { Stored::Register(register) }
 }
 impl From<Register> for Stored {
-  fn from(register: Register) -> Self { Rc::new(RefCell::new(register)).into() }
+  fn from(register: Register) -> Self { Rc::new(RegisterCell::new(RefCell::new(register))).into() }
 }
 
 impl From<Font> for Stored {
@@ -447,8 +447,8 @@ impl<'a> From<&'a Stored> for Option<Tokens> {
   }
 }
 
-impl<'a> From<&'a Stored> for Option<Rc<RefCell<Register>>> {
-  fn from(value: &'a Stored) -> Option<Rc<RefCell<Register>>> {
+impl<'a> From<&'a Stored> for Option<Rc<RegisterCell>> {
+  fn from(value: &'a Stored) -> Option<Rc<RegisterCell>> {
     match value {
       Stored::Register(ref reg) => Some(reg.clone()),
       _ => None,

--- a/rtx_core/src/common/store.rs
+++ b/rtx_core/src/common/store.rs
@@ -11,6 +11,7 @@ use crate::common::font::Font;
 use crate::common::glue::{Glue, MuGlue};
 use crate::common::ligature::Ligature;
 use crate::common::number::Number;
+use crate::common::locator::Locator;
 use crate::definition::conditional::{Conditional, IfFrame};
 use crate::definition::constructor::Constructor;
 use crate::definition::expandable::Expandable;
@@ -76,6 +77,7 @@ pub enum Stored {
   MuGlue(MuGlue),
   Dimension(Dimension),
   MuDimension(MuDimension),
+  Locator(Locator),
   // LaTeXML objects (Rc-wrapped)
   Expandable(Rc<Expandable>),
   Conditional(Rc<Conditional>),
@@ -104,6 +106,7 @@ impl fmt::Debug for Stored {
       Bool(ref b) => write!(f, "Stored::Bool[{:?}]", b),
       Token(ref t) => write!(f, "Stored::Token[{:?}]", t),
       Tokens(ref t) => write!(f, "Stored::Tokens[{:?}]", t),
+      Locator(ref t) => write!(f, "Stored::Locator[{:?}]", t),
       Catcode(ref cc) => write!(f, "Stored::Catcode[{:?}]", cc),
       Charcode(ref cc) => write!(f, "Stored::Charcode[{:?}]", cc),
       IfFrame(ref fr) => write!(f, "Stored::IfFrame[{:?}]", fr),
@@ -205,6 +208,10 @@ impl From<Token> for Stored {
 
 impl From<Tokens> for Stored {
   fn from(value: Tokens) -> Self { Stored::Tokens(value) }
+}
+
+impl From<Locator> for Stored {
+  fn from(value: Locator) -> Self { Stored::Locator(value) }
 }
 
 impl From<Rc<Expandable>> for Stored {

--- a/rtx_core/src/common/store.rs
+++ b/rtx_core/src/common/store.rs
@@ -1,4 +1,3 @@
-use log::warn;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
@@ -517,7 +516,8 @@ impl<'a> From<&'a Stored> for Token {
       Stored::Token(t) => (*t).clone(),
       Stored::String(t) => T_CS!(t),
       t => {
-        warn!(target:"Stored:cast", "dangerous cast to CS for {:?}", t);
+        let message = s!("dangerous cast to CS for {:?}", t);
+        Warn!("Stored", "cast", None, None, message);
         T_CS!(t.to_string())
       }, /* TODO, is this the right place to default to CS? Do we need a
           * custom method instead? */

--- a/rtx_core/src/common/xml.rs
+++ b/rtx_core/src/common/xml.rs
@@ -20,7 +20,10 @@ impl XPath {
   pub fn register_namespace(&mut self, codeprefix: &str, namespace: &str) {
     match self.context.register_namespace(codeprefix, namespace) {
       Ok(()) => {},
-      Err(_) => error!(target: "expected:XPath", "Failed to register an XPath namespace: prefix {:?} and href {:?}", codeprefix, namespace),
+      Err(_) => {
+        let message = s!("Failed to register an XPath namespace: prefix {:?} and href {:?}", codeprefix, namespace);
+        Error!("expected","XPath", None, None, message);
+      },
     };
   }
 
@@ -28,7 +31,8 @@ impl XPath {
     match self.context.findnodes(xpath, node) {
       Ok(nodes) => nodes,
       Err(e) => {
-        error!(target: "xpath:findnodes", "{:?}", e);
+        let message = s!("{:?}",e);
+        Error!("xpath","findnodes", None, None, message);
         Vec::new()
       },
     }

--- a/rtx_core/src/common/xml.rs
+++ b/rtx_core/src/common/xml.rs
@@ -1,6 +1,5 @@
 use libxml::tree::{Document, Node, NodeType};
 use libxml::xpath::Context;
-use log::error;
 use std::collections::HashMap;
 
 pub const XMLNS_NS: &str = "http://www.w3.org/2000/xmlns/";

--- a/rtx_core/src/definition/conditional.rs
+++ b/rtx_core/src/definition/conditional.rs
@@ -2,6 +2,7 @@ use log::*;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::fmt;
 
 use crate::common::error::*;
 use crate::common::locator::Locator;
@@ -86,8 +87,12 @@ impl PartialEq for Conditional {
   fn eq(&self, other: &Conditional) -> bool { self.cs == other.cs }
 }
 
+impl fmt::Display for Conditional {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { unimplemented!(); }
+}
 impl Object for Conditional {
   fn is_expandable(&self) -> bool { true }
+  fn stringify(&self) -> String { unimplemented!(); }
 }
 impl Definition for Conditional {
   // sub new {
@@ -150,7 +155,7 @@ impl Conditional {
     state.assign_value("if_count", ifid, Some(Scope::Global));
     let if_frame = Rc::new(RefCell::new(IfFrame {
       token: Rc::clone(state.current_token.as_ref().unwrap()),
-      start: gullet.get_locator(),
+      start: gullet.get_locator().into_owned(),
       parsing: true,
       elses: false,
       ifid,

--- a/rtx_core/src/definition/conditional.rs
+++ b/rtx_core/src/definition/conditional.rs
@@ -114,10 +114,8 @@ impl Definition for Conditional {
       Or => self.invoke_else(gullet, state),
       Fi => self.invoke_fi(gullet, state),
       _ => {
-        error!(
-          target: &s!("unexpected:{}", self.cs), //$gullet,
-          "Unknown conditional control sequence {:?}", state.current_token
-        );
+        let message = s!("Unknown conditional control sequence {}", state.current_token.as_ref().unwrap().stringify());
+        Error!("unexpected", self.cs, gullet, state, message);
         Ok(Tokens!())
       },
     }
@@ -280,7 +278,7 @@ impl Conditional {
         },
       };
     }
-    error!(target: "expected:\\fi", "Missing \\fi or \\else, conditional fell off end");
+    Error!("expected","\\fi", self, state, "Missing \\fi or \\else, conditional fell off end");
     Tokens!()
   }
 
@@ -301,14 +299,14 @@ impl Conditional {
         Ok(Tokens!(T_CS!("\\relax"), (**local_token).clone()))
       } else if stack_frame.borrow().elses {
         // Already seen an \else's at this level?
-        error!(
-          target: &s!("unexpected:{:?}", local_token),
-          "Extra {:?} already saw \\else for {:?} [{:?}] at {:?}",
-          local_token,
+        let message = s!("Extra {} already saw \\else for {:?} [{:?}] at {:?}",
+          local_token.stringify(),
           stack_frame.borrow().token,
           stack_frame.borrow().ifid,
           stack_frame.borrow().start
         );
+        let local_token_str = local_token.to_string();
+        Error!("unexpected", local_token_str, gullet, state, message);
         Ok(Tokens!())
       } else {
         state.if_frame = Some(Rc::clone(&stack_frame));
@@ -321,15 +319,14 @@ impl Conditional {
       }
     } else {
       // No if stack entry ?
-      error!(
-        target: &s!("unexpected:{:?}", local_token),
-        "Didn't expect a {:?} since we seem not to be in a conditional", local_token
-      );
+      let message = s!("Didn't expect a {:?} since we seem not to be in a conditional", local_token.stringify());
+      let local_token_str = local_token.to_string();
+      Error!("unexpected", local_token_str, gullet, state, message);
       Ok(Tokens!())
     }
   }
 
-  pub fn invoke_fi(&self, _gullet: &mut Gullet, state: &mut State) -> Result<Tokens> {
+  pub fn invoke_fi(&self, gullet: &mut Gullet, state: &mut State) -> Result<Tokens> {
     let stack_frame_opt: Option<Rc<RefCell<IfFrame>>> = if let Some(Stored::VecDequeStored(ref stack)) = state.lookup_value("if_stack") {
       if let Some(Stored::IfFrame(frame)) = stack.front() {
         Some(Rc::clone(frame))
@@ -355,7 +352,8 @@ impl Conditional {
         Ok(Tokens!())
       }
     } else {
-      error!(target: "unexpected:fi",  "Didn't expect a {:?} since we seem not to be in a conditional", state.current_token);
+      let message = s!("Didn't expect a {:?} since we seem not to be in a conditional", state.current_token.as_ref().unwrap().stringify());
+      Error!("unexpected","fi", gullet, state, message);
       Ok(Tokens!())
     }
   }

--- a/rtx_core/src/definition/conditional.rs
+++ b/rtx_core/src/definition/conditional.rs
@@ -122,7 +122,6 @@ impl Definition for Conditional {
   fn get_cs(&self) -> Cow<Token> { Cow::Borrowed(&self.cs) }
   fn get_cs_name(&self) -> Cow<str> { Cow::Borrowed(self.cs.get_cs_name()) }
   fn get_alias(&self) -> Option<&String> { None }
-  fn get_locator(&self) -> String { String::from("Locator is TODO") }
 
   // Not implemented for expandable
   fn invoke_primitive(&self, _gullet: &mut Stomach, _caller: Rc<Definition>, _state: &mut State) -> Result<Vec<Digested>> { unimplemented!() }

--- a/rtx_core/src/definition/conditional.rs
+++ b/rtx_core/src/definition/conditional.rs
@@ -1,4 +1,3 @@
-use log::*;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -170,12 +169,12 @@ impl Conditional {
     if let Some(ref test) = self.test {
       if (test)(gullet, args, state)? {
         if tracing {
-          debug!("{{true}}\n");
+          Debug!("{{true}}\n");
         }
       } else {
         let to = self.skip_conditional_body(-1.0, gullet, state);
         if tracing { 
-          debug!("{{false}} [skipped to {:?}]\n", to);
+          Debug!("{{false}} [skipped to {:?}]\n", to);
         }
       }
     } else {

--- a/rtx_core/src/definition/constructor.rs
+++ b/rtx_core/src/definition/constructor.rs
@@ -1,4 +1,3 @@
-use log::debug;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -128,7 +127,7 @@ impl Definition for Constructor {
   /// Digest the constructor; This should occur in the Stomach to create a Whatsit.
   /// The whatsit which will be further processed to create the document.
   fn invoke_primitive(&self, stomach: &mut Stomach, caller: Rc<Definition>, state: &mut State) -> Result<Vec<Digested>> {
-    debug!(target: "constructor", "invoke for {:?}", self.get_cs());
+    Debug!("invoke for {:?}", self.get_cs());
     // Call any `Before' code.
     // TODO: profiling / tracing
     // let profiled = state.lookup_value("PROFILING") && ($LaTeXML::CURRENT_TOKEN || $$self{cs});

--- a/rtx_core/src/definition/constructor.rs
+++ b/rtx_core/src/definition/constructor.rs
@@ -2,6 +2,7 @@ use log::debug;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::rc::Rc;
+use std::fmt;
 
 use crate::common::error::*;
 use crate::common::font::Font;
@@ -112,7 +113,12 @@ impl PartialEq for Constructor {
   fn eq(&self, other: &Constructor) -> bool { self.cs == other.cs }
 }
 
-impl Object for Constructor {}
+impl fmt::Display for Constructor {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { unimplemented!(); }
+}
+impl Object for Constructor {
+  fn stringify(&self) -> String { unimplemented!(); }
+}
 impl Definition for Constructor {
   fn before_digest(&self) -> Option<&Vec<BeforeDigestClosure>> { Some(&self.before_digest) }
   fn after_digest(&self) -> Option<&Vec<DigestionClosure>> { Some(&self.after_digest) }

--- a/rtx_core/src/definition/constructor.rs
+++ b/rtx_core/src/definition/constructor.rs
@@ -200,7 +200,6 @@ impl Definition for Constructor {
   fn get_cs(&self) -> Cow<Token> { Cow::Borrowed(&self.cs) }
   fn get_cs_name(&self) -> Cow<str> { Cow::Borrowed(self.cs.get_cs_name()) }
   fn get_alias(&self) -> Option<&String> { self.alias.as_ref() }
-  fn get_locator(&self) -> String { unimplemented!() }
   fn get_parameters(&self) -> Option<&Parameters> { self.paramlist.as_ref() }
   fn get_num_args(&self) -> usize {
     match self.nargs {

--- a/rtx_core/src/definition/expandable.rs
+++ b/rtx_core/src/definition/expandable.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 
 use crate::common::error::*;
 use crate::common::object::Object;
+use crate::common::locator::Locator;
 use crate::state::{Scope, State};
 
 use crate::definition::{BeforeDigestClosure, Definition, DigestionClosure, ExpansionBody};
@@ -43,7 +44,7 @@ pub struct Expandable {
   pub is_long: bool,
   pub is_outer: bool,
   pub alias: Option<String>,
-  pub locator: String,
+  pub locator: Locator,
   pub cs: Token,
   pub paramlist: Option<Parameters>,
   pub expansion: Option<ExpansionBody>,
@@ -57,7 +58,7 @@ impl Default for Expandable {
       is_outer: false,
       trivial_expansion: None,
       alias: None,
-      locator: String::new(),
+      locator: Locator::default(),
       cs: T_CS!("Expandable"),
       paramlist: None,
       expansion: None,
@@ -71,6 +72,7 @@ impl PartialEq for Expandable {
 impl Object for Expandable {
   fn is_definition(&self) -> bool { true }
   fn is_expandable(&self) -> bool { true }
+  fn get_locator(&self) -> Cow<Locator> { Cow::Borrowed(&self.locator) }
 }
 impl Definition for Expandable {
   fn is_protected(&self) -> bool { self.is_protected }
@@ -83,8 +85,6 @@ impl Definition for Expandable {
     })
   }
   fn get_alias(&self) -> Option<&String> { self.alias.as_ref() }
-  fn get_locator(&self) -> String { self.locator.clone() }
-
   fn invoke(&self, gullet: &mut Gullet, state: &mut State) -> Result<Tokens> {
     // Expand the expandable control sequence. This should be carried out by the Gullet.
     // log!("-- expandable invoke for {:?}", self.get_cs());

--- a/rtx_core/src/definition/expandable.rs
+++ b/rtx_core/src/definition/expandable.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::rc::Rc;
+use std::fmt;
 
 use crate::common::error::*;
 use crate::common::object::Object;
@@ -69,10 +70,14 @@ impl PartialEq for Expandable {
   fn eq(&self, other: &Expandable) -> bool { self.cs == other.cs }
 }
 
+impl fmt::Display for Expandable {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { unimplemented!(); }
+}
 impl Object for Expandable {
   fn is_definition(&self) -> bool { true }
   fn is_expandable(&self) -> bool { true }
   fn get_locator(&self) -> Cow<Locator> { Cow::Borrowed(&self.locator) }
+  fn stringify(&self) -> String { unimplemented!(); }
 }
 impl Definition for Expandable {
   fn is_protected(&self) -> bool { self.is_protected }

--- a/rtx_core/src/definition/math_primitive.rs
+++ b/rtx_core/src/definition/math_primitive.rs
@@ -212,7 +212,6 @@ impl Definition for MathPrimitive {
   fn get_cs(&self) -> Cow<Token> { Cow::Borrowed(&self.cs) }
   fn get_cs_name(&self) -> Cow<str> { Cow::Borrowed(self.cs.get_cs_name()) }
   fn get_alias(&self) -> Option<&String> { self.alias.as_ref() }
-  fn get_locator(&self) -> String { unimplemented!() }
   fn get_parameters(&self) -> Option<&Parameters> { self.paramlist.as_ref() }
   fn get_num_args(&self) -> usize {
     match self.nargs {

--- a/rtx_core/src/definition/math_primitive.rs
+++ b/rtx_core/src/definition/math_primitive.rs
@@ -2,6 +2,7 @@ use log::info;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::rc::Rc;
+use std::fmt;
 
 use crate::common::error::*;
 use crate::common::font::Font;
@@ -177,7 +178,12 @@ impl PartialEq for MathPrimitive {
   fn eq(&self, other: &MathPrimitive) -> bool { self.cs == other.cs }
 }
 
-impl Object for MathPrimitive {}
+impl fmt::Display for MathPrimitive {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { unimplemented!(); }
+}
+impl Object for MathPrimitive {
+  fn stringify(&self) -> String { unimplemented!(); }
+}
 impl Definition for MathPrimitive {
   fn before_digest(&self) -> Option<&Vec<BeforeDigestClosure>> { Some(&self.options.before_digest) }
   fn after_digest(&self) -> Option<&Vec<DigestionClosure>> { Some(&self.options.after_digest) }

--- a/rtx_core/src/definition/math_primitive.rs
+++ b/rtx_core/src/definition/math_primitive.rs
@@ -1,4 +1,3 @@
-use log::info;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -190,7 +189,7 @@ impl Definition for MathPrimitive {
 
   fn invoke(&self, _gullet: &mut Gullet, _state: &mut State) -> Result<Tokens> { Ok(Tokens!()) }
   fn invoke_primitive(&self, stomach: &mut Stomach, _caller: Rc<Definition>, state: &mut State) -> Result<Vec<Digested>> {
-    info!("-- Mathprimitive invoke for {:?}", self.cs);
+    Info!("MathPrimitive","invoke",stomach, state, "invoke for {:?}", self.cs);
     // my $profiled = $STATE->lookupValue('PROFILING') && ($LaTeXML::CURRENT_TOKEN || $$self{cs});
     // my $tracing = $STATE->lookupValue('TRACINGCOMMANDS');
     // LaTeXML::Core::Definition::startProfiling($profiled, 'digest') if $profiled;

--- a/rtx_core/src/definition/mod.rs
+++ b/rtx_core/src/definition/mod.rs
@@ -9,6 +9,7 @@ pub mod register;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::rc::Rc;
+use std::fmt;
 
 use crate::common::error::*;
 use crate::common::object::Object;
@@ -99,17 +100,6 @@ pub trait Definition: Object {
   fn get_parameters(&self) -> Option<&Parameters>;
 
   // ======================================================================
-  // Overriding methods
-  fn stringify(&self) -> String { unimplemented!() }
-
-  fn to_string(&self) -> String {
-    if let Some(params) = self.get_parameters() {
-      s!("{} {}", self.get_cs_name(), params.to_string())
-    } else {
-      self.get_cs_name().to_string()
-    }
-  }
-
   // Return the Tokens that would invoke the given definition with arguments.
   fn invocation(&mut self, args: Vec<Tokens>, gullet: &mut Gullet, state: &mut State) -> Result<Tokens> {
     let mut invocation_result: Vec<Token> = Vec::new();
@@ -173,6 +163,17 @@ pub trait Definition: Object {
   fn register_type(&self) -> Option<RegisterType> { None }
   fn get_reversion_spec(&self) -> Option<Reversion> { unimplemented!() }
 }
+
+impl fmt::Display for Definition {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    if let Some(params) = self.get_parameters() {
+      write!(f, "{} {}", self.get_cs_name(), params.to_string())
+    } else {
+      write!(f, "{}", self.get_cs_name())
+    }
+  }
+}
+
 
 impl ExpansionBody {
   pub fn to_string(&self) -> String {

--- a/rtx_core/src/definition/mod.rs
+++ b/rtx_core/src/definition/mod.rs
@@ -89,8 +89,6 @@ pub trait Definition: Object {
   fn is_prefix(&self) -> bool { false }
   fn is_readonly(&self) -> bool { false }
 
-  fn get_locator(&self) -> String;
-
   fn read_arguments(&self, gullet: &mut Gullet, state: &mut State) -> Result<Vec<Tokens>>
   where Self: Sized {
     match self.get_parameters() {

--- a/rtx_core/src/definition/mod.rs
+++ b/rtx_core/src/definition/mod.rs
@@ -70,6 +70,10 @@ impl From<&str> for ExpansionBody {
   fn from(s: &str) -> ExpansionBody { mouth::tokenize_internal(s, None).into() }
 }
 
+impl From<String> for ExpansionBody {
+  fn from(s: String) -> ExpansionBody { s.as_str().into() }
+}
+
 pub trait Definition: Object {
   fn invoke(&self, gullet: &mut Gullet, state: &mut State) -> Result<Tokens>;
   fn invoke_primitive(&self, gullet: &mut Stomach, caller: Rc<Definition>, state: &mut State) -> Result<Vec<Digested>>;

--- a/rtx_core/src/definition/primitive.rs
+++ b/rtx_core/src/definition/primitive.rs
@@ -116,7 +116,6 @@ impl Definition for Primitive {
   fn get_cs(&self) -> Cow<Token> { Cow::Borrowed(&self.cs) }
   fn get_cs_name(&self) -> Cow<str> { Cow::Borrowed(self.cs.get_cs_name()) }
   fn get_alias(&self) -> Option<&String> { self.alias.as_ref() }
-  fn get_locator(&self) -> String { unimplemented!() }
   fn get_parameters(&self) -> Option<&Parameters> { self.paramlist.as_ref() }
 
   fn get_num_args(&self) -> usize {

--- a/rtx_core/src/definition/primitive.rs
+++ b/rtx_core/src/definition/primitive.rs
@@ -1,4 +1,3 @@
-use log::debug;
 use std::borrow::Cow;
 use std::rc::Rc;
 use std::fmt;
@@ -94,7 +93,7 @@ impl Definition for Primitive {
 
   fn invoke(&self, _gullet: &mut Gullet, _state: &mut State) -> Result<Tokens> { Ok(Tokens!()) }
   fn invoke_primitive(&self, stomach: &mut Stomach, _caller: Rc<Definition>, state: &mut State) -> Result<Vec<Digested>> {
-    debug!(target:"primitive", "invoke for {:?}", self.cs);
+    Debug!("primitive invoke for {:?}", self.cs);
     // my $profiled = $STATE->lookupValue('PROFILING') && ($LaTeXML::CURRENT_TOKEN || $$self{cs});
     // my $tracing = $STATE->lookupValue('TRACINGCOMMANDS');
     // LaTeXML::Core::Definition::startProfiling($profiled, 'digest') if $profiled;

--- a/rtx_core/src/definition/primitive.rs
+++ b/rtx_core/src/definition/primitive.rs
@@ -1,6 +1,7 @@
 use log::debug;
 use std::borrow::Cow;
 use std::rc::Rc;
+use std::fmt;
 
 use crate::common::error::*;
 use crate::common::font::Font;
@@ -80,7 +81,12 @@ impl PartialEq for Primitive {
   fn eq(&self, other: &Primitive) -> bool { self.cs == other.cs }
 }
 
-impl Object for Primitive {}
+impl fmt::Display for Primitive {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { unimplemented!(); }
+}
+impl Object for Primitive {
+  fn stringify(&self) -> String { unimplemented!(); }
+}
 impl Definition for Primitive {
   fn before_digest(&self) -> Option<&Vec<BeforeDigestClosure>> { Some(&self.before_digest) }
   fn after_digest(&self) -> Option<&Vec<DigestionClosure>> { Some(&self.after_digest) }

--- a/rtx_core/src/definition/register.rs
+++ b/rtx_core/src/definition/register.rs
@@ -2,8 +2,9 @@ use lazy_static::lazy_static;
 use log::*;
 use regex::Regex;
 use std::borrow::Cow;
-use std::cell::RefCell;
+use std::cell::{Ref, RefMut, RefCell};
 use std::rc::Rc;
+use std::fmt;
 
 use crate::common::dimension::{Dimension, MuDimension};
 use crate::common::error::*;
@@ -73,6 +74,9 @@ impl<'a> From<&'a RegisterValue> for RegisterType {
 
 impl Default for RegisterValue {
   fn default() -> Self { RegisterValue::Number(Number::new(0.0)) }
+}
+impl Object for RegisterValue {
+  fn stringify(&self) -> String { s!("RegisterValue[{}]", self) }
 }
 
 const SCALES: &[f32] = &[1.0, 10.0, 100.0, 1000.0, 10000.0, 100_000.0];
@@ -291,16 +295,14 @@ impl<'a> From<&'a RegisterValue> for Glue {
   }
 }
 
-impl RegisterValue {
-  #[allow(clippy::wrong_self_convention)]
-  pub fn to_string(&self) -> String {
+impl fmt::Display for RegisterValue {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
-      RegisterValue::Dimension(d) => d.to_string(),
-      RegisterValue::Glue(g) => g.to_string(),
-      other => self.clone().value_of().to_string(),
+      RegisterValue::Dimension(d) => write!(f,"{}", d),
+      RegisterValue::Glue(g) => write!(f,"{}", g),
+      other => write!(f,"{}", self.clone().value_of()),
     }
   }
-  pub fn stringify(&self) -> String { s!("RegisterValue[{}]", self.to_string()) }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -349,8 +351,24 @@ impl PartialEq for Register {
   fn eq(&self, other: &Register) -> bool { self.cs == other.cs }
 }
 
-impl Object for RefCell<Register> {}
-impl Definition for RefCell<Register> {
+/// The only purpose of RegisterCell is to provide us with a place to implement fmt::Display over
+/// a `RefCell<Register>`.
+#[derive(PartialEq)]
+pub struct RegisterCell(RefCell<Register>);
+impl fmt::Display for RegisterCell {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    unimplemented!();
+  }
+}
+impl Object for RegisterCell {
+  fn stringify(&self) -> String { unimplemented!(); }
+}
+impl RegisterCell {
+pub fn new(cell: RefCell<Register>) -> Self { RegisterCell(cell) }
+  pub fn borrow(&self) -> Ref<Register> { self.0.borrow() }
+  pub fn borrow_mut(&self) -> RefMut<Register> { self.0.borrow_mut() }
+}
+impl Definition for RegisterCell {
   fn is_register(&self) -> bool { true }
   fn is_prefix(&self) -> bool { false }
   fn is_readonly(&self) -> bool { self.borrow().readonly }

--- a/rtx_core/src/definition/register.rs
+++ b/rtx_core/src/definition/register.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use log::*;
 use regex::Regex;
 use std::borrow::Cow;
 use std::cell::{Ref, RefMut, RefCell};
@@ -171,11 +170,13 @@ impl NumericOps for RegisterValue {
       RegisterValue::Glue(v) => v.value_of(),
       RegisterValue::MuGlue(v) => v.value_of(),
       RegisterValue::Token(v) => {
-        warn!(target: "register:value_of", ".value_of called on Token {:?}", v);
+        let message = s!(".value_of called on Token {:?}", v);
+        Warn!("register","value_of", None, None, message);
         -1.0
       },
       RegisterValue::Tokens(v) => {
-        warn!(target: "register:value_of", ".value_of called on Tokens {:?}", v);
+        let message = s!(".value_of called on Tokens {:?}", v);
+        Warn!("register","value_of", None, None, message);
         -1.0
       },
     }

--- a/rtx_core/src/definition/register.rs
+++ b/rtx_core/src/definition/register.rs
@@ -272,7 +272,8 @@ impl<'a> From<&'a RegisterValue> for Dimension {
       RegisterValue::MuGlue(other) => Dimension::new(other.value_of()),
       RegisterValue::Token(other) => other.to_number().into(),
       RegisterValue::Tokens(other) => {
-        error!(target:"expected:dimension", "Token register can not be cast into a dimension: {:?}", other);
+        let message = s!("Token register can not be cast into a dimension: {:?}", other);
+        Error!("expected","dimension", None, None, message);
         Dimension::new(0.0)
       },
     }
@@ -288,7 +289,8 @@ impl<'a> From<&'a RegisterValue> for Glue {
       RegisterValue::MuGlue(other) => Glue::new(other.value_of()),
       RegisterValue::Token(other) => other.to_number().into(),
       RegisterValue::Tokens(other) => {
-        error!(target:"expected:dimension", "Token register can not be cast into a Glue: {:?}", other);
+        let message = s!("Token register can not be cast into a Glue: {:?}", other);
+        Error!("expected","dimension", None, None, message);
         Glue::new(0.0)
       },
     }
@@ -405,7 +407,10 @@ impl Definition for RegisterCell {
         // primitive returns boxes, so these need to be digested!
         Stored::Token(t) => gullet.unread(Tokens!(t)),
         Stored::Tokens(tks) => gullet.unread(tks),
-        other => error!(target:"unexpected:afterassignment", "expected tokens, found: {:?}", other),
+        other => {
+          let message = s!("expected tokens, found: {:?}", other);
+          Error!("unexpected","afterassignment", stomach, state, message)
+        }
       };
     }
     // # Tracing ?
@@ -440,7 +445,8 @@ impl Register {
   pub fn is_readonly(&self) -> bool { self.readonly }
   pub fn set_value(&mut self, value: RegisterValue, args: Vec<Tokens>, state: &mut State) {
     if self.register_type == RegisterType::CharDef {
-      error!(target:"unexpected:chardef", "Can't assign to chardef {}",self.cs.get_cs_name());
+      let message = s!("Can't assign to chardef {}", self.cs.get_cs_name());
+      Error!("unexpected","chardef", None, state, message);
     } else {
       (self.setter)(value, args, state);
     }

--- a/rtx_core/src/definition/register.rs
+++ b/rtx_core/src/definition/register.rs
@@ -360,7 +360,6 @@ impl Definition for RefCell<Register> {
   fn get_cs(&self) -> Cow<Token> { Cow::Owned(self.borrow().cs.clone()) }
   fn get_cs_name(&self) -> Cow<str> { Cow::Owned(self.borrow().cs.get_cs_name().to_owned()) }
   fn get_alias(&self) -> Option<&String> { None }
-  fn get_locator(&self) -> String { String::from("Locator is TODO") }
 
   // No before/after daemons ???
   // (other than afterassign)

--- a/rtx_core/src/document/mod.rs
+++ b/rtx_core/src/document/mod.rs
@@ -15,6 +15,7 @@ use std::rc::Rc;
 use crate::common::error::*;
 use crate::common::font::{Font, FONT_TEXT_DEFAULT};
 use crate::common::store::Stored;
+use crate::common::object::Object;
 use crate::state::State;
 
 use crate::document::resource::Resource;
@@ -43,6 +44,7 @@ pub struct Document {
 impl Default for Document {
   fn default() -> Self { Self::new() }
 }
+impl Object for Document {}
 impl Document {
   pub fn new() -> Self {
     set_node_rc_guard(10); // We will need a high treshold for Node mutability
@@ -202,7 +204,8 @@ impl Document {
         }
         if self.can_contain(node, FONT_ELEMENT_NAME, state) && !pending_declaration.is_empty() {
           // Too late to do wrapNodes?
-          error!(target: "TODO", "too late to wrapNodes? {:?}", pending_declaration);
+          let message = s!("too late to wrapNodes? {:?}", pending_declaration);
+          Error!("TODO", "wrapNodes", self, state, message);
           //   my text = self.wrapNodes(FONT_ELEMENT_NAME, child);
           //   foreach my attr (keys %pending_declaration) {
           //     self.setAttribute(text, attr => pending_declaration{attr}{value}); }
@@ -447,23 +450,19 @@ impl Document {
         "#PCDATA" => qname.to_owned(),
         _ => s!("</{}>", qname),
       };
-      error!(
-        target: &s!("malformed:{:?}", qname),
-        "Attempt to close {}, which isn't open. Currently in {}",
+      let message = s!("Attempt to close {}, which isn't open. Currently in {}",
         qname_msg,
-        self.get_insertion_context(None, state)
-      );
+        self.get_insertion_context(None, state));
+      Error!("malformed", qname, self, state, message);
       Ok(None)
     } else {
       // Found node.
       if !cant_close.is_empty() {
         // Intervening non-auto-closeable nodes!!
-        error!(
-          target: &s!("malformed:{:?}", qname),
-          "Closing tag {:?} whose open descendents do not auto-close. Descendants are {:?}",
+        let message = s!("Closing tag {:?} whose open descendents do not auto-close. Descendants are {:?}",
           qname,
-          cant_close.into_iter().map(|n| n.get_name()).collect::<Vec<String>>().join(",")
-        );
+          cant_close.into_iter().map(|n| n.get_name()).collect::<Vec<String>>().join(","));
+        Error!("malformed", qname, self, state, message);
       }
       // So, now close up to the desired node.
       self.close_node_internal(&node, state)?;
@@ -561,23 +560,18 @@ impl Document {
     }
     if n_type == Some(NodeType::DocumentNode) {
       // Didn't find $node at all!!
-      error!(
-        target: &s!("malformed:{}", state.model.get_node_qname(node)),
-        "Attempt to close {:?}, which isn't open",
-        node.get_name()
-      );
+      let message = s!("Attempt to close {:?}, which isn't open", node.get_name());
+      Error!("malformed", state.model.get_node_qname(node), self, state, message);
     //     "Currently in " . $self->getInsertionContext()) unless $ifopen;
     } else {
       // Found node.
       if !cant_close.is_empty() {
         // But found has intervening non-auto-closeable nodes!!
         let qname = state.model.get_node_qname(node);
-        error!(
-          target: &s!("malformed:{}", qname),
-          "Closing {:?} whose open descendents do not auto-close. Descendants are: {:?}",
+        let message = s!("Closing {:?} whose open descendents do not auto-close. Descendants are: {:?}",
           qname,
-          cant_close.into_iter().map(|n| n.get_name()).collect::<Vec<String>>().join(",")
-        );
+          cant_close.into_iter().map(|n| n.get_name()).collect::<Vec<String>>().join(","));
+        Error!("malformed", qname, self, state, message);
       }
       if let Some(lastopen_node) = lastopen {
         self.close_node_internal(&lastopen_node, state)?;
@@ -603,23 +597,21 @@ impl Document {
     if t == Some(NodeType::DocumentNode) {
       // Didn't find $qname at all!!
       let qname = state.model.get_node_qname(&node);
-      error!(
-        target: &s!("malformed:{}", qname),
-        "Attempt to close {}, which isn't open. Currently in {:?}",
+      let message = s!("Attempt to close {}, which isn't open. Currently in {:?}",
         qname,
         self.get_insertion_context(None, state)
-      )
+      );
+      Error!("malformed", qname, self, state, message);
     } else {
       // Found node.
       // Intervening non-auto-closeable nodes!!
       if !cant_close.is_empty() {
         let qname = state.model.get_node_qname(&node);
-        error!(
-          target: &s!("malformed:{}", qname),
-          "Closing {} whose open descendents do not auto-close. Descendents are {}",
+        let message = s!("Closing {} whose open descendents do not auto-close. Descendents are {}",
           qname,
           cant_close.iter().map(Node::get_name).collect::<Vec<String>>().join(", ")
-        )
+        );
+        Error!("malformed", qname, self, state, message);
       }
       self.close_node_internal(node, state)?;
     }
@@ -1202,7 +1194,7 @@ impl Document {
 
   /// Return a string indicating the path to the current insertion point in the document.
   /// if $levels is defined, show only that many levels
-  pub fn get_insertion_context(&self, levels_opt: Option<usize>, state: &State) -> String {
+  pub fn get_insertion_context(&self, levels_opt: Option<usize>, state: &mut State) -> String {
     let mut levels = match levels_opt {
       None => {
         // Default depth is based on verbosity
@@ -1217,7 +1209,8 @@ impl Document {
     let mut node = self.node.clone();
     let node_type = node.get_type();
     if node_type != Some(NodeType::TextNode) && node_type != Some(NodeType::ElementNode) && node_type != Some(NodeType::DocumentNode) {
-      error!(target: "internal:context", "Insertion point is not an element, document or text: {:?}", self.document.node_to_string(&node));
+      let message = s!("Insertion point is not an element, document or text: {:?}", self.document.node_to_string(&node));
+      Error!("internal","context", self, state, message);
       return String::new();
     }
     let mut path = s!("TODO"); //TODO: Stringify($node);
@@ -1257,13 +1250,12 @@ impl Document {
 
     if let Some(has_opened) = has_opened_opt {
       // out of options if already inside an auto-open chain
-      error!(
-        target: &s!("malformed:{}", qname),
-        " failed auto-open through <{}> at inadmissible <{}>. Currently in {}",
+      let message = s!("failed auto-open through <{}> at inadmissible <{}>. Currently in {}",
         has_opened,
         cur_qname,
         self.get_insertion_context(None, state)
       );
+      Error!("malformed",qname, self, state,message);
       return Ok(self.node.clone()); // But we'll do it anyway, unless Error => Fatal.
     } else {
       // Now we're getting more desparate...
@@ -1290,10 +1282,11 @@ impl Document {
         self.find_insertion_point(qname, None, state) // Then retry, possibly w/auto open's
       } else {
         // Didn't find a legit place.
-        error!(target: &s!("malformed:{}", qname), "{:?} isn't allowed in <{}>", qname, cur_qname);
+        let message = s!("{:?} isn't allowed in <{}>", qname, cur_qname);
+        Error!("malformed", qname, self, state, message);
         // ($qname eq "#PCDATA" ? $qname : '<' . $qname . '>') . " isn't allowed
         // in <$cur_qname>", "Currently in " .
-        // self.getInsertionContext()); return self.node}; } } }
+        // self.getInsertionContext());
 
         // But we'll do it anyway, unless Error => Fatal.
         Ok(self.node.clone())
@@ -1758,7 +1751,8 @@ impl Document {
                 match Namespace::new(&prefix, &ns_uri, &mut root) {
                   Ok(ns) => Some(ns),
                   Err(_) => {
-                    error!(target: "document:open_element_internal", "failed to create namespace: {:?}", prefix);
+                    let message = s!("failed to create namespace: {:?}", prefix);
+                    Error!("document", "open_element_internal", self, state, message);
                     None
                   },
                 }
@@ -1767,7 +1761,8 @@ impl Document {
                 None
               }
             } else {
-              error!(target: "document:open_element_internal", "no namespace prefix found for {:?}", ns_uri);
+              let message = s!("no namespace prefix found for {:?}", ns_uri);
+              Error!("document", "open_element_internal", self, state, message);
               None
             }
           },
@@ -1777,7 +1772,8 @@ impl Document {
               match Namespace::new(&prefix, &ns_uri, &mut root) {
                 Ok(ns) => Some(ns),
                 Err(_) => {
-                  error!(target: "document:open_element_internal", "failed to create namespace: {:?}", prefix);
+                  let message = s!("failed to create namespace: {:?}", prefix);
+                  Error!("document", "open_element_internal", self, state, message);
                   None
                 },
               }

--- a/rtx_core/src/document/mod.rs
+++ b/rtx_core/src/document/mod.rs
@@ -7,7 +7,6 @@ use libxml::tree::Document as XmlDoc;
 use libxml::tree::{Namespace, Node, NodeType};
 use regex::Regex;
 
-use log::{debug, error, warn};
 use std::collections::{HashMap, VecDeque};
 use std::iter;
 use std::rc::Rc;
@@ -184,7 +183,7 @@ impl Document {
             .iter()
             .all(|gchild| self.can_contain_qname(&qname, &state.model.get_node_qname(gchild), state))
           {
-            debug!("will replace {} grandchildren nodes in finalize_rec", grandchildren.len());
+            Debug!("will replace {} grandchildren nodes in finalize_rec", grandchildren.len());
             self.replace_node(child, grandchildren)?;
           }
         }
@@ -278,7 +277,7 @@ impl Document {
       //   box_node.set_content(&tbox.text);
     }
     // if self.debug {
-    //   debug!("Document absorbed {:?} nodes", results.len());
+    //   Debug!("Document absorbed {:?} nodes", results.len());
     // }
     // Results never used, BUT leak Rc<Node> strong counts!!!
     // Ok(results)
@@ -327,7 +326,7 @@ impl Document {
     // TODO: Quickly hacked together, needs a careful refactor with all .clone()
     // calls removed
     let node = self.open_element(qname, attrib, None, state)?;
-    debug!("Inserting element {:?} with body: {:?}", qname, content);
+    Debug!("Inserting element {:?} with body: {:?}", qname, content);
     for digested in content {
       self.absorb(digested, state)?;
     }
@@ -392,7 +391,7 @@ impl Document {
   ) -> Result<Node>
   {
     // NoteProgress('.') if (self.progress}++ % 25) == 0;
-    debug!("Open element {:?} at {:?}", qname, self.get_node_qname(&self.node, state));
+    Debug!("Open element {:?} at {:?}", qname, self.get_node_qname(&self.node, state));
     let point = self.find_insertion_point(qname, None, state)?;
     let font_owned: Option<Font> = match font_opt {
       Some(f) => Some(f.clone()),
@@ -427,7 +426,7 @@ impl Document {
   /// ie. we're automatically closing them, even if they're the same type as we're asking to
   /// close!!! This is kinda risky! Maybe we should try to request closing of specific nodes.
   pub fn close_element(&mut self, qname: &str, state: &mut State) -> Result<Option<Node>> {
-    debug!("Close element {:?} at {:?}", qname, self.document.node_to_string(&self.node));
+    Debug!("Close element {:?} at {:?}", qname, self.document.node_to_string(&self.node));
     self.close_text_internal(state)?;
     let mut node = self.node.clone();
     let mut cant_close = Vec::new();
@@ -515,7 +514,7 @@ impl Document {
           break 'inner;
         }
         if !self.can_auto_close(node, state) {
-          debug!("It was impossible to autoclose node: {:?}", self.document.node_to_string(node));
+          Debug!("It was impossible to autoclose node: {:?}", self.document.node_to_string(node));
           return None;
         }
         node_opt = node.get_parent();
@@ -860,7 +859,7 @@ impl Document {
     state: &mut State,
   ) -> Result<Node>
   {
-    // debug!(target:"document:insert" ,"insert math token: {:?}", text);
+    // Debug!(target:"document:insert" ,"insert math token: {:?}", text);
     attributes.entry(s!("role")).or_insert_with(|| s!("UNKNOWN"));
 
     let font = match font_opt {
@@ -916,7 +915,7 @@ impl Document {
     if font.family == Some("nullfont".into()) {
       return Ok(None);
     }
-    debug!("Insert text {:?} at {:?}", text, self.document.node_to_string(&self.node));
+    Debug!("Insert text {:?} at {:?}", text, self.document.node_to_string(&self.node));
     // If not at document begin And not appending text in same font.
     if node_type != Some(NodeType::DocumentNode)
       && !(node_type == Some(NodeType::TextNode) && (font.distance(self.get_node_font(&self.node.get_parent().unwrap())) == 0))
@@ -1124,13 +1123,13 @@ impl Document {
   pub fn open_text_internal(&mut self, text: &str, state: &mut State) -> Result<()> {
     if self.node.get_type() == Some(NodeType::TextNode) {
       // current node already is a text node.
-      debug!("Appending text {:?} to {:?}", text, self.document.node_to_string(&self.node));
+      Debug!("Appending text {:?} to {:?}", text, self.document.node_to_string(&self.node));
       self.node.append_text(text)?;
     } else if HAS_NONSPACE_RE.is_match(text) || self.can_contain(&self.node, "#PCDATA", state) {
       // or text allowed here
       let mut point = self.find_insertion_point("#PCDATA", None, state)?;
       let mut node = Node::new_text(text, &self.document).unwrap();
-      debug!("Inserting text node for {:?} into {:?}", text, self.document.node_to_string(&point));
+      Debug!("Inserting text node for {:?} into {:?}", text, self.document.node_to_string(&point));
       point.add_child(&mut node)?;
       self.set_node(&node);
     }
@@ -1661,7 +1660,7 @@ impl Document {
     // If this will be the document root node, things are slightly more involved.
     if point.get_type() == Some(NodeType::DocumentNode) {
       // First node! (?)
-      debug!("adding schema declaration, new node will be : {}", tag);
+      Debug!("adding schema declaration, new node will be : {}", tag);
       state.model.add_schema_declaration(self);
       newnode = Node::new(&tag, None, &self.document).unwrap();
       self.document.set_root_element(&newnode);
@@ -1719,7 +1718,7 @@ impl Document {
       self.set_node_box(&newnode, digested.clone());
     }
 
-    debug!(
+    Debug!(
       "Inserting {:?} into {:?}",
       self.get_node_qname(&newnode, state),
       self.get_node_qname(&point, state)
@@ -2061,10 +2060,8 @@ impl Document {
       self.set_node(&node);
       Some(savenode)
     } else {
-      warn!(
-        target: &s!("malformed:{}", key),
-        "No open node with an xml:id can get attribute {:?}", key
-      );
+      let message = s!("No open node with an xml:id can get attribute {:?}", key);
+      Warn!("malformed", key, self, state, message);
       //  $self->getInsertionContext());
       None
     }

--- a/rtx_core/src/gullet.rs
+++ b/rtx_core/src/gullet.rs
@@ -50,6 +50,10 @@ impl Default for Gullet {
   }
 }
 
+impl Object for Gullet {
+  fn stringify(&self) -> String {unimplemented!();}
+}
+
 impl Gullet {
   /// This flushes a mouth so that it will be automatically closed, next time it's read
   /// Corresponds (I think) to TeX's \endinput
@@ -101,19 +105,23 @@ impl Gullet {
 
   pub fn close_mouth<'close>(&'close mut self, forced: bool, state: &mut State) {
     let mut shift_from_mouthstack = false;
-    match self.mouth {
-      None => {},
-      Some(ref mut runtime) => {
-        if !forced && (!runtime.pushback.is_empty()) || runtime.mouth.has_more_input() {
-          // TODO:
-          // let next = Stringify(self.read_token());
-          // Error('unexpected', $next, self, "Closing mouth with input remaining '$next'");
-        }
-        runtime.mouth.finish(state);
-        // I think I can refactor from the original state into this simple assignment, because of
-        // the Option type
-        shift_from_mouthstack = true;
-      },
+    let mut error_has_more_input = false;
+    if let Some(ref mut runtime) = self.mouth {
+      if !forced && (!runtime.pushback.is_empty()) || runtime.mouth.has_more_input() {
+        error_has_more_input = true
+      }
+    }
+    if error_has_more_input {
+      let next = match self.read_token(state) {
+        Some(t) => t.stringify(),
+        None => String::from("Empty")
+      };
+      let message = s!("Closing mouth with input remaining '{}'", next);
+      Error!("unexpected", next, self, state, message);
+    }
+    if let Some(ref mut runtime) = self.mouth {
+      runtime.mouth.finish(state);
+      shift_from_mouthstack = true;
     }
     if shift_from_mouthstack {
       self.mouth = self.mouthstack.pop_front();
@@ -399,7 +407,7 @@ impl Gullet {
       tokens.push(t);
     }
     if level > 0 {
-      error!(target: "expected:}", "Gullet->readBalanced ran out of input in an unbalanced state.");
+      Error!("expected","}", self, state, "Gullet->readBalanced ran out of input in an unbalanced state.");
     }
     if tokens.is_empty() {
       // Default to empty token list, to signify success (TODO, or improve to
@@ -995,9 +1003,8 @@ impl Gullet {
           self.close_mouth(true, state);
           break;
         } else if self.mouthstack.is_empty() {
-          error!(target: "unexpected:<closed>", "TODO: Mouth is unexpectedly already closed");
-          // Error('unexpected', '<closed>', $gullet, "Mouth is unexpectedly already closed",
-          //   "Reading from " . Stringify($mouth) . ", but it has already been closed.");
+          let message = s!("Reading from {}, but it has already been closed.", runtime.mouth.stringify());
+          Error!("unexpected", "<closed>", self, state, "Mouth is unexpectedly already closed", message);
           break;
         } else {
           let mut ready_to_read = false;
@@ -1010,7 +1017,7 @@ impl Gullet {
           }
           if ready_to_read {
             let _next = self.read_token(state); // stringify( ?
-            error!(target: "unexpected:next", "TODO: unexpected input remaining");
+            Error!("unexpected", "next", self, state, "TODO: unexpected input remaining");
             // Error('unexpected', $next, $gullet, "Unexpected input remaining: '$next'",
             //   "Finished reading from " . Stringify($mouth) . ", but it still has input.");
             {
@@ -1026,7 +1033,7 @@ impl Gullet {
           }
         }
       } else {
-        error!(target: "unexpected:runtime", "TODO: gullet had no active runtime");
+        Error!("unexpected", "runtime", self, state, "TODO: gullet had no active runtime");
         break;
       }
     }

--- a/rtx_core/src/gullet.rs
+++ b/rtx_core/src/gullet.rs
@@ -10,6 +10,7 @@ use crate::common::error::*;
 use crate::common::glue::{FillCode, Glue};
 use crate::common::locator::Locator;
 use crate::common::number::Number;
+use crate::common::object::Object;
 
 use crate::definition::conditional::ConditionalType;
 use crate::definition::register::{NumericOps, RegisterType, RegisterValue};
@@ -121,19 +122,22 @@ impl Gullet {
   }
 
   /// User feedback for where something (error?) occurred.
-  pub fn get_locator(&self) -> Locator {
-    // TODO:
-  //   let mouth = self.mouth.unwrap().mouth; // assume runtime exists, can make more robust if it ends up troublesome (when?)
-  //   let mut i = 0;
-  // while ((defined $mouth) && (!defined $$mouth{source})
-  //   && ($i < scalar(@{ $$self{mouthstack} }))) {
-  //   $mouth = $$self{mouthstack}[$i++][0]; }
-  // my $loc = (defined $mouth ? $mouth->getLocator : undef);
-  // return $loc if defined $loc;
-  // foreach my $frame (@{ $$self{mouthstack} }) {
-  //   my $ml = $$frame[0]->getLocator;
-  //   return $ml if defined $ml; }
-    Locator::default()
+  pub fn get_locator(&self) -> Cow<Locator> {
+    let mut runtime_opt = self.mouth.as_ref();
+    let mut mouthstack_iter = self.mouthstack.iter();
+    while runtime_opt.is_some() && runtime_opt.as_ref().unwrap().mouth.get_source().is_empty() {
+      runtime_opt = mouthstack_iter.next();
+    }
+    if let Some(runtime) = runtime_opt {
+      // First exit condition: we found a mouth with a source, and asked it for a locator
+      runtime.mouth.get_locator()
+    } else if let Some(runtime) = self.mouthstack.front() {
+      // Backup strategy: return the first locator in the mouthstack:
+      runtime.mouth.get_locator()
+    } else {
+      // Final backup -- the default locator
+      Cow::Owned(Locator::default())
+    }
   }
 
   pub fn get_mouth(&self) -> Option<&Mouth> {

--- a/rtx_core/src/gullet.rs
+++ b/rtx_core/src/gullet.rs
@@ -120,8 +120,19 @@ impl Gullet {
     return;
   }
 
+  /// User feedback for where something (error?) occurred.
   pub fn get_locator(&self) -> Locator {
-    // TODO
+    // TODO:
+  //   let mouth = self.mouth.unwrap().mouth; // assume runtime exists, can make more robust if it ends up troublesome (when?)
+  //   let mut i = 0;
+  // while ((defined $mouth) && (!defined $$mouth{source})
+  //   && ($i < scalar(@{ $$self{mouthstack} }))) {
+  //   $mouth = $$self{mouthstack}[$i++][0]; }
+  // my $loc = (defined $mouth ? $mouth->getLocator : undef);
+  // return $loc if defined $loc;
+  // foreach my $frame (@{ $$self{mouthstack} }) {
+  //   my $ml = $$frame[0]->getLocator;
+  //   return $ml if defined $ml; }
     Locator::default()
   }
 

--- a/rtx_core/src/gullet.rs
+++ b/rtx_core/src/gullet.rs
@@ -50,6 +50,24 @@ impl Default for Gullet {
 }
 
 impl Object for Gullet {
+  /// User feedback for where something (error?) occurred.
+  fn get_locator(&self) -> Cow<Locator> {
+    let mut runtime_opt = self.mouth.as_ref();
+    let mut mouthstack_iter = self.mouthstack.iter();
+    while runtime_opt.is_some() && runtime_opt.as_ref().unwrap().mouth.get_source().is_empty() {
+      runtime_opt = mouthstack_iter.next();
+    }
+    if let Some(runtime) = runtime_opt {
+      // First exit condition: we found a mouth with a source, and asked it for a locator
+      runtime.mouth.get_locator()
+    } else if let Some(runtime) = self.mouthstack.front() {
+      // Backup strategy: return the first locator in the mouthstack:
+      runtime.mouth.get_locator()
+    } else {
+      // Final backup -- the default locator
+      Cow::Owned(Locator::default())
+    }
+  }
   fn stringify(&self) -> String {unimplemented!();}
 }
 
@@ -126,25 +144,6 @@ impl Gullet {
       self.mouth = self.mouthstack.pop_front();
     }
     return;
-  }
-
-  /// User feedback for where something (error?) occurred.
-  pub fn get_locator(&self) -> Cow<Locator> {
-    let mut runtime_opt = self.mouth.as_ref();
-    let mut mouthstack_iter = self.mouthstack.iter();
-    while runtime_opt.is_some() && runtime_opt.as_ref().unwrap().mouth.get_source().is_empty() {
-      runtime_opt = mouthstack_iter.next();
-    }
-    if let Some(runtime) = runtime_opt {
-      // First exit condition: we found a mouth with a source, and asked it for a locator
-      runtime.mouth.get_locator()
-    } else if let Some(runtime) = self.mouthstack.front() {
-      // Backup strategy: return the first locator in the mouthstack:
-      runtime.mouth.get_locator()
-    } else {
-      // Final backup -- the default locator
-      Cow::Owned(Locator::default())
-    }
   }
 
   pub fn get_mouth(&self) -> Option<&Mouth> {

--- a/rtx_core/src/gullet.rs
+++ b/rtx_core/src/gullet.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use log::*;
 use regex::Regex;
 use std::borrow::Cow;
 use std::collections::VecDeque;
@@ -685,7 +684,8 @@ impl Gullet {
       Ok(Number::new(s * n.value_of()))
     } else {
       let next = self.read_token(state);
-      warn!(target:"expected:<number>", "Missing number, treated as zero while processing {:?}, next token is {:?}", state.current_token, next);
+      let message = s!("Missing number, treated as zero while processing {:?}, next token is {:?}", state.current_token, next);
+      Warn!("expected","<number>", self, state, message);
       if let Some(next) = next {
         self.unread(Tokens!(next));
       }
@@ -745,7 +745,8 @@ impl Gullet {
     let mut string = self.read_digits(&DIGIT_RE, true, state)?;
     match self.read_x_token(false, false, state)? {
       None => {
-        warn!(target:"expected:<float>", "Missing number, treated as zero while processing {:?}", state.current_token.as_ref().unwrap());
+        let message = s!("Missing number, treated as zero while processing {:?}", state.current_token.as_ref().unwrap());
+        Warn!("expected","<float>", self, state, message);
         Ok(Number::new(0.0))
       },
       Some(mut token) => {
@@ -768,7 +769,8 @@ impl Gullet {
         if let Some(n) = n_opt {
           Ok(Number::new(s * n.value_of()))
         } else {
-          warn!(target:"expected:<float>", "Missing number, treated as zero while processing {:?}", state.current_token.as_ref().unwrap());
+          let message = s!("Missing number, treated as zero while processing {:?}", state.current_token.as_ref().unwrap());
+          Warn!("expected","<float>", self, state, message);
           Ok(Number::new(0.0))
         }
       },
@@ -811,13 +813,14 @@ impl Gullet {
       let unit = match self.read_unit(state)? {
         Some(u) => u,
         None => {
-          warn!(target:"expected:<unit>", "Illegal unit of measure (pt inserted).");
+          Warn!("expected","<unit>", self, state, "Illegal unit of measure (pt inserted).");
           65536.0
         },
       };
       Ok(Dimension::new(s * d * unit))
     } else {
-      warn!(target: "expected:<number>", "Missing number, treated as zero. while processing {:?}", state.current_token.as_ref().unwrap());
+      let message = s!("Missing number, treated as zero. while processing {:?}", state.current_token.as_ref().unwrap());
+      Warn!("expected","<number>", self, state, message);
       Ok(Dimension::new(0.0))
     }
   }
@@ -901,7 +904,7 @@ impl Gullet {
           let u = if mu {
             match self.read_mu_unit(state)? {
               None => {
-                warn!(target:"expected<unit>", "Illegal unit of measure (mu inserted).");
+                Warn!("expected","unit>", self, state, "Illegal unit of measure (mu inserted).");
                 state.convert_unit("mu")
               },
               Some(v) => v,
@@ -909,7 +912,7 @@ impl Gullet {
           } else {
             match self.read_unit(state)? {
               None => {
-                warn!(target:"expected<unit>", "Illegal unit of measure (pt inserted).");
+                Warn!("expected","unit>", self, state, "Illegal unit of measure (pt inserted).");
                 65536.0
               },
               Some(v) => v,

--- a/rtx_core/src/keyvals.rs
+++ b/rtx_core/src/keyvals.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-// use std::fmt;
+use std::fmt;
 use std::collections::HashMap;
 // use std::rc::Rc;
 
@@ -7,6 +7,7 @@ use crate::common::error::*;
 use crate::common::font::Font;
 use crate::common::locator::Locator;
 use crate::common::store::Stored;
+use crate::common::object::Object;
 // use crate::definition::expandable::Expandable;
 // use crate::definition::Definition;
 use crate::document::Document;
@@ -62,6 +63,27 @@ impl PartialEq for KeyVals {
     false // TODO ?
   }
 }
+
+impl fmt::Display for KeyVals {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    unimplemented!();
+  }
+}
+
+impl Object for KeyVals {
+  fn get_locator(&self) -> Cow<Locator> {
+    unimplemented!(); 
+  }
+  fn stringify(&self) -> String { unimplemented!(); }
+}
+impl BoxOps for KeyVals {
+  fn get_properties_mut(&mut self) -> &mut HashMap<String, Stored> { unimplemented!() }
+  fn unlist(&self) -> Vec<Digested> { Vec::new() } // TODO
+  fn be_absorbed(&self, document: &mut Document, state: &mut State) -> Result<()> { Ok(()) } // TODO
+  fn revert(&self) -> Result<Tokens> { unimplemented!() } // TODO
+  fn get_font(&self) -> Option<Cow<Font>> { None } // TODO
+}
+
 
 impl KeyVals {
   ///======================================================================
@@ -222,19 +244,6 @@ impl KeyVals {
       self.tuples = newtuples;
     }
   }
-}
-
-impl BoxOps for KeyVals {
-  fn get_properties_mut(&mut self) -> &mut HashMap<String, Stored> { unimplemented!() }
-  fn to_string(&self) -> String { String::new() } // TODO
-  fn unlist(&self) -> Vec<Digested> { Vec::new() } // TODO
-  fn be_absorbed(&self, document: &mut Document, state: &mut State) -> Result<()> { Ok(()) } // TODO
-  fn revert(&self) -> Result<Tokens> { unimplemented!() } // TODO
-  fn get_locator(&self) -> Option<Locator> {
-    // TODO
-    None
-  }
-  fn get_font(&self) -> Option<Cow<Font>> { None } // TODO
 }
 
 impl From<KeyVals> for Result<Option<Digested>> {

--- a/rtx_core/src/lib.rs
+++ b/rtx_core/src/lib.rs
@@ -53,6 +53,7 @@ pub struct Core {
   pub stomach: Rc<RefCell<Stomach>>,
   pub preload: Vec<String>,
 }
+impl Object for Core {}
 pub struct CoreOptions {
   // First, state-related options:
   pub model: Option<Model>,
@@ -138,12 +139,12 @@ pub trait BoxOps: Object {
     let mut props = self.get_properties_mut();
     props.insert(key.to_string(), value.into());
   }
-  fn get_property(&self, _key: &str, _state: &mut State) -> Option<Cow<Stored>> {
-    error!(target: "boxops:get_property", "Generic BoxOps::get_property should never be called!");
+  fn get_property(&self, _key: &str, state: &mut State) -> Option<Cow<Stored>> {
+    Error!("boxops","get_property", self, state, "Generic BoxOps::get_property should never be called!");
     None
   }
   fn get_body(&self) -> Option<Digested> {
-    error!(target: "boxops:get_body", "Generic BoxOps::get_body should never be called!");
+    Error!("boxops","get_body", self, None, "Generic BoxOps::get_body should never be called!");
     None
   }
   fn get_font(&self) -> Option<Cow<Font>>;
@@ -293,8 +294,8 @@ impl BoxOps for Digested {
 
   fn set_property<T: Into<Stored>>(&mut self, key: &str, value: T) {
     match *self {
-      Digested::TBox(ref b) => error!(target: "digested:set_property", "Called set_property on Box: {:?}", b),
-      Digested::List(ref l) => error!(target: "digested:set_property", "Called set_property on List: {:?}", l),
+      Digested::TBox(ref b) => Error!("digested","set_property", self, None, s!("Called set_property on Box: {:?}", b)),
+      Digested::List(ref l) => Error!("digested","set_property", self, None, s!("Called set_property on List: {:?}", l)),
       Digested::Whatsit(ref w) => w.borrow_mut().set_property(key, value), // TODO
       _ => unimplemented!(),
     }
@@ -304,7 +305,7 @@ impl BoxOps for Digested {
     match *self {
       Digested::TBox(ref b) => b.get_property(key, state),
       Digested::List(ref l) => {
-        error!(target: "digested:get_property", "Called get_property on List: {:?}", l);
+        Error!("digested","get_property", self, state, "Called get_property on List: {:?}", l);
         None
       },
       Digested::Whatsit(ref w) => match w.borrow().get_property(key, state) {
@@ -317,11 +318,11 @@ impl BoxOps for Digested {
   fn get_body(&self) -> Option<Digested> {
     match *self {
       Digested::TBox(ref b) => {
-        error!(target: "digested:get_body", "Called get_body on Box: {:?}", b);
+        Error!("digested","get_body", self, None, s!("Called get_body on Box: {:?}", b));
         None
       },
       Digested::List(ref l) => {
-        error!(target: "digested:get_body", "Called get_body on List: {:?}", l);
+        Error!("digested","get_body", self, None, s!("Called get_body on List: {:?}", l));
         None
       },
       Digested::Whatsit(ref w) => w.borrow().get_body(),

--- a/rtx_core/src/lib.rs
+++ b/rtx_core/src/lib.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code, unused_variables, unused_mut, unused_macros, clippy::trivial_regex)]
 
-use log::error;
-
 #[macro_use]
 pub mod aux_macros;
 #[macro_use]

--- a/rtx_core/src/lib.rs
+++ b/rtx_core/src/lib.rs
@@ -37,6 +37,7 @@ use crate::common::locator::Locator;
 use crate::common::model::Model;
 use crate::common::number::Number;
 use crate::common::store::Stored;
+use crate::common::object::Object;
 use crate::definition::register::{NumericOps, RegisterValue};
 use crate::document::Document;
 use crate::keyvals::KeyVals;
@@ -129,11 +130,9 @@ impl Core {
   pub fn get_state_mut(&mut self) -> &mut State { &mut self.state }
 }
 
-pub trait BoxOps {
+pub trait BoxOps: Object {
   fn unlist(&self) -> Vec<Digested>;
   fn be_absorbed(&self, document: &mut Document, state: &mut State) -> Result<()>;
-  fn to_string(&self) -> String;
-  fn stringify(&self) -> String { s!("Vec<Tbox> for now ") }
   fn get_properties_mut(&mut self) -> &mut HashMap<String, Stored>;
   fn set_property<T: Into<Stored>>(&mut self, key: &str, value: T) {
     let mut props = self.get_properties_mut();
@@ -148,7 +147,6 @@ pub trait BoxOps {
     None
   }
   fn get_font(&self) -> Option<Cow<Font>>;
-  fn get_locator(&self) -> Option<Locator>;
   fn revert(&self) -> Result<Tokens>;
 
   fn set_width<T: Into<Stored>>(&mut self, width: T) {
@@ -226,6 +224,39 @@ impl Default for Digested {
   fn default() -> Self { Digested::TBox(Rc::new(Tbox::default())) }
 }
 
+impl fmt::Display for Digested {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    match *self {
+      Digested::TBox(ref b) => write!(f, "{}", b),
+      Digested::List(ref l) => write!(f, "{}", l),
+      Digested::Whatsit(ref w) => write!(f, "{}", w.borrow()),
+      Digested::Postponed(ref t) => write!(f, "{}", t),
+      Digested::KeyVals(ref kvs) => write!(f, "{}", kvs),
+      Digested::RegisterValue(ref rv) => write!(f, "{}", rv),
+    }
+  }
+}
+impl Object for Digested {
+  fn stringify(&self) -> String {
+    match *self {
+      Digested::TBox(ref b) => b.stringify(),
+      Digested::List(ref l) => l.stringify(),
+      Digested::Whatsit(ref w) => w.borrow().stringify(),
+      Digested::Postponed(ref t) => (*t).stringify(),
+      Digested::KeyVals(ref kvs) => kvs.stringify(),
+      Digested::RegisterValue(ref rv) => (*rv).stringify(),
+    }
+  }
+
+  fn get_locator(&self) -> Cow<Locator> {
+    match *self {
+      Digested::TBox(ref b) => b.get_locator(),
+      Digested::List(ref l) => l.get_locator(),
+      Digested::Whatsit(ref w) => Cow::Owned(w.borrow().get_locator().into_owned()),
+      _ => unimplemented!(),
+    }
+  }
+}
 impl BoxOps for Digested {
   fn unlist(&self) -> Vec<Digested> {
     match self {
@@ -258,28 +289,6 @@ impl BoxOps for Digested {
     //   Digested::KeyVals(ref mut kvs) => kvs.get_properties_mut(),
     //   Digested::Postponed(_) => unimplemented!(),
     // }
-  }
-
-  fn to_string(&self) -> String {
-    match *self {
-      Digested::TBox(ref b) => b.to_string(),
-      Digested::List(ref l) => l.to_string(),
-      Digested::Whatsit(ref w) => w.borrow().to_string(),
-      Digested::Postponed(ref t) => t.to_string(),
-      Digested::KeyVals(ref kvs) => kvs.to_string(),
-      Digested::RegisterValue(ref rv) => rv.to_string(),
-    }
-  }
-
-  fn stringify(&self) -> String {
-    match *self {
-      Digested::TBox(ref b) => b.stringify(),
-      Digested::List(ref l) => l.stringify(),
-      Digested::Whatsit(ref w) => w.borrow().stringify(),
-      Digested::Postponed(ref t) => (*t).stringify(),
-      Digested::KeyVals(ref kvs) => kvs.stringify(),
-      Digested::RegisterValue(ref rv) => rv.stringify(),
-    }
   }
 
   fn set_property<T: Into<Stored>>(&mut self, key: &str, value: T) {
@@ -328,15 +337,6 @@ impl BoxOps for Digested {
         None => None,
         Some(t) => Some(Cow::Owned(t.into_owned())),
       },
-      _ => unimplemented!(),
-    }
-  }
-
-  fn get_locator(&self) -> Option<Locator> {
-    match *self {
-      Digested::TBox(ref b) => b.get_locator(),
-      Digested::List(ref l) => l.get_locator(),
-      Digested::Whatsit(ref w) => w.borrow().get_locator(),
       _ => unimplemented!(),
     }
   }

--- a/rtx_core/src/list.rs
+++ b/rtx_core/src/list.rs
@@ -6,6 +6,7 @@ use crate::common::error::*;
 use crate::common::font::Font;
 use crate::common::locator::Locator;
 use crate::common::store::Stored;
+use crate::common::object::Object;
 use crate::document::Document;
 use crate::state::State;
 
@@ -18,6 +19,7 @@ pub struct List {
   pub boxes: Vec<Digested>,
   pub mode: Option<TexMode>,
   pub font: Option<Font>,
+  pub locator: Locator,
 }
 
 impl fmt::Debug for List {
@@ -30,11 +32,24 @@ impl fmt::Debug for List {
   }
 }
 
+impl fmt::Display for List {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    for inner in self.boxes.iter() {
+      write!(f, "{}", inner)?;
+    }
+    Ok(())
+  }
+}
+
+impl Object for List {
+  fn get_locator(&self) -> Cow<Locator> {
+    Cow::Borrowed(&self.locator)
+  }
+  fn stringify(&self) -> String { unimplemented!(); }
+}
 impl BoxOps for List {
   fn unlist(&self) -> Vec<Digested> { self.boxes.clone() }
   fn get_properties_mut(&mut self) -> &mut HashMap<String, Stored> { unimplemented!() }
-
-  fn to_string(&self) -> String { self.boxes.iter().fold(String::new(), |joined, x| joined + &x.to_string()) }
 
   /// NOTE: No longer used; Document->absorb bypasses this for stack efficiency.
   fn be_absorbed(&self, document: &mut Document, state: &mut State) -> Result<()> { unimplemented!() }
@@ -53,18 +68,21 @@ impl BoxOps for List {
       Some(ref f) => Some(Cow::Borrowed(&f)),
     }
   }
-
-  fn get_locator(&self) -> Option<Locator> {
-    // TODO
-    None
-  }
 }
 
 impl List {
   pub fn new(boxes: Vec<Digested>) -> Self {
     // while (defined($bx = shift(@bxs)) && (!defined $locator)) {
     //   $locator = $bx->getLocator unless defined $locator; }
-
+    // TODO: Should the locators be an Option<> type? Or can we test for the default here, since it's rare? Hmmmm
+    let mut locator: Locator = Locator::default();
+    for bx in boxes.iter().rev() {
+      let bx_locator = bx.get_locator();
+      if *bx_locator != locator { // not the default!
+        locator = bx_locator.into_owned();
+        break;
+      }
+    }
     // Maybe the most representative font for a List is the font of the LAST box (that _has_ a
     // font!) ???
     let mut font: Option<Font> = None;
@@ -74,7 +92,7 @@ impl List {
         break;
       }
     }
-    List { boxes, font, mode: None }
+    List { boxes, font, mode: None, locator }
   }
 }
 

--- a/rtx_core/src/mouth.rs
+++ b/rtx_core/src/mouth.rs
@@ -13,7 +13,6 @@ use encoding::all::ISO_8859_1;
 use core::ops::RangeBounds;
 use lazy_static::lazy_static;
 use regex::Regex;
-use log::*;
 
 use crate::common::error::*;
 use crate::common::store::Stored;
@@ -318,7 +317,8 @@ impl Mouth {
         let num_bytes = match reader.read_until(b'\n', &mut line_bytes) {
           Ok(count) => count,
           Err(e) => {
-            warn!(target: "mouth:io", "BufReader::read_until returned an error: {:?}", e);
+            let message = s!("BufReader::read_until returned an error: {:?}", e);
+            Warn!("mouth","io", self, state, message);
             0
           }
         };
@@ -341,14 +341,16 @@ impl Mouth {
             // line = encoding, line_bytes
       
             // Just remove the replacement chars, and warn (or Info?)
-            info!(target: &s!("misdefined:{}", encoding), "input isn't valid under encoding {}", encoding); 
+            let message = s!("input isn't valid under encoding {}", encoding);
+            Info!("misdefined", encoding, self, state, message); 
             unsafe { str::from_utf8_unchecked(&line_bytes).to_string() }
           } else {
             // no encoding, interpret as unicode! 
             match str::from_utf8(&line_bytes) {
               Ok(line_str) => line_str.to_string(),
               Err(e) => {
-                info!(target: "misdefined:utf8", "input isn't valid under encoding utf8: {:?}", e); 
+                let message = s!("input isn't valid under encoding utf8: {:?}", e);
+                Info!("misdefined", "utf8", self, state, message); 
                 unsafe { str::from_utf8_unchecked(&line_bytes).to_string() }
               }
             }

--- a/rtx_core/src/mouth.rs
+++ b/rtx_core/src/mouth.rs
@@ -170,6 +170,7 @@ impl Mouth {
       Mouth::new("", Some(options), state)
     } else {
       options.foodtype = FoodType::opt_from_str(&pathname::protocol(source));
+      options.source = Some(source.to_string());
       Mouth::new(source, Some(options), state)
     }
   }
@@ -184,6 +185,7 @@ impl Mouth {
         foodtype: opts.foodtype.unwrap_or(FoodType::Literal),
         fordefinitions: opts.fordefinitions,
         notes: opts.notes,
+        source: opts.source.unwrap_or_default(),
         ..Mouth::default()
       },
     };

--- a/rtx_core/src/mouth.rs
+++ b/rtx_core/src/mouth.rs
@@ -16,6 +16,8 @@ use log::*;
 
 use crate::common::error::*;
 use crate::common::store::Stored;
+use crate::common::locator::Locator;
+use crate::common::object::Object;
 use crate::state::{Catcodes, Scope, State, StateOptions};
 use crate::token::*;
 use crate::tokens::Tokens;
@@ -116,6 +118,22 @@ impl Default for Mouth {
       buffer: VecDeque::new(),
       reader: None,
     }
+  }
+}
+
+impl Object for Mouth {
+  fn stringify(&self) -> String {
+    s!("Mouth[<string>{}x{}]", self.lineno, self.colno)
+  }
+  fn get_locator(&self) -> Cow<Locator> {
+    let (to_line, to_column) = (self.lineno, self.colno);
+    let max_col = self.nchars - 1; // There is always a trailing EOL char
+    let (from_line, from_column) = if to_column > 0 && to_column >= max_col {
+      (to_line, 0)
+    } else {
+      (to_line, to_column)
+    };
+    Cow::Owned(Locator::new(self.source.clone(), from_line, from_column, to_line, to_column))
   }
 }
 
@@ -387,14 +405,6 @@ impl Mouth {
   }
   pub fn has_more_input(&mut self) -> bool { self.colno < self.nchars || !self.buffer.is_empty() || 
     (self.reader.is_some() && !self.reader.as_mut().unwrap().fill_buf().unwrap().is_empty()) }
-  // fn stringify(&self) -> String {
-  //   // TODO
-  //   s!("mouth stringify")
-  // } // This should be an implementation of Debug?
-  // fn get_locator(&self, length: usize) -> String {
-  //   // TODO
-  //   s!("mouth locator")
-  // }
 
   /// Read the next token, or undef if exhausted.
   /// Note that this also returns COMMENT tokens containing source comments,

--- a/rtx_core/src/mouth.rs
+++ b/rtx_core/src/mouth.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::fs::File;
+use std::fmt;
 use std::io;
 use std::str;
 use std::io::prelude::*;
@@ -121,13 +122,18 @@ impl Default for Mouth {
   }
 }
 
+impl fmt::Display for Mouth {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { 
+    write!(f, "Mouth[{}]", self.source)
+  }
+}
 impl Object for Mouth {
   fn stringify(&self) -> String {
     s!("Mouth[<string>{}x{}]", self.lineno, self.colno)
   }
   fn get_locator(&self) -> Cow<Locator> {
     let (to_line, to_column) = (self.lineno, self.colno);
-    let max_col = self.nchars - 1; // There is always a trailing EOL char
+    let max_col = if self.nchars > 0 { self.nchars - 1 } else { self.nchars }; // There is always a trailing EOL char, if any
     let (from_line, from_column) = if to_column > 0 && to_column >= max_col {
       (to_line, 0)
     } else {

--- a/rtx_core/src/parameter.rs
+++ b/rtx_core/src/parameter.rs
@@ -7,6 +7,7 @@ use std::rc::Rc;
 
 use crate::common::error::*;
 use crate::common::store::Stored;
+use crate::common::object::Object;
 use crate::definition::constructor::Constructor;
 use crate::definition::{BeforeDigestClosure, Definition, DigestionClosure};
 use crate::gullet::Gullet;
@@ -116,9 +117,16 @@ impl fmt::Debug for Parameter {
     )
   }
 }
+impl fmt::Display for Parameter {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(f, "{}", self.name)
+  }
+}
+
 impl PartialEq for Parameter {
   fn eq(&self, other: &Parameter) -> bool { self.name == other.name }
 }
+impl Object for Parameter {}
 
 lazy_static! {
   static ref OPTIONAL_REGEX: Regex = Regex::new(r"^Optional(.+)$").unwrap();
@@ -261,8 +269,7 @@ impl Parameter {
       // Deyan: Special exception, which may motivate switching the reader type to Option<Tokens> in the long-run
       //        Until *may* have a value, but it also may *not*, both OK. So... except it from the error message here
       if !self.name.starts_with("Until") {
-        error!(target: &s!("expected:{:?}", self.name), "Missing argument for TODO:fordefn {:?}", self);
-        //     $gullet->showUnexpected);
+        Error!("expected", self, gullet, state, s!("Missing argument {} for {}", self.stringify(), fordefn.stringify()));
         value = Tokens!(T_OTHER!("missing"));
       }
     }

--- a/rtx_core/src/parameter.rs
+++ b/rtx_core/src/parameter.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use log::{error, warn};
 use regex::Regex;
 use std::borrow::Cow;
 use std::fmt;
@@ -88,7 +87,7 @@ impl Default for Parameter {
       spec: String::new(),
       extra: Vec::new(),
       reader: Rc::new(|_gullet, _args, _extra, _state| {
-        warn!("-- Warning: please define a real reader, this is a mock fallback!");
+        Warn!("Parameter","mock_reader", None, None, "Please define a real reader, this is a mock fallback!");
         Ok(Tokens!())
       }),
       reader_predigest: None,

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use log::*;
 use regex::Regex;
 use std::borrow::Cow;
 use std::cell::RefCell;
@@ -673,11 +672,13 @@ impl State {
       if defn.is_register() {
         defn.value_of(parameters, self)
       } else {
-        warn!(target: "expected:register", "The control sequence {:?} is not a register",cs);
+        let message = s!("The control sequence {:?} is not a register",cs);
+        Warn!("expected","register", None, self, message);
         None
       }
     } else {
-      warn!(target: "expected:register", "The control sequence {:?} is not defined",cs);
+      let message = s!("The control sequence {:?} is not defined",cs);
+      Warn!("expected","register", None, self, message);
       None
     }
   }
@@ -1021,11 +1022,11 @@ impl State {
       cc.name()
     };
 
-    debug!("Looking up digestable {:?}", lookupname);
+    Debug!("Looking up digestable {:?}", lookupname);
     let entry = self.meaning.get(lookupname);
 
     if !lookupname.is_empty() && entry.is_some() {
-      debug!("Found definition for: {:?}", lookupname);
+      Debug!("Found definition for: {:?}", lookupname);
       let mut defn = entry.unwrap().front().unwrap().clone();
       if let Stored::Token(ref t) = defn {
         let cc = t.get_catcode();
@@ -1294,13 +1295,13 @@ impl State {
           (*table_entry).pop_front();
           countdown_keys.push((table_name, key));
         } else {
-          warn!(
-            target: &s!("internal:{}", key), // $self->getStomach,
-            "Unassigning wrong value for $key from table $table in deactivateScope\
-             value is {:?} but stack is {:?}",
+          let message = s!("Unassigning wrong value for $key from table $table in deactivateScope\
+            value is {:?} but stack is {:?}",
             value,
-            table_entry.iter().map(ToString::to_string).collect::<Vec<String>>().join(", ")
-          );
+            table_entry.iter().map(ToString::to_string).collect::<Vec<String>>().join(", "));
+          let stomach = self.stomach.borrow();
+          use crate::common::object::Object;
+          Warn!("internal", key, stomach, self, message);
         }
       }
 
@@ -1338,7 +1339,8 @@ impl State {
       u => match UNITS.get(u) {
         Some(sp) => *sp,
         None => {
-          warn!(target:"expected:<unit>", "Illegal unit of measure {:?}, assuming pt.", u);
+          let message = s!("Illegal unit of measure {:?}, assuming pt.", u);
+          Warn!("expected","<unit>", None, self, message);
           *UNITS.get("pt").unwrap()
         },
       },

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -897,7 +897,7 @@ impl State {
   /// Get the `Meaning' of a token.  For active control sequence's
   /// this may give the definition object (if defined) or another token (if \let) or undef
   /// Any other token is returned as is.
-  pub fn lookup_meaning(&mut self, token: &Token) -> Option<Stored> {
+  pub fn lookup_meaning(&self, token: &Token) -> Option<Stored> {
     if token.get_catcode().is_active_or_cs() && !token.get_string().is_empty() {
       match self.meaning.get(&token.get_cs_name().to_owned()) {
         Some(entry) => match entry.front() {

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -7,13 +7,13 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::hash::Hash;
 use std::rc::Rc;
 
+pub use crate::common::store::Stored; // reexport for convenience
 use crate::common::dimension::Dimension;
 use crate::common::error::*;
 use crate::common::font::{Font, Fontmap};
 use crate::common::glue::Glue;
 use crate::common::model::{IndirectModel, Model};
 use crate::common::number::Number;
-pub use crate::common::store::Stored; // reexport for convenience
 use crate::common::BindingDispatcher;
 use crate::definition::conditional::{ConditionalType, IfFrame};
 use crate::definition::expandable::Expandable;
@@ -212,7 +212,7 @@ pub struct State {
   pub model: Model,
   pub document: Option<Document>,
   pub prefixes: HashMap<String, bool>, // ?
-  pub status: HashMap<String, bool>,   // ?
+  pub status: RefCell<HashMap<String, bool>>,   // ?
   pub map: Vec<String>,                // ?
   pub tag_properties: HashMap<String, TagOptions>,
   pub indirect_model: Option<IndirectModel>,
@@ -267,7 +267,7 @@ impl Default for State {
       model: Model::default(),
       document: None,
       prefixes: HashMap::new(),
-      status: HashMap::new(),
+      status: RefCell::new(HashMap::new()),
       map: Vec::new(),
       tag_properties: HashMap::new(),
       indirect_model: None,
@@ -568,7 +568,7 @@ impl State {
     if let Some(&mut Stored::VecDequeStored(ref mut front)) = self.value.get_mut(key).unwrap().front_mut() {
       front.push_back(value);
     } else {
-      error!(target: "state:Stored", "BUG: Tried to push_value into a non-vecdeque value key!");
+      Error!("state","Stored", None, self, "BUG: Tried to push_value into a non-vecdeque value key!");
     }
   }
 
@@ -579,7 +579,7 @@ impl State {
     if let Some(&mut Stored::VecDequeStored(ref mut front)) = self.value.get_mut(key).unwrap().front_mut() {
       front.pop_back()
     } else {
-      error!(target: "state:Stored", "BUG: Tried to pop_value from a non-vecdeque value key!");
+      Error!("state","Stored", None, self, "BUG: Tried to pop_value from a non-vecdeque value key!");
       None
     }
   }
@@ -732,7 +732,7 @@ impl State {
     if let Some(&mut Stored::VecDequeStored(ref mut front)) = self.value.get_mut(key).unwrap().front_mut() {
       front.pop_front()
     } else {
-      error!(target: "state:Stored", "BUG: Tried to shift_value from a non-vecdeque value key!");
+      Error!("state","Stored", None, self, "BUG: Tried to shift_value from a non-vecdeque value key!");
       None
     }
   }
@@ -957,7 +957,8 @@ impl State {
           ..Expandable::default()
         })),
         Some(v) => {
-          error!(target:"unexpected:value", "in lookup_definition for {:?}. Value was: {:?}", key, v);
+          let message = s!("in lookup_definition for {:?}. Value was: {:?}", key, v);
+          Error!("unexpected","value", None, self, message);
           None
         },
         None => None,
@@ -986,7 +987,8 @@ impl State {
           ..Expandable::default()
         }))),
         Some(v) => {
-          error!(target:"unexpected:value", "in lookup_definition for {:?}. Value was: {:?}", key, v);
+          let message = s!("in lookup_definition for {:?}. Value was: {:?}", key, v);
+          Error!("unexpected","value", None, self, message);
           None
         },
         None => None,
@@ -1345,8 +1347,14 @@ impl State {
 
   // #======================================================================
 
-  pub fn note_status(&mut self, category: &str) {
-    // TODO
+  pub fn note_status(&self, category: &str) {
+    // Ok, note status is *EXTREMELY* localized
+    // it only touches the status field of state, 
+    // and has NO side-effects to any of the other stateful machinery.
+    // So. Let's make it possible to call it from any context, including immutable state borrows,
+    // by using interiror mutability. 
+    // "Proof by commenting intent"
+
     // if ($type eq 'undefined') {
     //   map { $$self{status}{undefined}{$_}++ } @data; }
     // elsif ($type eq 'missing') {

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -1345,15 +1345,15 @@ impl State {
 
   // #======================================================================
 
-  // sub noteStatus {
-  //   my ($self, $type, @data) = @_;
-  //   if ($type eq 'undefined') {
-  //     map { $$self{status}{undefined}{$_}++ } @data; }
-  //   elsif ($type eq 'missing') {
-  //     map { $$self{status}{missing}{$_}++ } @data; }
-  //   else {
-  //     $$self{status}{$type}++; }
-  //   return; }
+  pub fn note_status(&mut self, category: &str) {
+    // TODO
+    // if ($type eq 'undefined') {
+    //   map { $$self{status}{undefined}{$_}++ } @data; }
+    // elsif ($type eq 'missing') {
+    //   map { $$self{status}{missing}{$_}++ } @data; }
+    // else {
+    //   $$self{status}{$type}++; 
+  }
 
   // sub getStatus {
   //   my ($self, $type) = @_;

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -17,7 +17,7 @@ pub use crate::common::store::Stored; // reexport for convenience
 use crate::common::BindingDispatcher;
 use crate::definition::conditional::{ConditionalType, IfFrame};
 use crate::definition::expandable::Expandable;
-use crate::definition::register::{Register, RegisterValue};
+use crate::definition::register::{RegisterCell, RegisterValue};
 use crate::definition::Definition;
 use crate::document::resource::Resource;
 use crate::document::tag::TagOptions;
@@ -997,7 +997,7 @@ impl State {
 
   /// A specialized version of `lookup_definition` for registers, since we can't adequately perform
   /// multi-dispatch when we have a "Self: Sized" for the Definition trait object.
-  pub fn lookup_register_definition<'def>(&self, key: &'def Token) -> Option<Rc<RefCell<Register>>> {
+  pub fn lookup_register_definition<'def>(&self, key: &'def Token) -> Option<Rc<RegisterCell>> {
     match self.lookup_definition_internal(key) {
       Some(defs) => match defs.front() {
         Some(Stored::Register(entry)) => Some(Rc::clone(entry)),

--- a/rtx_core/src/stomach.rs
+++ b/rtx_core/src/stomach.rs
@@ -48,7 +48,7 @@ impl<'t> Stomach {
   // NOTE: Worry about whether the $autoflush thing is right?
   // It puts a lot of cruft in Gullet; Should we just create a new Gullet?
   pub fn digest_next_body(&mut self, terminal_opt: Option<Token>, state: &mut State) -> Result<Vec<Digested>> {
-    let start_location = self.get_locator();
+    let start_location = self.get_locator().into_owned();
     let init_depth = self.boxing.len();
     let mut found_terminal = false;
     let mut box_list: Vec<Digested> = Vec::new();
@@ -162,7 +162,7 @@ impl<'t> Stomach {
     Ok(())
   }
 
-  pub fn get_locator(&self) -> Locator { self.get_gullet().get_locator() }
+  pub fn get_locator(&self) -> Cow<Locator> { self.get_gullet().get_locator() }
 
   /// Invoke a token;
   /// If it is a primitive or constructor, the definition will be invoked,
@@ -352,7 +352,7 @@ impl<'t> Stomach {
         Ok(Some(Digested::TBox(Rc::new(Tbox::new(
           meaning.get_string().to_string(), //text
           font,
-          Some(self.gullet.get_locator()), //locator
+          Some(self.gullet.get_locator().into_owned()), //locator
           Tokens!(meaning),                // tokens
           HashMap::new(),                  // properties
           state,
@@ -469,7 +469,7 @@ impl<'t> Stomach {
     state.assign_value("afterAssignment", Stored::Tokens(Tokens!()), Some(Scope::Local)); // ALWAYS bind this!
     state.assign_value("groupNonBoxing", nobox, Some(Scope::Local)); // ALWAYS bind this!
     state.assign_value("groupInitiator", current_token.clone(), Some(Scope::Local));
-    state.assign_value("groupInitiatorLocator", self.get_locator(), Some(Scope::Local));
+    state.assign_value("groupInitiatorLocator", self.get_locator().into_owned(), Some(Scope::Local));
     if !nobox {
       self.boxing.push(current_token) // For begingroup/endgroup
     }

--- a/rtx_core/src/stomach.rs
+++ b/rtx_core/src/stomach.rs
@@ -1,4 +1,3 @@
-use log::{error, warn};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -84,10 +83,8 @@ impl<'t> Stomach {
 
     if let Some(ref terminal) = terminal_opt {
       if !found_terminal {
-        warn!(
-          target: &s!("expected:{}", terminal),
-          "body should have ended with {:?}. current body started at {:?}", terminal, start_location
-        );
+        let message = s!("body should have ended with {:?}. current body started at {:?}", terminal, start_location);
+        Warn!("expected", terminal, self, state, message);
       }
     }
 

--- a/rtx_core/src/stomach.rs
+++ b/rtx_core/src/stomach.rs
@@ -163,6 +163,14 @@ impl<'t> Stomach {
   }
 
   pub fn get_locator(&self) -> Cow<Locator> { self.get_gullet().get_locator() }
+  pub fn get_location(&self) -> String { 
+    let loc = self.get_locator();
+    if *loc == Locator::default() {
+      String::new()
+    } else {
+      loc.to_string()
+    }
+  }
 
   /// Invoke a token;
   /// If it is a primitive or constructor, the definition will be invoked,
@@ -285,10 +293,8 @@ impl<'t> Stomach {
     if cs.starts_with("\\if") {
       // Apparently an \ifsomething ???
       let name = cs.replace("\\if", "");
-      error!(
-        target: &s!("undefined:{}", cs),
-        "The token {} is not defined. Defining it now as with \\newif", cs
-      );
+      let message = s!("The token {} is not defined. Defining it now as with \\newif", cs);
+      Error!("undefined", cs, self, &message, state);
       // install stub definitions for new conditional
       let cs_clone = cs.clone();
       state.install_definition(
@@ -317,10 +323,8 @@ impl<'t> Stomach {
       gullet.unread(Tokens!(token.clone())); // Retry
       Ok(Vec::new())
     } else {
-      error!(
-        target: &s!("undefined:{}", cs),
-        "The token {:?} is not defined. Defining it now as <ltx:ERROR/>", cs
-      );
+      let message = s!("The token {:?} is not defined. Defining it now as <ltx:ERROR/>", cs);
+      Error!("undefined", cs, self, &message, state);
       let closure_cs = cs.clone();
       state.install_definition(
         Constructor {
@@ -406,7 +410,7 @@ impl<'t> Stomach {
             is_mouth = true;
           }
         } else {
-          error!(target: "unexpected:runtime", "TODO: gullet had no active runtime");
+          Error!("unexpected","runtime", self, "TODO: gullet had no active runtime", state);
           break;
         }
       }
@@ -414,7 +418,7 @@ impl<'t> Stomach {
         gullet.close_mouth(true, state);
         break;
       } else if gullet.mouthstack.is_empty() {
-        error!(target: "unexpected:<closed>", "TODO: Mouth is unexpectedly already closed");
+        Error!("unexpected", "<closed>", self, "TODO: Mouth is unexpectedly already closed", state);
         // Error('unexpected', '<closed>', $gullet, "Mouth is unexpectedly already closed",
         //   "Reading from " . Stringify($mouth) . ", but it has already been closed.");
         break;
@@ -518,10 +522,7 @@ impl<'t> Stomach {
   pub fn egroup(&mut self, state: &mut State) -> Result<()> {
     if state.lookup_bool("groupNonBoxing") {
       // or group was opened with \begingroup
-      error!(
-        target: &s!("unexpected:{}", state.current_token.as_ref().unwrap()),
-        "Attempt to close boxing group"
-      );
+      Error!("unexpected", state.current_token.as_ref().unwrap(), self, "Attempt to close boxing group", state);
     } else {
       // Don't pop if there's an error; maybe we'll recover?
       self.pop_stack_frame(false, state)?;
@@ -594,11 +595,13 @@ impl<'t> Stomach {
     // Last stack frame was NOT a mode switch!?!?!
     if !state.is_value_bound("MODE", Some(0)) || (state.lookup_string("MODE") != mode) {
       // Or was a mode switch to a different mode
-      if let Some(ref token) = state.current_token {
-        error!(target: &s!("unexpected:{}", token), "Attempt to end mode {}", mode); // self.currentFrameMessage);
+      let message = s!("Attempt to end mode {}", mode);
+      let category = if let Some(ref token) = state.current_token {
+        token.to_string()
       } else {
-        error!(target: &s!("unexpected:mode"), "Attempt to end mode {}", mode);
-      }
+        String::from("mode")
+      };
+      Error!("unexpected", category, self, &message, state); // self.currentFrameMessage);      
     } else {
       // Don"t pop if there"s an error; maybe we'll recover?
       self.pop_stack_frame(false, state)?;

--- a/rtx_core/src/stomach.rs
+++ b/rtx_core/src/stomach.rs
@@ -7,6 +7,7 @@ use crate::common::error::*;
 use crate::common::font;
 use crate::common::font::Font;
 use crate::common::store::Stored;
+use crate::common::locator::Locator;
 use crate::definition::constructor::Constructor;
 use crate::definition::expandable::Expandable;
 use crate::definition::Definition;
@@ -161,7 +162,7 @@ impl<'t> Stomach {
     Ok(())
   }
 
-  pub fn get_locator(&self) -> String { s!("fake stomach locator") }
+  pub fn get_locator(&self) -> Locator { self.get_gullet().get_locator() }
 
   /// Invoke a token;
   /// If it is a primitive or constructor, the definition will be invoked,

--- a/rtx_core/src/stomach.rs
+++ b/rtx_core/src/stomach.rs
@@ -8,6 +8,7 @@ use crate::common::font;
 use crate::common::font::Font;
 use crate::common::store::Stored;
 use crate::common::locator::Locator;
+use crate::common::object::Object;
 use crate::definition::constructor::Constructor;
 use crate::definition::expandable::Expandable;
 use crate::definition::Definition;
@@ -36,6 +37,11 @@ impl Default for Stomach {
       boxing: Vec::new(),
     }
   }
+}
+
+impl Object for Stomach {
+  fn get_locator(&self) -> Cow<Locator> { self.get_gullet().get_locator() }
+  fn stringify(&self) -> String { String::from("TODO Stomach") }
 }
 
 impl<'t> Stomach {
@@ -162,16 +168,6 @@ impl<'t> Stomach {
     Ok(())
   }
 
-  pub fn get_locator(&self) -> Cow<Locator> { self.get_gullet().get_locator() }
-  pub fn get_location(&self) -> String { 
-    let loc = self.get_locator();
-    if *loc == Locator::default() {
-      String::new()
-    } else {
-      loc.to_string()
-    }
-  }
-
   /// Invoke a token;
   /// If it is a primitive or constructor, the definition will be invoked,
   /// possibly arguments will be parsed from the Gullet.
@@ -210,10 +206,8 @@ impl<'t> Stomach {
               result.push(digested);
             }
           } else {
-            error!(
-              target: &s!("misdefined:{:?}", &token),
-              "The token {:?} should never reach Stomach!", token
-            );
+            let message = s!("The token {:?} should never reach Stomach!", token);
+            Error!("misdefined", token, self, state, &message);
             if let Some(digested) = self.invoke_token_simple(meaning, state)? {
               result.push(digested);
             }
@@ -293,8 +287,8 @@ impl<'t> Stomach {
     if cs.starts_with("\\if") {
       // Apparently an \ifsomething ???
       let name = cs.replace("\\if", "");
-      let message = s!("The token {} is not defined. Defining it now as with \\newif", cs);
-      Error!("undefined", cs, self, &message, state);
+      let message = s!("The token {} is not defined.", token.stringify());
+      Error!("undefined", token, self, state, &message, "Defining it now as with \\newif");
       // install stub definitions for new conditional
       let cs_clone = cs.clone();
       state.install_definition(
@@ -323,8 +317,8 @@ impl<'t> Stomach {
       gullet.unread(Tokens!(token.clone())); // Retry
       Ok(Vec::new())
     } else {
-      let message = s!("The token {:?} is not defined. Defining it now as <ltx:ERROR/>", cs);
-      Error!("undefined", cs, self, &message, state);
+      let message = s!("The token {} is not defined.", token.stringify());
+      Error!("undefined", token, self, state, &message, "Defining it now as <ltx:ERROR/>");
       let closure_cs = cs.clone();
       state.install_definition(
         Constructor {
@@ -410,7 +404,7 @@ impl<'t> Stomach {
             is_mouth = true;
           }
         } else {
-          Error!("unexpected","runtime", self, "TODO: gullet had no active runtime", state);
+          Error!("unexpected","runtime", self, state, "TODO: gullet had no active runtime");
           break;
         }
       }
@@ -418,24 +412,26 @@ impl<'t> Stomach {
         gullet.close_mouth(true, state);
         break;
       } else if gullet.mouthstack.is_empty() {
-        Error!("unexpected", "<closed>", self, "TODO: Mouth is unexpectedly already closed", state);
+        Error!("unexpected", "<closed>", self, state, "TODO: Mouth is unexpectedly already closed");
         // Error('unexpected', '<closed>', $gullet, "Mouth is unexpectedly already closed",
         //   "Reading from " . Stringify($mouth) . ", but it has already been closed.");
         break;
       } else {
+        let mut stringify_mouth = String::new();
         let mut ready_to_read = false;
         {
           if let Some(ref mut runtime) = gullet.mouth {
             if !runtime.autoclose || !runtime.pushback.is_empty() || runtime.mouth.has_more_input() {
               ready_to_read = true;
+              stringify_mouth = runtime.mouth.stringify();
             }
           }
         }
         if ready_to_read {
-          let _next = gullet.read_token(state); // stringify( ?
-          error!(target: "unexpected:next", "TODO: unexpected input remaining");
-          // Error('unexpected', $next, $gullet, "Unexpected input remaining: '$next'",
-          //   "Finished reading from " . Stringify($mouth) . ", but it still has input.");
+          let next = gullet.read_token(state);
+          let message = s!("Unexpected input remaining: {:?}", next);
+          let detail = s!("Finished reading from {}, but it still has input.", stringify_mouth);
+          Error!("unexpected","next", gullet, state, message, detail);          
           {
             if let Some(ref mut runtime) = gullet.mouth {
               runtime.mouth.finish(state);
@@ -522,7 +518,7 @@ impl<'t> Stomach {
   pub fn egroup(&mut self, state: &mut State) -> Result<()> {
     if state.lookup_bool("groupNonBoxing") {
       // or group was opened with \begingroup
-      Error!("unexpected", state.current_token.as_ref().unwrap(), self, "Attempt to close boxing group", state);
+      Error!("unexpected", state.current_token.as_ref().unwrap(), self, state, "Attempt to close boxing group");
     } else {
       // Don't pop if there's an error; maybe we'll recover?
       self.pop_stack_frame(false, state)?;
@@ -601,7 +597,7 @@ impl<'t> Stomach {
       } else {
         String::from("mode")
       };
-      Error!("unexpected", category, self, &message, state); // self.currentFrameMessage);      
+      Error!("unexpected", category, self, state, &message); // self.currentFrameMessage);      
     } else {
       // Don"t pop if there"s an error; maybe we'll recover?
       self.pop_stack_frame(false, state)?;

--- a/rtx_core/src/tbox.rs
+++ b/rtx_core/src/tbox.rs
@@ -2,11 +2,13 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
+use std::fmt;
 
 use crate::common::error::*;
 use crate::common::font::Font;
 use crate::common::locator::Locator;
 use crate::common::store::Stored;
+use crate::common::object::Object;
 use crate::document::Document;
 use crate::state::State;
 use crate::token::{Catcode, Token};
@@ -37,7 +39,17 @@ impl Default for Tbox {
 
 //======================================================================
 // Exported constructors
-
+impl fmt::Display for Tbox {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(f, "{}", self.text)
+  }
+}
+impl Object for Tbox {
+  fn get_locator(&self) -> Cow<Locator> {
+    Cow::Borrowed(&self.locator)
+  }
+  fn stringify(&self) -> String { unimplemented!(); }
+}
 impl Tbox {
   pub fn new(
     text: String,
@@ -94,7 +106,6 @@ impl Tbox {
 }
 
 impl BoxOps for Tbox {
-  fn to_string(&self) -> String { self.text.clone() }
   fn unlist(&self) -> Vec<Digested> { Vec::new() }
   fn get_properties_mut(&mut self) -> &mut HashMap<String, Stored> { &mut self.properties }
 
@@ -119,12 +130,6 @@ impl BoxOps for Tbox {
   fn revert(&self) -> Result<Tokens> { Ok(self.tokens.clone()) }
 
   fn get_font(&self) -> Option<Cow<Font>> { Some(Cow::Borrowed(&self.font)) }
-
-  fn get_locator(&self) -> Option<Locator> {
-    // TODO
-    // return $$self{properties}{locator};
-    None
-  }
 
   fn get_property(&self, key: &str, state: &mut State) -> Option<Cow<Stored>> {
     if key == "isSpace" {

--- a/rtx_core/src/token.rs
+++ b/rtx_core/src/token.rs
@@ -1,7 +1,6 @@
 use lazy_static::lazy_static;
 use log::warn;
 use std::borrow::Cow;
-use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::fmt;
 use std::fmt::Display;
@@ -14,7 +13,7 @@ use crate::common::glue::{Glue, MuGlue};
 use crate::common::number::Number;
 use crate::common::store::Stored;
 use crate::definition::register::NumericOps;
-use crate::definition::register::{Register, RegisterValue};
+use crate::definition::register::{RegisterValue, RegisterCell};
 use crate::definition::Definition;
 use crate::state::State;
 use crate::stomach::Stomach;
@@ -653,7 +652,7 @@ impl<'a> Token {
     s!("{}[{}]", self.code.short_name(), string)
   }
 
-  pub fn to_register(&self, state: &State) -> Option<Rc<RefCell<Register>>> { state.lookup_register_definition(self) }
+  pub fn to_register(&self, state: &State) -> Option<Rc<RegisterCell>> { state.lookup_register_definition(self) }
 
   pub fn to_number(&self) -> Number { Number::new(self.text.parse::<f32>().unwrap_or(0.0)) }
 

--- a/rtx_core/src/token.rs
+++ b/rtx_core/src/token.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use log::warn;
 use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::fmt;
@@ -74,7 +73,8 @@ impl From<u8> for Catcode {
       17 => NOTEXPANDED,
       18 => MARKER,
       _ => {
-        warn!(target:"unknown:catcode", "Unrecognized catcode: {:?}", num);
+        // let message = s!("Unrecognized catcode: {:?}", num);
+        // Warn!("unknown", "catcode", None, None, message);
         IGNORE
       },
     }

--- a/rtx_core/src/tokens.rs
+++ b/rtx_core/src/tokens.rs
@@ -1,6 +1,5 @@
 ///! Token List constructors.
 use crate::fmt;
-// use log::*;
 use proc_macro2::{Ident, Punct, Spacing, Span};
 use quote::{quote, ToTokens, TokenStreamExt};
 

--- a/rtx_core/src/util/pathname.rs
+++ b/rtx_core/src/util/pathname.rs
@@ -2,6 +2,7 @@ use dirs;
 use lazy_static::lazy_static;
 use regex::Regex;
 use kpathsea::Kpaths;
+use log::*;
 
 use std::env;
 use std::path::{Path, PathBuf};
@@ -31,6 +32,8 @@ lazy_static! {
   };
   static ref PROTOCOL_RE : Regex = Regex::new(r"(https|http|ftp):").unwrap();
   static ref PATHNAME_IS_NASTY_RE: Regex = Regex::new(r"[^\w\-_+=/\\\.~\s:]").unwrap();
+  // TODO: This is very pragmatic for now, we ought to use a real URL path library long-term
+  static ref URL_RE: Regex = Regex::new(r"^\w+://(.+)/([^/]+)$").unwrap();
   // static ref INSTALLDIRS : Vec<String> = match env::current_exe() {
   //     Ok(exe_path) => {
   //       match exe_path.as_path().parent() {
@@ -53,9 +56,8 @@ lazy_static! {
 
 }
 
-pub fn is_url(_path: &str) -> bool {
-  // TODO
-  false
+pub fn is_url(path: &str) -> bool {
+  URL_RE.is_match(path)
 }
 
 pub fn is_literaldata(data: &str) -> bool { data.starts_with(LITERAL_PROTOCOL) }
@@ -64,8 +66,8 @@ pub fn is_absolute(path: &str) -> bool { Path::new(&canonical(path)).is_absolute
 
 pub fn absolute(path: &str) -> String { Path::new(path).canonicalize().unwrap().to_string_lossy().to_string() }
 
-// Split the pathname into components (dir,name,type).
-// If pathname is absolute, dir starts with volume or '/'
+/// Split the pathname into components (dir,name,type).
+/// If pathname is absolute, dir starts with volume or '/'
 pub fn split(pathname: &str) -> (String, String, String) {
   let canonical_pathname = canonical(pathname);
   let canonical_path = Path::new(&canonical_pathname);
@@ -83,6 +85,15 @@ pub fn split(pathname: &str) -> (String, String, String) {
   }
   .to_lowercase();
   (pathdir, name, pathname_ext)
+}
+
+///  Simple logic for splitting a URL into protocol://base/path
+pub fn url_split(url: &str) -> (&str, &str) {
+  if let Some(caps) = URL_RE.captures(url) {
+    (caps.get(1).map_or("", |m| m.as_str()), caps.get(2).map_or("", |m| m.as_str()))
+  } else { 
+    (url, "index.tex")   // Well, what other default makes sense?
+  }
 }
 
 /// This likely needs portability work!!! (particularly regarding urls, separators, ...)

--- a/rtx_core/src/util/pathname.rs
+++ b/rtx_core/src/util/pathname.rs
@@ -2,7 +2,6 @@ use dirs;
 use lazy_static::lazy_static;
 use regex::Regex;
 use kpathsea::Kpaths;
-use log::*;
 
 use std::env;
 use std::path::{Path, PathBuf};

--- a/rtx_core/src/whatsit.rs
+++ b/rtx_core/src/whatsit.rs
@@ -8,6 +8,7 @@ use crate::common::error::*;
 use crate::common::font::Font;
 use crate::common::locator::Locator;
 use crate::common::store::Stored;
+use crate::common::object::Object;
 use crate::definition::expandable::Expandable;
 use crate::definition::{Definition, Reversion};
 use crate::document::Document;
@@ -27,6 +28,7 @@ pub struct Whatsit {
   pub definition: Rc<Definition>,
   pub reversion: Option<Tokens>,
   pub dual_reversion: Option<Tokens>,
+  pub locator: Locator,
 }
 
 impl Default for Whatsit {
@@ -37,6 +39,7 @@ impl Default for Whatsit {
       definition: Rc::new(Expandable::default()),
       reversion: None,
       dual_reversion: None,
+      locator: Locator::default()
     }
   }
 }
@@ -104,12 +107,19 @@ impl fmt::Debug for Whatsit {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "Whatsit {{ args: {:?}, properties: {:?} }}", self.args, self.properties) }
 }
 
+impl fmt::Display for Whatsit {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(f, "{}", self.revert().unwrap()) // What else??
+  }
+}
+impl Object for Whatsit {
+  fn get_locator(&self) -> Cow<Locator> {
+    Cow::Borrowed(&self.locator)
+  }
+  fn stringify(&self) -> String { unimplemented!(); }
+}
 impl BoxOps for Whatsit {
   fn get_properties_mut(&mut self) -> &mut HashMap<String, Stored> { &mut self.properties }
-  fn to_string(&self) -> String {
-    self.revert().unwrap().to_string() // What else??
-  }
-
   fn unlist(&self) -> Vec<Digested> { Vec::new() }
 
   fn be_absorbed(&self, document: &mut Document, state: &mut State) -> Result<()> {
@@ -235,10 +245,5 @@ impl BoxOps for Whatsit {
       Some(&Stored::Font(ref font)) => Some(Cow::Owned((**font).clone())),
       _ => None,
     }
-  }
-
-  fn get_locator(&self) -> Option<Locator> {
-    // TODO
-    None
   }
 }

--- a/rtx_core/tests/00_unit_state.rs
+++ b/rtx_core/tests/00_unit_state.rs
@@ -2,6 +2,7 @@ use rtx_core::definition::expandable::Expandable;
 use rtx_core::state::*;
 use rtx_core::token::{Catcode, Token};
 use rtx_core::tokens::Tokens;
+use rtx_core::common::locator::Locator;
 use rtx_core::{s, Explode, T_CS, T_OTHER, T_SPACE};
 use std::borrow::Cow;
 use std::collections::{HashMap, VecDeque};
@@ -182,7 +183,7 @@ fn install_definition_and_meaning() {
     paramlist: None,
     //       expansion: SimpleExpansion!(Tokens::new(Explode!("name"))),
     expansion: Tokens::new(Explode!("name")).into(),
-    locator: s!("from unit test, line 99"),
+    locator: Locator::new("00_unit_test.rs".to_string(), 180,1, 188, 5),
     is_protected: state.get_prefix("protected"),
     ..Expandable::default()
   };

--- a/rtx_package/src/converter.rs
+++ b/rtx_package/src/converter.rs
@@ -1,5 +1,4 @@
 use crate::core::DigestionAPI;
-use log::{error, info};
 use rtx_core::common::error::*;
 use rtx_core::common::{Config, DataSize, OutputFormat};
 use rtx_core::document::Document;
@@ -82,7 +81,7 @@ impl Converter {
     self.bind_log();
     // 1.2 Inform of identity, increase conversion counter
     if self.opts.verbosity >= 0 {
-      info!("{}", CONVERTER_IDENTITY);
+      Info!("{}",CONVERTER_IDENTITY);
       // info!( "invoked as [$0 " . join(' ', @ARGV) . "]\n" if $$opts{verbosity} >= 1;
       // info!("processing started " . localtime() . "\n"; )
     }
@@ -312,7 +311,7 @@ impl Converter {
     // else { $serialized = $result; }                              // Compressed case
 
     // 5.2 Finalize logging and return a response containing the document result, log and status
-    info!("status:conversion: {:?}", self.runtime.status_code);
+    Info!("status", "conversion", None, None, self.runtime.status_code);
     let log = self.flush_log();
     // self->sanitize($log) if ($$runtime{status_code} == 3);
 

--- a/rtx_package/src/converter.rs
+++ b/rtx_package/src/converter.rs
@@ -3,10 +3,11 @@ use log::{error, info};
 use rtx_core::common::error::*;
 use rtx_core::common::{Config, DataSize, OutputFormat};
 use rtx_core::document::Document;
+use rtx_core::common::object::Object;
 use rtx_core::list::List;
 use rtx_core::state::State;
 use rtx_core::token;
-use rtx_core::{BoxOps, Core, Digested};
+use rtx_core::{Core, Digested};
 use std::rc::Rc;
 
 const CONVERTER_IDENTITY: &str = "rtx (v0.1.12)";

--- a/rtx_package/src/converter.rs
+++ b/rtx_package/src/converter.rs
@@ -200,8 +200,11 @@ impl Converter {
         match dom_result {
           Ok(dom) => dom.to_string(self.state_mut()),
           Err(e) => {
-            error!(target: "document:convert", "{:?}", e);
-            s!("Fatal: convert document failed")
+            let message = s!("{:?}", e);
+            let error_state = &self.core.state;
+            let error_where = &self.core;
+            Error!("document", "convert", error_where, error_state, message);
+            String::new()
           },
         }
       },

--- a/rtx_package/src/core.rs
+++ b/rtx_package/src/core.rs
@@ -187,7 +187,7 @@ impl DigestionAPI for Core {
         document.insert_pi("latexml", Some(attributes))?;
       }
     }
-    debug!("DOC ABSORB: {:?}", digested);
+    Debug!("Doc absorb: {:?}", digested);
     document.absorb(digested, state)?;
     note_end("Building");
 

--- a/rtx_package/src/core.rs
+++ b/rtx_package/src/core.rs
@@ -232,7 +232,7 @@ impl DigestionAPI for Core {
 
   fn digest_file(&mut self, mut request: String, options: DigestionOptions) -> Result<Digested> {
     let mut dir = String::new();
-    let mut name = String::new();
+    let mut name;
     // let mut ext = String::new();
     let mode = match options.mode {
       None => DigestionMode::TeX,
@@ -265,10 +265,8 @@ impl DigestionAPI for Core {
         name = pathname::file_name(&request);
       // ext = pathname::extension(&request);
       } else {
-        error!(
-          target: &s!("Fatal:missing_file:{}", request_base),
-          "Can't find {} file {} ", mode, request
-        );
+        let message = s!("Can't find {} file {} ", mode, request);
+        fatal!(Core, MissingFile, self, None, message);
       }
     }
 

--- a/rtx_package/src/math_parser.rs
+++ b/rtx_package/src/math_parser.rs
@@ -22,7 +22,6 @@
 // use LaTeXML::Common::XML;
 // use List::Util qw(min max);
 use libxml::tree::{Node, NodeType};
-use log::info;
 use rtx_core::common::error::*;
 use rtx_core::common::xml::*;
 use rtx_core::document::Document;
@@ -954,7 +953,7 @@ impl MathParser {
       "ltx:XMApp" => {
         let app_role = node.get_attribute("role").unwrap_or_else(|| s!("missing_role"));
         let mut all_args = element_nodes(&node);
-        info!("xmapp args : {:?}", all_args.len());
+        Info!("xmapp args : {:?}", all_args.len());
         if all_args.is_empty() {
           String::new()
         } else {
@@ -964,8 +963,8 @@ impl MathParser {
             Some(op_node) => self.realize_xmnode(op_node, document),
             None => panic!("non empty array doesn't have a first element? Looks critical."),
           };
-          info!("first token meaning: {:?}", lead_meaning);
-          info!("remaining xmapp args: {:?}", args.len());
+          Info!("first token meaning: {:?}", lead_meaning);
+          Info!("remaining xmapp args: {:?}", args.len());
           //     if ($app_role && $app_role =~ /^FLOAT(SUB|SUPER)SCRIPT$/) {
           //       return ($1 eq 'SUPER' ? '^' : '_') . textrec($op); }
           //     else {
@@ -1100,7 +1099,7 @@ impl MathParser {
   // The following accessors work on both the LibXML and ARRAY representations
   // but they do NOT automatically dereference XMRef!
   fn p_get_value(&self, node: &Node) -> String {
-    info!("p_get_value for {} : {}", node.get_name(), node.get_content());
+    Info!("p_get_value for {} : {}", node.get_name(), node.get_content());
     let node_type = node.get_type();
     if node_type == Some(NodeType::ElementNode) {
       let x = node.get_content();

--- a/rtx_package/src/package/api/content.rs
+++ b/rtx_package/src/package/api/content.rs
@@ -1,4 +1,3 @@
-use log::*;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::Path;
@@ -105,8 +104,8 @@ pub fn input_definitions(raw_file: &str, mut options: InputDefinitionOptions, mu
   if !current_options.is_empty() {
     if let Some(Stored::String(prevoptions)) = state.lookup_value(&s!("{}_loaded_with_options",filename)) {
       if &current_options != prevoptions {
-        info!(target: "unexpected:options", //$STATE->getStomach->getGullet,
-          "Option clash for file {} with options {:?}, previously loaded with {:?}", filename, current_options, prevoptions);
+        let message = s!("Option clash for file {} with options {:?}, previously loaded with {:?}", filename, current_options, prevoptions);
+        Info!("unexpected","options", stomach, state, message);
       }
     }
   }
@@ -474,8 +473,7 @@ impl Default for RequireOptions {
 pub fn require_package(name: &str, mut options: RequireOptions, stomach: &mut Stomach, state: &mut State) -> Result<()> {
   if options.raw {
     options.raw = false;
-    warn!(target: "deprecated:raw",// $STATE->getStomach->getGullet,
-      "RequirePackage option raw is obsolete; it is not needed");
+    Warn!("deprecated","raw", stomach, state, "RequirePackage option raw is obsolete; it is not needed");
   }
 
   // We'll usually disallow raw TeX, unless the option explicitly given, or globally set.
@@ -508,7 +506,7 @@ pub fn require_package(name: &str, mut options: RequireOptions, stomach: &mut St
 
 pub fn require_resource(mut resource: Resource, state: &mut State) {
   if resource.name.is_empty() && resource.content.is_empty() {
-    warn!(target: "expected:resource", "Resource must have a resource pathname or content; skipping");
+    Warn!("expected","resource", None, state, "Resource must have a resource pathname or content; skipping");
     return;
   }
   if resource.mimetype.is_empty() && !resource.name.is_empty() {
@@ -516,7 +514,7 @@ pub fn require_resource(mut resource: Resource, state: &mut State) {
     resource.mimetype = resource_type(&ext);
   }
   if resource.mimetype.is_empty() {
-    warn!(target: "expected:mime-type", "Resource must have a mime-type; skipping");
+    Warn!("expected","mime-type", None, state, "Resource must have a mime-type; skipping");
     return;
   }
 
@@ -581,7 +579,7 @@ pub fn find_file(file: &str, options: Option<FindFileOptions>, state: &mut State
   let mut options = options.unwrap_or_default();
   if options.raw {
     options.raw = false;
-    warn!(target: "deprecated:raw", "FindFile option raw is deprecated; it is not needed");
+    Warn!("deprecated","raw", None, state, "FindFile option raw is deprecated; it is not needed");
   }
 
   if pathname::is_literaldata(file) {
@@ -675,7 +673,7 @@ pub fn find_file_aux(file: &str, options: &FindFileOptions, state: &mut State) -
     // if ($urlbase && ($path = url_find($file, urlbase => $urlbase))) {
     //   return $path; }
     // return; }
-    info!("No path found for: {:?}", file);
+    Info!("No path found for: {:?}", file);
     None
   }
 }

--- a/rtx_package/src/package/api/content.rs
+++ b/rtx_package/src/package/api/content.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 
 use rtx_core::common::error::*;
 use rtx_core::common::font::Font;
+use rtx_core::common::object::Object;
 use rtx_core::document::resource::*;
 use rtx_core::document::tag::{TagOptionName, TagOptions};
 use rtx_core::gullet::Gullet;
@@ -799,10 +800,8 @@ pub fn build_invocation<T: Into<Token>>(token: T, args: Vec<Tokens>, gullet: &mu
     invoked_tokens.append(&mut reverted_args);
     Ok(Tokens::new(invoked_tokens))
   } else {
-    error!(
-      target: &s!("undefined:{}", token.get_cs_name()),
-      "Can't invoke {:?}; it is undefined", token
-    );
+    let message = s!("Can't invoke {:?}; it is undefined", token.stringify());
+    Error!("undefined", token.get_cs_name(), gullet, state, message);
     let mut invoked_tokens = vec![token];
     // DefConstructorI!(token, convert_latex_args(args.len(), 0),
     // sub { LaTeXML::Core::Stomach::makeError($_[0], 'undefined', token); });

--- a/rtx_package/src/package/api/counter_dialect.rs
+++ b/rtx_package/src/package/api/counter_dialect.rs
@@ -1,5 +1,4 @@
 use libxml::tree::Node;
-use log::*;
 use std::borrow::Cow;
 use std::collections::{HashMap};
 use std::rc::Rc;
@@ -182,7 +181,8 @@ pub fn new_counter(ctr: &str, within: &str, options_opt: Option<NewCounterOption
 pub fn counter_value(ctr: &str, state: &mut State) -> Number {
   match state.lookup_number(&s!("\\c@{}", ctr)) {
     None => {
-      warn!(target: &s!("undefined:{:?}", ctr), "Counter {} was not defined; assuming 0", ctr);
+      let message = s!("Counter {} was not defined; assuming 0", ctr);
+      Warn!("undefined", ctr, None, state, message);
       Number!(0)
     },
     Some(value) => value,

--- a/rtx_package/src/package/api/counter_dialect.rs
+++ b/rtx_package/src/package/api/counter_dialect.rs
@@ -17,7 +17,6 @@ use rtx_core::state::{Scope, State, Stored};
 use rtx_core::stomach::Stomach;
 use rtx_core::token::*;
 use rtx_core::tokens::Tokens;
-use rtx_core::BoxOps;
 
 use super::*;
 use super::cleaners::clean_id;

--- a/rtx_package/src/package/api/def_dialect.rs
+++ b/rtx_package/src/package/api/def_dialect.rs
@@ -27,12 +27,12 @@ use super::*;
 use super::content::merge_font;
 
 /// Is defined in the `LaTeX`-y sense of also not being let to \relax.
-pub fn is_defined(name: &str, state: &mut State) -> bool {
+pub fn is_defined(name: &str, state: &State) -> bool {
   let cs = T_CS!(name);
   is_defined_token(&cs, state)
 }
 
-pub fn is_defined_token(cs: &Token, state: &mut State) -> bool {
+pub fn is_defined_token(cs: &Token, state: &State) -> bool {
   let meaning = state.lookup_meaning(cs);
   match meaning {
     Some(store) => match store {
@@ -46,6 +46,13 @@ pub fn is_defined_token(cs: &Token, state: &mut State) -> bool {
   }
 }
 
+pub fn is_definable(token: &Token, state: &State) -> bool {
+  let meaning = state.lookup_meaning(token);
+  let mut name = token.get_string();
+  (name != "\\relax" && !name.starts_with("\\end"))
+  &&
+  (meaning.is_none() || meaning == state.lookup_meaning(&T_CS!("\\relax")))
+}
 
 pub fn coerce_cs(t: &str) -> Token { T_CS!(t) }
 

--- a/rtx_package/src/package/api/def_dialect.rs
+++ b/rtx_package/src/package/api/def_dialect.rs
@@ -262,10 +262,8 @@ pub fn def_conditional(cs: Token, paramlist: Option<Parameters>, test: Option<Co
           );
         }
       } else {
-        error!(
-          target: &s!("misdefined:{}", cs),
-          "The conditional {} is being defined but doesn't start with \\if", cs
-        );
+        let message = s!("The conditional {} is being defined but doesn't start with \\if", cs);
+        Error!("misdefined", cs, None, state, message);
       }
     },
   }

--- a/rtx_package/src/package/api/def_dialect.rs
+++ b/rtx_package/src/package/api/def_dialect.rs
@@ -1,4 +1,3 @@
-use log::*;
 use std::borrow::Cow;
 use std::rc::Rc;
 
@@ -341,7 +340,8 @@ pub fn def_register<T: Into<RegisterValue>>(cs: Token, parameters: Option<Parame
     None => {
       if readonly {
         Rc::new(move |value, args, state| {
-          warn!(target: &s!("unexpected:{}", setter_name), "Can't assign to register {}", setter_name);
+          let message = s!("Can't assign to register {}", setter_name);
+          Warn!("unexpected", setter_name, None, state, message);
         })
       } else {
         Rc::new(move |value, args, state| {

--- a/rtx_package/src/package/mod.rs
+++ b/rtx_package/src/package/mod.rs
@@ -1,7 +1,6 @@
 #![allow(unreachable_code)]
 pub use lazy_static::lazy_static;
 pub use libxml::tree::{Namespace, Node};
-pub use log::{debug, error, info, warn};
 pub use regex::Regex;
 pub use std::borrow::Cow;
 pub use std::cell::RefCell;

--- a/rtx_package/src/package/mod.rs
+++ b/rtx_package/src/package/mod.rs
@@ -16,6 +16,8 @@ pub use rtx_core::common::font::Font;
 pub use rtx_core::common::glue::{Glue, MuGlue};
 pub use rtx_core::common::ligature::{FontTestClosure, Ligature};
 pub use rtx_core::common::number::Number;
+pub use rtx_core::common::object::Object;
+pub use rtx_core::common::locator::Locator;
 pub use rtx_core::definition::conditional::{Conditional, ConditionalOptions, ConditionalType};
 pub use rtx_core::definition::constructor::ConstructorOptions;
 pub use rtx_core::definition::expandable::{Expandable, ExpandableOptions};

--- a/rtx_package/src/package/pool/fontenc_sty.rs
+++ b/rtx_package/src/package/pool/fontenc_sty.rs
@@ -135,7 +135,8 @@ LoadDefinitions!(outer_stomach, state, {
             MergeFont!(encoding => encoding.to_string());
           }
         } else {
-          error!(target:"fontenc:font_encodings","Only strings should be stored as font encoding names, at: {:?}", encoding_stored);
+          let message = s!("Only strings should be stored as font encoding names, at: {:?}", encoding_stored);
+          Error!("fontenc", "font_encodings", outer_stomach, state, message);
         }
       }
     }

--- a/rtx_package/src/package/pool/inputenc_sty.rs
+++ b/rtx_package/src/package/pool/inputenc_sty.rs
@@ -45,7 +45,8 @@ LoadDefinitions!(outer_stomach, state, {
   DefMacro!("\\IeC{}", "#1");
 
   DefMacro!("\\@inpenc@undefined", sub[gullet, args, state] {
-    error!(target:"unexpected:<char>", "Keyboard character used is undefined in inputencoding {}", state.input_encoding.as_ref().unwrap());
+    let message = s!("Keyboard character used is undefined in inputencoding {}", state.input_encoding.as_ref().unwrap());
+    Error!("unexpected", "<char>", gullet, state, message);
   });
 
   DefPrimitive!("\\inputencoding{}", sub[stomach, args, state] {

--- a/rtx_package/src/package/pool/latex_ch11_moving_information.rs
+++ b/rtx_package/src/package/pool/latex_ch11_moving_information.rs
@@ -249,7 +249,7 @@ LoadDefinitions!(outer_stomach, state, {
     let mut tokens = Vec::new();
     // If we're in some sort of list environment, maybe we can recover
     if tag == "enumerate" || tag == "itemize" || tag == "description" {
-      info!("\nDamn! We're in a list {}; try to close it!", tag);
+      Info!("\nDamn! We're in a list {}; try to close it!", tag);
       tokens.extend(Invocation!("\\end", vec![env], gullet)?.unlist());
       tokens.extend(vec![
         T_CS!("\\let"),
@@ -261,10 +261,10 @@ LoadDefinitions!(outer_stomach, state, {
       ]);
     }
     // else ? it probably isn't going to work??
-    info!("Now, try to open {{thebibliography}}");
+    Info!("Now, try to open {{thebibliography}}");
     tokens.extend(Invocation!("\\begin", vec![Tokenize!("thebibliography"), Tokens!()], gullet)?.unlist());
     let tokens = Tokens::new(tokens);
-    info!("PATCHING with {:?}", tokens.to_string());
+    Info!("PATCHING with {:?}", tokens.to_string());
     Ok(tokens)
   });
 

--- a/rtx_package/src/package/pool/latex_ch13_boxes.rs
+++ b/rtx_package/src/package/pool/latex_ch13_boxes.rs
@@ -33,7 +33,8 @@ LoadDefinitions!(state, {
         DefRegisterI!(cs, None, Dimension::new(0.0));
       },
       Some(defn) => if !defn.is_register() {
-        error!(target: &s!("misdefined:{:?}", cs),"'{}' length was expected, got {:?} instead of register.", cs.to_string(), defn.register_type());
+        let message = s!("'{}' length was expected, got {:?} instead of register.", cs.to_string(), defn.register_type());
+        Error!("misdefined", cs, stomach, state, message);
       }
     };
   });

--- a/rtx_package/src/package/pool/latex_ch13_boxes.rs
+++ b/rtx_package/src/package/pool/latex_ch13_boxes.rs
@@ -29,7 +29,8 @@ LoadDefinitions!(state, {
     unpack_to_token!(args => cs);
     match state.lookup_definition(&cs) {
       None => {
-        warn!(target: &s!("undefined:{:?}", cs), "'{}' is not a length; defining it now", cs.to_string());
+        let message = s!("'{}' is not a length; defining it now", cs.stringify());
+        Warn!("undefined", cs, stomach, state, message);
         DefRegisterI!(cs, None, Dimension::new(0.0));
       },
       Some(defn) => if !defn.is_register() {

--- a/rtx_package/src/package/pool/latex_ch15_font_selection.rs
+++ b/rtx_package/src/package/pool/latex_ch15_font_selection.rs
@@ -41,7 +41,8 @@ LoadDefinitions!(outer_state, {
   DefPrimitive!("\\not@math@alphabet@@ {}", sub[stomach, args, inner_state] {
     if inner_state.lookup_bool("IN_MATH") {
       unpack_to_string!(args => c);
-      warn!(target: &s!("unexpected:{}", c), "Command {:?} invalid in math mode", c);
+      let message = s!("Command {:?} invalid in math mode", c);
+      Warn!("unexpected", c, stomach, inner_state, message);
     }
     Ok(vec![])
   });
@@ -76,11 +77,17 @@ LoadDefinitions!(outer_state, {
     let series = Expand!(T_CS!("\\f@series"),gullet).to_string();
     let shape  = Expand!(T_CS!("\\f@shape"), gullet).to_string();
     if let Some(sh) = font::lookup_font_family(&family) { MergeFont!(sh.clone()); }
-    else { info!(target: &s!("unexpected:{}", family), "Unrecognized font family {:?}.", family); }
+    else { 
+      let message = s!("Unrecognized font family {:?}.", family);
+      Info!("unexpected", family, stomach, inner_state, message); }
     if let Some(sh) = font::lookup_font_series(&series) { MergeFont!(sh.clone()); }
-    else { info!(target: &s!("unexpected:{}", series), "Unrecognized font series {:?}.", series); }
+    else { 
+      let message = s!("Unrecognized font series {:?}.", series);
+      Info!("unexpected", series, stomach, inner_state, message); }
     if let Some(sh) = font::lookup_font_shape(&shape) { MergeFont!(sh.clone()); }
-    else { info!(target: &s!("unexpected:{}",shape), "Unrecognized font shape {:?}.", shape); }
+    else { 
+      let message = s!("Unrecognized font shape {:?}.", shape);
+      Info!("unexpected",shape, stomach, inner_state, message); }
     Ok(vec![])
   });
 

--- a/rtx_package/src/package/pool/latex_ch1_environments.rs
+++ b/rtx_package/src/package/pool/latex_ch1_environments.rs
@@ -45,10 +45,10 @@ LoadDefinitions!(state, {
       let token = T_CS!(s!("\\{}", name));
       if !is_defined_token(&token, state) {
         let undef = s!("{{{}}}", name); // this creates {name} , {{ and }} are escapes in Rust's format!
-        error!(target: &s!("undefined:{}", undef), "The environment {} is not defined.", undef);
-        //TODO
+        let message = s!("The environment {} is not defined.", undef);
+        Error!("undefined", undef, gullet, state, message);
+        // TODO:
         // state.note_status("undefined", undef);
-        //   Error("undefined", $undef, $gullet, "The environment " . $undef . " is not defined.");
         // state.install_definition(LaTeXML::Core::Definition::Constructor->new($token, undef,
         //       sub { LaTeXML::Core::Stomach::makeError($_[0], "undefined", $undef); })); }
       }

--- a/rtx_package/src/package/pool/latex_ch5_packages.rs
+++ b/rtx_package/src/package/pool/latex_ch5_packages.rs
@@ -20,7 +20,7 @@ LoadDefinitions!(state, {
 
   DefConstructor!("\\usepackage OptionalSemiverbatim Semiverbatim []",
                   "<?latexml package='#2' ?#1(options='#1')?>",
-      before_digest => before_digest!(_stomach, state, { only_preamble("\\usepackage", state); }),
+      before_digest => before_digest!(stomach, state, { only_preamble("\\usepackage", stomach, state); }),
       after_digest => sub!(|stomach: &mut Stomach, whatsit: &mut Whatsit, state: &mut State| -> Result<Vec<Digested>> {
         let options: Option<&Digested> = whatsit.get_arg(1);
         let packages: Option<&Digested> = whatsit.get_arg(2);

--- a/rtx_package/src/package/pool/latex_ch6_verbatim.rs
+++ b/rtx_package/src/package/pool/latex_ch6_verbatim.rs
@@ -99,7 +99,7 @@ LoadDefinitions!(outer_state, {
       let cs = if state.lookup_bool("IN_MATH") { T_CS!("\\@math@verb") } else { T_CS!("\\@text@verb") };
       Ok(Invocation!(cs, vec![Tokens!(init.unwrap()), body], gullet)?)
     } else { // typically something read too far got \verb and the content is somewhere else..?
-      error!(target: "expected:delimiter", "Verbatim argument lost\n Bindings for preceding code is probably broken");
+      Error!("expected", "delimiter", gullet, state, "Verbatim argument lost\n Bindings for preceding code is probably broken");
       state.end_semiverbatim()?;
       Ok(Tokens!())
     }

--- a/rtx_package/src/package/pool/latex_ch6_verbatim.rs
+++ b/rtx_package/src/package/pool/latex_ch6_verbatim.rs
@@ -69,7 +69,7 @@ LoadDefinitions!(outer_state, {
       stomach.egroup(state)?;
       lines.push("\\end{verbatim}".to_string());
       whatsit.set_body(lines.into_iter().map(|line|
-        Tbox::new(line.clone(), font.clone(), loc.clone(), T_OTHER!(line).into(), HashMap::new(), state).into()
+        Tbox::new(line.clone(), font.clone(), Some(loc.clone().into_owned()), T_OTHER!(line).into(), HashMap::new(), state).into()
       ).collect());
     }),
     before_construct => construct!(document, whatsit, state, { document.maybe_close_element("ltx:p", state)?; })

--- a/rtx_package/src/package/pool/latex_ch8_defining_commands.rs
+++ b/rtx_package/src/package/pool/latex_ch8_defining_commands.rs
@@ -8,19 +8,20 @@ LoadDefinitions!(state, {
   // C.8.1 Defining Commands
   //======================================================================
 
-  // DefMacro('\@tabacckludge {}', '\csname\string#1\endcsname');
+  DefMacro!("\\@tabacckludge {}", "\\csname\\string#1\\endcsname");
 
   DefPrimitive!("\\newcommand OptionalMatch:* DefToken [Number][]{}", sub[stomach, args, state] {
     unpack!(args => star, cs, nargs, opt, body);
     let cs_token: Token = cs.into();
     let nargs_token: Token = nargs.into();
     let nargs = nargs_token.to_number().value_of() as usize;
-    // TODO:
-    // if (!isDefinable(cs)) {
-    //   Info('ignore', $cs, $stomach,
-    //     "Ignoring redefinition (\\newcommand) of '" . Stringify($cs) . "'")
-    //     unless LookupValue(ToString($cs) . ':locked');
-    //   return; }
+    if !IsDefinable!(&cs_token) {
+      if LookupValue!(&s!("{}:locked", cs_token.to_string())).is_none() { // not locked, inform.
+        let message = s!("Ignoring redefinition (\\newcommand) of {}", cs_token.stringify());
+        Info!("ignore", cs_token, stomach, state, message);
+      }
+      return Ok(vec![]); 
+    }
     let opt = if opt.is_empty() { None } else { Some(opt) };
     let macro_args = convert_latex_args(nargs, opt, state)?;
     DefMacroI!(cs_token, macro_args, body);
@@ -37,6 +38,55 @@ LoadDefinitions!(state, {
   });
 
 
+  // low-level implementation of both \newcommand and \renewcommand depends on \@argdef
+  // and robustness upgrades are often realized via redefining \l@ngrel@x
+  //
+  // Experiment: use \l@ngrel@x to carry over \protected information from outside, etoolbox-style.
+  // DefMacro('\@argdef','\l@ngrel@x\renewcommand');
+  //
+  // The etoolbox binding now defines \newrobustcmd & friends directly, so \@argdef is not directly needed
+  // However, we would need to add support for other packages that may leverage that machinery.
+
+  DefPrimitive!("\\providecommand OptionalMatch:* DefToken [Number][]{}", sub[stomach, args, state] {
+    unpack!(args => star, cs, nargs, opt, body);
+    // TODO: Consider if we should just treat the empty tokens directly in convert_latex_args ?
+    let opts = if opt.is_empty() { None } else { Some(opt)};
+    let cs : Token = cs.into();
+    if IsDefinable!(&cs) {
+      let nargs = nargs.to_number().value_of() as usize;
+      let cs_args = convert_latex_args(nargs, opts, state)?;
+      DefMacroI!(cs, cs_args, body);
+    }
+  });
+
+  // Crazy; define \cs in terms of \cs[space] !!!
+  DefPrimitive!("\\DeclareRobustCommand OptionalMatch:* DefToken [Number][]{}", sub[stomach, args, state] {
+    unpack!(args => star,cs,nargs,opt,body);
+    let cs:Token = cs.into();
+    let opts = if opt.is_empty() {
+      None
+    } else {
+      Some(opt)
+    };
+    let nargs = nargs.to_number().value_of() as usize;
+    let mungedcs = T_CS!(s!("{} ", cs.get_string()));
+    let mungedcs2 = mungedcs.clone();
+    let cs_args = convert_latex_args(nargs, opts, state)?;
+    DefMacroI!(mungedcs, cs_args, body);
+    DefMacroI!(cs, None, Tokens!(T_CS!("\\protect"), mungedcs2)); 
+  });
+
+  DefPrimitive!("\\MakeRobust DefToken", sub[stomach, args, state] {
+    unpack_to_token!(args => cs);  
+    let mungedcs = T_CS!(s!("{} ",cs.get_string()));
+    if LookupDefinition!(&cs).is_none()      { }    // Not defined
+    else if LookupDefinition!(&mungedcs).is_some() { }    // Already robust
+    else {
+      Let!(mungedcs, cs);
+      DefMacroI!(cs, None, Tokens!(T_CS!("\\protect"),mungedcs));
+    }
+  });
+
   //------------------------------------------------------------
   // The following commands define encoding-specific expansions
   // or glyphs.  The control-sequence is defined to use the expansion for
@@ -46,35 +96,54 @@ LoadDefinitions!(state, {
   // But more importantly, we don't want to override a hand-written definition (if any).
   //------------------------------------------------------------
   DefPrimitive!("\\DeclareTextCommand DefToken {}[Number][]{}", sub[stomach, args, state] {
-    unpack_to_token!(args => cs, encoding, nargs, opt, expansion);
-    // TODO
-//     my $css = ToString($cs);
-//     $encoding = ToString(Expand($encoding));
-//     if (!IsDefined($cs)) {    # If not already defined...
-//       DefMacroI($cs, undef,
-// '\expandafter\ifx\csname\cf@encoding\string' . $css . '\endcsname\relax\csname?\string' . $css . '\endcsname'
-//           . '\else\csname\cf@encoding\string' . $css . '\endcsname\fi'); }
-//     my $ecs = T_CS('\\' . $encoding . $css);
-//     DefMacroI($ecs, convertLaTeXArgs($nargs, $opt), $expansion);
-    
+    unpack!(args => cs, encoding, nargs, opt, expansion);
+    let cs : Token = cs.into();
+    let cs_str = cs.to_string();
+    let opts = if opt.is_empty() {
+      None
+    } else {
+      Some(opt)
+    };
+    let nargs = nargs.to_number().value_of() as usize;
+    let gullet = stomach.get_gullet_mut();
+    let encoding = Expand!(encoding, gullet, state);
+    if !IsDefined!(&cs) {    // If not already defined...
+      DefMacroI!(cs, None, Some(s!(r#"""
+      \expandafter\ifx\csname\cf@encoding\string{}\endcsname\relax\csname?\string{}\endcsname\else
+      \csname\cf@encoding\string{}\endcsname\fi
+      """#, cs_str, cs_str, cs_str).into()));
+    }
+     let ecs = T_CS!(s!("\\{}{}", encoding, cs_str));
+     let ecs_args = convert_latex_args(nargs, opts, state)?;
+     DefMacroI!(ecs, ecs_args, expansion);
   });
 
   DefMacro!("\\DeclareTextCommandDefault DefToken", "\\DeclareTextCommand{#1}{?}");
 
-  // DefPrimitive('\ProvideTextCommand DefToken {}[Number][]{}', sub {
-  //     my ($gullet, $cs, $encoding, $nargs, $opt, $expansion) = @_;
-  //     my $css = ToString($cs);
-  //     $encoding = ToString(Expand($encoding));
-  //     if (isDefinable($cs)) {    # If not already defined...
-  //       DefMacroI($cs, undef,
-  // '\expandafter\ifx\csname\cf@encoding\string' . $css . '\endcsname\relax\csname?\string' . $css . '\endcsname'
-  //           . '\else\csname\cf@encoding\string' . $css . '\endcsname\fi'); }
-  //     my $ecs = T_CS('\\' . $encoding . $css);
-  //     if (!IsDefined($ecs)) {    # If not already defined...
-  //       DefMacroI($ecs, convertLaTeXArgs($nargs, $opt), $expansion); }
-  //     return; });
+  DefPrimitive!("\\ProvideTextCommand DefToken {}[Number][]{}", sub[gullet, args, state] {
+    unpack!(args => cs, encoding, nargs, opt, expansion);
+    let cs : Token = cs.into();
+    let cs_str = cs.to_string();
+    let opts = if opt.is_empty() {
+      None
+    } else {
+      Some(opt)
+    };
+    let nargs = nargs.to_number().value_of() as usize;
+    if IsDefinable!(&cs) { // If not already defined...
+      DefMacroI!(cs, None, Some(s!(r#"""
+        \expandafter\ifx\csname\cf@encoding\string{}\endcsname\relax\csname?\string{}\endcsname
+        \else\csname\cf@encoding\string{}\endcsname\fi
+      """#, cs_str, cs_str, cs_str).into())); 
+    }
+    let ecs = T_CS!(s!("\\{}{}", encoding, cs_str));
+    if !IsDefined!(&ecs) { // If not already defined...
+      let ecs_args = convert_latex_args(nargs, opts, state)?;
+      DefMacroI!(ecs, ecs_args, expansion);
+    }
+  });
 
-  // DefMacro('\ProvideTextCommandDefault DefToken', '\ProvideTextCommand{#1}{?}');
+  DefMacro!("\\ProvideTextCommandDefault DefToken", "\\ProvideTextCommand{#1}{?}");
 
   // #------------------------------------------------------------
 
@@ -101,14 +170,14 @@ LoadDefinitions!(state, {
   DefPrimitive!("\\DeclareTextAccentDefault{}{}", None);
 
   // #------------------------------------------------------------
-  // DefPrimitive('\DeclareTextComposite{}{}{}{}',
-  //   sub { ignoredDefinition('DeclareTextComposite', $_[1]); });
-  // DefPrimitive('\DeclareTextCompositeCommand{}{}{}{}',
-  //   sub { ignoredDefinition('DeclareTextCompositeCommand', $_[1]); });
+  DefPrimitive!("\\DeclareTextComposite{}{}{}{}", None);
+    // sub { ignoredDefinition("DeclareTextComposite", $_[1]); });
+  DefPrimitive!("\\DeclareTextCompositeCommand{}{}{}{}", None);
+    // sub { ignoredDefinition("DeclareTextCompositeCommand", $_[1]); });
 
-  // DefPrimitive('\UndeclareTextCommand{}{}', undef);
-  // DefMacro('\UseTextSymbol{}{}', '{\fontencoding{#1}#2}');
-  // DefMacro('\UseTextAccent{}{}', '{\fontencoding{#1}#2{#3}}');
+  DefPrimitive!("\\UndeclareTextCommand{}{}", None);
+  DefMacro!("\\UseTextSymbol{}{}", "{\\fontencoding{#1}#2}");
+  DefMacro!("\\UseTextAccent{}{}", "{\\fontencoding{#1}#2{#3}}");
 
   // DefPrimitive('\DeclareMathAccent DefToken {}{} {Number}', sub {
   //     my ($stomach, $cs, $kind, $class, $code) = @_;
@@ -118,12 +187,12 @@ LoadDefinitions!(state, {
   //     DefMathI($cs, 'Digested', $glyph, operator_role => 'OVERACCENT');
   //     return; });
 
-  // DefPrimitive('\DeclareMathDelimiter{}{}{}{}',
-  //   sub { ignoredDefinition('DeclareMathAccent', $_[1]); });
-  // DefPrimitive('\DeclareMathRadical{}{}{}{}{}',
-  //   sub { ignoredDefinition('DeclareMathAccent', $_[1]); });
-  // DefPrimitive('\DeclareMathVersion{}',          undef);
-  // DefPrimitive('\DeclarePreloadSizes{}{}{}{}{}', undef);
+  DefPrimitive!("\\DeclareMathDelimiter{}{}{}{}", None);
+    // sub { ignoredDefinition("DeclareMathAccent", $_[1]); });
+  DefPrimitive!("\\DeclareMathRadical{}{}{}{}{}", None);
+    // sub { ignoredDefinition("DeclareMathAccent", $_[1]); });
+  DefPrimitive!("\\DeclareMathVersion{}",          None);
+  DefPrimitive!("\\DeclarePreloadSizes{}{}{}{}{}", None);
 
   // The next font declaration commands are based on
   // http://tex.loria.fr/general/new/fntguide.html

--- a/rtx_package/src/package/pool/latex_ch8_defining_commands.rs
+++ b/rtx_package/src/package/pool/latex_ch8_defining_commands.rs
@@ -35,4 +35,194 @@ LoadDefinitions!(state, {
     let macro_args = convert_latex_args(nargs, opt, state)?;
     DefMacroI!(cs_token, macro_args, body);
   });
+
+
+  //------------------------------------------------------------
+  // The following commands define encoding-specific expansions
+  // or glyphs.  The control-sequence is defined to use the expansion for
+  // the current encoding, if any, or the default expansion (for encoding "?").
+  // We don't want to redefine control-sequence if it already has a definition:
+  // It may be that we've already defined it to expand into the above conditional.
+  // But more importantly, we don't want to override a hand-written definition (if any).
+  //------------------------------------------------------------
+  DefPrimitive!("\\DeclareTextCommand DefToken {}[Number][]{}", sub[stomach, args, state] {
+    unpack_to_token!(args => cs, encoding, nargs, opt, expansion);
+    // TODO
+//     my $css = ToString($cs);
+//     $encoding = ToString(Expand($encoding));
+//     if (!IsDefined($cs)) {    # If not already defined...
+//       DefMacroI($cs, undef,
+// '\expandafter\ifx\csname\cf@encoding\string' . $css . '\endcsname\relax\csname?\string' . $css . '\endcsname'
+//           . '\else\csname\cf@encoding\string' . $css . '\endcsname\fi'); }
+//     my $ecs = T_CS('\\' . $encoding . $css);
+//     DefMacroI($ecs, convertLaTeXArgs($nargs, $opt), $expansion);
+    
+  });
+
+  DefMacro!("\\DeclareTextCommandDefault DefToken", "\\DeclareTextCommand{#1}{?}");
+
+  // DefPrimitive('\ProvideTextCommand DefToken {}[Number][]{}', sub {
+  //     my ($gullet, $cs, $encoding, $nargs, $opt, $expansion) = @_;
+  //     my $css = ToString($cs);
+  //     $encoding = ToString(Expand($encoding));
+  //     if (isDefinable($cs)) {    # If not already defined...
+  //       DefMacroI($cs, undef,
+  // '\expandafter\ifx\csname\cf@encoding\string' . $css . '\endcsname\relax\csname?\string' . $css . '\endcsname'
+  //           . '\else\csname\cf@encoding\string' . $css . '\endcsname\fi'); }
+  //     my $ecs = T_CS('\\' . $encoding . $css);
+  //     if (!IsDefined($ecs)) {    # If not already defined...
+  //       DefMacroI($ecs, convertLaTeXArgs($nargs, $opt), $expansion); }
+  //     return; });
+
+  // DefMacro('\ProvideTextCommandDefault DefToken', '\ProvideTextCommand{#1}{?}');
+
+  // #------------------------------------------------------------
+
+  DefPrimitive!("\\DeclareTextSymbol DefToken {}{Number}", sub[stomach, args, state] {
+    unpack_to_token!(args => cs, encoding, code);
+    // TODO:
+    //     $code = $code->valueOf;
+    //     my $css = ToString($cs);
+    //     $encoding = ToString(Expand($encoding));
+    //     if (isDefinable($cs)) {    # If not already defined...
+    //       DefMacroI($cs, undef,
+    // '\expandafter\ifx\csname\cf@encoding\string' . $css . '\endcsname\relax\csname?\string' . $css . '\endcsname'
+    //           . '\else\csname\cf@encoding\string' . $css . '\endcsname\fi'); }
+    //     my $ecs = T_CS('\\' . $encoding . $css);
+    //     DefPrimitiveI($ecs, undef, FontDecode($code, $encoding));
+  });
+      
+
+  // hmmm... what needs doing here; basically it means use this encoding as the default for the symbol
+  DefMacro!("\\DeclareTextSymbolDefault DefToken {}", "");
+
+  //------------------------------------------------------------
+  DefPrimitive!("\\DeclareTextAccent DefToken {}{}", None);
+  DefPrimitive!("\\DeclareTextAccentDefault{}{}", None);
+
+  // #------------------------------------------------------------
+  // DefPrimitive('\DeclareTextComposite{}{}{}{}',
+  //   sub { ignoredDefinition('DeclareTextComposite', $_[1]); });
+  // DefPrimitive('\DeclareTextCompositeCommand{}{}{}{}',
+  //   sub { ignoredDefinition('DeclareTextCompositeCommand', $_[1]); });
+
+  // DefPrimitive('\UndeclareTextCommand{}{}', undef);
+  // DefMacro('\UseTextSymbol{}{}', '{\fontencoding{#1}#2}');
+  // DefMacro('\UseTextAccent{}{}', '{\fontencoding{#1}#2{#3}}');
+
+  // DefPrimitive('\DeclareMathAccent DefToken {}{} {Number}', sub {
+  //     my ($stomach, $cs, $kind, $class, $code) = @_;
+  //     $class = ToString($class);
+  //     my $info = LookupValue('fontdeclaration@' . $class);
+  //     my $glyph = FontDecode($code->valueOf, ($info ? $$info{encoding} : $class));
+  //     DefMathI($cs, 'Digested', $glyph, operator_role => 'OVERACCENT');
+  //     return; });
+
+  // DefPrimitive('\DeclareMathDelimiter{}{}{}{}',
+  //   sub { ignoredDefinition('DeclareMathAccent', $_[1]); });
+  // DefPrimitive('\DeclareMathRadical{}{}{}{}{}',
+  //   sub { ignoredDefinition('DeclareMathAccent', $_[1]); });
+  // DefPrimitive('\DeclareMathVersion{}',          undef);
+  // DefPrimitive('\DeclarePreloadSizes{}{}{}{}{}', undef);
+
+  // The next font declaration commands are based on
+  // http://tex.loria.fr/general/new/fntguide.html
+  // we ignore font encoding
+  DefPrimitive!("\\DeclareSymbolFont{}{}{}{}{}", sub[stomach, args, state] {
+    unpack_to_token!(args => name, enc, family, series, shape);
+    AssignValue!(&s!("fontdeclaration@{}", name),
+      fontmap!(family => family.to_string(),
+        series   => series.to_string(),
+        shape    => shape.to_string(),
+        encoding => enc.to_string()
+      )
+    );
+  });
+  DefPrimitive!("\\DeclareSymbolFontAlphabet{}{}", sub[stomach, args, state] {
+    unpack_to_token!(args => cs, name);
+    let fontkey = s!("fontdeclarations@{}", name.to_string());
+    let font : Option<Font> = if let Some(Stored::Font(value)) = LookupValue!(&fontkey) {
+      Some((**value).clone())
+    } else {
+      None
+    };
+    DefPrimitiveII!(cs, None, None, font => font);
+  });
+
+  DefPrimitiveI!("\\DeclareFixedFont{}{}{}{}{}{}", None);
+  DefPrimitiveI!("\\DeclareErrorFont{}{}{}{}{}", None);
+
+  DefMacro!("\\cdp@list", "\\@empty");
+  Let!("\\cdp@elt", "\\relax");
+  DefPrimitive!("\\DeclareFontEncoding{}{}{}", sub[stomach, args, state] {
+    unpack_to_token!(args => encoding, x, y);
+    // TODO:
+    // AddToMacro!(T_CS!("\\cdp@list"), T_CS!("\\cdp@elt"),
+    //   T_BEGIN!(), encoding.unlist(), T_END,
+    //   T_BEGIN!(), T_CS!("\\default@family"), T_END!(),
+    //   T_BEGIN!(), T_CS!("\\default@series"), T_END!(),
+    //   T_BEGIN!(), T_CS!("\\default@shape"),  T_END!());
+    let gullet = stomach.get_gullet_mut();
+    let e = Expand!(encoding, gullet, state);
+    DefMacroI!(T_CS!("\\LastDeclaredEncoding"), None, e.clone());
+    DefMacroI!(T_CS!(s!("\\T@{}", e)), None, x);
+    DefMacroI!(T_CS!(s!("\\M@{}", e)), None, Tokens!(T_CS!("\\default@M"), y.unlist()));
+  });
+
+  DefMacroI!("\\LastDeclaredEncoding", None, "");
+  DefPrimitiveI!("\\DeclareFontSubstitution{}{}{}{}", None);
+  DefPrimitiveI!("\\DeclareFontEncodingDefaults{}{}", None);
+  DefMacroI!("\\LastDeclaredEncoding", None, "");
+
+  DefPrimitiveI!("\\SetSymbolFont{}{}{}{}{}{}",   None);
+  DefPrimitiveI!("\\SetMathAlphabet{}{}{}{}{}{}", None);
+  DefPrimitiveI!("\\addtoversion{}{}",            None);
+  DefPrimitiveI!("\\TextSymbolUnavailable{}",     None);
+
+  RawTeX!(r#"""
+  \DeclareSymbolFont{operators}   {OT1}{cmr} {m}{n}
+  \DeclareSymbolFont{letters}     {OML}{cmm} {m}{it}
+  \DeclareSymbolFont{symbols}     {OMS}{cmsy}{m}{n}
+  \DeclareSymbolFont{largesymbols}{OMX}{cmex}{m}{n}
+  """#);
+  // At least all things on uclclist need to be macros
+  DefMacroI!("\\lx@utf@OE", None, "\u{0152}", alias => "\\OE"); // LATIN CAPITAL LIGATURE OE
+  DefMacroI!("\\lx@utf@oe", None, "\u{0153}", alias => "\\oe"); // LATIN SMALL LIGATURE OE
+  DefMacroI!("\\lx@utf@AE", None, "\u{00C6}", alias => "\\AE"); // LATIN CAPITAL LETTER AE
+  DefMacroI!("\\lx@utf@ae", None, "\u{00E6}", alias => "\\ae"); // LATIN SMALL LETTER AE
+  DefMacroI!("\\lx@utf@AA", None, "\u{00C5}", alias => "\\AA"); // LATIN CAPITAL LETTER A WITH RING ABOVE
+  DefMacroI!("\\lx@utf@aa", None, "\u{00E5}", alias => "\\aa"); // LATIN SMALL LETTER A WITH RING ABOVE
+  DefMacroI!("\\lx@utf@O",  None, "\u{00D8}", alias => "\\O");  // LATIN CAPITAL LETTER O WITH STROKE
+  DefMacroI!("\\lx@utf@o",  None, "\u{00F8}", alias => "\\o");  // LATIN SMALL LETTER O WITH STROKE
+  DefMacroI!("\\lx@utf@L",  None, "\u{0141}", alias => "\\L");  // LATIN CAPITAL LETTER L WITH STROKE
+  DefMacroI!("\\lx@utf@l",  None, "\u{0142}", alias => "\\l");  // LATIN SMALL LETTER L WITH STROKE
+  DefMacroI!("\\lx@utf@ss", None, "\u{00DF}", alias => "\\ss"); // LATIN SMALL LETTER SHARP S
+  DefMacroI!("\\lx@utf@dh", None, "\u{00f0}", alias => "\\dh"); // eth
+  DefMacroI!("\\lx@utf@DH", None, "\u{00d0}", alias => "\\DH"); // Eth (looks same as \DJ!)
+  DefMacroI!("\\lx@utf@dj", None, "\u{0111}", alias => "\\dj"); // d with stroke
+  DefMacroI!("\\lx@utf@DJ", None, "\u{0110}", alias => "\\DJ"); // D with stroke (looks sames as \DH!)
+  DefMacroI!("\\lx@utf@ng", None, "\u{014B}", alias => "\\ng");
+  DefMacroI!("\\lx@utf@NG", None, "\u{014A}", alias => "\\NG");
+  DefMacroI!("\\lx@utf@th", None, "\u{00FE}", alias => "\\th");
+  DefMacroI!("\\lx@utf@TH", None, "\u{00DE}", alias => "\\TH");
+  DefMacroI!("\\OE", None, "\\lx@utf@OE");
+  DefMacroI!("\\oe", None, "\\lx@utf@oe");
+  DefMacroI!("\\AE", None, "\\lx@utf@AE");
+  DefMacroI!("\\ae", None, "\\lx@utf@ae");
+  DefMacroI!("\\ae", None, "\\lx@utf@ae");
+  DefMacroI!("\\AA", None, "\\lx@utf@AA");
+  DefMacroI!("\\aa", None, "\\lx@utf@aa");
+  DefMacroI!("\\O",  None, "\\lx@utf@O");
+  DefMacroI!("\\o",  None, "\\lx@utf@o");
+  DefMacroI!("\\L",  None, "\\lx@utf@L");
+  DefMacroI!("\\l",  None, "\\lx@utf@l");
+  DefMacroI!("\\ss", None, "\\lx@utf@ss");
+  DefMacroI!("\\dh", None, "\\lx@utf@dh"); // in latex?
+  DefMacroI!("\\DH", None, "\\lx@utf@DH");
+  DefMacroI!("\\dj", None, "\\lx@utf@dj");
+  DefMacroI!("\\DJ", None, "\\lx@utf@DJ");
+  DefMacroI!("\\ng", None, "\\lx@utf@ng");
+  DefMacroI!("\\NG", None, "\\lx@utf@NG");
+  DefMacroI!("\\th", None, "\\lx@utf@th");
+  DefMacroI!("\\TH", None, "\\lx@utf@TH");
 });

--- a/rtx_package/src/package/pool/latex_ch8_defining_environments.rs
+++ b/rtx_package/src/package/pool/latex_ch8_defining_environments.rs
@@ -15,7 +15,8 @@ LoadDefinitions!(state, {
     if IsDefined!(&name_cs) {
       let is_locked = LookupValue!(&s!("\\{}:locked",name)).is_some() || LookupValue!(&s!("\\begin{{{}}}:locked",name)).is_some();
       if !is_locked {
-        info!(target:&s!("ignore:{}", name), "Ignoring redefinition (\\newenvironment) of Environment {:?}", name);
+        let message = s!("Ignoring redefinition (\\newenvironment) of Environment {:?}", name);
+        Info!("ignore", name, stomach, state, message);
       }
     } else {
       let opt = if opt.is_empty() { None } else { Some(opt) };

--- a/rtx_package/src/package/pool/tex_accents.rs
+++ b/rtx_package/src/package/pool/tex_accents.rs
@@ -28,7 +28,7 @@ pub fn apply_accent(
   //     ? $standalonechar
   //     : NFC($letters[0] . $combiningchar . join('', @letters[1 .. $//letters]))),
   //   $font, $locator, $reversion); }
-  Ok(Tbox::new(string, font, locator, reversion.unwrap_or(Tokens!()), HashMap::new(), state))
+  Ok(Tbox::new(string, font, Some(locator.into_owned()), reversion.unwrap_or(Tokens!()), HashMap::new(), state))
 }
 
 LoadDefinitions!(state, {

--- a/rtx_package/src/package/pool/tex_alignment.rs
+++ b/rtx_package/src/package/pool/tex_alignment.rs
@@ -4,11 +4,11 @@ use crate::package::*;
 //======================================================================
 LoadDefinitions!(state, {
 
-  // Tag!("ltx:td", after_close => trim_node_whitespace);
+  Tag!("ltx:td", after_close => tagsub!(doc, node, state, { doc.trim_node_whitespace(node)?; }));
 
-  // #----------------------------------------------------------------------
-  // # Primitive column types;
-  // # This is really LaTeX, but the mechanisms are used behind-the-scenes here, too.
+  //----------------------------------------------------------------------
+  // Primitive column types;
+  // This is really LaTeX, but the mechanisms are used behind-the-scenes here, too.
   // DefColumnType('|', sub {
   //     $LaTeXML::BUILD_TEMPLATE->addBetweenColumn(T_CS('\vrule'), T_CS('\relax')); return; });
   // DefColumnType('l', sub {
@@ -19,14 +19,14 @@ LoadDefinitions!(state, {
   // DefColumnType('r', sub {
   //     $LaTeXML::BUILD_TEMPLATE->addColumn(before => Tokens(T_CS('\hfil'))); return; });
 
-  // # This collects paragraph text, like \hbox, but for use within alignment cells;
-  // # no ltx:text wrapper is needed, since it is within a cell.
-  // # and it handles $ and & appropriately
+  // This collects paragraph text, like \hbox, but for use within alignment cells;
+  // no ltx:text wrapper is needed, since it is within a cell.
+  // and it handles $ and & appropriately
   // DefConstructor('\tabularcell@hbox HBoxContents',
   //   "#1",
   //   mode => 'text', bounded => 1,
-  //   # Workaround for $ in alignment; an explicit \hbox gives us a normal $.
-  //   # And also things like \centerline that will end up bumping up to block level!
+  //   Workaround for $ in alignment; an explicit \hbox gives us a normal $.
+  //   And also things like \centerline that will end up bumping up to block level!
   //   beforeDigest => sub {
   //     ## reenterTextMode();  # BUT NOT \\\\ !!!!!!
   //     Let(T_MATH,        '\@dollar@in@textmode');

--- a/rtx_package/src/package/pool/tex_assignment.rs
+++ b/rtx_package/src/package/pool/tex_assignment.rs
@@ -117,7 +117,8 @@ LoadDefinitions!(state, {
           let defn_value = defn.value_of(var_tokens, state).unwrap_or_default();
           defn.borrow_mut().set_value(defn_value.add(summand), defn_args, state);
         } else {
-          error!(target: "expected:definition", "\\advance expected a defined variable for {:?}, found no definition", defn_token_rc);
+          let message = s!("\\advance expected a defined variable for {:?}, found no definition", defn_token_rc);
+          Error!("expected","definition", stomach, state, message);
         }
       }
     }
@@ -135,10 +136,12 @@ LoadDefinitions!(state, {
         let scale_value = scale.to_number().value_of();
         defn.borrow_mut().set_value(defn_value.multiply(scale_value), defn_args, state);
       } else {
-        error!(target: "expected:definition", "\\multiply expected a defined variable for {:?}, found no definition", varname);
+        let message = s!("\\multiply expected a defined variable for {:?}, found no definition", varname);
+        Error!("expected","definition", stomach, state, message);
       }
     } else {
-      error!(target: "expected:variable", "\\multiply expected a Variable argument, but got nothing.");
+      let message = s!("\\multiply expected a Variable argument, but got nothing.");
+      Error!("expected","variable", stomach, state, message);
     }
   });
 
@@ -153,15 +156,17 @@ LoadDefinitions!(state, {
         let defn_value = defn.value_of(args, state).unwrap_or_default();
         let mut denominator = scale.to_number().value_of();
         if denominator == 0.0 {
-          error!(target: &s!("misdefined:{:?}", scale), "Illegal \\divide by 0; assuming 1");
+          Error!("misdefined", scale, stomach, state, "Illegal \\divide by 0; assuming 1");
           denominator = 1.0;
         }
         defn.borrow_mut().set_value(defn_value.divide(denominator), defn_args, state);
       } else {
-        error!(target: "expected:definition", "\\divide expected a defined variable for {:?}, found no definition", varname);
+        let message = s!("\\divide expected a defined variable for {:?}, found no definition", varname);
+        Error!("expected","definition", stomach, state, message);
       }
     } else {
-      error!(target: "expected:variable", "\\divide expected a Variable argument, but got nothing.");
+      let message = s!("\\divide expected a Variable argument, but got nothing.");
+      Error!("expected","variable", stomach, state, message);
     }
   });
 

--- a/rtx_package/src/package/pool/tex_assignment.rs
+++ b/rtx_package/src/package/pool/tex_assignment.rs
@@ -75,8 +75,8 @@ LoadDefinitions!(state, {
       AssignValue!(&s!("fontinfo_{}", cs.to_string()), props.clone());
       DefPrimitiveII!(cs, None, None, font => Some(props));
     } else {    // Failed?
-      info!(target: &s!("unexpected:{}", name),
-        "Unrecognized font name {:?} Font switch macro {:?} will have no effect", name, cs.to_string());
+      let message = s!("Unrecognized font name {:?} Font switch macro {:?} will have no effect", name, cs.stringify());
+      Info!("unexpected", name, stomach, state,message);
     }
   });
 

--- a/rtx_package/src/package/pool/tex_boxes.rs
+++ b/rtx_package/src/package/pool/tex_boxes.rs
@@ -124,7 +124,7 @@ LoadDefinitions!(state, {
       let node = document.open_element(newtag, Some(string_map!("_noautoclose" => "true", "width" => width)), None, state)?;
       document.absorb(contents,state)?;
       document.close_node(&node, state)?;
-      debug!("FINAL DOC: {:?}", document.document.node_to_string(&document.get_element().unwrap()));
+      Debug!("FINAL DOC: {:?}", document.document.node_to_string(&document.get_element().unwrap()));
     },
     mode => "text".into_option(),
     bounded => true,

--- a/rtx_package/src/package/pool/tex_ch24_primitives.rs
+++ b/rtx_package/src/package/pool/tex_ch24_primitives.rs
@@ -34,7 +34,8 @@ LoadDefinitions!(state, {
       let body = stomach.digest_next_body(None, state)?;
       let mut boxes = vec![Digested::TBox(Rc::new(open))];
       boxes.extend(body);
-      let return_list = List { boxes, mode, font: None };
+      // TODO: Locator logic here needs to improve..
+      let return_list = List { boxes, mode, font: None, locator: Locator::default()  };
 
       return_list.into()
     })

--- a/rtx_package/src/package/pool/tex_expandable_primitives.rs
+++ b/rtx_package/src/package/pool/tex_expandable_primitives.rs
@@ -197,9 +197,11 @@ LoadDefinitions!(outer_state, {
       let cc = token.get_catcode();
       if cc == Catcode::CS {
         if let Some(defn) = state.lookup_definition(&token) {
-          error!(target: &s!("unexpected:{}", token), "The control sequence {:?} should not appear between \\csname and \\endcsname", token);
+          let message = s!("The control sequence {:?} should not appear between \\csname and \\endcsname", token);
+          Error!("unexpected", token, gullet, state, message);
         } else {
-          error!(target: &s!("undefined:{}", token), "The token {:?} is not defined", token);
+          let message = s!("The token {:?} is not defined", token);
+          Error!("undefined", token, gullet, state, message);
         }
       } else if cc == Catcode::SPACE {  // Keep newlines from having \n!
         cs.push(' ');
@@ -219,8 +221,8 @@ LoadDefinitions!(outer_state, {
     token
   });
 
-  DefPrimitive!("\\endcsname", sub {
-    error!(target: "unexpected:\\endcsname", "Extra \\endcsname");
+  DefPrimitive!("\\endcsname", sub[stomach, args, state] {
+    Error!("unexpected" ,"\\endcsname", stomach, state, "Extra \\endcsname");
   });
 
   DefMacro!("\\expandafter Token Token", sub[gullet, args, state] {
@@ -286,7 +288,7 @@ LoadDefinitions!(outer_state, {
       }
       tokens
     } else {
-      error!(target:"expected:<register>", "a register was expected to be here");
+      Error!("expected", "<register>", gullet, state, "a register was expected to be here");
       Vec::new()
     }
   });
@@ -321,7 +323,8 @@ fn compare(u: Token, rel: Token, v: Token) -> Result<bool> {
   } else if rel == T_OTHER!(">") || rel == T_CS!("\\@@>") {
     Ok(u > v)
   } else {
-    error!(target:"expected:<relationaltoken>", "Expected a relational token for comparision. Got {:?} (cc {:?})", rel, rel.get_catcode());
+    let message = s!("Expected a relational token for comparision. Got {:?} (cc {:?})", rel, rel.get_catcode());
+    Error!("expected","<relationaltoken>", None, None, message);
     Ok(false)
   }
 }

--- a/rtx_package/src/package/pool/tex_functions.rs
+++ b/rtx_package/src/package/pool/tex_functions.rs
@@ -24,10 +24,9 @@ pub fn reenter_text_mode(vertical_mode: bool, state: &mut State) {
   return;
 }
 
-pub fn only_preamble(cs: &str, state: &mut State) {
+pub fn only_preamble(cs: &str, stomach: &mut Stomach, state: &mut State) {
   if !state.lookup_bool("inPreamble") {
-    let category_object = s!("unexpected:{}", cs);
-    error!(target: &category_object, "The current command can only appear in the preamble");
+    Error!("unexpected", cs, stomach, state, "The current command can only appear in the preamble");
   }
 }
 

--- a/rtx_package/src/package/pool/tex_math_mode.rs
+++ b/rtx_package/src/package/pool/tex_math_mode.rs
@@ -31,9 +31,8 @@ LoadDefinitions!(state, {
             // Avoid a Fatal, but we're likely in trouble.
             // Should we switch to text mode? (LaTeX normally wouldn't)
             // Did we miss something and would should have already been in text mode? Possibly...
-            error!(target: "expected:$",
-          "Missing $ closing display math.\nIgnoring; expect to be in wrong math/text mode.");
-            op = ""
+            Error!("expected", "$", stomach, state, "Missing $ closing display math.\nIgnoring; expect to be in wrong math/text mode.");
+            op = "";
           }
         } else if mode == "inline_math" {
           op = "\\@@ENDINLINEMATH";

--- a/rtx_package/src/package/pool/tex_math_mode.rs
+++ b/rtx_package/src/package/pool/tex_math_mode.rs
@@ -22,7 +22,7 @@ LoadDefinitions!(state, {
       {
         let mut gullet = stomach.get_gullet_mut();
         let mode = LookupString!("MODE");
-        debug!("T_MATH primitive current mode: {:?}", mode);
+        Debug!("T_MATH primitive current mode: {:?}", mode);
         if mode == "display_math" {
           if gullet.if_next(T_MATH!(), state)? {
             gullet.read_token(state);

--- a/rtx_package/src/package/pool/tex_para.rs
+++ b/rtx_package/src/package/pool/tex_para.rs
@@ -54,7 +54,7 @@ LoadDefinitions!(state, {
   // OTOH, sometimes \par is just a minimalistic "start a new line"
   // This should be closer for those cases.
   DefConstructor!("\\inner@par", sub[document, args, props, state] {
-    debug!("inner@par invoked!\n");
+    Debug!("inner@par invoked!\n");
     if document.maybe_close_element("ltx:p", state)?.is_some() {
     } else if document.can_contain(document.get_node(), "ltx:break", state) {
       document.insert_element("ltx:break", Vec::new(), None, state)?;

--- a/rtx_package/src/package/pool/tex_setup.rs
+++ b/rtx_package/src/package/pool/tex_setup.rs
@@ -177,11 +177,11 @@ LoadDefinitions!(state, {
       if open == T_BEGIN!() {
         gullet.read_balanced(state)
       } else {
-        error!(target:"expected:{", "Expected <general text> here");
+        Error!("expected","{", gullet, state, "Expected <general text> here");
         Ok(Tokens!(open))
       }
     } else {
-      error!(target:"expected:{", "Expected <general text> here");
+      Error!("expected","{", gullet, state, "Expected <general text> here");
       Ok(Tokens!())
     }
   });
@@ -219,7 +219,7 @@ LoadDefinitions!(state, {
     match gullet.read_token(state) {
       Some(t) => Ok(Tokens!(t)),
       None => {
-        error!(target:"expected:Token", "Paramater <Token> found None.");
+        Error!("expected", "Token", gullet, state, "Paramater <Token> found None.");
         Ok(Tokens!())
       }
     }
@@ -230,7 +230,7 @@ LoadDefinitions!(state, {
     if let Some(t) = gullet.read_x_token(false, false, state)? {
       Ok(Tokens!(t))
     } else {
-      error!(target:"expected:XToken", "Paramater <XToken> found None.");
+      Error!("expected","XToken", gullet, state, "Paramater <XToken> found None.");
       Ok(Tokens!())
     }
   });
@@ -304,7 +304,7 @@ LoadDefinitions!(state, {
   // Yet another special case: Require a { but do not read it!!!
   DefParameterType!("RequireBrace", sub[gullet, inner, _extra, state] {
     if !gullet.if_next(T_BEGIN!(), state)? {
-      error!(target:"expected:{", "Expected a {{ here");
+      Error!("expected","{", gullet, state, "Expected a {{ here");
     }
     T_BEGIN!()
   },
@@ -359,7 +359,7 @@ LoadDefinitions!(state, {
         Ok(Tokens!(token))
       }
     } else {
-      error!(target:"expected:Expanded", "was expecting an Expanded parameter value, found nothing.");
+      Error!("expected","Expanded", gullet, state, "was expecting an Expanded parameter value, found nothing.");
       Ok(Tokens!())
     }
   },
@@ -529,7 +529,7 @@ LoadDefinitions!(state, {
     match token {
       Some(t) => Ok(Tokens!(t)),
       None => {
-        error!(target:"expected:DefToken", "Expected a DefToken parameter, found nothing.");
+        Error!("expected","DefToken", gullet, state, "Expected a DefToken parameter, found nothing.");
         Ok(Tokens!())
       }
     }
@@ -553,11 +553,13 @@ LoadDefinitions!(state, {
           // Ok(Tokens!(defn_tok, defn_args))
           Ok(Tokens::new(invoked))
         } else {
-          error!(target:"expected:<variable>", "A <variable> was supposed to be here\n Got {:?}", token_opt);
+          let message = s!("A <variable> was supposed to be here\n Got {:?}", token_opt);
+          Error!("expected","<variable>", gullet, state, message);
           Ok(Tokens!())
         }
     } else {
-      error!(target:"expected:<variable>", "A <variable> was supposed to be here\n Got {:?}", token_opt);
+      let message = s!("A <variable> was supposed to be here\n Got {:?}", token_opt);
+      Error!("expected","<variable>", gullet, state, message);
       Ok(Tokens!())
     }
   },
@@ -592,7 +594,8 @@ LoadDefinitions!(state, {
         return Ok(Tokens::new(invoked));
       },
       None => {
-        error!(target:"expected:<register>", "A <register> was supposed to be here. Got {:?}", token);
+        let message = s!("A <register> was supposed to be here. Got {:?}", token);
+        Error!("expected","<register>", gullet, state, message);
         // if isDefinable!(token) {
         //   DefRegisterI!(token, None, Tokens!(), state);
         //   return Tokens!(defn);
@@ -702,13 +705,15 @@ LoadDefinitions!(state, {
         _ => tbox.to_string()
       };
       if csname != "\\hbox" && csname != "\\vbox" && csname != "\\vtop" {
-        error!(target: "expected:<box>", "A <box> was supposed to be here.\nGot {}", csname);
+        let message = s!("A <box> was supposed to be here.\nGot {}", csname);
+        Error!("expected","<box>", stomach, state, message);
         None
       } else {
         Some(tbox)
       }
     } else {
-      error!(target: "expected:<box>", "A <box> was supposed to be here.\nGot none.");
+      let message = s!("A <box> was supposed to be here.\nGot none.");
+      Error!("expected","<box>", stomach, state, message);
       None
     }
   }));

--- a/rtx_package/src/package/pool/tex_setup.rs
+++ b/rtx_package/src/package/pool/tex_setup.rs
@@ -1037,12 +1037,4 @@ LoadDefinitions!(state, {
       Ok(if_token)
     }
   });
-
-  // sub isDefinable {
-  //   my ($token) = @_;
-  //   return unless $token;
-  //   my $meaning = LookupMeaning($token);
-  //   my $name = $token->getString; $name =~ s/^\\//;
-  //   return (((!defined $meaning) || ($meaning eq LookupMeaning(T_CS('\relax'))))
-  //       && (($name ne 'relax') && ($name !~ /^end/))); }
 });

--- a/rtx_package/src/package/pool/verbatim_sty.rs
+++ b/rtx_package/src/package/pool/verbatim_sty.rs
@@ -133,7 +133,8 @@ LoadDefinitions!(state, {
         },
       )
     } else {
-      error!("\\verbatiminput found no file for {:?}, output may be incomplete", file);
+      let message = s!("\\verbatiminput found no file for {:?}, output may be incomplete", file);
+      Error!("binding", "missing_file", gullet, state, message);
       Ok(Tokens!())
     }
   });

--- a/rtx_package/src/package/pool/verbatim_sty.rs
+++ b/rtx_package/src/package/pool/verbatim_sty.rs
@@ -86,7 +86,8 @@ LoadDefinitions!(state, {
         let post = caps.get(2).map_or("", |m| m.as_str()).to_string();
         lines.push(pre);
         if !post.is_empty() {
-          info!(target: "unexpected:stuff", "Characters dropped after '\\end{{{}}}'", env);
+          let message = s!("Characters dropped after '\\end{{{}}}'", env);
+          Info!("unexpected","stuff", gullet, state, message);
         }
         break;
       } else {

--- a/rtx_package/src/package/setup_binding_language.rs
+++ b/rtx_package/src/package/setup_binding_language.rs
@@ -499,7 +499,8 @@ macro_rules! LookupRegister {
     if let Some(defn) = $state_arg.lookup_register_definition(&T_CS!($cs)) {
       defn.value_of($parameters, $state_arg).unwrap_or_default()
     } else {
-      warn!(target:"expected:register", "The control sequence {:?} is not a register", $cs);
+      let message = s!("The control sequence {:?} is not a register", $cs);
+      Warn!("expected","register", None, $state_arg, message);
       RegisterValue::default()
     }
   }
@@ -802,7 +803,8 @@ macro_rules! requireMath {
   }};
   ($cs_name:expr, $state_arg:ident) => (
     if !LookupBool!("IN_MATH", $state_arg) {
-      warn!(target: "unexpected", "{} should only appear in math mode",$cs_name);
+      let message = s!("{} should only appear in math mode",$cs_name);
+      Warn!("unexpected", "mode", None, $state_arg, message);
     }
   )
 }
@@ -814,7 +816,8 @@ macro_rules! forbidMath {
   });
   ($cs_name:expr, $state_arg:ident) => (
     if LookupBool!("IN_MATH", $state_arg) {
-      warn!(target: "unexpected", "{} should not appear in math mode",$cs_name);
+      let message = s!("{} should not appear in math mode",$cs_name);
+      Warn!("unexpected", "mode", None, $state_arg, message);
     }
   )
 }

--- a/rtx_package/src/package/setup_binding_language.rs
+++ b/rtx_package/src/package/setup_binding_language.rs
@@ -1310,6 +1310,19 @@ macro_rules! IsDefinedToken {
   }};
 }
 #[macro_export]
+macro_rules! IsDefinable {
+  ($token: expr) => {{
+    bind_state_mut!(st);
+    IsDefinable!($token, st)
+  }};
+  ($token: expr, $state_arg: ident) => {
+    is_definable($token, $state_arg)
+  }
+}
+  
+  
+
+#[macro_export]
 macro_rules! Let {
   ($token1:literal, $token2:expr) => {{
     bind_state_mut!(st);

--- a/rtx_package/src/package/setup_binding_language.rs
+++ b/rtx_package/src/package/setup_binding_language.rs
@@ -1405,6 +1405,19 @@ macro_rules! DefMacroI(
     (DefMacroIWO!($cs, $paramlist, sub [ $gullet, $args, $inner_state ] $body, Some(NewDefaultV!(ExpandableOptions, $($key=>$val),*)), $state_arg));
 
   // Simple Expression syntax
+  ($cs:literal, $paramlist:expr, $expansion:literal) => {
+    let expansion;
+    compile_expansion!(expansion, $expansion);
+    DefMacroIWO!(T_CS!($cs), $paramlist, expansion, None)
+  };
+  ($cs:literal, $paramlist:expr, $expansion:literal, $($key:ident=>$val:expr),*) => {
+    let expansion;
+    compile_expansion!(expansion, $expansion);    
+    DefMacroIWO!(T_CS!($cs), $paramlist, expansion, Some(NewDefaultV!(ExpandableOptions, $($key=>$val),*)))
+  };
+  ($cs:literal, $paramlist:expr, $expansion:expr) => (DefMacroIWO!(T_CS!($cs), $paramlist, $expansion, None));
+  ($cs:literal, $paramlist:expr, $expansion:expr, $($key:ident=>$val:expr),*) =>
+    (DefMacroIWO!(T_CS!($cs), $paramlist, $expansion, Some(NewDefaultV!(ExpandableOptions, $($key=>$val),*))));
   ($cs:expr, $paramlist:expr, $expansion:expr) => (DefMacroIWO!($cs, $paramlist, $expansion, None));
   ($cs:expr, $paramlist:expr, $expansion:expr, $($key:ident=>$val:expr),*) =>
     (DefMacroIWO!($cs, $paramlist, $expansion, Some(NewDefaultV!(ExpandableOptions, $($key=>$val),*))));
@@ -1598,7 +1611,10 @@ macro_rules! DefPrimitive{
 
 #[macro_export]
 macro_rules! DefPrimitiveI{
+  ($proto:expr, None) => (DefPrimitiveIWO!($proto, noprimitive!(), PrimitiveOptions::default()));
   ($proto:expr, $compiled_replacement:expr) => (DefPrimitiveIWO!($proto, $compiled_replacement, PrimitiveOptions::default()));
+  ($proto:expr, None, $($key:ident=>$val:expr),*) =>
+    (DefPrimitiveIWO!($proto, noprimitive!(), NewDefault!(PrimitiveOptions, $($key => $val),*)));
   ($proto:expr, $compiled_replacement:expr, $($key:ident=>$val:expr),*) =>
     (DefPrimitiveIWO!($proto, $compiled_replacement, NewDefault!(PrimitiveOptions, $($key => $val),*)));
   // explicit state

--- a/rtx_package/src/util/test.rs
+++ b/rtx_package/src/util/test.rs
@@ -48,7 +48,7 @@ fn rtx_ok_internal(tex_path: &str, xml_path: &str, name: &str, extra_bindings_di
     let xml_strings = process_xmlfile(xml_path, name);
     if !xml_strings.is_empty() {
       for (lineno, (tex_line, xml_line)) in tex_strings.iter().zip(xml_strings.iter()).enumerate() {
-        assert_eq!(tex_line, xml_line, "rtx result (left) differs from expected XML (right), line {}", lineno);
+        assert_eq!(tex_line, xml_line, "rtx result (left) differs from expected XML (right), file {}; line {}", xml_path, lineno);
       }
       assert_eq!(
         tex_strings.len() - xml_strings.len(),

--- a/rtx_package/tests/30_encoding.rs
+++ b/rtx_package/tests/30_encoding.rs
@@ -5,7 +5,6 @@ use rtx_package::util::test::*;
 use std::collections::HashMap;
 
 #[test]
-#[ignore]
 fn can_encode() {
   let mut requires = HashMap::new();
   requires.insert("ansinew", "ansinew.def");


### PR DESCRIPTION
Draft PR to keep an eye on the file diffs as I get closer to the fully operational encoding dance. Continuing from #36

Tasks:
- [x] Refactor binding dialect to always require a `&mut Stomach` argument in loading definitions, thus enabling `ProcessOptions!(stomach, state)`
- [x] Refactor binding dialect to a convention where `state` is the last argument (whenever possible in macro signatures)
- [x] Precise parity for `Document::insert_pi` attribute order
- [x] Encoding refactor for file Mouths, setup buffered reads with decoding step
- [x] Refactor binding-related package submodules into the `rtx_package::package::api` sub-namespace, to make it a little more manageable
- [x] dev aid: would be nice to fully implement `Locator` 
- [x] dev aid: and integrate source file information in the errors, 
   * especially since loading the encoding `.def` files inititally generates a lot of unknown macro errors  
   * (as they should, a lot of the pool files are yet to be ported over).
- [ ] Add `fontenc.sty.ltxml`, `inputenc.sty.ltxml` and `textcomp.sty.ltxml` implementations
   - [x] binding skeleton and basic macros
   - [x] Flesh out full `InputDefinition` infrastructure
   - [x] including `kpathsea`-based file search
   - [x] Port latex package option processing
   - [ ] Port alignments `&`
   - [ ] Port `{tabular}`
- [x] minor: fix `\box` and `\copy` bindings to work at the primitive stage
