### PR TITLE
Add 'native_kpsewhich' feature

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,4 +20,4 @@ jobs:
       - name: run tests
         uses: actions-rs/cargo@v1
         with:
-          command: test
+          command: test --features=native_kpsewhich

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "rtx_core",
   "rtx_codegen",

--- a/rtx_core/Cargo.toml
+++ b/rtx_core/Cargo.toml
@@ -10,6 +10,9 @@ description = "Core conversion capabilities of rtx"
 name = "rtx_core"
 crate-type = ["lib"]
 
+[features]
+native_kpsewhich = ["kpathsea"]
+
 [dependencies]
 glob = "0.3"
 rand = "0.8"
@@ -23,4 +26,4 @@ ansi_term = "0.12"
 libxml = "0.3.0"
 dirs = "3.0"
 encoding = "0.2"
-kpathsea = "0.2.2"
+kpathsea = { version = "0.2.2", optional = true }

--- a/rtx_core/Cargo.toml
+++ b/rtx_core/Cargo.toml
@@ -11,7 +11,8 @@ name = "rtx_core"
 crate-type = ["lib"]
 
 [features]
-native_kpsewhich = ["kpathsea"]
+default = ["kpsewhich_libkpathsea"]
+kpsewhich_libkpathsea = ["kpathsea"]
 
 [dependencies]
 glob = "0.3"

--- a/rtx_core/src/util/pathname.rs
+++ b/rtx_core/src/util/pathname.rs
@@ -297,7 +297,7 @@ pub fn extension(pathname: &str) -> String {
 
 pub use kpsewhichimpl::kpsewhich as kpsewhich;
 
-#[cfg(feature = "native_kpsewhich")]
+#[cfg(feature = "kpsewhich_libkpathsea")]
 mod kpsewhichimpl {
   use kpathsea::Kpaths;
   pub fn kpsewhich(candidates: &[&str]) -> Option<String> {
@@ -311,7 +311,7 @@ mod kpsewhichimpl {
   }
 }
 
-#[cfg(not(feature = "native_kpsewhich"))]
+#[cfg(not(feature = "kpsewhich_libkpathsea"))]
 mod kpsewhichimpl {
   use std::process::Command;
   use std::string::String;

--- a/rtx_core/src/util/pathname.rs
+++ b/rtx_core/src/util/pathname.rs
@@ -1,4 +1,3 @@
-use kpathsea::Kpaths;
 use lazy_static::lazy_static;
 use regex::Regex;
 
@@ -295,15 +294,62 @@ pub fn extension(pathname: &str) -> String {
   .to_lowercase()
 }
 
-pub fn kpsewhich(candidates: &[&str]) -> Option<String> {
-  let kpse = Kpaths::new().unwrap();
-  for candidate in candidates {
-    if let Some(path) = kpse.find_file(candidate) {
-      return Some(path);
+
+pub use kpsewhichimpl::kpsewhich as kpsewhich;
+
+#[cfg(feature = "native_kpsewhich")]
+mod kpsewhichimpl {
+  use kpathsea::Kpaths;
+  pub fn kpsewhich(candidates: &[&str]) -> Option<String> {
+    let kpse = Kpaths::new().unwrap();
+    for candidate in candidates {
+      if let Some(path) = kpse.find_file(candidate) {
+        return Some(path);
+      }
     }
+    None
   }
-  None
 }
+
+#[cfg(not(feature = "native_kpsewhich"))]
+mod kpsewhichimpl {
+  use std::process::Command;
+  use std::string::String;
+
+  pub fn kpsewhich(candidates: &[&str]) -> Option<String> {
+    for candidate in candidates {
+      if let Some(path) = exec(candidate) {
+        return Some(path);
+      }
+    }
+    None
+  }
+
+  // executable name to be used for kpsewhich
+  static KPSEWHICH_EXECTUABLE: &str = "kpsewhich";
+
+  // runs kpsewhich directly from path, and returns the candidate to be found.
+  // requires the 'kpsewhich' executable at runtime, and will otherwhise return None.
+  fn exec(candidate: &str) -> Option<String> {
+    let output = match Command::new(KPSEWHICH_EXECTUABLE).arg(candidate).output() {
+      Ok(x) => x.stdout,
+      Err(_) => return None,
+    };
+
+    let stdout = match String::from_utf8(output) {
+      Ok(s) => s,
+      Err(_) => return None,
+    };
+
+    for line in stdout.lines() {
+      if !line.is_empty() {
+        return Some(String::from(line));
+      }
+    }
+    None
+  }
+}
+
 
 pub fn is_nasty(file: &str) -> bool { PATHNAME_IS_NASTY_RE.is_match(file) }
 


### PR DESCRIPTION
Previously this project required the 'libkpathsea' library in order to compile properly. This is not an issue on sufficiently new versions of Ubuntu, but was a problem on OS X machines.

Instead of using kpsewhich form the kpathsea library, it is possible touse the 'kpsewhich' executable at runtime. 
This PR implements this approach and hides the previous approach behind a 'native_kpsewhich' feature flag.