### PR TITLE
Unified type interface for binding arguments, Part 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,10 @@ Requires Rust `stable` v1.32, and newer.
     ```bash
     $ cargo run --release --bin rtx rtx/tests/hello/hello.tex
     ```
+
+### Docs
+
+To generate the project documentation locally, run:
+```bash
+$ cargo doc --workspace --no-deps --open
+```

--- a/README.md
+++ b/README.md
@@ -34,26 +34,6 @@ Design goals:
 
 There is demonstrable need for LaTeXML in the domain of academic writing, as well as various research areas on math-heavy documents. So here is a fast, safe, hip reimplementation that can usher LaTeXML uses in the 2020s.
 
-### Updates
-
- * `v0.1.12` is now capable of passing the `complex/xii.tex` test, which accurately converts the [infamous snippet](http://ctan.org/pkg/xii):
-
-  ```
-  \let~\catcode~`76~`A13~`F1~`j00~`P2jdefA71F~`7113jdefPALLF
-  PA''FwPA;;FPAZZFLaLPA//71F71iPAHHFLPAzzFenPASSFthP;A$$FevP
-  A@@FfPARR717273F737271P;ADDFRgniPAWW71FPATTFvePA**FstRsamP
-  AGGFRruoPAqq71.72.F717271PAYY7172F727171PA??Fi*LmPA&&71jfi
-  Fjfi71PAVVFjbigskipRPWGAUU71727374 75,76Fjpar71727375Djifx
-  :76jelse&U76jfiPLAKK7172F71l7271PAXX71FVLnOSeL71SLRyadR@oL
-  RrhC?yLRurtKFeLPFovPgaTLtReRomL;PABB71 72,73:Fjif.73.jelse
-  B73:jfiXF71PU71 72,73:PWs;AMM71F71diPAJJFRdriPAQQFRsreLPAI
-  I71Fo71dPA!!FRgiePBt'el@ lTLqdrYmu.Q.,Ke;vz vzLqpip.Q.,tz;
-  ;Lql.IrsZ.eap,qn.i. i.eLlMaesLdRcna,;!;h htLqm.MRasZ.ilk,%
-  s$;z zLqs'.ansZ.Ymi,/sx ;LYegseZRyal,@i;@ TLRlogdLrDsW,@;G
-  LcYlaDLbJsW,SWXJW ree @rzchLhzsW,;WERcesInW qt.'oL.Rtrul;e
-  doTsW,Wk;Rri@stW aHAHHFndZPpqar.tridgeLinZpe.LtYer.W,:
-  ```
-
 ### Fake Benchmark
  These are the times of different TeX-like engines ran over the `xii.tex` example above. That is not representative to all of TeX, but gives a minimal early feeling.
  It will be a lot more telling to provide tikz and expl3 runtime numbers.

--- a/rtx/Cargo.toml
+++ b/rtx/Cargo.toml
@@ -17,6 +17,13 @@ path = "src/main.rs"
 name = "rtxmath"
 path = "bin/rtx_math.rs"
 
+[[bench]]
+name = "integration_benchmarks"
+harness = false
+
+[dev-dependencies]
+criterion = "0.3.0"
+
 [dependencies]
 log = "0.4"
 libxml = "0.3.0"

--- a/rtx/benches/integration_benchmarks.rs
+++ b/rtx/benches/integration_benchmarks.rs
@@ -3,7 +3,7 @@ extern crate criterion;
 
 use criterion::Criterion;
 use rtx_core::{Core, CoreOptions};
-use rtx_package::core::DigestionAPI;
+use rtx::core::DigestionAPI;
 
 /// Convenience function for iteratively executing rtx under a Bencher
 fn benchmark_texfile(c: &mut Criterion, tex_path: &'static str) {

--- a/rtx/bin/rtx_math.rs
+++ b/rtx/bin/rtx_math.rs
@@ -30,7 +30,7 @@ fn main() {
 
   let (lexemes, lex_nodes, xmath_opt, mut doc) = lex_single_tex_formula(&source);
   assert!(!lexemes.is_empty());
-  eprintln!("lexemes: {:?}", lexemes);
+  eprintln!("lexemes: {lexemes:?}");
 
   let mut parser = MathParser::default();
   if let Ok(Some(mut parse_tree)) = parser.parse_lexemes(lexemes, lex_nodes, &mut doc) {

--- a/rtx/src/core.rs
+++ b/rtx/src/core.rs
@@ -121,7 +121,7 @@ impl DigestionAPI for Core {
 
     // if defined $dir && !grep { $_ eq $dir } @{ $state->lookupValue('GRAPHICSPATHS') };
 
-    let name_copy = name.clone();
+    let name_copy = name;
     self.state.install_definition(
       Stored::Expandable(Arc::new(Expandable {
         cs: T_CS!("\\jobname"),

--- a/rtx/src/main.rs
+++ b/rtx/src/main.rs
@@ -50,7 +50,7 @@ fn main() {
   // the right arguments can be passed in so that the response is either captured - and
   // passed, or printed internally by the logger info!("{:?}\n\n", r.log);
   if let Some(xml) = response.result {
-    println!("{}", xml);
+    println!("{xml}");
   }
 
   // Normal exit

--- a/rtx/src/util/test.rs
+++ b/rtx/src/util/test.rs
@@ -51,16 +51,12 @@ fn rtx_ok_internal(tex_path: &str, xml_path: &str, name: &str, extra_bindings_di
       for (lineno, (tex_line, xml_line)) in tex_strings.iter().zip(xml_strings.iter()).enumerate() {
         assert_eq!(
           tex_line, xml_line,
-          "rtx result (left) differs from expected XML (right), file {}; line {}",
-          xml_path, lineno
-        );
+          "rtx result (left) differs from expected XML (right), file {xml_path}; line {lineno}");
       }
       assert_eq!(
         tex_strings.len() - xml_strings.len(),
         0,
-        "Conversion of {:?} had more/fewer lines of content than expected",
-        name
-      );
+        "Conversion of {name:?} had more/fewer lines of content than expected");
     }
   }
 }
@@ -126,7 +122,7 @@ pub fn lex_single_tex_formula(tex: &str) -> (Vec<String>, Vec<Node>, Option<Node
     include_comments: Some(false),
     ..CoreOptions::default()
   });
-  let xml_result = latexml.convert_file(format!("literal:\\[ {} \\]", tex));
+  let xml_result = latexml.convert_file(format!("literal:\\[ {tex} \\]"));
   assert!(xml_result.is_ok());
   let doc = xml_result.unwrap();
 

--- a/rtx/src/util/test.rs
+++ b/rtx/src/util/test.rs
@@ -17,7 +17,7 @@ pub fn rtx_tests(dirpath: &str, requires: Option<HashMap<&str, &str>>, dispatche
 }
 #[allow(clippy::implicit_hasher)]
 pub fn rtx_tests_internal(dirpath: &str, requires: Option<HashMap<&str, &str>>, extra_bindings_dispatcher: Option<BindingDispatcher>) {
-  assert!(rtx_core::util::logger::init(log::LevelFilter::Warn).is_ok());
+  rtx_core::util::logger::init(log::LevelFilter::Warn).unwrap();
 
   if !validate_requirements(dirpath, requires) {
     return; // test group only if required files are found.

--- a/rtx_codegen/src/constructable.rs
+++ b/rtx_codegen/src/constructable.rs
@@ -520,7 +520,7 @@ fn parse_conditional(text: &mut String) -> (proc_macro2::TokenStream, String, St
   //   for testing the boolean branch
   //   we could make it more performant by defining a simple trait `.to_bool`
   //   and implementing it for all Core objects that may be passed in as arguments
-  let bool_branch = quote!(  match #translated_bool { None => false, Some(ref v) => { let v_str = v.to_string(); !v_str.is_empty() && v_str != "false" }} );
+  let bool_branch = quote!(  match #translated_bool { None => false, Some(ref v) => !v.to_string().is_empty()} );
   let if_branch_opt = extract_bracketed(text, Some(&Delimiter::Parenthesis));
   if let Some(if_branch) = if_branch_opt {
     let else_branch = extract_bracketed(text, Some(&Delimiter::Parenthesis)).unwrap_or_default();

--- a/rtx_codegen/src/constructable.rs
+++ b/rtx_codegen/src/constructable.rs
@@ -184,7 +184,7 @@ fn compile_replacement_tokens(mut replacement: String) -> Vec<proc_macro2::Token
         .to_string();
 
       if !pi_closed {
-        panic!("Missing '?>' at '{:?}'\n", replacement);
+        panic!("Missing '?>' at '{replacement:?}'\n");
       }
       continue;
     }
@@ -229,7 +229,7 @@ fn compile_replacement_tokens(mut replacement: String) -> Vec<proc_macro2::Token
       if replacement.starts_with('>') {
         replacement = replacement[1..].to_owned();
       } else {
-        panic!("Missing '>' at '{:?}'", replacement);
+        panic!("Missing '>' at '{replacement:?}'");
       }
       continue;
     }
@@ -334,7 +334,7 @@ fn translate_string(text: &mut String) -> proc_macro2::TokenStream {
           let escaped_match = &slashify(&unquote(&quoted_match));
           values.push(quote!(#escaped_match));
         } else {
-          panic!("Unrecognized at '{:?}'\n", text);
+          panic!("Unrecognized at '{text:?}'\n");
         }
       }
     }
@@ -454,7 +454,7 @@ fn translate_value(exclude_chars: &str, text: &mut String) -> proc_macro2::Token
     if text.starts_with(')') {
       text.remove(0);
     } else {
-      panic!("Missing ')' in &$fcn(...) at '{:?}'\n", text);
+      panic!("Missing ')' in &$fcn(...) at '{text:?}'\n");
     }
     // println!("text after translate_value: {:?}", text);
     val = quote!(#fcn( #(#args),* ));
@@ -469,7 +469,7 @@ fn translate_value(exclude_chars: &str, text: &mut String) -> proc_macro2::Token
         let n_int = n.parse::<i32>().unwrap_or(-1);
         if n_int < 1 {
           //|| (n_int > *NARGS) {
-          panic!("Illegal argument number {:?} at '{:?}'\n", n_int, text);
+          panic!("Illegal argument number {n_int:?} at '{text:?}'\n");
         } else {
           let n_usize: usize = (n_int - 1) as usize; // index starts at 0
           val = quote!(args[#n_usize])
@@ -507,7 +507,7 @@ fn translate_value(exclude_chars: &str, text: &mut String) -> proc_macro2::Token
       .to_string();
   }
   if !is_match {
-    panic!("Missing value at '{:?}'\n", text);
+    panic!("Missing value at '{text:?}'\n");
   }
   val
 }

--- a/rtx_codegen/src/constructable.rs
+++ b/rtx_codegen/src/constructable.rs
@@ -140,13 +140,12 @@ fn compile_replacement_tokens(mut replacement: String) -> Vec<proc_macro2::Token
 
     // ?test(ifclause)(elseclause)
     if LEAD_COND_RE.is_match(&replacement) {
-      // println!("Leading conditional at: {:?}", replacement);
       let (bool_branch, if_branch, else_branch) = parse_conditional(&mut replacement);
       let if_branch_compiled = compile_replacement_tokens(if_branch);
       let else_branch_compiled = compile_replacement_tokens(else_branch);
 
       operations.push(quote!(
-        if #bool_branch.is_some() && #bool_branch != Some(&Stored::Bool(false)) {
+        if #bool_branch {
           #(#if_branch_compiled)*
         } else {
           #(#else_branch_compiled)*
@@ -312,7 +311,7 @@ fn translate_string(text: &mut String) -> proc_macro2::TokenStream {
         let if_branch_translated = translate_value("", &mut if_branch);
         let else_branch_translated = translate_value("", &mut else_branch);
         let op = quote!(
-          if #bool_branch.is_some() {
+          if #bool_branch {
             #if_branch_translated
           } else {
             #else_branch_translated
@@ -378,7 +377,7 @@ fn translate_avpairs(text: &mut String) -> Vec<proc_macro2::TokenStream> {
       let if_branch_translated = translate_avpairs(&mut if_branch);
       let else_branch_translated = translate_avpairs(&mut else_branch);
       let op = quote!(
-        if #bool_branch.is_some() {
+        if #bool_branch {
           #(#if_branch_translated)*
         } else {
           #(#else_branch_translated)*
@@ -515,10 +514,13 @@ fn translate_value(exclude_chars: &str, text: &mut String) -> proc_macro2::Token
 
 fn parse_conditional(text: &mut String) -> (proc_macro2::TokenStream, String, String) {
   // Remove leading "?"
-  // println!("-- cond before: {:?}", text);
   *text = LEAD_QMARK.replace(text, |_: &Captures| String::new()).to_string();
   let translated_bool = translate_value("(", text);
-  let bool_branch = quote!(  #translated_bool );
+  // Note/TODO: This is a direct redo of latexml's "ToString(v) ? () : ()" approach
+  //   for testing the boolean branch
+  //   we could make it more performant by defining a simple trait `.to_bool`
+  //   and implementing it for all Core objects that may be passed in as arguments
+  let bool_branch = quote!(  match #translated_bool { None => false, Some(ref v) => { let v_str = v.to_string(); !v_str.is_empty() && v_str != "false" }} );
   let if_branch_opt = extract_bracketed(text, Some(&Delimiter::Parenthesis));
   if let Some(if_branch) = if_branch_opt {
     let else_branch = extract_bracketed(text, Some(&Delimiter::Parenthesis)).unwrap_or_default();

--- a/rtx_codegen/src/constructable.rs
+++ b/rtx_codegen/src/constructable.rs
@@ -520,7 +520,10 @@ fn parse_conditional(text: &mut String) -> (proc_macro2::TokenStream, String, St
   //   for testing the boolean branch
   //   we could make it more performant by defining a simple trait `.to_bool`
   //   and implementing it for all Core objects that may be passed in as arguments
-  let bool_branch = quote!(  match #translated_bool { None => false, Some(ref v) => !v.to_string().is_empty()} );
+  //   currently Stored::Bool(false) will serialize to "false" so we need an extra check...
+  let bool_branch = quote!(  match #translated_bool { None => false, Some(ref v) => {
+    let v_str = v.to_string();
+    !v_str.is_empty() && v_str != "false" }});
   let if_branch_opt = extract_bracketed(text, Some(&Delimiter::Parenthesis));
   if let Some(if_branch) = if_branch_opt {
     let else_branch = extract_bracketed(text, Some(&Delimiter::Parenthesis)).unwrap_or_default();

--- a/rtx_codegen/src/lib.rs
+++ b/rtx_codegen/src/lib.rs
@@ -26,7 +26,7 @@ pub fn derive_load_model(input: TokenStream) -> TokenStream {
   let item = parse_macro_input!(input as DeriveInput);
   match modelable::load_model(item) {
     Ok(loaded_model) => loaded_model,
-    Err(e) => panic!("Failed to load model: {:?}", e),
+    Err(e) => panic!("Failed to load model: {e:?}"),
   }
 }
 

--- a/rtx_codegen/src/modelable.rs
+++ b/rtx_codegen/src/modelable.rs
@@ -39,7 +39,7 @@ pub fn load_model(input: DeriveInput) -> Result<TokenStream> {
 
   let path = match pathname_opt {
     Some(n) => n,
-    None => panic!("Model {:?} not found, required to load a compiled model!", name),
+    None => panic!("Model {name:?} not found, required to load a compiled model!"),
   };
 
   let mut operations = Vec::new();

--- a/rtx_core/src/comment.rs
+++ b/rtx_core/src/comment.rs
@@ -12,7 +12,6 @@ use crate::common::store::Stored;
 use crate::definition::register::RegisterValue;
 use crate::document::Document;
 use crate::state::State;
-use crate::token::Token;
 use crate::tokens::Tokens;
 use crate::{BoxOps, Digested};
 

--- a/rtx_core/src/comment.rs
+++ b/rtx_core/src/comment.rs
@@ -15,7 +15,7 @@ use crate::state::State;
 use crate::tokens::Tokens;
 use crate::{BoxOps, Digested};
 
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Comment(pub String);
 
 impl fmt::Display for Comment {

--- a/rtx_core/src/common/dimension.rs
+++ b/rtx_core/src/common/dimension.rs
@@ -30,7 +30,7 @@ impl NumericOps for Dimension {
 }
 
 impl fmt::Display for Dimension {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{}", fixedformat(self.0 as i32, Some("pt"))) }
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{}", fixedformat(self.0, Some("pt"))) }
 }
 
 impl Dimension {
@@ -87,14 +87,14 @@ pub fn fixedformat(mut s: i32, unit_opt: Option<&str>) -> String {
   }
   string.push_str(&(((s as f32 / UNITY as f32).trunc() as i32).to_string()));
   string.push('.');
-  s = 10 * (s % UNITY as i32) + 5;
+  s = 10 * (s % UNITY) + 5;
   let mut delta = 10i32;
   loop {
-    if delta > UNITY as i32 {
+    if delta > UNITY {
       s += 0x8000 - 50000;
     }
     string.push_str(&((s as f32 / UNITY as f32).trunc() as i32).to_string());
-    s = 10 * (s % UNITY as i32);
+    s = 10 * (s % UNITY);
     delta *= 10;
     if s <= delta {
       break;

--- a/rtx_core/src/common/dimension.rs
+++ b/rtx_core/src/common/dimension.rs
@@ -14,7 +14,7 @@ lazy_static! {
   static ref SPEC_RE: Regex = Regex::new(r"^(-?\d*\.?\d*)([a-zA-Z][a-zA-Z])$").unwrap();
 }
 
-#[derive(Debug, Copy, Clone, Default, PartialEq)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
 pub struct Dimension(pub i32);
 
 impl Object for Dimension {

--- a/rtx_core/src/common/dimension.rs
+++ b/rtx_core/src/common/dimension.rs
@@ -1,27 +1,32 @@
+use std::fmt;
+use std::borrow::Cow;
+use regex::Regex;
+use lazy_static::lazy_static;
+
 use crate::common::numeric_ops::{kround,fixpoint,UNITY,NumericOps,round_to};
+use crate::common::object::Object;
+use crate::common::locator::Locator;
 use crate::common::error::*;
 use crate::state::State;
 use crate::definition::register::RegisterType;
-use std::fmt;
-use regex::Regex;
-use lazy_static::lazy_static;
 
 lazy_static! {
   static ref SPEC_RE: Regex = Regex::new(r"^(-?\d*\.?\d*)([a-zA-Z][a-zA-Z])$").unwrap();
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, Default, PartialEq)]
 pub struct Dimension(pub i32);
 
+impl Object for Dimension {
+  fn get_locator(&self) -> Option<Cow<Locator>> {
+    None
+  }
+}
 impl NumericOps for Dimension {
   fn new(number: i32) -> Self { Dimension(number) }
   fn new_f32(number: f32) -> Self { Dimension(kround(number)) }
   fn value_of(self) -> i32 { self.0 }
   fn register_type(&self) -> RegisterType { RegisterType::Dimension }
-}
-
-impl Default for Dimension {
-  fn default() -> Self { Dimension(0) }
 }
 
 impl fmt::Display for Dimension {

--- a/rtx_core/src/common/dimension.rs
+++ b/rtx_core/src/common/dimension.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 use std::borrow::Cow;
+use std::sync::Arc;
+
 use regex::Regex;
 use lazy_static::lazy_static;
 
@@ -8,6 +10,7 @@ use crate::common::object::Object;
 use crate::common::locator::Locator;
 use crate::common::error::*;
 use crate::state::State;
+use crate::{RegisterValue,Digested};
 use crate::definition::register::RegisterType;
 
 lazy_static! {
@@ -20,6 +23,10 @@ pub struct Dimension(pub i32);
 impl Object for Dimension {
   fn get_locator(&self) -> Option<Cow<Locator>> {
     None
+  }
+  fn be_digested(self, stomach: &mut crate::stomach::Stomach, state: &mut State) -> Result<Digested>
+    where Self: Sized, Self: fmt::Debug {
+      Ok(Digested::RegisterValue(Arc::new(RegisterValue::Dimension(self))))
   }
 }
 impl NumericOps for Dimension {

--- a/rtx_core/src/common/error.rs
+++ b/rtx_core/src/common/error.rs
@@ -24,12 +24,12 @@ macro_rules! Debug {
   }};
   ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr) => {{
     use log::debug;
-    $state.note_status("debug");
+    $state.note_status("debug","");
     debug!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1))
   }};
  ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr, $($details:expr),*) => {{
     use log::debug;
-    $state.note_status("debug");
+    $state.note_status("debug","");
     debug!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
   }};
   ($($simple:expr),*) => {{
@@ -53,12 +53,12 @@ macro_rules! Info {
     info!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
   }};
   ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr) => {{
-    $state.note_status("info");
+    $state.note_status("info","");
     use log::info;
     info!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1))
   }};
  ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr, $($details:expr),*) => {{
-    $state.note_status("info");
+    $state.note_status("info","");
     use log::info;
     info!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
   }};
@@ -82,12 +82,12 @@ macro_rules! Warn {
     warn!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
   }};
   ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr) => {{
-    $state.note_status("warn");
+    $state.note_status("warn","");
     use log::warn;
     warn!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1))
   }};
  ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr, $($details:expr),*) => {{
-    $state.note_status("warn");
+    $state.note_status("warn","");
     use log::warn;
     warn!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
   }}
@@ -106,12 +106,12 @@ macro_rules! Error {
     error!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
   }};
   ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr) => {{
-    $state.note_status("error");
+    $state.note_status("error","");
     use log::error;
     error!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1))
   }};
  ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr, $($details:expr),*) => {{
-    $state.note_status("error");
+    $state.note_status("error","");
     use log::error;
     error!(target: &s!("{}:{}", $category, $object), "{}", generate_message!($where, $message, -1, $($details),*))
   }}

--- a/rtx_core/src/common/error.rs
+++ b/rtx_core/src/common/error.rs
@@ -249,7 +249,7 @@ impl fmt::Display for Error {
       Endgroup => write!(f, "<endgroup>"),
       FailedParse => write!(f, "failed to parse"),
       Generic(ref err) => err.fmt(f),
-      Filename(ref name) => write!(f, "file:{}", name),
+      Filename(ref name) => write!(f, "file:{name}"),
     }
   }
 }

--- a/rtx_core/src/common/float.rs
+++ b/rtx_core/src/common/float.rs
@@ -1,10 +1,15 @@
-use crate::common::numeric_ops::NumericOps;
-use crate::definition::register::{RegisterType};
-use crate::mouth;
-use crate::tokens::Tokens;
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::fmt;
+use std::borrow::Cow;
+
+use crate::common::numeric_ops::NumericOps;
+use crate::common::locator::Locator;
+use crate::definition::register::{RegisterType};
+use crate::mouth;
+use crate::common::object::Object;
+use crate::tokens::Tokens;
+
 
 lazy_static! {
   static ref TRAILING_ZEROS: Regex = Regex::new(r"0+$").unwrap();
@@ -20,6 +25,11 @@ impl Default for Float {
   fn default() -> Self { Float(0.0) }
 }
 
+impl Object for Float {
+  fn get_locator(&self) -> Option<Cow<Locator>> {
+    None
+  }
+}
 impl NumericOps for Float {
   fn new(number: i32) -> Self { Float(number as f32) }
   fn new_f32(number: f32) -> Self { Float(number) }

--- a/rtx_core/src/common/font.rs
+++ b/rtx_core/src/common/font.rs
@@ -713,7 +713,7 @@ pub fn decode(code: u8, encoding_opt: Option<String>, implicit: bool, state: &St
       if let Some(ref font) = font {
         match font.get_encoding() {
           None => String::new(),
-          Some(encoding) => encoding.to_owned().into_owned(),
+          Some(encoding) => encoding.clone().into_owned(),
         }
       } else {
         String::new()

--- a/rtx_core/src/common/font/standard_metrics.rs
+++ b/rtx_core/src/common/font/standard_metrics.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 
 lazy_static! {
   // TODO: Change to f64 to keep precision
-  pub static ref STDMETRICS: HashMap<&'static str, HashMap<&'static str, f32>> = raw_map!("cmr" => raw_map!("emwidth"=>65536.1875, "exheight" => 28216.875),
-    "cmm"=>raw_map!("emwidth"=>65536.1875));
+  // raw_map!("emwidth"=>65536.1875, "exheight" => 28216.875),
+  pub static ref STDMETRICS: HashMap<&'static str, HashMap<&'static str, f32>> = raw_map!("cmr" => raw_map!("emwidth"=>65536.19, "exheight" => 28216.875),
+    "cmm"=>raw_map!("emwidth"=>65536.19));
 }

--- a/rtx_core/src/common/font/standard_metrics.rs
+++ b/rtx_core/src/common/font/standard_metrics.rs
@@ -2,6 +2,7 @@ use lazy_static::lazy_static;
 use std::collections::HashMap;
 
 lazy_static! {
+  // TODO: Change to f64 to keep precision
   pub static ref STDMETRICS: HashMap<&'static str, HashMap<&'static str, f32>> = raw_map!("cmr" => raw_map!("emwidth"=>65536.1875, "exheight" => 28216.875),
     "cmm"=>raw_map!("emwidth"=>65536.1875));
 }

--- a/rtx_core/src/common/glue.rs
+++ b/rtx_core/src/common/glue.rs
@@ -102,25 +102,13 @@ lazy_static! {
   static ref GLUE_RE: Regex = Regex::new(GLUE_RE_STR).unwrap();
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Default)]
 pub struct Glue {
   pub skip: i32,
   pub plus: Option<i32>,
   pub pfill: Option<FillCode>,
   pub minus: Option<i32>,
   pub mfill: Option<FillCode>,
-}
-
-impl Default for Glue {
-  fn default() -> Self {
-    Glue {
-      skip: 0,
-      plus: None,
-      pfill: None,
-      minus: None,
-      mfill: None,
-    }
-  }
 }
 
 impl NumericOps for Glue {
@@ -212,9 +200,9 @@ pub fn new_setup(
   // See comment in Dimension for why kround rather than int
   (
     kround(skip),
-    plus.map(|p| kround(p)),
+    plus.map(kround),
     pfill,
-    minus.map(|m| kround(m)),
+    minus.map(kround),
     mfill,
   )
 }

--- a/rtx_core/src/common/glue.rs
+++ b/rtx_core/src/common/glue.rs
@@ -102,7 +102,7 @@ lazy_static! {
   static ref GLUE_RE: Regex = Regex::new(GLUE_RE_STR).unwrap();
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Default)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
 pub struct Glue {
   pub skip: i32,
   pub plus: Option<i32>,

--- a/rtx_core/src/common/glue.rs
+++ b/rtx_core/src/common/glue.rs
@@ -183,7 +183,7 @@ pub fn glue_string(
 impl fmt::Display for Glue {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     let string = glue_string(self.skip, self.plus, self.pfill, self.minus, self.mfill, "pt");
-    write!(f, "{}", string)
+    write!(f, "{string}")
   }
 }
 impl Object for Glue {

--- a/rtx_core/src/common/glue.rs
+++ b/rtx_core/src/common/glue.rs
@@ -162,19 +162,19 @@ pub fn glue_string(
 ) -> String {
   // ??? TODO: There seems to be some messy confusion about the types of the
   // pieces of glue/dimensions -- are we consistently using i32 or f32?
-  let mut string = fixedformat(skip as i32, Some(unit));
+  let mut string = fixedformat(skip, Some(unit));
   if let Some(plus) = plus_opt {
     if plus != 0 {
       string.push_str(" plus ");
       let p_fill = if let Some(fill) = pfill_opt { fill.to_str() } else { unit };
-      string.push_str(&fixedformat(plus as i32, Some(p_fill)))
+      string.push_str(&fixedformat(plus, Some(p_fill)))
     }
   }
   if let Some(minus) = minus_opt {
     if minus != 0 {
       string.push_str(" minus ");
       let p_fill = if let Some(fill) = mfill_opt { fill.to_str() } else { unit };
-      string.push_str(&fixedformat(minus as i32, Some(p_fill)))
+      string.push_str(&fixedformat(minus, Some(p_fill)))
     }
   }
   string
@@ -286,7 +286,7 @@ pub fn spec_setup(
 
       if punit.is_empty() {
       } else if let Some(pfcode) = FillCode::from(punit) {
-        plus = Some(fixpoint(p as f32, None));
+        plus = Some(fixpoint(p, None));
         pfill = Some(pfcode);
       } else {
         plus = Some(fixpoint(p, Some(state.convert_unit(punit))));

--- a/rtx_core/src/common/locator.rs
+++ b/rtx_core/src/common/locator.rs
@@ -2,6 +2,7 @@ use crate::common::object::Object;
 use crate::util::pathname;
 use std::borrow::Cow;
 use std::fmt;
+use std::fmt::Write as _;
 
 // TODO: This will require a large refactor, but
 // switching the source from an owned String to a &str reference
@@ -13,7 +14,7 @@ use std::fmt;
 // but the mouth sources should be easier to manage.
 // definitely something that can be tried after test milestone is achieved.
 
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Locator {
   source: String,
   from_line: usize,
@@ -114,15 +115,15 @@ impl Object for Locator {
     };
     let range_from = if self.is_range() { " from" } else { "" };
     if self.from_line > 0 {
-      loc.push_str(&s!(";{} line {}", range_from, self.from_line));
+      write!(loc, ";{} line {}", range_from, self.from_line).ok();
       if self.from_column > 0 {
-        loc.push_str(&s!(" col {}", self.from_column));
+        write!(loc, " col {}", self.from_column).ok();
       }
     }
     if self.to_line > 0 {
-      loc.push_str(&s!(" to line {}", self.to_line));
+      write!(loc," to line {}", self.to_line).ok();
       if self.to_column > 0 {
-        loc.push_str(&s!(" col {}", self.to_column));
+        write!(loc, " col {}", self.to_column).ok();
       }
     }
     loc
@@ -136,7 +137,7 @@ impl Locator {
   fn to_attribute(&self) -> String {
     let mut loc = self.get_short_source("anonymous_string") + "#text";
     if self.is_range() {
-      loc.push_str(&s!("range(from='"));
+      loc.push_str("range(from='");
       // if self.from_line > 0 {
       loc.push_str(&self.from_line.to_string());
       // }

--- a/rtx_core/src/common/mod.rs
+++ b/rtx_core/src/common/mod.rs
@@ -59,7 +59,7 @@ impl fmt::Display for DigestionMode {
       AmSTeX => "AmSTeX",
       BibTeX => "BibTeX",
     };
-    write!(f, "{}", formatted)
+    write!(f, "{formatted}")
   }
 }
 

--- a/rtx_core/src/common/model.rs
+++ b/rtx_core/src/common/model.rs
@@ -184,16 +184,7 @@ impl Model {
   ///   the unprefixed form of elements (not used for attributes!)
   pub fn register_namespace(&mut self, codeprefix: &str, namespace_opt: Option<String>) {
     // double-check empty strings are None
-    let namespace_opt_checked = match namespace_opt {
-      None => None,
-      Some(val) => {
-        if val.is_empty() {
-          None
-        } else {
-          Some(val)
-        }
-      },
-    };
+    let namespace_opt_checked = namespace_opt.filter(|val| !val.is_empty());
 
     match namespace_opt_checked {
       Some(namespace) => {
@@ -270,16 +261,7 @@ impl Model {
         message2
       );
     }
-    match docprefix {
-      None => None,
-      Some(p) => {
-        if p == "#default" {
-          Some(String::new())
-        } else {
-          Some(p)
-        }
-      },
-    }
+    docprefix.filter(|p| p != "#default")
   }
 
   pub fn get_document_namespace(&mut self, mut docprefix: &str, probe: bool) -> Option<String> {

--- a/rtx_core/src/common/model.rs
+++ b/rtx_core/src/common/model.rs
@@ -387,15 +387,11 @@ impl Model {
         }
       },
       // Need others?
-      t => panic!("Fatal:misdefined:<caller> should not ask for qualified name for node of type {:?}", t), /* Fatal('misdefined', '<caller>',
-                                                                                                            * undef,
-                                                                                                            *   "Should not ask for Qualified Name
-                                                                                                            * for node of type $type: " .
-                                                                                                            * Stringify($node)); */
+      t => panic!("Fatal:misdefined:<caller> should not ask for qualified name for node of type {t:?}"),
     }
   }
 
-  /// Same as get_node_qname, but using the Document namespace prefixes
+/// Same as get_node_qname, but using the Document namespace prefixes
   pub fn get_node_document_qname(&mut self, node: &Node) -> String {
     use libxml::tree::NodeType::*;
     let node_type = node.get_type();
@@ -432,7 +428,7 @@ impl Model {
         }
       },
       // Need others?
-      t => panic!("Fatal:misdefined:<caller> should not ask for qualified name for node of type {:?}", t),
+      t => panic!("Fatal:misdefined:<caller> should not ask for qualified name for node of type {t:?}"),
     }
   }
 
@@ -550,11 +546,11 @@ impl Model {
         let namespace = caps.get(2).map_or("", |m| m.as_str());
         self.register_document_namespace(prefix, Some(namespace.to_owned()));
       } else {
-        panic!("Fatal:internal:{} Compiled model '{}' is malformatted at \"{}\"", path, path, line);
+        panic!("Fatal:internal:{path} Compiled model '{path}' is malformatted at \"{line}\"");
       }
     }
 
-    note_end(&s!("Loading compiled schema {}\n", path));
+    note_end(&s!("Loading compiled schema {path}\n"));
   }
 
   //**********************************************************************

--- a/rtx_core/src/common/mudimension.rs
+++ b/rtx_core/src/common/mudimension.rs
@@ -12,7 +12,7 @@ lazy_static! {
   static ref MUDIM_SPEC_RE: Regex = Regex::new(r"^(-?\d*\.?\d*)mu$").unwrap();
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Default, Eq)]
 pub struct MuDimension(pub i32);
 
 impl NumericOps for MuDimension {

--- a/rtx_core/src/common/mudimension.rs
+++ b/rtx_core/src/common/mudimension.rs
@@ -12,7 +12,7 @@ lazy_static! {
   static ref MUDIM_SPEC_RE: Regex = Regex::new(r"^(-?\d*\.?\d*)mu$").unwrap();
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Default)]
 pub struct MuDimension(pub i32);
 
 impl NumericOps for MuDimension {
@@ -20,10 +20,6 @@ impl NumericOps for MuDimension {
   fn new_f32(number: f32) -> Self { MuDimension(kround(number)) }
   fn value_of(self) -> i32 { self.0 }
   fn register_type(&self) -> RegisterType { RegisterType::MuDimension }
-}
-
-impl Default for MuDimension {
-  fn default() -> Self { MuDimension(0) }
 }
 
 impl fmt::Display for MuDimension {

--- a/rtx_core/src/common/muglue.rs
+++ b/rtx_core/src/common/muglue.rs
@@ -19,7 +19,7 @@ pub struct MuGlue {
 impl fmt::Display for MuGlue {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     let string = glue_string(self.skip, self.plus, self.pfill, self.minus, self.mfill, "mu");
-    write!(f, "{}", string)
+    write!(f, "{string}")
   }
 }
 

--- a/rtx_core/src/common/muglue.rs
+++ b/rtx_core/src/common/muglue.rs
@@ -7,7 +7,7 @@ use crate::{Locator, Object};
 use std::borrow::Cow;
 use std::fmt;
 
-#[derive(Debug, Copy, Clone, Default, PartialEq)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
 pub struct MuGlue {
   pub skip: i32,
   pub plus: Option<i32>,

--- a/rtx_core/src/common/muglue.rs
+++ b/rtx_core/src/common/muglue.rs
@@ -7,24 +7,13 @@ use crate::{Locator, Object};
 use std::borrow::Cow;
 use std::fmt;
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, Default, PartialEq)]
 pub struct MuGlue {
   pub skip: i32,
   pub plus: Option<i32>,
   pub pfill: Option<FillCode>,
   pub minus: Option<i32>,
   pub mfill: Option<FillCode>,
-}
-impl Default for MuGlue {
-  fn default() -> Self {
-    MuGlue {
-      skip: 0,
-      plus: None,
-      pfill: None,
-      minus: None,
-      mfill: None,
-    }
-  }
 }
 
 impl fmt::Display for MuGlue {

--- a/rtx_core/src/common/number.rs
+++ b/rtx_core/src/common/number.rs
@@ -6,7 +6,7 @@ use crate::{Locator, Object};
 use std::borrow::Cow;
 use std::fmt;
 
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct Number(pub i32);
 impl Object for Number {
   fn get_locator(&self) -> Option<Cow<Locator>> { None }

--- a/rtx_core/src/common/number.rs
+++ b/rtx_core/src/common/number.rs
@@ -1,3 +1,5 @@
+use crate::common::error::*;
+use crate::state::State;
 use crate::common::numeric_ops::NumericOps;
 use crate::definition::register::{RegisterType};
 use crate::mouth;
@@ -10,6 +12,11 @@ use std::fmt;
 pub struct Number(pub i32);
 impl Object for Number {
   fn get_locator(&self) -> Option<Cow<Locator>> { None }
+  fn revert(&self, state: &mut State) -> Result<Tokens> {
+    Ok(
+      mouth::tokenize_internal(&self.to_string(), Some(state))
+    )
+  }
 }
 impl NumericOps for Number {
   fn new(number: i32) -> Self { Number(number) }

--- a/rtx_core/src/common/number.rs
+++ b/rtx_core/src/common/number.rs
@@ -2,6 +2,7 @@ use crate::common::error::*;
 use crate::state::State;
 use crate::common::numeric_ops::NumericOps;
 use crate::definition::register::{RegisterType};
+use crate::token::Catcode;
 use crate::mouth;
 use crate::tokens::Tokens;
 use crate::{Locator, Object};
@@ -50,4 +51,10 @@ impl From<String> for Number {
 
 impl fmt::Display for Number {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{}", self.0) }
+}
+
+impl From<Catcode> for Number {
+  fn from(c: Catcode) -> Number {
+    Number::new(u8::from(c) as i32)
+  }
 }

--- a/rtx_core/src/common/object.rs
+++ b/rtx_core/src/common/object.rs
@@ -8,6 +8,7 @@ use crate::Digested;
 /// Exported generic functions for dealing with `LaTeXML`'s objects
 ///======================================================================
 use std::borrow::Cow;
+use std::fmt::Debug;
 
 // ======================================================================
 // LaTeXML Object
@@ -45,8 +46,8 @@ pub trait Object {
   // These should really only make sense for Data objects within the
   // processing stream.
   fn be_digested(self, stomach: &mut Stomach, state: &mut State) -> Result<Digested>
-  where Self: Sized {
-    unimplemented!()
+  where Self: Sized, Self: Debug {
+    panic!("Was it really intended to digest? We don't know how! {self:?} {:?}",self.get_locator());
   }
 
   // fn be_absorbed(&self, _document: Document) { unimplemented!() }

--- a/rtx_core/src/common/store.rs
+++ b/rtx_core/src/common/store.rs
@@ -107,43 +107,43 @@ impl fmt::Debug for Stored {
     use crate::Stored::*;
     match *self {
       None => write!(f, "None"),
-      String(ref s) => write!(f, "{}", s),
-      Int(ref num) => write!(f, "Stored::Int[{:?}]", num),
-      VecChar(ref vs) => write!(f, "Stored::VecChar[{:?}]", vs),
-      VecOptionChar(ref vs) => write!(f, "Stored::VecOptionChar[{:?}]", vs),
-      Stash(ref vs) => write!(f, "Stored::Stash[{:?}]", vs),
-      VecString(ref vs) => write!(f, "Stored::VecString[{:?}]", vs),
-      Bool(ref b) => write!(f, "Stored::Bool[{:?}]", b),
-      Token(ref t) => write!(f, "Stored::Token[{:?}]", t),
-      Tokens(ref t) => write!(f, "Stored::Tokens[{:?}]", t),
-      Locator(ref t) => write!(f, "Stored::Locator[{:?}]", t),
-      Catcode(ref cc) => write!(f, "Stored::Catcode[{:?}]", cc),
-      Charcode(ref cc) => write!(f, "Stored::Charcode[{:?}]", cc),
-      IfFrame(ref fr) => write!(f, "Stored::IfFrame[{:?}]", fr),
+      String(ref s) => write!(f, "{s}"),
+      Int(ref num) => write!(f, "Stored::Int[{num:?}]"),
+      VecChar(ref vs) => write!(f, "Stored::VecChar[{vs:?}]"),
+      VecOptionChar(ref vs) => write!(f, "Stored::VecOptionChar[{vs:?}]"),
+      Stash(ref vs) => write!(f, "Stored::Stash[{vs:?}]"),
+      VecString(ref vs) => write!(f, "Stored::VecString[{vs:?}]"),
+      Bool(ref b) => write!(f, "Stored::Bool[{b:?}]"),
+      Token(ref t) => write!(f, "Stored::Token[{t:?}]"),
+      Tokens(ref t) => write!(f, "Stored::Tokens[{t:?}]"),
+      Locator(ref t) => write!(f, "Stored::Locator[{t:?}]"),
+      Catcode(ref cc) => write!(f, "Stored::Catcode[{cc:?}]"),
+      Charcode(ref cc) => write!(f, "Stored::Charcode[{cc:?}]"),
+      IfFrame(ref fr) => write!(f, "Stored::IfFrame[{fr:?}]"),
       Expandable(ref _expandable) => write!(f, "Stored::Expandable[]"),
       Conditional(ref _conditional) => write!(f, "Stored::Conditional[]"),
       Primitive(ref _primitive) => write!(f, "Stored::Primitive[]"),
       MathPrimitive(ref _primitive) => write!(f, "Stored::MathPrimitive[]"),
       // MathPrimitiveOptions(ref _primitive) => write!(f, "<math primitive options>"),
       Constructor(ref _constructor) => write!(f, "Stored::Constructor[]"),
-      Digested(ref digested) => write!(f, "Stored::Digested[{:?}]", digested),
-      Parameter(ref parameter) => write!(f, "Stored::Parameter[{:?}]", parameter),
+      Digested(ref digested) => write!(f, "Stored::Digested[{digested:?}]"),
+      Parameter(ref parameter) => write!(f, "Stored::Parameter[{parameter:?}]"),
       Register(ref register) => write!(f, "Stored::Register[{:?}]", register.borrow().cs),
-      Rewrite(ref rewrite) => write!(f, "Stored::Rewrite[{:?}]", rewrite),
+      Rewrite(ref rewrite) => write!(f, "Stored::Rewrite[{rewrite:?}]"),
       Mouth(ref mouth) => write!(f, "Stored::Mouth[{:?}]", mouth.read().unwrap().get_source()),
-      Font(ref font) => write!(f, "Stored::Font[{:?}]", font),
-      Number(ref number) => write!(f, "Stored::Number[{:?}]", number),
-      Glue(ref glue) => write!(f, "Stored::Glue[{:?}]", glue),
-      MuGlue(ref glue) => write!(f, "Stored::MuGlue[{:?}]", glue),
-      Dimension(ref dimension) => write!(f, "Stored::Dimension[{:?}]", dimension),
-      MuDimension(ref dimension) => write!(f, "Stored::MuDimension[{:?}]", dimension),
-      VecDigested(ref digested_vec) => write!(f, "VecDigested{:?}", digested_vec),
-      VecTokens(ref vec) => write!(f, "VecTokens{:?}", vec),
-      VecDequeStored(ref vec) => write!(f, "VecDequeStored{:?}", vec),
-      HashStored(ref hos) => write!(f, "HashStored{:?}", hos),
-      HashTagData(ref htd) => write!(f, "HashTagData[{:?}]", htd),
-      HashString(ref hstr) => write!(f, "HashStr[{:?}]", hstr),
-      Ligature(ref lig) => write!(f, "Ligature[{:?}]", lig),
+      Font(ref font) => write!(f, "Stored::Font[{font:?}]"),
+      Number(ref number) => write!(f, "Stored::Number[{number:?}]"),
+      Glue(ref glue) => write!(f, "Stored::Glue[{glue:?}]"),
+      MuGlue(ref glue) => write!(f, "Stored::MuGlue[{glue:?}]"),
+      Dimension(ref dimension) => write!(f, "Stored::Dimension[{dimension:?}]"),
+      MuDimension(ref dimension) => write!(f, "Stored::MuDimension[{dimension:?}]"),
+      VecDigested(ref digested_vec) => write!(f, "VecDigested{digested_vec:?}"),
+      VecTokens(ref vec) => write!(f, "VecTokens{vec:?}"),
+      VecDequeStored(ref vec) => write!(f, "VecDequeStored{vec:?}"),
+      HashStored(ref hos) => write!(f, "HashStored{hos:?}"),
+      HashTagData(ref htd) => write!(f, "HashTagData[{htd:?}]"),
+      HashString(ref hstr) => write!(f, "HashStr[{hstr:?}]"),
+      Ligature(ref lig) => write!(f, "Ligature[{lig:?}]"),
     }
   }
 }
@@ -151,20 +151,20 @@ impl fmt::Display for Stored {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     use crate::Stored::*;
     match *self {
-      Digested(ref digested) => write!(f, "{}", digested),
-      Dimension(ref v) => write!(f, "{}", v),
-      Number(ref v) => write!(f, "{}", v),
-      Glue(ref v) => write!(f, "{}", v),
-      MuGlue(ref v) => write!(f, "{}", v),
-      MuDimension(ref v) => write!(f, "{}", v),
-      Font(ref font) => write!(f, "{}", font),
-      String(ref s) => write!(f, "{}", s),
-      Int(ref s) => write!(f, "{}", s),
-      Bool(ref s) => write!(f, "{}", s),
-      Tokens(ref s) => write!(f, "{}", s),
-      Token(ref s) => write!(f, "{}", s),
+      Digested(ref digested) => write!(f, "{digested}"),
+      Dimension(ref v) => write!(f, "{v}"),
+      Number(ref v) => write!(f, "{v}"),
+      Glue(ref v) => write!(f, "{v}"),
+      MuGlue(ref v) => write!(f, "{v}"),
+      MuDimension(ref v) => write!(f, "{v}"),
+      Font(ref font) => write!(f, "{font}"),
+      String(ref s) => write!(f, "{s}"),
+      Int(ref s) => write!(f, "{s}"),
+      Bool(ref s) => write!(f, "{s}"),
+      Tokens(ref s) => write!(f, "{s}"),
+      Token(ref s) => write!(f, "{s}"),
       ref variant => {
-        panic!("TODO: implement Display for Stored variant {:?}", variant);
+        panic!("TODO: implement Display for Stored variant {variant:?}");
         // write!(f, "{:?}", self)
       },
     }
@@ -708,8 +708,8 @@ impl<'a> From<&'a Stored> for bool {
 impl<'a> From<&'a Stored> for String {
   fn from(value: &Stored) -> String {
     match value {
-      &Stored::String(ref v) => v.to_owned(),
-      v => s!("{:?}", v),
+      Stored::String(v) => v.to_owned(),
+      v => s!("{v:?}"),
     }
   }
 }
@@ -741,7 +741,7 @@ impl<'a> From<&'a Stored> for Option<Number> {
       Stored::MuDimension(ref n) => Some(Number::new(n.value_of())),
       Stored::MuGlue(ref n) => Some(Number::new(n.value_of())),
       other => {
-        eprintln!("TODO: auto-cast of Stored to Number attempted on {:?}", other);
+        eprintln!("TODO: auto-cast of Stored to Number attempted on {other:?}");
         None
       },
     }

--- a/rtx_core/src/common/store.rs
+++ b/rtx_core/src/common/store.rs
@@ -12,6 +12,7 @@ use crate::common::mudimension::MuDimension;
 use crate::common::muglue::MuGlue;
 use crate::common::number::Number;
 use crate::common::numeric_ops::NumericOps;
+use crate::definition::argument::ArgWrap;
 use crate::definition::conditional::{Conditional, IfFrame};
 use crate::definition::constructor::Constructor;
 use crate::definition::expandable::Expandable;
@@ -175,10 +176,7 @@ impl PartialEq for Stored {
   fn eq(&self, other: &Stored) -> bool {
     use crate::Stored::*;
     match *self {
-      Stored::None => match other {
-        Stored::None => true,
-        _ => false
-      },
+      Stored::None => matches!(other, Stored::None),
       String(ref s) => {
         if let String(s2) = other {
           s == s2
@@ -447,7 +445,7 @@ impl Stored {
   }
   /// Dynamic dispatch for Definition's `read_arguments`,
   /// to circumvent the limitations of using trait objects with `Arc<Definition>`
-  pub fn read_arguments(&self, gullet: &mut Gullet, state: &mut State) -> Result<Vec<Option<Tokens>>> {
+  pub fn read_arguments(&self, gullet: &mut Gullet, state: &mut State) -> Result<Vec<ArgWrap>> {
     use crate::definition::Definition;
     match self {
       Stored::Conditional(ref entry) => entry.read_arguments(gullet, state),

--- a/rtx_core/src/definition/argument.rs
+++ b/rtx_core/src/definition/argument.rs
@@ -49,33 +49,33 @@ impl Default for ArgWrap {
 impl Display for ArgWrap {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
-      ArgWrap::Token(t) => write!(f, "{}", t),
+      ArgWrap::Token(t) => write!(f, "{t}"),
       ArgWrap::OptionToken(None) => write!(f, "None"),
-      ArgWrap::OptionToken(Some(ot)) => write!(f, "{}", ot),
-      ArgWrap::Tokens(ts) =>  write!(f, "{}", ts),
+      ArgWrap::OptionToken(Some(ot)) => write!(f, "{ot}"),
+      ArgWrap::Tokens(ts) =>  write!(f, "{ts}"),
       ArgWrap::OptionTokens(None) =>  write!(f, "None"),
-      ArgWrap::OptionTokens(Some(ots)) =>  write!(f, "{}", ots),
-      ArgWrap::Number(n) =>  write!(f, "{}", n),
+      ArgWrap::OptionTokens(Some(ots)) =>  write!(f, "{ots}"),
+      ArgWrap::Number(n) =>  write!(f, "{n}"),
       ArgWrap::OptionNumber(None) =>  write!(f, "None"),
-      ArgWrap::OptionNumber(Some(on)) =>  write!(f, "{}", on),
-      ArgWrap::Float(fl) =>  write!(f, "{}", fl),
+      ArgWrap::OptionNumber(Some(on)) =>  write!(f, "{on}"),
+      ArgWrap::Float(fl) =>  write!(f, "{fl}"),
       ArgWrap::OptionFloat(None) =>  write!(f, "None"),
-      ArgWrap::OptionFloat(Some(ofl)) =>  write!(f, "{}", ofl),
-      ArgWrap::Dimension(d) => write!(f, "{}", d),
+      ArgWrap::OptionFloat(Some(ofl)) =>  write!(f, "{ofl}"),
+      ArgWrap::Dimension(d) => write!(f, "{d}"),
       ArgWrap::OptionDimension(None) =>  write!(f, "None"),
-      ArgWrap::OptionDimension(Some(od)) =>  write!(f, "{}", od),
-      ArgWrap::Glue(gl) =>  write!(f, "{}", gl),
+      ArgWrap::OptionDimension(Some(od)) =>  write!(f, "{od}"),
+      ArgWrap::Glue(gl) =>  write!(f, "{gl}"),
       ArgWrap::OptionGlue(None) =>  write!(f, "None"),
-      ArgWrap::OptionGlue(Some(ogl)) =>  write!(f, "{}", ogl),
-      ArgWrap::MuGlue(mugl) =>  write!(f, "{}", mugl),
+      ArgWrap::OptionGlue(Some(ogl)) =>  write!(f, "{ogl}"),
+      ArgWrap::MuGlue(mugl) =>  write!(f, "{mugl}"),
       ArgWrap::OptionMuGlue(None) =>  write!(f, "None"),
-      ArgWrap::OptionMuGlue(Some(omugl)) =>  write!(f, "{}", omugl),
-      ArgWrap::MuDimension(mudim) =>  write!(f, "{}", mudim),
+      ArgWrap::OptionMuGlue(Some(omugl)) =>  write!(f, "{omugl}"),
+      ArgWrap::MuDimension(mudim) =>  write!(f, "{mudim}"),
       ArgWrap::OptionMuDimension(None) =>  write!(f, "None"),
-      ArgWrap::OptionMuDimension(Some(omudim)) =>  write!(f, "{}", omudim),
-      ArgWrap::KV(kv) =>  write!(f, "{}", kv),
+      ArgWrap::OptionMuDimension(Some(omudim)) =>  write!(f, "{omudim}"),
+      ArgWrap::KV(kv) =>  write!(f, "{kv}"),
       ArgWrap::OptionKV(None) =>  write!(f, "None"),
-      ArgWrap::OptionKV(Some(okv)) =>  write!(f, "{}", okv)
+      ArgWrap::OptionKV(Some(okv)) =>  write!(f, "{okv}")
     }
   }
 }
@@ -292,7 +292,7 @@ impl ArgWrap {
       Glue(v) => v.value_of(),
       MuGlue(v) => v.value_of(),
       MuDimension(v) => v.value_of(),
-      _ => panic!("ArgWrap::value_of not (yet?) defined on {:?}",self)
+      _ => panic!("ArgWrap::value_of not (yet?) defined on {self:?}")
     }
   }
 
@@ -302,7 +302,7 @@ impl ArgWrap {
       Number(v) => v,
       Token(t) => t.to_number(),
       Tokens(tks) => tks.to_number(),
-      _ => panic!("ArgWrap::to_number not (yet?) defined on {:?}",self)
+      _ => panic!("ArgWrap::to_number not (yet?) defined on {self:?}")
     }
   }
 
@@ -312,7 +312,7 @@ impl ArgWrap {
       Dimension(v) => v,
       Token(t) => t.to_dimension(),
       Tokens(tks) => tks.to_dimension(),
-      _ => panic!("ArgWrap::to_dimension not (yet?) defined on {:?}",self)
+      _ => panic!("ArgWrap::to_dimension not (yet?) defined on {self:?}")
     }
   }
   pub fn to_mu_dimension(self) -> MuDimension {
@@ -321,7 +321,7 @@ impl ArgWrap {
       MuDimension(v) => v,
       Token(t) => t.to_mu_dimension(),
       Tokens(tks) => tks.to_mu_dimension(),
-      _ => panic!("ArgWrap::to_mu_dimension not (yet?) defined on {:?}",self)
+      _ => panic!("ArgWrap::to_mu_dimension not (yet?) defined on {self:?}")
     }
   }
   pub fn to_glue(self) -> Glue {
@@ -330,7 +330,7 @@ impl ArgWrap {
       Glue(v) => v,
       Token(t) => t.to_glue(),
       Tokens(tks) => tks.to_glue(),
-      _ => panic!("ArgWrap::to_glue not (yet?) defined on {:?}",self)
+      _ => panic!("ArgWrap::to_glue not (yet?) defined on {self:?}")
     }
   }
   pub fn to_mu_glue(self) -> MuGlue {
@@ -339,7 +339,7 @@ impl ArgWrap {
       MuGlue(v) => v,
       Token(t) => t.to_mu_glue(),
       Tokens(tks) => tks.to_mu_glue(),
-      _ => panic!("ArgWrap::to_glue not (yet?) defined on {:?}",self)
+      _ => panic!("ArgWrap::to_glue not (yet?) defined on {self:?}")
     }
   }
   pub fn to_keyvals(self, state: &mut State) -> KeyVals {
@@ -347,7 +347,7 @@ impl ArgWrap {
     match self {
       KV(v) => v,
       Tokens(tks) => tks.to_keyvals(state),
-      _ => panic!("ArgWrap::to_keyvals not (yet?) defined on {:?}",self)
+      _ => panic!("ArgWrap::to_keyvals not (yet?) defined on {self:?}")
     }
   }
 

--- a/rtx_core/src/definition/argument.rs
+++ b/rtx_core/src/definition/argument.rs
@@ -118,20 +118,33 @@ impl Object for ArgWrap {
   }
   fn be_digested(self, stomach: &mut Stomach, state: &mut State) -> Result<Digested> {
     use ArgWrap::*;
+    // TODO: Should we just "do nothing" for the None cases, instead of panicking?
     match self {
       Token(t) => t.be_digested(stomach,state),
-      OptionToken(t) => unimplemented!(),
+      OptionToken(t) => match t {
+        Some(t) => t.be_digested(stomach, state),
+        None => unimplemented!()
+      },
       Tokens(t) => t.be_digested(stomach,state),
       OptionTokens(t_opt) => match t_opt {
         Some(tks) => tks.be_digested(stomach,state),
         None => Ok(Digested::default()),
       },
       Number(t) => t.be_digested(stomach,state),
-      OptionNumber(t) => unimplemented!(),
+      OptionNumber(t) => match t {
+        Some(n) => n.be_digested(stomach, state),
+        None => unimplemented!()
+      },
       Float(t) => t.be_digested(stomach,state),
-      OptionFloat(t) => unimplemented!(),
+      OptionFloat(t) => match t {
+        Some(fl) => fl.be_digested(stomach, state),
+        None => unimplemented!()
+      },
       Dimension(t) => t.be_digested(stomach,state),
-      OptionDimension(t) => unimplemented!(),
+      OptionDimension(t) => match t {
+        Some(t) => t.be_digested(stomach,state),
+        None => unimplemented!()
+      },
       Glue(t) => t.be_digested(stomach,state),
       OptionGlue(g_opt) => match g_opt {
         Some(g) => g.be_digested(stomach,state),
@@ -364,7 +377,7 @@ impl ArgWrap {
       ArgWrap::Tokens(tks) => tks.unlist(),
       ArgWrap::Token(t) => vec![t],
       ArgWrap::Number(n) => { let tks : Tokens = n.into(); tks.unlist() },
-      other => { dbg!(other); unimplemented!() }
+      other => { panic!("{other:?}"); }
     }
   }
 

--- a/rtx_core/src/definition/argument.rs
+++ b/rtx_core/src/definition/argument.rs
@@ -148,6 +148,42 @@ impl Object for ArgWrap {
       },
     }
   }
+  fn revert(&self, state:&mut State)-> Result<Tokens> {
+    use ArgWrap::*;
+    match self {
+      Token(t) => Ok(Tokens!(t.clone())),
+      OptionToken(t) => unimplemented!(),
+      Tokens(t) => Ok(t.clone()),
+      OptionTokens(t_opt) => match t_opt {
+        Some(tks) => Ok(tks.clone()),
+        None => Ok(Tokens!()),
+      },
+      Number(t) => t.revert(state),
+      OptionNumber(t) => unimplemented!(),
+      Float(t) => t.revert(state),
+      OptionFloat(t) => unimplemented!(),
+      Dimension(t) => t.revert(state),
+      OptionDimension(t) => unimplemented!(),
+      Glue(t) => t.revert(state),
+      OptionGlue(g_opt) => match g_opt {
+        Some(g) => g.revert(state),
+        None => unimplemented!() },
+      MuGlue(t) => t.revert(state),
+      OptionMuGlue(g_opt) => match g_opt {
+        Some(g) => g.revert(state),
+        None => unimplemented!()
+      },
+      MuDimension(t) => t.revert(state),
+      OptionMuDimension(d_opt) => match d_opt {
+        Some(d) => d.revert(state),
+        None => unimplemented!() },
+      KV(kv) => kv.revert(state),
+      OptionKV(kv_opt) => match kv_opt {
+        Some(kv) => kv.revert(state),
+        None => unimplemented!()
+      },
+    }
+  }
 }
 
 impl ArgWrap {
@@ -186,6 +222,7 @@ impl ArgWrap {
       ArgWrap::OptionTokens(tks_opt) => tks_opt,
       ArgWrap::Token(t) => Some(Tokens::new(vec![t])),
       ArgWrap::OptionToken(t_opt) => t_opt.map(|t| Tokens::new(vec![t])),
+      ArgWrap::Number(n) => {let tks : Tokens = n.into(); Some(tks) }
       _ => None
     }
   }
@@ -318,7 +355,8 @@ impl ArgWrap {
     match self {
       ArgWrap::Tokens(tks) => tks.unlist(),
       ArgWrap::Token(t) => vec![t],
-      _ => unimplemented!()
+      ArgWrap::Number(n) => { let tks : Tokens = n.into(); tks.unlist() },
+      other => { dbg!(other); unimplemented!() }
     }
   }
 

--- a/rtx_core/src/definition/argument.rs
+++ b/rtx_core/src/definition/argument.rs
@@ -47,7 +47,37 @@ impl Default for ArgWrap {
 }
 
 impl Display for ArgWrap {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{:?}", self) }
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    match self {
+      ArgWrap::Token(t) => write!(f, "{}", t),
+      ArgWrap::OptionToken(None) => write!(f, "None"),
+      ArgWrap::OptionToken(Some(ot)) => write!(f, "{}", ot),
+      ArgWrap::Tokens(ts) =>  write!(f, "{}", ts),
+      ArgWrap::OptionTokens(None) =>  write!(f, "None"),
+      ArgWrap::OptionTokens(Some(ots)) =>  write!(f, "{}", ots),
+      ArgWrap::Number(n) =>  write!(f, "{}", n),
+      ArgWrap::OptionNumber(None) =>  write!(f, "None"),
+      ArgWrap::OptionNumber(Some(on)) =>  write!(f, "{}", on),
+      ArgWrap::Float(fl) =>  write!(f, "{}", fl),
+      ArgWrap::OptionFloat(None) =>  write!(f, "None"),
+      ArgWrap::OptionFloat(Some(ofl)) =>  write!(f, "{}", ofl),
+      ArgWrap::Dimension(d) => write!(f, "{}", d),
+      ArgWrap::OptionDimension(None) =>  write!(f, "None"),
+      ArgWrap::OptionDimension(Some(od)) =>  write!(f, "{}", od),
+      ArgWrap::Glue(gl) =>  write!(f, "{}", gl),
+      ArgWrap::OptionGlue(None) =>  write!(f, "None"),
+      ArgWrap::OptionGlue(Some(ogl)) =>  write!(f, "{}", ogl),
+      ArgWrap::MuGlue(mugl) =>  write!(f, "{}", mugl),
+      ArgWrap::OptionMuGlue(None) =>  write!(f, "None"),
+      ArgWrap::OptionMuGlue(Some(omugl)) =>  write!(f, "{}", omugl),
+      ArgWrap::MuDimension(mudim) =>  write!(f, "{}", mudim),
+      ArgWrap::OptionMuDimension(None) =>  write!(f, "None"),
+      ArgWrap::OptionMuDimension(Some(omudim)) =>  write!(f, "{}", omudim),
+      ArgWrap::KV(kv) =>  write!(f, "{}", kv),
+      ArgWrap::OptionKV(None) =>  write!(f, "None"),
+      ArgWrap::OptionKV(Some(okv)) =>  write!(f, "{}", okv)
+    }
+  }
 }
 
 impl Object for ArgWrap {

--- a/rtx_core/src/definition/argument.rs
+++ b/rtx_core/src/definition/argument.rs
@@ -1,0 +1,393 @@
+use std::borrow::Cow;
+use std::fmt::{self, Display};
+
+use crate::state::State;
+use crate::Locator;
+use crate::token::Token;
+use crate::tokens::Tokens;
+use crate::stomach::Stomach;
+use crate::definition::Digested;
+use crate::common::error::Result;
+use crate::common::numeric_ops::NumericOps;
+use crate::common::number::Number;
+use crate::common::float::Float;
+use crate::common::dimension::Dimension;
+use crate::common::mudimension::MuDimension;
+use crate::common::glue::Glue;
+use crate::common::muglue::MuGlue;
+use crate::common::object::Object;
+use crate::keyvals::KeyVals;
+
+#[derive(Debug, Clone)]
+pub enum ArgWrap {
+  Token(Token),
+  OptionToken(Option<Token>),
+  Tokens(Tokens),
+  OptionTokens(Option<Tokens>),
+  Number(Number),
+  OptionNumber(Option<Number>),
+  Float(Float),
+  OptionFloat(Option<Float>),
+  Dimension(Dimension),
+  OptionDimension(Option<Dimension>),
+  Glue(Glue),
+  OptionGlue(Option<Glue>),
+  MuGlue(MuGlue),
+  OptionMuGlue(Option<MuGlue>),
+  MuDimension(MuDimension),
+  OptionMuDimension(Option<MuDimension>),
+  KV(KeyVals),
+  OptionKV(Option<KeyVals>)
+}
+
+impl Default for ArgWrap {
+  fn default() -> Self {
+    ArgWrap::OptionTokens(None)
+  }
+}
+
+impl Display for ArgWrap {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{:?}", self) }
+}
+
+impl Object for ArgWrap {
+  fn get_locator(&self) -> Option<Cow<Locator>> {
+    use ArgWrap::*;
+    match self {
+      Token(t) => None,
+      OptionToken(t) => None,
+      Tokens(t) => None,
+      OptionTokens(t) => None,
+      Number(t) => None,
+      OptionNumber(t) => None,
+      Float(t) => None,
+      OptionFloat(t) => None,
+      Dimension(t) => None,
+      OptionDimension(t) => None,
+      Glue(t) => t.get_locator(),
+      OptionGlue(g_opt) => match g_opt {
+        Some(g) => g.get_locator(),
+        None => None },
+      MuGlue(t) => t.get_locator(),
+      OptionMuGlue(g_opt) => match g_opt {
+        Some(g) => g.get_locator(),
+        None => None },
+      MuDimension(t) => t.get_locator(),
+      OptionMuDimension(d_opt) => match d_opt {
+        Some(d) => d.get_locator(),
+        None => None },
+      KV(kv) => kv.get_locator(),
+      OptionKV(kv_opt) => match kv_opt {
+        Some(kv) => kv.get_locator(),
+        None => None },
+    }
+  }
+  fn be_digested(self, stomach: &mut Stomach, state: &mut State) -> Result<Digested> {
+    use ArgWrap::*;
+    match self {
+      Token(t) => t.be_digested(stomach,state),
+      OptionToken(t) => unimplemented!(),
+      Tokens(t) => t.be_digested(stomach,state),
+      OptionTokens(t_opt) => match t_opt {
+        Some(tks) => tks.be_digested(stomach,state),
+        None => Ok(Digested::default()),
+      },
+      Number(t) => t.be_digested(stomach,state),
+      OptionNumber(t) => unimplemented!(),
+      Float(t) => t.be_digested(stomach,state),
+      OptionFloat(t) => unimplemented!(),
+      Dimension(t) => t.be_digested(stomach,state),
+      OptionDimension(t) => unimplemented!(),
+      Glue(t) => t.be_digested(stomach,state),
+      OptionGlue(g_opt) => match g_opt {
+        Some(g) => g.be_digested(stomach,state),
+        None => unimplemented!() },
+      MuGlue(t) => t.be_digested(stomach,state),
+      OptionMuGlue(g_opt) => match g_opt {
+        Some(g) => g.be_digested(stomach,state),
+        None => unimplemented!()
+      },
+      MuDimension(t) => t.be_digested(stomach,state),
+      OptionMuDimension(d_opt) => match d_opt {
+        Some(d) => d.be_digested(stomach,state),
+        None => unimplemented!() },
+      KV(kv) => kv.be_digested(stomach,state),
+      OptionKV(kv_opt) => match kv_opt {
+        Some(kv) => kv.be_digested(stomach,state),
+        None => unimplemented!()
+      },
+    }
+  }
+}
+
+impl ArgWrap {
+  pub fn is_some(&self) -> bool {
+    !self.is_none()
+  }
+  pub fn is_none(&self) -> bool {
+    use ArgWrap::*;
+    match self {
+      Token(_) | Tokens(_) | Number(_) | Float(_) |
+      Dimension(_) | Glue(_) | MuGlue(_) | MuDimension(_) | KV(_) => false,
+      OptionToken(t) => t.is_none(),
+      OptionTokens(t) => t.is_none(),
+      OptionNumber(t) => t.is_none(),
+      OptionFloat(t) => t.is_none(),
+      OptionDimension(t) => t.is_none(),
+      OptionGlue(g_opt) => g_opt.is_none(),
+      OptionMuGlue(g_opt) => g_opt.is_none(),
+      OptionMuDimension(d_opt) => d_opt.is_none(),
+      OptionKV(kv_opt) => kv_opt.is_none()
+    }
+  }
+  pub fn is_tokens(&self) -> bool {
+    matches!(self, ArgWrap::Tokens(_) | ArgWrap::Token(_) | ArgWrap::OptionTokens(_) | ArgWrap::OptionToken(_))
+  }
+  pub fn mut_tokens(&mut self) -> Option<&mut Tokens> {
+    match self {
+      ArgWrap::Tokens(tks) => Some(tks),
+      ArgWrap::OptionTokens(Some(tks)) => Some(tks),
+      _ => None
+    }
+  }
+  pub fn owned_tokens(self) -> Option<Tokens> {
+    match self {
+      ArgWrap::Tokens(tks) => Some(tks),
+      ArgWrap::OptionTokens(tks_opt) => tks_opt,
+      ArgWrap::Token(t) => Some(Tokens::new(vec![t])),
+      ArgWrap::OptionToken(t_opt) => t_opt.map(|t| Tokens::new(vec![t])),
+      _ => None
+    }
+  }
+
+  pub fn expected_token(self) -> Result<Token> {
+    match self {
+      ArgWrap::Token(t) => Ok(t),
+      ArgWrap::OptionToken(Some(t)) => Ok(t),
+      ArgWrap::Tokens(tks) => Ok(tks.unlist().remove(0)),
+      _ => Err(s!("Hard assumption for Token argument failed. Got instead: {:?}", self).into())
+    }
+  }
+
+
+  pub fn as_tokens<'a>(&'a self, state: &mut State) -> Result<Option<Cow<'a, Tokens>>> {
+    use ArgWrap::*;
+    let result = match self {
+      Token(t) => Some(Cow::Owned(Tokens!(t.clone()))), // ? avoid the clone ?
+      Tokens(tks) => Some(Cow::Borrowed(tks)),
+      Number(tks) => Some(Cow::Owned(self.revert(state)?)),
+      Float(t) => Some(Cow::Owned(self.revert(state)?)),
+      Dimension(t) => Some(Cow::Owned(self.revert(state)?)),
+      Glue(t) => Some(Cow::Owned(self.revert(state)?)),
+      MuGlue(t) => Some(Cow::Owned(self.revert(state)?)),
+      MuDimension(t) => Some(Cow::Owned(self.revert(state)?)),
+      KV(t) => Some(Cow::Owned(self.revert(state)?)),
+      OptionToken(opt) => opt.as_ref().map(|t| Cow::Owned(Tokens!(t.clone()))),
+      OptionTokens(opt) => opt.as_ref().map(Cow::Borrowed),
+      OptionNumber(opt) => match opt {
+        None => None,
+        Some(t) => Some(Cow::Owned(t.revert(state)?)),
+      },
+      OptionFloat(opt) => match opt {
+        None => None,
+        Some(t) => Some(Cow::Owned(t.revert(state)?)),
+      },
+      OptionDimension(opt) => match opt {
+        None => None,
+        Some(t) => Some(Cow::Owned(t.revert(state)?)),
+      },
+      OptionGlue(opt) => match opt {
+        None => None,
+        Some(t) => Some(Cow::Owned(t.revert(state)?)),
+      },
+      OptionMuGlue(opt) => match opt {
+        None => None,
+        Some(t) => Some(Cow::Owned(t.revert(state)?)),
+      },
+      OptionMuDimension(opt) => match opt {
+        None => None,
+        Some(t) => Some(Cow::Owned(t.revert(state)?)),
+      },
+      OptionKV(opt) => match opt {
+        None => None,
+        Some(t) => Some(Cow::Owned(t.revert(state)?)),
+      },
+    };
+    Ok(result)
+  }
+
+  pub fn value_of(&self) -> i32 {
+    use ArgWrap::*;
+    match self {
+      Number(v) => v.value_of(),
+      Float(v) => v.value_of(),
+      Dimension(v) => v.value_of(),
+      Glue(v) => v.value_of(),
+      MuGlue(v) => v.value_of(),
+      MuDimension(v) => v.value_of(),
+      _ => panic!("ArgWrap::value_of not (yet?) defined on {:?}",self)
+    }
+  }
+
+  pub fn to_number(self) -> Number {
+    use ArgWrap::*;
+    match self {
+      Number(v) => v,
+      Token(t) => t.to_number(),
+      Tokens(tks) => tks.to_number(),
+      _ => panic!("ArgWrap::to_number not (yet?) defined on {:?}",self)
+    }
+  }
+
+  pub fn to_dimension(self) -> Dimension {
+    use ArgWrap::*;
+    match self {
+      Dimension(v) => v,
+      Token(t) => t.to_dimension(),
+      Tokens(tks) => tks.to_dimension(),
+      _ => panic!("ArgWrap::to_dimension not (yet?) defined on {:?}",self)
+    }
+  }
+  pub fn to_mu_dimension(self) -> MuDimension {
+    use ArgWrap::*;
+    match self {
+      MuDimension(v) => v,
+      Token(t) => t.to_mu_dimension(),
+      Tokens(tks) => tks.to_mu_dimension(),
+      _ => panic!("ArgWrap::to_mu_dimension not (yet?) defined on {:?}",self)
+    }
+  }
+  pub fn to_glue(self) -> Glue {
+    use ArgWrap::*;
+    match self {
+      Glue(v) => v,
+      Token(t) => t.to_glue(),
+      Tokens(tks) => tks.to_glue(),
+      _ => panic!("ArgWrap::to_glue not (yet?) defined on {:?}",self)
+    }
+  }
+  pub fn to_mu_glue(self) -> MuGlue {
+    use ArgWrap::*;
+    match self {
+      MuGlue(v) => v,
+      Token(t) => t.to_mu_glue(),
+      Tokens(tks) => tks.to_mu_glue(),
+      _ => panic!("ArgWrap::to_glue not (yet?) defined on {:?}",self)
+    }
+  }
+  pub fn to_keyvals(self, state: &mut State) -> KeyVals {
+    use ArgWrap::*;
+    match self {
+      KV(v) => v,
+      Tokens(tks) => tks.to_keyvals(state),
+      _ => panic!("ArgWrap::to_keyvals not (yet?) defined on {:?}",self)
+    }
+  }
+
+  pub fn unlist(self) -> Vec<Token> {
+    match self {
+      ArgWrap::Tokens(tks) => tks.unlist(),
+      ArgWrap::Token(t) => vec![t],
+      _ => unimplemented!()
+    }
+  }
+
+  pub fn is_empty(&self) -> bool {
+    use ArgWrap::*;
+    match self {
+      Token(_) | Number(_) | Float(_) | Dimension(_) | Glue(_) | MuGlue(_) | MuDimension(_) | KV(_) => false,
+      Tokens(tks) => tks.is_empty(),
+      OptionTokens(Some(tks)) => tks.is_empty(),
+      OptionToken(None) | OptionTokens(None) | OptionNumber(None) | OptionFloat(None) |
+      OptionDimension(None) | OptionGlue(None) | OptionMuGlue(None) | OptionMuDimension(None) |
+      OptionKV(None) => true,
+      _ => false,
+    }
+  }
+}
+
+impl From<Token> for ArgWrap {
+  fn from(t: Token) -> Self {
+    ArgWrap::Token(t)
+  }
+}
+impl From<Option<Token>> for ArgWrap {
+  fn from(t: Option<Token>) -> Self {
+    ArgWrap::OptionToken(t)
+  }
+}
+impl From<ArgWrap> for Option<Tokens> {
+  fn from(t: ArgWrap) -> Option<Tokens> {
+    t.owned_tokens()
+  }
+}
+impl From<Tokens> for ArgWrap {
+  fn from(t: Tokens) -> Self {
+    ArgWrap::Tokens(t)
+  }
+}
+impl From<Option<Tokens>> for ArgWrap {
+  fn from(t: Option<Tokens>) -> Self {
+    ArgWrap::OptionTokens(t)
+  }
+}
+impl From<Number> for ArgWrap {
+  fn from(t: Number) -> Self {
+    ArgWrap::Number(t)
+  }
+}
+impl From<Option<Number>> for ArgWrap {
+  fn from(t: Option<Number>) -> Self {
+    ArgWrap::OptionNumber(t)
+  }
+}
+impl From<Float> for ArgWrap {
+  fn from(t: Float) -> Self {
+    ArgWrap::Float(t)
+  }
+}
+impl From<Option<Float>> for ArgWrap {
+  fn from(t: Option<Float>) -> Self {
+    ArgWrap::OptionFloat(t)
+  }
+}
+impl From<Dimension> for ArgWrap {
+  fn from(t: Dimension) -> Self {
+    ArgWrap::Dimension(t)
+  }
+}
+impl From<Option<Dimension>> for ArgWrap {
+  fn from(t: Option<Dimension>) -> Self {
+    ArgWrap::OptionDimension(t)
+  }
+}
+impl From<MuDimension> for ArgWrap {
+  fn from(t: MuDimension) -> Self {
+    ArgWrap::MuDimension(t)
+  }
+}
+impl From<Option<MuDimension>> for ArgWrap {
+  fn from(t: Option<MuDimension>) -> Self {
+    ArgWrap::OptionMuDimension(t)
+  }
+}
+impl From<Glue> for ArgWrap {
+  fn from(t: Glue) -> Self {
+    ArgWrap::Glue(t)
+  }
+}
+impl From<Option<Glue>> for ArgWrap {
+  fn from(t: Option<Glue>) -> Self {
+    ArgWrap::OptionGlue(t)
+  }
+}
+impl From<MuGlue> for ArgWrap {
+  fn from(t: MuGlue) -> Self {
+    ArgWrap::MuGlue(t)
+  }
+}
+impl From<Option<MuGlue>> for ArgWrap {
+  fn from(t: Option<MuGlue>) -> Self {
+    ArgWrap::OptionMuGlue(t)
+  }
+}

--- a/rtx_core/src/definition/argument.rs
+++ b/rtx_core/src/definition/argument.rs
@@ -37,7 +37,9 @@ pub enum ArgWrap {
   MuDimension(MuDimension),
   OptionMuDimension(Option<MuDimension>),
   KV(KeyVals),
-  OptionKV(Option<KeyVals>)
+  OptionKV(Option<KeyVals>),
+  // TODO: what do we do with this custom case? feels iffy
+  RegisterDefinition((Token, Vec<ArgWrap>))
 }
 
 impl Default for ArgWrap {
@@ -75,7 +77,8 @@ impl Display for ArgWrap {
       ArgWrap::OptionMuDimension(Some(omudim)) =>  write!(f, "{omudim}"),
       ArgWrap::KV(kv) =>  write!(f, "{kv}"),
       ArgWrap::OptionKV(None) =>  write!(f, "None"),
-      ArgWrap::OptionKV(Some(okv)) =>  write!(f, "{okv}")
+      ArgWrap::OptionKV(Some(okv)) =>  write!(f, "{okv}"),
+      ArgWrap::RegisterDefinition((t, args)) => write!(f, "({t},{args:?})")
     }
   }
 }
@@ -110,6 +113,7 @@ impl Object for ArgWrap {
       OptionKV(kv_opt) => match kv_opt {
         Some(kv) => kv.get_locator(),
         None => None },
+      RegisterDefinition(_) => None,
     }
   }
   fn be_digested(self, stomach: &mut Stomach, state: &mut State) -> Result<Digested> {
@@ -146,6 +150,7 @@ impl Object for ArgWrap {
         Some(kv) => kv.be_digested(stomach,state),
         None => unimplemented!()
       },
+      RegisterDefinition(_) => unimplemented!(), // ??? not meant for direct digestion I think
     }
   }
   fn revert(&self, state:&mut State)-> Result<Tokens> {
@@ -182,6 +187,7 @@ impl Object for ArgWrap {
         Some(kv) => kv.revert(state),
         None => unimplemented!()
       },
+      RegisterDefinition(_) => unimplemented!(), // ??? not meant for direct reversion I think
     }
   }
 }
@@ -203,7 +209,8 @@ impl ArgWrap {
       OptionGlue(g_opt) => g_opt.is_none(),
       OptionMuGlue(g_opt) => g_opt.is_none(),
       OptionMuDimension(d_opt) => d_opt.is_none(),
-      OptionKV(kv_opt) => kv_opt.is_none()
+      OptionKV(kv_opt) => kv_opt.is_none(),
+      RegisterDefinition(_) => false,
     }
   }
   pub fn is_tokens(&self) -> bool {
@@ -279,6 +286,7 @@ impl ArgWrap {
         None => None,
         Some(t) => Some(Cow::Owned(t.revert(state)?)),
       },
+      RegisterDefinition(_) => unimplemented!(), // ??? not meant for such use
     };
     Ok(result)
   }

--- a/rtx_core/src/definition/conditional.rs
+++ b/rtx_core/src/definition/conditional.rs
@@ -6,7 +6,7 @@ use crate::common::error::*;
 use crate::common::locator::Locator;
 use crate::common::object::Object;
 use crate::common::store::Stored;
-use crate::common::numeric_ops::NumericOps;
+// use crate::common::numeric_ops::NumericOps;
 use crate::definition::{BeforeDigestClosure, ConditionalClosure, Definition, DigestionClosure};
 use crate::document::Document;
 use crate::gullet::Gullet;
@@ -177,7 +177,7 @@ impl Conditional {
       }
     } else {
       // If there's no test, it must be the Special Case, \ifcase
-      let num = args[0].as_ref().unwrap().to_number().value_of();
+      let num = args[0].value_of();
       if num > 0 {
         let _to = self.skip_conditional_body(num, gullet, state);
         //       print STDERR "{$num} [skipped to " . ToString($to) . "]\n" if $tracing;

--- a/rtx_core/src/definition/conditional.rs
+++ b/rtx_core/src/definition/conditional.rs
@@ -22,7 +22,7 @@ use crate::Digested;
 //   Expand enough to determine true/false, then maybe skip
 //   record a flag somewhere so that \else or \fi is recognized
 //   (otherwise, they should signal an error)
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConditionalType {
   If,
   Unless,

--- a/rtx_core/src/definition/expandable.rs
+++ b/rtx_core/src/definition/expandable.rs
@@ -8,6 +8,7 @@ use crate::common::object::Object;
 use crate::state::{Scope, State};
 
 use crate::definition::{BeforeDigestClosure, Definition, DigestionClosure, ExpansionBody};
+use crate::definition::argument::ArgWrap;
 use crate::document::Document;
 use crate::gullet::Gullet;
 use crate::parameter::Parameters;
@@ -153,6 +154,10 @@ impl Definition for Expandable {
           } else {
             Vec::new()
           };
+          let mut args_tks = Vec::new();
+          for arg in args.iter() {
+            args_tks.push(arg.as_tokens(state)?);
+          }
           // for "real" macros, make sure all args are Tokens
           // let r;
           if tracing {
@@ -165,7 +170,7 @@ impl Definition for Expandable {
             unimplemented!();
             //LaTeXML::Core::Definition::startProfiling($profiled, 'expand');
           }
-          tokens.substitute_parameters(args)
+          tokens.substitute_parameters(args_tks.as_slice())
         };
         // Getting exclusive requires dubious Gullet support!
         if profiled {
@@ -220,13 +225,17 @@ impl Expandable {
     }
   }
 
-  fn do_invocation(&self, gullet: &mut Gullet, args: Vec<Option<Tokens>>, state: &mut State) -> Result<Tokens> {
+  fn do_invocation(&self, gullet: &mut Gullet, args: Vec<ArgWrap>, state: &mut State) -> Result<Tokens> {
     match self.expansion {
       Some(ExpansionBody::Closure(ref closure)) => closure(gullet, args, state),
       // but for tokens, make sure args are proper Tokens (lists)
       Some(ExpansionBody::Tokens(ref tks)) => {
         if !tks.is_empty() {
-          Ok(tks.substitute_parameters(args))
+          let mut args_tks = Vec::new();
+          for arg in args.iter() {
+            args_tks.push(arg.as_tokens(state)?);
+          }
+          Ok(tks.substitute_parameters(&args_tks))
         } else {
           Ok(Tokens!())
         }

--- a/rtx_core/src/definition/mod.rs
+++ b/rtx_core/src/definition/mod.rs
@@ -5,6 +5,7 @@ pub mod constructor;
 pub mod math_primitive;
 pub mod primitive;
 pub mod register;
+pub mod argument;
 
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -16,6 +17,7 @@ use crate::common::object::Object;
 use crate::common::store::Stored;
 
 use self::register::{RegisterType, RegisterValue};
+use self::argument::ArgWrap;
 use crate::document::Document;
 use crate::gullet::Gullet;
 use crate::mouth;
@@ -27,9 +29,9 @@ use crate::tokens::Tokens;
 use crate::whatsit::Whatsit;
 use crate::Digested;
 
-pub type ExpansionClosure = Arc<dyn Fn(&mut Gullet, Vec<Option<Tokens>>, &mut State) -> Result<Tokens>>;
-pub type ConditionalClosure = Arc<dyn Fn(&mut Gullet, Vec<Option<Tokens>>, &mut State) -> Result<bool>>;
-pub type PrimitiveFn = dyn Fn(&mut Stomach, Vec<Option<Tokens>>, &mut State) -> Result<Vec<Digested>>;
+pub type ExpansionClosure = Arc<dyn Fn(&mut Gullet, Vec<ArgWrap>, &mut State) -> Result<Tokens>>;
+pub type ConditionalClosure = Arc<dyn Fn(&mut Gullet, Vec<ArgWrap>, &mut State) -> Result<bool>>;
+pub type PrimitiveFn = dyn Fn(&mut Stomach, Vec<ArgWrap>, &mut State) -> Result<Vec<Digested>>;
 pub type PrimitiveClosure = Arc<PrimitiveFn>;
 pub type BeforeDigestClosure = Arc<dyn Fn(&mut Stomach, &mut State) -> Result<Vec<Digested>>>;
 pub type PropertiesClosure = Arc<dyn Fn(&mut Stomach, &Vec<Option<Digested>>, &mut State) -> Result<HashMap<String, Stored>>>;
@@ -37,7 +39,6 @@ pub type DigestionClosure = Arc<dyn Fn(&mut Stomach, &mut Whatsit, &mut State) -
 pub type ReplacementClosure = Arc<dyn Fn(&mut Document, &Vec<Option<Digested>>, &HashMap<String, Stored>, &mut State) -> Result<()>>;
 pub type ConstructionClosure = Arc<dyn Fn(&mut Document, &Whatsit, &mut State) -> Result<()>>;
 pub type DigestedReversionClosure = Arc<dyn Fn(&Whatsit, &Vec<Option<Digested>>, &mut State) -> Result<Tokens>>;
-
 pub type SizingClosure = Arc<dyn Fn(&Whatsit) -> (i32, i32, i32)>;
 
 #[derive(Clone)]
@@ -60,6 +61,7 @@ impl Default for ExpansionBody {
 }
 
 impl PartialEq for ExpansionBody {
+  #[allow(clippy::vtable_address_comparisons)]
   fn eq(&self, other: &ExpansionBody) -> bool {
     match self {
       ExpansionBody::Closure(self_closure) =>
@@ -115,6 +117,15 @@ impl From<String> for ExpansionBody {
   fn from(s: String) -> ExpansionBody { s.as_str().into() }
 }
 
+impl From<ArgWrap> for ExpansionBody {
+  fn from(t: ArgWrap) -> ExpansionBody { ExpansionBody::Tokens(t.owned_tokens().unwrap_or_default()) }
+}
+impl From<ArgWrap> for Option<ExpansionBody> {
+  fn from(t: ArgWrap) -> Option<ExpansionBody> {
+    t.owned_tokens().map(ExpansionBody::Tokens)
+  }
+}
+
 pub trait Definition: Object {
   fn invoke(&self, gullet: &mut Gullet, once_only: bool, state: &mut State) -> Result<Tokens>;
   fn invoke_primitive(&self, gullet: &mut Stomach, caller: Arc<dyn Definition>, state: &mut State) -> Result<Vec<Digested>>;
@@ -135,7 +146,7 @@ pub trait Definition: Object {
   fn is_prefix(&self) -> bool { false }
   fn is_readonly(&self) -> bool { false }
 
-  fn read_arguments(&self, gullet: &mut Gullet, state: &mut State) -> Result<Vec<Option<Tokens>>>
+  fn read_arguments(&self, gullet: &mut Gullet, state: &mut State) -> Result<Vec<ArgWrap>>
   where Self: Sized {
     match self.get_parameters() {
       None => Ok(Vec::new()),
@@ -203,7 +214,7 @@ pub trait Definition: Object {
     Ok(after_body_digested)
   }
 
-  fn value_of(&self, args: Vec<Token>, state: &State) -> Option<RegisterValue> { unimplemented!() }
+  fn value_of(&self, args: Vec<ArgWrap>, state: &State) -> Option<RegisterValue> { unimplemented!() }
   fn register_type(&self) -> Option<RegisterType> { None }
   fn get_reversion_spec(&self) -> Option<Reversion> { unimplemented!() }
   fn get_expansion(&self) -> Option<&ExpansionBody> { None }

--- a/rtx_core/src/definition/mod.rs
+++ b/rtx_core/src/definition/mod.rs
@@ -51,7 +51,7 @@ impl std::fmt::Debug for ExpansionBody {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
       ExpansionBody::Closure(_) => write!(f, "<ExpansionClosure>"),
-      ExpansionBody::Tokens(ts) => write!(f, "{:?}", ts),
+      ExpansionBody::Tokens(ts) => write!(f, "{ts:?}"),
     }
   }
 }
@@ -256,7 +256,7 @@ impl fmt::Display for dyn Definition {
 impl fmt::Display for ExpansionBody {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
-      ExpansionBody::Tokens(ref t) => write!(f, "{}", t),
+      ExpansionBody::Tokens(ref t) => write!(f, "{t}"),
       ExpansionBody::Closure(_) => unimplemented!(), // what is the right way to serialize this, e.g. for the \meaning macro
     }
   }

--- a/rtx_core/src/definition/register.rs
+++ b/rtx_core/src/definition/register.rs
@@ -22,6 +22,8 @@ use crate::tokens::Tokens;
 use crate::whatsit::Whatsit;
 use crate::{Digested, Locator};
 
+use super::argument::ArgWrap;
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum RegisterValue {
   Number(Number),
@@ -324,8 +326,8 @@ pub enum RegisterType {
   Any, // Placeholder for any argument accepted
 }
 
-pub type RegisterGetterClosure = Arc<dyn Fn(Vec<Token>, &State) -> Option<RegisterValue>>;
-pub type RegisterSetterClosure = Arc<dyn Fn(RegisterValue, Vec<Tokens>, &mut State)>;
+pub type RegisterGetterClosure = Arc<dyn Fn(Vec<ArgWrap>, &State) -> Option<RegisterValue>>;
+pub type RegisterSetterClosure = Arc<dyn Fn(RegisterValue, Vec<ArgWrap>, &mut State)>;
 
 #[derive(Clone)]
 pub struct Register {
@@ -345,8 +347,8 @@ impl Default for Register {
       cs: T_CS!("Register"),
       parameters: None,
       register_type: RegisterType::Number,
-      getter: Arc::new(|_: Vec<Token>, _: &State| Some(RegisterValue::Number(Number::new(0)))),
-      setter: Arc::new(|_: RegisterValue, _: Vec<Tokens>, _: &mut State| {}),
+      getter: Arc::new(|_: Vec<ArgWrap>, _: &State| Some(RegisterValue::Number(Number::new(0)))),
+      setter: Arc::new(|_: RegisterValue, _: Vec<ArgWrap>, _: &mut State| {}),
       readonly: false,
       internalcs: None,
       value: None,
@@ -418,14 +420,6 @@ impl Definition for RegisterCell {
     gullet.read_keyword(&["="], state)?;
     let value = gullet.read_value(self.register_type().unwrap(), state)?;
 
-    // TODO: For now assume that register setting requires Tokens in all argument slots. Revisit if that isn't accurate.
-    let args = args
-      .into_iter()
-      .map(|a| match a {
-        Some(a) => a,
-        None => Tokens!(),
-      })
-      .collect();
     self.borrow_mut().set_value(value, args, state);
 
     state.after_assignment(gullet);
@@ -437,7 +431,7 @@ impl Definition for RegisterCell {
 
   fn before_digest(&self) -> Option<&Vec<BeforeDigestClosure>> { None }
   fn after_digest(&self) -> Option<&Vec<DigestionClosure>> { None }
-  fn read_arguments(&self, gullet: &mut Gullet, state: &mut State) -> Result<Vec<Option<Tokens>>> {
+  fn read_arguments(&self, gullet: &mut Gullet, state: &mut State) -> Result<Vec<ArgWrap>> {
     match self.borrow().parameters {
       None => Ok(Vec::new()),
       Some(ref params) => params.read_arguments(gullet, self, state),
@@ -447,7 +441,7 @@ impl Definition for RegisterCell {
   fn do_absorbtion(&self, _document: &mut Document, _whatsit: &Whatsit, _state: &mut State) -> Result<()> {
     fatal!(Definition, Unexpected, "do_absorbtion on Primitive should never be called!");
   }
-  fn value_of(&self, args: Vec<Token>, state: &State) -> Option<RegisterValue> {
+  fn value_of(&self, args: Vec<ArgWrap>, state: &State) -> Option<RegisterValue> {
     if self.borrow().register_type == RegisterType::CharDef {
       self.borrow().value.clone()
     } else {
@@ -459,7 +453,7 @@ impl Definition for RegisterCell {
 
 impl Register {
   pub fn is_readonly(&self) -> bool { self.readonly }
-  pub fn set_value(&mut self, value: RegisterValue, args: Vec<Tokens>, state: &mut State) {
+  pub fn set_value(&mut self, value: RegisterValue, args: Vec<ArgWrap>, state: &mut State) {
     if self.register_type == RegisterType::CharDef {
       let message = s!("Can't assign to chardef {}", self.cs.get_cs_name());
       Error!("unexpected", "chardef", None, state, message);

--- a/rtx_core/src/definition/register.rs
+++ b/rtx_core/src/definition/register.rs
@@ -406,7 +406,8 @@ impl Definition for RegisterCell {
   fn invoke_primitive(&self, stomach: &mut Stomach, _caller: Arc<dyn Definition>, state: &mut State) -> Result<Vec<Digested>> {
     // CharDef case
     if self.borrow().register_type == RegisterType::CharDef {
-      return match self.borrow().internalcs {
+      let internalcs = &self.borrow().internalcs;
+      return match internalcs {
         // Tracing ?
         None => Ok(Vec::new()),
         Some(ref cs) => stomach.invoke_token(cs, state),
@@ -432,7 +433,8 @@ impl Definition for RegisterCell {
   fn before_digest(&self) -> Option<&Vec<BeforeDigestClosure>> { None }
   fn after_digest(&self) -> Option<&Vec<DigestionClosure>> { None }
   fn read_arguments(&self, gullet: &mut Gullet, state: &mut State) -> Result<Vec<ArgWrap>> {
-    match self.borrow().parameters {
+    let params = &self.borrow().parameters;
+    match params {
       None => Ok(Vec::new()),
       Some(ref params) => params.read_arguments(gullet, self, state),
     }

--- a/rtx_core/src/definition/register.rs
+++ b/rtx_core/src/definition/register.rs
@@ -304,6 +304,7 @@ impl<'a> From<&'a RegisterValue> for MuGlue {
 impl fmt::Display for RegisterValue {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
+      RegisterValue::Number(n) => write!(f, "{}", n),
       RegisterValue::Dimension(d) => write!(f, "{}", d),
       RegisterValue::MuDimension(d) => write!(f, "{}", d),
       RegisterValue::Glue(g) => write!(f, "{}", g),

--- a/rtx_core/src/definition/register.rs
+++ b/rtx_core/src/definition/register.rs
@@ -304,11 +304,11 @@ impl<'a> From<&'a RegisterValue> for MuGlue {
 impl fmt::Display for RegisterValue {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
-      RegisterValue::Number(n) => write!(f, "{}", n),
-      RegisterValue::Dimension(d) => write!(f, "{}", d),
-      RegisterValue::MuDimension(d) => write!(f, "{}", d),
-      RegisterValue::Glue(g) => write!(f, "{}", g),
-      RegisterValue::MuGlue(g) => write!(f, "{}", g),
+      RegisterValue::Number(n) => write!(f, "{n}"),
+      RegisterValue::Dimension(d) => write!(f, "{d}"),
+      RegisterValue::MuDimension(d) => write!(f, "{d}"),
+      RegisterValue::Glue(g) => write!(f, "{g}"),
+      RegisterValue::MuGlue(g) => write!(f, "{g}"),
       other => write!(f, "{}", self.clone().value_of()),
     }
   }
@@ -369,7 +369,7 @@ impl fmt::Debug for Register {
   }
 }
 impl fmt::Display for Register {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{:?}", self) }
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{self:?}") }
 }
 /// The only purpose of RegisterCell is to provide us with a place to implement fmt::Display over
 /// a `RefCell<Register>`.

--- a/rtx_core/src/definition/register.rs
+++ b/rtx_core/src/definition/register.rs
@@ -313,7 +313,7 @@ impl fmt::Display for RegisterValue {
   }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RegisterType {
   Number,
   Dimension,

--- a/rtx_core/src/document/mod.rs
+++ b/rtx_core/src/document/mod.rs
@@ -551,7 +551,7 @@ impl Document {
           Some(ref n) => n,
         };
         let node_type = node.get_type();
-        if node_type == Some(NodeType::DocumentNode) || node_type == None {
+        if node_type == Some(NodeType::DocumentNode) || node_type.is_none() {
           return None;
         }
         let this_qname = state.model.get_node_qname(node);

--- a/rtx_core/src/document/mod.rs
+++ b/rtx_core/src/document/mod.rs
@@ -1045,7 +1045,7 @@ impl Document {
 
       // Move to best starting point for this text.
       if *closeto != *rc_node {
-        self.close_to_node(&*closeto, false, state)?;
+        self.close_to_node(&closeto, false, state)?;
       }
       if bestdiff > 0 {
         self.open_element(FONT_ELEMENT_NAME, Some(string_map!("_fontswitch" => "true")), Some(font), state)?;

--- a/rtx_core/src/document/mod.rs
+++ b/rtx_core/src/document/mod.rs
@@ -2431,42 +2431,8 @@ impl Document {
   }
 
   pub fn trim_node_whitespace(&mut self, node: &mut Node) -> Result<()> {
-    self.trim_node_left_whitespace(node)?;
-    self.trim_node_right_whitespace(node)?;
-    Ok(())
-  }
-
-  pub fn trim_node_left_whitespace(&mut self, node: &mut Node) -> Result<()> {
-    if let Some(mut first_child) = node.get_first_child() {
-      match first_child.get_type() {
-        Some(NodeType::TextNode) => {
-          let content = first_child.get_content();
-          let trimmed_content = content.trim_start();
-          if !content.is_empty() && (trimmed_content != content) {
-            first_child.set_content(trimmed_content)?;
-          }
-        },
-        Some(NodeType::ElementNode) => self.trim_node_left_whitespace(&mut first_child)?,
-        _ => {},
-      };
-    }
-    Ok(())
-  }
-
-  pub fn trim_node_right_whitespace(&mut self, node: &mut Node) -> Result<()> {
-    if let Some(mut last_child) = node.get_last_child() {
-      match last_child.get_type() {
-        Some(NodeType::TextNode) => {
-          let content = last_child.get_content();
-          let trimmed_content = content.trim_end();
-          if !content.is_empty() && (trimmed_content != content) {
-            last_child.set_content(trimmed_content)?;
-          }
-        },
-        Some(NodeType::ElementNode) => self.trim_node_right_whitespace(&mut last_child)?,
-        _ => {},
-      };
-    }
+    trim_node_left_whitespace(node)?;
+    trim_node_right_whitespace(node)?;
     Ok(())
   }
 
@@ -2666,6 +2632,40 @@ fn serialize_attr(string: &str) -> String {
   serialized = serialized.replace('\n', "&#10;");
   serialized = serialized.replace('\t', "&#9;");
   serialized
+}
+
+fn trim_node_left_whitespace(node: &mut Node) -> Result<()> {
+  if let Some(mut first_child) = node.get_first_child() {
+    match first_child.get_type() {
+      Some(NodeType::TextNode) => {
+        let content = first_child.get_content();
+        let trimmed_content = content.trim_start();
+        if !content.is_empty() && (trimmed_content != content) {
+          first_child.set_content(trimmed_content)?;
+        }
+      },
+      Some(NodeType::ElementNode) => trim_node_left_whitespace(&mut first_child)?,
+      _ => {},
+    };
+  }
+  Ok(())
+}
+
+fn trim_node_right_whitespace(node: &mut Node) -> Result<()> {
+  if let Some(mut last_child) = node.get_last_child() {
+    match last_child.get_type() {
+      Some(NodeType::TextNode) => {
+        let content = last_child.get_content();
+        let trimmed_content = content.trim_end();
+        if !content.is_empty() && (trimmed_content != content) {
+          last_child.set_content(trimmed_content)?;
+        }
+      },
+      Some(NodeType::ElementNode) => trim_node_right_whitespace(&mut last_child)?,
+      _ => {},
+    };
+  }
+  Ok(())
 }
 
 pub trait IntoVDQS {

--- a/rtx_core/src/document/mod.rs
+++ b/rtx_core/src/document/mod.rs
@@ -162,7 +162,7 @@ impl Document {
     if let Some(mut root) = self.document.get_root_element() {
       let init_font = Font::text_default();
       self.finalize_rec(&mut root, init_font, state)?;
-      if let Some(&Stored::String(ref prefixes)) = state.lookup_value("RDFa_prefixes") {
+      if let Some(Stored::String(prefixes)) = state.lookup_value("RDFa_prefixes") {
         self.set_rdfa_prefixes(Some(prefixes.clone()));
       }
     }
@@ -195,7 +195,7 @@ impl Document {
       let desired_font = self.get_node_font(node);
       pending_declaration = desired_font.relative_to(&declared_font);
       if (!node.get_child_nodes().is_empty() || node.has_attribute("_force_font")) && !pending_declaration.is_empty() {
-        for (key, &(ref value, ref properties)) in &pending_declaration {
+        for (key, (value, properties)) in &pending_declaration {
           if state.model.can_have_attribute(&qname, key) {
             attrs_to_set.push((key.to_string(), value.to_string()));
             // Merge to set the font currently in effect
@@ -255,7 +255,7 @@ impl Document {
         if self.can_contain(node, FONT_ELEMENT_NAME, state) && !pending_declaration.is_empty() {
           // Too late to do wrapNodes?
           if let Some(mut text) = self.wrap_nodes(FONT_ELEMENT_NAME, vec![child], state)? {
-            for (key, &(ref value, ref properties)) in &pending_declaration {
+            for (key, (value, properties)) in &pending_declaration {
               self.set_attribute(&mut text, key, value)?;
             }
             self.finalize_rec(&mut text, declared_font.clone(), state)?; // Now have to clean up the new node!
@@ -799,14 +799,14 @@ impl Document {
         // let tag = state.model.get_node_document_qname(&node);
         let tag = node.get_name();
         let children = node.get_child_nodes();
-        let mut open_tag = s!("<{}", tag);
+        let mut open_tag = s!("<{tag}");
 
         let nsnodes = node.get_namespace_declarations();
         for ns in nsnodes {
           let prefix = ns.get_prefix();
           let prefix_declaration = if prefix.is_empty() { s!("xmlns") } else { s!("xmlns:{}", prefix) };
           let href = ns.get_href();
-          write!(open_tag," {}=\"{}\"", prefix_declaration, href).ok();
+          write!(open_tag," {prefix_declaration}=\"{href}\"").ok();
         }
 
         let anodes = node.get_attributes();
@@ -818,12 +818,12 @@ impl Document {
           } // HACK for xml:id
           let key_serialized = state.model.get_node_document_qname(&node.get_attribute_node(key).unwrap());
           let val_serialized = serialize_attr(&node.get_property(key).unwrap_or_default());
-          write!(open_tag, " {}=\"{}\"", key_serialized, val_serialized).ok();
+          write!(open_tag, " {key_serialized}=\"{val_serialized}\"").ok();
         }
         // HACK for xml:id for now, assuming last element
         if anodes.contains_key("id") {
           let val_serialized = serialize_attr(&node.get_property("id").unwrap_or_default());
-          write!(open_tag," xml:id=\"{}\"", val_serialized).ok();
+          write!(open_tag," xml:id=\"{val_serialized}\"").ok();
         }
 
         let noindent_children: bool = if heuristic {
@@ -851,7 +851,7 @@ impl Document {
           if !noindent_children {
             serialized.push_str(&indent)
           }
-          write!(serialized, "</{}>", tag).ok();
+          write!(serialized, "</{tag}>").ok();
         } else {
           // empty element.
           serialized.push_str("/>");

--- a/rtx_core/src/document/mod.rs
+++ b/rtx_core/src/document/mod.rs
@@ -11,6 +11,7 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
+use std::fmt::Write as _;
 
 use crate::common::error::*;
 use crate::common::font::{Font, FONT_TEXT_DEFAULT};
@@ -805,7 +806,7 @@ impl Document {
           let prefix = ns.get_prefix();
           let prefix_declaration = if prefix.is_empty() { s!("xmlns") } else { s!("xmlns:{}", prefix) };
           let href = ns.get_href();
-          open_tag.push_str(&s!(" {}=\"{}\"", prefix_declaration, href));
+          write!(open_tag," {}=\"{}\"", prefix_declaration, href).ok();
         }
 
         let anodes = node.get_attributes();
@@ -817,12 +818,12 @@ impl Document {
           } // HACK for xml:id
           let key_serialized = state.model.get_node_document_qname(&node.get_attribute_node(key).unwrap());
           let val_serialized = serialize_attr(&node.get_property(key).unwrap_or_default());
-          open_tag.push_str(&s!(" {}=\"{}\"", key_serialized, val_serialized));
+          write!(open_tag, " {}=\"{}\"", key_serialized, val_serialized).ok();
         }
         // HACK for xml:id for now, assuming last element
         if anodes.contains_key("id") {
           let val_serialized = serialize_attr(&node.get_property("id").unwrap_or_default());
-          open_tag.push_str(&s!(" {}=\"{}\"", "xml:id", val_serialized));
+          write!(open_tag," xml:id=\"{}\"", val_serialized).ok();
         }
 
         let noindent_children: bool = if heuristic {
@@ -850,7 +851,7 @@ impl Document {
           if !noindent_children {
             serialized.push_str(&indent)
           }
-          serialized.push_str(&s!("</{}>", tag));
+          write!(serialized, "</{}>", tag).ok();
         } else {
           // empty element.
           serialized.push_str("/>");
@@ -873,7 +874,7 @@ impl Document {
         }
       },
       Some(NodeType::CommentNode) => {
-        serialized.push_str(&s!("<!-- {}-->", serialize_string(&node.get_content())));
+        write!(serialized, "<!-- {}-->", serialize_string(&node.get_content())).ok();
       },
       _ => {},
     }

--- a/rtx_core/src/gullet.rs
+++ b/rtx_core/src/gullet.rs
@@ -793,7 +793,7 @@ impl Gullet {
       Some(token) => {
         let cc = token.get_catcode();
         let mut text = token.to_string();
-        if cc == Catcode::OTHER && text.chars().all(|c| c.is_digit(10)) {
+        if cc == Catcode::OTHER && text.chars().all(|c| c.is_ascii_digit()) {
           // Read decimal literal
           text.push_str(&self.read_digits(&DIGIT_RE, true, state)?);
           Ok(Some(Number::new(text.parse::<i32>()?)))

--- a/rtx_core/src/gullet.rs
+++ b/rtx_core/src/gullet.rs
@@ -377,6 +377,13 @@ impl Gullet {
       }
     };
   }
+  pub fn unread_mut(&mut self, tokens: &mut Tokens) {
+    if let Some(ref mut runtime) = self.mouth {
+      for token in tokens.as_mut_unlist().drain(..).rev() {
+        runtime.pushback.push_front(token);
+      }
+    };
+  }
   pub fn unread_one(&mut self, token: Token) {
     if let Some(ref mut runtime) = self.mouth {
       runtime.pushback.push_front(token);
@@ -674,7 +681,7 @@ impl Gullet {
               register_type = RegisterType::Number;
             }
             if register_type == value_type {
-              let args: Vec<Token> = defn.read_arguments(self, state)?.iter().map(|ts| ts.as_ref().unwrap().into()).collect();
+              let args = defn.read_arguments(self, state)?;
               Ok(defn.value_of(args, state))
             } else {
               self.unread_one(token); // Unread
@@ -991,7 +998,7 @@ impl Gullet {
         Ok((Some(f * s), None))
       },
       Some(f) => match self.read_keyword(&["filll", "fill", "fil"], state)? {
-        Some(fil) => Ok((Some(fixpoint(s as f32 * f, None)), FillCode::from(&fil.to_string()))),
+        Some(fil) => Ok((Some(fixpoint(s as f32 * f, None)), FillCode::from(&fil))),
         None => {
           let u = if mu {
             match self.read_mu_unit(state)? {
@@ -1106,7 +1113,7 @@ impl Gullet {
             Some(RegisterType::Tokens) | Some(RegisterType::Token) => {
               // TODO: The mismatch between Vec<Tokens> for read_arguments and Vec<Token> for value_of feels incorrect
               //       but in which direction should it be resolved?
-              let args: Vec<Token> = defn.read_arguments(self, state)?.iter().map(|ts| ts.as_ref().unwrap().into()).collect();
+              let args = defn.read_arguments(self, state)?;
               match defn.value_of(args, state) {
                 None => Ok(Tokens!()),
                 Some(v) => Ok(v.into()),

--- a/rtx_core/src/gullet.rs
+++ b/rtx_core/src/gullet.rs
@@ -815,7 +815,6 @@ impl Gullet {
             s.remove(0);
           }
           let s_char = s.chars().next().unwrap();
-          let s_char = s_char as u8;
           Ok(Some(Number::new(s_char as i32))) //  Only a character token!!! NOT expanded!!!!
         } else {
           self.unread_one(token); // Unread

--- a/rtx_core/src/gullet.rs
+++ b/rtx_core/src/gullet.rs
@@ -209,7 +209,7 @@ impl Gullet {
 
       // Wow!!!!! See TeX the Program \S 309
       if let Some(ref nextt) = next_token {
-        if !state.align_state && state.reading_alignment
+        if (state.align_group_count>0) && state.reading_alignment
         // SHOULD count nesting of { }!!! when SCANNED (not digested)
         {
           //&& (($atoken, $atype, $ahidden) = $self->isColumnEnd($token))) {

--- a/rtx_core/src/keyvals.rs
+++ b/rtx_core/src/keyvals.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use crate::common::error::*;
 use crate::common::font::Font;
+use crate::definition::argument::ArgWrap;
 use crate::common::locator::Locator;
 use crate::common::object::Object;
 use crate::common::store::Stored;
@@ -106,7 +107,7 @@ impl Object for KeyVals {
         // keydefs are actual Parameter objects, which should be able to digest their own values!
         // Hmmm, so we need to add Parameter to Store
         // This comes together with the DefKeyVal infrastructure, which assigns keydef parameters to keyval specifications.
-        keydef.digest(stomach, value_tokens_opt, None, state)?.unwrap()
+        keydef.digest(stomach, ArgWrap::OptionTokens(value_tokens_opt), None, state)?.unwrap()
       } else {
         let value_tokens = value_tokens_opt.unwrap_or_default();
         value_tokens.be_digested(stomach, state)?

--- a/rtx_core/src/lib.rs
+++ b/rtx_core/src/lib.rs
@@ -287,13 +287,13 @@ impl Default for Digested {
 impl fmt::Display for Digested {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match *self {
-      Digested::TBox(ref b) => write!(f, "{}", b),
-      Digested::List(ref l) => write!(f, "{}", l),
+      Digested::TBox(ref b) => write!(f, "{b}"),
+      Digested::List(ref l) => write!(f, "{l}"),
       Digested::Whatsit(ref w) => write!(f, "{}", w.read().unwrap()),
-      Digested::Postponed(ref t) => write!(f, "{}", t),
-      Digested::KeyVals(ref kvs) => write!(f, "{}", kvs),
-      Digested::Comment(ref c) => write!(f, "{}", c),
-      Digested::RegisterValue(ref rv) => write!(f, "{}", rv),
+      Digested::Postponed(ref t) => write!(f, "{t}"),
+      Digested::KeyVals(ref kvs) => write!(f, "{kvs}"),
+      Digested::Comment(ref c) => write!(f, "{c}"),
+      Digested::RegisterValue(ref rv) => write!(f, "{rv}"),
     }
   }
 }

--- a/rtx_core/src/lib.rs
+++ b/rtx_core/src/lib.rs
@@ -454,6 +454,16 @@ impl Digested {
     }
   }
 
+  pub fn is_empty(&self) -> bool {
+    match *self {
+      Digested::TBox(ref b) => b.is_empty(),
+      Digested::List(ref l) => l.is_empty(),
+      Digested::Whatsit(ref w) => w.read().unwrap().is_empty(),
+      Digested::Postponed(ref tks) => tks.is_empty(),
+      _ => unimplemented!(),
+    }
+  }
+
   /// Provide a way of emulating an `Undigested` argument, by requesting
   /// raw tokens, only when they are preserved -- empty otherwise.
   pub fn raw_tokens(&self) -> Arc<Tokens> {

--- a/rtx_core/src/lib.rs
+++ b/rtx_core/src/lib.rs
@@ -134,6 +134,7 @@ pub trait BoxOps: Object {
     None
   }
   fn get_font(&self) -> Option<Cow<Font>>;
+  fn set_font(&mut self, font: Arc<Font>) { unimplemented!() }
 
   fn set_width<T: Into<Stored>>(&mut self, width: T) {
     let mut props = self.get_properties_mut();
@@ -149,7 +150,7 @@ pub trait BoxOps: Object {
   }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TexMode {
   Math,
   Text,

--- a/rtx_core/src/ligature.rs
+++ b/rtx_core/src/ligature.rs
@@ -11,7 +11,7 @@ pub type LigatureClosure = Arc<dyn Fn(&str) -> String>;
 pub type FontTestClosure = Arc<dyn Fn(&Font) -> bool>;
 pub type LigatureMatcher = Arc<dyn Fn(&mut Document, &mut Node, &State) -> Result<Option<(usize, String, MathLigatureOptions)>>>;
 
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct MathLigatureOptions {
   pub role: Option<String>,
   pub name: Option<String>,

--- a/rtx_core/src/list.rs
+++ b/rtx_core/src/list.rs
@@ -26,7 +26,7 @@ impl fmt::Debug for List {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     write!(f, "\nList[")?;
     for tbox in &self.boxes {
-      writeln!(f, "  {:?}", tbox)?;
+      writeln!(f, "  {tbox:?}")?;
     }
     writeln!(f, "]({:?})", self.mode)
   }
@@ -35,7 +35,7 @@ impl fmt::Debug for List {
 impl fmt::Display for List {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     for inner in self.boxes.iter() {
-      write!(f, "{}", inner)?;
+      write!(f, "{inner}")?;
     }
     Ok(())
   }

--- a/rtx_core/src/list.rs
+++ b/rtx_core/src/list.rs
@@ -14,7 +14,7 @@ use crate::tokens::Tokens;
 use crate::{BoxOps, Digested, TexMode};
 
 /// Lists can contain any Digested items, such as boxes, whatsits or other lists
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Default, PartialEq)]
 pub struct List {
   pub boxes: Vec<Digested>,
   pub mode: Option<TexMode>,

--- a/rtx_core/src/mouth.rs
+++ b/rtx_core/src/mouth.rs
@@ -197,7 +197,7 @@ impl Mouth {
 
   pub fn get_source(&self) -> &str { &self.source }
 
-  pub fn open<'open>(&'open mut self, content: &str, state: &mut State) -> Result<()> {
+  pub fn open(&mut self, content: &str, state: &mut State) -> Result<()> {
     match self.foodtype {
       FoodType::File => self.open_file(content)?,
       FoodType::Literal => self.open_literal(content),
@@ -255,7 +255,7 @@ impl Mouth {
     if self.fordefinitions {
       self.saved_at_cc = state.lookup_catcode('@');
       self.saved_include_comments = match state.lookup_value("INCLUDE_COMMENTS") {
-        Some(&Stored::Bool(ref x)) => Some(*x),
+        Some(Stored::Bool(x)) => Some(*x),
         _ => None,
       };
       state.assign_catcode('@', Catcode::LETTER, None);

--- a/rtx_core/src/mouth.rs
+++ b/rtx_core/src/mouth.rs
@@ -38,7 +38,7 @@ lazy_static! {
   static ref TRAILING_SPACE_CHARS: Regex = Regex::new("(?s) +$").unwrap();
 }
 
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum FoodType {
   File,
   // Binding,

--- a/rtx_core/src/parameter.rs
+++ b/rtx_core/src/parameter.rs
@@ -9,6 +9,7 @@ use crate::common::object::Object;
 use crate::common::store::Stored;
 use crate::definition::constructor::Constructor;
 use crate::definition::{BeforeDigestClosure, Definition, DigestionClosure};
+use crate::definition::argument::ArgWrap;
 use crate::gullet::Gullet;
 use crate::mouth::Mouth;
 use crate::state::State;
@@ -18,8 +19,8 @@ use crate::tokens::Tokens;
 use crate::whatsit::Whatsit;
 use crate::{Digested, Locator};
 
-pub type ReaderFn = dyn Fn(&mut Gullet, Vec<Option<Parameters>>, &[ParameterExtra], &mut State) -> Result<Option<Tokens>>;
-pub type ReaderPredigestFn = dyn Fn(&mut Stomach, Tokens, &mut State) -> Result<Option<Digested>>;
+pub type ReaderFn = dyn Fn(&mut Gullet, Vec<Option<Parameters>>, &[ParameterExtra], &mut State) -> Result<ArgWrap>;
+pub type ReaderPredigestFn = dyn Fn(&mut Stomach, ArgWrap, &mut State) -> Result<Option<Digested>>;
 pub type ReaderPredigestClosure = Arc<ReaderPredigestFn>;
 pub type ReaderClosure = Arc<ReaderFn>;
 
@@ -117,7 +118,7 @@ impl Default for Parameter {
           None,
           "Please define a real reader, this is a mock fallback!"
         );
-        Ok(None)
+        Ok(ArgWrap::OptionTokens(None))
       }),
       reader_predigest: None,
       reversion: None,
@@ -287,7 +288,7 @@ impl Parameter {
     Ok(())
   }
 
-  pub fn read(&self, gullet: &mut Gullet, fordefn: &dyn Definition, state: &mut State) -> Result<Option<Tokens>> {
+  pub fn read(&self, gullet: &mut Gullet, fordefn: &dyn Definition, state: &mut State) -> Result<ArgWrap> {
     // For semiverbatim, I had messed with catcodes, but there are cases
     // (eg. \caption(...\label{badchars}}) where you really need to
     // cleanup after the fact!
@@ -295,19 +296,23 @@ impl Parameter {
     self.setup_catcodes(state);
 
     let closure = &self.reader;
-    let mut value_opt: Option<Tokens> = closure(gullet, vec![], &self.extra, state)?;
-    if let Some(mut value) = value_opt {
-      if let Some(ref semi_chars) = self.semiverbatim {
-        value = value.neutralize(semi_chars, state);
+    let mut value_arg: ArgWrap = closure(gullet, vec![], &self.extra, state)?;
+    if value_arg.is_tokens() {
+      if let Some(mut value) = value_arg.owned_tokens() {
+        if let Some(ref semi_chars) = self.semiverbatim {
+          value = value.neutralize(semi_chars, state);
+        }
+        if self.pack_parameters {
+          value = value.pack_parameters();
+        }
+        value_arg = ArgWrap::Tokens(value);
+      } else {
+        value_arg = ArgWrap::default();
       }
-      if self.pack_parameters {
-        value = value.pack_parameters();
-      }
-      value_opt = Some(value);
     }
     self.revert_catcodes(state)?;
 
-    if !self.optional && !self.novalue && (value_opt.is_none() && self.reader_predigest.is_none()) {
+    if !self.optional && !self.novalue && (value_arg.is_none() && self.reader_predigest.is_none()) {
       // Deyan: Special exception, which may motivate switching the reader type to Option<Tokens> in the long-run
       //        Until *may* have a value, but it also may *not*, both OK. So... except it from the error message here
       if !self.name.starts_with("Until") {
@@ -318,40 +323,44 @@ impl Parameter {
           state,
           s!("Missing argument {} for {}", self.stringify(), fordefn.stringify())
         );
-        value_opt = Some(Tokens!(T_OTHER!("missing")));
+        value_arg = ArgWrap::Tokens(Tokens!(T_OTHER!("missing")));
       }
     }
-    Ok(value_opt)
+    Ok(value_arg)
   }
 
   pub fn digest(
     &self,
     stomach: &mut Stomach,
-    mut value_opt: Option<Tokens>,
+    mut value_arg: ArgWrap,
     _fordefn: Option<&Constructor>,
     state: &mut State,
   ) -> Result<Option<Digested>> {
     // If semiverbatim, Expand (before digest), so tokens can be neutralized; BLECH!!!!
     if self.semiverbatim.is_some() {
       self.setup_catcodes(state);
-      if let Some(value) = value_opt {
-        let neutralized = stomach.reading_from_mouth(Mouth::default(), state, move |stomach: &mut Stomach, state: &mut State| {
-          let gullet = stomach.get_gullet_mut();
-          gullet.unread(value);
-          let mut tokens = Vec::new();
-          loop {
-            match gullet.read_x_token(true, true, state) {
-              Ok(token_opt) => match token_opt {
-                Some(token) => tokens.push(token),
-                None => break,
-              },
-              Err(x) => return Err(x),
+      if value_arg.is_tokens() {
+        if let Some(mut value) = value_arg.owned_tokens() {
+          let neutralized = stomach.reading_from_mouth(Mouth::default(), state, move |stomach: &mut Stomach, state: &mut State| {
+            let gullet = stomach.get_gullet_mut();
+            gullet.unread(value);
+            let mut tokens = Vec::new();
+            loop {
+              match gullet.read_x_token(true, true, state) {
+                Ok(token_opt) => match token_opt {
+                  Some(token) => tokens.push(token),
+                  None => break,
+                },
+                Err(x) => return Err(x),
+              }
             }
-          }
-          let evec = Vec::new();
-          Ok(Tokens::new(tokens).neutralize(&evec, state).unlist())
-        })?;
-        value_opt = Some(Tokens::new(neutralized));
+            let evec = Vec::new();
+            Ok(Tokens::new(tokens).neutralize(&evec, state).unlist())
+          })?;
+          value_arg = ArgWrap::Tokens(Tokens::new(neutralized));
+        } else {
+          value_arg = ArgWrap::default();
+        }
       }
     }
 
@@ -361,15 +370,9 @@ impl Parameter {
     }
 
     let digested_value = if let Some(ref closure) = &self.reader_predigest {
-      if let Some(value_to_digest) = value_opt {
-        closure(stomach, value_to_digest, state)?
-      } else {
-        None
-      }
-    } else if let Some(value_to_digest) = value_opt {
-      Some(value_to_digest.be_digested(stomach, state)?)
+      closure(stomach, value_arg, state)?
     } else {
-      None
+      Some(value_arg.be_digested(stomach, state)?)
     };
     for post in self.after_digest.iter() {
       // Done for effect only.
@@ -442,9 +445,8 @@ impl Parameters {
     Ok(tokens)
   }
 
-  pub fn read_arguments(&self, gullet: &mut Gullet, fordefn: &dyn Definition, state: &mut State) -> Result<Vec<Option<Tokens>>> {
+  pub fn read_arguments(&self, gullet: &mut Gullet, fordefn: &dyn Definition, state: &mut State) -> Result<Vec<ArgWrap>> {
     let mut args = Vec::new();
-    gullet.setup_scan();
     for parameter in &self.0 {
       let values = parameter.read(gullet, fordefn, state)?;
       if parameter.reader_predigest.is_some() {
@@ -475,7 +477,7 @@ impl Parameters {
     Ok(args)
   }
 
-  pub fn reparse_argument(&self, _gullet: &mut Gullet, _value: Option<Tokens>, _state: &mut State) -> Option<Tokens> { unimplemented!() }
+  pub fn reparse_argument(&self, _gullet: &mut Gullet, _value: ArgWrap, _state: &mut State) -> ArgWrap { unimplemented!() }
 }
 
 impl fmt::Display for Parameters {

--- a/rtx_core/src/parameter.rs
+++ b/rtx_core/src/parameter.rs
@@ -368,11 +368,23 @@ impl Parameter {
       // Done for effect only.
       pre(stomach, state)?; // maybe pass extras?
     }
-
     let digested_value = if let Some(ref closure) = &self.reader_predigest {
       closure(stomach, value_arg, state)?
     } else {
-      Some(value_arg.be_digested(stomach, state)?)
+      // Note: we have an open question for the type interface.
+      //  What happens when a wrapped "None" value,
+      // (such as the missing value of an Optional [] argument)
+      // gets digested?
+      //
+      // currently a `Digested::default` gets returned, which has an empty TBox and also gets returned
+      // for e.g. empty mandatory Plain arguments {}.
+      // But we need *different* values, as the explicit "\foo[]" is an override to empty, while "\foo"
+      // will use the default value for the Optional.
+      if self.optional && value_arg.is_none() {
+        None
+      } else {
+        Some(value_arg.be_digested(stomach, state)?)
+      }
     };
     for post in self.after_digest.iter() {
       // Done for effect only.

--- a/rtx_core/src/parameter.rs
+++ b/rtx_core/src/parameter.rs
@@ -58,7 +58,7 @@ impl From<ParameterExtra> for Token {
     if let ParameterExtra::Tokens(t) = param {
       t.into()
     } else {
-      panic!("Can't cast {:?} into Token", param);
+      panic!("Can't cast {param:?} into Token");
     }
   }
 }
@@ -67,7 +67,7 @@ impl From<ParameterExtra> for Tokens {
     if let ParameterExtra::Tokens(t) = param {
       t
     } else {
-      panic!("Can't cast {:?} into Tokens", param);
+      panic!("Can't cast {param:?} into Tokens");
     }
   }
 }
@@ -178,12 +178,12 @@ impl Parameter {
     // is defined.
     let looked_up_mapping = state.lookup_mapping("PARAMETER_TYPES", &self.name);
     let mut descriptor: Option<Arc<Parameter>>;
-    if let Some(&Stored::Parameter(ref d_lookup)) = looked_up_mapping {
+    if let Some(Stored::Parameter(d_lookup)) = looked_up_mapping {
       descriptor = Some(Arc::clone(d_lookup));
     } else if let Some(captures) = OPTIONAL_REGEX.captures(&self.name) {
       let basetype = captures.get(1).map_or("", |m| m.as_str());
       descriptor = match state.lookup_mapping("PARAMETER_TYPES", basetype) {
-        Some(&Stored::Parameter(ref d_lookup)) => Some(d_lookup.clone()),
+        Some(Stored::Parameter(d_lookup)) => Some(d_lookup.clone()),
         _ => match Parameter::check_reader_function(&s!("Read{}", &self.name), state) {
           Some(reader) => Some(Arc::new(Parameter {
             reader,
@@ -205,7 +205,7 @@ impl Parameter {
     } else if let Some(captures) = SKIP_REGEX.captures(&self.name) {
       let basetype = captures.get(1).map_or("", |m| m.as_str());
       descriptor = match state.lookup_mapping("PARAMETER_TYPES", basetype) {
-        Some(&Stored::Parameter(ref d_lookup)) => Some(d_lookup.clone()),
+        Some(Stored::Parameter(d_lookup)) => Some(d_lookup.clone()),
         _ => match Parameter::check_reader_function(&self.name, state) {
           Some(reader) => Some(Arc::new(Parameter {
             reader,
@@ -502,6 +502,6 @@ impl fmt::Display for Parameters {
       }
       content.push_str(&param_content);
     }
-    write!(f, "{}", content)
+    write!(f, "{content}")
   }
 }

--- a/rtx_core/src/rewrite.rs
+++ b/rtx_core/src/rewrite.rs
@@ -58,9 +58,9 @@ pub enum RewritePattern {
 impl fmt::Debug for RewritePattern {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
-      RewritePattern::String(x) => write!(f, "{:?}", x),
-      RewritePattern::Scope(x) => write!(f, "{:?}", x),
-      RewritePattern::Tokens(x) => write!(f, "{:?}", x),
+      RewritePattern::String(x) => write!(f, "{x:?}"),
+      RewritePattern::Scope(x) => write!(f, "{x:?}"),
+      RewritePattern::Tokens(x) => write!(f, "{x:?}"),
       RewritePattern::Closure(_) => write!(f, "<Rewrite Replacement Closure>"),
     }
   }

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -648,7 +648,7 @@ impl State {
     match self.lookup_value_mut(key) {
       Some(Stored::Tokens(ref mut tks)) => tks.as_mut_unlist().extend(value.unlist()),
       None | Some(Stored::None) => self.assign_value(key, Stored::Tokens(value), None),
-      Some(other) => panic!("Can only push_tokens into a Stored::Tokens, but got {:?}", other),
+      Some(other) => panic!("Can only push_tokens into a Stored::Tokens, but got {other:?}"),
     }
   }
 
@@ -728,14 +728,14 @@ impl State {
     match self.lookup_value(key) {
       Some(Stored::Glue(v)) => Some(*v),
       None | Some(Stored::None) => None,
-      Some(other) => panic!("state lookup expected Glue, found: {:?}", other),
+      Some(other) => panic!("state lookup expected Glue, found: {other:?}"),
     }
   }
   pub fn lookup_muglue(&self, key: &str) -> Option<MuGlue> {
     match self.lookup_value(key) {
       Some(Stored::MuGlue(v)) => Some(*v),
       None | Some(Stored::None) => None,
-      Some(other) => panic!("state lookup expected MuGlue, found: {:?}", other),
+      Some(other) => panic!("state lookup expected MuGlue, found: {other:?}"),
     }
   }
 
@@ -821,9 +821,7 @@ impl State {
       }
     } else {
       panic!(
-        "unshift_value can only work on a Stored::VecDequeStored receiver. Instead, key {:?} got: {:?}",
-        key, receiver
-      );
+        "unshift_value can only work on a Stored::VecDequeStored receiver. Instead, key {key:?} got: {receiver:?}");
     }
   }
 
@@ -844,7 +842,7 @@ impl State {
     match self.value.get(map) {
       None => None,
       Some(map_vec) => match map_vec.front() {
-        Some(&Stored::HashStored(ref h)) => h.get(key),
+        Some(Stored::HashStored(h)) => h.get(key),
         _ => None,
       },
     }
@@ -871,7 +869,7 @@ impl State {
     match self.value.get(map) {
       None => Vec::new(),
       Some(map_vec) => match map_vec.front() {
-        Some(&Stored::HashStored(ref h)) => h.keys().map(String::as_str).collect(),
+        Some(Stored::HashStored(h)) => h.keys().map(String::as_str).collect(),
         _ => Vec::new(),
       },
     }
@@ -928,7 +926,7 @@ impl State {
   pub fn lookup_mathcode(&self, key: &str) -> Option<u16> {
     match self.mathcode.get(&key.to_string()) {
       Some(c) => match c.front() {
-        Some(&Stored::Charcode(ref codeval)) => Some(*codeval),
+        Some(Stored::Charcode(codeval)) => Some(*codeval),
         _ => None,
       },
       None => None,
@@ -943,7 +941,7 @@ impl State {
   pub fn lookup_sfcode(&self, key: char) -> Option<u16> {
     match self.sfcode.get(&key.to_string()) {
       Some(c) => match c.front() {
-        Some(&Stored::Charcode(ref codeval)) => Some(*codeval),
+        Some(Stored::Charcode(codeval)) => Some(*codeval),
         _ => None,
       },
       None => None,
@@ -958,7 +956,7 @@ impl State {
   pub fn lookup_lccode(&self, key: char) -> Option<u16> {
     match self.lccode.get(&key.to_string()) {
       Some(c) => match c.front() {
-        Some(&Stored::Charcode(ref codeval)) => Some(*codeval),
+        Some(Stored::Charcode(codeval)) => Some(*codeval),
         _ => None,
       },
       None => None,
@@ -973,7 +971,7 @@ impl State {
   pub fn lookup_uccode(&self, key: char) -> Option<u16> {
     match self.uccode.get(&key.to_string()) {
       Some(c) => match c.front() {
-        Some(&Stored::Charcode(ref codeval)) => Some(*codeval),
+        Some(Stored::Charcode(codeval)) => Some(*codeval),
         _ => None,
       },
       None => None,
@@ -988,7 +986,7 @@ impl State {
   pub fn lookup_delcode(&self, key: char) -> Option<u16> {
     match self.delcode.get(&key.to_string()) {
       Some(c) => match c.front() {
-        Some(&Stored::Charcode(ref codeval)) => Some(*codeval),
+        Some(Stored::Charcode(codeval)) => Some(*codeval),
         _ => None,
       },
       None => None,
@@ -1185,7 +1183,7 @@ impl State {
     let is_state_unlocked = self.lookup_bool("UNLOCKED");
 
     if is_cs_locked && !is_state_unlocked {
-      if let Some(&Stored::String(ref s)) = self.lookup_value("SOURCEFILE") {
+      if let Some(Stored::String(s)) = self.lookup_value("SOURCEFILE") {
         // report if the redefinition seems to come from document source
         if ((s == "Anonymous String") || TEX_OR_BIB_EXT_RE.is_match(s)) && (!s.ends_with(CODE_TEX_EXT)) {
           //  info("ignore", cs, self.get_stomach(), "Ignoring redefinition of $cs");
@@ -1253,7 +1251,7 @@ impl State {
         all_specials.push(*special);
       }
     }
-    if let Some(&Stored::VecChar(ref specials_store)) = self.lookup_value("SPECIALS") {
+    if let Some(Stored::VecChar(specials_store)) = self.lookup_value("SPECIALS") {
       for special_char in specials_store {
         all_specials.push(*special_char);
       }
@@ -1758,7 +1756,7 @@ impl State {
       Some(Stored::Tokens(after)) => gullet.unread(after),
       Some(Stored::Token(after)) => gullet.unread_one(after),
       None | Some(Stored::None) => {},
-      Some(other) => panic!("unexpected in after_assignment: {:?}", other),
+      Some(other) => panic!("unexpected in after_assignment: {other:?}"),
     }
   }
 }

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -98,7 +98,7 @@ impl TableName {
 }
 
 /// High-level catcode profiles
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Catcodes {
   Standard,
   Style,
@@ -745,6 +745,12 @@ impl State {
       Some(v) => v.into(),
     }
   }
+  pub fn lookup_token(&self, key: &str) -> Option<&Token> {
+    match self.lookup_value(key) {
+      Some(Stored::Token(t)) => Some(t),
+      _ => None
+    }
+  }
 
   pub fn lookup_register(&self, cs: &str, parameters: Vec<ArgWrap>) -> Option<RegisterValue> {
     let cs = T_CS!(cs);
@@ -1234,6 +1240,14 @@ impl State {
     }
     Ok(())
   }
+
+  /// Determine depth of group nesting created by {,},\bgroup,\egroup,\begingroup,\endgroup
+  /// by counting all frames which are not Daemon frames (and thus don't possess _FRAME_LOCK_).
+  /// This may give incorrect results for some special environments (e.g. minipage)
+  pub fn get_frame_depth(&self) -> usize {
+    self.undo.iter().filter(|frame| !frame.locked).count() - 1
+  }
+
 
   pub fn begin_semiverbatim(&mut self, extraspecials: Option<&[char]>) {
     // Is this a good/safe enough shorthand, or should we really be doing beginMode?

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -770,17 +770,10 @@ impl State {
   }
 
   pub fn lookup_expandable(&self, token: &Token, toplevel: bool) -> Option<Arc<dyn Definition>> {
-    if let Some(defn) = self.lookup_definition(token) {
-      // Can only be a token or definition; we want defns!
-      if (*defn).is_expandable() && (toplevel || !(*defn).is_protected()) {
-        // is this the right logic here? don't expand unless digesting?
-        Some(defn)
-      } else {
-        None
-      }
-    } else {
-      None
-    }
+    // Can only be a token or definition; we want defns!
+    // is this the right logic here? don't expand unless digesting?
+    self.lookup_definition(token).filter(|defn|
+      (*defn).is_expandable() && (toplevel || !(*defn).is_protected()))
   }
 
   /// Whether token must be wrapped as dont_expand

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -16,6 +16,7 @@ use crate::common::number::Number;
 use crate::common::object::Object;
 pub use crate::common::store::Stored; // reexport for convenience
 use crate::common::BindingDispatcher;
+use crate::definition::argument::ArgWrap;
 use crate::definition::conditional::{ConditionalType, IfFrame};
 use crate::definition::constructor::Constructor;
 use crate::definition::expandable::Expandable;
@@ -745,7 +746,7 @@ impl State {
     }
   }
 
-  pub fn lookup_register(&self, cs: &str, parameters: Vec<Token>) -> Option<RegisterValue> {
+  pub fn lookup_register(&self, cs: &str, parameters: Vec<ArgWrap>) -> Option<RegisterValue> {
     let cs = T_CS!(cs);
     if let Some(defn) = self.lookup_definition(&cs) {
       if defn.is_register() {

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -240,6 +240,7 @@ pub struct State {
   // TODO: Maybe group these in a "SessionFlags" struct?
   //       we can then reset that if we reimplement a daemon app
   pub verbosity: i32,
+  pub align_group_count: i32, // was $LaTeXML::ALIGN_STATE
   pub status_code: usize,
   pub unlocked: bool,
   pub current_token: Option<Arc<Token>>,
@@ -254,7 +255,6 @@ pub struct State {
   pub include_styles: bool,
   pub nomathparse: bool,
   pub smuggle_the: bool,
-  pub align_state: bool,
   pub reading_alignment: bool,
   // Auxiliary convenience -- extra dispatch
   // TODO: We can make this a Vec<BindingDispatcher> if we want to accumulate more definitions
@@ -301,6 +301,7 @@ impl Default for State {
       // Stateful runtime - simple fields
       verbosity: 0,
       status_code: 0,
+      align_group_count: 0,
       unlocked: true,
       current_token: None,
       if_frame: None,
@@ -314,7 +315,6 @@ impl Default for State {
       include_styles: false,
       nomathparse: false,
       smuggle_the: false,
-      align_state: false,
       reading_alignment: false,
       extra_bindings_dispatch: None,
       // interiorly mutable
@@ -1477,7 +1477,7 @@ impl State {
 
   // #======================================================================
 
-  pub fn note_status(&self, category: &str) {
+  pub fn note_status(&self, category: &str, what: &str) {
     // Ok, note status is *EXTREMELY* localized
     // it only touches the status field of state,
     // and has NO side-effects to any of the other stateful machinery.
@@ -1709,7 +1709,7 @@ impl State {
   /// along with appropriate error messge.
   pub fn generate_error_stub(&mut self, caller: &mut Gullet, token: &Token) -> Result<Token> {
     let cs = token.get_cs_name();
-    self.note_status(cs); // TODO: Undefined:cs
+    self.note_status("undefined", cs); // TODO: Undefined:cs
                           // To minimize chatter, go ahead and define it...
     if cs.starts_with("\\if") {
       // Apparently an \ifsomething ???

--- a/rtx_core/src/stomach.rs
+++ b/rtx_core/src/stomach.rs
@@ -197,13 +197,13 @@ impl<'t> Stomach {
           if cc == Catcode::CS {
             result = self.invoke_token_undefined(&token, state)?;
           } else if cc.is_absorbable() {
-            if let Some(digested) = self.invoke_token_simple(&*token, meaning, state)? {
+            if let Some(digested) = self.invoke_token_simple(&token, meaning, state)? {
               result.push(digested);
             }
           } else {
             let message = s!("The token {:?} (catcode {:?}) should never reach Stomach!", token, cc);
             Error!("misdefined", token, self, state, &message);
-            if let Some(digested) = self.invoke_token_simple(&*token, meaning, state)? {
+            if let Some(digested) = self.invoke_token_simple(&token, meaning, state)? {
               result.push(digested);
             }
           }

--- a/rtx_core/src/stomach.rs
+++ b/rtx_core/src/stomach.rs
@@ -492,15 +492,24 @@ impl<'t> Stomach {
     Ok(())
   }
 
-  pub fn current_frame_message(&self) -> String {
-    // return "current frame is "
-    //   . (state.isValueBound('MODE', 0)       // SET mode in CURRENT frame ?
-    //   ? "mode-switch to " . state.lookup_value('MODE')
-    //   : (state.lookup_value('groupNonBoxing')    // Current frame is a non-boxing group?
-    //     ? "non-boxing" : "boxing") . " group")
-    //   . " due to " . Stringify(state.lookup_value('groupInitiator'))
-    //   . " " . ToString(state.lookup_value('groupInitiatorLocator')); }
-    s!("current frame is mock")
+  pub fn current_frame_message(&self, state:&State) -> String {
+    let target = if state.is_value_bound("MODE", Some(0)) { // SET mode in CURRENT frame ?
+      Cow::Owned(s!("mode-switch to {}",  state.lookup_string("MODE")))
+    } else if state.lookup_bool("groupNonBoxing") { // Current frame is a non-boxing group?
+      Cow::Borrowed("non-boxing group")
+    } else {
+      Cow::Borrowed("boxing group")
+    };
+
+
+    let initiator = if let Some(t) = state.lookup_token("groupInitiator") {
+      t.stringify()
+    } else {
+      String::new()
+    };
+    //   TODO:
+    //   . " " . ToString(state.lookup_value('groupInitiatorLocator'));
+    s!("current frame is {} due to {}",target, initiator)
   }
 
   //======================================================================
@@ -537,7 +546,7 @@ impl<'t> Stomach {
         state.current_token.as_ref().unwrap().to_string(),
         self,
         state,
-        s!("Attempt to close non-boxing group {}", self.current_frame_message())
+        s!("Attempt to close non-boxing group {}", self.current_frame_message(state))
       );
     } else {
       self.pop_stack_frame(true, state)?;
@@ -549,47 +558,54 @@ impl<'t> Stomach {
   // Mode (minimal so far; math vs text)
   // Could (should?) be taken up by Stomach by building horizontal, vertical or math lists ?
 
-  pub fn begin_mode(&mut self, mode: &str, state: &mut State) -> Result<()> {
-    self.push_stack_frame(false, state); // Effectively bgroup
+  /// This sets the mode without doing any grouping (NOR does it stack the modes!!)
+  /// Useful for environments, where the group has already been established.
+  /// (presumably, in the long run, modes & groups should be much less coupled)
+  pub fn set_mode(&mut self, mode: &str, state:&mut State) -> Result<()> {
     let prevmode = state.lookup_string("MODE");
     let ismath = mode.ends_with("math");
-    let isdisplay = mode.starts_with("display");
-    state.assign_value("MODE", mode.to_string(), Some(Scope::Local));
+    state.assign_value("MODE", mode, Some(Scope::Local));
     state.assign_value("IN_MATH", ismath, Some(Scope::Local));
-    let curfont = state.lookup_font();
-    if let Some(cf) = curfont {
-      if mode == prevmode {
-      } else if ismath {
-        // When entering math mode, we set the font to the default math font,
-        // and save the text font for any embedded text.
-        state.assign_value("savedfont", cf.clone(), Some(Scope::Local));
-        let new_font = state.lookup_mathfont().unwrap().merge(Font {
-          color: cf.color.clone(),
-          bg: cf.bg.clone(),
-          size: cf.size,
-          mathstyle: if isdisplay { Some("display".into()) } else { Some("text".into()) },
+    let curfont = state.lookup_font().unwrap();
+    if mode == prevmode {
+    } else if ismath {
+      // When entering math mode, we set the font to the default math font,
+      // and save the text font for any embedded text.
+      state.assign_value("savedfont", curfont.clone(), Some(Scope::Local));
+      // TODO:
+      // $STATE->assignValue(script_base_level => scalar(@{ $$self{boxing} }));    # See getScriptLevel
+      let isdisplay = mode.starts_with("display");
+      let new_font = state.lookup_mathfont().unwrap().merge(Font {
+        color: curfont.color.clone(),
+        bg: curfont.bg.clone(),
+        size: curfont.size,
+        mathstyle: if isdisplay { Some("display".into()) } else { Some("text".into()) },
+        ..Font::default()
+      });
+      state.assign_value("font", new_font, Some(Scope::Local));
+    } else {
+      // When entering text mode, we should set the font to the text font in use before the math
+      // but inherit color and size
+      let new_font = if let Some(&Stored::Font(ref saved_font)) = state.lookup_value("savedfont") {
+        Some(saved_font.merge(Font {
+          color: curfont.color.clone(),
+          bg: curfont.bg.clone(),
+          size: curfont.size,
           ..Font::default()
-        });
-        state.assign_value("font", new_font, Some(Scope::Local));
+        }))
       } else {
-        // When entering text mode, we should set the font to the text font in use before the math
-        // but inherit color and size
-        let new_font = if let Some(&Stored::Font(ref saved_font)) = state.lookup_value("savedfont") {
-          Some(saved_font.merge(Font {
-            color: cf.color.clone(),
-            bg: cf.bg.clone(),
-            size: cf.size,
-            ..Font::default()
-          }))
-        } else {
-          None
-        };
-        if let Some(nf) = new_font {
-          state.assign_value("font", nf, Some(Scope::Local));
-        }
+        None
+      };
+      if let Some(nf) = new_font {
+        state.assign_value("font", nf, Some(Scope::Local));
       }
     }
     Ok(())
+  }
+
+  pub fn begin_mode(&mut self, mode: &str, state: &mut State) -> Result<()> {
+    self.push_stack_frame(false, state); // Effectively bgroup
+    self.set_mode(mode, state)
   }
 
   pub fn end_mode(&mut self, mode: &str, state: &mut State) -> Result<()> {

--- a/rtx_core/src/stomach.rs
+++ b/rtx_core/src/stomach.rs
@@ -270,8 +270,8 @@ impl<'t> Stomach {
   }
 
   fn invoke_token_undefined(&mut self, token: &'t Token, state: &mut State) -> Result<Vec<Digested>> {
-    let cs = token.get_cs_name().to_owned(); // TODO: use the Cow directly
-                                             // TODO: state.note_status("undefined", cs);
+    let cs = token.get_cs_name();
+    state.note_status("undefined", cs);
 
     // To minimize chatter, go ahead and define it...
     if cs.starts_with("\\if") {
@@ -309,7 +309,7 @@ impl<'t> Stomach {
     } else {
       let message = s!("The token {} is not defined.", token.stringify());
       Error!("undefined", token, self, state, &message, "Defining it now as <ltx:ERROR/>");
-      let closure_cs = cs;
+      let closure_cs = cs.to_owned();
       state.install_definition(
         Constructor {
           cs: token.clone(),
@@ -444,7 +444,7 @@ impl<'t> Stomach {
 
   pub fn push_stack_frame(&mut self, nobox: bool, state: &mut State) {
     let current_token = match &state.current_token {
-      Some(t) => (*t).clone(),
+      Some(t) => Arc::clone(t),
       _ => unimplemented!(), // should never happen?
     };
 
@@ -462,6 +462,8 @@ impl<'t> Stomach {
   }
 
   pub fn pop_stack_frame(&mut self, nobox: bool, state: &mut State) -> Result<()> {
+    // WRONG! BROKEN! This needs to be a VecDequeStored<Tokens> or some such...
+    // WRONG! BROKEN! rewrite it soon...
     if let Some(Stored::Tokens(beforeafter)) = state.lookup_value("beforeAfterGroup") {
       if !beforeafter.is_empty() {
         let mut result = Vec::new();
@@ -470,12 +472,12 @@ impl<'t> Stomach {
         }
         // TODO
         // if (my ($x) = grep { !$_->isaBox } @result) {
-        // Fatal('misdefined', $x, $self, "Expected a Box|List|Whatsit, but got '" .
-        // Stringify($x) . "'"); }
+        // Error('misdefined', $x, $self, "Expected a Box|List|Whatsit, but got '" . Stringify($x) . "'");
+        // @result = (makeMisdefinedError(@result)); }
         self.box_list.extend(result);
       }
     }
-    let after = state.lookup_value("afterGroup").cloned();
+    let after = state.remove_value("afterGroup");
     state.pop_frame()?;
     if !nobox {
       self.boxing.pop(); // For begingroup/endgroup
@@ -517,7 +519,15 @@ impl<'t> Stomach {
   //======================================================================
 
   /// if $nobox is true, inhibit incrementing the boxingLevel
-  pub fn bgroup(&mut self, state: &mut State) { self.push_stack_frame(false, state); }
+  pub fn bgroup(&mut self, state: &mut State) {
+    self.push_stack_frame(false, state);
+    // NOTE: This is WRONG; should really only track "scanned" (not digested) braces
+    // Alas, there're too many code structuring differences between TeX and LaTeXML
+    // to find all the places to manage it.
+    // So, let's try this for now...
+    // was $LaTeXML::ALIGN_STATE
+    state.align_group_count +=1 ;
+  }
 
   pub fn egroup(&mut self, state: &mut State) -> Result<()> {
     if state.lookup_bool("groupNonBoxing") {
@@ -533,6 +543,7 @@ impl<'t> Stomach {
       // Don't pop if there's an error; maybe we'll recover?
       self.pop_stack_frame(false, state)?;
     }
+    state.align_group_count -=1 ;
     Ok(())
   }
 
@@ -546,7 +557,7 @@ impl<'t> Stomach {
         state.current_token.as_ref().unwrap().to_string(),
         self,
         state,
-        s!("Attempt to close non-boxing group {}", self.current_frame_message(state))
+        s!("Attempt to close non-boxing group; {}", self.current_frame_message(state))
       );
     } else {
       self.pop_stack_frame(true, state)?;

--- a/rtx_core/src/stomach.rs
+++ b/rtx_core/src/stomach.rs
@@ -280,12 +280,11 @@ impl<'t> Stomach {
       let message = s!("The token {} is not defined.", token.stringify());
       Error!("undefined", token, self, state, &message, "Defining it now as with \\newif");
       // install stub definitions for new conditional
-      let cs_clone = cs.clone();
       state.install_definition(
         Expandable::new(
           T_CS!(s!("\\{}true", name)),
           None,
-          Tokens!(T_CS!("\\let"), T_CS!(cs_clone), T_CS!("\\iftrue")),
+          Tokens!(T_CS!("\\let"), T_CS!(cs), T_CS!("\\iftrue")),
           None,
           state,
         ),

--- a/rtx_core/src/stomach.rs
+++ b/rtx_core/src/stomach.rs
@@ -486,7 +486,7 @@ impl<'t> Stomach {
         match entry {
           Stored::Tokens(t) => self.gullet.unread(t),
           Stored::Token(t) => self.gullet.unread_one(t),
-          other => panic!(r"\aftergroup should be used with tokens, got instead: {:?}", other),
+          other => panic!(r"\aftergroup should be used with tokens, got instead: {other:?}"),
         };
       }
     }
@@ -596,7 +596,7 @@ impl<'t> Stomach {
     } else {
       // When entering text mode, we should set the font to the text font in use before the math
       // but inherit color and size
-      let new_font = if let Some(&Stored::Font(ref saved_font)) = state.lookup_value("savedfont") {
+      let new_font = if let Some(Stored::Font(saved_font)) = state.lookup_value("savedfont") {
         Some(saved_font.merge(Font {
           color: curfont.color.clone(),
           bg: curfont.bg.clone(),

--- a/rtx_core/src/tbox.rs
+++ b/rtx_core/src/tbox.rs
@@ -84,7 +84,7 @@ impl Tbox {
     if state.lookup_bool("IN_MATH") {
       properties.insert(s!("mode"), String::from("math").into());
       if !text.is_empty() {
-        if let Some(&Stored::HashString(ref attr)) = state.lookup_value(&s!("math_token_attributes_{}", text)) {
+        if let Some(Stored::HashString(attr)) = state.lookup_value(&s!("math_token_attributes_{}", text)) {
           for (key, value) in attr.iter() {
             properties.entry(key.to_string()).or_insert_with(|| Stored::String(value.to_owned()));
           }

--- a/rtx_core/src/tbox.rs
+++ b/rtx_core/src/tbox.rs
@@ -109,6 +109,7 @@ impl Tbox {
     }
   }
 
+  pub fn is_empty(&self) -> bool { self.text.is_empty() }
   pub fn get_string(&self) -> &str { self.text.as_str() }
 }
 

--- a/rtx_core/src/token.rs
+++ b/rtx_core/src/token.rs
@@ -13,8 +13,7 @@ use crate::common::number::Number;
 use crate::common::object::Object;
 use crate::common::store::Stored;
 use crate::common::numeric_ops::NumericOps;
-use crate::definition::register::{RegisterCell, RegisterValue};
-use crate::definition::Definition;
+use crate::definition::register::{RegisterCell};
 use crate::state::State;
 use crate::stomach::Stomach;
 use crate::tokens::Tokens;
@@ -669,7 +668,7 @@ impl<'a> Token {
     self
   }
 
-  pub fn substitute_parameters(self, args: &[Token]) -> Self {
+  pub fn substitute_parameters(self, args: &[&Token]) -> Self {
     if self.code == Catcode::ARG {
       args[self.text.parse::<usize>().unwrap() - 1].clone()
     } else {
@@ -750,16 +749,6 @@ impl<'a> Token {
   pub fn to_glue(&self) -> Glue { Glue::new_f32(self.text.parse::<f32>().unwrap_or(0.0)) }
 
   pub fn to_mu_glue(&self) -> MuGlue { MuGlue::new_f32(self.text.parse::<f32>().unwrap_or(0.0)) }
-
-  // TODO: This method may cause more issues than it solves... reconsider?
-  // I have already accidentally done token.value_of(Vec::new(), state) and gotten a "0" back
-  // when I really meant "token.to_number().value_of()". The token in question was a simple T_OTHER!("3").
-  pub fn value_of(&self, args: Vec<Token>, state: &mut State) -> Option<RegisterValue> {
-    match self.to_register(state) {
-      None => None,
-      Some(register) => (*register).value_of(args, state),
-    }
-  }
 
   pub fn be_digested(self, stomach: &mut Stomach, state: &mut State) -> Result<Digested> { stomach.digest(Tokens::new(vec![self]), state) }
 }

--- a/rtx_core/src/token.rs
+++ b/rtx_core/src/token.rs
@@ -24,7 +24,7 @@ static CONTROLNAME: &[&str] = &[
   "SYN", "ETB", "CAN", "EM", "SUB", "ESC", "FS", "GS", "RS", "US",
 ];
 
-#[derive(PartialEq, Clone, Copy, Hash, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy, Hash, Debug)]
 pub enum Catcode {
   ESCAPE,
   BEGIN,

--- a/rtx_core/src/tokens.rs
+++ b/rtx_core/src/tokens.rs
@@ -18,7 +18,6 @@ use crate::common::muglue::MuGlue;
 use crate::common::numeric_ops::NumericOps;
 use crate::common::number::Number;
 use crate::common::store::Stored;
-use crate::definition::register::RegisterValue;
 use crate::keyvals::KeyVals;
 use crate::state::State;
 use crate::stomach::Stomach;
@@ -45,9 +44,9 @@ impl PartialEq for Tokens {
 #[macro_export]
 macro_rules! Tokens(
   ($( $tokens:expr ),*) => ({
-    let mut collected : Vec<Token> = Vec::new();
+    let mut collected : Vec<$crate::token::Token> = Vec::new();
     $(
-      let t_vec : Vec<Token> = $tokens.into();
+      let t_vec : Vec<$crate::token::Token> = $tokens.into();
       collected.extend(t_vec);
     )*
     $crate::tokens::Tokens::new(collected)
@@ -109,6 +108,9 @@ impl From<Option<Tokens>> for Token {
 
 impl From<Token> for Option<Tokens> {
   fn from(t: Token) -> Option<Tokens> { Some(Tokens::new(vec![t])) }
+}
+impl From<Token> for Option<Cow<'static, Tokens>> {
+  fn from(t: Token) -> Option<Cow<'static, Tokens>> { Some(Cow::Owned(Tokens::new(vec![t]))) }
 }
 
 impl Display for Tokens {
@@ -238,11 +240,6 @@ impl Tokens {
 
   pub fn stringify(&self) -> String { s!("Tokens[{}]", &self.0.iter().map(ToString::to_string).collect::<Vec<_>>().join(",")) }
 
-  pub fn value_of(&self, args: Vec<Token>, state: &mut State) -> Option<RegisterValue> {
-    let token: &Token = &self.0[0];
-    token.value_of(args, state)
-  }
-
   pub fn be_digested(self, stomach: &mut Stomach, state: &mut State) -> Result<Digested> { stomach.digest(self, state) }
 
   pub fn neutralize(self, extraspecials: &[char], state: &State) -> Tokens {
@@ -263,15 +260,15 @@ impl Tokens {
 
   // NOTE: Assumes each arg either undef or also Tokens
   // Using inline accessors on those assumptions
-  pub fn substitute_parameters(&self, args: Vec<Option<Tokens>>) -> Self {
+  pub fn substitute_parameters(&self, args: &[Option<Cow<Tokens>>]) -> Self {
     let mut result = Vec::new();
     let mut in_tokens = self.0.iter();
     for token in in_tokens {
       if token.get_catcode() != Catcode::ARG {
         // Non-match; copy it
         result.push(token.clone());
-      } else if let Some(arg) = args[token.text.parse::<usize>().unwrap() - 1].clone() {
-        result.extend(arg.unlist());
+      } else if let Some(ref arg) = args[token.text.parse::<usize>().unwrap() - 1] {
+        result.extend(arg.clone().into_owned().unlist());
       }
     }
     Tokens::new(result)

--- a/rtx_core/src/tokens.rs
+++ b/rtx_core/src/tokens.rs
@@ -89,7 +89,7 @@ impl<'a> From<&'a Tokens> for Token {
     } else if ts.0.len() == 1 {
       ts.0.first().unwrap().clone()
     } else {
-      panic!("Dangerous cast! Tokens->Token for {:?}", ts);
+      panic!("Dangerous cast! Tokens->Token for {ts:?}");
       //let code = ts.0.first().unwrap().get_catcode();
       // Warn!("expected","token","multiple Tokens {:?} cast into a single Token: {:?}", ts, single);
       //Token::new(Cow::Owned(ts.to_string()), code)
@@ -118,7 +118,7 @@ impl Display for Tokens {
   /// NOT for creating valid TeX (use revert or UnTeX for that!)
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     for t in &self.0 {
-      write!(f, "{}", t)?;
+      write!(f, "{t}")?;
     }
     Ok(())
   }

--- a/rtx_core/src/util/pathname.rs
+++ b/rtx_core/src/util/pathname.rs
@@ -90,7 +90,7 @@ pub fn canonical(pathname: &str) -> String {
     return pathname.to_owned();
   }
   // Don't call is_absolute, etc, here, cause THEY call US!
-  let home_path: &str = &*HOME_PATH;
+  let home_path: &str = &HOME_PATH;
 
   // TODO: consider using Path's .canonicalize()
 

--- a/rtx_core/src/util/pathname.rs
+++ b/rtx_core/src/util/pathname.rs
@@ -135,7 +135,7 @@ pub fn concat(dir: &str, file: &str) -> String {
   } else {
     let mut path = PathBuf::from(dir);
     path.push(file);
-    canonical(&path.to_string_lossy().to_string())
+    canonical(&path.to_string_lossy())
   }
 }
 

--- a/rtx_core/src/whatsit.rs
+++ b/rtx_core/src/whatsit.rs
@@ -277,4 +277,8 @@ impl BoxOps for Whatsit {
       _ => None,
     }
   }
+
+  fn set_font(&mut self, font: Arc<Font>) {
+    self.properties.insert("font".to_string(), Stored::Font(font));
+  }
 }

--- a/rtx_core/src/whatsit.rs
+++ b/rtx_core/src/whatsit.rs
@@ -67,7 +67,7 @@ impl Whatsit {
   pub fn get_definition(&self) -> Arc<dyn Definition> { Arc::clone(&self.definition) }
   pub fn get_arg(&self, n: usize) -> Option<&Digested> {
     match self.args.get(n - 1) {
-      Some(&Some(ref opt)) => Some(opt),
+      Some(Some(opt)) => Some(opt),
       _ => None,
     }
   }
@@ -75,7 +75,7 @@ impl Whatsit {
   pub fn set_args(&mut self, args: Vec<Option<Digested>>) { self.args = args; }
   pub fn get_trailer(&self) -> Option<Digested> {
     match self.properties.get("trailer") {
-      Some(&Stored::Digested(ref triler)) => Some(*triler.clone()),
+      Some(Stored::Digested(triler)) => Some(*triler.clone()),
       _ => None,
     }
   }
@@ -122,7 +122,7 @@ impl Whatsit {
         } else {
           match props.get(s) {
             Some(Stored::Digested(v)) => Some((**v).clone()),
-            Some(other) => panic!("unexpected prop in substitute_parameters, needed Digested, got: {:?}", other),
+            Some(other) => panic!("unexpected prop in substitute_parameters, needed Digested, got: {other:?}"),
             None => None,
           }
         };
@@ -171,7 +171,7 @@ impl Object for Whatsit {
           Stored::Tokens(tks) => Some(Reversion::Tokens(tks.clone())),
           // TODO?
           // Stored::ReversionClosure(rfn) => Some(Reversion::Closure(rfn)),
-          other => panic!("TODO: Unexpected reversion directive {:?}", other),
+          other => panic!("TODO: Unexpected reversion directive {other:?}"),
         }
       } else {
         defn.get_reversion_spec()
@@ -271,14 +271,14 @@ impl BoxOps for Whatsit {
   }
   fn get_body(&self) -> Option<Digested> {
     match self.properties.get("body") {
-      Some(&Stored::Digested(ref body)) => Some(*body.clone()),
+      Some(Stored::Digested(body)) => Some(*body.clone()),
       _ => None,
     }
   }
 
   fn get_font(&self) -> Option<Cow<Font>> {
     match self.properties.get("font") {
-      Some(&Stored::Font(ref font)) => Some(Cow::Owned((**font).clone())),
+      Some(Stored::Font(font)) => Some(Cow::Owned((**font).clone())),
       _ => None,
     }
   }

--- a/rtx_core/src/whatsit.rs
+++ b/rtx_core/src/whatsit.rs
@@ -53,6 +53,9 @@ impl Whatsit {
       _ => false,
     }
   }
+  pub fn is_empty(&self) -> bool {
+    self.args.is_empty()
+  }
 
   pub fn get_properties(&self) -> &HashMap<String, Stored> { &self.properties }
   pub fn properties(self) -> HashMap<String, Stored> { self.properties }

--- a/rtx_core/src/whatsit.rs
+++ b/rtx_core/src/whatsit.rs
@@ -88,7 +88,9 @@ impl Whatsit {
     self.properties.insert(s!("body"), Digested::List(Arc::new(list)).into());
     if let Some(Digested::Whatsit(ref trailer)) = trailer_opt {
       // And copy any otherwise undefined properties from the trailer
-      for (prop, value) in trailer.read().unwrap().get_properties() {
+      let trailer_val = trailer.read().unwrap();
+      let props = trailer_val.get_properties();
+      for (prop, value) in props {
         self.properties.entry(prop.to_string()).or_insert_with(|| value.clone());
       }
       self.properties.insert(s!("trailer"), trailer_opt.as_ref().unwrap().clone().into());

--- a/rtx_core/tests/01_unit_tokens.rs
+++ b/rtx_core/tests/01_unit_tokens.rs
@@ -41,7 +41,7 @@ fn unit_examples() {
   assert!(!unbalanced.is_balanced(), "Check is not balanced");
 
   // Macro arg substitution tests
-  let nosubst = balanced.substitute_parameters(vec![T_LETTER!("u").into(), T_LETTER!("v").into(), T_LETTER!("w").into()]);
+  let nosubst = balanced.substitute_parameters(&[T_LETTER!("u").into(), T_LETTER!("v").into(), T_LETTER!("w").into()]);
   assert_eq!(nosubst.stringify(), "Tokens[a,{,...,},z]", "Got correct (non)substitution");
   let pattern = Tokens!(
     T_LETTER!("a"),
@@ -55,6 +55,6 @@ fn unit_examples() {
     T_LETTER!("z")
   )
   .pack_parameters();
-  let subst = pattern.substitute_parameters(vec![T_LETTER!("u").into(), T_LETTER!("v").into(), T_LETTER!("w").into()]);
+  let subst = pattern.substitute_parameters(&[T_LETTER!("u").into(), T_LETTER!("v").into(), T_LETTER!("w").into()]);
   assert_eq!(subst.stringify(), "Tokens[a,{,u,m,v,},z]", "Got correct substitution");
 }

--- a/rtx_math_parser/src/grammar/macros.rs
+++ b/rtx_math_parser/src/grammar/macros.rs
@@ -15,11 +15,11 @@ macro_rules! set {
 }
 
 #[macro_export]
-macro_rules! unpack {
+macro_rules! unp {
   ($args:ident => $var:ident) => (let $var = $args.remove(0););
   ($args:ident => $var:ident,$($tail:ident),*) => {
     let $var = $args.remove(0);
-    unpack!($args => $($tail),*)
+    unp!($args => $($tail),*)
   }
 }
 

--- a/rtx_math_parser/src/parser.rs
+++ b/rtx_math_parser/src/parser.rs
@@ -595,7 +595,7 @@ fn textrec(node_opt: &Node, outer_bp_opt: Option<usize>, outer_name_opt: Option<
       };
       let (bp, string) = textrec_apply(&name, &op, args, document, state);
       if (bp < outer_bp) || ((bp == outer_bp) && (name != outer_name)) {
-        format!("({})", string)
+        format!("({string})")
       } else {
         string
       }

--- a/rtx_math_parser/src/pragmatics.rs
+++ b/rtx_math_parser/src/pragmatics.rs
@@ -303,7 +303,7 @@ fn pragma_opfunctions_are_rarely_arguments(tree: &Tree) -> Result<(), Box<dyn Er
 /// Mostly since we can't enforce IDs to strictly have "curry=1", rather
 /// we need them with "curry >= 1", to stay a little more lenient.
 fn pragma_higher_order_ids_are_exceptions(tree: &Tree) -> Result<(), Box<dyn Error>> {
-  if let Tree::Apply(ref op, ref args, _) = &*tree {
+  if let Tree::Apply(ref op, ref args, _) = tree {
     if args.0.len() == 1 {
       match &*op.0 {
         Tree::Lexeme(ref op_name, _) if op_name.starts_with("ID:") => match args.0[0] {

--- a/rtx_math_parser/src/pragmatics.rs
+++ b/rtx_math_parser/src/pragmatics.rs
@@ -100,7 +100,7 @@ impl ValidationPragmatics {
         }
       },
       Tree::Apply(Operator(op), args, _) => {
-        self.validate_recursive(&**op)?;
+        self.validate_recursive(op)?;
         for arg_subtree in args.trees() {
           self.validate_recursive(arg_subtree)?;
         }

--- a/rtx_math_parser/src/pragmatics.rs
+++ b/rtx_math_parser/src/pragmatics.rs
@@ -164,9 +164,9 @@ fn _pragma_letter_case_flat_unstyled(name: &str) -> String {
       match base.rfind(':') {
         Some(position) => {
           let (role, _discard) = base.split_at(position);
-          format!("{}:{}", role, lexeme)
+          format!("{role}:{lexeme}")
         },
-        None => format!("{}:{}", base, lexeme),
+        None => format!("{base}:{lexeme}"),
       }
     },
     None => name.to_owned(),
@@ -564,20 +564,20 @@ lazy_static! {
     let up_greek_blocks = [('Α','Γ'),('Ζ','Θ'),('Ι','Κ'),('Λ','Ξ'),('Ο','Ρ'),('Σ','Υ'),('Φ','Ψ')];
 
     for (start,end) in latin_blocks.iter() {
-      let mark = format!("{}{}",start,end);
+      let mark = format!("{start}{end}");
       let up_start = start.to_ascii_uppercase();
       let up_end = end.to_ascii_uppercase();
       for c_u8 in (*start as u8) ..= (*end as u8) {
         map.insert(c_u8.into(), mark.clone());
       }
-      let up_mark = format!("{}{}", up_start, up_end);
+      let up_mark = format!("{up_start}{up_end}");
       for c_u8 in (up_start as u8)..=(up_end as u8) {
         map.insert(c_u8.into(), up_mark.clone());
       }
     }
 
     for (start,end) in greek_blocks.iter().chain(up_greek_blocks.iter()) {
-      let mark = format!("{}{}",start,end);
+      let mark = format!("{start}{end}");
       for c_u32 in (*start as u32) ..= (*end as u32) {
         map.insert(std::char::from_u32(c_u32).unwrap(), mark.clone());
       }

--- a/rtx_math_parser/src/semantics.rs
+++ b/rtx_math_parser/src/semantics.rs
@@ -43,7 +43,7 @@ impl Actions {
         0 => Ok(None),
         1 => Ok(args.remove(0)),
         more => {
-          eprintln!("Only returning first of {:?} elements at rule id {:?} content: {:?}", more, id, args);
+          eprintln!("Only returning first of {more:?} elements at rule id {id:?} content: {args:?}");
           Ok(args.remove(0))
         },
       }
@@ -253,7 +253,7 @@ pub fn new_script(script: Tree, base: Option<Tree>, nodes: &[XMLNode]) -> Result
 
 /// Looks up the node associated with a given lexeme,
 /// via the node index held in the third colon-separated lexeme piece.
-pub fn lookup_lex_node<'a, 'b>(lex: &'a str, nodes: &'b [XMLNode]) -> Result<&'b XMLNode, Box<dyn Error>> {
+pub fn lookup_lex_node<'a>(lex: &'a str, nodes: &'a [XMLNode]) -> Result<&'a XMLNode, Box<dyn Error>> {
   let node_idx = lex.split(':').last().unwrap().parse::<usize>()?;
   Ok(nodes.get(node_idx).unwrap())
 }

--- a/rtx_math_parser/src/semantics.rs
+++ b/rtx_math_parser/src/semantics.rs
@@ -89,7 +89,7 @@ impl Actions {
 
 /// standard infix application of an operator
 pub fn infix_apply(_rule_id: i32, mut args: Vec<Option<Tree>>, _: &[ValidationPragmatics], _: &[XMLNode]) -> Result<Option<Tree>, Box<dyn Error>> {
-  unpack!(args => arg1, infixop, arg2);
+  unp!(args => arg1, infixop, arg2);
   let apply_tree = Tree::Apply(infixop.into(), Args(vec![arg1, arg2]), Meta::default());
   Ok(Some(apply_tree))
 }
@@ -101,7 +101,7 @@ pub fn infix_apply_and_elide(
   p: &[ValidationPragmatics],
   nodes: &[XMLNode],
 ) -> Result<Option<Tree>, Box<dyn Error>> {
-  unpack!(args => arg1, infixop, arg2, elision);
+  unp!(args => arg1, infixop, arg2, elision);
   // check if "left" is already an application of infix op, in which case we can do n-ary apply.
   if let Some(Tree::Apply(new_op, mut new_args, meta)) = infix_apply_nary(rule_id, vec![arg1, infixop, arg2], p, nodes)? {
     new_args.0.push(elision);
@@ -114,7 +114,7 @@ pub fn infix_apply_and_elide(
 // infix_apply in the base case,
 // but when chained, using the flat "multirelation" behavior of latexml
 pub fn infix_relation(_rule_id: i32, mut args: Vec<Option<Tree>>, _: &[ValidationPragmatics], _: &[XMLNode]) -> Result<Option<Tree>, Box<dyn Error>> {
-  unpack!(args => left, infixop, right);
+  unp!(args => left, infixop, right);
   // if left has a "multirelation" already, add right in.
   // if left applies a relation, flatten it out to infix form.
   // base case - build a simple infix apply
@@ -162,7 +162,7 @@ pub fn infix_apply_nary(
   _: &[ValidationPragmatics],
   _: &[XMLNode],
 ) -> Result<Option<Tree>, Box<dyn Error>> {
-  unpack!(args => left, infixop, right);
+  unp!(args => left, infixop, right);
   let mut left = left;
   // left-to-right associative:
   // 1. if "left" is already an application of "infixop",
@@ -189,11 +189,11 @@ pub fn infix_apply_nary(
 }
 
 pub fn prefix_apply(_rule_id: i32, mut args: Vec<Option<Tree>>, _: &[ValidationPragmatics], _: &[XMLNode]) -> Result<Option<Tree>, Box<dyn Error>> {
-  unpack!(args => prefixop, arg1);
+  unp!(args => prefixop, arg1);
   Ok(Some(Tree::Apply(prefixop.into(), Args(vec![arg1]), Meta::default())))
 }
 pub fn postfix_apply(_rule_id: i32, mut args: Vec<Option<Tree>>, _: &[ValidationPragmatics], _: &[XMLNode]) -> Result<Option<Tree>, Box<dyn Error>> {
-  unpack!(args => arg, op);
+  unp!(args => arg, op);
   Ok(Some(Tree::Apply(op.into(), Args(vec![arg]), Meta::default())))
 }
 
@@ -203,13 +203,13 @@ pub fn circumfix_fenced(
   _: &[ValidationPragmatics],
   _: &[XMLNode],
 ) -> Result<Option<Tree>, Box<dyn Error>> {
-  unpack!(args => _open, arg, _close);
+  unp!(args => _open, arg, _close);
   Ok(arg)
 }
 
 /// remove start_/end_ wrappers
 pub fn faux_wrap(_rule_id: i32, mut args: Vec<Option<Tree>>, _: &[ValidationPragmatics], _: &[XMLNode]) -> Result<Option<Tree>, Box<dyn Error>> {
-  unpack!(args => _faux1, content, _faux2);
+  unp!(args => _faux1, content, _faux2);
   Ok(content)
 }
 
@@ -219,7 +219,7 @@ pub fn postfix_script(
   _: &[ValidationPragmatics],
   nodes: &[XMLNode],
 ) -> Result<Option<Tree>, Box<dyn Error>> {
-  unpack!(args => base, op);
+  unp!(args => base, op);
   new_script(op.unwrap(), base, nodes)
 }
 
@@ -229,7 +229,7 @@ pub fn prefix_script(
   _: &[ValidationPragmatics],
   nodes: &[XMLNode],
 ) -> Result<Option<Tree>, Box<dyn Error>> {
-  unpack!(args => op, base);
+  unp!(args => op, base);
   new_script(op.unwrap(), base, nodes)
 }
 
@@ -272,7 +272,7 @@ pub fn obtain_arg(tree: Tree, n: usize) -> Option<Tree> {
 }
 
 pub fn invisible_times(_rule_id: i32, mut args: Vec<Option<Tree>>, _: &[ValidationPragmatics], _: &[XMLNode]) -> Result<Option<Tree>, Box<dyn Error>> {
-  unpack!(args => left, right);
+  unp!(args => left, right);
   let mut left = left;
   // left-to-right associative -- if "left" is already a "times", tuck "right" in:
   if let Some(Tree::Apply(ref op, ref mut left_args, ref _m)) = left {

--- a/rtx_math_parser/src/semantics/curry.rs
+++ b/rtx_math_parser/src/semantics/curry.rs
@@ -20,7 +20,7 @@ pub enum CurryTerm {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CurryConstraint(pub (CurryTerm, Ordering, CurryTerm));
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CurryConstraints(pub HashSet<CurryConstraint>);
 
 impl Display for CurryTerm {

--- a/rtx_math_parser/src/semantics/curry.rs
+++ b/rtx_math_parser/src/semantics/curry.rs
@@ -26,14 +26,14 @@ pub struct CurryConstraints(pub HashSet<CurryConstraint>);
 impl Display for CurryTerm {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
-      CurryTerm::Arg(v) => write!(f, "arg{}", v),
-      CurryTerm::Var(v) => write!(f, "{}", v),
-      CurryTerm::Literal(u) => write!(f, "{}", u),
+      CurryTerm::Arg(v) => write!(f, "arg{v}"),
+      CurryTerm::Var(v) => write!(f, "{v}"),
+      CurryTerm::Literal(u) => write!(f, "{u}"),
       CurryTerm::Sub(x, y) => match &**y {
-        CurryTerm::Sub(_, _) | CurryTerm::Add(_, _) => write!(f, "{}-({})", x, y),
-        _ => write!(f, "{}-{}", x, y),
+        CurryTerm::Sub(_, _) | CurryTerm::Add(_, _) => write!(f, "{x}-({y})"),
+        _ => write!(f, "{x}-{y}"),
       },
-      CurryTerm::Add(x, y) => write!(f, "{}+{}", x, y),
+      CurryTerm::Add(x, y) => write!(f, "{x}+{y}"),
     }
   }
 }
@@ -45,7 +45,7 @@ impl Display for CurryConstraint {
       Ordering::Less => "<",
       Ordering::Greater => ">",
     };
-    write!(f, "{}{}{}", lhs, cmp_str, rhs)
+    write!(f, "{lhs}{cmp_str}{rhs}")
   }
 }
 

--- a/rtx_math_parser/src/semantics/tree.rs
+++ b/rtx_math_parser/src/semantics/tree.rs
@@ -30,7 +30,7 @@ pub struct XMTok {
 impl Display for XMTok {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     // stub with Debug for now
-    writeln!(f, "{:?}", self)
+    writeln!(f, "{self:?}")
   }
 }
 
@@ -81,7 +81,7 @@ impl Operator {
       } else {
         aux_generate_indent(level, false)
       };
-      writeln!(f, "{}@-op┐", indent,)?;
+      writeln!(f, "{indent}@-op┐")?;
       let mut rhs_level: Vec<bool> = level.to_vec();
       rhs_level.push(true);
       rhs_level.push(false);
@@ -359,17 +359,17 @@ impl Tree {
       Tree::Apply(op, args, meta) => {
         if !meta.syntax_trace.is_empty() {
           let indent_base = aux_generate_indent(level, true);
-          writeln!(f, "{}\n{}{}", indent_base, indent_base, meta)?;
+          writeln!(f, "{indent_base}\n{indent_base}{meta}")?;
         }
         let mut arg_level: Vec<bool> = level.to_vec();
         arg_level.push(true);
         op.fmt_indented(level, f)?;
         args.fmt_indented(&arg_level, f)
       },
-      Tree::Lexeme(name, meta) => writeln!(f, "{}{} {}", indent, name, meta),
-      Tree::Token(t, meta) => writeln!(f, "{}{} {}", indent, t, meta),
+      Tree::Lexeme(name, meta) => writeln!(f, "{indent}{name} {meta}"),
+      Tree::Token(t, meta) => writeln!(f, "{indent}{t} {meta}"),
       Tree::Choices(args) => {
-        writeln!(f, "\n{}Choices", indent)?;
+        writeln!(f, "\n{indent}Choices")?;
         let mut arg_level: Vec<bool> = level.to_vec();
         arg_level.push(true);
         let mut peekable = args.iter().peekable();

--- a/rtx_math_parser/src/semantics/tree.rs
+++ b/rtx_math_parser/src/semantics/tree.rs
@@ -117,9 +117,9 @@ impl Args {
     Ok(())
   }
   /// Obtain defined subtrees as a slice, e.g. for consistency validation
-  pub fn trees(&self) -> Vec<&Tree> { self.0.iter().filter(|x| x.is_some()).map(|x| x.as_ref().unwrap()).collect() }
+  pub fn trees(&self) -> Vec<&Tree> { self.0.iter().filter_map(|x| x.as_ref()).collect() }
   /// Obtain defined subtrees as a mutable slice, e.g. for consistency validation
-  pub fn trees_mut(&mut self) -> Vec<&mut Tree> { self.0.iter_mut().filter(|x| x.is_some()).map(|x| x.as_mut().unwrap()).collect() }
+  pub fn trees_mut(&mut self) -> Vec<&mut Tree> { self.0.iter_mut().filter_map(|x| x.as_mut()).collect() }
 
   /// borrow the constraints and pass them to the outer caller
   pub fn get_constraints(&self) -> Vec<&CurryConstraint> { self.trees().into_iter().flat_map(|t| t.get_meta().curry_constraints.iter()).collect() }

--- a/rtx_math_parser/src/util.rs
+++ b/rtx_math_parser/src/util.rs
@@ -9,7 +9,7 @@ pub fn node_to_grammar_lexemes(mathnode: &Node, idx: &mut usize) -> (Vec<String>
   let top_role_opt = mathnode.get_attribute("role");
   if let Some(ref top_role) = top_role_opt {
     *idx += 1;
-    lexemes.push(format!("start_{}:start:{}", top_role, idx));
+    lexemes.push(format!("start_{top_role}:start:{idx}"));
     nodes.push(mathnode.clone());
   }
   let child_nodes = filter_hints(mathnode.get_child_nodes());
@@ -27,14 +27,14 @@ pub fn node_to_grammar_lexemes(mathnode: &Node, idx: &mut usize) -> (Vec<String>
         text = "UNKNOWN".to_string();
       }
       *idx += 1;
-      let lexeme = format!("{}:{}:{}", role, text, idx).replace(' ', "");
+      let lexeme = format!("{role}:{text}:{idx}").replace(' ', "");
       lexemes.push(lexeme);
       nodes.push(node);
     }
   }
   if let Some(top_role) = top_role_opt {
     *idx += 1;
-    lexemes.push(format!("end_{}:end:{}", top_role, idx));
+    lexemes.push(format!("end_{top_role}:end:{idx}"));
     nodes.push(mathnode.clone());
   }
   (lexemes, nodes)

--- a/rtx_package/Cargo.toml
+++ b/rtx_package/Cargo.toml
@@ -21,10 +21,3 @@ unidecode = "0.3.0"
 chrono = "0.4"
 rtx_codegen = {path = "../rtx_codegen"}
 rtx_core = {path = "../rtx_core"}
-
-[dev-dependencies]
-criterion = "0.3.0"
-
-[[bench]]
-name = "integration_benchmarks"
-harness = false

--- a/rtx_package/src/package/api/content.rs
+++ b/rtx_package/src/package/api/content.rs
@@ -304,8 +304,9 @@ pub fn input(mut request: &str, options: InputOptions, stomach: &mut Stomach, st
   //   }
   } else {
     // Couldn't find anything?
-    state.note_status("missing"); //, request);
-                                  // We presumably are trying to input Content; an error if we can't find it (contrast to Definitions)
+    state.note_status("missing", request);
+
+    // We presumably are trying to input Content; an error if we can't find it (contrast to Definitions)
     let gullet = stomach.get_gullet();
     Error!("missing_file", request, gullet, state, s!("Can't find TeX file {}", request));
     //  maybeReportSearchPaths());

--- a/rtx_package/src/package/api/counter_dialect.rs
+++ b/rtx_package/src/package/api/counter_dialect.rs
@@ -431,7 +431,7 @@ fn deactivate_counter_scope(ctr: &str, state: &mut State) {
       if let Stored::String(scope) = scope_stored {
         state.deactivate_scope(&scope);
       } else {
-        panic!("assignmenet scopes should be stored as strings, got: {:?}", scope_stored);
+        panic!("assignmenet scopes should be stored as strings, got: {scope_stored:?}");
       }
     }
   }

--- a/rtx_package/src/package/api/counter_dialect.rs
+++ b/rtx_package/src/package/api/counter_dialect.rs
@@ -286,11 +286,12 @@ pub fn step_counter(ctr: &str, noreset: bool, stomach: &mut Stomach, state: &mut
   Ok(())
 }
 
-pub struct RefStepValue {
-  pub id: Option<String>,
-  pub tags: Option<Tokens>,
-}
-
+/// Analog of `\refstepcounter`, steps the counter and returns a hash
+/// containing the keys `refnum` and `id`.  This makes it
+/// suitable for use in a `properties` option to constructors.
+/// The `id` is generated in parallel with the reference number
+/// to assist debugging.
+///
 pub fn ref_step_counter(ctype: &str, noreset: bool, stomach: &mut Stomach, state: &mut State) -> Result<HashMap<String, Stored>> {
   let ctr = match state.lookup_mapping("counter_for_type", ctype) {
     Some(Stored::String(ctr)) => ctr.to_string(),
@@ -443,7 +444,10 @@ fn deactivate_counter_scope(ctr: &str, state: &mut State) {
   }
 }
 
-// For UN-numbered units
+/// For UN-numbered units.
+/// Like `RefStepCounter`, but only steps the "uncounter",
+/// and returns only the id;  This is useful for unnumbered cases
+/// of objects that normally get both a refnum and id.
 pub fn ref_step_id(ctype: &str, stomach: &mut Stomach, state: &mut State) -> Result<HashMap<String, Stored>> {
   let ctr = match state.lookup_mapping("counter_for_type", ctype) {
     Some(map) => map.to_string(),

--- a/rtx_package/src/package/api/def_dialect.rs
+++ b/rtx_package/src/package/api/def_dialect.rs
@@ -24,6 +24,7 @@ use rtx_core::token::*;
 use rtx_core::tokens::Tokens;
 use rtx_core::whatsit::Whatsit;
 use rtx_core::Digested;
+use rtx_core::definition::argument::ArgWrap;
 
 use super::content::merge_font;
 use super::*;
@@ -319,7 +320,7 @@ pub fn def_register<T: Into<RegisterValue>>(cs: Token, parameters: Option<Parame
 
   let getter: RegisterGetterClosure = match options.getter {
     Some(getter) => getter.clone(),
-    None => Arc::new(move |args: Vec<Token>, state: &State| -> Option<RegisterValue> {
+    None => Arc::new(move |args: Vec<ArgWrap>, state: &State| -> Option<RegisterValue> {
       let args_string: String = args.iter().map(ToString::to_string).collect::<Vec<String>>().join("");
       match state.lookup_value(&(name.clone() + &args_string)) {
         None => Some(getter_value.clone()),
@@ -364,7 +365,7 @@ pub fn def_register<T: Into<RegisterValue>>(cs: Token, parameters: Option<Parame
   );
 }
 
-pub fn def_primitive(cs: Token, paramlist: Option<Parameters>, compiled_replacement: PrimitiveClosure, options: PrimitiveOptions, state: &mut State) {
+pub fn def_primitive(cs: Token, paramlist: Option<Parameters>, compiled_replacement: Option<PrimitiveClosure>, options: PrimitiveOptions, state: &mut State) {
   let options_locked = options.locked;
   let scope = options.scope;
   let mut before_digest_env: Vec<BeforeDigestClosure> = Vec::new();
@@ -419,7 +420,7 @@ pub fn def_primitive(cs: Token, paramlist: Option<Parameters>, compiled_replacem
     Primitive {
       cs,
       paramlist,
-      replacement: Some(compiled_replacement),
+      replacement: compiled_replacement,
       before_digest: before_digest_env,
       after_digest: after_digest_env,
       alias: options.alias,

--- a/rtx_package/src/package/api/def_dialect.rs
+++ b/rtx_package/src/package/api/def_dialect.rs
@@ -340,7 +340,7 @@ pub fn def_register<T: Into<RegisterValue>>(cs: Token, parameters: Option<Parame
         })
       } else {
         Arc::new(move |value, args, state| {
-          let args_string: String = args.iter().map(ToString::to_string).collect::<Vec<String>>().join("");
+          let args_string: String = args.into_iter().map(|a| a.owned_tokens().unwrap().to_string()).collect::<Vec<String>>().join("");
 
           state.assign_value(&(setter_name.clone() + &args_string), value, None);
         })

--- a/rtx_package/src/package/api/def_dialect.rs
+++ b/rtx_package/src/package/api/def_dialect.rs
@@ -340,7 +340,7 @@ pub fn def_register<T: Into<RegisterValue>>(cs: Token, parameters: Option<Parame
         })
       } else {
         Arc::new(move |value, args, state| {
-          let args_string: String = args.into_iter().map(|a| a.owned_tokens().unwrap().to_string()).collect::<Vec<String>>().join("");
+          let args_string: String = args.into_iter().map(|a| a.as_tokens(state).expect("TODO: handle malformed values here.").unwrap().to_string()).collect::<Vec<String>>().join("");
 
           state.assign_value(&(setter_name.clone() + &args_string), value, None);
         })

--- a/rtx_package/src/package/api/mod.rs
+++ b/rtx_package/src/package/api/mod.rs
@@ -284,6 +284,9 @@ impl IntoRegisterValueOption<Option<RegisterValue>> for () {
 impl IntoRegisterValueOption<Option<RegisterValue>> for Option<RegisterValue> {
   fn into_register_value_option(self) -> Option<RegisterValue> { self }
 }
+impl IntoRegisterValueOption<Option<RegisterValue>> for usize {
+  fn into_register_value_option(self) -> Option<RegisterValue> { Some(RegisterValue::Number(Number(self as i32))) }
+}
 impl IntoRegisterValueOption<Option<RegisterValue>> for Number {
   fn into_register_value_option(self) -> Option<RegisterValue> { Some(RegisterValue::Number(self)) }
 }

--- a/rtx_package/src/package/api/mod.rs
+++ b/rtx_package/src/package/api/mod.rs
@@ -15,6 +15,7 @@ use rtx_core::common::glue::Glue;
 use rtx_core::common::mudimension::MuDimension;
 use rtx_core::common::muglue::MuGlue;
 use rtx_core::common::number::Number;
+use rtx_core::common::float::Float;
 use rtx_core::common::store::Stored;
 use rtx_core::definition::register::*;
 use rtx_core::definition::argument::ArgWrap;
@@ -218,6 +219,48 @@ impl IntoResultArgWrap<Result<ArgWrap>> for Result<Tokens> {
 
 impl IntoResultArgWrap<Result<ArgWrap>> for Result<Option<Tokens>> {
   fn into_result_argwrap(self) -> Result<ArgWrap> { self.map(ArgWrap::OptionTokens) }
+}
+
+impl IntoResultArgWrap<Result<ArgWrap>> for Number {
+  fn into_result_argwrap(self) -> Result<ArgWrap> { Ok(ArgWrap::Number(self)) }
+}
+
+impl IntoResultArgWrap<Result<ArgWrap>> for Option<Number> {
+  fn into_result_argwrap(self) -> Result<ArgWrap> { Ok(ArgWrap::OptionNumber(self)) }
+}
+impl IntoResultArgWrap<Result<ArgWrap>> for Float {
+  fn into_result_argwrap(self) -> Result<ArgWrap> { Ok(ArgWrap::Float(self)) }
+}
+impl IntoResultArgWrap<Result<ArgWrap>> for Option<Float> {
+  fn into_result_argwrap(self) -> Result<ArgWrap> { Ok(ArgWrap::OptionFloat(self)) }
+}
+
+impl IntoResultArgWrap<Result<ArgWrap>> for Dimension {
+  fn into_result_argwrap(self) -> Result<ArgWrap> { Ok(ArgWrap::Dimension(self)) }
+}
+
+impl IntoResultArgWrap<Result<ArgWrap>> for Option<Dimension> {
+  fn into_result_argwrap(self) -> Result<ArgWrap> { Ok(ArgWrap::OptionDimension(self)) }
+}
+
+impl IntoResultArgWrap<Result<ArgWrap>> for MuDimension {
+  fn into_result_argwrap(self) -> Result<ArgWrap> { Ok(ArgWrap::MuDimension(self)) }
+}
+
+impl IntoResultArgWrap<Result<ArgWrap>> for Option<MuDimension> {
+  fn into_result_argwrap(self) -> Result<ArgWrap> { Ok(ArgWrap::OptionMuDimension(self)) }
+}
+impl IntoResultArgWrap<Result<ArgWrap>> for Glue {
+  fn into_result_argwrap(self) -> Result<ArgWrap> { Ok(ArgWrap::Glue(self)) }
+}
+impl IntoResultArgWrap<Result<ArgWrap>> for Option<Glue> {
+  fn into_result_argwrap(self) -> Result<ArgWrap> { Ok(ArgWrap::OptionGlue(self)) }
+}
+impl IntoResultArgWrap<Result<ArgWrap>> for MuGlue {
+  fn into_result_argwrap(self) -> Result<ArgWrap> { Ok(ArgWrap::MuGlue(self)) }
+}
+impl IntoResultArgWrap<Result<ArgWrap>> for Option<MuGlue> {
+  fn into_result_argwrap(self) -> Result<ArgWrap> { Ok(ArgWrap::OptionMuGlue(self)) }
 }
 
 

--- a/rtx_package/src/package/api/mod.rs
+++ b/rtx_package/src/package/api/mod.rs
@@ -17,6 +17,7 @@ use rtx_core::common::muglue::MuGlue;
 use rtx_core::common::number::Number;
 use rtx_core::common::store::Stored;
 use rtx_core::definition::register::*;
+use rtx_core::definition::argument::ArgWrap;
 use rtx_core::definition::{Reversion, SizingClosure};
 use rtx_core::keyvals::KeyVals;
 use rtx_core::list::List;
@@ -157,6 +158,15 @@ impl IntoTokensResult<Result<Tokens>> for () {
   fn into_tokens_result(self) -> Result<Tokens> { Ok(Tokens!()) }
 }
 
+impl IntoTokensResult<Result<Tokens>> for ArgWrap {
+  // TODO: maybe this should be .revert() ?
+  fn into_tokens_result(self) -> Result<Tokens> { Ok(self.owned_tokens().unwrap_or_default()) }
+}
+impl IntoTokensResult<Result<Tokens>> for Result<ArgWrap> {
+  // TODO: maybe this should be .revert() ?
+  fn into_tokens_result(self) -> Result<Tokens> { self.map(|w| w.owned_tokens().unwrap_or_default()) }
+}
+
 pub trait IntoResultOptTokens<T>: Sized {
   fn into_result_opt_tokens(self) -> Result<Option<Tokens>>;
 }
@@ -184,6 +194,41 @@ impl IntoResultOptTokens<Result<Option<Tokens>>> for Result<Option<Tokens>> {
 impl IntoResultOptTokens<Result<Option<Tokens>>> for () {
   fn into_result_opt_tokens(self) -> Result<Option<Tokens>> { Ok(None) }
 }
+
+
+pub trait IntoResultArgWrap<T>: Sized {
+  fn into_result_argwrap(self) -> Result<ArgWrap>;
+}
+
+impl IntoResultArgWrap<Result<ArgWrap>> for Token {
+  fn into_result_argwrap(self) -> Result<ArgWrap> { Ok(ArgWrap::Tokens(Tokens!(self))) }
+}
+
+impl IntoResultArgWrap<Result<ArgWrap>> for Vec<Token> {
+  fn into_result_argwrap(self) -> Result<ArgWrap> { Ok(ArgWrap::Tokens(Tokens::new(self))) }
+}
+
+impl IntoResultArgWrap<Result<ArgWrap>> for Tokens {
+  fn into_result_argwrap(self) -> Result<ArgWrap> { Ok(ArgWrap::Tokens(self)) }
+}
+
+impl IntoResultArgWrap<Result<ArgWrap>> for Result<Tokens> {
+  fn into_result_argwrap(self) -> Result<ArgWrap> { self.map(ArgWrap::Tokens) }
+}
+
+impl IntoResultArgWrap<Result<ArgWrap>> for Result<Option<Tokens>> {
+  fn into_result_argwrap(self) -> Result<ArgWrap> { self.map(ArgWrap::OptionTokens) }
+}
+
+
+impl IntoResultArgWrap<Result<ArgWrap>> for Result<ArgWrap> {
+  fn into_result_argwrap(self) -> Result<ArgWrap> { self }
+}
+
+impl IntoResultArgWrap<Result<ArgWrap>> for () {
+  fn into_result_argwrap(self) -> Result<ArgWrap> { Ok(ArgWrap::OptionTokens(None)) }
+}
+
 
 pub trait IntoBoolResult<T>: Sized {
   /// Performs the conversion, used for DefConditional return values etc

--- a/rtx_package/src/package/api_macros.rs
+++ b/rtx_package/src/package/api_macros.rs
@@ -49,14 +49,14 @@ macro_rules! transfer_opt_default {
 #[macro_export]
 macro_rules! noprimitive {
   () => {
-    |stomach: &mut Stomach, args: Vec<Option<Tokens>>, state: &mut State| Ok(Vec::new())
+    |stomach: &mut Stomach, args: Vec<ArgWrap>, state: &mut State| Ok(Vec::new())
   };
 }
 
 #[macro_export]
 macro_rules! primitivesub {
   ($stomach:ident, $args:ident, $inner_state:ident, $body:block) => {
-    move |$stomach: &mut Stomach, mut $args: Vec<Option<Tokens>>, $inner_state: &mut State| {
+    move |$stomach: &mut Stomach, mut $args: Vec<ArgWrap>, $inner_state: &mut State| {
       BindInnerState!($stomach, $inner_state);
       let macro_out = $body;
       end_state_frame!();
@@ -67,7 +67,7 @@ macro_rules! primitivesub {
 #[macro_export]
 macro_rules! primitiveproc {
   ($stomach:ident, $args:ident, $inner_state:ident, $body:block) => (
-    |$stomach:&mut Stomach, mut $args : Vec<Option<Tokens>>, $inner_state:&mut State| {
+    |$stomach:&mut Stomach, mut $args : Vec<ArgWrap>, $inner_state:&mut State| {
       BindInnerState!($stomach, $inner_state);
       $body
       end_state_frame!();
@@ -208,8 +208,8 @@ macro_rules! after_digest_single {
 macro_rules! reader {
   ($gullet:ident, $inner:ident, $extra:ident, $state:ident, $body:block) => {
     Arc::new(
-      |$gullet: &mut Gullet, $inner: Vec<Option<Parameters>>, $extra: &[ParameterExtra], $state: &mut State| -> Result<Option<Tokens>> {
-        WithInnerState!($body, $state).into_result_opt_tokens()
+      |$gullet: &mut Gullet, $inner: Vec<Option<Parameters>>, $extra: &[ParameterExtra], $state: &mut State| -> Result<ArgWrap> {
+        WithInnerState!($body, $state).into_result_argwrap()
       },
     )
   };
@@ -219,7 +219,7 @@ macro_rules! reader {
 macro_rules! reader_predigest {
   ($stomach:ident, $arg:ident, $state:ident, $body:block) => {
     Some(Arc::new(
-      |$stomach: &mut Stomach, $arg: Tokens, $state: &mut State| -> Result<Option<Digested>> {
+      |$stomach: &mut Stomach, $arg: ArgWrap, $state: &mut State| -> Result<Option<Digested>> {
         WithInnerState!($body, $stomach, $state).into_digested_option_result()
       },
     ))
@@ -229,7 +229,7 @@ macro_rules! reader_predigest {
 #[macro_export]
 macro_rules! getter {
   ($args: ident, $state:ident, $body:block) => {
-    Some(Arc::new(move |$args: Vec<Token>, $state: &State| -> Option<RegisterValue> {
+    Some(Arc::new(move |mut $args: Vec<ArgWrap>, $state: &State| -> Option<RegisterValue> {
       WithInnerState!($body, $state).into_register_value_option()
     }))
   };
@@ -238,7 +238,7 @@ macro_rules! getter {
 #[macro_export]
 macro_rules! setter {
   ($value:ident, $args: ident, $state:ident, $body:block) => {
-    Some(Arc::new(move |$value: RegisterValue, $args: Vec<Tokens>, $state: &mut State| {
+    Some(Arc::new(move |$value: RegisterValue, mut $args: Vec<ArgWrap>, $state: &mut State| {
       WithInnerState!($body, $state)
     }))
   };
@@ -248,7 +248,7 @@ macro_rules! setter {
 macro_rules! undigested {
   () => {
     Some(Arc::new(
-      |stomach: &mut Stomach, arg: Tokens, state: &mut State| -> Result<Option<Digested>> { Ok(Some(Digested::Postponed(Arc::new(arg)))) },
+      |stomach: &mut Stomach, arg: ArgWrap, state: &mut State| -> Result<Option<Digested>> { Ok(Some(Digested::Postponed(Arc::new(arg.owned_tokens().unwrap_or_default())))) },
     ))
   };
 }
@@ -361,11 +361,7 @@ macro_rules! unpack_to_string {
 #[macro_export]
 macro_rules! unpack_to_token {
   ($args:ident => $var:ident) => (
-    let tmp_tks = $args.remove(0);
-    if tmp_tks.is_none() || tmp_tks.as_ref().unwrap().is_empty() {
-      panic!("Hard assumption for Token argument failed -- arg was empty in unpack_to_token!()");
-    }
-    let $var : Token = tmp_tks.unwrap().into();
+    let $var : Token = $args.remove(0).expected_token()?;
   );
   ($args:ident => $var:ident,$($tail:ident),*) => (
     unpack_to_token!($args => $var);
@@ -389,9 +385,9 @@ macro_rules! count_unpack_to_string {
 
 #[macro_export]
 macro_rules! unpack {
-  ($args:ident => $var:ident) => (let $var = $args.remove(0).unwrap_or_default(););
+  ($args:ident => $var:ident) => (let $var = $args.remove(0).owned_tokens().unwrap(););
   ($args:ident => $var:ident,$($tail:ident),*) => {
-    let $var = $args.remove(0).unwrap_or_default();
+    let $var = $args.remove(0).owned_tokens().unwrap();
     unpack!($args => $($tail),*)
   }
 }

--- a/rtx_package/src/package/api_macros.rs
+++ b/rtx_package/src/package/api_macros.rs
@@ -352,6 +352,8 @@ macro_rules! prop_bool {
   };
 }
 
+/// unpacks a `Vec<ArgWrap>` argument into a flexary number of `String`-typed variables
+/// uses the usual `.to_string()` method from the `Display` trait.
 #[macro_export]
 macro_rules! unpack_to_string {
   ($args:ident => $var:ident) => (count_unpack_to_string!(0usize, $args => $var));
@@ -392,6 +394,7 @@ macro_rules! unpack {
   }
 }
 
+/// Convenience macro to flexibly unpack a collection of `Vec<ArgWrap>` arguments into individual `Tokens` variables.
 #[macro_export]
 macro_rules! unref {
   ($args:ident => $var:ident) => (count_unpack_ref!(0usize, $args => $var));
@@ -408,26 +411,29 @@ macro_rules! count_unpack_ref {
   };
 }
 
-/// Meant to be used for unpacking &Vec<Option<Digested>> in particular.
+/// An alternative to `unpack!(args=>arg1,arg2...)`
+/// which allows for optional arguments.
 #[macro_export]
 macro_rules! unpack_opt {
+  ($args:ident => $var:ident) => (let $var = $args.remove(0););
+  ($args:ident => $var:ident,$($tail:ident),*) => {
+    let $var = $args.remove(0);
+    unpack_opt!($args => $($tail),*)
+  }
+}
+
+/// Meant to be used for unpacking &Vec<Option<Digested>> in particular.
+#[macro_export]
+macro_rules! unpack_opt_ref {
   ($args:ident => $var:ident) => (count_unpack_opt!(0usize, $args => $var));
   ($args:ident => $var:ident,$($tail:ident),*) => (count_unpack_opt!(0usize, $args => $var,$($tail),*));
 }
-
-#[macro_export]
 macro_rules! count_unpack_opt {
   ($index:expr, $args:ident => $var:ident) => (
-    let $var = match $args.get($index) {
-      Some(v) => v,
-      None => &None
-    };
+    let $var = $args.get($index);
   );
   ($index:expr, $args:ident => $var:ident,$($tail:ident),*) => {
-    let $var = match $args.get($index) {
-      Some(v) => v,
-      None => &None
-    };
+    let $var = $args.get($index);
     count_unpack_opt!(1usize+$index, $args => $($tail),*)
   }
 }

--- a/rtx_package/src/package/api_macros.rs
+++ b/rtx_package/src/package/api_macros.rs
@@ -248,7 +248,13 @@ macro_rules! setter {
 macro_rules! undigested {
   () => {
     Some(Arc::new(
-      |stomach: &mut Stomach, arg: ArgWrap, state: &mut State| -> Result<Option<Digested>> { Ok(Some(Digested::Postponed(Arc::new(arg.owned_tokens().unwrap_or_default())))) },
+      |stomach: &mut Stomach, arg: ArgWrap, state: &mut State| -> Result<Option<Digested>> {
+        if arg.is_none() {
+          Ok(None)
+        } else {
+          Ok(Some(Digested::Postponed(Arc::new(arg.owned_tokens().unwrap_or_default()))))
+        }
+      }
     ))
   };
 }

--- a/rtx_package/src/package/api_macros.rs
+++ b/rtx_package/src/package/api_macros.rs
@@ -378,6 +378,17 @@ macro_rules! unpack_to_token {
 }
 
 #[macro_export]
+macro_rules! unpack_to_number {
+  ($args:ident => $var:ident) => (
+    let $var : Number = $args.remove(0).to_number();
+  );
+  ($args:ident => $var:ident,$($tail:ident),*) => (
+    unpack_to_number!($args => $var);
+    unpack_to_number!($args => $($tail),*)
+  );
+}
+
+#[macro_export]
 macro_rules! count_unpack_to_string {
   ($index:expr, $args:ident => $var:ident) => (
     let $var = match $args[$index].as_ref() {

--- a/rtx_package/src/package/mod.rs
+++ b/rtx_package/src/package/mod.rs
@@ -26,6 +26,7 @@ pub use rtx_core::definition::expandable::{Expandable, ExpandableOptions};
 pub use rtx_core::definition::math_primitive::{MathPrimitive, MathPrimitiveOptions};
 pub use rtx_core::definition::primitive::{Primitive, PrimitiveOptions};
 pub use rtx_core::definition::register::{Register, RegisterType, RegisterValue};
+pub use rtx_core::definition::argument::ArgWrap;
 pub use rtx_core::common::numeric_ops::NumericOps;
 pub use rtx_core::definition::ConditionalClosure;
 pub use rtx_core::definition::{

--- a/rtx_package/src/package/pool/comment_sty.rs
+++ b/rtx_package/src/package/pool/comment_sty.rs
@@ -5,7 +5,7 @@ LoadDefinitions!(outer_state, {
   // Define \name and \begin{name} to start an ignored section
   // until \endname or \end{name}, respectively
   let define_excluded: PrimitiveClosure = Arc::new(primitiveproc!(stomach, args, state, {
-    let name = args[0].to_string();
+    unpack!(args=>name);
     let begin_mark = s!("\\begin{{{}}}", name);
     let end_mark = s!("\\end{{{}}}", name);
     DefConstructor!(T_CS!(begin_mark), None, None,
@@ -28,7 +28,7 @@ LoadDefinitions!(outer_state, {
   // twice instead, via a macro
   let define_included: PrimitiveClosure = Arc::new(primitiveproc!(stomach, args, inner_state, {
     args.reverse(); // we'll be using .pop() from the front
-    let name = args.pop().unwrap().to_string();
+    let name = args.pop().unwrap().owned_tokens().expect("expecting a Tokens argument").to_string();
     let mut before_tokens = match args.pop() {
       Some(arg) => arg.unlist(),
       None => Vec::new(),

--- a/rtx_package/src/package/pool/comment_sty.rs
+++ b/rtx_package/src/package/pool/comment_sty.rs
@@ -5,7 +5,7 @@ LoadDefinitions!(outer_state, {
   // Define \name and \begin{name} to start an ignored section
   // until \endname or \end{name}, respectively
   let define_excluded: PrimitiveClosure = Arc::new(primitiveproc!(stomach, args, state, {
-    unpack_to_string!(args => name);
+    let name = args[0].to_string();
     let begin_mark = s!("\\begin{{{}}}", name);
     let end_mark = s!("\\end{{{}}}", name);
     DefConstructor!(T_CS!(begin_mark), None, None,
@@ -28,14 +28,14 @@ LoadDefinitions!(outer_state, {
   // twice instead, via a macro
   let define_included: PrimitiveClosure = Arc::new(primitiveproc!(stomach, args, inner_state, {
     args.reverse(); // we'll be using .pop() from the front
-    let name = args.pop().unwrap().unwrap().to_string();
+    let name = args.pop().unwrap().to_string();
     let mut before_tokens = match args.pop() {
-      Some(arg) => arg.unwrap().unlist(),
+      Some(arg) => arg.unlist(),
       None => Vec::new(),
     };
     before_tokens.push(T_CS!("\\ignorespaces"));
     let mut after_tokens = match args.pop() {
-      Some(arg) => arg.unwrap().unlist(),
+      Some(arg) => arg.unlist(),
       None => Vec::new(),
     };
     after_tokens.push(T_CS!("\\ignorespaces"));
@@ -45,16 +45,16 @@ LoadDefinitions!(outer_state, {
     None,
     sub[gullet, _args, macro_state] {
       gullet.read_raw_line(macro_state); // IGNORE 1st line (after the \begin{$name} !!!
-      Ok(before_tokens.clone().into())
+      before_tokens.clone()
     });
     DefMacro!(T_CS!(s!("\\end{{{}}}", name)), None, Tokens::new(after_tokens));
   }));
 
   let mut mock_stomach = Stomach::default();
-  define_excluded(&mut mock_stomach, vec![Some(Tokenize!("comment", None))], outer_state)?;
+  define_excluded(&mut mock_stomach, vec![ArgWrap::Tokens(Tokenize!("comment", None))], outer_state)?;
 
-  DefPrimitive!("\\includecomment{}", Arc::clone(&define_included));
-  DefPrimitive!("\\excludecomment{}", define_excluded);
-  DefPrimitive!("\\specialcomment{}{}{}", define_included);
+  DefPrimitive!("\\includecomment{}", Some(Arc::clone(&define_included)));
+  DefPrimitive!("\\excludecomment{}", Some(define_excluded));
+  DefPrimitive!("\\specialcomment{}{}{}", Some(define_included));
   DefPrimitive!("\\processcomment{}{}{}{}", None);
 });

--- a/rtx_package/src/package/pool/etex.rs
+++ b/rtx_package/src/package/pool/etex.rs
@@ -32,8 +32,8 @@ LoadDefinitions!(state, {
 
   // \readline; like \read, but only spaces & other
   DefMacro!("\\readline Number SkipKeyword:to SkipSpaces Token", sub[gullet, args, state] {
-    unpack_to_token!(args => port, token);
-    let port = port.to_number();
+    let port = args.remove(0).to_number();
+    unpack_to_token!(args => token);
     let mouth_opt = if let Some(Stored::Mouth(mouth)) = LookupValue!(&s!("input_file:{}",port)) {
       Some(Arc::clone(mouth))
     } else {

--- a/rtx_package/src/package/pool/etex.rs
+++ b/rtx_package/src/package/pool/etex.rs
@@ -56,13 +56,12 @@ LoadDefinitions!(state, {
   DefMacro!("\\eTeXrevision", sub[gullet,args,state] { Explode!(".2") });
   DefRegister!("\\eTeXversion" => Number!(2));
 
-  // # \currentgrouplevel
-  // DefRegister('\currentgrouplevel', Number(0),
-  //   readonly => 1,
-  //   getter => sub { $STATE->getFrameDepth; });
+  // \currentgrouplevel
+  DefRegister!("\\currentgrouplevel", Number!(0), readonly => true,
+    getter => sub[args, state] { state.get_frame_depth() });
 
-  // # \currentgrouptype returns group types from 0..16 ; but what IS a "group type"?
-  // DefRegister('\currentgrouptype', Number(0), readonly => 1);
+  // \currentgrouptype returns group types from 0..16 ; but what IS a "group type"?
+  DefRegister!("\\currentgrouptype", Number!(0), readonly => true);
 
   // \ifcsname stuff \endcsname
   DefConditional!("\\ifcsname CSName", sub[gullet, args, state] {
@@ -117,26 +116,31 @@ LoadDefinitions!(state, {
 
   // #======================================================================
   // # 3.6 Additional debugging features
-  // DefRegister('\interactionmode' => Number(0));
+  DefRegister!("\\interactionmode" => Number::new(0));
 
   // # Should show all open groups & their type.
-  // DefPrimitive('\showgroups', undef);
+  DefPrimitive!("\\showgroups", None);
 
   // # \showtokens <generaltext>
-  // # NOTE Debugging aids are currently IGNORED!
-  // DefPrimitive('\showtokens GeneralText', undef);
+  // DefPrimitive!("\\showtokens GeneralText",  sub {
+  //   Note("> " . writableTokens($_[1]));
+  //   Note($_[0]->getLocator->toString());
+  //   return; });
 
-  // DefRegister('\tracingassigns'    => Number(0));    # ???
-  // DefRegister('\tracinggroups'     => Number(0));
-  // DefRegister('\tracingifs'        => Number(0));    # ???
-  // DefRegister('\tracingscantokens' => Number(0));
+  DefRegister!("\\tracingassigns"    => Number::new(0));    // ???
+  DefRegister!("\\tracinggroups"     => Number::new(0));
+  DefRegister!("\\tracingifs"        => Number::new(0));    // ???
+  DefRegister!("\\tracingscantokens" => Number::new(0));
+  DefRegister!("\\tracingnesting"    => Number::new(0));
+  DefRegister!("\\savingvdiscards"   => Number::new(0));
+  DefRegister!("\\savinghyphcodes"   => Number::new(0));
 
   // #======================================================================
   // # 3.7 Miscellaneous primitives
 
   // # \everyeof
   // # NOTE: These tokens are NOT used anywhere (yet?)
-  // DefRegister('\everyeof', Tokens());
+  DefRegister!("\\everyeof", Tokens!());
 
   // DefConstructor('\middle Token', '#1',
   //   afterConstruct => sub {
@@ -217,12 +221,15 @@ LoadDefinitions!(state, {
   // DefParameterType('GlueExpr', sub { etex_readexpr($_[0], 'Glue'); });
   // DefParameterType('MuExpr',   sub { etex_readexpr($_[0], 'MuGlue'); });
 
-  // DefRegister('\numexpr NumExpr',   Number(0),    getter => sub { $_[0]; });
-  // DefRegister('\dimexpr DimExpr',   Dimension(0), getter => sub { $_[0]; });
-  // DefRegister('\glueexpr GlueExpr', Glue(0),      getter => sub { $_[0]; });
-  // DefRegister('\muexpr MuExpr',     MuGlue(0),    getter => sub { $_[0]; });
+  // TODO: ArgWrap for trait into_register_value_option ?
+  // DefRegister!("\\numexpr NumExpr",   Number::new(0),    getter => sub[args, state] { args[0].clone() });
+  // DefRegister!("\\dimexpr DimExpr",   Dimension::new(0), getter => sub[args, state] { args[0].clone() });
+  // DefRegister!("\\glueexpr GlueExpr", Glue::new(0),      getter => sub[args, state] { args[0].clone() });
+  // DefRegister!("\\muexpr MuExpr",     MuGlue::new(0),    getter => sub[args, state] { args[0].clone() });
 
-  // # Not really sure where this comes from; pdftex?
-  // DefRegister('\synctex', Number(0));
+  DefPrimitive!("\\pdftexcmds@directlua{}", None);
+
+  // Not really sure where this comes from; pdftex?
+  DefRegister!("\\synctex", Number::new(0));
   // #======================================================================
 });

--- a/rtx_package/src/package/pool/inputenc_sty.rs
+++ b/rtx_package/src/package/pool/inputenc_sty.rs
@@ -34,15 +34,17 @@ fn set_input_encoding(encoding: &str, stomach: &mut Stomach, state: &mut State) 
 LoadDefinitions!(outer_stomach, state, {
   //**********************************************************************
   DefPrimitive!("\\DeclareInputMath {Number} {}", sub[stomach, args, state] {
-    unpack_to_token!(args => code, expansion);
-    let ch = code.to_number().value_of() as u8 as char;
+    let code = args.remove(0).to_number();
+    unpack_to_token!(args => expansion);
+    let ch = code.value_of() as u8 as char;
     AssignCatcode!(ch, Catcode::ACTIVE);
     DefMacro!(T_ACTIVE!(ch), None, expansion);
   });
 
   DefPrimitive!("\\DeclareInputText {Number} {}", sub[stomach, args, state] {
-    unpack_to_token!(args => code, expansion);
-    let ch = code.to_number().value_of() as u8 as char;
+    let code = args.remove(0).to_number();
+    unpack_to_token!(args => expansion);
+    let ch = code.value_of() as u8 as char;
     AssignCatcode!(ch, Catcode::ACTIVE);
     DefMacro!(T_ACTIVE!(ch), None, expansion);
   });
@@ -55,7 +57,7 @@ LoadDefinitions!(outer_stomach, state, {
   });
 
   DefPrimitive!("\\inputencoding{}", sub[stomach, args, state] {
-    unpack_to_token!(args => encoding);
+    unpack!(args => encoding);
     let gullet = stomach.get_gullet_mut();
     set_input_encoding(&Expand!(encoding, gullet).to_string(), stomach, state)?;
   });

--- a/rtx_package/src/package/pool/latex_ch11_moving_information.rs
+++ b/rtx_package/src/package/pool/latex_ch11_moving_information.rs
@@ -243,10 +243,10 @@ LoadDefinitions!(outer_stomach, outer_state, {
       tokens.extend(Invocation!("\\end", vec![env], gullet)?.unlist());
       tokens.extend(vec![
         T_CS!("\\let"),
-        T_CS!(format!("\\end{}", tag)),
+        T_CS!(format!("\\end{tag}")),
         T_CS!("\\endthebibliography"),
         T_CS!("\\let"),
-        T_CS!(format!("\\end{{{}}}", tag)),
+        T_CS!(format!("\\end{{{tag}}}")),
         T_CS!("\\end{thebibliography}")
       ]);
     }

--- a/rtx_package/src/package/pool/latex_ch11_moving_information.rs
+++ b/rtx_package/src/package/pool/latex_ch11_moving_information.rs
@@ -67,8 +67,8 @@ LoadDefinitions!(outer_stomach, outer_state, {
   DefConstructor!("\\ref OptionalMatch:* Semiverbatim",
     "<ltx:ref labelref='#label' _force_font='true'/>",
     properties => sub[stomach, args, state] {
-      unpack_opt!(args => _star,label_opt);
-      let label = label_opt.as_ref().unwrap().to_string();
+      unpack_opt_ref!(args => _star, label_opt);
+      let label = label_opt.unwrap().as_ref().unwrap().to_string();
       Ok(map!("label" => Stored::String(clean_label(&label, None).into_owned())))
   });
 
@@ -203,15 +203,13 @@ LoadDefinitions!(outer_stomach, outer_state, {
   // Hack for abused bibliographies; see below
   DefMacro!(
     "\\bibitem",
-    "\\if@lx@inbibliography\\else\\expandafter\\lx@mung@bibliography\\expandafter{\\@currenvir}\\fi\\lx@bibitem"
-  );
+    "\\if@lx@inbibliography\\else\\expandafter\\lx@mung@bibliography\\expandafter{\\@currenvir}\\fi\\lx@bibitem", locked=>true);
   DefConstructor!("\\lx@bibitem[] Semiverbatim", "<ltx:bibitem key='#key' xml:id='#id'>#tags<ltx:bibblock>",
     after_digest => sub[stomach, whatsit, state] {
       let tag_opt = whatsit.get_arg(1);
-      let key = clean_bib_key(&match whatsit.get_arg(2) {
-        None => String::new(),
-        Some(key) => key.to_string(),
-      });
+      let key = if let Some(key) = whatsit.get_arg(2) {
+        clean_bib_key(&key.to_string())
+      } else { String::default() };
       if let Some(tag) = tag_opt {
         let mut properties = RefStepID!("@bibitem", stomach)?;
         properties.insert("key".to_string(), key.into());
@@ -224,6 +222,7 @@ LoadDefinitions!(outer_stomach, outer_state, {
         tag_tokens.push(T_END!());
         properties.insert("tags".to_string(),
           stomach.digest(tag_tokens, state)?.into());
+        whatsit.set_properties(properties);
       } else {
         let mut properties = RefStepCounter!("@bibitem", false, stomach)?;
         properties.insert("key".to_string(), key.into());
@@ -330,12 +329,16 @@ LoadDefinitions!(outer_stomach, outer_state, {
   DefConstructor!("\\@@citephrase{}", "<ltx:bibrefphrase>#1</ltx:bibrefphrase>", mode => "text");
 
   DefMacro!("\\cite[] Semiverbatim", sub[gullet, args, state] {
-    unpack!(args => post, keys);
+    unpack_opt!(args => post_opt, keys_opt);
+    let keys = keys_opt.owned_tokens().unwrap();
     let style = state.lookup_tokens("CITE_STYLE").unwrap_or_else(|| Tokens!());
     let open = state.lookup_tokens("CITE_OPEN");
     let open = open.unwrap_or_else(|| Tokens!());
     let close = state.lookup_tokens("CITE_CLOSE").unwrap_or_else(|| Tokens!());
-    let mut post_tokens = post.unlist();
+    let mut post_tokens = match post_opt.owned_tokens() {
+      Some(tks) => tks.unlist(),
+      None => Vec::new()
+    };
     if !post_tokens.is_empty() {
       let ns = state.lookup_tokens("CITE_NOTE_SEPARATOR").unwrap_or_else(|| Tokens!());
       let mut post_wrapped = ns.unlist();

--- a/rtx_package/src/package/pool/latex_ch15_font_selection.rs
+++ b/rtx_package/src/package/pool/latex_ch15_font_selection.rs
@@ -40,7 +40,7 @@ LoadDefinitions!(outer_state, {
   // For fonts not allowed in math!!!
   DefPrimitive!("\\not@math@alphabet@@ {}", sub[stomach, args, inner_state] {
     if inner_state.lookup_bool("IN_MATH") {
-      unpack_to_string!(args => c);
+      let c = args[0].to_string();
       let message = s!("Command {:?} invalid in math mode", c);
       Warn!("unexpected", c, stomach, inner_state, message);
     }

--- a/rtx_package/src/package/pool/latex_ch1_documentclass.rs
+++ b/rtx_package/src/package/pool/latex_ch1_documentclass.rs
@@ -10,8 +10,8 @@ LoadDefinitions!(state, {
   //**********************************************************************
   // Basic \documentclass & \documentstyle
 
-  //AssignValue('2.09_COMPATIBILITY'=>0);
-  // DefConditionalI('\if@compatibility', undef, sub { LookupValue('2.09_COMPATIBILITY'); });
+  DefConditional!("\\if@compatibility", sub [gullet, args, state] {
+    state.lookup_bool("2.09_COMPATIBILITY") });
   DefMacro!("\\@compatibilitytrue", "");
   DefMacro!("\\@compatibilityfalse", "");
 
@@ -23,7 +23,7 @@ LoadDefinitions!(state, {
   DefConstructor!("\\documentclass OptionalSemiverbatim SkipSpaces Semiverbatim []",
                   "<?latexml class='#2' ?#1(options='#1')?>",
     after_digest => sub[stomach, whatsit, state] {
-      let options: Option<&Digested> = dbg!(whatsit.get_arg(1));
+      let options: Option<&Digested> = whatsit.get_arg(1);
       let class_opts = match options {
         Some(opts) => OPTS_REGEX.split(&opts.to_string()).map(ToString::to_string).collect(),
         None => Vec::new(),

--- a/rtx_package/src/package/pool/latex_ch1_documentclass.rs
+++ b/rtx_package/src/package/pool/latex_ch1_documentclass.rs
@@ -23,7 +23,7 @@ LoadDefinitions!(state, {
   DefConstructor!("\\documentclass OptionalSemiverbatim SkipSpaces Semiverbatim []",
                   "<?latexml class='#2' ?#1(options='#1')?>",
     after_digest => sub[stomach, whatsit, state] {
-      let options: Option<&Digested> = whatsit.get_arg(1);
+      let options: Option<&Digested> = dbg!(whatsit.get_arg(1));
       let class_opts = match options {
         Some(opts) => OPTS_REGEX.split(&opts.to_string()).map(ToString::to_string).collect(),
         None => Vec::new(),

--- a/rtx_package/src/package/pool/latex_ch1_environments.rs
+++ b/rtx_package/src/package/pool/latex_ch1_environments.rs
@@ -60,7 +60,7 @@ LoadDefinitions!(state, {
   });
 
   DefMacro!("\\end{}", sub[gullet, args, state]{
-    unpack_to_string!(args => name);
+    let name = args[0].to_string();
     let mut t = T_CS!(s!("\\end{{{}}}", name));
     if is_defined_token(&t, state) {
       // Magic CS!

--- a/rtx_package/src/package/pool/latex_ch1_environments.rs
+++ b/rtx_package/src/package/pool/latex_ch1_environments.rs
@@ -67,13 +67,19 @@ LoadDefinitions!(state, {
   });
 
   DefMacro!("\\end{}", sub[gullet, args, state]{
-    let name = args[0].to_string();
+    unpack!(args => env);
+    let name = Expand!(env, gullet).to_string();
+    let before = state.lookup_value(&s!("@environment@{}@atend",name));
+    let after  = state.lookup_value(&s!("@environment@{}@afterend",name));
+
     let mut t = T_CS!(s!("\\end{{{}}}", name));
     if is_defined_token(&t, state) {
       // Magic CS!
+      // TODO: also add "after" tokens
       Ok(Tokens!(t))
     } else {
       t = T_CS!(s!("\\end{}", name));
+      // TODO: also add "before" tokens
       if is_defined_token(&t, state) {
         Ok(Tokens!(t, T_CS!("\\endgroup")))
       } else {

--- a/rtx_package/src/package/pool/latex_ch1_environments.rs
+++ b/rtx_package/src/package/pool/latex_ch1_environments.rs
@@ -34,13 +34,15 @@ LoadDefinitions!(state, {
 
   DefMacro!("\\begin{}", sub[gullet, args, state] {
     unpack!(args => env);
-    let name = Expand!(env, gullet).to_string();
+    let name = Expand!(env.clone(), gullet).to_string();
     let begin_name = s!("\\begin{{{}}}", name);
-    let before = LookupValue!(&s!("@environment@{}@beforebegin", name));
-    let after  = LookupValue!(&s!("@environment@{}@atbegin", name));
+    let before_opt = state.lookup_tokens(&s!("@environment@{}@beforebegin", name));
+    let after_opt  = state.lookup_tokens(&s!("@environment@{}@atbegin", name));
 
     if is_defined(&begin_name, state) {
-      Ok(Tokens!(T_CS!(begin_name))) // Magic cs!
+      let mut tks = before_opt.map(Tokens::unlist).unwrap_or_default();
+      tks.push(T_CS!(begin_name));
+      Ok(Tokens::new(tks)) // Magic cs!
     } else {
       let token = T_CS!(s!("\\{}", name));
       if !is_defined_token(&token, state) {
@@ -52,8 +54,13 @@ LoadDefinitions!(state, {
         // state.install_definition(LaTeXML::Core::Definition::Constructor->new($token, undef,
         //       sub { LaTeXML::Core::Stomach::makeError($_[0], "undefined", $undef); })); }
       }
-      let mut out_tokens = vec![T_CS!("\\begingroup")];
-      out_tokens.extend(Invocation!(T_CS!("\\lx@setcurrenvir"), vec![Tokenize!(&name)], gullet)?.unlist());
+      let mut out_tokens = if let Some(before) = before_opt { before.unlist() }
+      else { Vec::new() };
+      out_tokens.push(T_CS!("\\begingroup"));
+      if let Some(after) = after_opt {
+        out_tokens.extend(after.unlist());
+      }
+      out_tokens.extend(Invocation!(T_CS!("\\lx@setcurrenvir"), vec![env], gullet)?.unlist());
       out_tokens.push(token);
       Ok(Tokens::new(out_tokens))
     }

--- a/rtx_package/src/package/pool/latex_ch2_document.rs
+++ b/rtx_package/src/package/pool/latex_ch2_document.rs
@@ -31,11 +31,11 @@ LoadDefinitions!(state, {
     }
   },
   after_digest => sub[stomach, whatsit, state] {
-    {
+    stomach.begin_mode("text", state)?;
+    { // we need to re-bind in order to nest calls to the binding macro machinery
       bind_state_mut!(stomach,state);
       DefMacro!("\\@currenvir", "document");
     }
-    stomach.begin_mode("text", state)?;
     let mut gullet = stomach.get_gullet_mut();
     state.assign_value("current_environment", "document", None);
     let expanded_id = Expand!(T_CS!("\\thedocument@ID"),gullet,state);
@@ -66,12 +66,11 @@ LoadDefinitions!(state, {
   },
   before_digest => sub[stomach,state] {
     let mut boxes : Vec<Digested> = Vec::new();
-    if let Some(ops) = state.lookup_value("@at@end@document") {
-      unimplemented!();
-      // boxes.extend(stomach.digest(Tokens::new(ops)));
+    if let Some(ops) = state.lookup_tokens("@at@end@document") {
+      boxes.push(stomach.digest(ops,state)?);
     }
     // Should we try to indent the last paragraph? If so, it goes like this:
-    //     push(@boxes, $stomach->digest(T_CS('\normal@par')));
+    // boxes.push(stomach.digest(T_CS!("\\normal@par"), state)?);
     // Now we check whether we're down to the last stack frame.
     // It is common for unclosed { or even environments
     // and we want to at least compress & avoid unnecessary errors & warnings.

--- a/rtx_package/src/package/pool/latex_ch2_document.rs
+++ b/rtx_package/src/package/pool/latex_ch2_document.rs
@@ -10,46 +10,106 @@ LoadDefinitions!(state, {
   //    text
   //   \end{document}
 
-  // DefMacro('\AtBeginDocument{}', sub {
-  //     AssignValue('@at@begin@document', []) unless LookupValue('@at@begin@document');
-  //     PushValue('@at@begin@document', $_[1]->unlist); });
-  // DefMacro('\AtEndDocument{}', sub {
-  //     AssignValue('@at@end@document', []) unless LookupValue('@at@end@document');
-  //     PushValue('@at@end@document', $_[1]->unlist); });
+  DefMacro!("\\AtBeginDocument{}", sub[gullet,args,state] {
+    state.push_value("@at@begin@document", args.remove(0).unlist());
+  });
+  DefMacro!("\\AtEndDocument{}", sub[gullet,args,state] {
+    state.push_value("@at@end@document", args.remove(0).unlist());
+  });
 
-  DefEnvironment!("{document}", sub[document, args, props, state] {
-      let id = prop_str!(props,"id");
-      let body = prop_whatsit!(props,"body");
-      if let Some(mut docel) = document.findnode("/ltx:document", None, state) { // Already (auto) created?
-        if !id.is_empty() {
-          document.set_attribute(&mut docel, "xml:id", id)?;
-        }
-        document.absorb(&body, None, state)?;
-      } else {
-        let attrib = string_map!("xml:id" => id);
-        document.insert_element("ltx:document", vec![&body], Some(attrib), state)?;
+  // Like  "<ltx:document xml:id='#id'>#body</ltx:document>",
+  // But more complicated due to id, at begin/end document and so forth.
+  // AND, lower-level so that we can cope with common errors at document end.
+  DefConstructor!(T_CS!("\\begin{document}"), None, sub[document, args, props, state] {
+    let id = prop_str!(props,"id");
+    if let Some(mut docel) = document.findnode("/ltx:document", None, state) { // Already (auto) created?
+      if !id.is_empty() {
+        document.set_attribute(&mut docel, "xml:id", id)?;
       }
-      Ok(())
-    },
-    before_digest => { AssignValue!("inPreamble", false); },
-    // after_digest_begin => vec![|stomach, whatsit, state| {
-    //   whatsit.set_property("id", Expand!(T_CS!("\\thedocument@ID"), state));
-    //   if let Some(ops) = LookupValue!("@at@begin@document", state) {
-    //     let boxes = Digest!(ops, stomach);
-    //     whatsit.set_font(LookupValue!("font")); // Start w/ whatever font was selected.
-    //     return boxes
-    //   } else {
-    //     return Vec::new()
-    //   }
-    // }],
-    before_digest_end => sub[stomach, inner_state] {
-      stomach.get_gullet_mut().flush(inner_state);
-      if let Some(Stored::Tokens(ops)) = RemoveValue!("@at@end@document") {
-        Ok(vec![stomach.digest(ops, inner_state)?]) // TODO: Can we improve to the regular Digest!(ops) syntax?
-      } else {
-        Ok(Vec::new())
-      }
-    },
-    mode => "text"
-  );
+    } else {
+      document.open_element("ltx:document", Some(string_map!("xml:id" => id)), None, state)?;
+    }
+  },
+  after_digest => sub[stomach, whatsit, state] {
+    {
+      bind_state_mut!(stomach,state);
+      DefMacro!("\\@currenvir", "document");
+    }
+    stomach.begin_mode("text", state)?;
+    let mut gullet = stomach.get_gullet_mut();
+    state.assign_value("current_environment", "document", None);
+    let expanded_id = Expand!(T_CS!("\\thedocument@ID"),gullet,state);
+    whatsit.set_property("id", expanded_id);
+    let mut boxes = Vec::new();
+    if let Some(ops) = state.lookup_value("@document@preamble@atend") {
+      unimplemented!();
+      //       push(@boxes, $stomach->digest(Tokens(@$ops)));
+    }
+    if let Some(ops) = state.lookup_value("@at@begin@document") {
+      //       push(@boxes, $stomach->digest(Tokens(@$ops)));
+      unimplemented!();
+    }
+    state.assign_value("inPreamble", false, None); // atbegin is still (sorta) preamble
+    if let Some(ops) = state.lookup_value("@document@preamble@afterend") {
+      unimplemented!();
+    //       push(@boxes, $stomach->digest(Tokens(@$ops)));
+    }
+    whatsit.set_font(state.lookup_font().unwrap()); // Start w/ whatever font was last selected.
+    boxes
+  });
+
+  // \document is used directly in e.g. expl3.sty
+  Let!(&T_CS!("\\document"), T_CS!("\\begin{document}"), Some(Scope::Global));
+
+  DefConstructor!(T_CS!("\\end{document}"), None, sub[document,args,props,state] {
+    document.close_element("ltx:document", state)?;
+  },
+  before_digest => sub[stomach,state] {
+    let mut boxes : Vec<Digested> = Vec::new();
+    if let Some(ops) = state.lookup_value("@at@end@document") {
+      unimplemented!();
+      // boxes.extend(stomach.digest(Tokens::new(ops)));
+    }
+    // Should we try to indent the last paragraph? If so, it goes like this:
+    //     push(@boxes, $stomach->digest(T_CS('\normal@par')));
+    // Now we check whether we're down to the last stack frame.
+    // It is common for unclosed { or even environments
+    // and we want to at least compress & avoid unnecessary errors & warnings.
+    let nframes = state.get_frame_depth();
+    //     my $ifstack;
+    //     if ($STATE->isValueBound('current_environment', 0)
+    //       && ($STATE->valueInFrame('current_environment', 0) eq 'document')
+    //       && (!($ifstack = $STATE->lookupValue('if_stack')) || !$$ifstack[0])) { }    # OK!
+    //     else {
+    //       my @lines = ();
+    //       while ((!$STATE->isValueBound('current_environment', 0)
+    //           || ($STATE->valueInFrame('current_environment', 0) ne 'document'))
+    //         && ($STATE->getFrameDepth > 0)) {
+    //         # my $nonbox = $STATE->valueInFrame('groupNonBoxing',0) || 0;
+    //         my $tok = $STATE->valueInFrame('groupInitiator',        0) || '<unknown>';
+    //         my $loc = $STATE->valueInFrame('groupInitiatorLocator', 0);
+    //         $loc = defined $loc ? ToString($loc) : '<unknown>';
+    //         my $env = $STATE->isValueBound('current_environment', 0)
+    //           && $STATE->valueInFrame('current_environment', 0);
+    //         if ($env) {
+    //           push(@lines, "Environment $env opened by " . ToString($tok) . ' ' . $loc); }
+    //         else {    # but unclosed { is so common and latex itself doesn't Error!
+//           push(@lines, "Group opened by " . ToString($tok) . ' ' . $loc); }
+//         $STATE->popFrame; }
+//       while (($ifstack = $STATE->lookupValue('if_stack')) && $$ifstack[0]) {
+//         my $frame = $STATE->shiftValue('if_stack');
+//         push(@lines, "Conditional " . ToString($$frame{token})
+//             . "started " . ToString($$frame{start})); }
+//       Warn('unexpected', '\end{document}', $stomach,
+//         "Attempt to end document with open groups, environments or conditionals", @lines);
+//     }
+    stomach.end_mode("text", state)?;
+    stomach.get_gullet_mut().flush(state);
+    boxes
+});
+
+  // \enddocument is used directly in e.g. standalone.cls
+  Let!(&T_CS!("\\enddocument"), T_CS!("\\end{document}"), Some(Scope::Global));
+
+
 });

--- a/rtx_package/src/package/pool/latex_ch4_sectioning_and_toc.rs
+++ b/rtx_package/src/package/pool/latex_ch4_sectioning_and_toc.rs
@@ -111,7 +111,7 @@ LoadDefinitions!(outer_stomach, outer_state, {
       // Update 2022: The notes are generally still accurate, but cloning a Digested object is now cheap enough,
       // as each enum variant is guarded by an Arc reference counter. Arc<Tbox>, Arc<List>, etc.
       if let Some(Stored::Digested(tags)) = props.get("tags") {
-        document.absorb(&(**tags), None, state)?;
+        document.absorb(tags, None, state)?;
       }
       let title = prop_digested!(props, "title");
       document.insert_element("ltx:title", title, None, state)?;

--- a/rtx_package/src/package/pool/latex_ch7_math_mode_environments.rs
+++ b/rtx_package/src/package/pool/latex_ch7_math_mode_environments.rs
@@ -27,7 +27,7 @@ fn before_equation(stomach: &mut Stomach, state: &mut State) -> Result<()> {
     has_preset = numbering.contains_key("preset");
     match numbering.get("counter") {
       Some(Stored::String(v)) => v.to_owned(),
-      Some(other) => panic!("eq counter should be stored as string, was instead: {:?}", other),
+      Some(other) => panic!("eq counter should be stored as string, was instead: {other:?}"),
       _ => String::from("equation"),
     }
   } else {

--- a/rtx_package/src/package/pool/latex_ch8_defining_commands.rs
+++ b/rtx_package/src/package/pool/latex_ch8_defining_commands.rs
@@ -13,10 +13,10 @@ LoadDefinitions!(state, {
   DefPrimitive!("\\newcommand OptionalMatch:* DefToken [Number][]{}", sub[stomach, args, state] {
     let star = args.remove(0);
     let cs = args.remove(0);
-    let nargs_opt = args.remove(0).unwrap_or_default();
-    let opt = args.remove(0).unwrap_or_default();
-    let body = args.remove(0).unwrap();
-    let cs_token: Token = cs.into();
+    let nargs_opt = args.remove(0);
+    let opt = args.remove(0);
+    let body = args.remove(0);
+    let cs_token: Token = cs.expected_token()?;
     let nargs = if nargs_opt.is_empty() { 0 } else {
       nargs_opt.unlist().first().unwrap().to_number().value_of() as usize
     };
@@ -27,8 +27,7 @@ LoadDefinitions!(state, {
       }
       return Ok(vec![]);
     }
-    let opt = if opt.is_empty() { None } else { Some(opt) };
-    let macro_args = convert_latex_args(nargs, opt, state)?;
+    let macro_args = convert_latex_args(nargs, opt.owned_tokens(), state)?;
     DefMacro!(cs_token, macro_args, body);
   });
 

--- a/rtx_package/src/package/pool/latex_ch8_defining_environments.rs
+++ b/rtx_package/src/package/pool/latex_ch8_defining_environments.rs
@@ -7,11 +7,15 @@ use crate::package::*;
 // invoked directly.
 LoadDefinitions!(state, {
   DefPrimitive!("\\newenvironment OptionalMatch:* {}[Number][]{}{}", sub[stomach, args, state] {
-    unpack!(args => star, name, nargs, opt, begin, end);
+    unpack_opt!(args => star_opt, name_opt, nargs_opt, opt_opt, begin_opt, end_opt);
+    let name = name_opt.owned_tokens().unwrap();
+    let nargs = if nargs_opt.is_empty() { Number::new(0) } else { nargs_opt.owned_tokens().unwrap().to_number() };
+    let begin = begin_opt.owned_tokens().unwrap();
+    let end = end_opt.owned_tokens().unwrap();
+
     let name = { stomach.digest(name, state)?.to_string() };
     let name_cs = T_CS!(s!("\\{}",name));
     let end_name_cs = T_CS!(s!("\\end{}",name));
-    let nargs : usize = nargs.to_string().parse().unwrap_or(0);
     if IsDefined!(&name_cs) {
       let is_locked = state.has_value(&s!("\\{}:locked",name)) ||
        state.has_value(&s!("\\begin{{{}}}:locked",name));
@@ -20,8 +24,8 @@ LoadDefinitions!(state, {
         Info!("ignore", name, stomach, state, message);
       }
     } else {
-      let opt = if opt.is_empty() { None } else { Some(opt) };
-      let converted_args = convert_latex_args(nargs, opt, state)?; // TODO: can we convince DefMacro! this is not a second mutable borrow of state?
+      let opt = if opt_opt.is_empty() { None } else { Some(opt_opt.owned_tokens().unwrap()) };
+      let converted_args = convert_latex_args(nargs.value_of() as usize, opt, state)?; // TODO: can we convince DefMacro! this is not a second mutable borrow of state?
       DefMacro!(name_cs, converted_args, begin);
       DefMacro!(end_name_cs, None, end);
     }

--- a/rtx_package/src/package/pool/latex_ch8_numbering.rs
+++ b/rtx_package/src/package/pool/latex_ch8_numbering.rs
@@ -92,8 +92,8 @@ LoadDefinitions!(state, {
   });
 
   DefMacro!("\\@arabic{Number}", sub[gullet, args, state] {
-    unpack_to_token!(args => token);
-    let value = token.to_number().value_of();
+    let number = args.remove(0).to_number();
+    let value = number.value_of();
     ExplodeText!(value.to_string())
   });
   DefMacro!("\\arabic{}", sub[gullet, args, inner_state] {
@@ -104,8 +104,8 @@ LoadDefinitions!(state, {
   });
 
   DefMacro!("\\@roman{Number}", sub[gullet, args, state] {
-    unpack_to_token!(args => token);
-    let value = token.to_number().value_of();
+    unpack_to_number!(args => number);
+    let value = number.value_of();
     ExplodeText!(radix::radix_roman(value))
   });
   DefMacro!("\\roman{}", sub[gullet, args, state] {
@@ -114,8 +114,8 @@ LoadDefinitions!(state, {
     ExplodeText!(radix::radix_roman(CounterValue!(&ctr).value_of()))
   });
   DefMacro!("\\@Roman{Number}", sub[gullet, args, state] {
-    unpack_to_token!(args => token);
-    let value = token.to_number().value_of();
+    unpack_to_number!(args => number);
+    let value = number.value_of();
     ExplodeText!(radix::radix_up_roman(value))
   });
   DefMacro!("\\Roman{}", sub[gullet, args, state] {
@@ -124,8 +124,8 @@ LoadDefinitions!(state, {
     ExplodeText!(radix::radix_up_roman(CounterValue!(&ctr).value_of()))
   });
   DefMacro!("\\@alph{Number}", sub[gullet, args, state] {
-    unpack_to_token!(args => token);
-    let value = token.to_number().value_of();
+    unpack_to_number!(args => number);
+    let value = number.value_of();
     ExplodeText!(radix::radix_alpha(value))
   });
   DefMacro!("\\alph{}", sub[gullet, args, state] {
@@ -134,8 +134,8 @@ LoadDefinitions!(state, {
     ExplodeText!(radix::radix_alpha(CounterValue!(&ctr).value_of()))
   });
   DefMacro!("\\@Alph{Number}", sub[gullet, args, state] {
-    unpack_to_token!(args => token);
-    let value = token.to_number().value_of();
+    unpack_to_number!(args => number);
+    let value = number.value_of();
     ExplodeText!(radix::radix_up_alpha(value))
   });
   DefMacro!("\\Alph{}", sub[gullet, args, state] {
@@ -145,8 +145,8 @@ LoadDefinitions!(state, {
   });
 
   DefMacro!("\\@fnsymbol{Number}", sub[gullet, args, state] {
-    unpack!(args => token);
-    ExplodeText!(radix::radix_format_str(token.to_number().value_of(), FNSYMBOLS))
+    unpack_to_number!(args => number);
+    ExplodeText!(radix::radix_format_str(number.value_of(), FNSYMBOLS))
   });
   DefMacro!("\\fnsymbol{}", sub[gullet, args, state] {
     unpack!(args => token);

--- a/rtx_package/src/package/pool/latex_ch8_numbering.rs
+++ b/rtx_package/src/package/pool/latex_ch8_numbering.rs
@@ -23,12 +23,13 @@ LoadDefinitions!(state, {
   });
 
   DefPrimitive!("\\newcounter{}[]", sub[stomach, args, state] {
-    unpack!(args => cs, default);
+    unpack_opt!(args => cs_opt, default_opt);
+    let cs = cs_opt.owned_tokens().unwrap();
     let gullet = stomach.get_gullet_mut();
-    let default = if !default.is_empty() {
-      Expand!(default, gullet)
+    let default = if !default_opt.is_empty() {
+      Expand!(default_opt.owned_tokens().unwrap(), gullet)
     } else {
-      default
+      Tokens!()
     };
     let cs_expanded = &Expand!(cs, gullet).to_string();
     NewCounter!(cs_expanded, &default.to_string());

--- a/rtx_package/src/package/pool/latex_ch8_numbering.rs
+++ b/rtx_package/src/package/pool/latex_ch8_numbering.rs
@@ -105,52 +105,52 @@ LoadDefinitions!(state, {
 
   DefMacro!("\\@roman{Number}", sub[gullet, args, state] {
     unpack_to_token!(args => token);
-    let value = token.to_number().value_of() as i32;
+    let value = token.to_number().value_of();
     ExplodeText!(radix::radix_roman(value))
   });
   DefMacro!("\\roman{}", sub[gullet, args, state] {
     unpack!(args => token);
     let ctr = Expand!(token, gullet).to_string();
-    ExplodeText!(radix::radix_roman(CounterValue!(&ctr).value_of() as i32))
+    ExplodeText!(radix::radix_roman(CounterValue!(&ctr).value_of()))
   });
   DefMacro!("\\@Roman{Number}", sub[gullet, args, state] {
     unpack_to_token!(args => token);
-    let value = token.to_number().value_of() as i32;
+    let value = token.to_number().value_of();
     ExplodeText!(radix::radix_up_roman(value))
   });
   DefMacro!("\\Roman{}", sub[gullet, args, state] {
     unpack!(args => token);
     let ctr = Expand!(token, gullet).to_string();
-    ExplodeText!(radix::radix_up_roman(CounterValue!(&ctr).value_of() as i32))
+    ExplodeText!(radix::radix_up_roman(CounterValue!(&ctr).value_of()))
   });
   DefMacro!("\\@alph{Number}", sub[gullet, args, state] {
     unpack_to_token!(args => token);
-    let value = token.to_number().value_of() as i32;
+    let value = token.to_number().value_of();
     ExplodeText!(radix::radix_alpha(value))
   });
   DefMacro!("\\alph{}", sub[gullet, args, state] {
     unpack!(args => token);
     let ctr = Expand!(token, gullet).to_string();
-    ExplodeText!(radix::radix_alpha(CounterValue!(&ctr).value_of() as i32))
+    ExplodeText!(radix::radix_alpha(CounterValue!(&ctr).value_of()))
   });
   DefMacro!("\\@Alph{Number}", sub[gullet, args, state] {
     unpack_to_token!(args => token);
-    let value = token.to_number().value_of() as i32;
+    let value = token.to_number().value_of();
     ExplodeText!(radix::radix_up_alpha(value))
   });
   DefMacro!("\\Alph{}", sub[gullet, args, state] {
     unpack!(args => token);
     let ctr = Expand!(token, gullet).to_string();
-    ExplodeText!(radix::radix_up_alpha(CounterValue!(&ctr).value_of() as i32))
+    ExplodeText!(radix::radix_up_alpha(CounterValue!(&ctr).value_of()))
   });
 
   DefMacro!("\\@fnsymbol{Number}", sub[gullet, args, state] {
     unpack!(args => token);
-    ExplodeText!(radix::radix_format_str(token.to_number().value_of() as i32, FNSYMBOLS))
+    ExplodeText!(radix::radix_format_str(token.to_number().value_of(), FNSYMBOLS))
   });
   DefMacro!("\\fnsymbol{}", sub[gullet, args, state] {
     unpack!(args => token);
     let ctr = Expand!(token, gullet).to_string();
-    ExplodeText!(radix::radix_format_str(CounterValue!(&ctr).value_of() as i32, FNSYMBOLS))
+    ExplodeText!(radix::radix_format_str(CounterValue!(&ctr).value_of(), FNSYMBOLS))
   });
 });

--- a/rtx_package/src/package/pool/latex_ch9_figures_and_tables.rs
+++ b/rtx_package/src/package/pool/latex_ch9_figures_and_tables.rs
@@ -60,8 +60,9 @@ LoadDefinitions!(state, {
   );
 
   DefPrimitive!("\\lx@note@caption@label{}", sub[stomach,args,state] {
-    let arg = args[0].to_string();
-    maybe_note_label(&arg, state); });
+    unpack!(args => label);
+    let label = label.to_string();
+    maybe_note_label(&label, state); });
 
   DefMacro!(
     "\\@caption@@@{}{}{}",

--- a/rtx_package/src/package/pool/latex_ch9_figures_and_tables.rs
+++ b/rtx_package/src/package/pool/latex_ch9_figures_and_tables.rs
@@ -60,7 +60,7 @@ LoadDefinitions!(state, {
   );
 
   DefPrimitive!("\\lx@note@caption@label{}", sub[stomach,args,state] {
-    unpack_to_string!(args=>arg);
+    let arg = args[0].to_string();
     maybe_note_label(&arg, state); });
 
   DefMacro!(

--- a/rtx_package/src/package/pool/latex_other_in_appendices.rs
+++ b/rtx_package/src/package/pool/latex_other_in_appendices.rs
@@ -69,11 +69,11 @@ LoadDefinitions!(state, {
   DefMacro!(r"\@gobble{}", "");
   DefMacro!(r"\@gobbletwo{}{}", "");
   DefMacro!(r"\@gobblefour{}{}{}{}", "");
-  DefMacro!(r"\@firstofone{}",       sub[gullet, args, state] { Ok(args.remove(0).unwrap()) });
+  DefMacro!(r"\@firstofone{}",       sub[gullet, args, state] { Ok(args.remove(0)) });
   Let!("\\@iden", "\\@firstofone");
-  DefMacro!("\\@firstoftwo{}{}",     sub[gullet, args, state] { Ok(args.remove(0).unwrap()) });
-  DefMacro!("\\@secondoftwo{}{}",    sub[gullet, args, state] { Ok(args.remove(1).unwrap()) });
-  DefMacro!("\\@thirdofthree{}{}{}", sub[gullet, args, state] { Ok(args.remove(2).unwrap()) });
+  DefMacro!("\\@firstoftwo{}{}",     sub[gullet, args, state] { Ok(args.remove(0)) });
+  DefMacro!("\\@secondoftwo{}{}",    sub[gullet, args, state] { Ok(args.remove(1)) });
+  DefMacro!("\\@thirdofthree{}{}{}", sub[gullet, args, state] { Ok(args.remove(2)) });
   // DefMacro('\@expandtwoargs{}{}{}', sub {
   //     ($_[1]->unlist, T_BEGIN, Expand($_[2])->unlist, T_END, T_BEGIN, Expand($_[3])->unlist, T_END); });
   DefMacro!("\\@makeother{}", sub[gullet,args,state] {

--- a/rtx_package/src/package/pool/latex_semi_undocumented.rs
+++ b/rtx_package/src/package/pool/latex_semi_undocumented.rs
@@ -16,7 +16,7 @@ LoadDefinitions!(state, {
     } else {
       t_else
     };
-    let mut result = which.substitute_parameters(Vec::new()).unlist();
+    let mut result = which.substitute_parameters(&[]).unlist();
     if let Some(t_next) = next {
       result.push(t_next);
     }

--- a/rtx_package/src/package/pool/mod.rs
+++ b/rtx_package/src/package/pool/mod.rs
@@ -1,4 +1,5 @@
 // TeX Pool
+pub mod test;
 pub mod tex;
 mod tex_accents;
 mod tex_alignment;

--- a/rtx_package/src/package/pool/pdftex.rs
+++ b/rtx_package/src/package/pool/pdftex.rs
@@ -108,7 +108,7 @@ LoadDefinitions!(state, {
   DefMacro!("\\pdfinfo{}", "");
 
   // Ugh, what a mess of ugly syntax....
-  DefParameterType!("OpenActionSpecification", reader => reader!(gullet, args, extra, state, {
+  DefParameterType!(OpenActionSpecification, reader => reader!(gullet, args, extra, state, {
   unimplemented!(); ()
   //   my ($gullet) = @_;
   //   if (my $key = $gullet->readKeyword('openaction')) {

--- a/rtx_package/src/package/pool/test.rs
+++ b/rtx_package/src/package/pool/test.rs
@@ -1,4 +1,4 @@
-use crate::package::*;
+// use crate::package::*;
 
 #[macro_export]
 macro_rules! TypedMacro {

--- a/rtx_package/src/package/pool/test.rs
+++ b/rtx_package/src/package/pool/test.rs
@@ -1,0 +1,40 @@
+use crate::package::*;
+
+#[macro_export]
+macro_rules! TypedMacro {
+  // closure
+  ($cs:literal [ $($var:ident : $ptype:ident),+ ] => sub [ $gullet:ident, $inner_state:ident ] $body:block $($input:tt)*) => {{
+    let options = defi_opts!(@munch ($($input)*) -> {ExpandableOptions,});
+    let mut parameters = Vec::new();
+    $(
+    parameters.push(
+        Parameter {
+          name: stringify!($ptype).to_string(),
+          ..Parameter::default()
+        }
+        .init(state)?,
+      );
+    )+
+    // let (cs, params) = parse_prototype!($proto);
+    let expansion_closure: Option<ExpansionBody> = Some(ExpansionBody::Closure(Arc::new(
+      move |$gullet, mut args, $inner_state| {
+        $(
+          let $var: $ptype = args.remove(0).into();
+        )+
+        WithInnerState!($body, $inner_state).into_tokens_result()
+      }
+    )));
+    // defi_macro!(cs, params, expansion_closure, Some(options));
+  }};
+}
+
+// LoadDefinitions!(state, {
+
+//   TypedMacro!("\\sampler"[number:OptionalNumber, token:OptionalToken, dimension:OptionalDimension] => sub[gullet,state] {
+//     dbg!(dbg!(number).unwrap().value_of());
+//     dbg!(token);
+//     dbg!(dbg!(dimension).unwrap().value_of());
+//     Ok(Vec::new())
+//   });
+
+// });

--- a/rtx_package/src/package/pool/test.rs
+++ b/rtx_package/src/package/pool/test.rs
@@ -12,14 +12,14 @@ macro_rules! TypedMacro {
           name: stringify!($ptype).to_string(),
           ..Parameter::default()
         }
-        .init(state)?,
+        .init($inner_state)?,
       );
     )+
     // let (cs, params) = parse_prototype!($proto);
     let expansion_closure: Option<ExpansionBody> = Some(ExpansionBody::Closure(Arc::new(
       move |$gullet, mut args, $inner_state| {
         $(
-          let $var: $ptype = args.remove(0).into();
+          let $var: $ptype = args.remove(0).try_into()?;
         )+
         WithInnerState!($body, $inner_state).into_tokens_result()
       }

--- a/rtx_package/src/package/pool/tex_appendix_b_p358.rs
+++ b/rtx_package/src/package/pool/tex_appendix_b_p358.rs
@@ -355,11 +355,11 @@ LoadDefinitions!(state, {
       }
 
       if let Some(meaning) = thing.get_attribute("meaning") {
-        document.set_attribute(thing, "meaning",  &format!("not-{}",meaning))?; }
+        document.set_attribute(thing, "meaning",  &format!("not-{meaning}"))?; }
       if let Some(name) = thing.get_attribute("name") {
-        document.set_attribute(thing, "name", &format!("not-{}",name))?; }
+        document.set_attribute(thing, "name", &format!("not-{name}"))?; }
       else if !text.is_empty() {
-        document.set_attribute(thing, "name", &format!("not-{}",text))?; }
+        document.set_attribute(thing, "name", &format!("not-{text}"))?; }
 
       let known_c = MATH_CHAR_NEGATIONS.get(&text);
       let new : Cow<'_, str> = match known_c {
@@ -371,7 +371,7 @@ LoadDefinitions!(state, {
       document.get_node_mut().add_child(thing)?;
       // Since the <not> element is disappearing, if it had an id that was referenced...!?!?
       if let Some(id) = not_node.get_attribute("xml:id") {
-        for n in document.findnodes(&format!("descendant-or-self::ltx:XMRef[@idref='{}']", id), None, state) {
+        for n in document.findnodes(&format!("descendant-or-self::ltx:XMRef[@idref='{id}']"), None, state) {
           document.remove_node(n);
         }
       }   // ? Hopefully this is safe.

--- a/rtx_package/src/package/pool/tex_appendix_b_to_p349.rs
+++ b/rtx_package/src/package/pool/tex_appendix_b_to_p349.rs
@@ -315,7 +315,7 @@ LoadDefinitions!(state, {
   // # which means they actually work quite differently
   DefRegister!("\\allocationnumber" => Number::new(0));
   DefMacro!("\\alloc@@ {}", sub[gullet, args, state] {
-    unpack_to_string!(args => atype);
+    let atype = args[0].to_string();
     let c = s!("allocation @{}", atype);
     let n = LookupRegisterOrDefault!(c).value_of();
     AssignValue!(&c                  => n + 1,     Some(Scope::Global));
@@ -372,7 +372,7 @@ LoadDefinitions!(state, {
 
   DefMacro!("\\magstephalf", "1095");
   DefMacro!("\\magstep{}", sub[gullet, args, state] {
-    unpack_to_string!(args => mag);
+    let mag = args[0].to_string();
     Explode!(match mag.as_str() {
       "0" => "1000",
       "1" => "1200",

--- a/rtx_package/src/package/pool/tex_appendix_b_to_p349.rs
+++ b/rtx_package/src/package/pool/tex_appendix_b_to_p349.rs
@@ -315,7 +315,8 @@ LoadDefinitions!(state, {
   // # which means they actually work quite differently
   DefRegister!("\\allocationnumber" => Number::new(0));
   DefMacro!("\\alloc@@ {}", sub[gullet, args, state] {
-    let atype = args[0].to_string();
+    unpack!(args => atype_tokens);
+    let atype = atype_tokens.to_string();
     let c = s!("allocation @{}", atype);
     let n = LookupRegisterOrDefault!(c).value_of();
     AssignValue!(&c                  => n + 1,     Some(Scope::Global));

--- a/rtx_package/src/package/pool/tex_assignment.rs
+++ b/rtx_package/src/package/pool/tex_assignment.rs
@@ -113,16 +113,16 @@ LoadDefinitions!(outer_state, {
   DefPrimitive!("\\advance Variable SkipKeyword:by", sub[stomach, args, state] {
     unpack!(args => var);
     // TODO: Variable type unpacking seems to require special INFRA again...
-    let mut var_tokens = var.unlist();
+    let mut var_tokens : Vec<ArgWrap> = var.unlist().into_iter().map(ArgWrap::Token).collect();
     if !var_tokens.is_empty() {
-      let defn_token = var_tokens.remove(0);
+      let defn_token = var_tokens.remove(0).expected_token()?;
       if defn_token.to_string() != "missing" {
         let defn_opt = state.lookup_register_definition(&defn_token);
         let defn_token_rc = Arc::new(defn_token);
         state.current_token = Some(Arc::clone(&defn_token_rc));
         if let Some(defn) = defn_opt {
           let summand = stomach.get_gullet_mut().read_value(defn.register_type().unwrap(), state)?;
-          let defn_args : Vec<Tokens> = var_tokens.iter().map(|a| Tokens!(a.clone())).collect();
+          let defn_args : Vec<ArgWrap> = var_tokens.clone();
           let defn_value = defn.value_of(var_tokens, state).unwrap_or_default();
           defn.borrow_mut().set_value(defn_value.add(summand), defn_args, state);
         } else {
@@ -136,10 +136,10 @@ LoadDefinitions!(outer_state, {
   DefPrimitive!("\\multiply Variable SkipKeyword:by Number", sub[stomach, args, state] {
     unpack!(args => var, scale);
     if !var.is_empty() {
-      let mut args = var.unlist();
-      let varname = args.remove(0);
+      let mut args : Vec<ArgWrap> = var.unlist().into_iter().map(ArgWrap::Token).collect();
+      let varname = args.remove(0).expected_token()?;
       // Upgrade: Why are the arguments used twice here? Is there a way to avoid cloning them?
-      let defn_args : Vec<Tokens> = args.iter().map(|a| Tokens!(a.clone())).collect();
+      let defn_args : Vec<ArgWrap> = args.clone();
       if let Some(defn) = state.lookup_register_definition(&varname) {
         let defn_value = defn.value_of(args, state).unwrap_or_default();
         let scale_value = scale.to_number().value_of();
@@ -157,10 +157,10 @@ LoadDefinitions!(outer_state, {
   DefPrimitive!("\\divide Variable SkipKeyword:by Number", sub[stomach, args, state] {
     unpack!(args => var, scale);
     if !var.is_empty() {
-      let mut args = var.unlist();
-      let varname = args.remove(0);
+      let mut args : Vec<ArgWrap> = var.unlist().into_iter().map(ArgWrap::Token).collect();
+      let varname = args.remove(0).expected_token()?;
       // Upgrade: Why are the arguments used twice here? Is there a way to avoid cloning them?
-      let defn_args : Vec<Tokens> = args.iter().map(|a| Tokens!(a.clone())).collect();
+      let defn_args : Vec<ArgWrap> = args.clone();
       if let Some(defn) = state.lookup_register_definition(&varname) {
         let defn_value = defn.value_of(args, state).unwrap_or_default();
         let mut denominator = scale.to_number().value_f32();
@@ -303,14 +303,14 @@ LoadDefinitions!(outer_state, {
   // <codename> = \catcode | \mathcode | \lccode | \uccode | \sfcode | \delcode
   DefRegister!("\\catcode Number", Number::new(0),
     getter => sub[args, state] {
-      let num = args[0].to_number().value_of();
+      let num = args.remove(0).to_number().value_of();
       let refchar = (num as u8) as char;
       let code : Catcode = state.lookup_catcode(refchar).unwrap_or(Catcode::OTHER);
       let code : u8 = code.into();
       Number!(code)
     },
     setter => sub[value, args, state] {
-      let c_char = (args[0].to_number().value_of() as u8) as char;
+      let c_char = (args.remove(0).to_number().value_of() as u8) as char;
       let c_code = From::from(value.value_of() as u8);
       state.assign_catcode(c_char, c_code, None);
     }
@@ -319,7 +319,7 @@ LoadDefinitions!(outer_state, {
   // Only used for active math characters, so far
   DefRegister!("\\mathcode Number", Number::new(0),
     getter => sub[args, state] {
-      let ch_code   = args[0].to_number().value_of() as u8;
+      let ch_code   = args.remove(0).to_number().value_of() as u8;
       let ch : char = ch_code as char;
       let code = match state.lookup_mathcode(&ch.to_string()) {
         None => ch_code,
@@ -328,7 +328,7 @@ LoadDefinitions!(outer_state, {
       Number!(code)
     },    // defaults to the char's code itself(?)
     setter => sub[value, args, state] {
-      let ch = args[0].to_number().value_of() as u8;
+      let ch = args.remove(0).to_number().value_of() as u8;
       let ch : char = ch as char;
       state.assign_mathcode(ch, value.value_of() as u16, None);
     }

--- a/rtx_package/src/package/pool/tex_assignment.rs
+++ b/rtx_package/src/package/pool/tex_assignment.rs
@@ -303,8 +303,10 @@ LoadDefinitions!(outer_state, {
   // <codename> = \catcode | \mathcode | \lccode | \uccode | \sfcode | \delcode
   DefRegister!("\\catcode Number", Number::new(0),
     getter => sub[args, state] {
-      let num = args.remove(0).to_number().value_of();
-      let refchar = (num as u8) as char;
+      // dbg!(&args);
+      unpack_opt!(args => num);
+      // dbg!(&num);
+      let refchar = (num.to_number().value_of() as u8) as char;
       let code : Catcode = state.lookup_catcode(refchar).unwrap_or(Catcode::OTHER);
       let code : u8 = code.into();
       Number!(code)

--- a/rtx_package/src/package/pool/tex_assignment.rs
+++ b/rtx_package/src/package/pool/tex_assignment.rs
@@ -303,16 +303,14 @@ LoadDefinitions!(outer_state, {
   // <codename> = \catcode | \mathcode | \lccode | \uccode | \sfcode | \delcode
   DefRegister!("\\catcode Number", Number::new(0),
     getter => sub[args, state] {
-      // dbg!(&args);
       unpack_opt!(args => num);
-      // dbg!(&num);
       let refchar = (num.to_number().value_of() as u8) as char;
       let code : Catcode = state.lookup_catcode(refchar).unwrap_or(Catcode::OTHER);
-      let code : u8 = code.into();
-      Number!(code)
+      Number::from(code)
     },
     setter => sub[value, args, state] {
-      let c_char = (args.remove(0).to_number().value_of() as u8) as char;
+      unpack_opt!(args => num);
+      let c_char = (num.to_number().value_of() as u8) as char;
       let c_code = From::from(value.value_of() as u8);
       state.assign_catcode(c_char, c_code, None);
     }

--- a/rtx_package/src/package/pool/tex_assignment.rs
+++ b/rtx_package/src/package/pool/tex_assignment.rs
@@ -111,19 +111,15 @@ LoadDefinitions!(outer_state, {
   //    | \divide <numeric variable><optional by><number>
 
   DefPrimitive!("\\advance Variable SkipKeyword:by", sub[stomach, args, state] {
-    unpack!(args => var);
-    // TODO: Variable type unpacking seems to require special INFRA again...
-    let mut var_tokens : Vec<ArgWrap> = var.unlist().into_iter().map(ArgWrap::Token).collect();
-    if !var_tokens.is_empty() {
-      let defn_token = var_tokens.remove(0).expected_token()?;
+    if let ArgWrap::RegisterDefinition((defn_token, inner)) = args.remove(0) {
       if defn_token.to_string() != "missing" {
         let defn_opt = state.lookup_register_definition(&defn_token);
         let defn_token_rc = Arc::new(defn_token);
         state.current_token = Some(Arc::clone(&defn_token_rc));
         if let Some(defn) = defn_opt {
           let summand = stomach.get_gullet_mut().read_value(defn.register_type().unwrap(), state)?;
-          let defn_args : Vec<ArgWrap> = var_tokens.clone();
-          let defn_value = defn.value_of(var_tokens, state).unwrap_or_default();
+          let defn_args : Vec<ArgWrap> = inner.clone();
+          let defn_value = defn.value_of(inner, state).unwrap_or_default();
           defn.borrow_mut().set_value(defn_value.add(summand), defn_args, state);
         } else {
           let message = s!("\\advance expected a defined variable for {:?}, found no definition", defn_token_rc);
@@ -134,14 +130,12 @@ LoadDefinitions!(outer_state, {
   });
 
   DefPrimitive!("\\multiply Variable SkipKeyword:by Number", sub[stomach, args, state] {
-    unpack!(args => var, scale);
-    if !var.is_empty() {
-      let mut args : Vec<ArgWrap> = var.unlist().into_iter().map(ArgWrap::Token).collect();
-      let varname = args.remove(0).expected_token()?;
+    if let ArgWrap::RegisterDefinition((varname, inner)) = args.remove(0) {
+      unpack!(args => scale);
       // Upgrade: Why are the arguments used twice here? Is there a way to avoid cloning them?
-      let defn_args : Vec<ArgWrap> = args.clone();
+      let defn_args : Vec<ArgWrap> = inner.clone();
       if let Some(defn) = state.lookup_register_definition(&varname) {
-        let defn_value = defn.value_of(args, state).unwrap_or_default();
+        let defn_value = defn.value_of(inner, state).unwrap_or_default();
         let scale_value = scale.to_number().value_of();
         defn.borrow_mut().set_value(defn_value.multiply(Number::new(scale_value)), defn_args, state);
       } else {
@@ -155,14 +149,12 @@ LoadDefinitions!(outer_state, {
   });
 
   DefPrimitive!("\\divide Variable SkipKeyword:by Number", sub[stomach, args, state] {
-    unpack!(args => var, scale);
-    if !var.is_empty() {
-      let mut args : Vec<ArgWrap> = var.unlist().into_iter().map(ArgWrap::Token).collect();
-      let varname = args.remove(0).expected_token()?;
+    if let ArgWrap::RegisterDefinition((varname, inner)) = args.remove(0) {
+      unpack!(args => scale);
       // Upgrade: Why are the arguments used twice here? Is there a way to avoid cloning them?
-      let defn_args : Vec<ArgWrap> = args.clone();
+      let defn_args : Vec<ArgWrap> = inner.clone();
       if let Some(defn) = state.lookup_register_definition(&varname) {
-        let defn_value = defn.value_of(args, state).unwrap_or_default();
+        let defn_value = defn.value_of(inner, state).unwrap_or_default();
         let mut denominator = scale.to_number().value_f32();
         if denominator == 0.0 {
           Error!("misdefined", scale, stomach, state, "Illegal \\divide by 0; assuming 1");
@@ -284,7 +276,7 @@ LoadDefinitions!(outer_state, {
 
   // \parshape !?!??
   DefPrimitive!("\\parshape SkipMatch:= Number", sub[stomach, args, state] {
-    unpack_to_token!(args => n);
+    unpack_to_number!(args => n);
     // $n = $n->valueOf;
     // my $gullet = $stomach->getGullet;
     // for (my $i = 0 ; $i < $n ; $i++) {

--- a/rtx_package/src/package/pool/tex_boxes.rs
+++ b/rtx_package/src/package/pool/tex_boxes.rs
@@ -56,7 +56,7 @@ LoadDefinitions!(state, {
     }
   });
 
-  DefParameterType!("BoxSpecification",  reader => reader!(gullet, inner, extra, state, {
+  DefParameterType!(BoxSpecification,  reader => reader!(gullet, inner, extra, state, {
       if let Some(key) = gullet.read_keyword(&["to", "spread"], state)? {
         Ok(Tokens!(T_OTHER!(key)))
       } else {
@@ -82,13 +82,13 @@ LoadDefinitions!(state, {
     }),
     optional => true);
 
-  DefParameterType!("HBoxContents", reader => reader!(gullet, _inner, _extra, state, {
+  DefParameterType!(HBoxContents, reader => reader!(gullet, _inner, _extra, state, {
       read_box_contents(gullet, state.lookup_tokens("\\everyhbox"), state)
     }),
     reader_predigest=>reader_predigest!(stomach, arg, state, { predigest_box_contents(stomach, arg, state) })
   );
 
-  DefParameterType!("VBoxContents", reader=>reader!(gullet, _inner, _extra, state, {
+  DefParameterType!(VBoxContents, reader=>reader!(gullet, _inner, _extra, state, {
       read_box_contents(gullet, state.lookup_tokens("\\everyvbox"), state)
     }),
     reader_predigest=>reader_predigest!(stomach, arg, state, { predigest_box_contents(stomach, arg, state) })
@@ -199,7 +199,7 @@ LoadDefinitions!(state, {
     }
   );
 
-  DefParameterType!("RuleSpecification", reader=>reader!(gullet, inner, extra, state, {
+  DefParameterType!(RuleSpecification, reader=>reader!(gullet, inner, extra, state, {
     unimplemented!(); ()
     // my $keyvals = LaTeXML::Core::KeyVals->new(undef, undef, skipMissing => 1);
     // while (my $key = $gullet->readKeyword('width', 'height', 'depth')) {

--- a/rtx_package/src/package/pool/tex_boxes.rs
+++ b/rtx_package/src/package/pool/tex_boxes.rs
@@ -10,8 +10,8 @@ LoadDefinitions!(state, {
   // \setbox<number>=\hbox to <dimen>{<horizontal mode material>}
 
   DefPrimitive!("\\setbox Number SkipMatch:=", sub[stomach, args, state] {
-    unpack_to_token!(args => token);
-    let tbox = s!("box{}", token.to_number().value_of() as u8);
+    unpack_to_number!(args => number);
+    let tbox = s!("box{}", number.value_of() as u8);
     // If there is any afterAssignment tokens, move them over so BoxContents parameter will use them
     if let Some(after_token) = state.remove_value("afterAssignment") {
       state.assign_value("BeforeNextBox", after_token, None);
@@ -36,8 +36,8 @@ LoadDefinitions!(state, {
   });
 
   DefPrimitive!("\\box Number", sub[gullet, args, state] {
-    unpack_to_token!(args => token);
-    let box_key = s!("box{}", token.to_number().value_of() as u8);
+    unpack_to_number!(args => number);
+    let box_key = s!("box{}", number.value_of() as u8);
     if let Some(Stored::Digested(stuff)) = state.remove_value(&box_key) {
       Ok(vec![*stuff])
     } else {
@@ -46,8 +46,8 @@ LoadDefinitions!(state, {
   });
 
   DefPrimitive!("\\copy Number", sub[stomach, args, state] {
-    unpack_to_token!(args => token);
-    let box_key = s!("box{}", token.to_number().value_of() as u8);
+    unpack_to_number!(args => number);
+    let box_key = s!("box{}", number.value_of() as u8);
     if let Some(Stored::Digested(stuff)) = state.lookup_value(&box_key) {
       let cloned_stuff : Digested = (**stuff).clone();
       Ok(vec![cloned_stuff])

--- a/rtx_package/src/package/pool/tex_boxes.rs
+++ b/rtx_package/src/package/pool/tex_boxes.rs
@@ -74,7 +74,7 @@ LoadDefinitions!(state, {
       if !key.is_empty() {
         let mut keyvals = KeyVals::new(KeyValsOptions{skip_missing: true, ..KeyValsOptions::default()}, state);
         let dim = stomach.get_gullet_mut().read_dimension(state)?;
-        keyvals.set_value(&key.to_string(), dim.into(), false, state);
+        keyvals.set_value(&key.owned_tokens().unwrap().to_string(), dim.into(), false, state);
         keyvals.into()
       } else {
         Ok(None)
@@ -105,7 +105,8 @@ LoadDefinitions!(state, {
 
   DefConstructor!("\\hbox BoxSpecification HBoxContents", sub[document, args, props, state] {
       // "<ltx:text width='#width' _noautoclose='1'>#2</ltx:text>",
-      let contents = args[1].as_ref().unwrap();
+      unpack_opt_ref!(args => spec_opt, contents_opt);
+      let contents = contents_opt.unwrap().as_ref().unwrap();
       let current_opt = document.get_element();
 
       // What is the CORRECT (& general) way to ask whether we're in "vertical mode"??
@@ -143,18 +144,19 @@ LoadDefinitions!(state, {
     //   # And also things like \centerline that will end up bumping up to block level!
     before_digest => sub[stomach, state] {reenter_text_mode(false, stomach.get_gullet_mut(), state)},
     after_digest => sub[stomach, whatsit, state] {
-      let mut width : Option<RegisterValue>= None;
-      {
+      let width : Option<RegisterValue> = {
         let spec = whatsit.get_arg(1);
         let tbox = whatsit.get_arg(2).unwrap();
-        if let Some(w) = GetKeyVal!(spec, "to") {
-          width = w.into();
+         if let Some(w) = GetKeyVal!(spec, "to") {
+          w.into()
         } else if let Some(s) = GetKeyVal!(spec, "spread") {
           let s_num_opt : Option<RegisterValue> = s.into();
           let s_num = s_num_opt.unwrap_or_else(|| Number::new(0).into());
-          width = Some( tbox.get_width(state).unwrap().add(s_num) );
+          Some( tbox.get_width(state).unwrap().add(s_num) )
+        } else {
+          None
         }
-      }
+      };
       if let Some(w) = width {
         whatsit.set_width(w);
       }

--- a/rtx_package/src/package/pool/tex_ch24_primitives.rs
+++ b/rtx_package/src/package/pool/tex_ch24_primitives.rs
@@ -162,7 +162,8 @@ LoadDefinitions!(state, {
 
   // TeX I/O primitives
   DefPrimitive!("\\openin Number SkipMatch:= SkipSpaces TeXFileName", sub[stomach, args, state] {
-    unpack_to_string!(args => port, filename);
+    let port = args[0].to_string();
+    let filename = args[1].to_string();
     // possibly should close $port if it's already been opened?
     // Rely on FindFile to enforce any access restrictions
     if let Some(path) = find_file(&filename, None, state) {
@@ -239,7 +240,8 @@ LoadDefinitions!(state, {
   // For output files, we'll write the data to a cached internal copy
   // rather than to the actual file system.
   DefPrimitive!("\\openout Number SkipMatch:= SkipSpaces TeXFileName", sub[stomach, args, state] {
-    unpack_to_string!(args => port, filename);
+    let port = args[0].to_string();
+    let filename = args[1].to_string();
     let contents_key = &s!("{}_contents",filename);
     AssignValue!(&s!("output_file:{}",port)  => filename,  Some(Scope::Global));
     AssignValue!(contents_key => "",  Some(Scope::Global));

--- a/rtx_package/src/package/pool/tex_ch24_primitives.rs
+++ b/rtx_package/src/package/pool/tex_ch24_primitives.rs
@@ -162,8 +162,9 @@ LoadDefinitions!(state, {
 
   // TeX I/O primitives
   DefPrimitive!("\\openin Number SkipMatch:= SkipSpaces TeXFileName", sub[stomach, args, state] {
-    let port = args[0].to_string();
-    let filename = args[1].to_string();
+    unpack!(args => port, filename);
+    let port = port.to_string();
+    let filename = filename.to_string();
     // possibly should close $port if it's already been opened?
     // Rely on FindFile to enforce any access restrictions
     if let Some(path) = find_file(&filename, None, state) {
@@ -183,6 +184,7 @@ LoadDefinitions!(state, {
 
   DefPrimitive!("\\closein Number", sub[stomach, args, state] {
     unpack!(args => port);
+    let port = port.to_number();
     // Clone the Rc<> for mouth out of state, since we'll be mutating.
     let mouth_opt = if let Some(Stored::Mouth(ref mouth)) = LookupValue!(&s!("input_file:{}", port)) {
       Some(Arc::clone(mouth))
@@ -200,7 +202,7 @@ LoadDefinitions!(state, {
     unpack!(args => port, token);
     let token: Token = token.into(); // downcast from Tokens
     let port = port.to_number();
-    if let Some(Stored::Mouth(mouth_stored)) = LookupValue!(&s!("input_file:{}",port)) {
+    if let Some(Stored::Mouth(mouth_stored)) = state.lookup_value(&s!("input_file:{}",port)) {
       let mouth_obj = Arc::clone(mouth_stored);
       stomach.bgroup(state);
       AssignValue!("PRESERVE_NEWLINES", 2); // Special EOL/EOF treatment for \read
@@ -240,8 +242,9 @@ LoadDefinitions!(state, {
   // For output files, we'll write the data to a cached internal copy
   // rather than to the actual file system.
   DefPrimitive!("\\openout Number SkipMatch:= SkipSpaces TeXFileName", sub[stomach, args, state] {
-    let port = args[0].to_string();
-    let filename = args[1].to_string();
+    unpack!(args => port, filename);
+    let port = port.to_string();
+    let filename = filename.to_string();
     let contents_key = &s!("{}_contents",filename);
     AssignValue!(&s!("output_file:{}",port)  => filename,  Some(Scope::Global));
     AssignValue!(contents_key => "",  Some(Scope::Global));

--- a/rtx_package/src/package/pool/tex_ch24_primitives.rs
+++ b/rtx_package/src/package/pool/tex_ch24_primitives.rs
@@ -118,7 +118,7 @@ LoadDefinitions!(state, {
 
   // \afterassignment saves ONE token (globally!) to execute after the next assignment
   DefPrimitive!("\\afterassignment Token", sub[stomach, args, state] {
-    unpack!(args => t);
+    unpack_to_token!(args => t);
     state.assign_value("afterAssignment", t, Some(Scope::Global));
   });
   // \aftergroup saves ALL tokens (from repeated calls) to be executed IN ORDER after the next egroup or }
@@ -230,8 +230,7 @@ LoadDefinitions!(state, {
   });
 
   DefConditional!("\\ifeof Number", sub[gullet, args, state] {
-    unpack_to_token!(args => port);
-    let port = port.to_number();
+    let port = args.remove(0).to_number();
     if let Some(Stored::Mouth(mouth)) = LookupValue!(&s!("input_file:{}", port)) {
       mouth.read().unwrap().at_eof()
     } else {

--- a/rtx_package/src/package/pool/tex_ch25_primitives.rs
+++ b/rtx_package/src/package/pool/tex_ch25_primitives.rs
@@ -64,7 +64,7 @@ LoadDefinitions!(state, {
     after_digest => sub[stomach, whatsit, state] {
       whatsit.set_property("y",
         // can the ergonomics of this Dimension cast be improved?
-        Dimension(-1 * whatsit.get_arg(1).unwrap().value_of())
+        Dimension(-whatsit.get_arg(1).unwrap().value_of())
       );
     }
   );

--- a/rtx_package/src/package/pool/tex_expandable_primitives.rs
+++ b/rtx_package/src/package/pool/tex_expandable_primitives.rs
@@ -316,7 +316,7 @@ LoadDefinitions!(outer_state, {
 // Hmm... I wonder, should getString itself be dealing with escapechar?
 fn escapechar(state: &State) -> String {
   let code: i32 = match state.lookup_register("\\escapechar", Vec::new()) {
-    Some(RegisterValue::Number(v)) => v.value_of() as i32,
+    Some(RegisterValue::Number(v)) => v.value_of(),
     _ => -1,
   };
   if (0..=255).contains(&code) {

--- a/rtx_package/src/package/pool/tex_expandable_primitives.rs
+++ b/rtx_package/src/package/pool/tex_expandable_primitives.rs
@@ -187,7 +187,7 @@ LoadDefinitions!(outer_state, {
 
   //======================================================================
 
-  DefParameterType!("CSName", reader => reader!(gullet, inner, extra, state, {
+  DefParameterType!(CSName, reader => reader!(gullet, inner, extra, state, {
     let mut cs = escapechar(state);
     // keep newlines from having \n inside!
     while let Some(token) = gullet.read_x_token(true, true, state)? {

--- a/rtx_package/src/package/pool/tex_expandable_primitives.rs
+++ b/rtx_package/src/package/pool/tex_expandable_primitives.rs
@@ -268,7 +268,8 @@ LoadDefinitions!(outer_state, {
   // stomach, but we may require some special-case treatment in other pieces of code...
   DefMacro!("\\input", "\\ltx@input");
   DefPrimitive!("\\ltx@input TeXFileName", sub[stomach,args,state] {
-    input(&args[0].to_string(), InputOptions::default(), stomach, state)?;
+    unpack!(args => name);
+    input(&name.to_string(), InputOptions::default(), stomach, state)?;
   });
 
   // Note that TeX doesn't actually close the mouth;

--- a/rtx_package/src/package/pool/tex_expandable_primitives.rs
+++ b/rtx_package/src/package/pool/tex_expandable_primitives.rs
@@ -72,18 +72,17 @@ LoadDefinitions!(outer_state, {
   // define it here (only approxmiately), since it's already useful.
   Let!("\\protect", "\\relax");
 
-  DefMacro!("\\romannumeral Number", sub[gullet, args, state] { roman!(args[0].as_ref().unwrap().to_number().value_of()) });
+  DefMacro!("\\romannumeral Number", sub[gullet, args, state] { roman!(args.remove(0).to_number().value_of()) });
 
   // # 1) Knuth, The TeXBook, page 40, paragraph 1, Chapter 7: How TEX Reads What You Type.
   // # suggests all characters except spaces are returned in category code Other, i.e. Explode()
   DefMacro!("\\string Token", sub[gullet, args, state] {
-    unpack!(args => token);
-    let token : Token = token.into();
+    let token = args.remove(0).expected_token()?;
     let mut s = token.to_string();
     if s.starts_with('/') {
       s = escapechar(state) + &s;
     }
-    Ok(Explode!(s).into())
+    Explode!(s)
   });
 
   DefMacro!(T_CS!("\\jobname"), None, Tokens!()); // Set to the filename by initialization
@@ -269,7 +268,7 @@ LoadDefinitions!(outer_state, {
   // stomach, but we may require some special-case treatment in other pieces of code...
   DefMacro!("\\input", "\\ltx@input");
   DefPrimitive!("\\ltx@input TeXFileName", sub[stomach,args,state] {
-    input(&args[0].as_ref().unwrap().to_string(), InputOptions::default(), stomach, state)?;
+    input(&args[0].to_string(), InputOptions::default(), stomach, state)?;
   });
 
   // Note that TeX doesn't actually close the mouth;
@@ -297,7 +296,7 @@ LoadDefinitions!(outer_state, {
       //     if (!$type) {
       //       my $cs = ToString($defn->getCS);
       //       Error('unexpected', "\\the$cs", $gullet, "You can't use $cs after \\the"); return (); }
-      let value = defn.value_of(args, state)
+      let value = defn.value_of(args.into_iter().map(ArgWrap::Token).collect(), state)
         .unwrap_or_else(|| RegisterValue::Tokens(Tokens!()));
       // In all cases, these should be OTHER, except for space. (!?)
       let mut tokens : Vec<Token> = match value {

--- a/rtx_package/src/package/pool/tex_expandable_primitives.rs
+++ b/rtx_package/src/package/pool/tex_expandable_primitives.rs
@@ -13,16 +13,20 @@ LoadDefinitions!(outer_state, {
   DefConditional!("\\ifcase Number");
 
   DefConditional!("\\ifnum Number Token Number", sub[gullet, args, state] {
-    unpack_to_token!(args =>u,rel,v);
+    unpack_to_number!(args => u);
+    unpack_to_token!(args => rel);
+    unpack_to_number!(args => v);
     compare(u, rel, v)
   });
   DefConditional!("\\ifdim Dimension Token Dimension", sub[gullet, args, state] {
-    unpack_to_token!(args =>u,rel,v);
+    unpack_to_number!(args => u);
+    unpack_to_token!(args =>rel);
+    unpack_to_number!(args => v);
     compare(u, rel, v)
   });
   DefConditional!("\\ifodd Number", sub[gullet, args, state] {
-    unpack_to_token!(args => u);
-    let uint = u.to_number().value_of();
+    unpack_to_number!(args => u);
+    let uint = u.value_of();
     uint % 2 == 1
   });
 
@@ -47,9 +51,9 @@ LoadDefinitions!(outer_state, {
     XEquals!(&token1, &token2)
   });
 
-  DefConditional!("\\ifvoid Number", sub[_g, args, state] {unpack_to_token!(args=>arg); classify_box(arg, state).is_empty() });
-  DefConditional!("\\ifhbox Number", sub[_g, args, state] {unpack_to_token!(args=>arg); classify_box(arg, state) == "hbox" });
-  DefConditional!("\\ifvbox Number", sub[_g, args, state] {unpack_to_token!(args=>arg); classify_box(arg, state) == "vbox" });
+  DefConditional!("\\ifvoid Number", sub[_g, args, state] {unpack_to_number!(args=>arg); classify_box(arg, state).is_empty() });
+  DefConditional!("\\ifhbox Number", sub[_g, args, state] {unpack_to_number!(args=>arg); classify_box(arg, state) == "hbox" });
+  DefConditional!("\\ifvbox Number", sub[_g, args, state] {unpack_to_number!(args=>arg); classify_box(arg, state) == "vbox" });
 
   DefConditional!("\\iftrue", { true });
   DefConditional!("\\iffalse", { false });
@@ -64,8 +68,8 @@ LoadDefinitions!(outer_state, {
   //// shouldn't be a box; See the isRelax code in handleScripts, below
 
   DefMacro!("\\number Number", sub[gullet, args, state] {
-    unpack_to_token!(args=>num);
-    let num_str = num.to_number().value_of();
+    unpack_to_number!(args=>num);
+    let num_str = num.value_of();
     Explode!(num_str)
   });
 
@@ -176,8 +180,7 @@ LoadDefinitions!(outer_state, {
           meaning = s!("{}macro:{}->{}",prefixes, spec, expansion);
         },
         e => { // are there other cases that could occur here? should we handle them?
-          dbg!(e);
-          unimplemented!();
+          panic!("this may be a missing case in \\meaning's implementation: {e}");
         }
       }
     }
@@ -325,9 +328,9 @@ fn escapechar(state: &State) -> String {
   }
 }
 
-fn compare(u: Token, rel: Token, v: Token) -> Result<bool> {
-  let u = u.to_number().value_of();
-  let v = v.to_number().value_of();
+fn compare(u: Number, rel: Token, v: Number) -> Result<bool> {
+  let u = u.value_of();
+  let v = v.value_of();
   // NOTE: One would expect this to be best written as an advanced match statement
   // however, due to the shallow comparison of Cow<str> the Cow::Borrowed("<") and
   // Cow::Owned("<") variants will NOT be equal via a destructuring match.

--- a/rtx_package/src/package/pool/tex_expandable_primitives.rs
+++ b/rtx_package/src/package/pool/tex_expandable_primitives.rs
@@ -289,15 +289,13 @@ LoadDefinitions!(outer_state, {
 
   // \the<internal quantity>
   DefMacro!("\\the Register", sub[gullet, args, state] {
-    unpack!(args => variable);
-    let mut args = variable.unlist();
-    let defn = args.remove(0).to_register(state);
-    if let Some(defn) = defn {
+    if let ArgWrap::RegisterDefinition((rtoken, inner)) = args.remove(0) {
       // let register_type = defn.borrow().register_type;
       //     if (!$type) {
       //       my $cs = ToString($defn->getCS);
       //       Error('unexpected', "\\the$cs", $gullet, "You can't use $cs after \\the"); return (); }
-      let value = defn.value_of(args.into_iter().map(ArgWrap::Token).collect(), state)
+      let defn = rtoken.to_register(state).expect("if a Register parameter provides a token, it must have a Register definition.");
+      let value = defn.value_of(inner, state)
         .unwrap_or_else(|| RegisterValue::Tokens(Tokens!()));
       // In all cases, these should be OTHER, except for space. (!?)
       let mut tokens : Vec<Token> = match value {

--- a/rtx_package/src/package/pool/tex_fonts.rs
+++ b/rtx_package/src/package/pool/tex_fonts.rs
@@ -502,11 +502,11 @@ LoadDefinitions!(outer_state, {
         reversion =>  sub[_whatsit,_args,st] {
           Ok(Tokens::new(
             if (glyph_c as usize) < 128 {
-              eprintln!("-- glyph c: {}", glyph_c);
+              eprintln!("-- glyph c: {glyph_c}");
               vec![T_OTHER!(glyph_c.clone())]
             } else {
               let v = value.value_of();
-              eprintln!("-- matchar v: {}", v);
+              eprintln!("-- matchar v: {v}");
               vec![T_CS!("\\mathchar"),T_OTHER!(v),T_CS!("\\relax")]
             }))
         }

--- a/rtx_package/src/package/pool/tex_fonts.rs
+++ b/rtx_package/src/package/pool/tex_fonts.rs
@@ -92,7 +92,7 @@ LoadDefinitions!(outer_state, {
   // # 2nd arg is <font> = <fontdef token> | \font | <family member>
   // #  <family member> = <font range><4bit number>
   // #  <font range> = \textfont | \scriptfont | \scriptscriptfont
-  DefParameterType!("FontToken", reader => reader!(gullet, inner, extra, state, {
+  DefParameterType!(FontToken, reader => reader!(gullet, inner, extra, state, {
     let token = gullet.read_token(state).unwrap();
     if FONT_TOKEN_RE.is_match(&token.to_string()) {
       gullet.read_number(state)?;

--- a/rtx_package/src/package/pool/tex_fonts.rs
+++ b/rtx_package/src/package/pool/tex_fonts.rs
@@ -13,31 +13,31 @@ LoadDefinitions!(outer_state, {
   // These look essentially like Registers, although Knuth doesn't call them that.
   DefRegister!("\\textfont Number", T_CS!("\\tenrm"),
   getter => sub[args, state] {
-    let fam = args[0].to_number().value_of();
+    let fam = args.remove(0).to_number().value_of();
     state.lookup_number(&s!("fontinfo_{}_text", fam)).unwrap_or_default()
   },
   setter => sub[font,args,state] {
-    let fam = args[0].to_number().value_of();
+    let fam = args.remove(0).to_number().value_of();
     state.assign_value(&s!("fontinfo_{}_text", fam), font, Some(Scope::Global));
   });
 
   DefRegister!("\\scriptfont Number" => T_CS!("\\sevenrm"),
   getter => sub[args, state] {
-    let fam = args[0].to_number().value_of();
+    let fam = args.remove(0).to_number().value_of();
     state.lookup_number(&s!("fontinfo_{}_script", fam)).unwrap_or_default()
   },
   setter => sub[font,args,state] {
-    let fam = args[0].to_number().value_of();
+    let fam = args.remove(0).to_number().value_of();
     state.assign_value(&s!("fontinfo_{}_script", fam), font, Some(Scope::Global));
   });
 
   DefRegister!("\\scriptscriptfont Number" => T_CS!("\\fiverm"),
   getter => sub[args, state] {
-    let fam = args[0].to_number().value_of();
+    let fam = args.remove(0).to_number().value_of();
     state.lookup_number(&s!("fontinfo_{}_scriptscript", fam)).unwrap_or_default()
   },
   setter => sub[font,args,state] {
-    let fam = args[0].to_number().value_of();
+    let fam = args.remove(0).to_number().value_of();
     state.assign_value(&s!("fontinfo_{}_scriptscript", fam), font, Some(Scope::Global));
   });
 
@@ -420,8 +420,8 @@ LoadDefinitions!(outer_state, {
   );
 
   DefPrimitive!("\\char Number", sub[stomach, args, p_state] {
-    unpack_to_token!(args=>token);
-    let number = token.to_number();
+    let token = args.remove(0);
+    let number = token.clone().to_number();
     let gullet = stomach.get_gullet_mut();
     let decoded = match font::decode(number.value_of() as u8, None, false, p_state) {
       None => String::new(),

--- a/rtx_package/src/package/pool/tex_functions.rs
+++ b/rtx_package/src/package/pool/tex_functions.rs
@@ -158,19 +158,13 @@ pub fn parse_def_parameters(cs: &Token, params_in: Tokens, state: &mut State) ->
   }
 }
 
-pub fn do_def(globally: bool, stomach: &mut Stomach, mut args: Vec<Option<Tokens>>, state: &mut State) -> Result<()> {
+pub fn do_def(globally: bool, stomach: &mut Stomach, mut args: Vec<ArgWrap>, state: &mut State) -> Result<()> {
   BindState!(stomach, state);
   let cs_opt = args.remove(0);
   let params_opt = args.remove(0);
-  let body = args.remove(0).unwrap();
-  let cs: Token = match cs_opt {
-    Some(ts) => ts.into(),
-    None => {
-      Error!("expected", "Token", stomach, state, "Expected definition token");
-      return Ok(());
-    },
-  };
-  let params = match params_opt {
+  let body = args.remove(0).owned_tokens().unwrap();
+  let cs: Token = cs_opt.expected_token()?;
+  let params = match params_opt.owned_tokens() {
     Some(ts) => ts,
     None => {
       Error!("misdefined", cs, stomach, state, "Expected definition parameter list");
@@ -273,7 +267,7 @@ pub fn read_box_contents(gullet: &mut Gullet, everybox_opt: Option<Tokens>, stat
 
 /// Reading a Box's content is crucially dependent on invoking the "{" token and obtaining a digested result
 /// Hence it is *always* needed to pair `read_box_contents` with its stomach-level counterpart, `predigest_box_contents`
-pub fn predigest_box_contents(stomach: &mut Stomach, _tokens: Tokens, state: &mut State) -> Result<Option<Digested>> {
+pub fn predigest_box_contents(stomach: &mut Stomach, _tokens: ArgWrap, state: &mut State) -> Result<Option<Digested>> {
   let mut contents = stomach.invoke_token(&T_BEGIN!(), state)?;
   if contents.is_empty() {
     Ok(None)
@@ -385,7 +379,7 @@ pub fn insert_block(document: &mut Document, contents: &Digested, mut blockattr:
       // Insertion came up empty?
       document.remove_node(blocknode); // then remove the new block entirely
     } else if rows.len() == 1 &&crows.len() == 1 &&
-    state.model.get_node_qname(&rows.first().unwrap()) == "ltx:p" &&
+    state.model.get_node_qname(rows.first().unwrap()) == "ltx:p" &&
     document.can_contain(&blocknode.get_parent().unwrap(),
       &state.model.get_node_qname(&crows[0]), state)
     // TODO: && (!hasattr || blockattr.keys().any(...

--- a/rtx_package/src/package/pool/tex_functions.rs
+++ b/rtx_package/src/package/pool/tex_functions.rs
@@ -194,8 +194,7 @@ pub fn do_def(globally: bool, stomach: &mut Stomach, mut args: Vec<ArgWrap>, sta
 // Kinda rough: We don't really keep track of modes as carefully as TeX does.
 // We'll assume that a box is horizontal if there's anything at all,
 // but it's not a vbox (!?!?)
-pub fn classify_box(boxnum: Token, state: &State) -> &'static str {
-  let boxnum: Number = boxnum.to_number();
+pub fn classify_box(boxnum: Number, state: &State) -> &'static str {
   match state.lookup_value(&s!("box{}", boxnum.value_of())) {
     Some(Stored::Digested(ref d)) => match **d {
       Digested::Whatsit(ref w) if w.read().unwrap().definition == state.lookup_definition(&T_CS!("\\vbox")).unwrap() => "vbox",

--- a/rtx_package/src/package/pool/tex_scripts.rs
+++ b/rtx_package/src/package/pool/tex_scripts.rs
@@ -233,14 +233,14 @@ LoadDefinitions!(state, {
   def_primitive(
     T_SUPER!(),
     None,
-    Arc::new(|stomach: &mut Stomach, _args: Vec<Option<Tokens>>, state: &mut State| script_handler(stomach, Catcode::SUPER, state)),
+    Some(Arc::new(|stomach: &mut Stomach, _args: Vec<ArgWrap>, state: &mut State| script_handler(stomach, Catcode::SUPER, state))),
     PrimitiveOptions::default(),
     state,
   );
   def_primitive(
     T_SUB!(),
     None,
-    Arc::new(|stomach: &mut Stomach, _args: Vec<Option<Tokens>>, state: &mut State| script_handler(stomach, Catcode::SUB, state)),
+    Some(Arc::new(|stomach: &mut Stomach, _args: Vec<ArgWrap>, state: &mut State| script_handler(stomach, Catcode::SUB, state))),
     PrimitiveOptions::default(),
     state,
   );

--- a/rtx_package/src/package/pool/tex_setup.rs
+++ b/rtx_package/src/package/pool/tex_setup.rs
@@ -83,7 +83,7 @@ LoadDefinitions!(state, {
 
   // ======================================================================
   // Define parsers for standard parameter types.
-  DefParameterType!("Plain", sub[gullet, inner, _extra, state] {
+  DefParameterType!(Plain, sub[gullet, inner, _extra, state] {
       let mut value = Some(gullet.read_arg(state)?);
       for inner_p in inner.into_iter().flatten() {
         value = inner_p.reparse_argument(gullet, value, state);
@@ -110,7 +110,7 @@ LoadDefinitions!(state, {
     })
   );
 
-  DefParameterType!("DefPlain", sub[gullet, inner, _extra, state] {
+  DefParameterType!(DefPlain, sub[gullet, inner, _extra, state] {
       let mut value = Some(gullet.read_arg(state)?);
       for inner_p in inner.into_iter().flatten() {
         value = inner_p.reparse_argument(gullet, value, state);
@@ -138,7 +138,7 @@ LoadDefinitions!(state, {
     })
   );
 
-  DefParameterType!("Optional", sub[gullet, inner, default, state] {
+  DefParameterType!(Optional, sub[gullet, inner, default, state] {
       let mut value = gullet.read_optional(state)?;
       if value.is_none() && !default.is_empty() {
         if let ParameterExtra::Tokens(ref tks) = default[0] {
@@ -182,7 +182,7 @@ LoadDefinitions!(state, {
   //   <general text> = <filler>{<balanced text><right brace>
   // however, <filler> does get expanded while searching for the initial {
   // which IS required in contrast to a general argument; ie a single token is not correct.
-  DefParameterType!("GeneralText", sub[gullet, inner, _extra, state] {
+  DefParameterType!(GeneralText, sub[gullet, inner, _extra, state] {
     if let Some(open) = gullet.read_x_token(false ,false, state)? {
       if open == T_BEGIN!() {
         Ok(gullet.read_balanced(false, state)?.unwrap_or_default())
@@ -196,7 +196,7 @@ LoadDefinitions!(state, {
     }
   });
 
-  DefParameterType!("Until", sub[gullet, _inner, until_extra, state] {
+  DefParameterType!(Until, sub[gullet, _inner, until_extra, state] {
     let mut until = Vec::new();
     for x in until_extra.iter() {
       if let ParameterExtra::Tokens(ref t) = x {
@@ -221,16 +221,16 @@ LoadDefinitions!(state, {
   }));
 
   // Skip any spaces, but don't contribute an argument.
-  DefParameterType!("SkipSpaces", sub[gullet, inner, _extra, state] {
+  DefParameterType!(SkipSpaces, sub[gullet, inner, _extra, state] {
     gullet.skip_spaces(state);
   }, novalue => true);
 
-  DefParameterType!("Skip1Space", sub[gullet, inner, _extra, state] {
+  DefParameterType!(Skip1Space, sub[gullet, inner, _extra, state] {
     gullet.skip_one_space(state);
   }, novalue => true);
 
   // Read the next token
-  DefParameterType!("Token", sub[gullet, _inner, _extra, state] {
+  DefParameterType!(Token, sub[gullet, _inner, _extra, state] {
     match gullet.read_token(state) {
       Some(t) => Ok(Tokens!(t)),
       None => {
@@ -241,7 +241,7 @@ LoadDefinitions!(state, {
   });
 
   // Read the next token, after expanding any expandable ones.
-  DefParameterType!("XToken", sub[gullet, inner, _extra, state] {
+  DefParameterType!(XToken, sub[gullet, inner, _extra, state] {
     if let Some(t) = gullet.read_x_token(false, false, state)? {
       Ok(Tokens!(t))
     } else {
@@ -251,7 +251,7 @@ LoadDefinitions!(state, {
   });
 
   // Read a number
-  DefParameterType!("Number", sub[gullet, inner, _extra, state] {
+  DefParameterType!(Number, sub[gullet, inner, _extra, state] {
       gullet.read_number(state)?.to_token()
     },
     reader_predigest => reader_predigest!(stomach, arg, state, {
@@ -260,7 +260,7 @@ LoadDefinitions!(state, {
   );
 
   // Read a floating point number
-  DefParameterType!("Float", sub[gullet, inner, _extra, state] {
+  DefParameterType!(Float, sub[gullet, inner, _extra, state] {
       gullet.read_float(state)?.to_token()
     },
     reader_predigest => reader_predigest!(stomach, arg, state, {
@@ -275,7 +275,7 @@ LoadDefinitions!(state, {
   //   return ($gullet->readFloat || Float(0)); }
 
   // Read a dimension
-  DefParameterType!("Dimension", sub[gullet, inner, _extra, state] {
+  DefParameterType!(Dimension, sub[gullet, inner, _extra, state] {
       gullet.read_dimension(state)?.to_token()
     },
     reader_predigest => reader_predigest!(stomach, arg, state, {
@@ -284,7 +284,7 @@ LoadDefinitions!(state, {
   );
 
   // Read a Glue (aka skip)
-  DefParameterType!("Glue", sub[gullet, inner, _extra, state] {
+  DefParameterType!(Glue, sub[gullet, inner, _extra, state] {
       gullet.read_glue(state)?.to_token()
     },
     reader_predigest => reader_predigest!(stomach, arg, state, {
@@ -293,7 +293,7 @@ LoadDefinitions!(state, {
   );
 
   // Read a MuDimension (math)
-  DefParameterType!("MuDimension", sub[gullet, inner, _extra, state] {
+  DefParameterType!(MuDimension, sub[gullet, inner, _extra, state] {
       gullet.read_mu_dimension(state)?.to_token()
     },
     reader_predigest => reader_predigest!(stomach, arg, state, {
@@ -302,7 +302,7 @@ LoadDefinitions!(state, {
   );
 
   // Read a MuGlue (math)
-  DefParameterType!("MuGlue", sub[gullet, inner, _extra, state] {
+  DefParameterType!(MuGlue, sub[gullet, inner, _extra, state] {
       gullet.read_mu_glue(state)?.to_token()
     },
     reader_predigest => reader_predigest!(stomach, arg, state, {
@@ -312,12 +312,12 @@ LoadDefinitions!(state, {
 
   // Read until the next (balanced) open brace {
   // used for the last TeX-style delimited argument
-  DefParameterType!("UntilBrace", sub[gullet, inner, _extra, state] {
+  DefParameterType!(UntilBrace, sub[gullet, inner, _extra, state] {
     gullet.read_until_brace(state)?.unwrap_or_default()
   });
 
   // Yet another special case: Require a { but do not read it!!!
-  DefParameterType!("RequireBrace", sub[gullet, inner, _extra, state] {
+  DefParameterType!(RequireBrace, sub[gullet, inner, _extra, state] {
     if !gullet.if_next(T_BEGIN!(), state)? {
       Error!("expected","{", gullet, state, "Expected a {{ here");
     }
@@ -325,7 +325,7 @@ LoadDefinitions!(state, {
   },
   novalue => true);
 
-  DefParameterType!("XUntil", sub[gullet, inner, untils, state] {
+  DefParameterType!(XUntil, sub[gullet, inner, untils, state] {
     let until : Token = match untils[0] {
       ParameterExtra::Tokens(ref t) => t.into(),
       _ => panic!("XUntil needs a token ParameterExtra.")
@@ -351,7 +351,7 @@ LoadDefinitions!(state, {
   // This is sorta like readbalanced, but expands as it goes.
   // This appears to be needed by certain primitives (eg. \noalign ?)
   // and maybe what we should be using for some Digested ??
-  DefParameterType!("Expanded", sub[gullet, inner, untils, state] {
+  DefParameterType!(Expanded, sub[gullet, inner, untils, state] {
     if let Some(token) = gullet.read_x_token(false, false, state)? {
       let mut tokens   = Vec::new();
       if token.get_catcode() == Catcode::BEGIN {
@@ -394,7 +394,7 @@ LoadDefinitions!(state, {
   // to enact the neutralization and discard the temporary smuggle flag that is required
   //
   // Whenever possible, use this `DefExpanded` parameter type directly, rather than hand-crafting a new one.
-  DefParameterType!("DefExpanded", sub[gullet, _inner, _extra, state] {
+  DefParameterType!(DefExpanded, sub[gullet, _inner, _extra, state] {
       state.smuggle_the = true;
       let expanded = if let Some(token) = gullet.read_x_token(false, false, state)? {
         if token.get_catcode() == Catcode::BEGIN {
@@ -416,7 +416,7 @@ LoadDefinitions!(state, {
   );
 
   // Read a matching keyword, eg. Match:=
-  DefParameterType!("Match", sub[gullet, _inner, extra, state] {
+  DefParameterType!(Match, sub[gullet, _inner, extra, state] {
     let extra_tokens : Vec<Token> = extra.iter().filter(|e|
     matches!(e, ParameterExtra::Tokens(t))).cloned().map(Into::into).collect();
     match gullet.read_match(&[&Tokens::new(extra_tokens)], state)? {
@@ -427,7 +427,7 @@ LoadDefinitions!(state, {
 
   // Read a keyword; eg. Keyword:to
   // (like Match, but ignores catcodes)
-  DefParameterType!("Keyword", sub[gullet, _inner, extra, state] {
+  DefParameterType!(Keyword, sub[gullet, _inner, extra, state] {
     let extra_string : String = extra.iter().map(|e|
     if let ParameterExtra::Tokens(t) = e {
         t.to_string()
@@ -443,12 +443,12 @@ LoadDefinitions!(state, {
   });
 
   // Read balanced material (?)
-  DefParameterType!("Balanced", sub[gullet, _inner, _extra, state] {
+  DefParameterType!(Balanced, sub[gullet, _inner, _extra, state] {
     gullet.read_balanced(false, state)
   });
 
   // Read a Semiverbatim argument; ie w/ most catcodes neutralized.
-  DefParameterType!("Semiverbatim",
+  DefParameterType!(Semiverbatim,
     sub[gullet, inner, _extra, state] { gullet.read_arg(state) },
     reversion => reversion!(gullet, arg, inner, state, {
       // let mut reverted_inner;
@@ -471,7 +471,7 @@ LoadDefinitions!(state, {
     semiverbatim => Some(Vec::new()));
 
   // Read a LaTeX-style optional argument (ie. in []), but the contents read as Semiverbatim.
-  DefParameterType!("OptionalSemiverbatim",
+  DefParameterType!(OptionalSemiverbatim,
     sub[gullet, inner, _extra, state] { gullet.read_optional(state) },
     semiverbatim => Some(Vec::new()),
     optional => true,
@@ -490,7 +490,7 @@ LoadDefinitions!(state, {
 
   // Be careful here: if % appears before the initial {, it's still a comment!
   // Also, note that non-typewriter fonts will mess up some chars on digestion!
-  DefParameterType!("Verbatim", sub[gullet, inner, _extra, state] {
+  DefParameterType!(Verbatim, sub[gullet, inner, _extra, state] {
       gullet.read_until(Tokens!(T_BEGIN!()), state)?;
       let verb_chars = vec!['%', '\\'];
       state.begin_semiverbatim(Some(&verb_chars));
@@ -515,7 +515,7 @@ LoadDefinitions!(state, {
   );
 
   // Read an argument that will not be digested.
-  DefParameterType!("Undigested", sub[gullet, inner, _extra, state] { gullet.read_arg(state)},
+  DefParameterType!(Undigested, sub[gullet, inner, _extra, state] { gullet.read_arg(state)},
   reader_predigest => undigested!(),
   reversion => reversion!(gullet, arg, inner, state, {
     let mut read_tokens = vec!(T_BEGIN!());
@@ -526,7 +526,7 @@ LoadDefinitions!(state, {
   }));
 
   // Read a LaTeX-style optional argument (ie. in []), but it will not be digested.
-  DefParameterType!("OptionalUndigested", sub[gullet, inner, _extra, state] { gullet.read_optional(state) },
+  DefParameterType!(OptionalUndigested, sub[gullet, inner, _extra, state] { gullet.read_optional(state) },
   reader_predigest => undigested!(),
   optional => true,
   reversion => reversion!(gullet, arg, inner, state, {
@@ -542,13 +542,13 @@ LoadDefinitions!(state, {
   }));
 
   // Read a keyword value (KeyVals), that will not be digested.
-  DefParameterType!("UndigestedKey", sub[gullet, inner, _extra, state] {
+  DefParameterType!(UndigestedKey, sub[gullet, inner, _extra, state] {
     gullet.read_arg(state)
   },
   reader_predigest => undigested!());
 
   // Read a token as used when defining it, ie. it may be enclosed in braces.
-  DefParameterType!("DefToken", sub[gullet, inner, _extra, state] {
+  DefParameterType!(DefToken, sub[gullet, inner, _extra, state] {
     let mut token = gullet.read_token(state);
     let begin_token = Some(T_BEGIN!());
     let space_token = T_SPACE!();
@@ -574,7 +574,7 @@ LoadDefinitions!(state, {
   }, reader_predigest => undigested!());
 
   // Read a variable, ie. a token (after expansion) that is a writable register.
-  DefParameterType!("Variable", sub[gullet, inner, _extra, state] {
+  DefParameterType!(Variable, sub[gullet, inner, _extra, state] {
     let token_opt = gullet.read_x_token(false, false, state)?;
     let defn_opt = match token_opt {
       Some(ref token) => state.lookup_register_definition(token),
@@ -621,7 +621,7 @@ LoadDefinitions!(state, {
   }));
 
   // Same, but not necessarily writable
-  DefParameterType!("Register", sub[gullet, inner, _extra, state] {
+  DefParameterType!(Register, sub[gullet, inner, _extra, state] {
     let token = gullet.read_x_token(false, false, state)?;
     let defn = match token {
       None => None,
@@ -658,7 +658,7 @@ LoadDefinitions!(state, {
     Ok(Tokens!())
   }));
 
-  DefParameterType!("TeXFileName", sub[gullet, inner, _extra, state] {
+  DefParameterType!(TeXFileName, sub[gullet, inner, _extra, state] {
       let mut tokens : Vec<Token> = Vec::new();
       while let Some(token) = gullet.read_x_token(false, false, state)? {
         match token.get_catcode() {
@@ -692,7 +692,7 @@ LoadDefinitions!(state, {
   });
 
   // A LaTeX style directory List
-  DefParameterType!("DirectoryList", sub[gullet, inner, _extra, state] {
+  DefParameterType!(DirectoryList, sub[gullet, inner, _extra, state] {
       // my ($gullet) = @_;
       // $gullet->skipSpaces;
       // if ($gullet->ifNext(T_BEGIN)) {
@@ -720,7 +720,7 @@ LoadDefinitions!(state, {
   // This reads a Box as needed by \raise, \lower, \moveleft, \moveright.
   // Hopefully there are no issues with the box being digested
   // as part of the reader???
-  DefParameterType!("MoveableBox", sub[gullet, inner, _extra, state] {
+  DefParameterType!(MoveableBox, sub[gullet, inner, _extra, state] {
     gullet.skip_spaces(state);
     if let Some(xtoken) = gullet.read_x_token(false, false, state)? {
       Tokens!(xtoken)
@@ -752,7 +752,7 @@ LoadDefinitions!(state, {
 
   // Read a parenthesis delimited argument.
   // Note that this does NOT balance () within the argument.
-  DefParameterType!("BalancedParen", sub[gullet, inner, _extra, state] {
+  DefParameterType!(BalancedParen, sub[gullet, inner, _extra, state] {
     let tok_opt = gullet.read_x_token(false,false,state)?;
     let is_paren = match tok_opt {
       Some(ref t) => t.get_string() == "(",
@@ -780,7 +780,7 @@ LoadDefinitions!(state, {
   // This parameter gets digested until the (required) opening { is balanced.
   // It is useful when the content would usually need to have been \protect'd
   // in order to correctly deal with catcodes.
-  DefParameterType!("Digested", sub[gullet, inner, _extra, state] {
+  DefParameterType!(Digested, sub[gullet, inner, _extra, state] {
     //   my ($gullet) = @_;
     //   $gullet->skipSpaces;
     //   my $ismath = $STATE->lookupValue('IN_MATH');
@@ -804,7 +804,7 @@ LoadDefinitions!(state, {
   });
 
   // A variation: Digest until we encounter a given token!
-  DefParameterType!("DigestUntil", sub[gullet, inner, _extra, state] {
+  DefParameterType!(DigestUntil, sub[gullet, inner, _extra, state] {
     //   my ($gullet, $until) = @_;
     //   ($until) = $until->unlist;                              # Make sure it's a single token!!!
     //   $gullet->skipSpaces;
@@ -823,7 +823,7 @@ LoadDefinitions!(state, {
   // particularly alignments (which may or may not be actual environments),
   // but which need special treatment of some of their content
   // as the expansion is carried out.
-  DefParameterType!("DigestedBody", reader => reader!(gullet, inner, extra, state, {
+  DefParameterType!(DigestedBody, reader => reader!(gullet, inner, extra, state, {
       Ok(Tokens!()) // all done in predigestion
     }),
     reader_predigest => reader_predigest!(stomach, arg, state, {
@@ -848,11 +848,11 @@ LoadDefinitions!(state, {
   //     (b) pstricks accepts a float, and optionally a unit,
   //        If the unit is omitted, it is relative to \psxunit or \psyunit.
   // How to capture these ?
-  //DefParameterType!("Length", sub {
+  //DefParameterType!(Length, sub {
   ////   my($gullet,$unit)=@_;
 
   // CommaList expects something like {balancedstuff,...}
-  DefParameterType!("CommaList", sub[gullet, inner, _extra, state] {
+  DefParameterType!(CommaList, sub[gullet, inner, _extra, state] {
       // my ($gullet, $type) = @_;
       // my $typedef = $type && LaTeXML::Package::parseParameters(ToString($type), "CommaList")->[0];
       // my @items = ();
@@ -960,19 +960,19 @@ LoadDefinitions!(state, {
 
   //   return (KeyVals_aux($gullet, $until, [$star, $plus, @keyspec])); }
 
-  DefParameterType!("RequiredKeyVals", sub[gullet, inner, _extra, state] {unimplemented!(); ()
+  DefParameterType!(RequiredKeyVals, sub[gullet, inner, _extra, state] {unimplemented!(); ()
     // RequiredKeyVals(0, 0, @_); },
   });
   //   reversion => sub { (T_BEGIN, Revert($_[0]), T_END); });
-  DefParameterType!("RequiredKeyVals", sub[gullet, inner, _extra, state] {unimplemented!(); ()
+  DefParameterType!(RequiredKeyValsStar, sub[gullet, inner, _extra, state] {unimplemented!(); ()
     // RequiredKeyVals(1, 0, @_); },
   });
   //   reversion => sub { (T_BEGIN, Revert($_[0]), T_END); });
-  DefParameterType!("RequiredKeyVals", sub[gullet, inner, _extra, state] {unimplemented!(); ()
+  DefParameterType!(RequiredKeyValsPlus, sub[gullet, inner, _extra, state] {unimplemented!(); ()
     // RequiredKeyVals(0, 1, @_); },
   });
   //   reversion => sub { (T_BEGIN, Revert($_[0]), T_END); });
-  DefParameterType!("RequiredKeyVals", sub[gullet, inner, _extra, state] {unimplemented!(); ()
+  DefParameterType!(RequiredKeyValsStarPlus, sub[gullet, inner, _extra, state] {unimplemented!(); ()
     // RequiredKeyVals(1, 1, @_); },
   });
   //   reversion => sub { (T_BEGIN, Revert($_[0]), T_END); });
@@ -996,7 +996,7 @@ LoadDefinitions!(state, {
     }
   }
 
-  DefParameterType!("OptionalKeyVals", sub[gullet, inner, extra, state] {
+  DefParameterType!(OptionalKeyVals, sub[gullet, inner, extra, state] {
       optional_key_vals(false, false, inner, gullet, state)
     },
     reader_predigest => reader_predigest!(stomach, arg, state, {
@@ -1008,7 +1008,7 @@ LoadDefinitions!(state, {
     }),
    optional=>true);
   // reversion => sub { ($_[0] ? (T_OTHER('['), Revert($_[0]), T_OTHER(']')) : ()); });
-  DefParameterType!("OptionalKeyVals*", sub[gullet, inner, extra, state] {
+  DefParameterType!(OptionalKeyValsStar, sub[gullet, inner, extra, state] {
       optional_key_vals(true, false, inner, gullet, state)
     },
     reader_predigest => reader_predigest!(stomach, arg, state, {
@@ -1016,7 +1016,7 @@ LoadDefinitions!(state, {
     }),
    optional=>true);
   // reversion => sub { ($_[0] ? (T_OTHER('['), Revert($_[0]), T_OTHER(']')) : ()); });
-  DefParameterType!("OptionalKeyVals+", sub[gullet, inner, extra, state] {
+  DefParameterType!(OptionalKeyValsPlus, sub[gullet, inner, extra, state] {
       optional_key_vals(false, true, inner, gullet, state)
     },
     reader_predigest => reader_predigest!(stomach, arg, state, {
@@ -1024,7 +1024,7 @@ LoadDefinitions!(state, {
     }),
    optional=>true);
   // reversion => sub { ($_[0] ? (T_OTHER('['), Revert($_[0]), T_OTHER(']')) : ()); });
-  DefParameterType!("OptionalKeyVals*+", sub[gullet, inner, extra, state] {
+  DefParameterType!(OptionalKeyValsPlusStar, sub[gullet, inner, extra, state] {
       optional_key_vals(true, true, inner, gullet, state)
     },
     reader_predigest => reader_predigest!(stomach, arg, state, {
@@ -1035,7 +1035,7 @@ LoadDefinitions!(state, {
 
   // # Not sure that this is the most elegant solution, but...
   // # What I'd really like are some sort of parameter modifiers, mathstyle, font... until...?
-  DefParameterType!("DisplayStyle", sub[gullet, inner, _extra, state] {unimplemented!(); () });
+  DefParameterType!(DisplayStyle, sub[gullet, inner, _extra, state] {unimplemented!(); () });
   //     $_[0]->readArg; },
   //   beforeDigest => sub {
   //     $_[0]->bgroup;
@@ -1043,7 +1043,7 @@ LoadDefinitions!(state, {
   //   afterDigest => sub {
   //     $_[0]->egroup; },
   //   reversion => sub { (T_BEGIN, Revert($_[0]), T_END); });
-  DefParameterType!("TextStyle", sub[gullet, inner, _extra, state] {unimplemented!(); () });
+  DefParameterType!(TextStyle, sub[gullet, inner, _extra, state] {unimplemented!(); () });
   //     $_[0]->readArg; },
   //   beforeDigest => sub {
   //     $_[0]->bgroup;
@@ -1051,7 +1051,7 @@ LoadDefinitions!(state, {
   //   afterDigest => sub {
   //     $_[0]->egroup; },
   //   reversion => sub { (T_BEGIN, Revert($_[0]), T_END); });
-  DefParameterType!("ScriptStyle", sub[gullet, inner, _extra, state] {unimplemented!(); () });
+  DefParameterType!(ScriptStyle, sub[gullet, inner, _extra, state] {unimplemented!(); () });
   //     $_[0]->readArg; },
   //   beforeDigest => sub {
   //     $_[0]->bgroup;
@@ -1059,7 +1059,7 @@ LoadDefinitions!(state, {
   //   afterDigest => sub {
   //     $_[0]->egroup; },
   //   reversion => sub { (T_BEGIN, Revert($_[0]), T_END); });
-  DefParameterType!("ScriptscriptStyle", sub[gullet, inner, _extra, state] {unimplemented!(); () });
+  DefParameterType!(ScriptscriptStyle, sub[gullet, inner, _extra, state] {unimplemented!(); () });
   //     $_[0]->readArg; },
   //   beforeDigest => sub {
   //     $_[0]->bgroup;
@@ -1068,7 +1068,7 @@ LoadDefinitions!(state, {
   //     $_[0]->egroup; },
   //   reversion => sub { (T_BEGIN, Revert($_[0]), T_END); });
   // # Perverse naming convention: not script style, but in the style of a script relative to current.
-  DefParameterType!("InScriptStyle", sub[gullet, inner, _extra, state] {unimplemented!(); () });
+  DefParameterType!(InScriptStyle, sub[gullet, inner, _extra, state] {unimplemented!(); () });
   //     $_[0]->readArg; },
   //   beforeDigest => sub {
   //     $_[0]->bgroup;
@@ -1079,7 +1079,7 @@ LoadDefinitions!(state, {
   // # NOTE: the various parameter features don't combine easily!!
   // # I need a ScriptStyleUntil for \root!!!
   // # I also need to redo fractions using these new types....
-  DefParameterType!("OptionalInScriptStyle", sub[gullet, inner, _extra, state] {unimplemented!(); () });
+  DefParameterType!(OptionalInScriptStyle, sub[gullet, inner, _extra, state] {unimplemented!(); () });
   //     $_[0]->readOptional; },
   //   beforeDigest => sub {
   //     $_[0]->bgroup;
@@ -1088,7 +1088,7 @@ LoadDefinitions!(state, {
   //     $_[0]->egroup; },
   //   optional => 1,
   //   reversion => sub { ($_[0] ? (T_OTHER('['), Revert($_[0]), T_OTHER(']')) : ()); });
-  DefParameterType!("InFractionStyle", sub[gullet, inner, _extra, state] {unimplemented!(); () });
+  DefParameterType!(InFractionStyle, sub[gullet, inner, _extra, state] {unimplemented!(); () });
   //     $_[0]->readArg; },
   //   beforeDigest => sub {
   //     $_[0]->bgroup;

--- a/rtx_package/src/package/pool/tex_setup.rs
+++ b/rtx_package/src/package/pool/tex_setup.rs
@@ -203,7 +203,7 @@ LoadDefinitions!(state, {
       if let ParameterExtra::Tokens(ref t) = x {
         until.extend(t.clone().unlist());
       } else {
-        panic!("unexpected ParameterExtra in Until: {:?}",x);
+        panic!("unexpected ParameterExtra in Until: {x:?}");
       }
     }
     gullet.read_until(Tokens::new(until), state)

--- a/rtx_package/src/package/pool/tex_setup.rs
+++ b/rtx_package/src/package/pool/tex_setup.rs
@@ -680,8 +680,8 @@ LoadDefinitions!(state, {
   });
 
   DefPrimitive!("\\ltx@loadpool {}", sub[stomach,args,state] {
-    let name = args[0].to_string();
-    LoadPool!(&name);
+    unpack!(args=>name);
+    LoadPool!(&name.to_string());
   });
 
   // A LaTeX style directory List

--- a/rtx_package/src/package/pool/tex_setup.rs
+++ b/rtx_package/src/package/pool/tex_setup.rs
@@ -823,7 +823,7 @@ LoadDefinitions!(state, {
       let ismath   = state.lookup_bool("IN_MATH");
       let mut list     = stomach.digest_next_body(None, state)?;
       // In most (all?) cases, we're really looking for a single Whatsit here...
-      list = list.into_iter().filter(|tbox| !tbox.is_comment()).collect();
+      list.retain(|tbox| !tbox.is_comment());
       let mut digested = List::new(list);
       digested.mode = if ismath { Some(TexMode::Math) } else { Some(TexMode::Text) };
       digested

--- a/rtx_package/src/package/pool/tex_setup.rs
+++ b/rtx_package/src/package/pool/tex_setup.rs
@@ -253,20 +253,13 @@ LoadDefinitions!(state, {
 
   // Read a number
   DefParameterType!(Number, sub[gullet, inner, _extra, state] {
-      gullet.read_number(state)?.to_token()
-    },
-    reader_predigest => reader_predigest!(stomach, arg, state, {
-      arg.to_number()
-    })
-  );
+    gullet.read_number(state)?
+  });
 
   // Read a floating point number
   DefParameterType!(Float, sub[gullet, inner, _extra, state] {
-      gullet.read_float(state)?.to_token()
-    },
-    reader_predigest => reader_predigest!(stomach, arg, state, {
-      arg.to_number()
-    })
+      gullet.read_float(state)?
+    }
   );
 
   // ???
@@ -276,40 +269,13 @@ LoadDefinitions!(state, {
   //   return ($gullet->readFloat || Float(0)); }
 
   // Read a dimension
-  DefParameterType!(Dimension, sub[gullet, inner, _extra, state] {
-      gullet.read_dimension(state)?.to_token()
-    },
-    reader_predigest => reader_predigest!(stomach, arg, state, {
-      arg.to_dimension()
-    })
-  );
-
+  DefParameterType!(Dimension, sub[gullet, inner, _extra, state] { gullet.read_dimension(state)? });
   // Read a Glue (aka skip)
-  DefParameterType!(Glue, sub[gullet, inner, _extra, state] {
-      gullet.read_glue(state)?.to_token()
-    },
-    reader_predigest => reader_predigest!(stomach, arg, state, {
-      arg.to_glue()
-    })
-  );
-
+  DefParameterType!(Glue, sub[gullet, inner, _extra, state] { gullet.read_glue(state)? });
   // Read a MuDimension (math)
-  DefParameterType!(MuDimension, sub[gullet, inner, _extra, state] {
-      gullet.read_mu_dimension(state)?.to_token()
-    },
-    reader_predigest => reader_predigest!(stomach, arg, state, {
-      arg.to_mu_dimension()
-    })
-  );
-
+  DefParameterType!(MuDimension, sub[gullet, inner, _extra, state] { gullet.read_mu_dimension(state)? });
   // Read a MuGlue (math)
-  DefParameterType!(MuGlue, sub[gullet, inner, _extra, state] {
-      gullet.read_mu_glue(state)?.to_token()
-    },
-    reader_predigest => reader_predigest!(stomach, arg, state, {
-      arg.to_mu_glue()
-    })
-  );
+  DefParameterType!(MuGlue, sub[gullet, inner, _extra, state] { gullet.read_mu_glue(state)? });
 
   // Read until the next (balanced) open brace {
   // used for the last TeX-style delimited argument

--- a/rtx_package/src/package/pool/tex_setup.rs
+++ b/rtx_package/src/package/pool/tex_setup.rs
@@ -592,11 +592,8 @@ LoadDefinitions!(state, {
     };
     match defn {
       Some(register) => {
-        let mut invoked = vec![token.unwrap()];
-        for arg in register.read_arguments(gullet, state)? {
-          invoked.append(&mut arg.unlist());
-        }
-        return Ok(ArgWrap::Tokens(Tokens::new(invoked)));
+        let args = register.read_arguments(gullet, state)?;
+        return Ok(ArgWrap::RegisterDefinition((token.unwrap(), args)));
       },
       None => {
         let message = s!("A <register> was supposed to be here. Got {:?}", token);

--- a/rtx_package/src/package/pool/tex_setup.rs
+++ b/rtx_package/src/package/pool/tex_setup.rs
@@ -84,7 +84,7 @@ LoadDefinitions!(state, {
   // ======================================================================
   // Define parsers for standard parameter types.
   DefParameterType!(Plain, sub[gullet, inner, _extra, state] {
-      let mut value = Some(gullet.read_arg(state)?);
+      let mut value = ArgWrap::Tokens(gullet.read_arg(state)?);
       for inner_p in inner.into_iter().flatten() {
         value = inner_p.reparse_argument(gullet, value, state);
       }
@@ -111,7 +111,7 @@ LoadDefinitions!(state, {
   );
 
   DefParameterType!(DefPlain, sub[gullet, inner, _extra, state] {
-      let mut value = Some(gullet.read_arg(state)?);
+      let mut value = ArgWrap::Tokens(gullet.read_arg(state)?);
       for inner_p in inner.into_iter().flatten() {
         value = inner_p.reparse_argument(gullet, value, state);
       }
@@ -145,6 +145,7 @@ LoadDefinitions!(state, {
           value = Some(tks.clone());
         }
       }
+      let mut value = ArgWrap::OptionTokens(value);
       if !inner.is_empty() {
         for inner_p in inner.into_iter().flatten() {
           value = inner_p.reparse_argument(gullet, value, state);
@@ -583,12 +584,8 @@ LoadDefinitions!(state, {
     if let Some(defn) = defn_opt {
         if defn.is_register() && !defn.is_readonly() {
           let mut invoked = vec![token_opt.unwrap()];
-          for arg_opt in defn.read_arguments(gullet, state)? {
-            if let Some(arg) = arg_opt {
-              invoked.append(&mut arg.unlist());
-            } else {
-              unimplemented!(); // ???
-            }
+          for arg in defn.read_arguments(gullet, state)? {
+            invoked.append(&mut arg.unlist());
           }
           // TODO: What is this datatype ? How does it fit the rtx typed interfaces for parameter types?
           // An extension seems required, also due to the Register parameter type right under.
@@ -630,14 +627,10 @@ LoadDefinitions!(state, {
     match defn {
       Some(register) => {
         let mut invoked = vec![token.unwrap()];
-        for arg_opt in register.read_arguments(gullet, state)? {
-          if let Some(arg) = arg_opt {
-            invoked.append(&mut arg.unlist());
-          } else {
-            unimplemented!();
-          }
+        for arg in register.read_arguments(gullet, state)? {
+          invoked.append(&mut arg.unlist());
         }
-        return Ok(Some(Tokens::new(invoked)));
+        return Ok(ArgWrap::Tokens(Tokens::new(invoked)));
       },
       None => {
         let message = s!("A <register> was supposed to be here. Got {:?}", token);
@@ -687,7 +680,7 @@ LoadDefinitions!(state, {
   });
 
   DefPrimitive!("\\ltx@loadpool {}", sub[stomach,args,state] {
-    unpack_to_string!(args=>name);
+    let name = args[0].to_string();
     LoadPool!(&name);
   });
 

--- a/rtx_package/src/package/pool/tex_setup.rs
+++ b/rtx_package/src/package/pool/tex_setup.rs
@@ -549,23 +549,20 @@ LoadDefinitions!(state, {
     };
     if let Some(defn) = defn_opt {
         if defn.is_register() && !defn.is_readonly() {
-          let mut invoked = vec![token_opt.unwrap()];
-          for arg in defn.read_arguments(gullet, state)? {
-            invoked.append(&mut arg.unlist());
-          }
+          let args = defn.read_arguments(gullet, state)?;
           // TODO: What is this datatype ? How does it fit the rtx typed interfaces for parameter types?
           // An extension seems required, also due to the Register parameter type right under.
           // Ok(Tokens!(defn_tok, defn_args))
-          Ok(Tokens::new(invoked))
+          Ok(ArgWrap::RegisterDefinition((token_opt.unwrap(), args)))
         } else {
           let message = s!("A <variable> was supposed to be here\n Got {:?}", token_opt);
           Error!("expected","<variable>", gullet, state, message);
-          Ok(Tokens!())
+          Ok(ArgWrap::Tokens(Tokens!()))
         }
     } else {
       let message = s!("A <variable> was supposed to be here\n Got {:?}", token_opt);
       Error!("expected","<variable>", gullet, state, message);
-      Ok(Tokens!())
+      Ok(ArgWrap::Tokens(Tokens!()))
     }
   },
   reversion => reversion!(gullet,args, inner, state, {

--- a/rtx_package/src/package/pool/url_sty.rs
+++ b/rtx_package/src/package/pool/url_sty.rs
@@ -96,7 +96,8 @@ LoadDefinitions!(state, {
   // Kinda tricky, since we need to get the expansion of \cmd as the value of \newcmd
   // Along with the annoying \endgroup that must balance the one always preceding \Url!
   DefPrimitive!("\\urldef{}", sub[stomach, args, url_state] {
-    let cmd = args[0].to_string();
+    unpack!(args => cmd);
+    let cmd = cmd.to_string();
     let expansion : Vec<Digested> = stomach.digest_next_body(Some(T_CS!("\\endgroup")), url_state)?;
     let gullet = stomach.get_gullet_mut();
     DefPrimitive!(&cmd, { Ok(expansion.clone()) });

--- a/rtx_package/src/package/pool/url_sty.rs
+++ b/rtx_package/src/package/pool/url_sty.rs
@@ -96,7 +96,7 @@ LoadDefinitions!(state, {
   // Kinda tricky, since we need to get the expansion of \cmd as the value of \newcmd
   // Along with the annoying \endgroup that must balance the one always preceding \Url!
   DefPrimitive!("\\urldef{}", sub[stomach, args, url_state] {
-    unpack_to_string!(args => cmd);
+    let cmd = args[0].to_string();
     let expansion : Vec<Digested> = stomach.digest_next_body(Some(T_CS!("\\endgroup")), url_state)?;
     let gullet = stomach.get_gullet_mut();
     DefPrimitive!(&cmd, { Ok(expansion.clone()) });

--- a/rtx_package/src/package/pool/verbatim_sty.rs
+++ b/rtx_package/src/package/pool/verbatim_sty.rs
@@ -78,7 +78,7 @@ LoadDefinitions!(state, {
     let mut lines = Vec::new();
     // TODO: UGH!!! Isn't there a better way to approximate the Perl simplicity of writing an inline regex?
     // the escaping is very easy to get wrong!
-    let env_re = Regex::new(&format!("^(.*)\\\\end\\s*\\{{{}\\}}(.*)$", env)).unwrap();
+    let env_re = Regex::new(&format!("^(.*)\\\\end\\s*\\{{{env}\\}}(.*)$")).unwrap();
     while let Some(line) = gullet.read_raw_line(state) {
       if let Some(caps) = env_re.captures(&line) {
         let pre = caps.get(1).map_or("", |m| m.as_str()).to_string();

--- a/rtx_package/src/package/setup_binding_language.rs
+++ b/rtx_package/src/package/setup_binding_language.rs
@@ -995,6 +995,8 @@ macro_rules! StepCounter {
     step_counter($ctr, $noreset, $stomach, $state_arg)
   };
 }
+
+/// convenience macro for `api::counter_dialect::ref_step_counter`
 #[macro_export]
 macro_rules! RefStepCounter {
   ($ctr:expr, $noreset:expr, $stomach:ident) => {{
@@ -1005,6 +1007,8 @@ macro_rules! RefStepCounter {
     ref_step_counter($ctr, $noreset, $stomach, $state_arg)
   };
 }
+
+/// convenience macro for `api::counter_dialect::ref_step_id`
 #[macro_export]
 macro_rules! RefStepID {
   ($ctr:expr) => {{

--- a/rtx_package/src/package/setup_binding_language.rs
+++ b/rtx_package/src/package/setup_binding_language.rs
@@ -155,12 +155,14 @@ macro_rules! bind_state_mut {
 //======================================================================
 #[macro_export]
 macro_rules! DefParameterTypeWO {
-  ($name:expr, $param:expr) => {
+  ($name:ident, $param:expr) => {
     bind_state_mut!(st);
-    st.assign_mapping("PARAMETER_TYPES", $name, Some(Stored::Parameter(Arc::new($param))))
+    // pub type $name = Tokens;
+    st.assign_mapping("PARAMETER_TYPES", stringify!($name), Some(Stored::Parameter(Arc::new($param))))
   };
-  ($name:expr, $param:expr, $state_arg:ident) => {
-    $state_arg.assign_mapping("PARAMETER_TYPES", $name, Some(Stored::Parameter(Arc::new($param))))
+  ($name:ident, $param:expr, $state_arg:ident) => {
+    // pub type $name = Tokens;
+    $state_arg.assign_mapping("PARAMETER_TYPES", stringify!($name), Some(Stored::Parameter(Arc::new($param))))
   };
 }
 
@@ -1704,18 +1706,18 @@ macro_rules! DefMath(
 
 #[macro_export]
 macro_rules! DefParameterType {
-  ($name:literal) => (DefParameterTypeWO!($name, NewDefault!(Parameter, name => $name.to_string())));
-  ($name:literal, $state_arg:ident) => (DefParameterTypeWO!($name, NewDefault!(Parameter, name => $name.to_string()), $state_arg));
-  ($name:literal, $($key:ident => $value:expr),*)=>(DefParameterTypeWO!($name, NewDefault!(Parameter, name => $name.to_string(), $($key=>$value),*)));
-  ($name:literal, $($key:ident => $value:expr),*, $state_arg:ident)=>
-    (DefParameterTypeWO!($name, NewDefault!(Parameter, name => $name.to_string(), $($key=>$value),*), $state_arg));
+  ($name:ident) => (DefParameterTypeWO!($name, NewDefault!(Parameter, name => stringify!($name).to_string())));
+  ($name:ident, $state_arg:ident) => (DefParameterTypeWO!($name, NewDefault!(Parameter, name => stringify!($name.to_string())), $state_arg));
+  ($name:ident, $($key:ident => $value:expr),*)=>(DefParameterTypeWO!($name, NewDefault!(Parameter, name => stringify!($name).to_string(), $($key=>$value),*)));
+  ($name:ident, $($key:ident => $value:expr),*, $state_arg:ident)=>
+    (DefParameterTypeWO!($name, NewDefault!(Parameter, name => stringify!($name.to_string()), $($key=>$value),*), $state_arg));
   // with reader as explicit sub
-  ($name:literal, sub[$gullet:ident, $inner:ident, $extra:ident, $inner_state:ident] $body:block) => (
+  ($name:ident, sub[$gullet:ident, $inner:ident, $extra:ident, $inner_state:ident] $body:block) => (
     DefParameterTypeWO!($name, NewDefault!(Parameter, reader => reader!($gullet, $inner, $extra, $inner_state, $body))));
-  ($name:literal, sub[$gullet:ident, $inner:ident, $extra:ident, $inner_state:ident] $body:block, $($key:ident => $value:expr),*) => (
+  ($name:ident, sub[$gullet:ident, $inner:ident, $extra:ident, $inner_state:ident] $body:block, $($key:ident => $value:expr),*) => (
     DefParameterTypeWO!($name, NewDefault!(Parameter, reader => reader!($gullet, $inner, $extra, $inner_state, $body),
-      name => $name.to_string(),  $($key=>$value),*)));
-  ($name:literal, sub[$gullet:ident, $inner:ident, $extra:ident, $inner_state:ident] $body:block, $($key:ident => $value:expr),*) => (
+      name => stringify!($name).to_string(),  $($key=>$value),*)));
+  ($name:ident, sub[$gullet:ident, $inner:ident, $extra:ident, $inner_state:ident] $body:block, $($key:ident => $value:expr),*) => (
     DefParameterTypeWO!($name, NewDefault!(Parameter, reader => reader!($gullet, $inner, $extra, $inner_state, $body),
       name => $name.to_string(),  $($key=>$value),*), $state_arg));
 }

--- a/rtx_package/src/package/setup_binding_language.rs
+++ b/rtx_package/src/package/setup_binding_language.rs
@@ -468,48 +468,48 @@ macro_rules! DefPrimitive {
   ($proto:literal, $replacement:literal $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
     let (cs, params) = parse_prototype!($proto);
-    let replacement_closure = Arc::new(|stomach: &mut Stomach, args: Vec<Option<Tokens>>, inner_state: &mut State| {
+    let replacement_closure = Arc::new(|stomach: &mut Stomach, args: Vec<ArgWrap>, inner_state: &mut State| {
       Tbox::new($replacement.to_string(), None, None, Tokens!(), HashMap::new(), inner_state).into_digested_result()
     });
-    defi_primitive!(cs, params, replacement_closure, options);
+    defi_primitive!(cs, params, Some(replacement_closure), options);
   }};
   // Case: closure pattern replacement
   ($proto:expr, sub[$stomach_arg:ident, $args:ident, $state_arg:ident] $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
     let (cs, params) = parse_prototype!($proto);
-    let replacement_closure = Arc::new(move |$stomach_arg: &mut Stomach, mut $args: Vec<Option<Tokens>>, $state_arg: &mut State| {
+    let replacement_closure = Arc::new(move |$stomach_arg: &mut Stomach, mut $args: Vec<ArgWrap>, $state_arg: &mut State| {
       WithInnerState!($body, $stomach_arg, $state_arg).into_digested_result()
     });
-    defi_primitive!(cs, params, replacement_closure, options);
+    defi_primitive!(cs, params, Some(replacement_closure), options);
   }};
   // Case: cs-noparams with closure pattern replacement
   ($cs:expr, None, sub[$stomach_arg:ident, $args:ident, $state_arg:ident] $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
-    let replacement_closure = Arc::new(move |$stomach_arg: &mut Stomach, mut $args: Vec<Option<Tokens>>, $state_arg: &mut State| {
+    let replacement_closure = Arc::new(move |$stomach_arg: &mut Stomach, mut $args: Vec<ArgWrap>, $state_arg: &mut State| {
       WithInnerState!($body, $stomach_arg, $state_arg).into_digested_result()
     });
-    defi_primitive!($cs, None, replacement_closure, options);
+    defi_primitive!($cs, None, Some(replacement_closure), options);
   }};
   // Case: no replacement
   ($proto:literal, None $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
     let (cs, params) = parse_prototype!($proto);
-    defi_primitive!(cs, params, Arc::new(noprimitive!()), options);
+    defi_primitive!(cs, params, None, options);
   }};
   // Case: no params, no replacement
   ($cs:expr, None, None $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
-    defi_primitive!($cs, None, Arc::new(noprimitive!()), options);
+    defi_primitive!($cs, None, None, options);
   }};
 
   // Case: closure block with implicit arguments
   ($proto:expr, $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
     let (cs, params) = parse_prototype!($proto);
-    let replacement_closure =  Arc::new(move |stomach: &mut Stomach, args: Vec<Option<Tokens>>, state: &mut State| {
+    let replacement_closure =  Arc::new(move |stomach: &mut Stomach, args: Vec<ArgWrap>, state: &mut State| {
       WithInnerState!($body, stomach, state).into_digested_result()
     });
-    defi_primitive!(cs, params, replacement_closure, options);
+    defi_primitive!(cs, params, Some(replacement_closure), options);
   }};
   // Case: direct closure provided (for reasons of reusing the same closure in several definitions)
   ($proto:expr, $replacement_closure:expr, $($input:tt)*) => {{
@@ -1135,7 +1135,7 @@ macro_rules! DefAccent {
       let invoked = Invocation!(T_CS!($accent), letter.clone(), stomach.get_gullet_mut(), inner_state)?;
       // TODO: check if letter.to_string has artefacts
       $crate::package::pool::tex_accents::apply_accent(
-        stomach, &letter[0].as_ref().unwrap().to_string(), $combiningchar, $standalonechar, Some(invoked), inner_state)?;
+        stomach, &letter[0].as_tokens(inner_state)?.unwrap().to_string(), $combiningchar, $standalonechar, Some(invoked), inner_state)?;
       Ok(vec![])
     }, mode => "text");
   }};
@@ -1940,7 +1940,7 @@ macro_rules! DeclareOption {
     let code: PrimitiveClosure = Arc::new(move |$stomach, _args, $inner_state|
       WithInnerState!($body, $stomach, $inner_state).into_digested_result()
     );
-    def_primitive(T_CS!(cs), None, code, PrimitiveOptions::default(), $outer_state);
+    def_primitive(T_CS!(cs), None, Some(code), PrimitiveOptions::default(), $outer_state);
   };
   ($option:expr, sub[$stomach:ident, $inner_state:ident] $body:block, $outer_state: ident) => {
     $outer_state.push_value("@declaredoptions", $option);
@@ -1949,7 +1949,7 @@ macro_rules! DeclareOption {
     let code: PrimitiveClosure = Arc::new(move |$stomach, _args, $inner_state|
       WithInnerState!($body, $stomach, $inner_state).into_digested_result()
     );
-    def_primitive(T_CS!(cs), None, code, PrimitiveOptions::default(), $outer_state);
+    def_primitive(T_CS!(cs), None, Some(code), PrimitiveOptions::default(), $outer_state);
   }
 }
 

--- a/rtx_package/src/package/setup_binding_language.rs
+++ b/rtx_package/src/package/setup_binding_language.rs
@@ -658,12 +658,13 @@ macro_rules! DefConstructor {
   }};
   // Pre-parsed prototype flavors
   // Pre-parsed prototype; Closure replacement flavors
-  ($cs:literal, $parameters:expr, sub [ $document:ident, $args:ident, $props:ident, $inner_state:ident ] $body:block, $($input:tt)+) => {{
+  ($cs:expr, $parameters:expr, sub [ $document:ident, $args:ident, $props:ident, $inner_state:ident ] $body:block, $($input:tt)+) => {{
     let options = defi_opts!(@munch ($($input)*) -> {ConstructorOptions,});
-    defi_constr!($proto, $document, $args, $props, $inner_state, $body, options);
+    let compiled_replacement : Option<ReplacementClosure>= Some(Arc::new(replacement!($document, $args, $props, $inner_state, $body)));
+    defi_constr!($cs, $parameters, compiled_replacement, options);
   }};
-  ($cs:literal, $parameters:expr, sub [ $document:ident, $args:ident, $props:ident, $inner_state:ident ] $body:block) => {{
-    let compiled_replacement = Some(Arc::new(replacement!($document, $args, $props, $inner_state, $body)));
+  ($cs:expr, $parameters:expr, sub [ $document:ident, $args:ident, $props:ident, $inner_state:ident ] $body:block) => {{
+    let compiled_replacement : Option<ReplacementClosure>= Some(Arc::new(replacement!($document, $args, $props, $inner_state, $body)));
     defi_constr!($cs, $parameters, compiled_replacement, ConstructorOptions::default());
   }};
   //  Pre-parsed prototype; Literal replacement flavors


### PR DESCRIPTION
This PR marks a "part 1" of the refactoring that gets us to typed binding closures.

Namely, an introduction to a badly named (needs a better name!) `ArgWrap` type, which wraps around any argument of a binding - commonly things like `Tokens`, `Number`, single `Token`, `Dimension`, etc. Or the advanced and unusual `RegisterDefinition` trick from the `Register` DefParameterType.

A lot is left to be desired, but I would really want to move this into master, so that I can align to the latest rust clippy lints and keep the next PR small.