### PR TITLE
Optimizations in arg unpacking and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Rust port of [LaTeXML](https://github.com/brucemiller/latexml)
 
 ## Progress
 
-[![test porting progress](http://progressed.io/bar/10)](https://github.com/dginev/rtx/issues/30) | ? of ? core LaTeXML tests PASS
+[![test porting progress](http://progressed.io/bar/10)](https://github.com/dginev/rtx/issues/30) | 23 of ? core LaTeXML tests PASS
 
 ### Why?
 

--- a/README.md
+++ b/README.md
@@ -51,18 +51,19 @@ There is demonstrable need for LaTeXML in the domain of academic writing, as wel
   ```
 
 ### Fake Benchmark
- These are the times of different TeX-like engines ran over the `xii.tex` example above. That is not representative to all of TeX, but gives a good early feeling:
+ These are the times of different TeX-like engines ran over the `xii.tex` example above. That is not representative to all of TeX, but gives a minimal early feeling.
+ It will be a lot more telling to provide tikz and expl3 runtime numbers.
 
 | executable | time      |
 |------------|-----------|
 | tralics    |  0.011s   |
 | rtx        |  0.033s   |
-| tex        | 	0.067s   |
-| pdftex     |  0.125s   |
-| luatex     |  0.158s   |
-| xetex      |  0.310s   |
-| httex      |  0.333s   |
-| latexml    |  0.562s   |
+| tex        |  0.096s   |
+| pdftex     |  0.215s   |
+| luatex     |  0.226s   |
+| xetex      |  0.430s   |
+| httex      |  0.608s   |
+| latexml    |  0.745s   |
 
 ### Installation
 

--- a/rtx/src/core.rs
+++ b/rtx/src/core.rs
@@ -194,7 +194,7 @@ impl DigestionAPI for Core {
       }
     }
     Debug!("Doc absorb: {:?}", digested);
-    document.absorb(digested, None, state)?;
+    document.absorb(&digested, None, state)?;
     note_end("Building");
 
     let has_rewrites = state.has_value("DOCUMENT_REWRITE_RULES");

--- a/rtx_codegen/src/constructable.rs
+++ b/rtx_codegen/src/constructable.rs
@@ -254,7 +254,7 @@ fn compile_replacement_tokens(mut replacement: String) -> Vec<proc_macro2::Token
       operations.push(quote!(
         if let Some(ref stored_digested) = #to_absorb {
           let digested_opt : Option<Digested> = stored_digested.into();
-          if let Some(digested) = digested_opt {
+          if let Some(ref digested) = digested_opt {
             document.absorb(digested, None, state)?;
           }
         }

--- a/rtx_core/src/document/mod.rs
+++ b/rtx_core/src/document/mod.rs
@@ -293,28 +293,28 @@ impl Document {
   /// $box can also be a plain string (Digested::Postponed)
   /// which will be inserted according to whatever
   /// font, mode, etc, are in %props.
-  pub fn absorb(&mut self, object: Digested, props_opt: Option<HashMap<String, Stored>>, state: &mut State) -> Result<()> {
+  pub fn absorb(&mut self, object: &Digested, props_opt: Option<HashMap<String, Stored>>, state: &mut State) -> Result<()> {
     // let mut results = Vec::new();
     let props = props_opt.unwrap_or_default(); // is there a better way to deal with the Option?
-    let mut boxes = vec![object];
+    let mut boxes = vec![Cow::Borrowed(object)];
     while let Some(front_box) = boxes.pop() {
-      if let Digested::List(ref list) = front_box {
+      if let Digested::List(ref list) = *front_box {
         // Simply unwind Lists to avoid unneccessary recursion; This occurs quite frequently!
         for tbox in list.unlist().into_iter().rev() {
-          boxes.push(tbox);
+          boxes.push(Cow::Owned(tbox));
         }
       } else {
         // info!(target: "document:absorb", "front box: {:?}", front_box);
         // self.constructed_nodes = Vec::new();
-        match front_box {
+        match *front_box {
           // A Proper Box or Whatsit? Absorb it.
           Digested::TBox(ref digested) => {
-            self.set_box_to_absorb(Some(front_box.clone()));
+            self.set_box_to_absorb(Some((*front_box).clone()));
             digested.be_absorbed(self, state)?;
             self.localize_box_to_absorb();
           },
           Digested::Whatsit(ref digested) => {
-            self.set_box_to_absorb(Some(front_box.clone()));
+            self.set_box_to_absorb(Some((*front_box).clone()));
             digested.read().unwrap().be_absorbed(self, state)?;
             self.localize_box_to_absorb();
           },
@@ -373,7 +373,7 @@ impl Document {
   //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
   /// Shorthand for open,absorb,close, but returns the new node.
-  pub fn insert_element(&mut self, qname: &str, content: Vec<Digested>, attrib: Option<HashMap<String, String>>, state: &mut State) -> Result<Node> {
+  pub fn insert_element(&mut self, qname: &str, content: Vec<&Digested>, attrib: Option<HashMap<String, String>>, state: &mut State) -> Result<Node> {
     // TODO: Quickly hacked together, needs a careful refactor with all .clone()
     // calls removed
     let node = self.open_element(qname, attrib, None, state)?;
@@ -2452,7 +2452,7 @@ impl Document {
       text: resource.content,
       ..Tbox::default()
     }));
-    self.insert_element("ltx:resource", vec![content_box], Some(attrib), state)?;
+    self.insert_element("ltx:resource", vec![&content_box], Some(attrib), state)?;
     if let Some(savenode) = savenode_opt {
       self.set_node(&savenode);
     }

--- a/rtx_core/src/lib.rs
+++ b/rtx_core/src/lib.rs
@@ -152,6 +152,17 @@ pub enum TexMode {
   Text,
 }
 
+/// These are all kinds of data which rtx considers officially supported
+/// as outputs from the digestion phase of TeX, i.e. from invoking a token.
+/// Each variant is wrapped in an `Arc`, for cheap(er) cloning when passing around
+/// these objects to various auxiliary state (e.g. bookkeeping current box),
+/// but also for repeatedly passing them as owned into binding closures
+/// while also storing them in their owner Box.
+//
+// This model is incredibly hard to achieve with lifetimes, so
+// we employ reference counting instead (close to their original Perl design).
+// A strict OO-hierarchy of object ownership (with no auxiliary state metadata)
+// would allow a Rust-like redesign. But it could be too hard to achieve in practice.
 #[derive(Clone, Debug)]
 pub enum Digested {
   TBox(Arc<Tbox>),

--- a/rtx_core/src/token.rs
+++ b/rtx_core/src/token.rs
@@ -460,10 +460,6 @@ macro_rules! Token {
   };
 }
 
-impl Default for Token {
-  fn default() -> Self { T_OTHER!("") }
-}
-
 // Explode a string into a list of tokens, all w/catcode OTHER (except space).
 #[macro_export]
 macro_rules! Explode(($text:expr) => (

--- a/rtx_core/src/tokens.rs
+++ b/rtx_core/src/tokens.rs
@@ -183,6 +183,8 @@ impl Tokens {
   // stopgap, how do we unpack! gullet-stage arguments without the unwrap?
   // should we unify the interfaces so that Options are always used? Could be cumbursome...
   pub fn unwrap_or_default(self) -> Tokens { self }
+  pub fn as_ref(&self) -> &Tokens { &self }
+  pub fn unwrap(&self) -> &Tokens { &self }
 
   pub fn stringify(&self) -> String { s!("Tokens[{}]", &self.0.iter().map(ToString::to_string).collect::<Vec<_>>().join(",")) }
 

--- a/rtx_math_parser/src/grammar/macros.rs
+++ b/rtx_math_parser/src/grammar/macros.rs
@@ -16,18 +16,10 @@ macro_rules! set {
 
 #[macro_export]
 macro_rules! unpack {
-  ($args:ident => $var:ident) => (count_unpack!(0usize, $args => $var));
-  ($args:ident => $($var:ident),*) => (count_unpack!(0usize, $args => $($var),*));
-}
-
-#[macro_export]
-macro_rules! count_unpack {
-  ($index:expr, $args:ident => $var:ident) => (
+  ($args:ident => $var:ident) => (let $var = $args.remove(0););
+  ($args:ident => $var:ident,$($tail:ident),*) => {
     let $var = $args.remove(0);
-  );
-  ($index:expr, $args:ident => $var:ident,$($tail:ident),*) => {
-    count_unpack!($index,$args => $var);
-    count_unpack!(1usize+$index, $args => $($tail),*)
+    unpack!($args => $($tail),*)
   }
 }
 

--- a/rtx_package/src/package/api_macros.rs
+++ b/rtx_package/src/package/api_macros.rs
@@ -385,15 +385,6 @@ macro_rules! count_unpack_to_string {
 }
 
 #[macro_export]
-macro_rules! unpack_opt {
-  ($args:ident => $var:ident) => (let $var = $args.remove(0););
-  ($args:ident => $var:ident,$($tail:ident),*) => {
-    let $var = $args.remove(0);
-    unpack!($args => $($tail),*)
-  }
-}
-
-#[macro_export]
 macro_rules! unpack {
   ($args:ident => $var:ident) => (let $var = $args.remove(0).unwrap_or_default(););
   ($args:ident => $var:ident,$($tail:ident),*) => {
@@ -416,6 +407,30 @@ macro_rules! count_unpack_ref {
     count_unpack_ref!($index,$args => $var);
     count_unpack_ref!(1usize+$index, $args => $($tail),*)
   };
+}
+
+/// Meant to be used for unpacking &Vec<Option<Digested>> in particular.
+#[macro_export]
+macro_rules! unpack_opt {
+  ($args:ident => $var:ident) => (count_unpack_opt!(0usize, $args => $var));
+  ($args:ident => $var:ident,$($tail:ident),*) => (count_unpack_opt!(0usize, $args => $var,$($tail),*));
+}
+
+#[macro_export]
+macro_rules! count_unpack_opt {
+  ($index:expr, $args:ident => $var:ident) => (
+    let $var = match $args.get($index) {
+      Some(v) => v,
+      None => &None
+    };
+  );
+  ($index:expr, $args:ident => $var:ident,$($tail:ident),*) => {
+    let $var = match $args.get($index) {
+      Some(v) => v,
+      None => &None
+    };
+    count_unpack_opt!(1usize+$index, $args => $($tail),*)
+  }
 }
 
 /// Convert the number to lower case roman numerals, returning a list of LaTeXML::Core::Token

--- a/rtx_package/src/package/api_macros.rs
+++ b/rtx_package/src/package/api_macros.rs
@@ -290,9 +290,9 @@ macro_rules! reversion_digested {
 macro_rules! prop_digested {
   ($props:ident, $key:expr) => {
     match $props.get($key) {
-      Some(Stored::VecDigested(vd)) => vd.clone(),
-      Some(Stored::Digested(d)) => vec![(**d).clone()],
-      Some(Stored::String(s)) => vec![s.into()],
+      Some(Stored::VecDigested(ref vd)) => vd.iter().collect::<Vec<&Digested>>(),
+      Some(Stored::Digested(d)) => vec![&(**d)],
+      Some(Stored::String(s)) => panic!("prop_digested! called on a string property {:?} with value {:?}.",$key, s),
       None => Vec::new(),
       other => {
         eprintln!("Please extend the api_macros::prop_digested macro to support: {:?}", other);
@@ -360,14 +360,23 @@ macro_rules! unpack_to_string {
 
 #[macro_export]
 macro_rules! unpack_to_token {
-  ($args:ident => $var:ident) => (count_unpack_to_token!(0usize, $args => $var));
-  ($args:ident => $($var:ident),*) => (count_unpack_to_token!(0usize, $args => $($var),*));
+  ($args:ident => $var:ident) => (
+    let tmp_tks = $args.remove(0);
+    if tmp_tks.is_empty() {
+      panic!("Hard assumption for Token argument failed -- arg was empty in unpack_to_token!()");
+    }
+    let $var : Token = tmp_tks.into();
+  );
+  ($args:ident => $var:ident,$($tail:ident),*) => (
+    unpack_to_token!($args => $var);
+    unpack_to_token!($args => $($tail),*)
+  );
 }
 
 #[macro_export]
 macro_rules! count_unpack_to_string {
   ($index:expr, $args:ident => $var:ident) => (
-    let $var = $args[$index].clone().unwrap_or_default().to_string();
+    let $var = $args[$index].as_ref().unwrap().to_string();
   );
   ($index:expr, $args:ident => $var:ident,$($tail:ident),*) => {
     count_unpack_to_string!($index,$args => $var);
@@ -376,32 +385,37 @@ macro_rules! count_unpack_to_string {
 }
 
 #[macro_export]
-macro_rules! count_unpack_to_token {
-  ($index:expr, $args:ident => $var:ident) => (
-    let tmp_tks : Tokens = $args[$index].clone().unwrap_or_default();
-    let $var : Token = tmp_tks.into();
-  );
-  ($index:expr, $args:ident => $var:ident,$($tail:ident),*) => {
-    count_unpack_to_token!($index,$args => $var);
-    count_unpack_to_token!(1usize+$index, $args => $($tail),*)
+macro_rules! unpack_opt {
+  ($args:ident => $var:ident) => (let $var = $args.remove(0););
+  ($args:ident => $var:ident,$($tail:ident),*) => {
+    let $var = $args.remove(0);
+    unpack!($args => $($tail),*)
   }
 }
 
 #[macro_export]
 macro_rules! unpack {
-  ($args:ident => $var:ident) => (count_unpack!(0usize, $args => $var));
-  ($args:ident => $($var:ident),*) => (count_unpack!(0usize, $args => $($var),*));
+  ($args:ident => $var:ident) => (let $var = $args.remove(0).unwrap_or_default(););
+  ($args:ident => $var:ident,$($tail:ident),*) => {
+    let $var = $args.remove(0).unwrap_or_default();
+    unpack!($args => $($tail),*)
+  }
 }
 
 #[macro_export]
-macro_rules! count_unpack {
-  ($index:expr, $args:ident => $var:ident) => (
-    let mut $var = $args[$index].clone().unwrap_or_default();
-  );
+macro_rules! unref {
+  ($args:ident => $var:ident) => (count_unpack_ref!(0usize, $args => $var));
+  ($args:ident => $var:ident,$($tail:ident),*) => (count_unpack_ref!(0usize,$args => $var,$($tail),*))
+}
+#[macro_export]
+macro_rules! count_unpack_ref {
+  ($index:expr, $args:ident => $var:ident) => {
+    let $var = $args[$index].as_ref().unwrap();
+  };
   ($index:expr, $args:ident => $var:ident,$($tail:ident),*) => {
-    count_unpack!($index,$args => $var);
-    count_unpack!(1usize+$index, $args => $($tail),*)
-  }
+    count_unpack_ref!($index,$args => $var);
+    count_unpack_ref!(1usize+$index, $args => $($tail),*)
+  };
 }
 
 /// Convert the number to lower case roman numerals, returning a list of LaTeXML::Core::Token

--- a/rtx_package/src/package/pool/latex_ch11_moving_information.rs
+++ b/rtx_package/src/package/pool/latex_ch11_moving_information.rs
@@ -67,7 +67,7 @@ LoadDefinitions!(outer_stomach, outer_state, {
   DefConstructor!("\\ref OptionalMatch:* Semiverbatim",
     "<ltx:ref labelref='#label' _force_font='true'/>",
     properties => sub[stomach, args, state] {
-      unpack_to_string!(args => mstar, label);
+      let label = args[1].as_ref().unwrap().to_string();
       Ok(map!("label" => Stored::String(clean_label(&label, None))))
   });
 
@@ -317,7 +317,7 @@ LoadDefinitions!(outer_stomach, outer_state, {
   DefConstructor!("\\@@bibref Semiverbatim Semiverbatim {}{}",
     "<ltx:bibref show='#1' bibrefs='#bibrefs' separator='#separator' yyseparator='#yyseparator'>#3#4</ltx:bibref>",
     properties => sub[stomach, args, state] {
-      unpack!(args => show, keys, phrase1, phrase2);
+      unref!(args => show, keys, phrase1, phrase2);
       Ok(map!("bibrefs" => clean_bib_key(&keys.to_string()).into(),
         "separator" => match state.lookup_tokens("CITE_SEPARATOR") {
           Some(sep) => stomach.digest(sep, state)?.to_string().into(),

--- a/rtx_package/src/package/pool/latex_ch11_moving_information.rs
+++ b/rtx_package/src/package/pool/latex_ch11_moving_information.rs
@@ -67,7 +67,8 @@ LoadDefinitions!(outer_stomach, outer_state, {
   DefConstructor!("\\ref OptionalMatch:* Semiverbatim",
     "<ltx:ref labelref='#label' _force_font='true'/>",
     properties => sub[stomach, args, state] {
-      let label = args[1].as_ref().unwrap().to_string();
+      unpack_opt!(args => _star,label_opt);
+      let label = label_opt.as_ref().unwrap().to_string();
       Ok(map!("label" => Stored::String(clean_label(&label, None))))
   });
 

--- a/rtx_package/src/package/pool/latex_ch2_document.rs
+++ b/rtx_package/src/package/pool/latex_ch2_document.rs
@@ -24,10 +24,10 @@ LoadDefinitions!(state, {
         if !id.is_empty() {
           document.set_attribute(&mut docel, "xml:id", id)?;
         }
-        document.absorb(body, None, state)?;
+        document.absorb(&body, None, state)?;
       } else {
         let attrib = string_map!("xml:id" => id);
-        document.insert_element("ltx:document", vec![body], Some(attrib), state)?;
+        document.insert_element("ltx:document", vec![&body], Some(attrib), state)?;
       }
       Ok(())
     },

--- a/rtx_package/src/package/pool/latex_ch4_sectioning_and_toc.rs
+++ b/rtx_package/src/package/pool/latex_ch4_sectioning_and_toc.rs
@@ -111,7 +111,7 @@ LoadDefinitions!(outer_stomach, outer_state, {
       // Update 2022: The notes are generally still accurate, but cloning a Digested object is now cheap enough,
       // as each enum variant is guarded by an Arc reference counter. Arc<Tbox>, Arc<List>, etc.
       if let Some(Stored::Digested(tags)) = props.get("tags") {
-        document.absorb((**tags).clone(), None, state)?;
+        document.absorb(&(**tags), None, state)?;
       }
       let title = prop_digested!(props, "title");
       document.insert_element("ltx:title", title, None, state)?;
@@ -122,12 +122,12 @@ LoadDefinitions!(outer_stomach, outer_state, {
       }
     },
     properties => sub[stomach, args, state] {
-      unpack!(args => stype, inlist, toctitle_arg, title);
+      unref!(args => stype, inlist, toctitle_arg, title);
       let mut props = ref_step_counter(&stype.to_string(), false, stomach, state)?;
       let toctitle = if !toctitle_arg.to_string().is_empty() {
         toctitle_arg
       } else {
-        title.clone()
+        title
       };
       let stype_tokens = stype.revert(state)?;
       let title_tokens = title.revert(state)?;
@@ -156,7 +156,7 @@ LoadDefinitions!(outer_stomach, outer_state, {
 
   // No tags, at all? Consider...
   DefConstructor!("\\@@unnumbered@section{} Undigested OptionalUndigested Undigested", sub[document, args, props, state] {
-      unpack!( args => stype, inlist, toctitle, title);
+      unref!( args => stype, inlist, toctitle, title);
       let id = props.get("id").unwrap().to_string();
       document.open_element(&s!("ltx:{}", stype),
         Some(string_map!(
@@ -173,20 +173,20 @@ LoadDefinitions!(outer_stomach, outer_state, {
       }
     },
     properties => sub[stomach, args, state] {
-      unpack!(args => stype, inlist, toctitle, title);
+      unref!(args => stype, inlist, toctitle, title);
       let mut props = RefStepID!(&stype.to_string())?;
       let title_digested = if let Digested::Postponed(tokens) = title {
         // TODO: tokens.clone().unlist() looks like a code smell.
         // Should Digested::Postponed() hold a Tokens directly instead?
-        stomach.digest(Tokens!(T_CS!("\\@hidden@bgroup"), (*tokens).clone().unlist(), T_CS!("\\@hidden@egroup")), state)?
+        stomach.digest(Tokens!(T_CS!("\\@hidden@bgroup"), (**tokens).clone().unlist(), T_CS!("\\@hidden@egroup")), state)?
       } else {
-        title
+        title.clone()
       };
       props.insert("title".to_string(), title_digested.into());
 
       if let Digested::Postponed(toctokens) = toctitle {
         if !toctokens.is_empty() {
-          let toctitle_digested = stomach.digest(Tokens!(T_CS!("\\@hidden@bgroup"), (*toctokens).clone().unlist(), T_CS!("\\@hidden@egroup")), state)?;
+          let toctitle_digested = stomach.digest(Tokens!(T_CS!("\\@hidden@bgroup"), (**toctokens).clone().unlist(), T_CS!("\\@hidden@egroup")), state)?;
           props.insert("toctitle".to_string(), toctitle_digested.into());
         }
       }

--- a/rtx_package/src/package/pool/latex_ch6_list_and_trivlist_environments.rs
+++ b/rtx_package/src/package/pool/latex_ch6_list_and_trivlist_environments.rs
@@ -35,7 +35,7 @@ LoadDefinitions!(state, {
   DefConstructor!("\\list@item OptionalUndigested",
     "<ltx:item xml:id='#id' itemsep='#itemsep'>#tags",
     properties => sub[stomach, args, state] {
-      unpack!(args => tag);
+      unref!(args => tag);
       ref_step_item_counter(&tag.to_string(), stomach, state) }
   );
 

--- a/rtx_package/src/package/pool/latex_ch6_verbatim.rs
+++ b/rtx_package/src/package/pool/latex_ch6_verbatim.rs
@@ -144,7 +144,7 @@ LoadDefinitions!(outer_state, {
   DefConstructor!("\\@internal@verb{} Undigested {}",
     "?#isMath(<ltx:XMTok font='#font'>#text</ltx:XMTok>)(<ltx:verbatim font='#font'>#text</ltx:verbatim>)",
     properties => sub[stomach, args, state] {
-      unpack!(args => a1, a2, a3);
+      unref!(args => a1, a2, a3);
       Ok(map!("text" => Stored::String(a3.to_string())))
     },
   font => { family => "typewriter", series => "medium", shape => "upright" },

--- a/rtx_package/src/package/pool/tex_boxes.rs
+++ b/rtx_package/src/package/pool/tex_boxes.rs
@@ -105,7 +105,7 @@ LoadDefinitions!(state, {
 
   DefConstructor!("\\hbox BoxSpecification HBoxContents", sub[document, args, props, state] {
       // "<ltx:text width='#width' _noautoclose='1'>#2</ltx:text>",
-      unpack!(args => spec, contents);
+      let contents = args[1].as_ref().unwrap();
       let current_opt = document.get_element();
 
       // What is the CORRECT (& general) way to ask whether we're in "vertical mode"??
@@ -124,6 +124,8 @@ LoadDefinitions!(state, {
         String::new()
       };
       let node = document.open_element(newtag, Some(string_map!("_noautoclose" => "true", "width" => width)), None, state)?;
+      // Note on the clone: Remember that contents is a Digested, i.e. we are cloning an Arc<> wrapper, which is relatively cheap.
+      // see the documentation on `Digested` on why we don't have a neater way of dealing with this.
       document.absorb(contents, None, state)?;
       if !is_svg {
         while !document.get_element().unwrap().has_attribute("_beginscope") &&
@@ -160,7 +162,7 @@ LoadDefinitions!(state, {
   );
 
   DefConstructor!("\\vbox BoxSpecification VBoxContents", sub[document, args, props, state] {
-      unpack!(args => spec, contents);
+      let contents = args[1].as_ref().unwrap();
       let block = insert_block(document, contents, string_map!("vattach" => "bottom"), state);
     },
     // sizer       => "#2",
@@ -179,7 +181,7 @@ LoadDefinitions!(state, {
   );
 
   DefConstructor!("\\vtop BoxSpecification VBoxContents", sub[document, args, props, state] {
-      unpack!(args => spec, contents);
+      let contents = args[1].as_ref().unwrap();
       insert_block(document, contents, string_map!("vattach" => "top"), state)?;
     },
     // sizer       => '#2',

--- a/rtx_package/src/package/pool/tex_ch24_primitives.rs
+++ b/rtx_package/src/package/pool/tex_ch24_primitives.rs
@@ -341,7 +341,7 @@ LoadDefinitions!(state, {
   // If this is the right solution...
   // then we also should put the desired spacing on a style attribute?!?!?!
   DefConstructor!("\\vskip Glue", sub[document, args, props, state] {
-    unpack!(args => length);
+    unref!(args => length);
     let length = length.pt_value(None);
 
     if length > 10.0 {    // Or what!?!?!?!

--- a/rtx_package/src/package/pool/tex_frontmatter.rs
+++ b/rtx_package/src/package/pool/tex_frontmatter.rs
@@ -131,7 +131,7 @@ LoadDefinitions!(state, {
         for (tag, attr, stuff) in list {
           document.open_element(&tag, attr, None, state)?; // TODO:  (scalar(@stuff) && $document->canHaveAttribute($tag, 'font')
                                                            //        ? (font => $stuff[0]->getFont, _force_font => 'true') : ()));
-          document.absorb(stuff, None, state)?;
+          document.absorb(&stuff, None, state)?;
 
           document.close_element(&tag, state)?;
         }

--- a/rtx_package/src/package/pool/tex_functions.rs
+++ b/rtx_package/src/package/pool/tex_functions.rs
@@ -137,7 +137,7 @@ pub fn parse_def_parameters(cs: &Token, params_in: Tokens, state: &mut State) ->
   }
 }
 
-pub fn do_def(globally: bool, stomach: &mut Stomach, args: Vec<Tokens>, state: &mut State) -> Result<()> {
+pub fn do_def(globally: bool, stomach: &mut Stomach, mut args: Vec<Tokens>, state: &mut State) -> Result<()> {
   BindState!(stomach, state);
   unpack!(args => cs, params, body);
   let cs: Token = cs.into();
@@ -265,7 +265,7 @@ pub fn revert_spec(whatsit: &mut Whatsit, keyword: &str, state: &mut State) -> V
 /// need to be explicitly wrapped in some kind of block element (presumably ltx:p).
 /// It returns the inserted inner blocks,
 /// whether or not they got wrapped by that ltx:inline-block; which it DOESN'T TELL YOU ABOUT!
-pub fn insert_block(document: &mut Document, contents: Digested, mut blockattr: HashMap<String, String>, state: &mut State) -> Result<Vec<Node>> {
+pub fn insert_block(document: &mut Document, contents: &Digested, mut blockattr: HashMap<String, String>, state: &mut State) -> Result<Vec<Node>> {
   // Create something like:
   // "<ltx:inline-block vattach='$vattach' height='#height'>#2</ltx:inline-block>"
   let context = document.get_element().unwrap(); // Where we originally start inserting.

--- a/rtx_package/src/package/pool/tex_scripts.rs
+++ b/rtx_package/src/package/pool/tex_scripts.rs
@@ -210,7 +210,7 @@ fn script_handler(stomach: &mut Stomach, cc: Catcode, state: &mut State) -> Resu
 // OTOH, direct use of \@@POSTSUPERSCRIPT, etal, MAY need to have extra braces around them.
 // So, when reverting, we're going to a bit of extra trouble to make sure we have ONE set
 // of braces, but no extras!!  [Worry about lists of lists...]
-pub fn revert_script(script: Digested, state: &mut State) -> Result<Vec<Token>> {
+pub fn revert_script(script: &Digested, state: &mut State) -> Result<Vec<Token>> {
   let tokens = script.revert(state)?;
   let mut ts = tokens.unlist();
   let mut level = 0;
@@ -248,7 +248,7 @@ LoadDefinitions!(state, {
   </ltx:XMApp>
   "###,
     reversion => sub[whatsit,args,state] {
-      unpack!(args=>arg);
+      unref!(args=>arg);
       Ok(Tokens!(T_SUPER!(), revert_script(arg,state)?)) }
     // sizer     => sub { script_sizer($_[0]->getArg(1), $_[0].get_property("base"),
     //     $_[0].get_property("prevscript"), "SUPERSCRIPT", "post"); }
@@ -261,7 +261,7 @@ LoadDefinitions!(state, {
   "###
     ,
     reversion => sub[whatsit,args,state] {
-      unpack!(args=>arg);
+      unref!(args=>arg);
       Ok(Tokens!(T_SUB!(), revert_script(arg,state)?)) }
     // sizer     => sub { script_sizer($_[0]->getArg(1), $_[0].get_property("base"),
     //     $_[0].get_property("prevscript"),
@@ -274,7 +274,7 @@ LoadDefinitions!(state, {
   </ltx:XMApp>
   "###,
     reversion => sub[whatsit,args,state] {
-      unpack!(args=>arg);
+      unref!(args=>arg);
       Ok(Tokens!(T_BEGIN!(), T_END!(), T_SUPER!(), revert_script(arg,state)?)) }
     // sizer     => sub { script_sizer($_[0]->getArg(1), undef, undef, "SUPERSCRIPT", 'post"); }
   );
@@ -284,7 +284,7 @@ LoadDefinitions!(state, {
   </ltx:XMApp>
   "###,
     reversion => sub[whatsit,args,state] {
-      unpack!(args=>arg);
+      unref!(args=>arg);
       Ok(Tokens!(T_BEGIN!(), T_END!(), T_SUB!(), revert_script(arg,state)?)) }
     // sizer     => sub { script_sizer($_[0]->getArg(1), undef, undef, 'SUBSCRIPT', 'post"); }
   );

--- a/rtx_package/src/package/pool/url_sty.rs
+++ b/rtx_package/src/package/pool/url_sty.rs
@@ -76,7 +76,7 @@ LoadDefinitions!(state, {
   DefConstructor!("\\@@Url Undigested {}{} Semiverbatim {}",// Allow this to work in Math!
     "?#isMath(<ltx:XMWrap href='#href'>#5</ltx:XMWrap>) (<ltx:ref href='#href' class='#class'>#5</ltx:ref>)",
     properties => sub[stomach, args, state] {
-      unpack!(args => cmd, open, close, url, formattedurl);
+      unref!(args => cmd, open, close, url, formattedurl);
       let ltx_cmd = s!("ltx_{}", LEADING_BACKSLASH_RE.replace(&cmd.to_string(),""));
       Ok(map!(
         "href" => Stored::String(compose_url(&state.lookup_string("BASE_URL"), &url.to_string(), None)),

--- a/rtx_package/src/package/setup_binding_language.rs
+++ b/rtx_package/src/package/setup_binding_language.rs
@@ -388,7 +388,7 @@ macro_rules! DefConditional(
   ($proto:literal, sub [$gullet:ident, $args:ident, $inner_state:ident] $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {ConditionalOptions,});
     let (cs, paramlist) = parse_prototype!($proto);
-    let test : ConditionalClosure = Arc::new(move |$gullet, $args, $inner_state| { WithInnerState!($body, $inner_state).into_bool_result() });
+    let test : ConditionalClosure = Arc::new(move |$gullet, mut $args, $inner_state| { WithInnerState!($body, $inner_state).into_bool_result() });
     defi_conditional!(cs, paramlist, Some(test), options);
   }};
   ($proto:literal, $body:block $($input:tt)*) => {{
@@ -474,7 +474,7 @@ macro_rules! DefPrimitive {
   ($proto:expr, sub[$stomach_arg:ident, $args:ident, $state_arg:ident] $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
     let (cs, params) = parse_prototype!($proto);
-    let replacement_closure = Arc::new(move |$stomach_arg: &mut Stomach, $args: Vec<Tokens>, $state_arg: &mut State| {
+    let replacement_closure = Arc::new(move |$stomach_arg: &mut Stomach, mut $args: Vec<Tokens>, $state_arg: &mut State| {
       WithInnerState!($body, $stomach_arg, $state_arg).into_digested_result()
     });
     defi_primitive!(cs, params, replacement_closure, options);
@@ -482,7 +482,7 @@ macro_rules! DefPrimitive {
   // Case: cs-noparams with closure pattern replacement
   ($cs:expr, None, sub[$stomach_arg:ident, $args:ident, $state_arg:ident] $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
-    let replacement_closure = Arc::new(move |$stomach_arg: &mut Stomach, $args: Vec<Tokens>, $state_arg: &mut State| {
+    let replacement_closure = Arc::new(move |$stomach_arg: &mut Stomach, mut $args: Vec<Tokens>, $state_arg: &mut State| {
       WithInnerState!($body, $stomach_arg, $state_arg).into_digested_result()
     });
     defi_primitive!($cs, None, replacement_closure, options);
@@ -1485,14 +1485,14 @@ macro_rules! DefMacro {
     let options = defi_opts!(@munch ($($input)*) -> {ExpandableOptions,});
     let (cs, params) = parse_prototype!($proto);
     let expansion_closure: Option<ExpansionBody> = Some(ExpansionBody::Closure(Arc::new(
-      move |$gullet, $args, $inner_state| WithInnerState!($body, $inner_state).into_tokens_result()
+      move |$gullet, mut $args, $inner_state| WithInnerState!($body, $inner_state).into_tokens_result()
     )));
     defi_macro!(cs, params, expansion_closure, Some(options));
   }};
   ($proto:expr, $body:block) => {{
     let (cs, params) = parse_prototype!($proto);
     let expansion_closure: Option<ExpansionBody> = Some(ExpansionBody::Closure(Arc::new(
-      move |gullet, args, inner_state| WithInnerState!($body, inner_state).into_tokens_result()
+      move |gullet, mut args, inner_state| WithInnerState!($body, inner_state).into_tokens_result()
     )));
     defi_macro!(cs, params, expansion_closure, None);
   }};
@@ -1508,7 +1508,7 @@ macro_rules! DefMacro {
   ($cs:expr, $parameters:expr, sub [ $gullet:ident, $args:ident, $inner_state:ident ] $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {ExpandableOptions,});
     let expansion_closure: Option<ExpansionBody> = Some(ExpansionBody::Closure(Arc::new(
-      move |$gullet, $args, $inner_state| WithInnerState!($body, $inner_state).into_tokens_result()
+      move |$gullet, mut $args, $inner_state| WithInnerState!($body, $inner_state).into_tokens_result()
     )));
     defi_macro!($cs, $parameters, expansion_closure, Some(options));
   }};


### PR DESCRIPTION
Fixes #65 
Fixes #45 

I want to re-read the code I added to make sure it's a reasonable trade-off, but it's a step in the right direction. Rather than cloning bravely various Tokens and Digested objects (even though I made Digested fast+safe to clone by using a wrapping `Arc<>` for the inner data), the PR now detaches the individual arguments from the input Vec, or simply borrows them in the digested case (via a new `unref!` macro).

Ideally this keeps the binding execution chain a lot lighter on allocations, so we stay fast.