### PR TITLE
compile-time typed parameters for DefMacro, DefPrimitive, DefConditional. part 4

### DIFF
--- a/rtx_codegen/src/lib.rs
+++ b/rtx_codegen/src/lib.rs
@@ -43,6 +43,12 @@ pub fn derive_compile_tokenize_internal(input: TokenStream) -> TokenStream {
   tokenizeable::compile_tokenize_internal(item)
 }
 
+#[proc_macro_derive(CompilePrototypeForTypedMacro, attributes(prototype))]
+pub fn derive_compile_prototype_for_typed_macro(input: TokenStream) -> TokenStream {
+  let item = parse_macro_input!(input as DeriveInput);
+  parametrizeable::compile_prototype_for_typed_macro(item)
+}
+
 #[proc_macro_derive(CompilePrototype, attributes(prototype))]
 pub fn derive_compile_prototype(input: TokenStream) -> TokenStream {
   let item = parse_macro_input!(input as DeriveInput);

--- a/rtx_codegen/src/lib.rs
+++ b/rtx_codegen/src/lib.rs
@@ -43,10 +43,10 @@ pub fn derive_compile_tokenize_internal(input: TokenStream) -> TokenStream {
   tokenizeable::compile_tokenize_internal(item)
 }
 
-#[proc_macro_derive(CompilePrototypeForTypedMacro, attributes(prototype))]
-pub fn derive_compile_prototype_for_typed_macro(input: TokenStream) -> TokenStream {
+#[proc_macro_derive(CompilePrototypeFor, attributes(prototype, inner))]
+pub fn derive_compile_prototype_for(input: TokenStream) -> TokenStream {
   let item = parse_macro_input!(input as DeriveInput);
-  parametrizeable::compile_prototype_for_typed_macro(item)
+  parametrizeable::compile_prototype_for(item)
 }
 
 #[proc_macro_derive(CompilePrototype, attributes(prototype))]

--- a/rtx_codegen/src/parametrizeable.rs
+++ b/rtx_codegen/src/parametrizeable.rs
@@ -5,7 +5,7 @@ use syn::{DeriveInput, Lit, Meta};
 
 /// For now this prototype compilation technique is tied tightly to the `TypedMacroWO!` macro from rtx_package
 /// until we can figure out how to improve the code organization.
-pub fn compile_prototype(input: DeriveInput) -> TokenStream {
+pub fn compile_prototype_for_typed_macro(input: DeriveInput) -> TokenStream {
   let prototype: String = match input.attrs[0].parse_meta().unwrap() {
     Meta::NameValue(v) => match v.lit {
       Lit::Str(v) => v.value(),
@@ -39,4 +39,35 @@ pub fn compile_prototype(input: DeriveInput) -> TokenStream {
       Err(e) => panic!("Failed to compile binding prototype: {prototype}\n Reason: {e}"),
     }
   }
+}
+
+
+pub fn compile_prototype(input: DeriveInput) -> TokenStream {
+  let prototype: String = match input.attrs[0].parse_meta().unwrap() {
+    Meta::NameValue(v) => match v.lit {
+      Lit::Str(v) => v.value(),
+      _ => panic!("only accepts #[prototype = \"value\"] attribute syntax, mandatory double-quotes (Lit)"),
+    },
+    _ => panic!("only accepts #[prototype = \"value\"] attribute syntax, mandatory double-quotes (parse_meta)"),
+  };
+  if prototype.is_empty() {
+    panic!("Must never call on empty prototype?! input was {prototype}");
+  } else {
+    match parse_prototype(&prototype, None) {
+      Ok((cs, params_opt)) => {
+        match params_opt {
+          Some(params) => quote!(
+            macro_rules! this_cs_and_parameters {
+              () => { (#cs, Some(#params)) };
+            }).into(),
+          None => quote!(
+            macro_rules! this_cs_and_parameters {
+              () => { (#cs, None) };
+            }).into()
+        }
+      },
+      Err(e) => panic!("Failed to compile binding prototype: {prototype}\n Reason: {e}"),
+    }
+  }
+
 }

--- a/rtx_codegen/src/parametrizeable.rs
+++ b/rtx_codegen/src/parametrizeable.rs
@@ -1,17 +1,25 @@
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use rtx_core::common::def_parser::parse_prototype;
+use rtx_core::parameter::ParameterExtra;
 use syn::{DeriveInput, Lit, Meta};
 
 /// For now this prototype compilation technique is tied tightly to the `TypedMacroWO!` macro from rtx_package
 /// until we can figure out how to improve the code organization.
-pub fn compile_prototype_for_typed_macro(input: DeriveInput) -> TokenStream {
+pub fn compile_prototype_for(input: DeriveInput) -> TokenStream {
   let prototype: String = match input.attrs[0].parse_meta().unwrap() {
     Meta::NameValue(v) => match v.lit {
       Lit::Str(v) => v.value(),
       _ => panic!("only accepts #[prototype = \"value\"] attribute syntax, mandatory double-quotes (Lit)"),
     },
     _ => panic!("only accepts #[prototype = \"value\"] attribute syntax, mandatory double-quotes (parse_meta)"),
+  };
+  let inner: String = match input.attrs[1].parse_meta().unwrap() {
+    Meta::NameValue(v) => match v.lit {
+      Lit::Str(v) => v.value(),
+      _ => panic!("only accepts #[macro = \"TypedMacro\"] attribute syntax, mandatory double-quotes (Lit)"),
+    },
+    _ => panic!("only accepts #[macro = \"TypedMacro\"] attribute syntax, mandatory double-quotes (parse_meta)"),
   };
 
   if prototype.is_empty() {
@@ -20,17 +28,41 @@ pub fn compile_prototype_for_typed_macro(input: DeriveInput) -> TokenStream {
     match parse_prototype(&prototype, None) {
       Ok((cs, params_opt)) => {
         let csname = cs.get_cs_name();
-        let proto_types: Vec<_> = params_opt
-          .unwrap_or_default()
-          .get_parameters()
-          .iter()
-          .map(|p| format_ident!("{}", p.name))
-          .collect();
-
+        let proto_types: Vec<_> = if let Some(ref params) = params_opt {
+          // this is a bit odd... if there is an *inner* parameter, as with {Number}
+          // the name we want to pass in is the inner one. Otherwise the main one.
+          params
+            .get_parameters()
+            .iter()
+            .filter(|p| !p.name.starts_with("Skip"))
+            .map(|p| {
+              if let Some(ParameterExtra::ParametersOption(Some(inner_ps))) =
+                p.extra.iter().find(|ip| matches!(ip, ParameterExtra::ParametersOption(Some(_))))
+              {
+                if let Some(inner_p) = inner_ps.get_parameters().first() {
+                  format_ident!("{}", inner_p.name)
+                } else {
+                  format_ident!("{}", p.name)
+                }
+              } else {
+                format_ident!("{}", p.name)
+              }
+            })
+            .collect()
+        } else {
+          Vec::new()
+        };
+        let quoted_params = if let Some(params) = params_opt {
+          quote!(Some(#params.init(outer_state!())?))
+        } else {
+          quote!(None)
+        };
+        let inneri = format_ident!("{}", inner);
         quote!(
           macro_rules! this_prototype {
-          (sub [ $gullet:ident, ( $($var:ident),+ ), $inner_state:ident ] $body:block $($input:tt)*) => {
-            TypedMacroWO!(T_CS(#csname) #(#proto_types)*, sub [ $gullet, ( $($var),+ ), $inner_state ] $body $($input)*)
+          (sub [ $gullet:ident, ( $($var:ident),* ), $inner_state:ident ] $body:block $($input:tt)*) => {
+            let these_parameters = #quoted_params;
+            #inneri!(#csname, these_parameters, sub [ $gullet, ( $($var),* ):(#(#proto_types),*), $inner_state ] $body $($input)*)
           }
         }
         )
@@ -40,7 +72,6 @@ pub fn compile_prototype_for_typed_macro(input: DeriveInput) -> TokenStream {
     }
   }
 }
-
 
 pub fn compile_prototype(input: DeriveInput) -> TokenStream {
   let prototype: String = match input.attrs[0].parse_meta().unwrap() {
@@ -54,20 +85,21 @@ pub fn compile_prototype(input: DeriveInput) -> TokenStream {
     panic!("Must never call on empty prototype?! input was {prototype}");
   } else {
     match parse_prototype(&prototype, None) {
-      Ok((cs, params_opt)) => {
-        match params_opt {
-          Some(params) => quote!(
-            macro_rules! this_cs_and_parameters {
+      Ok((cs, params_opt)) => match params_opt {
+        Some(params) => quote!(
+          macro_rules! this_cs_and_parameters {
               () => { (#cs, Some(#params)) };
-            }).into(),
-          None => quote!(
-            macro_rules! this_cs_and_parameters {
+            }
+        )
+        .into(),
+        None => quote!(
+          macro_rules! this_cs_and_parameters {
               () => { (#cs, None) };
-            }).into()
-        }
+            }
+        )
+        .into(),
       },
       Err(e) => panic!("Failed to compile binding prototype: {prototype}\n Reason: {e}"),
     }
   }
-
 }

--- a/rtx_contrib/src/lib.rs
+++ b/rtx_contrib/src/lib.rs
@@ -11,14 +11,12 @@ use rtx_core::stomach::Stomach;
 // I. Add your custom binding definition as a module delcaration here
 pub mod mytemplate_sty;
 pub mod scopemacro_sty;
-pub mod typed_bindings_sty;
 
 pub fn dispatch(filename: &str, stomach: &mut Stomach, state: &mut State) -> Option<Result<()>> {
   match filename {
     // II. Connect the filename to the `load_definitions` function of your .rs binding:
     "mytemplate.sty" => Some(mytemplate_sty::load_definitions(stomach, state)),
     "scopemacro.sty" => Some(scopemacro_sty::load_definitions(stomach, state)),
-    "typedbindings.sty" => Some(typed_bindings_sty::load_definitions(stomach, state)),
     _ => None,
   }
 }

--- a/rtx_contrib/src/typed_bindings_sty.rs
+++ b/rtx_contrib/src/typed_bindings_sty.rs
@@ -1,8 +1,0 @@
-use rtx_package::*;
-
-// This is a first demonstration of using the Rust codegen approach for inducing argument types from TeX ParameterTypes.
-// More to be done: so far this is the only variant that has been implemented (and only in DefMacro)
-
-LoadDefinitions!(state, {
-  DefMacro!("\\thanks{}", "\\def\\@thanks{#1}\\lx@make@thanks{#1}");
-});

--- a/rtx_contrib/src/typed_bindings_sty.rs
+++ b/rtx_contrib/src/typed_bindings_sty.rs
@@ -4,10 +4,5 @@ use rtx_package::*;
 // More to be done: so far this is the only variant that has been implemented (and only in DefMacro)
 
 LoadDefinitions!(state, {
-  DefMacro!("\\sampler Number Token Dimension",
-    sub[gullet, (number, token, dimension), _state] {
-      number.value_of();
-      dbg!(token);
-      dbg!(dimension);
-    });
+  DefMacro!("\\thanks{}", "\\def\\@thanks{#1}\\lx@make@thanks{#1}");
 });

--- a/rtx_core/src/common/def_parser.rs
+++ b/rtx_core/src/common/def_parser.rs
@@ -73,7 +73,11 @@ pub fn parse_parameters(mut prototype: String, cs: &Token, mut state_opt: Option
       };
       let mut p = Parameter {
         name: Cow::Borrowed("Plain"),
-        spec: if spec.is_empty() { Cow::Borrowed("") } else { Cow::Owned(spec.to_string()) },
+        spec: if spec.is_empty() {
+          Cow::Borrowed("")
+        } else {
+          Cow::Owned(spec.to_string())
+        },
         extra: vec![inner.into()],
         ..Parameter::default()
       };
@@ -90,7 +94,11 @@ pub fn parse_parameters(mut prototype: String, cs: &Token, mut state_opt: Option
         // TODO: Add the defaults !
         let mut p = Parameter {
           name: Cow::Borrowed("Optional"),
-          spec: if spec.is_empty() { Cow::Borrowed("") } else { Cow::Owned(spec.to_string()) },
+          spec: if spec.is_empty() {
+            Cow::Borrowed("")
+          } else {
+            Cow::Owned(spec.to_string())
+          },
           // extra: vec![TokenizeInternal!(default_captures.get(0).map_or("", |m| m.as_str())), None]});
           extra: Vec::new(),
           ..Parameter::default()
@@ -102,7 +110,11 @@ pub fn parse_parameters(mut prototype: String, cs: &Token, mut state_opt: Option
       } else if !inner_spec.is_empty() {
         let mut p = Parameter {
           name: Cow::Borrowed("Optional"),
-          spec: if spec.is_empty() { Cow::Borrowed("") } else { Cow::Owned(spec.to_string()) },
+          spec: if spec.is_empty() {
+            Cow::Borrowed("")
+          } else {
+            Cow::Owned(spec.to_string())
+          },
           extra: vec![
             ParameterExtra::ParametersOption(None),
             parse_parameters(inner_spec.to_string(), cs, state_opt.as_deref_mut())?.into(),

--- a/rtx_core/src/common/def_parser.rs
+++ b/rtx_core/src/common/def_parser.rs
@@ -72,8 +72,8 @@ pub fn parse_parameters(mut prototype: String, cs: &Token, mut state_opt: Option
         parse_parameters(inner_spec.to_string(), cs, state_opt.as_deref_mut())?
       };
       let mut p = Parameter {
-        name: s!("Plain"),
-        spec: spec.to_string(),
+        name: Cow::Borrowed("Plain"),
+        spec: if spec.is_empty() { Cow::Borrowed("") } else { Cow::Owned(spec.to_string()) },
         extra: vec![inner.into()],
         ..Parameter::default()
       };
@@ -89,8 +89,8 @@ pub fn parse_parameters(mut prototype: String, cs: &Token, mut state_opt: Option
       if let Some(default_captures) = DEFAULT_CHECK_RE.captures(inner_spec) {
         // TODO: Add the defaults !
         let mut p = Parameter {
-          name: s!("Optional"),
-          spec: spec.to_string(),
+          name: Cow::Borrowed("Optional"),
+          spec: if spec.is_empty() { Cow::Borrowed("") } else { Cow::Owned(spec.to_string()) },
           // extra: vec![TokenizeInternal!(default_captures.get(0).map_or("", |m| m.as_str())), None]});
           extra: Vec::new(),
           ..Parameter::default()
@@ -101,8 +101,8 @@ pub fn parse_parameters(mut prototype: String, cs: &Token, mut state_opt: Option
         parameters.push(p);
       } else if !inner_spec.is_empty() {
         let mut p = Parameter {
-          name: s!("Optional"),
-          spec: spec.to_string(),
+          name: Cow::Borrowed("Optional"),
+          spec: if spec.is_empty() { Cow::Borrowed("") } else { Cow::Owned(spec.to_string()) },
           extra: vec![
             ParameterExtra::ParametersOption(None),
             parse_parameters(inner_spec.to_string(), cs, state_opt.as_deref_mut())?.into(),
@@ -115,8 +115,8 @@ pub fn parse_parameters(mut prototype: String, cs: &Token, mut state_opt: Option
         parameters.push(p);
       } else {
         let mut p = Parameter {
-          name: s!("Optional"),
-          spec: spec.to_string(),
+          name: Cow::Borrowed("Optional"),
+          spec: Cow::Owned(spec.to_string()),
           extra: Vec::new(),
           ..Parameter::default()
         };
@@ -137,8 +137,8 @@ pub fn parse_parameters(mut prototype: String, cs: &Token, mut state_opt: Option
         .map(Into::into)
         .collect::<Vec<ParameterExtra>>();
       let mut p = Parameter {
-        name,
-        spec,
+        name: name.into(),
+        spec: spec.into(),
         extra,
         ..Parameter::default()
       };

--- a/rtx_core/src/common/model.rs
+++ b/rtx_core/src/common/model.rs
@@ -23,7 +23,6 @@ pub const LTX_NAMESPACE: &str = "http://dlmf.nist.gov/LaTeXML";
 pub type IndirectModel = HashMap<String, HashMap<String, String>>;
 
 lazy_static! {
-  // static ref OPTIONAL_RE : Regex = Regex::new(r"^Optional(.+)$").unwrap();
   static ref PREFIXED_LOCALNAME_RE : Regex = Regex::new(r"^([^:]+):(.+)$").unwrap();
   static ref CAPTURE_TAG_RE : Regex = Regex::new(r"(.*?:)?_Capture_$").unwrap();
   static ref TAG_MODEL_LINE : Regex = Regex::new(r"^([^\{]+)\{(.*?)\}\((.*?)\)$").unwrap();

--- a/rtx_core/src/common/model.rs
+++ b/rtx_core/src/common/model.rs
@@ -23,11 +23,11 @@ pub const LTX_NAMESPACE: &str = "http://dlmf.nist.gov/LaTeXML";
 pub type IndirectModel = HashMap<String, HashMap<String, String>>;
 
 lazy_static! {
-  static ref PREFIXED_LOCALNAME_RE : Regex = Regex::new(r"^([^:]+):(.+)$").unwrap();
-  static ref CAPTURE_TAG_RE : Regex = Regex::new(r"(.*?:)?_Capture_$").unwrap();
-  static ref TAG_MODEL_LINE : Regex = Regex::new(r"^([^\{]+)\{(.*?)\}\((.*?)\)$").unwrap();
-  static ref CLASS_MODEL_LINE : Regex = Regex::new(r"^([^:=]+):=(.*?)$").unwrap();
-  static ref NAMESPACE_MODEL_LINE : Regex = Regex::new(r"^([^=]+)=(.*?)$").unwrap();
+  static ref PREFIXED_LOCALNAME_RE: Regex = Regex::new(r"^([^:]+):(.+)$").unwrap();
+  static ref CAPTURE_TAG_RE: Regex = Regex::new(r"(.*?:)?_Capture_$").unwrap();
+  static ref TAG_MODEL_LINE: Regex = Regex::new(r"^([^\{]+)\{(.*?)\}\((.*?)\)$").unwrap();
+  static ref CLASS_MODEL_LINE: Regex = Regex::new(r"^([^:=]+):=(.*?)$").unwrap();
+  static ref NAMESPACE_MODEL_LINE: Regex = Regex::new(r"^([^=]+)=(.*?)$").unwrap();
 }
 
 #[derive(Default)]

--- a/rtx_core/src/definition/argument.rs
+++ b/rtx_core/src/definition/argument.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 use std::borrow::Cow;
 use std::fmt::{self, Display};
 
@@ -327,7 +328,7 @@ impl ArgWrap {
       Glue(v) => v.value_of(),
       MuGlue(v) => v.value_of(),
       MuDimension(v) => v.value_of(),
-      _ => panic!("ArgWrap::value_of not (yet?) defined on {self:?}"),
+      _ => panic!("ArgWrap::value_of not (yet?) defined on {:?}", self),
     }
   }
 
@@ -337,7 +338,17 @@ impl ArgWrap {
       Number(v) => Ok(v),
       Token(t) => Ok(t.to_number()),
       Tokens(tks) => Ok(tks.to_number()),
-      _ => Err("ArgWrap::to_number not (yet?) defined on {self:?}".into()),
+      OptionTokens(tks_opt) => match tks_opt {
+        Some(tks) => Ok(tks.to_number()),
+        // None => Err("ArgWrap::try_to_number expected a Tokens for number conversion, but got None.".into()),
+        // When is the None case useful? you can see it triggered with an error in the tests.
+        None => Ok(crate::common::number::Number::default()),
+      },
+      OptionToken(tk_opt) => match tk_opt {
+        Some(tk) => Ok(tk.to_number()),
+        None => Err("ArgWrap::try_to_number expected a Token for number conversion, but got None.".into()),
+      },
+      _ => Err(format!("ArgWrap::to_number not (yet?) defined on {:?}", self).into()),
     }
   }
   pub fn expect_number(self) -> Number {
@@ -353,7 +364,7 @@ impl ArgWrap {
       Dimension(v) => Ok(v),
       Token(t) => Ok(t.to_dimension()),
       Tokens(tks) => Ok(tks.to_dimension()),
-      _ => Err("ArgWrap::to_dimension not (yet?) defined on {self:?}".into()),
+      _ => Err(format!("ArgWrap::to_dimension not (yet?) defined on {:?}", self).into()),
     }
   }
   pub fn expect_dimension(self) -> Dimension {
@@ -378,7 +389,7 @@ impl ArgWrap {
       Glue(v) => v,
       Token(t) => t.to_glue(),
       Tokens(tks) => tks.to_glue(),
-      _ => panic!("ArgWrap::to_glue not (yet?) defined on {self:?}"),
+      _ => panic!("ArgWrap::to_glue not (yet?) defined on {:?}", self),
     }
   }
   pub fn to_mu_glue(self) -> MuGlue {
@@ -387,19 +398,26 @@ impl ArgWrap {
       MuGlue(v) => v,
       Token(t) => t.to_mu_glue(),
       Tokens(tks) => tks.to_mu_glue(),
-      _ => panic!("ArgWrap::to_glue not (yet?) defined on {self:?}"),
+      _ => panic!("ArgWrap::to_glue not (yet?) defined on {:?}", self),
     }
   }
-  pub fn to_keyvals(self, state: &mut State) -> KeyVals {
+  pub fn expected_keyvals(self, state: &mut State) -> KeyVals {
+    match self.try_to_keyvals(state) {
+      Ok(t) => t,
+      Err(e) => panic!("{e}"),
+    }
+  }
+
+  pub fn try_to_keyvals(self, state: &mut State) -> Result<KeyVals> {
     use ArgWrap::*;
     match self {
-      KV(v) => v,
-      Tokens(tks) => tks.to_keyvals(state),
+      KV(v) => Ok(v),
+      Tokens(tks) => Ok(tks.to_keyvals(state)),
       OptionTokens(tks_opt) => match tks_opt {
-        Some(tks) => tks.to_keyvals(state),
-        None => KeyVals::default()
+        Some(tks) => Ok(tks.to_keyvals(state)),
+        None => Ok(KeyVals::default()),
       },
-      _ => panic!("ArgWrap::to_keyvals not (yet?) defined on {self:?}"),
+      _ => panic!("ArgWrap::to_keyvals not (yet?) defined on {:?}", self),
     }
   }
 
@@ -446,15 +464,18 @@ impl ArgWrap {
 
   pub fn is_option(&self) -> bool {
     use ArgWrap::*;
-    matches!(self, OptionTokens(_)
-      |  OptionToken(_)
-      | OptionNumber(_)
-      | OptionFloat(_)
-      | OptionDimension(_)
-      | OptionGlue(_)
-      | OptionMuGlue(_)
-      | OptionMuDimension(_)
-      | OptionKV(_))
+    matches!(
+      self,
+      OptionTokens(_)
+        | OptionToken(_)
+        | OptionNumber(_)
+        | OptionFloat(_)
+        | OptionDimension(_)
+        | OptionGlue(_)
+        | OptionMuGlue(_)
+        | OptionMuDimension(_)
+        | OptionKV(_)
+    )
   }
 }
 
@@ -468,9 +489,13 @@ impl From<ArgWrap> for Option<Tokens> {
   fn from(t: ArgWrap) -> Option<Tokens> { t.owned_tokens() }
 }
 
-// TODO: this is just a demo, make it robust against unwrap (add defaults)
 impl From<ArgWrap> for Tokens {
-  fn from(t: ArgWrap) -> Tokens { t.owned_tokens().unwrap() }
+  fn from(t: ArgWrap) -> Tokens {
+    match t.owned_tokens() {
+      Some(tks) => tks,
+      None => Tokens!(),
+    }
+  }
 }
 
 impl From<Tokens> for ArgWrap {
@@ -529,3 +554,8 @@ impl TryFrom<ArgWrap> for Token {
   type Error = crate::common::error::Error;
   fn try_from(aw: ArgWrap) -> Result<Token> { aw.try_to_token() }
 }
+
+// impl TryFrom<ArgWrap> for KeyVals {
+//   type Error = crate::common::error::Error;
+//   fn try_from(aw: ArgWrap) -> Result<KeyVals> { aw.try_to_keyvals() }
+// }

--- a/rtx_core/src/definition/argument.rs
+++ b/rtx_core/src/definition/argument.rs
@@ -395,6 +395,10 @@ impl ArgWrap {
     match self {
       KV(v) => v,
       Tokens(tks) => tks.to_keyvals(state),
+      OptionTokens(tks_opt) => match tks_opt {
+        Some(tks) => tks.to_keyvals(state),
+        None => KeyVals::default()
+      },
       _ => panic!("ArgWrap::to_keyvals not (yet?) defined on {self:?}"),
     }
   }
@@ -402,7 +406,15 @@ impl ArgWrap {
   pub fn unlist(self) -> Vec<Token> {
     match self {
       ArgWrap::Tokens(tks) => tks.unlist(),
+      ArgWrap::OptionTokens(tks_opt) => match tks_opt {
+        Some(tks) => tks.unlist(),
+        None => Vec::new(),
+      },
       ArgWrap::Token(t) => vec![t],
+      ArgWrap::OptionToken(t_opt) => match t_opt {
+        Some(t) => vec![t],
+        None => Vec::new(),
+      },
       ArgWrap::Number(n) => {
         let tks: Tokens = n.into();
         tks.unlist()
@@ -430,6 +442,19 @@ impl ArgWrap {
       | OptionKV(None) => true,
       _ => false,
     }
+  }
+
+  pub fn is_option(&self) -> bool {
+    use ArgWrap::*;
+    matches!(self, OptionTokens(_)
+      |  OptionToken(_)
+      | OptionNumber(_)
+      | OptionFloat(_)
+      | OptionDimension(_)
+      | OptionGlue(_)
+      | OptionMuGlue(_)
+      | OptionMuDimension(_)
+      | OptionKV(_))
   }
 }
 

--- a/rtx_core/src/parameter.rs
+++ b/rtx_core/src/parameter.rs
@@ -3,6 +3,8 @@ use regex::Regex;
 use std::borrow::Cow;
 use std::fmt;
 use std::sync::Arc;
+use proc_macro2::{TokenStream}; // use proc_macro2::{Ident, Punct, Spacing, Span, TokenStream};
+use quote::{quote, ToTokens}; // TokenStreamExt
 
 use crate::common::error::*;
 use crate::common::object::Object;
@@ -522,5 +524,46 @@ impl fmt::Display for Parameters {
       content.push_str(&param_content);
     }
     write!(f, "{content}")
+  }
+}
+
+
+impl ToTokens for Parameters {
+  fn to_tokens(&self, stream: &mut TokenStream) {
+    let params = &self.0;
+    stream.extend(quote! {
+        Parameters::new(<[Parameter]>::into_vec(Box::new([ #(#params),* ])))
+    });
+  }
+}
+
+impl ToTokens for Parameter {
+  fn to_tokens(&self, stream: &mut TokenStream) {
+    let name = &self.name;
+    let spec = &self.spec;
+    let extra = &self.extra;
+    stream.extend(quote! {
+      Parameter {
+        name: String::from(#name),
+        spec: String::from(#spec),
+        extra: <[ParameterExtra]>::into_vec(Box::new([ #(#extra),* ])),
+        ..Parameter::default()
+      }
+    });
+  }
+}
+
+impl ToTokens for ParameterExtra {
+  fn to_tokens(&self, stream: &mut TokenStream) {
+    stream.extend(match self {
+      ParameterExtra::Tokens(ts) =>
+         quote!( ParameterExtra::Tokens(#ts) ),
+      ParameterExtra::ParametersOption(Some(po)) => {
+        quote!( ParameterExtra::ParametersOption(Some(#po)))
+      },
+      ParameterExtra::ParametersOption(None) => {
+        quote!( ParameterExtra::ParametersOption(None))
+      }
+    });
   }
 }

--- a/rtx_core/src/parameter.rs
+++ b/rtx_core/src/parameter.rs
@@ -93,8 +93,8 @@ pub struct Parameter {
   pub semiverbatim: Option<Vec<char>>,
   pub optional: bool,
   pub pack_parameters: bool,
-  pub name: String,
-  pub spec: String,
+  pub name: Cow<'static, str>,
+  pub spec: Cow<'static, str>,
   pub extra: Vec<ParameterExtra>,
   pub reader: ReaderClosure,
   pub reader_predigest: Option<ReaderPredigestClosure>,
@@ -109,8 +109,8 @@ impl Default for Parameter {
       semiverbatim: None,
       optional: false,
       pack_parameters: false,
-      name: s!("parameter_default"),
-      spec: String::new(),
+      name: Cow::Borrowed("parameter_default"),
+      spec: Cow::Borrowed(""),
       extra: Vec::new(),
       reader: Arc::new(|_gullet, _args, _extra, _state| {
         Warn!(
@@ -166,10 +166,10 @@ lazy_static! {
 }
 
 impl Parameter {
-  pub fn new(name: &str, spec: &str, state: &mut State) -> Result<Self> {
+  pub fn new(name: Cow<'static, str>, spec: Cow<'static, str>, state: &mut State) -> Result<Self> {
     Parameter {
-      name: name.to_string(),
-      spec: spec.to_string(),
+      name,
+      spec,
       ..Parameter::default()
     }
     .init(state)
@@ -539,13 +539,19 @@ impl ToTokens for Parameters {
 
 impl ToTokens for Parameter {
   fn to_tokens(&self, stream: &mut TokenStream) {
-    let name = &self.name;
-    let spec = &self.spec;
+    let name = match &self.name {
+      Cow::Borrowed(v) => quote!(Cow::Borrowed(#v)),
+      Cow::Owned(v) => quote!(Cow::Borrowed(#v)),
+    };
+    let spec = match &self.spec {
+      Cow::Borrowed(v) => quote!(Cow::Borrowed(#v)),
+      Cow::Owned(v) => quote!(Cow::Borrowed(#v)),
+    };
     let extra = &self.extra;
     stream.extend(quote! {
       Parameter {
-        name: String::from(#name),
-        spec: String::from(#spec),
+        name: #name,
+        spec: #spec,
         extra: <[ParameterExtra]>::into_vec(Box::new([ #(#extra),* ])),
         ..Parameter::default()
       }

--- a/rtx_core/src/parameter.rs
+++ b/rtx_core/src/parameter.rs
@@ -296,23 +296,35 @@ impl Parameter {
     self.setup_catcodes(state);
 
     let closure = &self.reader;
-    let mut value_arg: ArgWrap = closure(gullet, vec![], &self.extra, state)?;
-    if value_arg.is_tokens() {
-      if let Some(mut value) = value_arg.owned_tokens() {
-        if let Some(ref semi_chars) = self.semiverbatim {
-          value = value.neutralize(semi_chars, state);
+    let value_from_reader: ArgWrap = closure(gullet, vec![], &self.extra, state)?;
+    let value_arg = if value_from_reader.is_tokens() {
+      let wants_option = self.optional || value_from_reader.is_option();
+      match value_from_reader.owned_tokens() {
+        Some(mut value) => {
+          if let Some(ref semi_chars) = self.semiverbatim {
+            value = value.neutralize(semi_chars, state);
+          }
+          if self.pack_parameters {
+            value = value.pack_parameters();
+          }
+          if wants_option {
+            if value.is_empty() {
+              ArgWrap::OptionTokens(None)
+            } else {
+              ArgWrap::OptionTokens(Some(value))
+            }
+          } else {
+            ArgWrap::Tokens(value)
+          }
         }
-        if self.pack_parameters {
-          value = value.pack_parameters();
-        }
-        value_arg = ArgWrap::Tokens(value);
-      } else {
-        value_arg = ArgWrap::default();
+        None => if wants_option { ArgWrap::OptionTokens(None) } else { ArgWrap::Tokens(Tokens!()) }
       }
-    }
+    } else {
+      value_from_reader
+    };
     self.revert_catcodes(state)?;
 
-    if !self.optional && !self.novalue && (value_arg.is_none() && self.reader_predigest.is_none()) {
+    let checked_value = if !self.optional && !self.novalue && (value_arg.is_none() && self.reader_predigest.is_none()) {
       // Deyan: Special exception, which may motivate switching the reader type to Option<Tokens> in the long-run
       //        Until *may* have a value, but it also may *not*, both OK. So... except it from the error message here
       if !self.name.starts_with("Until") {
@@ -323,10 +335,14 @@ impl Parameter {
           state,
           s!("Missing argument {} for {}", self.stringify(), fordefn.stringify())
         );
-        value_arg = ArgWrap::Tokens(Tokens!(T_OTHER!("missing")));
+        ArgWrap::Tokens(Tokens!(T_OTHER!("missing")))
+      } else {
+        value_arg
       }
-    }
-    Ok(value_arg)
+    } else {
+      value_arg
+    };
+    Ok(checked_value)
   }
 
   pub fn digest(&self, stomach: &mut Stomach, mut value_arg: ArgWrap, _fordefn: Option<&Constructor>, state: &mut State) -> Result<Option<Digested>> {

--- a/rtx_core/src/parameter.rs
+++ b/rtx_core/src/parameter.rs
@@ -1,10 +1,10 @@
 use lazy_static::lazy_static;
+use proc_macro2::TokenStream; // use proc_macro2::{Ident, Punct, Spacing, Span, TokenStream};
+use quote::{quote, ToTokens};
 use regex::Regex;
 use std::borrow::Cow;
 use std::fmt;
-use std::sync::Arc;
-use proc_macro2::{TokenStream}; // use proc_macro2::{Ident, Punct, Spacing, Span, TokenStream};
-use quote::{quote, ToTokens}; // TokenStreamExt
+use std::sync::Arc; // TokenStreamExt
 
 use crate::common::error::*;
 use crate::common::object::Object;
@@ -318,8 +318,14 @@ impl Parameter {
           } else {
             ArgWrap::Tokens(value)
           }
-        }
-        None => if wants_option { ArgWrap::OptionTokens(None) } else { ArgWrap::Tokens(Tokens!()) }
+        },
+        None => {
+          if wants_option {
+            ArgWrap::OptionTokens(None)
+          } else {
+            ArgWrap::Tokens(Tokens!())
+          }
+        },
       }
     } else {
       value_from_reader
@@ -527,7 +533,6 @@ impl fmt::Display for Parameters {
   }
 }
 
-
 impl ToTokens for Parameters {
   fn to_tokens(&self, stream: &mut TokenStream) {
     let params = &self.0;
@@ -562,14 +567,13 @@ impl ToTokens for Parameter {
 impl ToTokens for ParameterExtra {
   fn to_tokens(&self, stream: &mut TokenStream) {
     stream.extend(match self {
-      ParameterExtra::Tokens(ts) =>
-         quote!( ParameterExtra::Tokens(#ts) ),
+      ParameterExtra::Tokens(ts) => quote!( ParameterExtra::Tokens(#ts) ),
       ParameterExtra::ParametersOption(Some(po)) => {
         quote!( ParameterExtra::ParametersOption(Some(#po)))
       },
       ParameterExtra::ParametersOption(None) => {
-        quote!( ParameterExtra::ParametersOption(None))
-      }
+        quote!(ParameterExtra::ParametersOption(None))
+      },
     });
   }
 }

--- a/rtx_core/src/stomach.rs
+++ b/rtx_core/src/stomach.rs
@@ -32,8 +32,9 @@ pub struct Stomach {
 }
 
 impl Object for Stomach {
+  fn get_location(&self) -> String { self.get_gullet().get_location() }
   fn get_locator(&self) -> Option<Cow<Locator>> { self.get_gullet().get_locator() }
-  fn stringify(&self) -> String { String::from("TODO Stomach") }
+  fn stringify(&self) -> String { unimplemented!() }
 }
 
 impl<'t> Stomach {

--- a/rtx_package/src/macros/mod.rs
+++ b/rtx_package/src/macros/mod.rs
@@ -39,6 +39,18 @@ macro_rules! compile_prototype_for_typed_primitive {
 }
 
 #[macro_export]
+/// Macro for compiling string binding prototypes into Conditional closures
+macro_rules! compile_prototype_for_typed_conditional {
+  ($prototype:literal, sub [ $gullet:ident, ( $($var:ident),* ), $inner_state:ident ] $body:block $($input:tt)*) => {{
+    #[derive(CompilePrototypeFor)]
+    #[prototype=$prototype]
+    #[inner="TypedConditional"]
+    struct _DummyP;
+    this_prototype!(sub [ $gullet, ( $($var),* ), $inner_state ] $body $($input)*);
+  }};
+}
+
+#[macro_export]
 /// Macro for compiling string literal prototypes into a Token and Parameters structs
 macro_rules! compile_prototype {
   ($prototype:literal) => {{
@@ -117,7 +129,7 @@ macro_rules! compile_tokenize_internal {
   }};
 }
 
-// ideally we can auto-infer this based on DefParameterType declarations but the **timing** is tricky?
+// TODO: ideally we can auto-infer this based on DefParameterType declarations but the **timing** is tricky?
 // what to do? For now, hardcode.
 #[macro_export]
 macro_rules! parameter_rust_type {
@@ -131,6 +143,7 @@ macro_rules! parameter_rust_type {
   (Optional) => {Option<Tokens>};
   (OptionalMatch) => {Option<Tokens>};
   (DefToken) => {Token};
+  (XToken) => {Token};
   (CSName) => {Token};
   // For now return the raw Tokens for KeyVals, until we figure out how to
   // do TryInto with access to the current "State" object.

--- a/rtx_package/src/macros/mod.rs
+++ b/rtx_package/src/macros/mod.rs
@@ -14,14 +14,27 @@ macro_rules! compile_replacement {
 }
 
 #[macro_export]
-/// Macro for compiling string binding prototypes into closures
+/// Macro for compiling string binding prototypes into Expandable closures
 /// Approach borrowed from diesel-codegen
 macro_rules! compile_prototype_for_typed_macro {
-  ($prototype:literal, sub [ $gullet:ident, ( $($var:ident),+ ), $inner_state:ident ] $body:block $($input:tt)*) => {{
-    #[derive(CompilePrototypeForTypedMacro)]
+  ($prototype:literal, sub [ $gullet:ident, ( $($var:ident),* ), $inner_state:ident ] $body:block $($input:tt)*) => {{
+    #[derive(CompilePrototypeFor)]
     #[prototype=$prototype]
+    #[inner="TypedMacro"]
     struct _DummyP;
-    this_prototype!(sub [ $gullet, ( $($var),+ ), $inner_state ] $body $($input)*);
+    this_prototype!(sub [ $gullet, ( $($var),* ), $inner_state ] $body $($input)*);
+  }};
+}
+
+#[macro_export]
+/// Macro for compiling string binding prototypes into Primitive closures
+macro_rules! compile_prototype_for_typed_primitive {
+  ($prototype:literal, sub [ $gullet:ident, ( $($var:ident),* ), $inner_state:ident ] $body:block $($input:tt)*) => {{
+    #[derive(CompilePrototypeFor)]
+    #[prototype=$prototype]
+    #[inner="TypedPrimitive"]
+    struct _DummyP;
+    this_prototype!(sub [ $gullet, ( $($var),* ), $inner_state ] $body $($input)*);
   }};
 }
 
@@ -110,10 +123,18 @@ macro_rules! compile_tokenize_internal {
 macro_rules! parameter_rust_type {
   (GeneralText) => {Tokens};
   (Semiverbatim) => {Tokens};
+  (UntilBrace) => {Tokens};
+  (TeXFileName) => {Tokens};
+  (DefPlain) => {Tokens};
+  (DefExpanded) => {Tokens};
   (Plain) => {Tokens};
   (Optional) => {Option<Tokens>};
   (OptionalMatch) => {Option<Tokens>};
   (DefToken) => {Token};
   (CSName) => {Token};
+  // For now return the raw Tokens for KeyVals, until we figure out how to
+  // do TryInto with access to the current "State" object.
+  (OptionalKeyVals) => {Tokens};
+  (KeyVals) => {KeyVals};
   ($other:ident) => {$other};
 }

--- a/rtx_package/src/macros/mod.rs
+++ b/rtx_package/src/macros/mod.rs
@@ -16,12 +16,23 @@ macro_rules! compile_replacement {
 #[macro_export]
 /// Macro for compiling string binding prototypes into closures
 /// Approach borrowed from diesel-codegen
-macro_rules! compile_prototype {
+macro_rules! compile_prototype_for_typed_macro {
   ($prototype:literal, sub [ $gullet:ident, ( $($var:ident),+ ), $inner_state:ident ] $body:block $($input:tt)*) => {{
-    #[derive(CompilePrototype)]
+    #[derive(CompilePrototypeForTypedMacro)]
     #[prototype=$prototype]
     struct _DummyP;
     this_prototype!(sub [ $gullet, ( $($var),+ ), $inner_state ] $body $($input)*);
+  }};
+}
+
+#[macro_export]
+/// Macro for compiling string literal prototypes into a Token and Parameters structs
+macro_rules! compile_prototype {
+  ($prototype:literal) => {{
+    #[derive(CompilePrototype)]
+    #[prototype=$prototype]
+    struct _DummyPR;
+    this_cs_and_parameters!()
   }};
 }
 

--- a/rtx_package/src/macros/mod.rs
+++ b/rtx_package/src/macros/mod.rs
@@ -92,3 +92,17 @@ macro_rules! compile_tokenize_internal {
     $var = tmp;
   }};
 }
+
+// ideally we can auto-infer this based on DefParameterType declarations but the **timing** is tricky?
+// what to do? For now, hardcode.
+#[macro_export]
+macro_rules! parameter_rust_type {
+  (GeneralText) => {Tokens};
+  (Semiverbatim) => {Tokens};
+  (Plain) => {Tokens};
+  (Optional) => {Option<Tokens>};
+  (OptionalMatch) => {Option<Tokens>};
+  (DefToken) => {Token};
+  (CSName) => {Token};
+  ($other:ident) => {$other};
+}

--- a/rtx_package/src/package/api/content.rs
+++ b/rtx_package/src/package/api/content.rs
@@ -916,8 +916,8 @@ pub fn convert_latex_args(mut nargs: usize, optional: Option<Tokens>, state: &mu
   if let Some(tks) = optional {
     params.push(
       Parameter {
-        name: s!("Optional"),
-        spec: s!("[Default:{}]", tks.untex(state)),
+        name: Cow::Borrowed("Optional"),
+        spec: Cow::Owned(s!("[Default:{}]", tks.untex(state))),
         extra: vec![ParameterExtra::Tokens(tks), ParameterExtra::ParametersOption(None)],
         ..Parameter::default()
       }
@@ -929,8 +929,8 @@ pub fn convert_latex_args(mut nargs: usize, optional: Option<Tokens>, state: &mu
   for _ in 1..=nargs {
     params.push(
       Parameter {
-        name: s!("Plain"),
-        spec: "{}".to_string(),
+        name: Cow::Borrowed("Plain"),
+        spec: Cow::Borrowed("{}"),
         ..Parameter::default()
       }
       .init(state)?,

--- a/rtx_package/src/package/pool/article_cls.rs
+++ b/rtx_package/src/package/pool/article_cls.rs
@@ -108,5 +108,5 @@ LoadDefinitions!(stomach, state, {
   DefMacro!("\\appendix", "\\@appendix");
 
   // Actually we should be using section counter
-  DefPrimitive!("\\@appendix", sub[stomach,whatsit,state] { start_appendices("section", state); });
+  DefPrimitive!("\\@appendix", sub[stomach,(),state] { start_appendices("section", state); });
 });

--- a/rtx_package/src/package/pool/etex.rs
+++ b/rtx_package/src/package/pool/etex.rs
@@ -1,6 +1,6 @@
 use crate::package::*;
 
-LoadDefinitions!(state, {
+LoadDefinitions!(outer_state, {
   // See http://tex.loria.fr/moteurs/etex_ref.html
   // Or better yet, see the full manual
   // http://texdoc.net/texmf-dist/doc/etex/base/etex_man.pdf
@@ -62,14 +62,12 @@ LoadDefinitions!(state, {
   DefRegister!("\\currentgrouptype", Number!(0), readonly => true);
 
   // \ifcsname stuff \endcsname
-  DefConditional!("\\ifcsname CSName", sub[gullet, args, state] {
-    unpack_to_token!(args =>t);
+  DefConditional!("\\ifcsname CSName", sub[gullet, (t), state] {
     state.lookup_meaning(&t).is_some()
   });
 
   // \ifdefined <token>
-  DefConditional!("\\ifdefined Token", sub[gullet, args, state] {
-    unpack_to_token!(args =>t);
+  DefConditional!("\\ifdefined Token", sub[gullet, (t), state] {
     state.lookup_meaning(&t).is_some()
   });
 
@@ -150,8 +148,7 @@ LoadDefinitions!(state, {
   //     return; });
 
   // # \unless someif
-  DefConditional!("\\unless Token", sub [gullet, args, state] {
-    unpack_to_token!(args => if_token);
+  DefConditional!("\\unless Token", sub[gullet, (if_token), state] {
     if let Some(Stored::Conditional(defn)) = state.lookup_definition_stored(&if_token) {
       if defn.conditional_type == ConditionalType::If {
         if let Some(ref closure) = defn.test {

--- a/rtx_package/src/package/pool/etex.rs
+++ b/rtx_package/src/package/pool/etex.rs
@@ -16,8 +16,7 @@ LoadDefinitions!(state, {
   is_prefix => true);
 
   // \detokenize
-  DefMacro!("\\detokenize GeneralText", sub [gullet, args, state] {
-    unpack!(args => text);
+  DefMacro!("\\detokenize GeneralText", sub [gullet, (text), state] {
     Explode!(writable_tokens(text, state)?)
   });
 
@@ -25,7 +24,7 @@ LoadDefinitions!(state, {
   // of \unexpanded are not expanded further (this is the same behaviour as is
   // exhibited by the tokens resulting from the expansion of
   // \the〈token variable〉in both TEX and ε-TEX).
-  DefMacro!("\\unexpanded GeneralText", "#1");
+  DefMacro!("\\unexpanded GeneralText", sub [gullet, (text), state] { text });
 
   // ======================================================================
   // 3.2. Provision for re-scanning already read text
@@ -45,8 +44,7 @@ LoadDefinitions!(state, {
     }
   });
 
-  DefMacro!("\\scantokens GeneralText", sub[gullet, args, state] {
-    unpack!(args=>tokens);
+  DefMacro!("\\scantokens GeneralText", sub[gullet, (tokens), state] {
     Mouth::new(&untex(tokens,false,state)?, None, state)?.read_tokens(state)
   });
 
@@ -83,11 +81,11 @@ LoadDefinitions!(state, {
   // # but since we don't manage Pages...
 
   DefPrimitive!("\\marks Number GeneralText", None);
-  DefMacro!("\\topmarks Number", "");
-  DefMacro!("\\firstmarks Number", "");
-  DefMacro!("\\botmarks Number", "");
-  DefMacro!("\\splitfirstmarks Number", "");
-  DefMacro!("\\splitbotmarks Number", "");
+  DefMacro!("\\topmarks Number", sub[gullet, (num), state] {()});
+  DefMacro!("\\firstmarks Number", sub[gullet, (num), state] {()});
+  DefMacro!("\\botmarks Number", sub[gullet, (num), state] {()});
+  DefMacro!("\\splitfirstmarks Number", sub[gullet, (num), state] {()});
+  DefMacro!("\\splitbotmarks Number", sub[gullet, (num), state] {()});
 
   // #======================================================================
   // # 3.5 Bi-directional typesetting: the TeX--XeT primitives

--- a/rtx_package/src/package/pool/etex.rs
+++ b/rtx_package/src/package/pool/etex.rs
@@ -10,7 +10,7 @@ LoadDefinitions!(state, {
   // 3.1 Additional control over expansion
   // \protected associates with the next defn
   // (note that it isn't actually used anywhere).
-  DefPrimitive!("\\protected", sub[stomach, args, state] {
+  DefPrimitive!("\\protected", sub[stomach, (), state] {
     state.set_prefix("protected");
   },
   is_prefix => true);

--- a/rtx_package/src/package/pool/inputenc_sty.rs
+++ b/rtx_package/src/package/pool/inputenc_sty.rs
@@ -33,17 +33,13 @@ fn set_input_encoding(encoding: &str, stomach: &mut Stomach, state: &mut State) 
 
 LoadDefinitions!(outer_stomach, state, {
   //**********************************************************************
-  DefPrimitive!("\\DeclareInputMath {Number} {}", sub[stomach, args, state] {
-    unpack_to_number!(args => code);
-    unpack_to_token!(args => expansion);
+  DefPrimitive!("\\DeclareInputMath {Number} {}", sub[stomach, (code,expansion), state] {
     let ch = code.value_of() as u8 as char;
     AssignCatcode!(ch, Catcode::ACTIVE);
     DefMacro!(T_ACTIVE!(ch), None, expansion);
   });
 
-  DefPrimitive!("\\DeclareInputText {Number} {}", sub[stomach, args, state] {
-    unpack_to_number!(args => code);
-    unpack_to_token!(args => expansion);
+  DefPrimitive!("\\DeclareInputText {Number} {}", sub[stomach, (code, expansion), state] {
     let ch = code.value_of() as u8 as char;
     AssignCatcode!(ch, Catcode::ACTIVE);
     DefMacro!(T_ACTIVE!(ch), None, expansion);
@@ -51,13 +47,12 @@ LoadDefinitions!(outer_stomach, state, {
 
   DefMacro!("\\IeC{}", "#1");
 
-  DefMacro!("\\@inpenc@undefined", sub[gullet, args, state] {
+  DefMacro!("\\@inpenc@undefined", sub[gullet, (), state] {
     let message = s!("Keyboard character used is undefined in inputencoding {}", state.input_encoding.as_ref().unwrap());
     Error!("unexpected", "<char>", gullet, state, message);
   });
 
-  DefPrimitive!("\\inputencoding{}", sub[stomach, args, state] {
-    unpack!(args => encoding);
+  DefPrimitive!("\\inputencoding{}", sub[stomach, (encoding), state] {
     let gullet = stomach.get_gullet_mut();
     set_input_encoding(&Expand!(encoding, gullet).to_string(), stomach, state)?;
   });

--- a/rtx_package/src/package/pool/latex_ch11_moving_information.rs
+++ b/rtx_package/src/package/pool/latex_ch11_moving_information.rs
@@ -233,8 +233,7 @@ LoadDefinitions!(outer_stomach, outer_state, {
 
   // This attempts to handle the case where folks put \bibitem's within an enumerate or such.
   // We try to close the list and open the bibliography
-  DefMacro!("\\lx@mung@bibliography{}", sub[gullet, args, state] {
-    unpack!(args => env);
+  DefMacro!("\\lx@mung@bibliography{}", sub[gullet, (env), state] {
     let tag = env.to_string();
     let mut tokens = Vec::new();
     // If we're in some sort of list environment, maybe we can recover
@@ -328,14 +327,12 @@ LoadDefinitions!(outer_stomach, outer_state, {
   // Simple container for any phrases used in the bibref
   DefConstructor!("\\@@citephrase{}", "<ltx:bibrefphrase>#1</ltx:bibrefphrase>", mode => "text");
 
-  DefMacro!("\\cite[] Semiverbatim", sub[gullet, args, state] {
-    unpack_opt!(args => post_opt, keys_opt);
-    let keys = keys_opt.owned_tokens().unwrap();
+  DefMacro!("\\cite[] Semiverbatim", sub[gullet, (post_opt, keys), state] {
     let style = state.lookup_tokens("CITE_STYLE").unwrap_or_else(|| Tokens!());
     let open = state.lookup_tokens("CITE_OPEN");
     let open = open.unwrap_or_else(|| Tokens!());
     let close = state.lookup_tokens("CITE_CLOSE").unwrap_or_else(|| Tokens!());
-    let mut post_tokens = match post_opt.owned_tokens() {
+    let mut post_tokens = match post_opt {
       Some(tks) => tks.unlist(),
       None => Vec::new()
     };

--- a/rtx_package/src/package/pool/latex_ch13_boxes.rs
+++ b/rtx_package/src/package/pool/latex_ch13_boxes.rs
@@ -25,8 +25,7 @@ LoadDefinitions!(state, {
   // \fill
   DefMacro!("\\stretch{}", "0pt plus #1fill\\relax");
 
-  DefPrimitive!("\\@check@length DefToken", sub[stomach, args, state] {
-    unpack_to_token!(args => cs);
+  DefPrimitive!("\\@check@length DefToken", sub[stomach, (cs), state] {
     match state.lookup_definition(&cs) {
       None => {
         let message = s!("'{}' is not a length; defining it now", cs.stringify());
@@ -40,8 +39,7 @@ LoadDefinitions!(state, {
     };
   });
 
-  DefPrimitive!("\\newlength DefToken", sub[stomach, args, inner_state] {
-    unpack_to_token!(args => cs);
+  DefPrimitive!("\\newlength DefToken", sub[stomach, (cs), inner_state] {
     DefRegister!(cs, None, Glue::new(0));
     Ok(vec![])
   });
@@ -61,24 +59,19 @@ LoadDefinitions!(state, {
 
   // Assuming noone tries to get clever with figuring out the allocation of
   // numbers, these become simple DefRegister's
-  DefPrimitive!("\\newcount Token", sub[stomach, args, state] {
-    unpack_to_token!(args => name);
+  DefPrimitive!("\\newcount Token", sub[stomach, (name), state] {
     DefRegister!(name, None, Number::new(0));
   });
-  DefPrimitive!("\\newdimen Token", sub[stomach, args, state] {
-    unpack_to_token!(args => name);
+  DefPrimitive!("\\newdimen Token", sub[stomach, (name), state] {
     DefRegister!(name, None, Dimension::new(0));
   });
-  DefPrimitive!("\\newskip Token", sub[stomach, args, state] {
-    unpack_to_token!(args => name);
+  DefPrimitive!("\\newskip Token", sub[stomach, (name), state] {
     DefRegister!(name, None, Glue::new(0));
   });
-  DefPrimitive!("\\newmuskip Token", sub[stomach, args, state] {
-    unpack_to_token!(args => name);
+  DefPrimitive!("\\newmuskip Token", sub[stomach, (name), state] {
     DefRegister!(name, None, MuGlue::new(0));
   });
-  DefPrimitive!("\\newtoks Token", sub[stomach, args, state] {
-    unpack_to_token!(args => name);
+  DefPrimitive!("\\newtoks Token", sub[stomach, (name), state] {
     DefRegister!(name, None, Tokens!());
   });
 

--- a/rtx_package/src/package/pool/latex_ch15_font_selection.rs
+++ b/rtx_package/src/package/pool/latex_ch15_font_selection.rs
@@ -38,9 +38,9 @@ LoadDefinitions!(outer_state, {
   DefMacro!("\\fontshape{}", "\\edef\\f@shape{#1}");
 
   // For fonts not allowed in math!!!
-  DefPrimitive!("\\not@math@alphabet@@ {}", sub[stomach, args, inner_state] {
+  DefPrimitive!("\\not@math@alphabet@@ {}", sub[stomach, (c), inner_state] {
     if inner_state.lookup_bool("IN_MATH") {
-      let c = args[0].to_string();
+      let c = c.to_string();
       let message = s!("Command {:?} invalid in math mode", c);
       Warn!("unexpected", c, stomach, inner_state, message);
     }
@@ -71,7 +71,7 @@ LoadDefinitions!(outer_state, {
 
   Let!("\\reset@font", "\\normalfont");
 
-  DefPrimitive!("\\selectfont", sub[stomach, args, inner_state] {
+  DefPrimitive!("\\selectfont", sub[stomach, (), inner_state] {
     let mut gullet = stomach.get_gullet_mut();
     let family = Expand!(T_CS!("\\f@family"), gullet).to_string();
     let series = Expand!(T_CS!("\\f@series"),gullet).to_string();

--- a/rtx_package/src/package/pool/latex_ch1_documentclass.rs
+++ b/rtx_package/src/package/pool/latex_ch1_documentclass.rs
@@ -10,7 +10,7 @@ LoadDefinitions!(state, {
   //**********************************************************************
   // Basic \documentclass & \documentstyle
 
-  DefConditional!("\\if@compatibility", sub [gullet, args, state] {
+  DefConditional!("\\if@compatibility", sub [gullet, (), state] {
     state.lookup_bool("2.09_COMPATIBILITY") });
   DefMacro!("\\@compatibilitytrue", "");
   DefMacro!("\\@compatibilityfalse", "");

--- a/rtx_package/src/package/pool/latex_ch1_environments.rs
+++ b/rtx_package/src/package/pool/latex_ch1_environments.rs
@@ -16,16 +16,14 @@ use crate::package::*;
 LoadDefinitions!(state, {
   AssignValue!("current_environment", String::new(), Some(Scope::Global));
   DefMacro!("\\@currenvir", "");
-  DefPrimitive!("\\f{}", sub[stomach, args, state] {
-    unpack!(args => env);
+  DefPrimitive!("\\f{}", sub[stomach, (env), state] {
     let env_string = env.to_string();
     DefMacro!(T_CS!("\\@currenvir"), None, env);
     AssignValue!("current_environment", env_string);
   });
 
   DefPrimitive!(
-  "\\lx@setcurrenvir{}", sub[stomach, args, state] {
-    unpack!(args => env);
+  "\\lx@setcurrenvir{}", sub[stomach, (env), state] {
     let env_string = env.to_string();
     DefMacro!(T_CS!("\\@currenvir"), None, env);
     AssignValue!("current_environment", env_string);

--- a/rtx_package/src/package/pool/latex_ch1_environments.rs
+++ b/rtx_package/src/package/pool/latex_ch1_environments.rs
@@ -32,8 +32,7 @@ LoadDefinitions!(state, {
   });
   Let!("\\@currenvline", "\\@empty");
 
-  DefMacro!("\\begin{}", sub[gullet, args, state] {
-    unpack!(args => env);
+  DefMacro!("\\begin{}", sub[gullet, (env), state] {
     let name = Expand!(env.clone(), gullet).to_string();
     let begin_name = s!("\\begin{{{}}}", name);
     let before_opt = state.lookup_tokens(&s!("@environment@{}@beforebegin", name));
@@ -66,8 +65,7 @@ LoadDefinitions!(state, {
     }
   });
 
-  DefMacro!("\\end{}", sub[gullet, args, state]{
-    unpack!(args => env);
+  DefMacro!("\\end {}", sub[gullet, (env), state]{
     let name = Expand!(env, gullet).to_string();
     let before = state.lookup_value(&s!("@environment@{}@atend",name));
     let after  = state.lookup_value(&s!("@environment@{}@afterend",name));

--- a/rtx_package/src/package/pool/latex_ch2_document.rs
+++ b/rtx_package/src/package/pool/latex_ch2_document.rs
@@ -10,11 +10,11 @@ LoadDefinitions!(state, {
   //    text
   //   \end{document}
 
-  DefMacro!("\\AtBeginDocument{}", sub[gullet,args,state] {
-    state.push_value("@at@begin@document", args.remove(0).unlist());
+  DefMacro!("\\AtBeginDocument{}", sub[gullet,(rules),state] {
+    state.push_value("@at@begin@document", rules.unlist());
   });
-  DefMacro!("\\AtEndDocument{}", sub[gullet,args,state] {
-    state.push_value("@at@end@document", args.remove(0).unlist());
+  DefMacro!("\\AtEndDocument{}", sub[gullet,(rules),state] {
+    state.push_value("@at@end@document", rules.unlist());
   });
 
   // Like  "<ltx:document xml:id='#id'>#body</ltx:document>",

--- a/rtx_package/src/package/pool/latex_ch4_sectioning_and_toc.rs
+++ b/rtx_package/src/package/pool/latex_ch4_sectioning_and_toc.rs
@@ -32,9 +32,8 @@ LoadDefinitions!(outer_stomach, outer_state, {
     Tag!(&s!("ltx:{}",tag), auto_close => true);
   }
 
-  DefMacro!("\\secdef {}{} OptionalMatch:*", sub[gullet, args, state] {
-    unpack!(args=>token1, token2);
-    if args.len() == 3 {
+  DefMacro!("\\secdef {}{} OptionalMatch:*", sub[gullet, (token1, token2, star), state] {
+    if star.is_some() {
       Ok(token2) // can't move out without clone, how to circumvent?
     } else {
       Ok(token1)
@@ -46,9 +45,8 @@ LoadDefinitions!(outer_stomach, outer_state, {
   NewCounter!("secnumdepth");
   SetCounter!("secnumdepth", Number::new(3));
   DefMacro!(
-    "\\@startsection{}{}{}{}{}{} OptionalMatch:*", sub[gullet,args,state] {
-      unpack!(args => type_tokens, level_arg, ignore3, ignore4, ignore5, ignore6, flag);
-
+    "\\@startsection{}{}{}{}{}{} OptionalMatch:*",
+    sub[ gullet, (type_tokens, level_arg, ignore3, ignore4, ignore5, ignore6, flag), state ] {
       let stype = type_tokens.to_string();
       let level = level_arg.to_string();
       let level_int = if level.is_empty() { 0 } else { level.parse::<i32>()? };
@@ -57,7 +55,7 @@ LoadDefinitions!(outer_stomach, outer_state, {
         None => stype
       };
       let mut tokens: Vec<Token>;
-      if !flag.is_empty() { // No number, not in TOC
+      if flag.is_some() { // No number, not in TOC
         tokens = vec![T_CS!("\\par"), T_CS!("\\@startsection@hook"), T_CS!("\\@@unnumbered@section"),
         T_BEGIN!()];
         tokens.extend(type_tokens.unlist());

--- a/rtx_package/src/package/pool/latex_ch5_packages.rs
+++ b/rtx_package/src/package/pool/latex_ch5_packages.rs
@@ -60,9 +60,7 @@ LoadDefinitions!(state, {
     DefMacro!(T_CS!(ltxtrigger), None, Tokens!());
   }
 
-  DefPrimitive!("\\g@addto@macro DefToken {}", sub[stomach,args,state] {
-    unpack!(args => target, content);
-    let target : Token = target.into();
+  DefPrimitive!("\\g@addto@macro DefToken {}", sub[stomach,(target, content),state] {
     AddToMacro!(target, content, stomach, state);
   });
   DefMacro!("\\addto@hook DefToken {}", "#1\\expandafter{\\the#1#2}");

--- a/rtx_package/src/package/pool/latex_ch5_title_page_and_abstract.rs
+++ b/rtx_package/src/package/pool/latex_ch5_title_page_and_abstract.rs
@@ -52,8 +52,7 @@ LoadDefinitions!(state, {
 
   DefMacro!("\\@author", "\\@empty");
   DefMacro!("\\author{}", "\\def\\@author{#1}\\lx@make@authors@anded{#1}", locked => true);
-  DefMacro!("\\lx@make@authors@anded{}", sub[gullet, args, state] {
-    unpack!(args => authors);
+  DefMacro!("\\lx@make@authors@anded{}", sub[gullet, (authors), state] {
     and_split(T_CS!("\\lx@author"), authors)
   });
   DefPrimitive!("\\ltx@authors@oneline", sub[stomach, args, state] {

--- a/rtx_package/src/package/pool/latex_ch5_title_page_and_abstract.rs
+++ b/rtx_package/src/package/pool/latex_ch5_title_page_and_abstract.rs
@@ -25,7 +25,7 @@ LoadDefinitions!(state, {
   DefConstructor!("\\and", " and ");
 
   AssignValue!("NUMBER_OF_AUTHORS" => 0);
-  DefPrimitive!("\\lx@count@author", sub[stomach, args, state] {
+  DefPrimitive!("\\lx@count@author", sub[stomach, (), state] {
     let current = state.lookup_int("NUMBER_OF_AUTHORS");
     AssignValue!("NUMBER_OF_AUTHORS" => current + 1, Some(Scope::Global));
   });
@@ -55,10 +55,10 @@ LoadDefinitions!(state, {
   DefMacro!("\\lx@make@authors@anded{}", sub[gullet, (authors), state] {
     and_split(T_CS!("\\lx@author"), authors)
   });
-  DefPrimitive!("\\ltx@authors@oneline", sub[stomach, args, state] {
+  DefPrimitive!("\\ltx@authors@oneline", sub[stomach, (), state] {
     AssignMapping!("DOCUMENT_CLASSES", "ltx_authors_1line" => true);
   });
-  DefPrimitive!("\\ltx@authors@multiline", sub[stomach, args, state] {
+  DefPrimitive!("\\ltx@authors@multiline", sub[stomach, (), state] {
     AssignMapping!("DOCUMENT_CLASSES", "ltx_authors_multiline" => true);
   });
 

--- a/rtx_package/src/package/pool/latex_ch6_list_and_trivlist_environments.rs
+++ b/rtx_package/src/package/pool/latex_ch6_list_and_trivlist_environments.rs
@@ -8,8 +8,7 @@ LoadDefinitions!(state, {
 
   DefConditional!("\\if@nmbrlist");
   DefMacro!("\\@listctr", "");
-  DefPrimitive!("\\usecounter{}", sub[stomach, args, state] {
-    unpack!(args => counter);
+  DefPrimitive!("\\usecounter{}", sub[stomach, (counter), state] {
     let gullet = stomach.get_gullet_mut();
     let counter = Expand!(counter, gullet, state).to_string();
     if counter.is_empty() {

--- a/rtx_package/src/package/pool/latex_ch6_list_making_environments.rs
+++ b/rtx_package/src/package/pool/latex_ch6_list_making_environments.rs
@@ -140,8 +140,7 @@ LoadDefinitions!(state, {
   DefMacro!("\\fnum@@itemiii", r"{\makelabel{\label@itemiii}}");
   DefMacro!("\\fnum@@itemiv", r"{\makelabel{\label@itemiv}}");
 
-  DefMacro!("\\lx@poormans@ordinal{}", sub[gullet, args, state] {
-    unpack!(args => ctr);
+  DefMacro!("\\lx@poormans@ordinal{}", sub[gullet, (ctr), state] {
     let mut ctr_str      = CounterValue!(&ctr.to_string()).value_of().to_string();
     let last_char = ctr_str.chars().last().unwrap_or('.');
     if last_char.is_ascii_digit() {

--- a/rtx_package/src/package/pool/latex_ch6_verbatim.rs
+++ b/rtx_package/src/package/pool/latex_ch6_verbatim.rs
@@ -87,7 +87,7 @@ LoadDefinitions!(outer_state, {
     before_construct => sub[document, whatsit, state] { document.maybe_close_element("ltx:p", state)?; }
   );
 
-  DefPrimitive!("\\@vobeyspaces", sub[stomach, args, state] {
+  DefPrimitive!("\\@vobeyspaces", sub[stomach, (), state] {
     AssignCatcode!(' ', Catcode::ACTIVE);
     Let!(&T_ACTIVE!(" "), T_CS!("\\nobreakspace"));
   });
@@ -136,7 +136,7 @@ LoadDefinitions!(outer_state, {
     }
   });
 
-  DefPrimitive!("\\lx@use@visiblespace", sub[stomach, args, state] {
+  DefPrimitive!("\\lx@use@visiblespace", sub[stomach, (), state] {
     state.assign_catcode(' ', Catcode::ACTIVE, None); // Do NOT (necessarily) skip spaces after \verb!!!
     Let!(&T_ACTIVE!(" "), T_OTHER!("\u{2423}")); // Visible space
   });

--- a/rtx_package/src/package/pool/latex_ch8_defining_commands.rs
+++ b/rtx_package/src/package/pool/latex_ch8_defining_commands.rs
@@ -10,16 +10,8 @@ LoadDefinitions!(state, {
 
   DefMacro!("\\@tabacckludge {}", "\\csname\\string#1\\endcsname");
 
-  DefPrimitive!("\\newcommand OptionalMatch:* DefToken [Number][]{}", sub[stomach, args, state] {
-    let star = args.remove(0);
-    let cs = args.remove(0);
-    let nargs_opt = args.remove(0);
-    let opt = args.remove(0);
-    let body = args.remove(0);
-    let cs_token: Token = cs.try_to_token()?;
-    let nargs = if nargs_opt.is_empty() { 0 } else {
-      nargs_opt.unlist().first().unwrap().to_number().value_of() as usize
-    };
+  DefPrimitive!("\\newcommand OptionalMatch:* DefToken [Number][]{}", sub[stomach, (star,cs_token,nargs,opt,body), state] {
+    let nargs = nargs.value_of() as usize;
     if !IsDefinable!(&cs_token) {
       if !state.has_value(&s!("{}:locked", cs_token.to_string())) { // not locked, inform.
         let message = s!("Ignoring redefinition (\\newcommand) of {}", cs_token.stringify());
@@ -27,19 +19,17 @@ LoadDefinitions!(state, {
       }
       return Ok(vec![]);
     }
-    let macro_args = convert_latex_args(nargs, opt.owned_tokens(), state)?;
+    let macro_args = convert_latex_args(nargs, opt, state)?;
     DefMacro!(cs_token, macro_args, body);
   });
 
-  DefPrimitive!("\\renewcommand OptionalMatch:* DefToken [Number][]{}", sub[stomach, args, state] {
-    unpack!(args => star, cs, nargs_opt, opt, body);
-    let cs_token: Token = cs.into();
-    let nargs = if nargs_opt.is_empty() { 0 } else {
-      nargs_opt.unlist().first().unwrap().to_number().value_of() as usize
-    };
-    let opt = if opt.is_empty() { None } else { Some(opt) };
+  DefPrimitive!("\\renewcommand OptionalMatch:* DefToken [Number][]{}", sub[stomach, (star, cs, nargs_num, opt, body), state] {
+    let nargs = nargs_num.value_of() as usize;
+    let opt = if let Some(ref opt_content) = opt {
+      if opt_content.is_empty() { None } else { opt }
+    } else { opt };
     let macro_args = convert_latex_args(nargs, opt, state)?;
-    DefMacro!(cs_token, macro_args, body);
+    DefMacro!(cs, macro_args, body);
   });
 
   // low-level implementation of both \newcommand and \renewcommand depends on \@argdef
@@ -51,37 +41,36 @@ LoadDefinitions!(state, {
   // The etoolbox binding now defines \newrobustcmd & friends directly, so \@argdef is not directly needed
   // However, we would need to add support for other packages that may leverage that machinery.
 
-  DefPrimitive!("\\providecommand OptionalMatch:* DefToken [Number][]{}", sub[stomach, args, state] {
-    unpack!(args => star, cs, nargs, opt, body);
+  DefPrimitive!("\\providecommand OptionalMatch:* DefToken [Number][]{}", sub[stomach, (star, cs, nargs, opt, body), state] {
     // TODO: Consider if we should just treat the empty tokens directly in convert_latex_args ?
-    let opts = if opt.is_empty() { None } else { Some(opt)};
-    let cs : Token = cs.into();
+    let opt_checked = if let Some(ref opt_content) = opt {
+      if opt_content.is_empty() {
+        None
+      } else { opt }
+    } else { opt };
     if IsDefinable!(&cs) {
-      let nargs = nargs.to_number().value_of() as usize;
-      let cs_args = convert_latex_args(nargs, opts, state)?;
+      let nargs = nargs.value_of() as usize;
+      let cs_args = convert_latex_args(nargs, opt_checked, state)?;
       DefMacro!(cs, cs_args, body);
     }
   });
 
   // Crazy; define \cs in terms of \cs[space] !!!
-  DefPrimitive!("\\DeclareRobustCommand OptionalMatch:* DefToken [Number][]{}", sub[stomach, args, state] {
-    unpack!(args => star,cs,nargs,opt,body);
-    let cs:Token = cs.into();
-    let opts = if opt.is_empty() {
-      None
-    } else {
-      Some(opt)
-    };
-    let nargs = nargs.to_number().value_of() as usize;
+  DefPrimitive!("\\DeclareRobustCommand OptionalMatch:* DefToken [Number][]{}", sub[stomach, (star,cs,nargs,opt,body), state] {
+    let opt_checked = if let Some(ref opt_content) = opt {
+      if opt_content.is_empty() {
+        None
+      } else { opt }
+    } else { opt };
+    let nargs = nargs.value_of() as usize;
     let mungedcs = T_CS!(s!("{} ", cs.get_string()));
     let mungedcs2 = mungedcs.clone();
-    let cs_args = convert_latex_args(nargs, opts, state)?;
+    let cs_args = convert_latex_args(nargs, opt_checked, state)?;
     DefMacro!(mungedcs, cs_args, body);
     DefMacro!(cs, None, Tokens!(T_CS!("\\protect"), mungedcs2));
   });
 
-  DefPrimitive!("\\MakeRobust DefToken", sub[stomach, args, state] {
-    unpack_to_token!(args => cs);
+  DefPrimitive!("\\MakeRobust DefToken", sub[stomach, (cs), state] {
     let mungedcs = T_CS!(s!("{} ",cs.get_string()));
     // only if defined but not yet robust
     if LookupDefinition!(&cs).is_some() &&
@@ -99,16 +88,9 @@ LoadDefinitions!(state, {
   // It may be that we've already defined it to expand into the above conditional.
   // But more importantly, we don't want to override a hand-written definition (if any).
   //------------------------------------------------------------
-  DefPrimitive!("\\DeclareTextCommand DefToken {}[Number][]{}", sub[stomach, args, state] {
-    unpack!(args => cs, encoding, nargs, opt, expansion);
-    let cs : Token = cs.into();
+  DefPrimitive!("\\DeclareTextCommand DefToken {}[Number][]{}", sub[stomach, (cs, encoding, nargs, opts, expansion), state] {
     let cs_str = cs.to_string();
-    let opts = if opt.is_empty() {
-      None
-    } else {
-      Some(opt)
-    };
-    let nargs = nargs.to_number().value_of() as usize;
+    let nargs = nargs.value_of() as usize;
     let gullet = stomach.get_gullet_mut();
     let encoding = Expand!(encoding, gullet, state);
     if !IsDefined!(&cs) {    // If not already defined...
@@ -124,16 +106,9 @@ LoadDefinitions!(state, {
 
   DefMacro!("\\DeclareTextCommandDefault DefToken", "\\DeclareTextCommand{#1}{?}");
 
-  DefPrimitive!("\\ProvideTextCommand DefToken {}[Number][]{}", sub[gullet, args, state] {
-    unpack!(args => cs, encoding, nargs, opt, expansion);
-    let cs : Token = cs.into();
+  DefPrimitive!("\\ProvideTextCommand DefToken {}[Number][]{}", sub[gullet, (cs, encoding, nargs, opts, expansion), state] {
     let cs_str = cs.to_string();
-    let opts = if opt.is_empty() {
-      None
-    } else {
-      Some(opt)
-    };
-    let nargs = nargs.to_number().value_of() as usize;
+    let nargs = nargs.value_of() as usize;
     if IsDefinable!(&cs) { // If not already defined...
       DefMacro!(cs, None, Some(s!(r#"""
         \expandafter\ifx\csname\cf@encoding\string{}\endcsname\relax\csname?\string{}\endcsname
@@ -151,8 +126,7 @@ LoadDefinitions!(state, {
 
   // #------------------------------------------------------------
 
-  DefPrimitive!("\\DeclareTextSymbol DefToken {}{Number}", sub[stomach, args, state] {
-    unpack_to_token!(args => cs, encoding, code);
+  DefPrimitive!("\\DeclareTextSymbol DefToken {}{Number}", sub[stomach, (cs, encoding, code), state] {
     // TODO:
     //     $code = $code->valueOf;
     //     my $css = ToString($cs);
@@ -200,8 +174,7 @@ LoadDefinitions!(state, {
   // The next font declaration commands are based on
   // http://tex.loria.fr/general/new/fntguide.html
   // we ignore font encoding
-  DefPrimitive!("\\DeclareSymbolFont{}{}{}{}{}", sub[stomach, args, state] {
-    unpack!(args => name, enc, family, series, shape);
+  DefPrimitive!("\\DeclareSymbolFont{}{}{}{}{}", sub[stomach, (name, enc, family, series, shape), state] {
     AssignValue!(&s!("fontdeclaration@{}", name),
       fontmap!(family => family.to_string(),
         series   => series.to_string(),
@@ -210,8 +183,7 @@ LoadDefinitions!(state, {
       )
     );
   });
-  DefPrimitive!("\\DeclareSymbolFontAlphabet{}{}", sub[stomach, args, state] {
-    unpack_to_token!(args => cs, name);
+  DefPrimitive!("\\DeclareSymbolFontAlphabet {Token} {}", sub[stomach, (cs, name), state] {
     let fontkey = s!("fontdeclarations@{}", name.to_string());
     let font : Option<Font> = if let Some(Stored::Font(value)) = LookupValue!(&fontkey) {
       Some((**value).clone())
@@ -226,8 +198,7 @@ LoadDefinitions!(state, {
 
   DefMacro!("\\cdp@list", "\\@empty");
   Let!("\\cdp@elt", "\\relax");
-  DefPrimitive!("\\DeclareFontEncoding{}{}{}", sub[stomach, args, state] {
-    unpack_to_token!(args => encoding, x, y);
+  DefPrimitive!("\\DeclareFontEncoding{}{}{}", sub[stomach, (encoding, x, y), state] {
     // TODO:
     // AddToMacro!(T_CS!("\\cdp@list"), T_CS!("\\cdp@elt"),
     //   T_BEGIN!(), encoding.unlist(), T_END,

--- a/rtx_package/src/package/pool/latex_ch8_defining_environments.rs
+++ b/rtx_package/src/package/pool/latex_ch8_defining_environments.rs
@@ -6,13 +6,7 @@ use crate::package::*;
 // Note that \env & \endenv defined by \newenvironment CAN be
 // invoked directly.
 LoadDefinitions!(state, {
-  DefPrimitive!("\\newenvironment OptionalMatch:* {}[Number][]{}{}", sub[stomach, args, state] {
-    unpack_opt!(args => star_opt, name_opt, nargs_opt, opt_opt, begin_opt, end_opt);
-    let name = name_opt.owned_tokens().unwrap();
-    let nargs = if nargs_opt.is_empty() { Number::new(0) } else { nargs_opt.owned_tokens().unwrap().to_number() };
-    let begin = begin_opt.owned_tokens().unwrap();
-    let end = end_opt.owned_tokens().unwrap();
-
+  DefPrimitive!("\\newenvironment OptionalMatch:* {}[Number][]{}{}", sub[stomach, (star_opt, name, nargs, opt, begin, end), state] {
     let name = { stomach.digest(name, state)?.to_string() };
     let name_cs = T_CS!(s!("\\{}",name));
     let end_name_cs = T_CS!(s!("\\end{}",name));
@@ -24,7 +18,6 @@ LoadDefinitions!(state, {
         Info!("ignore", name, stomach, state, message);
       }
     } else {
-      let opt = if opt_opt.is_empty() { None } else { Some(opt_opt.owned_tokens().unwrap()) };
       // TODO: can we convince DefMacro! this is not a second mutable borrow of state?
       let converted_args = convert_latex_args(nargs.value_of() as usize, opt, state)?;
       DefMacro!(name_cs, converted_args, begin);

--- a/rtx_package/src/package/pool/latex_ch8_numbering.rs
+++ b/rtx_package/src/package/pool/latex_ch8_numbering.rs
@@ -22,43 +22,36 @@ LoadDefinitions!(state, {
     generate_id(document, node, "p", state)?;
   });
 
-  DefPrimitive!("\\newcounter{}[]", sub[stomach, args, state] {
-    unpack_opt!(args => cs_opt, default_opt);
-    let cs = cs_opt.owned_tokens().unwrap();
+  DefPrimitive!("\\newcounter{}[]", sub[stomach, (cs, default_opt), state] {
     let gullet = stomach.get_gullet_mut();
-    let default = if !default_opt.is_empty() {
-      Expand!(default_opt.owned_tokens().unwrap(), gullet)
+    let default = if let Some(tks) = default_opt {
+      if !tks.is_empty() {
+        Expand!(tks, gullet)
+      } else {
+        Tokens!()
+      }
     } else {
       Tokens!()
     };
     let cs_expanded = &Expand!(cs, gullet).to_string();
     NewCounter!(cs_expanded, &default.to_string());
   });
-  DefPrimitive!("\\setcounter{}{Number}", sub[stomach, args, state] {
-    unpack!(args=>cs, default);
+  DefPrimitive!("\\setcounter{}{Number}", sub[stomach, (cs, default), state] {
     let gullet = stomach.get_gullet_mut();
     let cs_expanded = &Expand!(cs, gullet).to_string();
-    let default = default.to_number();
     SetCounter!(cs_expanded, default, stomach, state);
   });
-  DefPrimitive!("\\addtocounter{}{Number}", sub[stomach, args, state] {
-    unpack!(args=>cs, default);
+  DefPrimitive!("\\addtocounter{}{Number}", sub[stomach, (cs,default), state] {
     let gullet = stomach.get_gullet_mut();
     let cs_expanded = &Expand!(cs, gullet).to_string();
-    // TODO: Continue here: The {Number} parameter type should be expanded already,
-    //       I need to carefully study the differences with LaTeXML and smooth the edges
-    //
-    let default = Expand!(default, gullet).to_number();
     AddToCounter!(cs_expanded, default, gullet);
   });
-  DefPrimitive!("\\stepcounter{}",    sub[stomach, args, state] {
-    unpack!(args=>cs);
+  DefPrimitive!("\\stepcounter{}",    sub[stomach, (cs), state] {
     let gullet = stomach.get_gullet_mut();
     let cs_expanded = &Expand!(cs, gullet).to_string();
     StepCounter!(cs_expanded, false, stomach)?;
   });
-  DefPrimitive!("\\refstepcounter{}", sub[stomach, args, state] {
-    unpack!(args=>cs);
+  DefPrimitive!("\\refstepcounter{}", sub[stomach, (cs), state] {
     let gullet = stomach.get_gullet_mut();
     let cs_expanded = &Expand!(cs, gullet).to_string();
     RefStepCounter!(cs_expanded, false, stomach)?;
@@ -90,8 +83,7 @@ LoadDefinitions!(state, {
     ExplodeText!(ctr_value)
   });
 
-  DefMacro!("\\@arabic{Number}", sub[gullet, args, state] {
-    unpack_to_number!(args => number);
+  DefMacro!("\\@arabic{Number}", sub[gullet, (number), state] {
     let value = number.value_of();
     ExplodeText!(value.to_string())
   });
@@ -101,8 +93,7 @@ LoadDefinitions!(state, {
     ExplodeText!(ctr_value)
   });
 
-  DefMacro!("\\@roman{Number}", sub[gullet, args, state] {
-    unpack_to_number!(args => number);
+  DefMacro!("\\@roman{Number}", sub[gullet, (number), state] {
     let value = number.value_of();
     ExplodeText!(radix::radix_roman(value))
   });
@@ -110,8 +101,7 @@ LoadDefinitions!(state, {
     let ctr = Expand!(token, gullet).to_string();
     ExplodeText!(radix::radix_roman(CounterValue!(&ctr).value_of()))
   });
-  DefMacro!("\\@Roman{Number}", sub[gullet, args, state] {
-    unpack_to_number!(args => number);
+  DefMacro!("\\@Roman{Number}", sub[gullet, (number), state] {
     let value = number.value_of();
     ExplodeText!(radix::radix_up_roman(value))
   });
@@ -119,8 +109,7 @@ LoadDefinitions!(state, {
     let ctr = Expand!(token, gullet).to_string();
     ExplodeText!(radix::radix_up_roman(CounterValue!(&ctr).value_of()))
   });
-  DefMacro!("\\@alph{Number}", sub[gullet, args, state] {
-    unpack_to_number!(args => number);
+  DefMacro!("\\@alph{Number}", sub[gullet, (number), state] {
     let value = number.value_of();
     ExplodeText!(radix::radix_alpha(value))
   });
@@ -128,8 +117,7 @@ LoadDefinitions!(state, {
     let ctr = Expand!(token, gullet).to_string();
     ExplodeText!(radix::radix_alpha(CounterValue!(&ctr).value_of()))
   });
-  DefMacro!("\\@Alph{Number}", sub[gullet, args, state] {
-    unpack_to_number!(args => number);
+  DefMacro!("\\@Alph{Number}", sub[gullet, (number), state] {
     let value = number.value_of();
     ExplodeText!(radix::radix_up_alpha(value))
   });
@@ -138,8 +126,7 @@ LoadDefinitions!(state, {
     ExplodeText!(radix::radix_up_alpha(CounterValue!(&ctr).value_of()))
   });
 
-  DefMacro!("\\@fnsymbol{Number}", sub[gullet, args, state] {
-    unpack_to_number!(args => number);
+  DefMacro!("\\@fnsymbol{Number}", sub[gullet, (number), state] {
     ExplodeText!(radix::radix_format_str(number.value_of(), FNSYMBOLS))
   });
   DefMacro!("\\fnsymbol{}", sub[gullet, (token), state] {

--- a/rtx_package/src/package/pool/latex_ch8_numbering.rs
+++ b/rtx_package/src/package/pool/latex_ch8_numbering.rs
@@ -84,8 +84,7 @@ LoadDefinitions!(state, {
   //       DefMacroI(T_CS("\\\@$ctr\@ID"), undef, "0", scope => 'global'); }
   //     return; });
 
-  DefMacro!("\\value{}", sub[gullet, args, inner_state] {
-    unpack!(args => value);
+  DefMacro!("\\value{}", sub[gullet, (value), inner_state] {
     let ctr_expansion = Expand!(value, gullet, inner_state).to_string();
     let ctr_value = CounterValue!(&ctr_expansion, inner_state).value_of();
     ExplodeText!(ctr_value)
@@ -96,8 +95,7 @@ LoadDefinitions!(state, {
     let value = number.value_of();
     ExplodeText!(value.to_string())
   });
-  DefMacro!("\\arabic{}", sub[gullet, args, inner_state] {
-    unpack!(args => value);
+  DefMacro!("\\arabic{}", sub[gullet, (value), inner_state] {
     let ctr_expansion = Expand!(value, gullet, inner_state).to_string();
     let ctr_value = CounterValue!(&ctr_expansion, inner_state).value_of();
     ExplodeText!(ctr_value)
@@ -108,8 +106,7 @@ LoadDefinitions!(state, {
     let value = number.value_of();
     ExplodeText!(radix::radix_roman(value))
   });
-  DefMacro!("\\roman{}", sub[gullet, args, state] {
-    unpack!(args => token);
+  DefMacro!("\\roman{}", sub[gullet, (token), state] {
     let ctr = Expand!(token, gullet).to_string();
     ExplodeText!(radix::radix_roman(CounterValue!(&ctr).value_of()))
   });
@@ -118,8 +115,7 @@ LoadDefinitions!(state, {
     let value = number.value_of();
     ExplodeText!(radix::radix_up_roman(value))
   });
-  DefMacro!("\\Roman{}", sub[gullet, args, state] {
-    unpack!(args => token);
+  DefMacro!("\\Roman{}", sub[gullet, (token), state] {
     let ctr = Expand!(token, gullet).to_string();
     ExplodeText!(radix::radix_up_roman(CounterValue!(&ctr).value_of()))
   });
@@ -128,8 +124,7 @@ LoadDefinitions!(state, {
     let value = number.value_of();
     ExplodeText!(radix::radix_alpha(value))
   });
-  DefMacro!("\\alph{}", sub[gullet, args, state] {
-    unpack!(args => token);
+  DefMacro!("\\alph{}", sub[gullet, (token), state] {
     let ctr = Expand!(token, gullet).to_string();
     ExplodeText!(radix::radix_alpha(CounterValue!(&ctr).value_of()))
   });
@@ -138,8 +133,7 @@ LoadDefinitions!(state, {
     let value = number.value_of();
     ExplodeText!(radix::radix_up_alpha(value))
   });
-  DefMacro!("\\Alph{}", sub[gullet, args, state] {
-    unpack!(args => token);
+  DefMacro!("\\Alph{}", sub[gullet, (token), state] {
     let ctr = Expand!(token, gullet).to_string();
     ExplodeText!(radix::radix_up_alpha(CounterValue!(&ctr).value_of()))
   });
@@ -148,8 +142,7 @@ LoadDefinitions!(state, {
     unpack_to_number!(args => number);
     ExplodeText!(radix::radix_format_str(number.value_of(), FNSYMBOLS))
   });
-  DefMacro!("\\fnsymbol{}", sub[gullet, args, state] {
-    unpack!(args => token);
+  DefMacro!("\\fnsymbol{}", sub[gullet, (token), state] {
     let ctr = Expand!(token, gullet).to_string();
     ExplodeText!(radix::radix_format_str(CounterValue!(&ctr).value_of(), FNSYMBOLS))
   });

--- a/rtx_package/src/package/pool/latex_ch9_figures_and_tables.rs
+++ b/rtx_package/src/package/pool/latex_ch9_figures_and_tables.rs
@@ -59,8 +59,7 @@ LoadDefinitions!(state, {
     r"\lx@note@caption@label{#4}\@hack@caption@{#1}{#2}{#3\label{#4}#5}\label#6\endcaption"
   );
 
-  DefPrimitive!("\\lx@note@caption@label{}", sub[stomach,args,state] {
-    unpack!(args => label);
+  DefPrimitive!("\\lx@note@caption@label{}", sub[stomach,(label),state] {
     let label = label.to_string();
     maybe_note_label(&label, state); });
 
@@ -70,7 +69,7 @@ LoadDefinitions!(state, {
   );
 
   // Note that the counters only get incremented by \caption, NOT by \table, \figure, etc.
-  DefPrimitive!("\\@@add@caption@counters", sub[stomach, args, state] {
+  DefPrimitive!("\\@@add@caption@counters", sub[stomach, (), state] {
     let captype = stomach.digest(T_CS!("\\@captype"), state)?.to_string();
     let props   = ref_step_counter(&captype, false, stomach, state)?;
     let inlist  = stomach.digest(T_CS!(s!("\\ext@{}", captype)), state)?.to_string();

--- a/rtx_package/src/package/pool/latex_hook.rs
+++ b/rtx_package/src/package/pool/latex_hook.rs
@@ -41,7 +41,7 @@ LoadDefinitions!(state, {
     DefMacro!(T_CS!(ltxtrigger), None, { Tokens!(T_CS!("\\@load@latex@pool"), T_CS!(ltxtrigger)) });
   }
 
-  DefPrimitive!("\\@load@latex@pool", sub[stomach, args, state] {
+  DefPrimitive!("\\@load@latex@pool", sub[stomach, (), state] {
     input_definitions(
       "LaTeX",
       InputDefinitionOptions {

--- a/rtx_package/src/package/pool/latex_other_in_appendices.rs
+++ b/rtx_package/src/package/pool/latex_other_in_appendices.rs
@@ -76,8 +76,7 @@ LoadDefinitions!(state, {
   DefMacro!("\\@thirdofthree{}{}{}", sub[gullet, args, state] { Ok(args.remove(2)) });
   // DefMacro('\@expandtwoargs{}{}{}', sub {
   //     ($_[1]->unlist, T_BEGIN, Expand($_[2])->unlist, T_END, T_BEGIN, Expand($_[3])->unlist, T_END); });
-  DefMacro!("\\@makeother{}", sub[gullet,args,state] {
-    unpack_to_token!(args=>arg);
+  DefMacro!("\\@makeother Token", sub[gullet,(arg),state] {
     let arg_c = arg.get_string().chars().next().unwrap();
     state.assign_catcode(arg_c, Catcode::OTHER, Some(Scope::Local));
   });

--- a/rtx_package/src/package/pool/latex_semi_undocumented.rs
+++ b/rtx_package/src/package/pool/latex_semi_undocumented.rs
@@ -4,9 +4,7 @@ use crate::package::*;
 //**********************************************************************
 
 LoadDefinitions!(state, {
-  DefMacro!("\\@ifnextchar DefToken {}{}", sub[gullet, args, state] {
-    unpack!(args => token, t_if, t_else);
-    let token : Token = token.into();
+  DefMacro!("\\@ifnextchar DefToken {}{}", sub[gullet, (token, t_if, t_else), state] {
     let next = gullet.read_non_space(state);
     // NOTE: Not actually substituting, but collapsing ## pairs!!!!
     // use \egroup for $next, if we've fallen off end?
@@ -26,8 +24,7 @@ LoadDefinitions!(state, {
   Let!("\\@ifnext", "\\@ifnextchar"); // ????
 
   // Hacky version matches multiple chars! but does NOT expand
-  DefMacro!(r"\@ifnext@n {}{}{}", sub[gullet,args,state] {
-    unpack!(args=>tokens,if_toks,else_toks);
+  DefMacro!(r"\@ifnext@n {}{}{}", sub[gullet,(tokens,if_toks,else_toks),state] {
     let mut toks = VecDeque::from(tokens.unlist());
     let mut read = Vec::new();
     while let Some(t) = gullet.read_token(state) {
@@ -48,8 +45,7 @@ LoadDefinitions!(state, {
     Ok(Tokens::new(result))
   });
 
-  DefMacro!("\\@ifstar {}{}", sub[gullet,args,state] {
-  unpack!(args=>if_toks,else_toks);
+  DefMacro!("\\@ifstar {}{}", sub[gullet,(if_toks,else_toks),state] {
   let next_opt = gullet.read_non_space(state);
   if Some(T_OTHER!("*")) == next_opt {
     Ok(if_toks)
@@ -64,8 +60,7 @@ LoadDefinitions!(state, {
   DefMacro!("\\@dblarg {}", r"\kernel@ifnextchar[{#1}{\@xdblarg{#1}}");
   DefMacro!("\\@xdblarg {}{}", r"#1[{#2}]{#2}");
 
-  DefMacro!("\\@testopt{}{}", sub[gullet,args,state] {
-    unpack!(args => cmd, option);
+  DefMacro!("\\@testopt{}{}", sub[gullet,(cmd, option),state] {
     if gullet.if_next(T_OTHER!("["), state)? {
       Ok(cmd)
     } else {

--- a/rtx_package/src/package/pool/tex_alignment.rs
+++ b/rtx_package/src/package/pool/tex_alignment.rs
@@ -142,7 +142,7 @@ LoadDefinitions!(state, {
 
   // This is the "normal" case: $ appearing with an alignment that is in text mode.
   // It's just like regular $, except it doesn't look for $$ (no display math).
-  DefPrimitive!(r"\@dollar@in@textmode", sub [stomach,whatsit,state] {
+  DefPrimitive!(r"\@dollar@in@textmode", sub [stomach, (), state] {
     let mathcs = if state.lookup_bool("IN_MATH") { T_CS!("\\@@ENDINLINEMATH") }
       else {T_CS!("\\@@BEGININLINEMATH") };
     stomach.invoke_token(&mathcs, state)

--- a/rtx_package/src/package/pool/tex_appendix_b_p357.rs
+++ b/rtx_package/src/package/pool/tex_appendix_b_p357.rs
@@ -195,7 +195,7 @@ LoadDefinitions!(state, {
   //     width => sub { LookupValue('\medmuskip'); } });
   // DefPrimitiveI('\@text@medmuskip', undef, "", alias => '\>');
 
-  DefPrimitive!("\\;", sub[stomach, args, state] {
+  DefPrimitive!("\\;", sub[stomach, (), state] {
     Tbox::new("\u{2004}".to_string(), None, None, Tokens!(T_CS!("\\;")),
       stored_map!("name"  => "thickspace", "isSpace" => true,
       "width" => state.lookup_value("\\thickmuskip")), state)

--- a/rtx_package/src/package/pool/tex_appendix_b_to_p349.rs
+++ b/rtx_package/src/package/pool/tex_appendix_b_to_p349.rs
@@ -285,25 +285,20 @@ LoadDefinitions!(state, {
   // # TeX Book, Appendix B, p. 347
   // # \wlog ??
   // # From plain.tex
-  DefPrimitive!("\\newcount Token", sub[stomach, args, state] {
-    unpack_to_token!(args => name);
+  DefPrimitive!("\\newcount Token", sub[stomach, (name), state] {
     DefRegister!(name, None, Number::new(0));
   });
-  DefPrimitive!("\\newdimen Token", sub[stomach, args, state] {
-    unpack_to_token!(args => name);
+  DefPrimitive!("\\newdimen Token", sub[stomach, (name), state] {
     DefRegister!(name, None, Dimension::new(0));
   });
-  DefPrimitive!("\\newskip Token", sub[stomach, args, state] {
-    unpack_to_token!(args => name);
+  DefPrimitive!("\\newskip Token", sub[stomach, (name), state] {
     DefRegister!(name, None, Glue::new(0));
   });
-  DefPrimitive!("\\newmuskip Token", sub[stomach, args, state] {
-    unpack_to_token!(args => name);
+  DefPrimitive!("\\newmuskip Token", sub[stomach, (name), state] {
     DefRegister!(name, None, MuGlue::new(0));
   });
   AssignValue!("allocated_boxes" => false);
-  DefPrimitive!("\\newbox Token", sub[stomach, args, state] {
-    unpack_to_token!(args => t);
+  DefPrimitive!("\\newbox Token", sub[stomach, (t), state] {
     let n = state.lookup_int("allocated_boxes");
     AssignValue!("allocated_boxes" => n + 1, Some(Scope::Global));
     AssignValue!(&s!("box{}",n), List::new(Vec::new()));
@@ -569,7 +564,7 @@ LoadDefinitions!(state, {
   DefPrimitive!("\\allowbreak", None);
   DefMacro!("\\nobreakspace", "\\ifmmode\\math@nobreakspace\\else\\text@nobreakspace\\fi");
 
-  DefPrimitive!("\\text@nobreakspace", sub[stomach, whatsit, state] {
+  DefPrimitive!("\\text@nobreakspace", sub[stomach, (), state] {
     Tbox::new(String::from("\u{00A0}"), None, None, Tokens!(T_CS!("~")), map!("isSpace" => Stored::Bool(true)), state)
   });
 

--- a/rtx_package/src/package/pool/tex_appendix_b_to_p349.rs
+++ b/rtx_package/src/package/pool/tex_appendix_b_to_p349.rs
@@ -314,8 +314,7 @@ LoadDefinitions!(state, {
   // # the next 4 actually work by doing a \chardef instead of \countdef, etc.
   // # which means they actually work quite differently
   DefRegister!("\\allocationnumber" => Number::new(0));
-  DefMacro!("\\alloc@@ {}", sub[gullet, args, state] {
-    unpack!(args => atype_tokens);
+  DefMacro!("\\alloc@@ {}", sub[gullet, (atype_tokens), state] {
     let atype = atype_tokens.to_string();
     let c = s!("allocation @{}", atype);
     let n = LookupRegisterOrDefault!(c).value_of();
@@ -372,9 +371,8 @@ LoadDefinitions!(state, {
   DefRegister!("\\interfootnotelinepenalty", Number(100));
 
   DefMacro!("\\magstephalf", "1095");
-  DefMacro!("\\magstep{}", sub[gullet, args, state] {
-    let mag = args[0].to_string();
-    Explode!(match mag.as_str() {
+  DefMacro!("\\magstep{}", sub[gullet, (mag), state] {
+    Explode!(match mag.to_string().as_str() {
       "0" => "1000",
       "1" => "1200",
       "2" => "1440",

--- a/rtx_package/src/package/pool/tex_assignment.rs
+++ b/rtx_package/src/package/pool/tex_assignment.rs
@@ -14,23 +14,23 @@ LoadDefinitions!(outer_state, {
   // <def> = \def | \gdef | \edef | \xdef
   // <definition text> = <register text><left brace><balanced text><right brace>
   DefPrimitive!("\\def SkipSpaces Token UntilBrace DefPlain",
-    sub[stomach, args, state] {
-      do_def(false, stomach, args, state)?;
+    sub[stomach, (cs,params,body), state] {
+      do_def(false, stomach, cs,params,body, state)?;
     },
     locked => true);
   DefPrimitive!("\\gdef SkipSpaces Token UntilBrace DefPlain",
-    sub[stomach, args, state] {
-      do_def(true, stomach, args, state)?;
+    sub[stomach, (cs,params,body), state] {
+      do_def(true, stomach, cs,params,body, state)?;
     },
     locked => true);
   DefPrimitive!("\\edef SkipSpaces Token UntilBrace DefExpanded",
-    sub[stomach, args, state] {
-      do_def(false, stomach, args, state)?;
+    sub[stomach, (cs,params,body), state] {
+      do_def(false, stomach, cs,params,body, state)?;
     },
     locked => true);
   DefPrimitive!("\\xdef SkipSpaces Token UntilBrace DefExpanded",
-    sub[stomach, args, state] {
-      do_def(true, stomach, args, state)?;
+    sub[stomach, (cs,params,body), state] {
+      do_def(true, stomach, cs,params,body, state)?;
     },
     locked => true);
 
@@ -64,9 +64,7 @@ LoadDefinitions!(outer_state, {
   // <code assignment> = <codename><8bit><equals><number>
 
   // Need to handle "at" too!!!
-  DefPrimitive!("\\font Token SkipMatch:= SkipSpaces TeXFileName", sub[stomach, args, state] {
-    unpack!(args => cs_arg, name_arg);
-    let cs : Token = cs_arg.into();
+  DefPrimitive!("\\font Token SkipMatch:= SkipSpaces TeXFileName", sub[stomach, (cs, name_arg), state] {
     let gullet = stomach.get_gullet_mut();
     let name = name_arg.to_string();
     let props_opt = if let Some(mut props) = font::decode_fontname(&name,
@@ -173,14 +171,12 @@ LoadDefinitions!(outer_state, {
 
   // <let assignment> = \futurelet <control sequence><token><token>
   //  | \let<control sequence><equals><one optional space><token>
-  DefPrimitive!("\\let Token SkipMatch:= Skip1Space Token", sub[stomach, args, state] {
-   unpack_to_token!(args => token1, token2);
+  DefPrimitive!("\\let Token SkipMatch:= Skip1Space Token", sub[stomach, (token1, token2), state] {
    Let!(&token1, token2);
    Ok(Vec::new())
   });
 
-  DefPrimitive!("\\futurelet Token Token Token", sub[stomach, args, state] {
-      unpack_to_token!(args => cs, token1, token2);
+  DefPrimitive!("\\futurelet Token Token Token", sub[stomach, (cs, token1, token2), state] {
       stomach.get_gullet_mut().unread(Tokens!(token1,token2.clone())); // NOT expandable, but puts tokens back
       Let!(&cs, token2);
       Ok(Vec::new())
@@ -198,8 +194,7 @@ LoadDefinitions!(outer_state, {
   // specifically for the getter/setter routines.
   // instead, here is the same pattern of definition, with different concrete value types.
 
-  DefPrimitive!("\\countdef Token SkipMatch:=", sub[stomach, args, state] {
-    unpack_to_token!(args => cs);
+  DefPrimitive!("\\countdef Token SkipMatch:=", sub[stomach, (cs), state] {
     state.assign_meaning(&cs, state.lookup_meaning(&T_CS!("\\relax")).unwrap(),None);
     let num = stomach.get_gullet_mut().read_number(state)?;
     let reg = s!("\\count{}", num.value_of());
@@ -211,8 +206,7 @@ LoadDefinitions!(outer_state, {
     Ok(Vec::new())
   });
 
-  DefPrimitive!("\\dimendef Token SkipMatch:=", sub[stomach,args,state] {
-    unpack_to_token!(args=> cs);
+  DefPrimitive!("\\dimendef Token SkipMatch:=", sub[stomach, (cs), state] {
     state.assign_meaning(&cs, state.lookup_meaning(&T_CS!("\\relax")).unwrap(),None);
     let num = stomach.get_gullet_mut().read_number(state)?;
     let dimen = s!("\\dimen{}", num.value_of());
@@ -225,8 +219,7 @@ LoadDefinitions!(outer_state, {
     Ok(Vec::new())
   });
 
-  DefPrimitive!("\\skipdef Token SkipMatch:=", sub[stomach,args,state] {
-    unpack_to_token!(args=> cs);
+  DefPrimitive!("\\skipdef Token SkipMatch:=", sub[stomach, (cs), state] {
     state.assign_meaning(&cs, state.lookup_meaning(&T_CS!("\\relax")).unwrap(),None);
     let num = stomach.get_gullet_mut().read_number(state)?;
     let skip = s!("\\skip{}", num.value_of());
@@ -239,8 +232,7 @@ LoadDefinitions!(outer_state, {
     Ok(Vec::new())
   });
 
-  DefPrimitive!("\\muskipdef Token SkipMatch:=", sub[stomach,args,state] {
-    unpack_to_token!(args=>cs);
+  DefPrimitive!("\\muskipdef Token SkipMatch:=", sub[stomach, (cs), state] {
     state.assign_meaning(&cs, state.lookup_meaning(&T_CS!("\\relax")).unwrap(),None);
     let num = stomach.get_gullet_mut().read_number(state)?;
     let muglue = s!("\\muskip{}",num.value_of());
@@ -253,8 +245,7 @@ LoadDefinitions!(outer_state, {
     Ok(Vec::new())
   });
 
-  DefPrimitive!("\\toksdef Token SkipMatch:=", sub[stomach,args,state] {
-    unpack_to_token!(args=>cs);
+  DefPrimitive!("\\toksdef Token SkipMatch:=", sub[stomach, (cs), state] {
     state.assign_meaning(&cs, state.lookup_meaning(&T_CS!("\\relax")).unwrap(),None);
     let num = stomach.get_gullet_mut().read_number(state)?;
     let toks = s!("\\toks{}", num.value_of() as usize);
@@ -275,8 +266,7 @@ LoadDefinitions!(outer_state, {
   DefRegister!("\\lastpenalty", Number::new(0), readonly => true);
 
   // \parshape !?!??
-  DefPrimitive!("\\parshape SkipMatch:= Number", sub[stomach, args, state] {
-    unpack_to_number!(args => n);
+  DefPrimitive!("\\parshape SkipMatch:= Number", sub[stomach, (n), state] {
     // $n = $n->valueOf;
     // my $gullet = $stomach->getGullet;
     // for (my $i = 0 ; $i < $n ; $i++) {

--- a/rtx_package/src/package/pool/tex_boxes.rs
+++ b/rtx_package/src/package/pool/tex_boxes.rs
@@ -9,8 +9,7 @@ LoadDefinitions!(state, {
 
   // \setbox<number>=\hbox to <dimen>{<horizontal mode material>}
 
-  DefPrimitive!("\\setbox Number SkipMatch:=", sub[stomach, args, state] {
-    unpack_to_number!(args => number);
+  DefPrimitive!("\\setbox Number SkipMatch:=", sub[stomach, (number), state] {
     let tbox = s!("box{}", number.value_of() as u8);
     // If there is any afterAssignment tokens, move them over so BoxContents parameter will use them
     if let Some(after_token) = state.remove_value("afterAssignment") {
@@ -35,8 +34,7 @@ LoadDefinitions!(state, {
     rest
   });
 
-  DefPrimitive!("\\box Number", sub[gullet, args, state] {
-    unpack_to_number!(args => number);
+  DefPrimitive!("\\box Number", sub[gullet, (number), state] {
     let box_key = s!("box{}", number.value_of() as u8);
     if let Some(Stored::Digested(stuff)) = state.remove_value(&box_key) {
       Ok(vec![*stuff])
@@ -45,8 +43,7 @@ LoadDefinitions!(state, {
     }
   });
 
-  DefPrimitive!("\\copy Number", sub[stomach, args, state] {
-    unpack_to_number!(args => number);
+  DefPrimitive!("\\copy Number", sub[stomach, (number), state] {
     let box_key = s!("box{}", number.value_of() as u8);
     if let Some(Stored::Digested(stuff)) = state.lookup_value(&box_key) {
       let cloned_stuff : Digested = (**stuff).clone();

--- a/rtx_package/src/package/pool/tex_ch24_primitives.rs
+++ b/rtx_package/src/package/pool/tex_ch24_primitives.rs
@@ -221,8 +221,7 @@ LoadDefinitions!(state, {
     }
   });
 
-  DefConditional!("\\ifeof Number", sub[gullet, args, state] {
-    unpack_to_number!(args => port);
+  DefConditional!("\\ifeof Number", sub[gullet, (port), state] {
     if let Some(Stored::Mouth(mouth)) = LookupValue!(&s!("input_file:{}", port)) {
       mouth.read().unwrap().at_eof()
     } else {

--- a/rtx_package/src/package/pool/tex_ch24_primitives.rs
+++ b/rtx_package/src/package/pool/tex_ch24_primitives.rs
@@ -21,7 +21,7 @@ LoadDefinitions!(state, {
 
   // These are actually TeX primitives, but we treat them as a Whatsit so they
   // remain in the constructed tree.
-  DefPrimitive!("{", sub[stomach, args, state] {
+  DefPrimitive!("{", sub[stomach, (), state] {
     stomach.bgroup(state);
     let open = Tbox::new(String::new(), None, None, Tokens!(T_BEGIN!()), HashMap::new(), state);
     let mode = if LookupBool!("IN_MATH") {
@@ -43,7 +43,7 @@ LoadDefinitions!(state, {
 
   DefPrimitive!(
     "}",
-    sub[stomach, args, state] {
+    sub[stomach, (), state] {
       let f = LookupFont!();
       stomach.egroup(state)?;
       Tbox::new(String::new(), f, None, Tokens!(T_END!()), HashMap::new(), state)
@@ -67,11 +67,11 @@ LoadDefinitions!(state, {
   );
 
   DefPrimitive!(
-  "\\begingroup", sub[stomach, _args, state] {
+  "\\begingroup", sub[stomach, (), state] {
     stomach.begingroup(state);
   });
   DefPrimitive!(
-  "\\endgroup", sub[stomach, _args, state] {
+  "\\endgroup", sub[stomach, (), state] {
     stomach.endgroup(state)?;
   });
 
@@ -84,7 +84,7 @@ LoadDefinitions!(state, {
   // DefPrimitive('\shipout ??
   DefPrimitive!("\\ignorespaces SkipSpaces", None);
 
-  DefPrimitive!("\\lx@ignorehardspaces", sub[stomach, whatsit, state] {
+  DefPrimitive!("\\lx@ignorehardspaces", sub[stomach, (), state] {
     let mut boxes = Vec::new();
     while let Some(token) = stomach.get_gullet_mut().read_x_token(false, false, state)? {
       boxes = stomach.invoke_token(&token, state)?;
@@ -117,13 +117,11 @@ LoadDefinitions!(state, {
   });
 
   // \afterassignment saves ONE token (globally!) to execute after the next assignment
-  DefPrimitive!("\\afterassignment Token", sub[stomach, args, state] {
-    unpack_to_token!(args => t);
+  DefPrimitive!("\\afterassignment Token", sub[stomach, (t), state] {
     state.assign_value("afterAssignment", t, Some(Scope::Global));
   });
   // \aftergroup saves ALL tokens (from repeated calls) to be executed IN ORDER after the next egroup or }
-  DefPrimitive!("\\aftergroup Token", sub[stomach, args, state] {
-    unpack_to_token!(args => t);
+  DefPrimitive!("\\aftergroup Token", sub[stomach, (t), state] {
     state.push_value("afterGroup", t);
   });
 
@@ -146,8 +144,7 @@ LoadDefinitions!(state, {
   //     my ($gullet, $tokens) = @_;
   //     return map { lcToken($_) } $tokens->unlist; });
 
-  DefPrimitive!("\\message{}", sub [stomach, args, state] {
-    unpack!(args => message);
+  DefPrimitive!("\\message{}", sub [stomach, (message), state] {
     if state.lookup_int("VERBOSITY") > -1 {
       eprintln!("{}", writable_tokens(
         do_expand(message, stomach.get_gullet_mut(), state)?, state)?);
@@ -161,8 +158,8 @@ LoadDefinitions!(state, {
   // T_CS('\errhelp')))) . "\n";     return; });
 
   // TeX I/O primitives
-  DefPrimitive!("\\openin Number SkipMatch:= SkipSpaces TeXFileName", sub[stomach, args, state] {
-    unpack!(args => port, filename);
+  DefPrimitive!("\\openin Number SkipMatch:= SkipSpaces TeXFileName",
+  sub[stomach, (port, filename), state] {
     let port = port.to_string();
     let filename = filename.to_string();
     // possibly should close $port if it's already been opened?
@@ -182,9 +179,7 @@ LoadDefinitions!(state, {
     }
   });
 
-  DefPrimitive!("\\closein Number", sub[stomach, args, state] {
-    unpack!(args => port);
-    let port = port.to_number();
+  DefPrimitive!("\\closein Number", sub[stomach, (port), state] {
     // Clone the Rc<> for mouth out of state, since we'll be mutating.
     let mouth_opt = if let Some(Stored::Mouth(ref mouth)) = LookupValue!(&s!("input_file:{}", port)) {
       Some(Arc::clone(mouth))
@@ -198,10 +193,7 @@ LoadDefinitions!(state, {
     }
   });
 
-  DefPrimitive!("\\read Number SkipKeyword:to SkipSpaces Token", sub[stomach, args, state] {
-    unpack!(args => port, token);
-    let token: Token = token.into(); // downcast from Tokens
-    let port = port.to_number();
+  DefPrimitive!("\\read Number SkipKeyword:to SkipSpaces Token", sub[stomach, (port, token), state] {
     if let Some(Stored::Mouth(mouth_stored)) = state.lookup_value(&s!("input_file:{}",port)) {
       let mouth_obj = Arc::clone(mouth_stored);
       stomach.bgroup(state);
@@ -240,8 +232,7 @@ LoadDefinitions!(state, {
 
   // For output files, we'll write the data to a cached internal copy
   // rather than to the actual file system.
-  DefPrimitive!("\\openout Number SkipMatch:= SkipSpaces TeXFileName", sub[stomach, args, state] {
-    unpack!(args => port, filename);
+  DefPrimitive!("\\openout Number SkipMatch:= SkipSpaces TeXFileName", sub[stomach, (port, filename), state] {
     let port = port.to_string();
     let filename = filename.to_string();
     let contents_key = &s!("{}_contents",filename);
@@ -249,14 +240,11 @@ LoadDefinitions!(state, {
     AssignValue!(contents_key => "",  Some(Scope::Global));
   });
 
-  DefPrimitive!("\\closeout Number", sub[stomach, args, state] {
-    unpack!(args => port);
+  DefPrimitive!("\\closeout Number", sub[stomach, (port), state] {
     AssignValue!(&s!("output_file:{}",port), false, Some(Scope::Global));
   });
 
-  DefPrimitive!("\\write Number {}", sub[stomach, args, state] {
-    unpack!(args => port, tokens);
-    let port = port.to_number();
+  DefPrimitive!("\\write Number {}", sub[stomach, (port, tokens), state] {
     if let Some(filename) = LookupValue!(&s!("output_file:{}", port)) {
       let handle   = s!("{}_contents",filename);
       let mut contents : String = LookupString!(&handle);
@@ -303,8 +291,7 @@ LoadDefinitions!(state, {
     "\\LTX@clear@vadjust@afterpar",
     "\\def\\LTX@vadjust@afterpar{\\def\\LTX@vadjust@afterpar{}}"
   );
-  DefPrimitive!("\\vadjust {}", sub[stomach,args,state] {
-    unpack!(args=>arg);
+  DefPrimitive!("\\vadjust {}", sub[stomach,(arg),state] {
     state.push_tokens("vAdjust", arg);
   });
 

--- a/rtx_package/src/package/pool/tex_expandable_primitives.rs
+++ b/rtx_package/src/package/pool/tex_expandable_primitives.rs
@@ -67,8 +67,7 @@ LoadDefinitions!(outer_state, {
   //// But if you do that, you've got to watch out since it usually
   //// shouldn't be a box; See the isRelax code in handleScripts, below
 
-  DefMacro!("\\number Number", sub[gullet, args, state] {
-    unpack_to_number!(args=>num);
+  DefMacro!("\\number Number", sub[gullet, (num), state] {
     let num_str = num.value_of();
     Explode!(num_str)
   });
@@ -76,12 +75,11 @@ LoadDefinitions!(outer_state, {
   // define it here (only approxmiately), since it's already useful.
   Let!("\\protect", "\\relax");
 
-  DefMacro!("\\romannumeral Number", sub[gullet, args, state] { roman!(args.remove(0).expect_number().value_of()) });
+  DefMacro!("\\romannumeral Number", sub[gullet, (num), state] { roman!(num.value_of()) });
 
   // # 1) Knuth, The TeXBook, page 40, paragraph 1, Chapter 7: How TEX Reads What You Type.
   // # suggests all characters except spaces are returned in category code Other, i.e. Explode()
-  DefMacro!("\\string Token", sub[gullet, args, state] {
-    unpack_to_token!(args => token);
+  DefMacro!("\\string Token", sub[gullet, (token), state] {
     let mut s = token.to_string();
     if s.starts_with('/') {
       s = escapechar(state) + &s;
@@ -93,8 +91,7 @@ LoadDefinitions!(outer_state, {
 
   DefMacro!(T_CS!("\\fontname"), None, Tokens::new(Explode!("fontname not implemented")));
 
-  DefMacro!("\\meaning Token", sub[gullet, args, state] {
-    unpack_to_token!(args => token);
+  DefMacro!("\\meaning Token", sub[gullet, (token), state] {
     let mut meaning = String::from("undefined");
     let definition_opt = if token == T_ALIGN!() {
       Some(Stored::Token(token))
@@ -213,8 +210,7 @@ LoadDefinitions!(outer_state, {
     T_CS!(cs)
   }));
 
-  DefMacro!("\\csname CSName", sub[gullet, args, state] {
-    unpack_to_token!(args => token);
+  DefMacro!("\\csname CSName", sub[gullet, (token), state] {
     if LookupMeaning!(&token).is_none() {
       state.assign_meaning(&token, state.lookup_meaning(&T_CS!("\\relax")).unwrap(), None);
     }
@@ -225,8 +221,7 @@ LoadDefinitions!(outer_state, {
     Error!("unexpected" ,"\\endcsname", stomach, state, "Extra \\endcsname");
   });
 
-  DefMacro!("\\expandafter Token Token", sub[gullet, args, state] {
-    unpack_to_token!(args => tok, xtok);
+  DefMacro!("\\expandafter Token Token", sub[gullet, (tok, xtok), state] {
     let mut tokens : Vec<Token> = vec![tok];
     if let Some(defn) = state.lookup_expandable(&xtok, false) {
       state.current_token=Some(Arc::new(xtok.clone()));

--- a/rtx_package/src/package/pool/tex_expandable_primitives.rs
+++ b/rtx_package/src/package/pool/tex_expandable_primitives.rs
@@ -217,7 +217,7 @@ LoadDefinitions!(outer_state, {
     token
   });
 
-  DefPrimitive!("\\endcsname", sub[stomach, args, state] {
+  DefPrimitive!("\\endcsname", sub[stomach, (), state] {
     Error!("unexpected" ,"\\endcsname", stomach, state, "Extra \\endcsname");
   });
 
@@ -263,8 +263,7 @@ LoadDefinitions!(outer_state, {
   // For now I have changed to DefPrimitive, so that there is a clear access to the
   // stomach, but we may require some special-case treatment in other pieces of code...
   DefMacro!("\\input", "\\ltx@input");
-  DefPrimitive!("\\ltx@input TeXFileName", sub[stomach,args,state] {
-    unpack!(args => name);
+  DefPrimitive!("\\ltx@input TeXFileName", sub[stomach, (name), state] {
     input(&name.to_string(), InputOptions::default(), stomach, state)?;
   });
 

--- a/rtx_package/src/package/pool/tex_expandable_primitives.rs
+++ b/rtx_package/src/package/pool/tex_expandable_primitives.rs
@@ -12,20 +12,13 @@ LoadDefinitions!(outer_state, {
   DefConditional!("\\fi");
   DefConditional!("\\ifcase Number");
 
-  DefConditional!("\\ifnum Number Token Number", sub[gullet, args, state] {
-    unpack_to_number!(args => u);
-    unpack_to_token!(args => rel);
-    unpack_to_number!(args => v);
+  DefConditional!("\\ifnum Number Token Number", sub[gullet, (u,rel,v), state] {
     compare(u, rel, v)
   });
-  DefConditional!("\\ifdim Dimension Token Dimension", sub[gullet, args, state] {
-    unpack_to_number!(args => u);
-    unpack_to_token!(args =>rel);
-    unpack_to_number!(args => v);
-    compare(u, rel, v)
+  DefConditional!("\\ifdim Dimension Token Dimension", sub[gullet, (u,rel,v), state] {
+    compare(Number::new(u.value_of()), rel, Number::new(v.value_of()))
   });
-  DefConditional!("\\ifodd Number", sub[gullet, args, state] {
-    unpack_to_number!(args => u);
+  DefConditional!("\\ifodd Number", sub[gullet, (u), state] {
     let uint = u.value_of();
     uint % 2 == 1
   });
@@ -36,24 +29,21 @@ LoadDefinitions!(outer_state, {
   DefConditional!("\\ifinner", { false });
   DefConditional!("\\ifmmode", { LookupBool!("IN_MATH") });
 
-  DefConditional!("\\if XToken XToken", sub[gullet, args, state] {
-    unpack_to_token!(args=>token1, token2);
+  DefConditional!("\\if XToken XToken", sub[gullet, (token1,token2), state] {
     token1.get_charcode() == token2.get_charcode()
   });
 
-  DefConditional!("\\ifcat XToken XToken", sub[gullet, args, state] {
-    unpack_to_token!(args=>token1, token2);
+  DefConditional!("\\ifcat XToken XToken", sub[gullet, (token1,token2), state] {
     token1.get_catcode() == token2.get_catcode()
   });
 
-  DefConditional!("\\ifx Token Token", sub[gullet, args, state] {
-    unpack_to_token!(args => token1, token2);
+  DefConditional!("\\ifx Token Token", sub[gullet, (token1,token2), state] {
     XEquals!(&token1, &token2)
   });
 
-  DefConditional!("\\ifvoid Number", sub[_g, args, state] {unpack_to_number!(args=>arg); classify_box(arg, state).is_empty() });
-  DefConditional!("\\ifhbox Number", sub[_g, args, state] {unpack_to_number!(args=>arg); classify_box(arg, state) == "hbox" });
-  DefConditional!("\\ifvbox Number", sub[_g, args, state] {unpack_to_number!(args=>arg); classify_box(arg, state) == "vbox" });
+  DefConditional!("\\ifvoid Number", sub[_g, (arg), state] { classify_box(arg, state).is_empty() });
+  DefConditional!("\\ifhbox Number", sub[_g, (arg), state] { classify_box(arg, state) == "hbox" });
+  DefConditional!("\\ifvbox Number", sub[_g, (arg), state] { classify_box(arg, state) == "vbox" });
 
   DefConditional!("\\iftrue", { true });
   DefConditional!("\\iffalse", { false });

--- a/rtx_package/src/package/pool/tex_fonts.rs
+++ b/rtx_package/src/package/pool/tex_fonts.rs
@@ -140,8 +140,7 @@ LoadDefinitions!(outer_state, {
 
   DefMacro!("\\fontencoding{}", "\\@@@fontencoding{#1}");
 
-  DefPrimitive!("\\@@@fontencoding{}", sub[stomach, args, state] {
-    unpack_to_token!(args => encoding);
+  DefPrimitive!("\\@@@fontencoding{}", sub[stomach, (encoding), state] {
     let gullet = stomach.get_gullet_mut();
     let encoding = Expand!(encoding, gullet).to_string();
     if LoadFontMap!(&encoding).is_some() {
@@ -438,8 +437,7 @@ LoadDefinitions!(outer_state, {
   });
 
   // Almost like a register, but different...
-  DefPrimitive!("\\chardef Token SkipMatch:=", sub[stomach, args, state] {
-    unpack_to_token!(args => newcs);
+  DefPrimitive!("\\chardef Token SkipMatch:=", sub[stomach, (newcs), state] {
     state.assign_meaning(&newcs, state.lookup_meaning(&T_CS!("\\relax")).unwrap(), None); // Let w/o AfterAssignment
     let value = stomach.get_gullet_mut().read_number(state)?;
     let csname = newcs.get_cs_name().to_owned();
@@ -480,8 +478,7 @@ LoadDefinitions!(outer_state, {
   );
 
   // Almost like a register, but different...
-  DefPrimitive!("\\mathchardef Token SkipMatch:=", sub[stomach, args, state] {
-    unpack_to_token!(args => newcs);
+  DefPrimitive!("\\mathchardef Token SkipMatch:=", sub[stomach, (newcs), state] {
     state.assign_meaning(&newcs, state.lookup_meaning(&T_CS!("\\relax")).unwrap(), None);// Let w/o AfterAssignment
     let value  = stomach.get_gullet_mut().read_number(state).unwrap();
     let csname = newcs.get_cs_name().to_owned();

--- a/rtx_package/src/package/pool/tex_frontmatter.rs
+++ b/rtx_package/src/package/pool/tex_frontmatter.rs
@@ -34,11 +34,8 @@ LoadDefinitions!(state, {
   // //   replace (to replace the current entry, if any)
   // //   ifnew   (only add if no previous entry)//
 
-  DefPrimitive!("\\@add@frontmatter OptionalKeyVals {} OptionalKeyVals {}", sub[stomach, args, state] {
-    unpack_opt!(args => keys);
-    unpack!(args => tag);
-    unpack_opt!(args => attrs);
-    unpack!(args => tokens);
+  DefPrimitive!("\\@add@frontmatter OptionalKeyVals {} OptionalKeyVals {}",
+    sub[stomach, (keys_tks,tag,attrs_tks,tokens), state] {
     // Digest this as if we're already in the document body!
     let inpreamble = LookupBool!("inPreamble");
     AssignValue!("inPreamble", false);
@@ -48,11 +45,11 @@ LoadDefinitions!(state, {
     // So, we append this entry before digesting
 
     // TODO: Port over keys handling from TeX.pool
-    let attrs_digested = if attrs.is_empty() {
+    let attrs_digested = if attrs_tks.is_empty() {
       None
     } else {
       // WAS: $$entry[1] = { $attr->beDigested($stomach)->getHash };
-      let attr_kvs = attrs.to_keyvals(state);
+      let attr_kvs = attrs_tks.to_keyvals(state);
       if let Digested::KeyVals(digested) = attr_kvs.be_digested(stomach, state)? {
         Some(digested.get_hash())
       } else {

--- a/rtx_package/src/package/pool/tex_frontmatter.rs
+++ b/rtx_package/src/package/pool/tex_frontmatter.rs
@@ -35,7 +35,10 @@ LoadDefinitions!(state, {
   // //   ifnew   (only add if no previous entry)//
 
   DefPrimitive!("\\@add@frontmatter OptionalKeyVals {} OptionalKeyVals {}", sub[stomach, args, state] {
-    unpack!(args => keys, tag, attrs, tokens);
+    unpack_opt!(args => keys);
+    unpack!(args => tag);
+    unpack_opt!(args => attrs);
+    unpack!(args => tokens);
     // Digest this as if we're already in the document body!
     let inpreamble = LookupBool!("inPreamble");
     AssignValue!("inPreamble", false);
@@ -184,8 +187,7 @@ LoadDefinitions!(state, {
   // The design reflects LaTeX needs, more than TeX, but support starts here!
 
   // This collects up the various declared ltx:tag's into an ltx:tags
-  DefMacro!("\\lx@make@tags {}", sub[gullet, args, state] {
-    unpack!(args => ttype);
+  DefMacro!("\\lx@make@tags {}", sub[gullet, (ttype), state] {
     let formatters = if let Some(Stored::HashStored(formatters)) = state.lookup_value("type_tag_formatter") {
       Some(formatters.clone())
     } else {
@@ -250,8 +252,7 @@ LoadDefinitions!(state, {
   // "refnum" is the lowest level reference number for an object is typically \the<counter>
   // but be sure to use the right counter!  This is how \ref will show the number.
   // You'll typically customize this by defining \the<counter> (and \p@<counter) as in LaTeX.
-  DefMacro!("\\lx@counterfor{}", sub[gullet, args, state] {
-    unpack!(args => ctr_type);
+  DefMacro!("\\lx@counterfor{}", sub[gullet, (ctr_type), state] {
     if let Some(ctr) = LookupMapping!("counter_for_type", &ctr_type.to_string()) {
       Tokens!(T_OTHER!(ctr))
     } else {

--- a/rtx_package/src/package/pool/tex_functions.rs
+++ b/rtx_package/src/package/pool/tex_functions.rs
@@ -158,19 +158,8 @@ pub fn parse_def_parameters(cs: &Token, params_in: Tokens, state: &mut State) ->
   }
 }
 
-pub fn do_def(globally: bool, stomach: &mut Stomach, mut args: Vec<ArgWrap>, state: &mut State) -> Result<()> {
+pub fn do_def(globally: bool, stomach: &mut Stomach, cs: Token, params: Tokens, body: Tokens, state: &mut State) -> Result<()> {
   BindState!(stomach, state);
-  let cs_opt = args.remove(0);
-  let params_opt = args.remove(0);
-  let body = args.remove(0).owned_tokens().unwrap();
-  let cs: Token = cs_opt.try_to_token()?;
-  let params = match params_opt.owned_tokens() {
-    Some(ts) => ts,
-    None => {
-      Error!("misdefined", cs, stomach, state, "Expected definition parameter list");
-      return Ok(());
-    },
-  };
   let paramlist = parse_def_parameters(&cs, params, state)?;
 
   let scope = if globally { Some(Scope::Global) } else { None };

--- a/rtx_package/src/package/pool/tex_functions.rs
+++ b/rtx_package/src/package/pool/tex_functions.rs
@@ -68,7 +68,7 @@ pub fn parse_def_parameters(cs: &Token, params_in: Tokens, state: &mut State) ->
         if tokens.is_empty() {
           // Special case: lone # NOT following a numbered parameter
           // Note that we require a { to appear next, but do NOT read it!
-          params.push(Parameter::new("RequireBrace", "RequireBrace", state)?);
+          params.push(Parameter::new(Cow::Borrowed("RequireBrace"), Cow::Borrowed("RequireBrace"), state)?);
           break;
         } else {
           n += 1;
@@ -112,8 +112,8 @@ pub fn parse_def_parameters(cs: &Token, params_in: Tokens, state: &mut State) ->
         let expected = Tokens::new(delim);
         params.push(
           Parameter {
-            name: s!("Until"),
-            spec: s!("Until:{}", expected),
+            name: Cow::Borrowed("Until"),
+            spec: Cow::Owned(format!("Until:{expected}")),
             extra: expected.into(),
             ..Parameter::default()
           }
@@ -122,10 +122,10 @@ pub fn parse_def_parameters(cs: &Token, params_in: Tokens, state: &mut State) ->
       } else if tokens.len() == 1 && tokens.front().unwrap().get_catcode() == Catcode::PARAM {
         // Special case: trailing sole # => delimited by next opening brace.
         tokens.pop_front();
-        params.push(Parameter::new("UntilBrace", "UntilBrace", state)?);
+        params.push(Parameter::new(Cow::Borrowed("UntilBrace"), Cow::Borrowed("UntilBrace"), state)?);
       } else {
         // Nothing? Just a plain parameter.
-        params.push(Parameter::new("Plain", "{}", state)?);
+        params.push(Parameter::new(Cow::Borrowed("Plain"), Cow::Borrowed("{}"), state)?);
       }
     } else {
       // Initial delimiting text is required.
@@ -140,8 +140,8 @@ pub fn parse_def_parameters(cs: &Token, params_in: Tokens, state: &mut State) ->
       let expected = Tokens::new(lit);
       params.push(
         Parameter {
-          name: s!("Match"),
-          spec: s!("Match:{}", expected),
+          name: Cow::Borrowed("Match"),
+          spec: Cow::Owned(s!("Match:{}", expected)),
           extra: expected.into(),
           novalue: true,
           ..Parameter::default()

--- a/rtx_package/src/package/pool/tex_para.rs
+++ b/rtx_package/src/package/pool/tex_para.rs
@@ -102,5 +102,5 @@ LoadDefinitions!(state, {
   });
 
   // \dump ???
-  DefPrimitive!("\\end", sub[stomach, args, state] { stomach.get_gullet_mut().flush(state); });
+  DefPrimitive!("\\end", sub[stomach, (), state] { stomach.get_gullet_mut().flush(state); });
 });

--- a/rtx_package/src/package/pool/tex_setup.rs
+++ b/rtx_package/src/package/pool/tex_setup.rs
@@ -639,8 +639,7 @@ LoadDefinitions!(state, {
       tokens
   });
 
-  DefPrimitive!("\\ltx@loadpool {}", sub[stomach,args,state] {
-    unpack!(args=>name);
+  DefPrimitive!("\\ltx@loadpool {}", sub[stomach,(name),state] {
     LoadPool!(&name.to_string());
   });
 
@@ -954,7 +953,7 @@ LoadDefinitions!(state, {
     },
     reader_predigest => reader_predigest!(stomach, arg, state, {
       if !arg.is_empty() {
-        Some(arg.to_keyvals(state))
+        Some(arg.expected_keyvals(state))
       } else {
         None
       }
@@ -965,7 +964,7 @@ LoadDefinitions!(state, {
       optional_key_vals(true, false, inner, gullet, state)
     },
     reader_predigest => reader_predigest!(stomach, arg, state, {
-      arg.to_keyvals(state)
+      arg.expected_keyvals(state)
     }),
    optional=>true);
   // reversion => sub { ($_[0] ? (T_OTHER('['), Revert($_[0]), T_OTHER(']')) : ()); });
@@ -973,7 +972,7 @@ LoadDefinitions!(state, {
       optional_key_vals(false, true, inner, gullet, state)
     },
     reader_predigest => reader_predigest!(stomach, arg, state, {
-      arg.to_keyvals(state)
+      arg.expected_keyvals(state)
     }),
    optional=>true);
   // reversion => sub { ($_[0] ? (T_OTHER('['), Revert($_[0]), T_OTHER(']')) : ()); });
@@ -981,7 +980,7 @@ LoadDefinitions!(state, {
       optional_key_vals(true, true, inner, gullet, state)
     },
     reader_predigest => reader_predigest!(stomach, arg, state, {
-      arg.to_keyvals(state)
+      arg.expected_keyvals(state)
     }),
    optional=>true);
   // reversion => sub { ($_[0] ? (T_OTHER('['), Revert($_[0]), T_OTHER(']')) : ()); });

--- a/rtx_package/src/package/pool/tex_setup.rs
+++ b/rtx_package/src/package/pool/tex_setup.rs
@@ -1054,8 +1054,7 @@ LoadDefinitions!(state, {
   // LaTeX has a very particular notion of "Undefined",
   // so let's get that squared away at the outset; it's useful for TeX, too!
   // Naturally, it uses \csname to check, which ends up DEFINING the possibly undefined macro as \relax
-  DefMacro!("\\@ifundefined{}{}{}", sub[gullet, args, inner_state] {
-    unpack!(args=>name, if_token, else_token);
+  DefMacro!("\\@ifundefined{}{}{}", sub[gullet, (name, if_token, else_token), inner_state] {
     let cs = T_CS!(s!("\\{}", Expand!(name,gullet).to_string()));
     if IsDefined!(&cs, inner_state) {
       Ok(else_token)

--- a/rtx_package/src/package/pool/url_sty.rs
+++ b/rtx_package/src/package/pool/url_sty.rs
@@ -34,8 +34,7 @@ LoadDefinitions!(state, {
   // That token is the cs that invoked it, so that it can be reflected in the generated XML,
   // as well as used to generate the reversion.
   // In any case, we read the verbatim arg, and build a Whatsit for @@Url
-  DefMacro!("\\@Url Token", sub[gullet, args, state] {
-    unpack_to_token!(args => cmd);
+  DefMacro!("\\@Url Token", sub[gullet, (cmd), state] {
     let perc = vec!['%'];
     state.begin_semiverbatim(Some(&perc));
     let mut open = gullet.read_token(state).unwrap();

--- a/rtx_package/src/package/pool/url_sty.rs
+++ b/rtx_package/src/package/pool/url_sty.rs
@@ -94,8 +94,7 @@ LoadDefinitions!(state, {
   // \urldef{newcmd}\cmd{arg}
   // Kinda tricky, since we need to get the expansion of \cmd as the value of \newcmd
   // Along with the annoying \endgroup that must balance the one always preceding \Url!
-  DefPrimitive!("\\urldef{}", sub[stomach, args, url_state] {
-    unpack!(args => cmd);
+  DefPrimitive!("\\urldef{}", sub[stomach, (cmd), url_state] {
     let cmd = cmd.to_string();
     let expansion : Vec<Digested> = stomach.digest_next_body(Some(T_CS!("\\endgroup")), url_state)?;
     let gullet = stomach.get_gullet_mut();

--- a/rtx_package/src/package/pool/verbatim_sty.rs
+++ b/rtx_package/src/package/pool/verbatim_sty.rs
@@ -108,8 +108,7 @@ LoadDefinitions!(state, {
 
   // //======================================================================
   // // Read verbatim material from file.
-  DefMacro!("\\verbatiminput {}", sub[gullet, args, state] {
-    unpack!(args => file);
+  DefMacro!("\\verbatiminput {}", sub[gullet, (file), state] {
     if let Some(path) = find_file(&file.to_string(), None, state) {
       gullet.reading_from_mouth(Mouth::create(&path, MouthOptions::default(), state)?,
         state,

--- a/rtx_package/src/package/setup_binding_language.rs
+++ b/rtx_package/src/package/setup_binding_language.rs
@@ -1621,7 +1621,7 @@ macro_rules! TypedMacroWO {
     let options = defi_opts!(@munch ($($input)*) -> {ExpandableOptions,});
     let parameters = vec![
     $(Parameter {
-        name: String::from(stringify!($ptype)),
+        name: Cow::Borrowed(stringify!($ptype)),
         ..Parameter::default()
       }
       .init(outer_state!())? ),+
@@ -1776,18 +1776,18 @@ macro_rules! DefParameterType {
   ($name:ident) => (DefParameterTypeWO!($name, NewDefault!(Parameter, name => stringify!($name).to_string())));
   ($name:ident, $state_arg:ident) => (DefParameterTypeWO!($name, NewDefault!(Parameter, name => stringify!($name.to_string())), $state_arg));
   ($name:ident, $($key:ident => $value:expr),*)=>(
-    DefParameterTypeWO!($name, NewDefault!(Parameter, name => stringify!($name).to_string(), $($key=>$value),*)));
+    DefParameterTypeWO!($name, NewDefault!(Parameter, name => Cow::Borrowed(stringify!($name)), $($key=>$value),*)));
   ($name:ident, $($key:ident => $value:expr),*, $state_arg:ident)=>
-    (DefParameterTypeWO!($name, NewDefault!(Parameter, name => stringify!($name.to_string()), $($key=>$value),*), $state_arg));
+    (DefParameterTypeWO!($name, NewDefault!(Parameter, name => Cow::Borrowed(stringify!($name)), $($key=>$value),*), $state_arg));
   // with reader as explicit sub
   ($name:ident, sub[$gullet:ident, $inner:ident, $extra:ident, $inner_state:ident] $body:block) => (
     DefParameterTypeWO!($name, NewDefault!(Parameter, reader => reader!($gullet, $inner, $extra, $inner_state, $body))));
   ($name:ident, sub[$gullet:ident, $inner:ident, $extra:ident, $inner_state:ident] $body:block, $($key:ident => $value:expr),*) => (
     DefParameterTypeWO!($name, NewDefault!(Parameter, reader => reader!($gullet, $inner, $extra, $inner_state, $body),
-      name => stringify!($name).to_string(),  $($key=>$value),*)));
+      name => Cow::Borrowed(stringify!($name)),  $($key=>$value),*)));
   ($name:ident, sub[$gullet:ident, $inner:ident, $extra:ident, $inner_state:ident] $body:block, $($key:ident => $value:expr),*) => (
     DefParameterTypeWO!($name, NewDefault!(Parameter, reader => reader!($gullet, $inner, $extra, $inner_state, $body),
-      name => $name.to_string(),  $($key=>$value),*), $state_arg));
+      name => Cow::Borrowed($name),  $($key=>$value),*), $state_arg));
 }
 
 // Reverts an object into TeX code, as a Tokens list, that would create it.

--- a/rtx_package/src/package/setup_binding_language.rs
+++ b/rtx_package/src/package/setup_binding_language.rs
@@ -387,13 +387,18 @@ macro_rules! DefMathLigature {
 
 #[macro_export]
 macro_rules! DefConditional(
+  // test with explicit arguments can get typed at compile-time
+  ($proto:literal, sub [ $gullet:ident, ( $($var:ident),* ), $inner_state:ident ] $body:block $($input:tt)*) => {{
+    compile_prototype_for_typed_conditional!($proto, sub [ $gullet, ( $($var),* ), $inner_state ] $body $($input)*)
+  }};
   // test is always a rust closure
-  ($proto:literal, sub [$gullet:ident, $args:ident, $inner_state:ident] $body:block $($input:tt)*) => {{
+  ($proto:literal, sub [ $gullet:ident, $args:ident, $inner_state:ident ] $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {ConditionalOptions,});
     let (cs, paramlist) = parse_prototype!($proto);
     let test : ConditionalClosure = Arc::new(move |$gullet, mut $args, $inner_state| { WithInnerState!($body, $inner_state).into_bool_result() });
     defi_conditional!(cs, paramlist, Some(test), options);
   }};
+  // other shorthand cases
   ($proto:literal, $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {ConditionalOptions,});
     let (cs, paramlist) = parse_prototype!($proto);
@@ -409,8 +414,31 @@ macro_rules! DefConditional(
   ($cs:ident, None  $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {ConditionalOptions,});
     defi_conditional!($cs, None, None, options);
-  }}
+  }};
 );
+
+#[macro_export]
+macro_rules! TypedConditional {
+  ($cs:literal, $these_parameters:ident,
+      sub [ $gullet:ident, ( $($var:ident),* ):($($ptype:ident),*), $inner_state:ident ] $body:block $($input:tt)*) => {{
+
+    let options = defi_opts!(@munch ($($input)*) -> {ConditionalOptions,});
+    let closure : ConditionalClosure =  Arc::new(move |$gullet: &mut Gullet, mut args: Vec<ArgWrap>, $inner_state: &mut State| {
+      $(
+          let $var: parameter_rust_type!($ptype) = match args.remove(0).try_into() {
+            Ok(v) => v,
+            Err(e) => {
+              Error!("expected", "argument", $gullet, None, e);
+              <parameter_rust_type!($ptype)>::default()
+            }
+          };
+      )*
+      WithInnerState!($body, $inner_state).into_bool_result()
+    });
+    defi_conditional!(T_CS!($cs), $these_parameters, Some(closure), options);
+  }};
+
+}
 
 #[macro_export]
 macro_rules! defi_conditional {
@@ -469,10 +497,10 @@ macro_rules! DefPrimitive {
   ($proto:literal, $replacement:literal $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
     let (cs, params) = parse_prototype!($proto);
-    let replacement_closure = Arc::new(|stomach: &mut Stomach, args: Vec<ArgWrap>, inner_state: &mut State| {
+    let closure : PrimitiveClosure = Arc::new(|stomach: &mut Stomach, args: Vec<ArgWrap>, inner_state: &mut State| {
       Tbox::new($replacement.to_string(), None, None, Tokens!(), HashMap::new(), inner_state).into_digested_result()
     });
-    defi_primitive!(cs, params, Some(replacement_closure), options);
+    defi_primitive!(cs, params, Some(closure), options);
   }};
   // closure with literal prototype
   ($proto:literal, sub[$stomach_arg:ident,  ( $($var:ident),* ), $state_arg:ident] $body:block $($input:tt)*) => {{
@@ -482,10 +510,10 @@ macro_rules! DefPrimitive {
   ($proto:expr, sub[$stomach_arg:ident, $args:ident, $state_arg:ident] $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
     let (cs, params) = parse_prototype!($proto);
-    let replacement_closure = Arc::new(move |$stomach_arg: &mut Stomach, mut $args: Vec<ArgWrap>, $state_arg: &mut State| {
+    let closure : PrimitiveClosure = Arc::new(move |$stomach_arg: &mut Stomach, mut $args: Vec<ArgWrap>, $state_arg: &mut State| {
       WithInnerState!($body, $stomach_arg, $state_arg).into_digested_result()
     });
-    defi_primitive!(cs, params, Some(replacement_closure), options);
+    defi_primitive!(cs, params, Some(closure), options);
   }};
   // Case: cs-noparams with closure pattern replacement
   ($cs:expr, None, sub[$stomach_arg:ident, $args:ident, $state_arg:ident] $body:block $($input:tt)*) => {{
@@ -2318,8 +2346,8 @@ macro_rules! defi_opts {
   };
 
   // misc ident with literal value
-  (@munch ( $(,)? $id:ident $(:)?$(=>)? $literal:literal $($next:tt)*) -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
-    defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])* [$id @ $literal]})
+  (@munch ( $(,)? $id:ident $(:)?$(=>)? $lit:literal $($next:tt)*) -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])* [$id @ $lit]})
   };
   // misc ident with block value
   (@munch ( $(,)? $id:ident $(:)?$(=>)? $body:block $($next:tt)*) -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {

--- a/rtx_package/src/package/setup_binding_language.rs
+++ b/rtx_package/src/package/setup_binding_language.rs
@@ -1613,11 +1613,11 @@ macro_rules! TypedMacroWO {
     let expansion_closure: Option<ExpansionBody> = Some(ExpansionBody::Closure(Arc::new(
       move |$gullet: &mut Gullet, mut args: Vec<ArgWrap>, $inner_state:&mut State| {
         $(
-          let $var: $ptype = match args.remove(0).try_into() {
+          let $var: parameter_rust_type!($ptype) = match args.remove(0).try_into() {
             Ok(v) => v,
             Err(e) => {
               Error!("expected", "argument", $gullet, None, e);
-              $ptype::default()
+              <parameter_rust_type!($ptype)>::default()
             }
           };
         )+

--- a/rtx_package/src/package/setup_binding_language.rs
+++ b/rtx_package/src/package/setup_binding_language.rs
@@ -58,6 +58,7 @@ macro_rules! BindInnerState {
     start_state_frame!();
   };
   ($inner_stomach:ident, $inner_state:ident) => {
+    #[allow(unused_macros)]
     macro_rules! inner_stomach {
       () => {
         $inner_stomach
@@ -473,6 +474,10 @@ macro_rules! DefPrimitive {
     });
     defi_primitive!(cs, params, Some(replacement_closure), options);
   }};
+  // closure with literal prototype
+  ($proto:literal, sub[$stomach_arg:ident,  ( $($var:ident),* ), $state_arg:ident] $body:block $($input:tt)*) => {{
+    compile_prototype_for_typed_primitive!($proto, sub [ $stomach_arg, ( $($var),* ), $state_arg ] $body $($input)*)
+  }};
   // Case: closure pattern replacement
   ($proto:expr, sub[$stomach_arg:ident, $args:ident, $state_arg:ident] $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
@@ -519,6 +524,27 @@ macro_rules! DefPrimitive {
   ($proto:expr, $replacement_closure:expr) => {{
     let (cs, params) = parse_prototype!($proto);
     defi_primitive!(cs, params, $replacement_closure, PrimitiveOptions::default());
+  }};
+}
+
+#[macro_export]
+macro_rules! TypedPrimitive {
+  ($cs:literal, $these_parameters:ident ,
+      sub [ $stomach_arg:ident, ( $($var:ident),* ):($($ptype:ident),*), $inner_state:ident ] $body:block $($input:tt)*) => {{
+    let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
+    let replacement_closure =  Arc::new(move |$stomach_arg: &mut Stomach, mut args: Vec<ArgWrap>, $inner_state: &mut State| {
+      $(
+          let $var: parameter_rust_type!($ptype) = match args.remove(0).try_into() {
+            Ok(v) => v,
+            Err(e) => {
+              Error!("expected", "argument", $stomach_arg, None, e);
+              <parameter_rust_type!($ptype)>::default()
+            }
+          };
+      )*
+      WithInnerState!($body, $stomach_arg, $inner_state).into_digested_result()
+    });
+    defi_primitive!(T_CS!($cs), $these_parameters, Some(replacement_closure), options);
   }};
 }
 
@@ -1526,8 +1552,8 @@ macro_rules! MergeFont {
 #[macro_export]
 macro_rules! DefMacro {
   // closure with literal prototype
-  ($prototype:literal, sub [ $gullet:ident, ( $($var:ident),+ ), $inner_state:ident ] $body:block $($input:tt)*) => {{
-    compile_prototype_for_typed_macro!($prototype, sub [ $gullet, ( $($var),+ ), $inner_state ] $body $($input)*)
+  ($prototype:literal, sub [ $gullet:ident, ( $($var:ident),* ), $inner_state:ident ] $body:block $($input:tt)*) => {{
+    compile_prototype_for_typed_macro!($prototype, sub [ $gullet, ( $($var),* ), $inner_state ] $body $($input)*)
   }};
   // closure, general form
   ($proto:expr, sub [ $gullet:ident, $args:ident, $inner_state:ident ] $body:block $($input:tt)*) => {{
@@ -1608,24 +1634,10 @@ macro_rules! DefMacro {
 }
 
 #[macro_export]
-macro_rules! TypedMacroWO {
-  // closure
-  ( $cs:ident $($ptype:ident)+ , sub [ $gullet:ident, ( $($var:ident),+ ), $inner_state:ident ] $body:block $($input:tt)*) => {
-    let cs_token = concat!("\\", stringify!($cs));
-    TypedMacroWO!(T_CS(cs_token) $($ptype )+ , sub [ $gullet, ( $($var),+ ), $inner_state ] $body $($input)*)
-  };
-  ($cs:literal $($ptype:ident)+ , sub [ $gullet:ident, ( $($var:ident),+ ), $inner_state:ident ] $body:block $($input:tt)*) => {
-    TypedMacroWO!(T_CS($cs) $($ptype)+ , sub [ $gullet, ( $($var),+ ), $inner_state ] $body $($input)*)
-  };
-  ( T_CS($cs:expr) $($ptype:ident)+ , sub [ $gullet:ident, ( $($var:ident),+ ), $inner_state:ident ] $body:block $($input:tt)*) => {{
+macro_rules! TypedMacro {
+  ( $cs:literal, $these_parameters:ident,
+    sub [ $gullet:ident, ( $($var:ident),* ):($($ptype:ident),*), $inner_state:ident ] $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {ExpandableOptions,});
-    let parameters = vec![
-    $(Parameter {
-        name: Cow::Borrowed(stringify!($ptype)),
-        ..Parameter::default()
-      }
-      .init(outer_state!())? ),+
-    ];
     let expansion_closure: Option<ExpansionBody> = Some(ExpansionBody::Closure(Arc::new(
       move |$gullet: &mut Gullet, mut args: Vec<ArgWrap>, $inner_state:&mut State| {
         $(
@@ -1636,16 +1648,11 @@ macro_rules! TypedMacroWO {
               <parameter_rust_type!($ptype)>::default()
             }
           };
-        )+
+        )*
         WithInnerState!($body, $inner_state).into_tokens_result()
       }
     )));
-    let params = if parameters.is_empty() {
-      None
-    } else {
-      Some(Parameters::new(parameters))
-    };
-    defi_macro!(T_CS!($cs), params, expansion_closure, Some(options));
+    defi_macro!(T_CS!($cs), $these_parameters, expansion_closure, Some(options));
   }};
 }
 

--- a/rtx_package/src/package/setup_binding_language.rs
+++ b/rtx_package/src/package/setup_binding_language.rs
@@ -710,17 +710,33 @@ macro_rules! defi_constr {
   };
 }
 
-/// Internal auxiliary, taking a prototype string (possibly through a variable) and
-/// invoking the state
+/// A macro that uses rtx_codegen to expand a prototype at compile time,
+/// and initialize all parameters with the in-scope state at runtime.
+/// Returns a (cs, parameters) pair.
 #[macro_export]
 macro_rules! parse_prototype(
+  // literals get handled at compile time
+  ($proto:literal) => {{
+    bind_state_mut!(st);
+    let (cs, params_opt) : (Token,Option<Parameters>) = compile_prototype!($proto);
+    match params_opt {
+      Some(params) => (cs, Some(params.init(st)?)),
+      None => (cs, None),
+    }
+  }};
+  ($proto:literal, $state_arg:ident) => {{
+    let (cs, params_opt) : (Token,Option<Parameters>) = compile_prototype!($proto);
+    match params_opt {
+      Some(params) => (cs, Some(params.init($state_arg)?)),
+      None => (cs, None),
+    }
+  }};
+  // expressions get handled at runtime
   ($proto:expr) => {{
     bind_state_mut!(st);
-    rtx_core::common::def_parser::parse_prototype($proto, Some(st))?
-  }};
+    rtx_core::common::def_parser::parse_prototype($proto, Some(st))? }};
   ($proto:expr, $state_arg:ident) => {{
-    rtx_core::common::def_parser::parse_prototype($proto, Some($state_arg))?
-  }};
+    rtx_core::common::def_parser::parse_prototype($proto, Some($state_arg))? }};
 );
 
 // sub DocType {
@@ -1509,7 +1525,11 @@ macro_rules! MergeFont {
 //  and we have a several places where we get compile-time speedups by pre-tokenizing into Rust Tokens objects / Replacement closures
 #[macro_export]
 macro_rules! DefMacro {
-  // closure
+  // closure with literal prototype
+  ($prototype:literal, sub [ $gullet:ident, ( $($var:ident),+ ), $inner_state:ident ] $body:block $($input:tt)*) => {{
+    compile_prototype_for_typed_macro!($prototype, sub [ $gullet, ( $($var),+ ), $inner_state ] $body $($input)*)
+  }};
+  // closure, general form
   ($proto:expr, sub [ $gullet:ident, $args:ident, $inner_state:ident ] $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {ExpandableOptions,});
     let (cs, params) = parse_prototype!($proto);
@@ -1524,10 +1544,6 @@ macro_rules! DefMacro {
       move |gullet, mut args, inner_state| WithInnerState!($body, inner_state).into_tokens_result()
     )));
     defi_macro!(cs, params, expansion_closure, None);
-  }};
-  // closure with unwrapped arguments
-  ($prototype:literal, sub [ $gullet:ident, ( $($var:ident),+ ), $inner_state:ident ] $body:block $($input:tt)*) => {{
-    compile_prototype!($prototype, sub [ $gullet, ( $($var),+ ), $inner_state ] $body $($input)*)
   }};
   // String; implicit state
   ($proto:literal, $expansion:literal $($input:tt)*) => {{


### PR DESCRIPTION
Moving about two dozen DefMacro definitions to the new compile-time prototypes freshly introduced in #98 .

I'll look into whether I can move the simpler DefMacros to compile-time prototypes as well, to maximize performance.
