### PR TITLE
avoid always cloning on State::lookup_meaning

### DIFF
--- a/rtx_core/src/binding/def/dialect.rs
+++ b/rtx_core/src/binding/def/dialect.rs
@@ -55,7 +55,7 @@ pub fn is_defined(name: &str, state: &State) -> bool {
 pub fn is_defined_token(cs: &Token, state: &State) -> bool {
   let meaning = state.lookup_meaning(cs);
   match meaning {
-    Some(store) => match store {
+    Some(store) => match store.as_ref() {
       Stored::Token(ref m) => true,
       Stored::Expandable(ref m) => m.get_cs_name() != "\\relax",
       Stored::Primitive(ref m) => m.get_cs_name() != "\\relax",

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -1052,17 +1052,17 @@ impl State {
   /// Get the `Meaning' of a token.  For active control sequence's
   /// this may give the definition object (if defined) or another token (if \let) or undef
   /// Any other token is returned as is.
-  pub fn lookup_meaning(&self, token: &Token) -> Option<Stored> {
+  pub fn lookup_meaning(&self, token: &Token) -> Option<Cow<Stored>> {
     if token.get_catcode().is_active_or_cs() && !token.has_smuggled() && !token.get_string().is_empty() {
       match self.meaning.get(&token.get_cs_name().to_owned()) {
         Some(entry) => match entry.front() {
           None | Some(Stored::None) => None,
-          Some(other) => Some(other.clone()),
+          Some(other) => Some(Cow::Borrowed(other)),
         },
         None => None,
       }
     } else {
-      Some(Stored::Token(token.clone()))
+      Some(Cow::Owned(Stored::Token(token.clone())))
     }
   }
 
@@ -1697,11 +1697,11 @@ impl State {
   /// `Let` macro setter
   pub fn let_i(&mut self, token1: &Token, token2: Token, scope: Option<Scope>, gullet: &mut Gullet) {
     let meaning = if token2.get_dont_expand().is_some() {
-      Stored::Token(token2)
+      Cow::Owned(Stored::Token(token2))
     } else {
-      self.lookup_meaning(&token2).unwrap_or(Stored::None)
+      self.lookup_meaning(&token2).unwrap_or(Cow::Owned(Stored::None))
     };
-    self.assign_meaning(token1, meaning, scope);
+    self.assign_meaning(token1, meaning.into_owned(), scope);
     self.after_assignment(gullet);
   }
   /// `XEquals` check for two token arguments

--- a/rtx_core/tests/00_unit_state.rs
+++ b/rtx_core/tests/00_unit_state.rs
@@ -197,17 +197,17 @@ fn install_definition_and_meaning() {
 
   // Assign a Meaning
   state.assign_meaning(&T_CS!("\\foobar"), job_definition, Some(Scope::Local));
-  if let Some(Stored::Expandable(ref stored_meaning)) = state.lookup_meaning(&T_CS!("\\foobar")) {
+  if let Some(Stored::Expandable(ref stored_meaning)) = state.lookup_meaning(&T_CS!("\\foobar")).as_deref() {
     assert_eq!(stored_meaning.cs, T_CS!("\\jobname")); // Note: meaning for \foobar still has definition for CS \jobname
   } else {
     panic!("Failed to lookup installed meaning!");
   }
 
-  let looked_up_meaning = { state.lookup_meaning(&T_CS!("\\foobar")).unwrap().clone() };
+  let looked_up_meaning = { state.lookup_meaning(&T_CS!("\\foobar")).unwrap().into_owned() };
   {
     state.assign_meaning(&T_CS!("\\foolet"), looked_up_meaning.clone(), Some(Scope::Local));
   }
-  assert_eq!(state.lookup_meaning(&T_CS!("\\foolet")), Some(looked_up_meaning), "Meanings match");
+  assert_eq!(state.lookup_meaning(&T_CS!("\\foolet")).as_deref(), Some(&looked_up_meaning), "Meanings match");
 }
 
 #[test]

--- a/rtx_package/src/package/pool/tex_assignment.rs
+++ b/rtx_package/src/package/pool/tex_assignment.rs
@@ -195,7 +195,7 @@ LoadDefinitions!(outer_state, {
   // instead, here is the same pattern of definition, with different concrete value types.
 
   DefPrimitive!("\\countdef Token SkipMatch:=", sub[stomach, (cs), state] {
-    state.assign_meaning(&cs, state.lookup_meaning(&T_RELAX).unwrap(),None);
+    state.assign_meaning(&cs, state.lookup_meaning(&T_RELAX).unwrap().into_owned(),None);
     let num = stomach.get_gullet_mut().read_number(state)?;
     let reg = s!("\\count{}", num.value_of());
     let setter_count = reg.clone();
@@ -208,7 +208,7 @@ LoadDefinitions!(outer_state, {
   });
 
   DefPrimitive!("\\dimendef Token SkipMatch:=", sub[stomach, (cs), state] {
-    state.assign_meaning(&cs, state.lookup_meaning(&T_RELAX).unwrap(),None);
+    state.assign_meaning(&cs, state.lookup_meaning(&T_RELAX).unwrap().into_owned(),None);
     let num = stomach.get_gullet_mut().read_number(state)?;
     let dimen = s!("\\dimen{}", num.value_of());
     let dimen2 = dimen.clone();
@@ -221,7 +221,7 @@ LoadDefinitions!(outer_state, {
   });
 
   DefPrimitive!("\\skipdef Token SkipMatch:=", sub[stomach, (cs), state] {
-    state.assign_meaning(&cs, state.lookup_meaning(&T_RELAX).unwrap(),None);
+    state.assign_meaning(&cs, state.lookup_meaning(&T_RELAX).unwrap().into_owned(),None);
     let num = stomach.get_gullet_mut().read_number(state)?;
     let skip = s!("\\skip{}", num.value_of());
     let skip2 = skip.clone();
@@ -234,7 +234,7 @@ LoadDefinitions!(outer_state, {
   });
 
   DefPrimitive!("\\muskipdef Token SkipMatch:=", sub[stomach, (cs), state] {
-    state.assign_meaning(&cs, state.lookup_meaning(&T_RELAX).unwrap(),None);
+    state.assign_meaning(&cs, state.lookup_meaning(&T_RELAX).unwrap().into_owned(),None);
     let num = stomach.get_gullet_mut().read_number(state)?;
     let muglue = s!("\\muskip{}",num.value_of());
     let muglue_setter = muglue.clone();
@@ -247,7 +247,7 @@ LoadDefinitions!(outer_state, {
   });
 
   DefPrimitive!("\\toksdef Token SkipMatch:=", sub[stomach, (cs), state] {
-    state.assign_meaning(&cs, state.lookup_meaning(&T_RELAX).unwrap(),None);
+    state.assign_meaning(&cs, state.lookup_meaning(&T_RELAX).unwrap().into_owned(),None);
     let num = stomach.get_gullet_mut().read_number(state)?;
     let toks = s!("\\toks{}", num.value_of() as usize);
     let toks_setter = toks.clone();

--- a/rtx_package/src/package/pool/tex_expandable_primitives.rs
+++ b/rtx_package/src/package/pool/tex_expandable_primitives.rs
@@ -35,8 +35,8 @@ LoadDefinitions!(outer_state, {
     let token_opt = gullet.read_x_token(Some(false), false, state)?.map(|t| {
       // Also resolve \let variants:
       let meaning_opt = state.lookup_meaning(&t);
-      if let Some(Stored::Token(meaning)) = meaning_opt {
-        meaning
+      if let Some(Stored::Token(ref meaning)) = meaning_opt.as_deref() {
+        meaning.clone()
       } else {
         t
       }});
@@ -114,7 +114,7 @@ LoadDefinitions!(outer_state, {
     if let Some(definition) = if token == T_ALIGN!() {
       Some(Stored::Token(token))
     } else {
-      state.lookup_meaning(&token)
+      state.lookup_meaning(&token).map(|d| d.into_owned())
     } {
       // First, if this definition is a primitive or constructor, check to see if it has an alias, which would allow us to work with a token
       let definition : Stored = match definition {
@@ -270,7 +270,7 @@ LoadDefinitions!(outer_state, {
 
   DefMacro!("\\csname CSName", sub[gullet, (token), state] {
     if LookupMeaning!(&token).is_none() {
-      state.assign_meaning(&token, state.lookup_meaning(&T_RELAX).unwrap(), None);
+      state.assign_meaning(&token, state.lookup_meaning(&T_RELAX).unwrap().into_owned(), None);
     }
     token
   });

--- a/rtx_package/src/package/pool/tex_fonts.rs
+++ b/rtx_package/src/package/pool/tex_fonts.rs
@@ -463,7 +463,7 @@ LoadDefinitions!(outer_state, {
 
   // Almost like a register, but different...
   DefPrimitive!("\\chardef Token SkipMatch:=", sub[stomach, (newcs), state] {
-    state.assign_meaning(&newcs, state.lookup_meaning(&T_RELAX).unwrap(), None); // Let w/o AfterAssignment
+    state.assign_meaning(&newcs, state.lookup_meaning(&T_RELAX).unwrap().into_owned(), None); // Let w/o AfterAssignment
     let value = stomach.get_gullet_mut().read_number(state)?;
     let csname = newcs.get_cs_name().to_owned();
     let internalcs = T_CS!(s!("\\@chardef@{}", csname));
@@ -504,7 +504,7 @@ LoadDefinitions!(outer_state, {
 
   // Almost like a register, but different...
   DefPrimitive!("\\mathchardef Token SkipMatch:=", sub[stomach, (newcs), state] {
-    state.assign_meaning(&newcs, state.lookup_meaning(&T_RELAX).unwrap(), None);// Let w/o AfterAssignment
+    state.assign_meaning(&newcs, state.lookup_meaning(&T_RELAX).unwrap().into_owned(), None);// Let w/o AfterAssignment
     let value  = stomach.get_gullet_mut().read_number(state).unwrap();
     let csname = newcs.get_cs_name().to_owned();
     // eprintln!(" ** {} + {}", value,csname);


### PR DESCRIPTION
I was looking for easy wins in a quick profiling run - though of course it really depends on the kinds of source getting converted. This was on my synthetic `primes_3000.tex` test. With the PR, generating the first 3000 primes now takes 7.4 seconds, compared to 7.6 s with the master branch.

There is also a small speedup when running the full tests, but just a handful of percent.

Long-term this may be a bit too much fine-tuning, but since it only took a handful of minutes today, might as well check it in.

<img src="https://user-images.githubusercontent.com/348975/222246725-490137de-e0fb-431a-acf4-7efc4ca4a9fa.png" width="900px">
