### PR TITLE
use tinyvec in known fixed-size lists

### DIFF
--- a/rtx_codegen/src/constructable.rs
+++ b/rtx_codegen/src/constructable.rs
@@ -95,7 +95,7 @@ pub fn compile_replacement(input: DeriveInput) -> TokenStream {
 
     quote!(
     Some(Arc::new(
-    |document: &mut Document, args: &Vec<Option<Digested>>, props: &HashMap<String, Stored>, state: &mut State| {
+    |document: &mut Document, args: &ArrayVec<[Option<Digested>;9]>, props: &HashMap<String, Stored>, state: &mut State| {
       #[allow(unused_assignments)]
       let mut savenode : Option<Node> = None;
 

--- a/rtx_core/Cargo.toml
+++ b/rtx_core/Cargo.toml
@@ -25,3 +25,4 @@ dirs = "4.0"
 encoding = "0.2"
 kpathsea = "0.2.3"
 marpa = { git = "https://github.com/dginev/marpa", branch = "abstract_syntax_forests" }
+tinyvec = "1.6.0"

--- a/rtx_core/src/common/store.rs
+++ b/rtx_core/src/common/store.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::sync::{Arc, RwLock};
+use tinyvec::ArrayVec;
 
 use crate::common::dimension::Dimension;
 use crate::common::error::*;
@@ -445,7 +446,7 @@ impl Stored {
   }
   /// Dynamic dispatch for Definition's `read_arguments`,
   /// to circumvent the limitations of using trait objects with `Arc<Definition>`
-  pub fn read_arguments(&self, gullet: &mut Gullet, state: &mut State) -> Result<Vec<ArgWrap>> {
+  pub fn read_arguments(&self, gullet: &mut Gullet, state: &mut State) -> Result<ArrayVec<[ArgWrap;9]>> {
     use crate::definition::Definition;
     match self {
       Stored::Conditional(ref entry) => entry.read_arguments(gullet, state),

--- a/rtx_core/src/definition/constructor.rs
+++ b/rtx_core/src/definition/constructor.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
+use tinyvec::ArrayVec;
 
 use crate::common::error::*;
 use crate::common::font::Font;
@@ -177,8 +178,8 @@ impl Definition for Constructor {
     let ismath = state.lookup_bool("IN_MATH");
     // info!(target: "constructor", "invoke for {:?} ({:?})", self.get_cs(), ismath);
     // Parse AND digest the arguments to the Constructor
-    let mut args: Vec<Option<Digested>> = match self.get_parameters() {
-      None => Vec::new(),
+    let mut args: ArrayVec<[Option<Digested>;9]> = match self.get_parameters() {
+      None => ArrayVec::default(),
       Some(params) => params.read_arguments_and_digest(stomach, self, state)?,
     };
     // info!($self->tracingArgs(@args) . "\n" if $tracing && @args;

--- a/rtx_core/src/definition/expandable.rs
+++ b/rtx_core/src/definition/expandable.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::fmt;
 use std::sync::Arc;
+use tinyvec::ArrayVec;
 
 use crate::common::error::*;
 use crate::common::locator::Locator;
@@ -95,7 +96,7 @@ impl Definition for Expandable {
         let args = if let Some(ref parms) = self.paramlist {
           parms.read_arguments(gullet, self, state)?
         } else {
-          Vec::new()
+          ArrayVec::default()
         };
         if profiled {
           // LaTeXML::Core::Definition::startProfiling($profiled, 'expand')
@@ -149,7 +150,7 @@ impl Definition for Expandable {
           let args = if let Some(ref parms) = self.paramlist {
             parms.read_arguments(gullet, self, state)?
           } else {
-            Vec::new()
+            ArrayVec::default()
           };
           let mut args_tks = Vec::new();
           for arg in args.iter() {
@@ -222,7 +223,7 @@ impl Expandable {
     }
   }
 
-  fn do_invocation(&self, gullet: &mut Gullet, args: Vec<ArgWrap>, state: &mut State) -> Result<Tokens> {
+  fn do_invocation(&self, gullet: &mut Gullet, args: ArrayVec<[ArgWrap;9]>, state: &mut State) -> Result<Tokens> {
     match self.expansion {
       Some(ExpansionBody::Closure(ref closure)) => closure(gullet, args, state),
       // but for tokens, make sure args are proper Tokens (lists)

--- a/rtx_core/src/definition/mod.rs
+++ b/rtx_core/src/definition/mod.rs
@@ -11,6 +11,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
+use tinyvec::ArrayVec;
 
 use crate::common::error::*;
 use crate::common::object::Object;
@@ -29,16 +30,16 @@ use crate::tokens::Tokens;
 use crate::whatsit::Whatsit;
 use crate::Digested;
 
-pub type ExpansionClosure = Arc<dyn Fn(&mut Gullet, Vec<ArgWrap>, &mut State) -> Result<Tokens>>;
-pub type ConditionalClosure = Arc<dyn Fn(&mut Gullet, Vec<ArgWrap>, &mut State) -> Result<bool>>;
-pub type PrimitiveFn = dyn Fn(&mut Stomach, Vec<ArgWrap>, &mut State) -> Result<Vec<Digested>>;
+pub type ExpansionClosure = Arc<dyn Fn(&mut Gullet, ArrayVec<[ArgWrap;9]>, &mut State) -> Result<Tokens>>;
+pub type ConditionalClosure = Arc<dyn Fn(&mut Gullet, ArrayVec<[ArgWrap;9]>, &mut State) -> Result<bool>>;
+pub type PrimitiveFn = dyn Fn(&mut Stomach, ArrayVec<[ArgWrap;9]>, &mut State) -> Result<Vec<Digested>>;
 pub type PrimitiveClosure = Arc<PrimitiveFn>;
 pub type BeforeDigestClosure = Arc<dyn Fn(&mut Stomach, &mut State) -> Result<Vec<Digested>>>;
-pub type PropertiesClosure = Arc<dyn Fn(&mut Stomach, &Vec<Option<Digested>>, &mut State) -> Result<HashMap<String, Stored>>>;
+pub type PropertiesClosure = Arc<dyn Fn(&mut Stomach, &ArrayVec<[Option<Digested>;9]>, &mut State) -> Result<HashMap<String, Stored>>>;
 pub type DigestionClosure = Arc<dyn Fn(&mut Stomach, &mut Whatsit, &mut State) -> Result<Vec<Digested>>>;
-pub type ReplacementClosure = Arc<dyn Fn(&mut Document, &Vec<Option<Digested>>, &HashMap<String, Stored>, &mut State) -> Result<()>>;
+pub type ReplacementClosure = Arc<dyn Fn(&mut Document, &ArrayVec<[Option<Digested>;9]>, &HashMap<String, Stored>, &mut State) -> Result<()>>;
 pub type ConstructionClosure = Arc<dyn Fn(&mut Document, &Whatsit, &mut State) -> Result<()>>;
-pub type DigestedReversionClosure = Arc<dyn Fn(&Whatsit, &Vec<Option<Digested>>, &mut State) -> Result<Tokens>>;
+pub type DigestedReversionClosure = Arc<dyn Fn(&Whatsit, &ArrayVec<[Option<Digested>;9]>, &mut State) -> Result<Tokens>>;
 pub type SizingClosure = Arc<dyn Fn(&Whatsit) -> (i32, i32, i32)>;
 
 #[derive(Clone)]
@@ -146,10 +147,10 @@ pub trait Definition: Object {
   fn is_prefix(&self) -> bool { false }
   fn is_readonly(&self) -> bool { false }
 
-  fn read_arguments(&self, gullet: &mut Gullet, state: &mut State) -> Result<Vec<ArgWrap>>
+  fn read_arguments(&self, gullet: &mut Gullet, state: &mut State) -> Result<ArrayVec<[ArgWrap;9]>>
   where Self: Sized {
     match self.get_parameters() {
-      None => Ok(Vec::new()),
+      None => Ok(ArrayVec::default()),
       Some(params) => params.read_arguments(gullet, self, state),
     }
   }
@@ -214,7 +215,7 @@ pub trait Definition: Object {
     Ok(after_body_digested)
   }
 
-  fn value_of(&self, args: Vec<ArgWrap>, state: &State) -> Option<RegisterValue> { unimplemented!() }
+  fn value_of(&self, args: ArrayVec<[ArgWrap;9]>, state: &State) -> Option<RegisterValue> { unimplemented!() }
   fn register_type(&self) -> Option<RegisterType> { None }
   fn get_reversion_spec(&self) -> Option<Reversion> { unimplemented!() }
   fn get_expansion(&self) -> Option<&ExpansionBody> { None }

--- a/rtx_core/src/definition/register.rs
+++ b/rtx_core/src/definition/register.rs
@@ -2,6 +2,7 @@ use std::borrow::Borrow;
 use std::borrow::Cow;
 use std::fmt;
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use tinyvec::ArrayVec;
 
 use crate::common::dimension::Dimension;
 use crate::common::error::*;
@@ -327,8 +328,8 @@ pub enum RegisterType {
   Any, // Placeholder for any argument accepted
 }
 
-pub type RegisterGetterClosure = Arc<dyn Fn(Vec<ArgWrap>, &State) -> Option<RegisterValue>>;
-pub type RegisterSetterClosure = Arc<dyn Fn(RegisterValue, Vec<ArgWrap>, &mut State)>;
+pub type RegisterGetterClosure = Arc<dyn Fn(ArrayVec<[ArgWrap;9]>, &State) -> Option<RegisterValue>>;
+pub type RegisterSetterClosure = Arc<dyn Fn(RegisterValue, ArrayVec<[ArgWrap;9]>, &mut State)>;
 
 #[derive(Clone)]
 pub struct Register {
@@ -348,8 +349,8 @@ impl Default for Register {
       cs: T_CS!("Register"),
       parameters: None,
       register_type: RegisterType::Number,
-      getter: Arc::new(|_: Vec<ArgWrap>, _: &State| Some(RegisterValue::Number(Number::new(0)))),
-      setter: Arc::new(|_: RegisterValue, _: Vec<ArgWrap>, _: &mut State| {}),
+      getter: Arc::new(|_: ArrayVec<[ArgWrap;9]>, _: &State| Some(RegisterValue::Number(Number::new(0)))),
+      setter: Arc::new(|_: RegisterValue, _: ArrayVec<[ArgWrap;9]>, _: &mut State| {}),
       readonly: false,
       internalcs: None,
       value: None,
@@ -433,10 +434,10 @@ impl Definition for RegisterCell {
 
   fn before_digest(&self) -> Option<&Vec<BeforeDigestClosure>> { None }
   fn after_digest(&self) -> Option<&Vec<DigestionClosure>> { None }
-  fn read_arguments(&self, gullet: &mut Gullet, state: &mut State) -> Result<Vec<ArgWrap>> {
+  fn read_arguments(&self, gullet: &mut Gullet, state: &mut State) -> Result<ArrayVec<[ArgWrap;9]>> {
     let params = &self.borrow().parameters;
     match params {
-      None => Ok(Vec::new()),
+      None => Ok(ArrayVec::default()),
       Some(ref params) => params.read_arguments(gullet, self, state),
     }
   }
@@ -444,7 +445,7 @@ impl Definition for RegisterCell {
   fn do_absorbtion(&self, _document: &mut Document, _whatsit: &Whatsit, _state: &mut State) -> Result<()> {
     fatal!(Definition, Unexpected, "do_absorbtion on Primitive should never be called!");
   }
-  fn value_of(&self, args: Vec<ArgWrap>, state: &State) -> Option<RegisterValue> {
+  fn value_of(&self, args: ArrayVec<[ArgWrap;9]>, state: &State) -> Option<RegisterValue> {
     if self.borrow().register_type == RegisterType::CharDef {
       self.borrow().value.clone()
     } else {
@@ -456,7 +457,7 @@ impl Definition for RegisterCell {
 
 impl Register {
   pub fn is_readonly(&self) -> bool { self.readonly }
-  pub fn set_value(&mut self, value: RegisterValue, args: Vec<ArgWrap>, state: &mut State) {
+  pub fn set_value(&mut self, value: RegisterValue, args: ArrayVec<[ArgWrap;9]>, state: &mut State) {
     if self.register_type == RegisterType::CharDef {
       let message = s!("Can't assign to chardef {}", self.cs.get_cs_name());
       Error!("unexpected", "chardef", None, state, message);

--- a/rtx_core/src/mouth.rs
+++ b/rtx_core/src/mouth.rs
@@ -7,6 +7,7 @@ use std::io::prelude::*;
 use std::io::BufReader;
 use std::str;
 use std::sync::{Mutex, RwLock};
+use tinyvec::ArrayVec;
 
 use core::ops::RangeBounds;
 // TODO:
@@ -412,7 +413,7 @@ impl Mouth {
         let read_mode = state.lookup_int("PRESERVE_NEWLINES") > 1;
         let eolch = if let Some(defn) = state.lookup_definition(&CS_ENDLINECHAR) {
           if defn.is_register() {
-            if let Some(eol) = defn.value_of(Vec::new(), state) {
+            if let Some(eol) = defn.value_of(ArrayVec::default(), state) {
               let eol = eol.value_of() as i16;
               if eol > 0 && eol <= 255 {
                 let mch = (eol as u8) as char;

--- a/rtx_core/src/parameter.rs
+++ b/rtx_core/src/parameter.rs
@@ -5,6 +5,7 @@ use regex::Regex;
 use std::borrow::Cow;
 use std::fmt;
 use std::sync::Arc; // TokenStreamExt
+use tinyvec::ArrayVec;
 
 use crate::common::error::*;
 use crate::common::object::Object;
@@ -21,7 +22,7 @@ use crate::tokens::Tokens;
 use crate::whatsit::Whatsit;
 use crate::{Digested, Locator};
 
-pub type ReaderFn = dyn Fn(&mut Gullet, Vec<Option<Parameters>>, &[ParameterExtra], &mut State) -> Result<ArgWrap>;
+pub type ReaderFn = dyn Fn(&mut Gullet, ArrayVec<[Option<Parameters>;9]>, &[ParameterExtra], &mut State) -> Result<ArgWrap>;
 pub type ReaderPredigestFn = dyn Fn(&mut Stomach, ArgWrap, &mut State) -> Result<Option<Digested>>;
 pub type ReaderPredigestClosure = Arc<ReaderPredigestFn>;
 pub type ReaderClosure = Arc<ReaderFn>;
@@ -298,7 +299,7 @@ impl Parameter {
     self.setup_catcodes(state);
 
     let closure = &self.reader;
-    let value_from_reader: ArgWrap = closure(gullet, vec![], &self.extra, state)?;
+    let value_from_reader: ArgWrap = closure(gullet, ArrayVec::default(), &self.extra, state)?;
     let value_arg = if value_from_reader.is_tokens() {
       let wants_option = self.optional || value_from_reader.is_option();
       match value_from_reader.owned_tokens() {
@@ -484,8 +485,8 @@ impl Parameters {
     Ok(self)
   }
 
-  pub fn read_arguments(&self, gullet: &mut Gullet, fordefn: &dyn Definition, state: &mut State) -> Result<Vec<ArgWrap>> {
-    let mut args = Vec::new();
+  pub fn read_arguments(&self, gullet: &mut Gullet, fordefn: &dyn Definition, state: &mut State) -> Result<ArrayVec<[ArgWrap;9]>> {
+    let mut args = ArrayVec::default();
     for parameter in &self.0 {
       let values = parameter.read(gullet, fordefn, state)?;
       if parameter.reader_predigest.is_some() {
@@ -503,8 +504,8 @@ impl Parameters {
     Ok(args)
   }
 
-  pub fn read_arguments_and_digest(&self, stomach: &mut Stomach, fordefn: &Constructor, state: &mut State) -> Result<Vec<Option<Digested>>> {
-    let mut args = Vec::new();
+  pub fn read_arguments_and_digest(&self, stomach: &mut Stomach, fordefn: &Constructor, state: &mut State) -> Result<ArrayVec<[Option<Digested>;9]>> {
+    let mut args = ArrayVec::default();
     stomach.gullet.setup_scan();
     for parameter in &self.0 {
       let value = parameter.read(&mut stomach.gullet, fordefn, state)?;

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -5,6 +5,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt::{self, Display};
 use std::hash::Hash;
 use std::sync::{Arc, RwLock};
+use tinyvec::ArrayVec;
 
 use crate::common::dimension::Dimension;
 use crate::common::error::*;
@@ -762,7 +763,7 @@ impl State {
     }
   }
 
-  pub fn lookup_register(&self, cs: &str, parameters: Vec<ArgWrap>) -> Option<RegisterValue> {
+  pub fn lookup_register(&self, cs: &str, parameters: ArrayVec<[ArgWrap;9]>) -> Option<RegisterValue> {
     let cs = T_CS!(cs);
     if let Some(defn) = self.lookup_definition(&cs) {
       if defn.is_register() {

--- a/rtx_core/src/whatsit.rs
+++ b/rtx_core/src/whatsit.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::sync::Arc;
+use tinyvec::ArrayVec;
 
 use crate::common::error::*;
 use crate::common::font::Font;
@@ -22,7 +23,7 @@ const DUAL_BRANCH: bool = false; // TODO: what is this about?
 
 #[derive(Clone)]
 pub struct Whatsit {
-  pub args: Vec<Option<Digested>>,
+  pub args: ArrayVec<[Option<Digested>; 9]>,
   pub properties: HashMap<String, Stored>,
   pub definition: Arc<dyn Definition>,
   pub reversion: Option<Tokens>,
@@ -33,7 +34,7 @@ pub struct Whatsit {
 impl Default for Whatsit {
   fn default() -> Self {
     Whatsit {
-      args: Vec::new(),
+      args: ArrayVec::<[Option<Digested>; 9]>::default(),
       properties: HashMap::new(),
       definition: Arc::new(Expandable::default()),
       reversion: None,
@@ -69,8 +70,8 @@ impl Whatsit {
       _ => None,
     }
   }
-  pub fn get_args(&self) -> &Vec<Option<Digested>> { &self.args }
-  pub fn set_args(&mut self, args: Vec<Option<Digested>>) { self.args = args; }
+  pub fn get_args(&self) -> &ArrayVec<[Option<Digested>;9]> { &self.args }
+  pub fn set_args(&mut self, args: ArrayVec<[Option<Digested>;9]>) { self.args = args; }
   pub fn get_trailer(&self) -> Option<Digested> {
     match self.properties.get("trailer") {
       Some(Stored::Digested(triler)) => Some(*triler.clone()),

--- a/rtx_package/Cargo.toml
+++ b/rtx_package/Cargo.toml
@@ -19,5 +19,6 @@ log = "0.4"
 libxml = "0.3.0"
 unidecode = "0.3.0"
 chrono = "0.4"
+tinyvec = "1.6.0"
 rtx_codegen = {path = "../rtx_codegen"}
 rtx_core = {path = "../rtx_core"}

--- a/rtx_package/src/package/api/counter_dialect.rs
+++ b/rtx_package/src/package/api/counter_dialect.rs
@@ -2,6 +2,7 @@ use libxml::tree::Node;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
+use tinyvec::ArrayVec;
 
 use rtx_core::common::error::*;
 use rtx_core::common::number::Number;
@@ -604,7 +605,7 @@ pub fn begin_itemize(
   AssignRegister!(
     "\\itemsep",
     state.lookup_dimension("\\lx@default@itemsep").unwrap_or_default().into(),
-    Vec::new(),
+    ArrayVec::default(),
     state
   );
   state.assign_value("itemization_level", listlevel, None);

--- a/rtx_package/src/package/api/def_dialect.rs
+++ b/rtx_package/src/package/api/def_dialect.rs
@@ -1,5 +1,6 @@
 use std::borrow::{Borrow, Cow};
 use std::sync::Arc;
+use tinyvec::ArrayVec;
 
 use rtx_core::common::error::*;
 use rtx_core::common::font::Font;
@@ -190,7 +191,7 @@ pub fn def_register<T: Into<RegisterValue>>(cs: Token, parameters: Option<Parame
 
   let getter: RegisterGetterClosure = match options.getter {
     Some(getter) => getter.clone(),
-    None => Arc::new(move |args: Vec<ArgWrap>, state: &State| -> Option<RegisterValue> {
+    None => Arc::new(move |args: ArrayVec<[ArgWrap;9]>, state: &State| -> Option<RegisterValue> {
       let args_string: String = args.iter().map(ToString::to_string).collect::<Vec<String>>().join("");
       match state.lookup_value(&(name.clone() + &args_string)) {
         None => Some(getter_value.clone()),

--- a/rtx_package/src/package/api_macros.rs
+++ b/rtx_package/src/package/api_macros.rs
@@ -49,14 +49,14 @@ macro_rules! transfer_opt_default {
 #[macro_export]
 macro_rules! noprimitive {
   () => {
-    |stomach: &mut Stomach, args: Vec<ArgWrap>, state: &mut State| Ok(Vec::new())
+    |stomach: &mut Stomach, args: ArrayVec<[ArgWrap;9]>, state: &mut State| Ok(Vec::new())
   };
 }
 
 #[macro_export]
 macro_rules! primitivesub {
   ($stomach:ident, $args:ident, $inner_state:ident, $body:block) => {
-    move |$stomach: &mut Stomach, mut $args: Vec<ArgWrap>, $inner_state: &mut State| {
+    move |$stomach: &mut Stomach, mut $args: ArrayVec<[ArgWrap;9]>, $inner_state: &mut State| {
       BindInnerState!($stomach, $inner_state);
       let macro_out = $body;
       end_state_frame!();
@@ -67,7 +67,7 @@ macro_rules! primitivesub {
 #[macro_export]
 macro_rules! primitiveproc {
   ($stomach:ident, $args:ident, $inner_state:ident, $body:block) => (
-    |$stomach:&mut Stomach, mut $args : Vec<ArgWrap>, $inner_state:&mut State| {
+    |$stomach:&mut Stomach, mut $args : ArrayVec<[ArgWrap;9]>, $inner_state:&mut State| {
       BindInnerState!($stomach, $inner_state);
       $body
       end_state_frame!();
@@ -136,7 +136,7 @@ macro_rules! noreplacement {
 #[macro_export]
 macro_rules! replacement {
   ($doc:ident, $args:ident, $props:ident, $state:ident, $body:block) => (
-    move |$doc:&mut Document,$args: &Vec<Option<Digested>>, $props: &HashMap<String, Stored>, $state: &mut State| -> Result<()> {
+    move |$doc:&mut Document,$args: &ArrayVec<[Option<Digested>;9]>, $props: &HashMap<String, Stored>, $state: &mut State| -> Result<()> {
     BindInnerState!($state);
     $body
     end_state_frame!();
@@ -164,21 +164,21 @@ macro_rules! properties {
   };
   ($stomach:ident, $args:ident, $inner_state:ident, $body:block) => {
     Arc::new(
-      move |$stomach: &mut Stomach, mut $args: &Vec<Option<Digested>>, $inner_state: &mut State| -> Result<HashMap<String, Stored>> {
+      move |$stomach: &mut Stomach, mut $args: &ArrayVec<[Option<Digested>;9]>, $inner_state: &mut State| -> Result<HashMap<String, Stored>> {
         WithInnerState!($body, $stomach, $inner_state)
       },
     )
   };
   ($(sub)? $body:block) => {
     Arc::new(
-      move |stomach: &mut Stomach, args: &Vec<Option<Digested>>, state: &mut State| -> Result<HashMap<String, Stored>> {
+      move |stomach: &mut Stomach, args: &ArrayVec<[Option<Digested>;9]>, state: &mut State| -> Result<HashMap<String, Stored>> {
         WithInnerState!($body, stomach, state).into_properties_result()
       },
     )
   };
   ($value:expr) => {
     Arc::new(
-      move |_stomach: &mut Stomach, _args: &Vec<Option<Digested>>, _state: &mut State| -> Result<HashMap<String, Stored>> { Ok($value.clone()) },
+      move |_stomach: &mut Stomach, _args: &ArrayVec<[Option<Digested>;9]>, _state: &mut State| -> Result<HashMap<String, Stored>> { Ok($value.clone()) },
     )
   };
 }
@@ -208,7 +208,7 @@ macro_rules! after_digest_single {
 macro_rules! reader {
   ($gullet:ident, $inner:ident, $extra:ident, $state:ident, $body:block) => {
     Arc::new(
-      |$gullet: &mut Gullet, $inner: Vec<Option<Parameters>>, $extra: &[ParameterExtra], $state: &mut State| -> Result<ArgWrap> {
+      |$gullet: &mut Gullet, $inner: ArrayVec<[Option<Parameters>;9]>, $extra: &[ParameterExtra], $state: &mut State| -> Result<ArgWrap> {
         WithInnerState!($body, $state).into_result_argwrap()
       },
     )
@@ -229,7 +229,7 @@ macro_rules! reader_predigest {
 #[macro_export]
 macro_rules! getter {
   ($args: ident, $state:ident, $body:block) => {
-    Some(Arc::new(move |mut $args: Vec<ArgWrap>, $state: &State| -> Option<RegisterValue> {
+    Some(Arc::new(move |mut $args: ArrayVec<[ArgWrap;9]>, $state: &State| -> Option<RegisterValue> {
       WithInnerState!($body, $state).into_register_value_option()
     }))
   };
@@ -238,7 +238,7 @@ macro_rules! getter {
 #[macro_export]
 macro_rules! setter {
   ($value:ident, $args: ident, $state:ident, $body:block) => {
-    Some(Arc::new(move |$value: RegisterValue, mut $args: Vec<ArgWrap>, $state: &mut State| {
+    Some(Arc::new(move |$value: RegisterValue, mut $args: ArrayVec<[ArgWrap;9]>, $state: &mut State| {
       WithInnerState!($body, $state)
     }))
   };
@@ -277,7 +277,7 @@ macro_rules! reversion {
 macro_rules! reversion_digested {
   ($whatsit:ident, $args:ident, $state:ident, $body:block) => {
     Some(Reversion::Closure(Arc::new(
-      move |$whatsit: &Whatsit, $args: &Vec<Option<Digested>>, $state: &mut State| -> Result<Tokens> {
+      move |$whatsit: &Whatsit, $args: &ArrayVec<[Option<Digested>;9]>, $state: &mut State| -> Result<Tokens> {
         BindInnerState!($state);
         let macro_out = $body;
         end_state_frame!();

--- a/rtx_package/src/package/mod.rs
+++ b/rtx_package/src/package/mod.rs
@@ -7,6 +7,8 @@ pub use std::borrow::Cow;
 pub use std::collections::HashMap;
 pub use std::collections::VecDeque;
 pub use std::sync::{Arc, RwLock};
+pub use std::cmp::{min,max};
+pub use tinyvec::{array_vec, ArrayVec};
 
 pub use rtx_core::common::dimension::Dimension;
 pub use rtx_core::common::mudimension::MuDimension;

--- a/rtx_package/src/package/pool/comment_sty.rs
+++ b/rtx_package/src/package/pool/comment_sty.rs
@@ -51,7 +51,7 @@ LoadDefinitions!(outer_state, {
   }));
 
   let mut mock_stomach = Stomach::default();
-  define_excluded(&mut mock_stomach, vec![ArgWrap::Tokens(Tokenize!("comment", None))], outer_state)?;
+  define_excluded(&mut mock_stomach, array_vec!([ArgWrap; 9] => ArgWrap::Tokens(Tokenize!("comment", None))), outer_state)?;
 
   DefPrimitive!("\\includecomment{}", Some(Arc::clone(&define_included)));
   DefPrimitive!("\\excludecomment{}", Some(define_excluded));

--- a/rtx_package/src/package/pool/tex_assignment.rs
+++ b/rtx_package/src/package/pool/tex_assignment.rs
@@ -109,15 +109,16 @@ LoadDefinitions!(outer_state, {
   //    | \divide <numeric variable><optional by><number>
 
   DefPrimitive!("\\advance Variable SkipKeyword:by", sub[stomach, args, state] {
-    if let ArgWrap::RegisterDefinition((defn_token, inner)) = args.remove(0) {
+    if let ArgWrap::RegisterDefinition((defn_token, mut inner)) = args.remove(0) {
       if defn_token.to_string() != "missing" {
         let defn_opt = state.lookup_register_definition(&defn_token);
         let defn_token_rc = Arc::new(defn_token);
         state.current_token = Some(Arc::clone(&defn_token_rc));
         if let Some(defn) = defn_opt {
           let summand = stomach.get_gullet_mut().read_value(defn.register_type().unwrap(), state)?;
-          let defn_args : Vec<ArgWrap> = inner.clone();
-          let defn_value = defn.value_of(inner, state).unwrap_or_default();
+          let tiny_inner :ArrayVec<[ArgWrap;9]> = inner.drain(..min(inner.len(),9)).collect();
+          let defn_args = tiny_inner.clone();
+          let defn_value = defn.value_of(tiny_inner, state).unwrap_or_default();
           defn.borrow_mut().set_value(defn_value.add(summand), defn_args, state);
         } else {
           let message = s!("\\advance expected a defined variable for {:?}, found no definition", defn_token_rc);
@@ -128,12 +129,13 @@ LoadDefinitions!(outer_state, {
   });
 
   DefPrimitive!("\\multiply Variable SkipKeyword:by Number", sub[stomach, args, state] {
-    if let ArgWrap::RegisterDefinition((varname, inner)) = args.remove(0) {
+    if let ArgWrap::RegisterDefinition((varname, mut inner)) = args.remove(0) {
       unpack!(args => scale);
       // Upgrade: Why are the arguments used twice here? Is there a way to avoid cloning them?
-      let defn_args : Vec<ArgWrap> = inner.clone();
+      let tiny_inner :ArrayVec<[ArgWrap;9]> = inner.drain(..min(inner.len(),9)).collect();
+      let defn_args = tiny_inner.clone();
       if let Some(defn) = state.lookup_register_definition(&varname) {
-        let defn_value = defn.value_of(inner, state).unwrap_or_default();
+        let defn_value = defn.value_of(tiny_inner, state).unwrap_or_default();
         let scale_value = scale.to_number().value_of();
         defn.borrow_mut().set_value(defn_value.multiply(Number::new(scale_value)), defn_args, state);
       } else {
@@ -147,12 +149,13 @@ LoadDefinitions!(outer_state, {
   });
 
   DefPrimitive!("\\divide Variable SkipKeyword:by Number", sub[stomach, args, state] {
-    if let ArgWrap::RegisterDefinition((varname, inner)) = args.remove(0) {
+    if let ArgWrap::RegisterDefinition((varname, mut inner)) = args.remove(0) {
       unpack!(args => scale);
       // Upgrade: Why are the arguments used twice here? Is there a way to avoid cloning them?
-      let defn_args : Vec<ArgWrap> = inner.clone();
+      let tiny_inner :ArrayVec<[ArgWrap;9]> = inner.drain(..min(inner.len(),9)).collect();
+      let defn_args = tiny_inner.clone();
       if let Some(defn) = state.lookup_register_definition(&varname) {
-        let defn_value = defn.value_of(inner, state).unwrap_or_default();
+        let defn_value = defn.value_of(tiny_inner, state).unwrap_or_default();
         let mut denominator = scale.to_number().value_f32();
         if denominator == 0.0 {
           Error!("misdefined", scale, stomach, state, "Illegal \\divide by 0; assuming 1");

--- a/rtx_package/src/package/pool/tex_expandable_primitives.rs
+++ b/rtx_package/src/package/pool/tex_expandable_primitives.rs
@@ -111,7 +111,7 @@ LoadDefinitions!(outer_state, {
           meaning.push_str(text);
         },
         Stored::Register(register) => {
-          let value = register.value_of(vec![],state);
+          let value = register.value_of(ArrayVec::default(),state);
           let register_type = register.register_type().unwrap();
           let prefix = match register_type {
             RegisterType::Glue | RegisterType::MuGlue =>  "\\skip",
@@ -274,13 +274,14 @@ LoadDefinitions!(outer_state, {
 
   // \the<internal quantity>
   DefMacro!("\\the Register", sub[gullet, args, state] {
-    if let ArgWrap::RegisterDefinition((rtoken, inner)) = args.remove(0) {
+    if let ArgWrap::RegisterDefinition((rtoken, mut inner)) = args.remove(0) {
       // let register_type = defn.borrow().register_type;
       //     if (!$type) {
       //       my $cs = ToString($defn->getCS);
       //       Error('unexpected', "\\the$cs", $gullet, "You can't use $cs after \\the"); return (); }
       let defn = rtoken.to_register(state).expect("if a Register parameter provides a token, it must have a Register definition.");
-      let value = defn.value_of(inner, state)
+      let tiny_inner :ArrayVec<[ArgWrap;9]> = inner.drain(..min(9,inner.len())).collect();
+      let value = defn.value_of(tiny_inner, state)
         .unwrap_or_else(|| RegisterValue::Tokens(Tokens!()));
       // In all cases, these should be OTHER, except for space. (!?)
       let mut tokens : Vec<Token> = match value {
@@ -298,7 +299,7 @@ LoadDefinitions!(outer_state, {
 
 // Hmm... I wonder, should getString itself be dealing with escapechar?
 fn escapechar(state: &State) -> String {
-  let code: i32 = match state.lookup_register("\\escapechar", Vec::new()) {
+  let code: i32 = match state.lookup_register("\\escapechar", ArrayVec::default()) {
     Some(RegisterValue::Number(v)) => v.value_of(),
     _ => -1,
   };

--- a/rtx_package/src/package/pool/tex_functions.rs
+++ b/rtx_package/src/package/pool/tex_functions.rs
@@ -46,9 +46,9 @@ pub fn today(state: &State) -> String {
     "November",
     "December",
   ];
-  let month = month_names[state.lookup_register("\\month", vec![]).unwrap().value_of() as usize - 1];
-  let day = state.lookup_register("\\day", vec![]).unwrap().value_of();
-  let year = state.lookup_register("\\year", vec![]).unwrap().value_of();
+  let month = month_names[state.lookup_register("\\month", ArrayVec::default()).unwrap().value_of() as usize - 1];
+  let day = state.lookup_register("\\day", ArrayVec::default()).unwrap().value_of();
+  let year = state.lookup_register("\\year", ArrayVec::default()).unwrap().value_of();
   s!("{} {}, {}", month, day, year)
 }
 
@@ -710,7 +710,7 @@ pub struct KVSpec {
   pub star: bool,
   pub plus: bool,
   pub prefix: Option<String>,
-  pub keysets: Vec<Option<Parameters>>,
+  pub keysets: ArrayVec<[Option<Parameters>;9]>,
   pub skip: bool,
 }
 pub fn keyvals_aux(gullet: &mut Gullet, until: Option<Token>, mut spec: KVSpec, state: &mut State) -> Result<KeyVals> {

--- a/rtx_package/src/package/pool/tex_para.rs
+++ b/rtx_package/src/package/pool/tex_para.rs
@@ -67,7 +67,7 @@ LoadDefinitions!(state, {
           state.assign_value("next_para_class", Stored::None, None);
         }
         // Fish out flags for next ltx:para, to be used when the next \par closes:
-        if state.lookup_register("\\parindent",Vec::new()).unwrap().value_of() == 0 {
+        if state.lookup_register("\\parindent",ArrayVec::default()).unwrap().value_of() == 0 {
           // respect \parindent if no overrides are given
           state.assign_value("next_para_class", "ltx_noindent", None);
         }

--- a/rtx_package/src/package/pool/tex_scripts.rs
+++ b/rtx_package/src/package/pool/tex_scripts.rs
@@ -182,7 +182,7 @@ fn script_handler(stomach: &mut Stomach, cc: Catcode, state: &mut State) -> Resu
       }
       let mut with_script = vec![Digested::Whatsit(Arc::new(RwLock::new(Whatsit {
         definition: state.lookup_definition(&T_CS!(cs)).unwrap(),
-        args: vec![Some(script)],
+        args: array_vec!([Option<Digested>; 9] =>Some(script)),
         properties,
         //         locator     => $gullet->getLocator,
         ..Whatsit::default()
@@ -233,7 +233,7 @@ LoadDefinitions!(state, {
   def_primitive(
     T_SUPER!(),
     None,
-    Some(Arc::new(|stomach: &mut Stomach, _args: Vec<ArgWrap>, state: &mut State| {
+    Some(Arc::new(|stomach: &mut Stomach, _, state: &mut State| {
       script_handler(stomach, Catcode::SUPER, state)
     })),
     PrimitiveOptions::default(),
@@ -242,7 +242,7 @@ LoadDefinitions!(state, {
   def_primitive(
     T_SUB!(),
     None,
-    Some(Arc::new(|stomach: &mut Stomach, _args: Vec<ArgWrap>, state: &mut State| {
+    Some(Arc::new(|stomach: &mut Stomach, _, state: &mut State| {
       script_handler(stomach, Catcode::SUB, state)
     })),
     PrimitiveOptions::default(),

--- a/rtx_package/src/package/pool/tex_setup.rs
+++ b/rtx_package/src/package/pool/tex_setup.rs
@@ -553,7 +553,7 @@ LoadDefinitions!(state, {
           // TODO: What is this datatype ? How does it fit the rtx typed interfaces for parameter types?
           // An extension seems required, also due to the Register parameter type right under.
           // Ok(Tokens!(defn_tok, defn_args))
-          Ok(ArgWrap::RegisterDefinition((token_opt.unwrap(), args)))
+          Ok(ArgWrap::RegisterDefinition((token_opt.unwrap(), args.to_vec())))
         } else {
           let message = s!("A <variable> was supposed to be here\n Got {:?}", token_opt);
           Error!("expected","<variable>", gullet, state, message);
@@ -590,7 +590,7 @@ LoadDefinitions!(state, {
     match defn {
       Some(register) => {
         let args = register.read_arguments(gullet, state)?;
-        return Ok(ArgWrap::RegisterDefinition((token.unwrap(), args)));
+        return Ok(ArgWrap::RegisterDefinition((token.unwrap(), args.to_vec())));
       },
       None => {
         let message = s!("A <register> was supposed to be here. Got {:?}", token);
@@ -929,7 +929,7 @@ LoadDefinitions!(state, {
   });
   //   reversion => sub { (T_BEGIN, Revert($_[0]), T_END); });
 
-  pub fn optional_key_vals(star: bool, plus: bool, keysets: Vec<Option<Parameters>>, gullet: &mut Gullet, state: &mut State) -> Result<Tokens> {
+  pub fn optional_key_vals(star: bool, plus: bool, keysets: ArrayVec<[Option<Parameters>;9]>, gullet: &mut Gullet, state: &mut State) -> Result<Tokens> {
     if gullet.if_next(T_OTHER!("["), state)? {
       let kvs: KeyVals = keyvals_aux(
         gullet,

--- a/rtx_package/src/package/setup_binding_language.rs
+++ b/rtx_package/src/package/setup_binding_language.rs
@@ -423,7 +423,7 @@ macro_rules! TypedConditional {
       sub [ $gullet:ident, ( $($var:ident),* ):($($ptype:ident),*), $inner_state:ident ] $body:block $($input:tt)*) => {{
 
     let options = defi_opts!(@munch ($($input)*) -> {ConditionalOptions,});
-    let closure : ConditionalClosure =  Arc::new(move |$gullet: &mut Gullet, mut args: Vec<ArgWrap>, $inner_state: &mut State| {
+    let closure : ConditionalClosure =  Arc::new(move |$gullet: &mut Gullet, mut args: ArrayVec<[ArgWrap;9]>, $inner_state: &mut State| {
       $(
           let $var: parameter_rust_type!($ptype) = match args.remove(0).try_into() {
             Ok(v) => v,
@@ -497,7 +497,7 @@ macro_rules! DefPrimitive {
   ($proto:literal, $replacement:literal $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
     let (cs, params) = parse_prototype!($proto);
-    let closure : PrimitiveClosure = Arc::new(|stomach: &mut Stomach, args: Vec<ArgWrap>, inner_state: &mut State| {
+    let closure : PrimitiveClosure = Arc::new(|stomach: &mut Stomach, args: ArrayVec<[ArgWrap;9]>, inner_state: &mut State| {
       Tbox::new($replacement.to_string(), None, None, Tokens!(), HashMap::new(), inner_state).into_digested_result()
     });
     defi_primitive!(cs, params, Some(closure), options);
@@ -510,7 +510,7 @@ macro_rules! DefPrimitive {
   ($proto:expr, sub[$stomach_arg:ident, $args:ident, $state_arg:ident] $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
     let (cs, params) = parse_prototype!($proto);
-    let closure : PrimitiveClosure = Arc::new(move |$stomach_arg: &mut Stomach, mut $args: Vec<ArgWrap>, $state_arg: &mut State| {
+    let closure : PrimitiveClosure = Arc::new(move |$stomach_arg: &mut Stomach, mut $args: ArrayVec<[ArgWrap;9]>, $state_arg: &mut State| {
       WithInnerState!($body, $stomach_arg, $state_arg).into_digested_result()
     });
     defi_primitive!(cs, params, Some(closure), options);
@@ -518,7 +518,7 @@ macro_rules! DefPrimitive {
   // Case: cs-noparams with closure pattern replacement
   ($cs:expr, None, sub[$stomach_arg:ident, $args:ident, $state_arg:ident] $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
-    let replacement_closure = Arc::new(move |$stomach_arg: &mut Stomach, mut $args: Vec<ArgWrap>, $state_arg: &mut State| {
+    let replacement_closure = Arc::new(move |$stomach_arg: &mut Stomach, mut $args: ArrayVec<[ArgWrap;9]>, $state_arg: &mut State| {
       WithInnerState!($body, $stomach_arg, $state_arg).into_digested_result()
     });
     defi_primitive!($cs, None, Some(replacement_closure), options);
@@ -539,7 +539,7 @@ macro_rules! DefPrimitive {
   ($proto:expr, $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
     let (cs, params) = parse_prototype!($proto);
-    let replacement_closure =  Arc::new(move |stomach: &mut Stomach, args: Vec<ArgWrap>, state: &mut State| {
+    let replacement_closure =  Arc::new(move |stomach: &mut Stomach, args: ArrayVec<[ArgWrap;9]>, state: &mut State| {
       WithInnerState!($body, stomach, state).into_digested_result()
     });
     defi_primitive!(cs, params, Some(replacement_closure), options);
@@ -560,7 +560,7 @@ macro_rules! TypedPrimitive {
   ($cs:literal, $these_parameters:ident ,
       sub [ $stomach_arg:ident, ( $($var:ident),* ):($($ptype:ident),*), $inner_state:ident ] $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
-    let replacement_closure =  Arc::new(move |$stomach_arg: &mut Stomach, mut args: Vec<ArgWrap>, $inner_state: &mut State| {
+    let replacement_closure =  Arc::new(move |$stomach_arg: &mut Stomach, mut args: ArrayVec<[ArgWrap;9]>, $inner_state: &mut State| {
       $(
           let $var: parameter_rust_type!($ptype) = match args.remove(0).try_into() {
             Ok(v) => v,
@@ -590,7 +590,7 @@ macro_rules! defi_primitive(
 #[macro_export]
 macro_rules! LookupRegister {
   ($cs:expr) => {
-    LookupRegister!($cs, Vec::new())
+    LookupRegister!($cs, ArrayVec::default())
   };
   ($cs:expr, $parameters:expr) => {{
     bind_state_mut!(st);
@@ -610,7 +610,7 @@ macro_rules! LookupRegister {
 #[macro_export]
 macro_rules! LookupRegisterOrDefault {
   ($cs:expr) => {
-    LookupRegisterOrDefault!($cs, Vec::new())
+    LookupRegisterOrDefault!($cs, ArrayVec::default())
   };
   ($cs:expr, $parameters:expr) => {{
     bind_state_mut!(st);
@@ -1667,7 +1667,7 @@ macro_rules! TypedMacro {
     sub [ $gullet:ident, ( $($var:ident),* ):($($ptype:ident),*), $inner_state:ident ] $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {ExpandableOptions,});
     let expansion_closure: Option<ExpansionBody> = Some(ExpansionBody::Closure(Arc::new(
-      move |$gullet: &mut Gullet, mut args: Vec<ArgWrap>, $inner_state:&mut State| {
+      move |$gullet: &mut Gullet, mut args: ArrayVec<[ArgWrap;9]>, $inner_state:&mut State| {
         $(
           let $var: parameter_rust_type!($ptype) = match args.remove(0).try_into() {
             Ok(v) => v,


### PR DESCRIPTION
Fixes #99 .

The refactor is straightforward (though it took an hour), as `ArrayVec` implements the same interface as `Vec`. 

The first test I tried seems to have a rather minor difference, details below. Maybe there is more fine-tuning needed and/or a bigger test would show the difference more decidedly.

---

<details>

Here are screenshots of the inclusive time based on "instruction fetch". 

Vec | ArrayVec
:---|:----
<img width="400px" src="https://user-images.githubusercontent.com/348975/215349238-8bcb2476-9b9c-4da3-b9b0-6e8e4b1a55ce.png"> | <img width="400px" src="https://user-images.githubusercontent.com/348975/215349357-dfa8f997-ca15-405f-8534-20e3f0cb21c9.png">



Here is a valgrind run summary using `Vec` on my usual `structure/itemize.tex` test:
```
==392696== 
==392696== Events    : Ir Dr Dw I1mr D1mr D1mw ILmr DLmr DLmw
==392696== Collected : 319191253 77747944 55215950 1521635 1474636 662362 53616 46546 184749
==392696== 
==392696== I   refs:      319,191,253
==392696== I1  misses:      1,521,635
==392696== LLi misses:         53,616
==392696== I1  miss rate:        0.48%
==392696== LLi miss rate:        0.02%
==392696== 
==392696== D   refs:      132,963,894  (77,747,944 rd + 55,215,950 wr)
==392696== D1  misses:      2,136,998  ( 1,474,636 rd +    662,362 wr)
==392696== LLd misses:        231,295  (    46,546 rd +    184,749 wr)
==392696== D1  miss rate:         1.6% (       1.9%   +        1.2%  )
==392696== LLd miss rate:         0.2% (       0.1%   +        0.3%  )
==392696== 
==392696== LL refs:         3,658,633  ( 2,996,271 rd +    662,362 wr)
==392696== LL misses:         284,911  (   100,162 rd +    184,749 wr)
==392696== LL miss rate:          0.1% (       0.0%   +        0.3%  )
```

and here is the same run using `ArrayVec`, this PR's branch:
```
==379424== 
==379424== Events    : Ir Dr Dw I1mr D1mr D1mw ILmr DLmr DLmw
==379424== Collected : 324356001 79500228 57053246 1613672 1699389 948146 53750 46603 186075
==379424== 
==379424== I   refs:      324,356,001
==379424== I1  misses:      1,613,672
==379424== LLi misses:         53,750
==379424== I1  miss rate:        0.50%
==379424== LLi miss rate:        0.02%
==379424== 
==379424== D   refs:      136,553,474  (79,500,228 rd + 57,053,246 wr)
==379424== D1  misses:      2,647,535  ( 1,699,389 rd +    948,146 wr)
==379424== LLd misses:        232,678  (    46,603 rd +    186,075 wr)
==379424== D1  miss rate:         1.9% (       2.1%   +        1.7%  )
==379424== LLd miss rate:         0.2% (       0.1%   +        0.3%  )
==379424== 
==379424== LL refs:         4,261,207  ( 3,313,061 rd +    948,146 wr)
==379424== LL misses:         286,428  (   100,353 rd +    186,075 wr)
==379424== LL miss rate:          0.1% (       0.0%   +        0.3%  )
```

</details>