### PR TITLE
switch to FxHasher from std HashMap

### DIFF
--- a/rtx/Cargo.toml
+++ b/rtx/Cargo.toml
@@ -30,6 +30,7 @@ libxml = "0.3.2"
 lazy_static = "1.0"
 regex = "1.7.1"
 glob = "0.3"
+rustc-hash = "1.1.0"
 rtx_codegen = {path = "../rtx_codegen"}
 rtx_core = {path = "../rtx_core"}
 rtx_package = {path = "../rtx_package"}

--- a/rtx/src/core.rs
+++ b/rtx/src/core.rs
@@ -3,6 +3,7 @@ use regex::{Captures, Regex};
 use std::borrow::Cow;
 use std::path::Path;
 use std::sync::Arc;
+use rustc_hash::{FxHashMap as HashMap};
 
 use rtx_core::common::error::{note_begin, note_end, Result};
 use rtx_core::common::DigestionMode;

--- a/rtx/src/util/test.rs
+++ b/rtx/src/util/test.rs
@@ -2,7 +2,7 @@ use glob::glob;
 use libxml::parser::Parser;
 use libxml::tree::Document as XmlDoc;
 use libxml::tree::{Node, SaveOptions};
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 use std::sync::Arc;
 
 use crate::core::DigestionAPI;

--- a/rtx/tests/10_expansion.rs
+++ b/rtx/tests/10_expansion.rs
@@ -9,7 +9,7 @@ mod helpers;
 /// Test cases for rtx
 ///**********************************************************************
 use std::sync::Arc;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 
 use rtx_core::stomach::Stomach;
 use rtx_core::state::State;
@@ -20,7 +20,7 @@ use rtx::util::test::*;
 
 #[test]
 fn can_expand() {
-  let mut requires = HashMap::new();
+  let mut requires = HashMap::default();
   requires.insert("meaning", "t1enc.def");
   requires.insert("ifthen", "ifthen.sty");
 

--- a/rtx/tests/30_encoding.rs
+++ b/rtx/tests/30_encoding.rs
@@ -2,12 +2,12 @@
 /// Test cases for rtx
 ///**********************************************************************
 use rtx::util::test::*;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 
 #[test]
 #[ignore]
 fn can_encode() {
-  let mut requires = HashMap::new();
+  let mut requires = HashMap::default();
   requires.insert("ansinew", "ansinew.def");
   requires.insert("applemac", "applemac.def");
   requires.insert("cp437", "cp437.def");

--- a/rtx/tests/50_structure.rs
+++ b/rtx/tests/50_structure.rs
@@ -2,11 +2,11 @@ use rtx::util::test::*;
 ///**********************************************************************
 /// Test cases for rtx
 ///**********************************************************************
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 
 #[test]
 fn can_structure() {
-  let mut requires = HashMap::new();
+  let mut requires = HashMap::default();
   requires.insert("csquotes", "csquotes.sty");
   rtx_tests("tests/structure", Some(requires), None);
 }

--- a/rtx/tests/53_alignment.rs
+++ b/rtx/tests/53_alignment.rs
@@ -2,12 +2,12 @@
 /// Test cases for rtx
 ///**********************************************************************
 use rtx::util::test::*;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 
 #[test]
 #[ignore]
 fn can_align() {
-  let mut requires = HashMap::new();
+  let mut requires = HashMap::default();
   requires.insert("listing", "listings.cfg");
   rtx_tests("tests/alignment", Some(requires), None);
 }

--- a/rtx/tests/55_theorem.rs
+++ b/rtx/tests/55_theorem.rs
@@ -2,12 +2,12 @@
 /// Test cases for rtx
 ///**********************************************************************
 use rtx::util::test::*;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 
 #[test]
 #[ignore]
 fn can_theorem() {
-  let mut requires = HashMap::new();
+  let mut requires = HashMap::default();
   requires.insert("ntheorem", "ntheorem.std");
   rtx_tests("tests/theorem", Some(requires), None);
 }

--- a/rtx/tests/65_graphics.rs
+++ b/rtx/tests/65_graphics.rs
@@ -2,12 +2,12 @@
 /// Test cases for rtx
 ///**********************************************************************
 use rtx::util::test::*;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 
 #[test]
 #[ignore]
 fn can_graphics() {
-  let mut requires = HashMap::new();
+  let mut requires = HashMap::default();
   requires.insert("colors", "dvipsnam.def");
   requires.insert("xcolors", "dvipsnam.def");
   rtx_tests("tests/graphics", Some(requires), None);

--- a/rtx/tests/81_babel.rs
+++ b/rtx/tests/81_babel.rs
@@ -2,12 +2,12 @@
 /// Test cases for rtx
 ///**********************************************************************
 use rtx::util::test::*;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 
 #[test]
 #[ignore]
 fn can_babel() {
-  let mut requires = HashMap::new();
+  let mut requires = HashMap::default();
   requires.insert("*", "babel.sty");
   requires.insert("numprints", "numprint.sty");
   requires.insert("german", "germanb.ldf");

--- a/rtx_codegen/src/constructable.rs
+++ b/rtx_codegen/src/constructable.rs
@@ -174,7 +174,7 @@ fn compile_replacement_tokens(mut replacement: String) -> Vec<proc_macro2::Token
       // makes `current_tag` in particular look very misplaced
       let av = translate_avpairs(&mut replacement);
       operations.push(quote!(
-        let mut av_props : HashMap<String, String> = HashMap::new();
+        let mut av_props : HashMap<String, String> = HashMap::default();
         #(#av)*
         document.insert_pi(#current_tag, Some(av_props))?;
       ));
@@ -219,7 +219,7 @@ fn compile_replacement_tokens(mut replacement: String) -> Vec<proc_macro2::Token
       // Fonts require a bit too much boilerplate at the moment, due to having
       // different directives (code vs asset) and trying to avoid deep cloning.
       operations.push(quote!(
-        let mut av_props : HashMap<String, String> = HashMap::new();
+        let mut av_props : HashMap<String, String> = HashMap::default();
         #(#av)*
         let this_font_opt = match props.get("font") {
           Some(Stored::Font(f)) => Some(Cow::Borrowed(&**f)),

--- a/rtx_core/Cargo.toml
+++ b/rtx_core/Cargo.toml
@@ -25,4 +25,5 @@ dirs = "5.0"
 encoding = "0.2"
 kpathsea = "0.2.3"
 unidecode = "0.3.0"
+rustc-hash = "1.1.0"
 marpa = { git = "https://github.com/dginev/marpa", branch = "abstract_syntax_forests" }

--- a/rtx_core/src/aux_macros.rs
+++ b/rtx_core/src/aux_macros.rs
@@ -4,7 +4,7 @@
 #[macro_export]
 macro_rules! static_map {
   ($( $key:expr => $val:expr ),*) => {{
-    let mut map : HashMap<&'static str, &'static str> = ::std::collections::HashMap::new();
+    let mut map : HashMap<&'static str, &'static str> = HashMap::default();
     $( map.insert($key, $val); )*
     map
   }}
@@ -14,7 +14,7 @@ macro_rules! static_map {
 #[macro_export]
 macro_rules! map {
   ($( $key:expr => $val:expr ),*) => {{
-    let mut map = ::std::collections::HashMap::new();
+    let mut map = HashMap::default();
     $( map.insert($key.to_string(), $val); )*
     map
   }}
@@ -24,7 +24,7 @@ macro_rules! map {
 #[macro_export]
 macro_rules! stored_map {
   ($( $key:expr => $val:expr ),*) => {{
-    let mut map : ::std::collections::HashMap<String,Stored> = ::std::collections::HashMap::new();
+    let mut map : HashMap<String,Stored> = HashMap::default();
     $( map.insert($key.to_string(), $val.into()); )*
     map
   }}
@@ -34,7 +34,7 @@ macro_rules! stored_map {
 #[macro_export]
 macro_rules! string_map {
   ($( $key:expr => $val:expr ),*) => {{
-    let mut map = ::std::collections::HashMap::new();
+    let mut map = HashMap::default();
     $( map.insert($key.to_string(), $val.to_string()); )*
     map
   }}
@@ -44,7 +44,7 @@ macro_rules! string_map {
 #[macro_export]
 macro_rules! raw_map {
   ($( $key:expr => $val:expr ),*) => {{
-    let mut map = ::std::collections::HashMap::new();
+    let mut map = HashMap::default();
     $( map.insert($key, $val); )*
     map
   }}
@@ -54,7 +54,7 @@ macro_rules! raw_map {
 #[macro_export]
 macro_rules! raw_char_map {
   ($( $key:literal => $val:expr ),*) => {{
-    let mut map : HashMap<char,_> = ::std::collections::HashMap::new();
+    let mut map : HashMap<char,_> = HashMap::default();
     $( map.insert($key, $val); )*
     map
   }}

--- a/rtx_core/src/aux_macros.rs
+++ b/rtx_core/src/aux_macros.rs
@@ -94,8 +94,9 @@ macro_rules! fontmap {
 macro_rules! set {
     ( $( $x:expr ),* ) => {  // Match zero or more comma delimited items
         {
-            use std::collections::HashSet;
-            let mut temp_set = HashSet::new();  // Create a mutable HashSet
+            // use std::collections::HashSet;
+            use rustc_hash::FxHashSet as HashSet;
+            let mut temp_set = HashSet::default();  // Create a mutable HashSet
             $(
                 temp_set.insert($x); // Insert each item matched into the HashSet
             )*

--- a/rtx_core/src/binding/content.rs
+++ b/rtx_core/src/binding/content.rs
@@ -1,7 +1,8 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashSet, VecDeque};
+use rustc_hash::{FxHashMap as HashMap};
 use std::path::Path;
 
 use crate::common::error::*;

--- a/rtx_core/src/binding/content.rs
+++ b/rtx_core/src/binding/content.rs
@@ -1,8 +1,8 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::borrow::Cow;
-use std::collections::{HashSet, VecDeque};
-use rustc_hash::{FxHashMap as HashMap};
+use std::collections::{VecDeque};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::path::Path;
 
 use crate::common::error::*;
@@ -479,7 +479,7 @@ pub fn process_options(stomach: &mut Stomach, state: &mut State) -> Result<()> {
   //   else if execute_default_option_internal(option)) { }
   // } }
   // else {
-  let mut requested_options: HashSet<String> = HashSet::new();
+  let mut requested_options: HashSet<String> = HashSet::default();
   for option in current_options.iter() {
     match option {
       Stored::String(content) => {

--- a/rtx_core/src/binding/counter/dialect.rs
+++ b/rtx_core/src/binding/counter/dialect.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{VecDeque};
+use rustc_hash::{FxHashMap as HashMap};
 use std::sync::Arc;
 
 use crate::binding::content::{build_invocation, digest_if, digest_literal, digest_text};
@@ -508,7 +509,7 @@ pub fn ref_step_item_counter(tag_opt: Option<&Tokens>, stomach: &mut Stomach, st
   let counter = state.lookup_string("itemcounter");
   let n = state.lookup_int("itemization_items");
   state.assign_value("itemization_items", n + 1, None);
-  let mut attr: HashMap<String, Stored> = HashMap::new();
+  let mut attr: HashMap<String, Stored> = HashMap::default();
   if n > 0 {
     if let Some(sep) = state.lookup_dimension("\\itemsep") {
       let default_opt = state.lookup_dimension("\\lx@default@itemsep");

--- a/rtx_core/src/binding/def/dialect.rs
+++ b/rtx_core/src/binding/def/dialect.rs
@@ -1,6 +1,7 @@
 use lazy_static::lazy_static;
 use std::borrow::{Borrow, Cow};
 use std::sync::Arc;
+use rustc_hash::{FxHashMap as HashMap};
 
 use regex::Regex;
 
@@ -422,7 +423,7 @@ pub fn def_math_dual(cs: Token, paramlist: Option<Parameters>, presentation: Str
   let nargs = paramlist.as_ref().map(|pl| pl.get_parameters().len()).unwrap_or(0);
   let content_closure : ReplacementClosure = if nargs == 0 {
     Arc::new(|document, _args, props, state| {
-      let mut attrs = HashMap::new();
+      let mut attrs = HashMap::default();
       for key in ["role", "scriptpos", "stretchy"] {
         if let Some(v) = props.get(key) {
           attrs.insert(key.to_owned(), v.to_string());
@@ -438,14 +439,14 @@ pub fn def_math_dual(cs: Token, paramlist: Option<Parameters>, presentation: Str
     })
   } else {
     Arc::new(|document, args, props, state| {
-      let mut app_attrs = HashMap::new();
+      let mut app_attrs = HashMap::default();
       for key in ["role", "scriptpos"] {
         if let Some(v) = props.get(key) {
           app_attrs.insert(key.to_owned(), v.to_string());
         }
       }
       document.open_element("ltx:XMApp", Some(app_attrs), None, state)?;
-      let mut op_attrs = HashMap::new();
+      let mut op_attrs = HashMap::default();
       if let Some(v) = props.get("operator_stretchy") {
         op_attrs.insert("stretchy".to_owned(), v.to_string());
       }
@@ -568,7 +569,7 @@ pub fn def_math_constructor(cs: Token, paramlist: Option<Parameters>, presentati
   let compiled_replacement: Option<ReplacementClosure> = Some(if nargs == 0 {
     // If trivial presentation, allow it in Text
     Arc::new(move |document: &mut Document, _, props: &HashMap<String, Stored>, state: &mut State| {
-      let mut attrs = HashMap::new();
+      let mut attrs = HashMap::default();
       for key in ["role", "scriptpos", "stretchy"] {
         if let Some(v) = props.get(key) {
           attrs.insert(key.to_owned(), v.to_string());
@@ -597,7 +598,7 @@ pub fn def_math_constructor(cs: Token, paramlist: Option<Parameters>, presentati
     })
   } else {
     Arc::new(move |document: &mut Document, args: &Vec<Option<Digested>>, props: &HashMap<String, Stored>, state: &mut State| {
-      let mut attrs = HashMap::new();
+      let mut attrs = HashMap::default();
       for key in ["role", "scriptpos", "stretchy"] {
         if let Some(v) = props.get(key) {
           attrs.insert(key.to_owned(), v.to_string());
@@ -615,7 +616,7 @@ pub fn def_math_constructor(cs: Token, paramlist: Option<Parameters>, presentati
         document.open_element("ltx:XMApp", Some(attrs), None, state)?;
       }
       // operator
-      let mut op_attrs = HashMap::new();
+      let mut op_attrs = HashMap::default();
       if let Some(role) = props.get("operator_role") {
         op_attrs.insert(String::from("role"), role.to_string());
       }
@@ -651,7 +652,7 @@ pub fn def_math_constructor(cs: Token, paramlist: Option<Parameters>, presentati
     })
   });
   let sizer: Option<SizingClosure> = Some(Arc::new(move |_, state| {
-    Ok(Font::math_default().compute_string_size(&presentation_for_sizer, HashMap::new(), state))
+    Ok(Font::math_default().compute_string_size(&presentation_for_sizer, HashMap::default(), state))
   }));
 
   // let mut prop_options = options.clone();
@@ -1024,7 +1025,7 @@ type ArgsUnpacked = Vec<Option<Tokens>>;
 // UNLESS they are hidden, in which case they'll be on the content side.
 // So, how do we know if they're hidden? We'll scan the presentation for #\d, that's how!
 pub fn dualize_arglist(presentation: &str, args: Vec<Option<Tokens>>, gullet: &mut Gullet, state: &mut State) -> Result<(ArgsUnpacked,ArgsUnpacked)> {
-  let mut used = HashMap::new();
+  let mut used = HashMap::default();
   for cap in ARG_HOLE.captures_iter(presentation) {  // Get the args that were actually used!
     let argi = cap.get(1).unwrap().as_str();
     let entry = used.entry(argi.parse::<usize>()?).or_insert(0);
@@ -1103,7 +1104,7 @@ pub fn def_math(cs: Token, paramlist: Option<Parameters>, presentation: String, 
 
   // If single character, handle with a rewrite rule
   if csname.len() == 1 {
-    let mut math_attr_hash: HashMap<String, String> = HashMap::new();
+    let mut math_attr_hash: HashMap<String, String> = HashMap::default();
     transfer_opt_default!(name, options, math_attr_hash);
     transfer_opt_default!(meaning, options, math_attr_hash);
     transfer_opt_default!(omcd, options, math_attr_hash);

--- a/rtx_core/src/binding/def/traits.rs
+++ b/rtx_core/src/binding/def/traits.rs
@@ -1,6 +1,7 @@
 ///! A variety of traits helpful for auto-casting between the different components of the conversion toolchain
 use std::borrow::Cow;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{VecDeque};
+use rustc_hash::{FxHashMap as HashMap};
 use std::sync::Arc;
 
 use crate::common::dimension::Dimension;
@@ -108,7 +109,7 @@ impl IntoOption<Option<SizingClosure>> for &str {
     } else if let Some(stripped) = self.strip_prefix('#') {
       let arg = stripped.parse::<usize>().unwrap_or(1);
       Some(Arc::new(move |w, state| match w.get_arg(arg) {
-        Some(arg) => arg.compute_size(HashMap::new(), state),
+        Some(arg) => arg.compute_size(HashMap::default(), state),
         None => Ok((Dimension::default(), Dimension::default(), Dimension::default())),
       }))
     } else if self.is_empty() || self == "0" {
@@ -127,7 +128,7 @@ impl IntoOption<Option<SizingClosure>> for &str {
             text: sized_data.clone(),
             ..Tbox::default()
           })],
-          HashMap::new(),
+          HashMap::default(),
           state,
         )
       }))

--- a/rtx_core/src/comment.rs
+++ b/rtx_core/src/comment.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 use std::fmt;
 use libxml::tree::Node;
 

--- a/rtx_core/src/common/error.rs
+++ b/rtx_core/src/common/error.rs
@@ -1,5 +1,5 @@
 use lazy_static::lazy_static;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 use std::error::Error as ErrorTrait;
 use std::fmt;
 use std::io;
@@ -7,7 +7,7 @@ use std::num::{ParseFloatError, ParseIntError};
 use std::result;
 
 lazy_static! {
-  static ref _NOTE_TIMERS: HashMap<String, String> = HashMap::new();
+  static ref _NOTE_TIMERS: HashMap<String, String> = HashMap::default();
 }
 
 #[macro_export]

--- a/rtx_core/src/common/font.rs
+++ b/rtx_core/src/common/font.rs
@@ -16,7 +16,7 @@ use regex::Regex;
 use std::borrow::Cow;
 use std::cmp::max;
 use std::collections::hash_map::DefaultHasher;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
@@ -704,7 +704,7 @@ impl Font {
       diffs.push(shape);
       font_properties.shape = self.shape.clone();
     }
-    let mut result = HashMap::new();
+    let mut result = HashMap::default();
 
     if !diffs.is_empty() {
       let font_value = diffs.join(" ");

--- a/rtx_core/src/common/font.rs
+++ b/rtx_core/src/common/font.rs
@@ -15,10 +15,9 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use std::borrow::Cow;
 use std::cmp::max;
-use std::collections::hash_map::DefaultHasher;
+use std::hash::{BuildHasher, Hasher, Hash};
 use rustc_hash::{FxHashMap as HashMap};
 use std::fmt;
-use std::hash::{Hash, Hasher};
 
 mod standard_metrics;
 use standard_metrics::{MetricData, STDMETRICS};
@@ -376,9 +375,10 @@ impl Font {
   }
 
   pub fn to_hashable(&self) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    Hash::hash(self, &mut hasher);
-    hasher.finish()
+    let s = std::collections::hash_map::RandomState::new();
+    let mut new_s = s.build_hasher();
+    Hash::hash(self, &mut new_s);
+    new_s.finish()
   }
 
   // pub fn stringify(&self) -> String {

--- a/rtx_core/src/common/font/standard_metrics.rs
+++ b/rtx_core/src/common/font/standard_metrics.rs
@@ -1,5 +1,5 @@
 use lazy_static::lazy_static;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 
 pub struct MetricData {
   pub file: &'static str,
@@ -29,9 +29,9 @@ impl Default for MetricData {
       quad: 0.0,
       extraspace: 0.0,
       exheight: 0.0,
-      ligatures: HashMap::new(),
-      sizes: HashMap::new(),
-      kerns: HashMap::new(),
+      ligatures: HashMap::default(),
+      sizes: HashMap::default(),
+      kerns: HashMap::default(),
       slant: 0.0,
     }
   }

--- a/rtx_core/src/common/model.rs
+++ b/rtx_core/src/common/model.rs
@@ -1,8 +1,7 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::borrow::Cow;
-use std::collections::{HashSet};
-use rustc_hash::{FxHashMap as HashMap};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::fs::File;
 use std::io::BufRead;
 use std::io::BufReader;
@@ -534,7 +533,7 @@ impl Model {
       } else if let Some(caps) = CLASS_MODEL_LINE.captures(&line) {
         let classname = caps.get(1).map_or("", |m| m.as_str());
         let elements = caps.get(2).map_or("", |m| m.as_str());
-        let mut class_set = HashSet::new();
+        let mut class_set = HashSet::default();
         for set_element in elements.split(',').collect::<Vec<&str>>() {
           class_set.insert(set_element.to_owned());
         }

--- a/rtx_core/src/common/model.rs
+++ b/rtx_core/src/common/model.rs
@@ -1,7 +1,8 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashSet};
+use rustc_hash::{FxHashMap as HashMap};
 use std::fs::File;
 use std::io::BufRead;
 use std::io::BufReader;
@@ -159,7 +160,7 @@ impl Model {
   pub fn describe_model(&self) {}
 
   pub fn get_xpath<'o>(&'o self, document: &'o XmlDoc) -> XPath {
-    let mut context = XPath::new(document, HashMap::new());
+    let mut context = XPath::new(document, HashMap::default());
     for (prefix, ns) in &self.code_namespaces {
       // TODO: Is this too slow? We may need to store an active context in the State as an
       // alternative

--- a/rtx_core/src/common/relaxng.rs
+++ b/rtx_core/src/common/relaxng.rs
@@ -1,6 +1,6 @@
 ///! Extract Model information from a RelaxNG schema
 use crate::document::Document;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 /// an internal representation for a RelaxNG schema
 pub struct Relaxng {
   /// the schema name
@@ -22,9 +22,9 @@ impl Default for Relaxng {
     Relaxng {
       name: s!("LaTeXML"),
       modules: Vec::new(),
-      elementdefs: HashMap::new(),
-      defs: HashMap::new(),
-      elements: HashMap::new(),
+      elementdefs: HashMap::default(),
+      defs: HashMap::default(),
+      elements: HashMap::default(),
       internal_grammars: 0,
     }
   }
@@ -32,7 +32,7 @@ impl Default for Relaxng {
 impl Relaxng {
   /// declare the schema on a given `Document`
   pub fn add_schema_declaration(&self, document: &mut Document) {
-    let mut attributes = HashMap::new();
+    let mut attributes = HashMap::default();
     if self.name != "DTD" {
       // provisions for phasing out DTD
       attributes.insert(s!("RelaxNGSchema"), self.name.clone());

--- a/rtx_core/src/common/store.rs
+++ b/rtx_core/src/common/store.rs
@@ -1,6 +1,7 @@
 use libxml::tree::Node;
 use std::borrow::Cow;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{VecDeque};
+use rustc_hash::{FxHashMap as HashMap};
 use std::fmt;
 use std::sync::{Arc, RwLock};
 
@@ -517,7 +518,7 @@ unsafe impl Sync for Stored {}
 impl Stored {
   /// helper method that uses `ToString::to_string` to flatten a map with Stored values
   pub fn cast_to_string_hash(in_map: &HashMap<String, Stored>) -> HashMap<String, String> {
-    let mut out_map: HashMap<String, String> = HashMap::new();
+    let mut out_map: HashMap<String, String> = HashMap::default();
     for (key, val) in in_map.iter() {
       out_map.insert(key.to_owned(), val.to_string());
     }

--- a/rtx_core/src/common/xml.rs
+++ b/rtx_core/src/common/xml.rs
@@ -1,6 +1,6 @@
 use libxml::tree::{Document, Node, NodeType};
 use libxml::xpath::Context;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 
 pub const XMLNS_NS: &str = "http://www.w3.org/2000/xmlns/";
 pub const XML_NS: &str = "http://www.w3.org/XML/1998/namespace";

--- a/rtx_core/src/definition.rs
+++ b/rtx_core/src/definition.rs
@@ -8,7 +8,7 @@ pub mod primitive;
 pub mod register;
 
 use std::borrow::Cow;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 use std::fmt;
 use std::sync::Arc;
 use libxml::tree::Node;

--- a/rtx_core/src/definition/constructor.rs
+++ b/rtx_core/src/definition/constructor.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 use std::fmt;
 use std::sync::Arc;
 use libxml::tree::Node;
@@ -84,7 +84,7 @@ impl Default for ConstructorOptions {
       // environment-specific
       require_math: false,
       forbid_math: false,
-      properties: Arc::new(|_stomach, _whatsit, _state| Ok(HashMap::new())),
+      properties: Arc::new(|_stomach, _whatsit, _state| Ok(HashMap::default())),
       capture_body: false,
       font: None,
       after_digest_begin: vec![],
@@ -157,7 +157,7 @@ impl Default for Constructor {
       after_digest: vec![],
       before_construct: vec![],
       after_construct: vec![],
-      properties: Arc::new(|_stomach, _whatsit, _state| Ok(HashMap::new())),
+      properties: Arc::new(|_stomach, _whatsit, _state| Ok(HashMap::default())),
       capture_body: false,
       after_digest_body: vec![],
       reversion: None,

--- a/rtx_core/src/definition/math_primitive.rs
+++ b/rtx_core/src/definition/math_primitive.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 use libxml::tree::Node;
 
 use crate::common::error::*;
@@ -126,7 +126,7 @@ impl PartialEq for MathPrimitiveOptions {
 
 impl MathPrimitiveOptions {
   pub fn to_hash_stored(&self) -> HashMap<String, Stored> {
-    let mut h = HashMap::new();
+    let mut h = HashMap::default();
     if let Some(ref meaning) = self.meaning {
       h.insert("meaning".to_string(), meaning.into());
     }

--- a/rtx_core/src/document.rs
+++ b/rtx_core/src/document.rs
@@ -10,7 +10,8 @@ use regex::Regex;
 
 use std::borrow::Cow;
 use std::collections::HashSet;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{VecDeque};
+use rustc_hash::{FxHashMap as HashMap};
 use std::fmt::Write as _;
 use std::sync::Arc;
 
@@ -95,10 +96,10 @@ impl Document {
     Document {
       document: doc_scaffold,
       node: root,
-      node_boxes: HashMap::new(),
-      node_fonts: HashMap::new(),
-      idstore: HashMap::new(),
-      rewrite_labels: HashMap::new(),
+      node_boxes: HashMap::default(),
+      node_fonts: HashMap::default(),
+      idstore: HashMap::default(),
+      rewrite_labels: HashMap::default(),
       pending: Vec::new(),
       localized_constructed_nodes: Vec::new(),
       constructed_nodes: Vec::new(),
@@ -215,7 +216,7 @@ impl Document {
 
     let mut keys_to_remove: Vec<String> = Vec::new();
     let mut attrs_to_set: Vec<(String, String)> = Vec::new();
-    let mut pending_declaration = HashMap::new();
+    let mut pending_declaration = HashMap::default();
 
     if self.has_node_font(node) {
       let desired_font = self.get_node_font(node);
@@ -443,10 +444,10 @@ impl Document {
       };
       if let Some(font_math) = font_math_opt {
         Ok(Some(
-          self.insert_math_token(object, HashMap::new(), Some(&font_math), state)?))
+          self.insert_math_token(object, HashMap::default(), Some(&font_math), state)?))
       } else {
         Ok(Some(
-        self.insert_math_token(object, HashMap::new(), None, state)?))
+        self.insert_math_token(object, HashMap::default(), None, state)?))
       }
     }
   }
@@ -2446,7 +2447,7 @@ impl Document {
     // Expand any document fragments
     let new_children = new_children.into_iter().flat_map(|child| if child.get_type() == Some(NodeType::DocumentFragNode) {  child.get_child_nodes() } else { vec![child] } ).collect::<Vec<Node>>();
     // Now find all xml:id's in the new_children and record replacement id's for them
-    let mut id_map = HashMap::new();
+    let mut id_map = HashMap::default();
     // Find all id's defined in the copy and change the id.
     for child in new_children.iter() {
       for id in self.findvalues(".//@xml:id", Some(child), state) {
@@ -2588,7 +2589,7 @@ impl Document {
   pub fn add_resource(&mut self, resource: Resource, state: &mut State) -> Result<()> {
     // let savenode_opt = self.float_to_element("ltx:resource", false);
     let savenode_opt = None;
-    let mut attrib: HashMap<String, String> = HashMap::new();
+    let mut attrib: HashMap<String, String> = HashMap::default();
     attrib.insert(s!("src"), resource.name);
     attrib.insert(s!("type"), resource.mimetype);
     attrib.insert(s!("media"), resource.media);
@@ -2842,7 +2843,7 @@ impl Document {
       match child.get_type() {
         Some(NodeType::ElementNode) => {
           let tag = self.get_node_qname(&child, state);
-          let attributes = child.get_attributes(); // map { $_->nodeType == XML_ATTRIBUTE_NODE ? ($self->getNodeQName($_) => $_->getValue) : () }
+          let attributes = child.get_attributes().into_iter().collect(); // map { $_->nodeType == XML_ATTRIBUTE_NODE ? ($self->getNodeQName($_) => $_->getValue) : () }
                                                    // TODO:
                                                    // DANGER: REMOVE the xml:id attribute from $child!!!!
                                                    // This protects against some versions of XML::LibXML that warn against duplicate id's

--- a/rtx_core/src/document/tag.rs
+++ b/rtx_core/src/document/tag.rs
@@ -1,5 +1,5 @@
 use libxml::tree::Node;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 use std::sync::Arc;
 
 use crate::common::error::*;

--- a/rtx_core/src/gullet.rs
+++ b/rtx_core/src/gullet.rs
@@ -1,7 +1,8 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::borrow::Cow;
-use std::collections::{HashSet, VecDeque};
+use std::collections::{VecDeque};
+use rustc_hash::FxHashSet as HashSet;
 use std::mem;
 use std::sync::Arc;
 

--- a/rtx_core/src/keyval.rs
+++ b/rtx_core/src/keyval.rs
@@ -1,5 +1,5 @@
 // use std::borrow::Cow;
-// use std::collections::HashMap;
+// use rustc_hash::{FxHashMap as HashMap};
 // use std::fmt;
 use std::sync::Arc;
 

--- a/rtx_core/src/keyvals.rs
+++ b/rtx_core/src/keyvals.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 use std::borrow::Cow;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 use std::fmt;
 use libxml::tree::Node;
 
@@ -58,7 +58,7 @@ impl Default for KeyVals {
       hook_missing: None,
       tuples: Vec::new(),
       cached_pairs: Vec::new(),
-      cached_hash: HashMap::new(),
+      cached_hash: HashMap::default(),
       punct: Vec::new(),
       assign: Vec::new(),
     }
@@ -413,7 +413,7 @@ impl KeyVals {
     // the new data structures to create
     let mut newtuples: Vec<KVTuple> = Vec::new();
     let mut pairs = Vec::new();
-    let mut hash: HashMap<String, Vec<Stored>> = HashMap::new();
+    let mut hash: HashMap<String, Vec<Stored>> = HashMap::default();
 
     for tuple in &self.tuples {
       // take all the elements we need from the stack
@@ -571,7 +571,7 @@ impl KeyVals {
 
   // returns a key => ToString(value)
   pub fn get_hash(&self) -> HashMap<String, String> {
-    let mut hashed = HashMap::new();
+    let mut hashed = HashMap::default();
     for (k, v) in &self.cached_hash {
       hashed.insert(k.to_string(), v.iter().map(ToString::to_string).collect::<Vec<String>>().join(""));
     }

--- a/rtx_core/src/lib.rs
+++ b/rtx_core/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 
 #![allow(missing_docs)]
+extern crate rustc_hash;
 
 /// Auxiliary macros
 #[macro_use]
@@ -52,7 +53,7 @@ pub mod util;
 pub mod whatsit;
 
 use std::borrow::Cow;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 use std::fmt;
 use std::sync::{Arc, RwLock}; //,RwLockReadGuard,RwLockWriteGuard};
                               //use lazy_static::lazy_static;

--- a/rtx_core/src/list.rs
+++ b/rtx_core/src/list.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 use std::fmt;
 use libxml::tree::Node;
 
@@ -111,7 +111,7 @@ impl List {
       font,
       mode: None,
       locator,
-      properties: HashMap::new(),
+      properties: HashMap::default(),
     }
   }
 

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -1,8 +1,8 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::borrow::Cow;
-use std::collections::{HashSet, VecDeque};
-use rustc_hash::{FxHashMap as HashMap};
+use std::collections::{VecDeque};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::fmt::{self, Display};
 use std::sync::{Arc, RwLock};
 
@@ -1605,7 +1605,7 @@ impl State {
   pub fn compute_indirect_model(&mut self) -> IndirectModel {
     let mut imodel: IndirectModel = HashMap::default();
     // Determine any indirect paths to each descendent via an `autoOpen-able' tag.
-    let mut openable: HashSet<String> = HashSet::new();
+    let mut openable: HashSet<String> = HashSet::default();
     for tag in self.model.get_tags() {
       if let Some(x) = self.tag_properties.get(&tag) {
         if let Some(true) = x.auto_open {

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -1,7 +1,8 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashSet, VecDeque};
+use rustc_hash::{FxHashMap as HashMap};
 use std::fmt::{self, Display};
 use std::sync::{Arc, RwLock};
 
@@ -279,25 +280,25 @@ impl Default for State {
 
     State {
       // Tables
-      value: HashMap::new(),
-      meaning: HashMap::new(),
-      stash: HashMap::new(),
-      stash_active: HashMap::new(),
-      catcode: HashMap::new(),
-      mathcode: HashMap::new(),
-      sfcode: HashMap::new(),
-      lccode: HashMap::new(),
-      uccode: HashMap::new(),
-      delcode: HashMap::new(),
+      value: HashMap::default(),
+      meaning: HashMap::default(),
+      stash: HashMap::default(),
+      stash_active: HashMap::default(),
+      catcode: HashMap::default(),
+      mathcode: HashMap::default(),
+      sfcode: HashMap::default(),
+      lccode: HashMap::default(),
+      uccode: HashMap::default(),
+      delcode: HashMap::default(),
       // Table bookkeeping
       undo: undo_vdq,
       // Stateful runtime - data structures
       model: Model::default(),
       document: None,
-      prefixes: HashMap::new(),
-      status: RwLock::new(HashMap::new()),
+      prefixes: HashMap::default(),
+      status: RwLock::new(HashMap::default()),
       map: Vec::new(),
-      tag_properties: HashMap::new(),
+      tag_properties: HashMap::default(),
       indirect_model: None,
       pending_resources: Vec::new(),
       // Stateful runtime - simple fields
@@ -354,7 +355,7 @@ impl State {
       Some(cp) => cp,
     };
 
-    let mut catcodes: HashMap<char, Catcode> = HashMap::new();
+    let mut catcodes: HashMap<char, Catcode> = HashMap::default();
     match catcode_profile {
       Catcodes::Standard | Catcodes::Style => {
         catcodes.insert('\\', ESCAPE);
@@ -382,12 +383,12 @@ impl State {
       catcodes.insert('@', LETTER);
     }
 
-    let mut value_table = HashMap::new();
+    let mut value_table = HashMap::default();
     let mut specials_vdq = VecDeque::new();
     specials_vdq.push_front(Stored::VecChar(vec!['^', '_', '~', '&', '$', '#', '\'']));
     value_table.insert(s!("SPECIALS"), specials_vdq);
 
-    let mut catcodes_typed: Table = HashMap::new();
+    let mut catcodes_typed: Table = HashMap::default();
     for (k, v) in catcodes {
       let mut vdq = VecDeque::new();
       vdq.push_front(Stored::Catcode(v));
@@ -910,10 +911,10 @@ impl State {
 
   pub fn assign_mapping<T: Into<Stored>>(&mut self, map: &str, key: &str, value: Option<T>) {
     if !self.value.contains_key(map) || self.value[map].is_empty() {
-      self.assign_internal(TableName::Value, map, Stored::HashStored(HashMap::new()), Some(Scope::Global));
+      self.assign_internal(TableName::Value, map, Stored::HashStored(HashMap::default()), Some(Scope::Global));
     }
     let map_store = self.value.get_mut(map).unwrap();
-    let mut stub_hash = HashMap::new(); // TODO: What is the right abstraction here? this is hacky
+    let mut stub_hash = HashMap::default(); // TODO: What is the right abstraction here? this is hacky
     let mapping = match *map_store.front_mut().unwrap() {
       Stored::HashStored(ref mut mapping) => mapping,
       _ => &mut stub_hash,
@@ -1401,7 +1402,7 @@ impl State {
     }
   }
 
-  pub fn clear_prefixes(&mut self) { self.prefixes = HashMap::new(); }
+  pub fn clear_prefixes(&mut self) { self.prefixes = HashMap::default(); }
 
   // #======================================================================
 
@@ -1602,7 +1603,7 @@ impl State {
   /// [Thus it should NOT be modifying the Model object, which may cover several documents in `]
   /// $imodel{$tag}{$child} => $open means if in $tag, to open $child, we must first open $open
   pub fn compute_indirect_model(&mut self) -> IndirectModel {
-    let mut imodel: IndirectModel = HashMap::new();
+    let mut imodel: IndirectModel = HashMap::default();
     // Determine any indirect paths to each descendent via an `autoOpen-able' tag.
     let mut openable: HashSet<String> = HashSet::new();
     for tag in self.model.get_tags() {
@@ -1614,7 +1615,7 @@ impl State {
     }
 
     for tag in self.model.get_tags() {
-      let mut desc: HashMap<String, HashMap<String, usize>> = HashMap::new();
+      let mut desc: HashMap<String, HashMap<String, usize>> = HashMap::default();
       {
         self.compute_indirect_model_aux(&tag, None, 1, &mut openable, &mut desc);
       }
@@ -1625,20 +1626,20 @@ impl State {
         let mut best = 0; // Find best path to $kid.
         let mut desc_kid_keys: Vec<String> = desc
           .entry(kid.to_owned())
-          .or_insert_with(HashMap::new)
+          .or_insert_with(HashMap::default)
           .keys()
           .map(ToString::to_string)
           .collect();
         desc_kid_keys.sort();
         for start in desc_kid_keys {
           let start_entry = {
-            let kid_entry = desc.entry(kid.to_owned()).or_insert_with(HashMap::new);
+            let kid_entry = desc.entry(kid.to_owned()).or_insert_with(HashMap::default);
             *kid_entry.entry(start.to_owned()).or_insert(0)
           };
           if start_entry > best {
             imodel
               .entry(tag.to_owned())
-              .or_insert_with(HashMap::new)
+              .or_insert_with(HashMap::default)
               .insert(kid.to_owned(), start.to_owned());
             {
               best = desc[&kid][&start];
@@ -1652,7 +1653,7 @@ impl State {
       // !!! Alarm!!!
       imodel
         .entry(s!("#Document"))
-        .or_insert_with(HashMap::new)
+        .or_insert_with(HashMap::default)
         .insert(s!("#PCDATA"), s!("ltx:p"));
     }
 
@@ -1678,12 +1679,12 @@ impl State {
     let tag_contents: Vec<String> = self.model.get_tag_contents(tag).iter().map(ToString::to_string).collect();
 
     for kid in tag_contents {
-      if desc.entry(kid.clone()).or_insert_with(HashMap::new).contains_key(&start) {
+      if desc.entry(kid.clone()).or_insert_with(HashMap::default).contains_key(&start) {
         continue;
       } // Already solved
 
       if !start.is_empty() {
-        desc.entry(kid.clone()).or_insert_with(HashMap::new).insert(start.clone(), desirability);
+        desc.entry(kid.clone()).or_insert_with(HashMap::default).insert(start.clone(), desirability);
       }
 
       if kid != "#PCDATA" && openable.contains(&kid) {

--- a/rtx_core/src/stomach.rs
+++ b/rtx_core/src/stomach.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{VecDeque};
+use rustc_hash::{FxHashMap as HashMap};
 use std::sync::Arc;
 
 use crate::common::error::*;
@@ -350,7 +351,7 @@ impl<'t> Stomach {
             font,
             self.gullet.get_locator().map(|l| l.into_owned()),
             Tokens!(meaning),
-            HashMap::new(),
+            HashMap::default(),
             state,
           ))))
         }
@@ -371,7 +372,7 @@ impl<'t> Stomach {
           None,
           None,             // locator
           Tokens!(meaning), // tokens
-          HashMap::new(),   // properties
+          HashMap::default(),   // properties
           state,
         ))))
       },

--- a/rtx_core/src/tbox.rs
+++ b/rtx_core/src/tbox.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 use std::fmt;
 use std::sync::Arc;
 use libxml::tree::Node;
@@ -32,7 +32,7 @@ impl Default for Tbox {
       text: String::new(),
       font: Arc::new(Font::text_default()),
       locator: Locator::default(),
-      properties: HashMap::new(),
+      properties: HashMap::default(),
       tokens: Tokens!(),
     }
   }

--- a/rtx_core/src/whatsit.rs
+++ b/rtx_core/src/whatsit.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 // use std::cell::RefCell;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{VecDeque};
+use rustc_hash::{FxHashMap as HashMap};
 use std::fmt;
 use std::sync::Arc;
 use libxml::tree::Node;
@@ -44,7 +45,7 @@ impl Default for Whatsit {
   fn default() -> Self {
     Whatsit {
       args: Vec::new(),
-      properties: HashMap::new(),
+      properties: HashMap::default(),
       definition: Arc::new(Expandable::default()),
       reversion: None,
       dual_reversion: None,

--- a/rtx_core/tests/00_unit_state.rs
+++ b/rtx_core/tests/00_unit_state.rs
@@ -5,7 +5,8 @@ use rtx_core::token::{Catcode, Token};
 use rtx_core::tokens::Tokens;
 use rtx_core::{s, Explode, T_CS, T_OTHER, T_SPACE};
 use std::borrow::Cow;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{VecDeque};
+use rustc_hash::{FxHashMap as HashMap};
 
 #[test]
 fn basic_state_init() {
@@ -40,7 +41,7 @@ fn assign_lookup_value() {
     Some(_) => panic!("Looked up value of STRICT didn't match assigned value"),
   };
 
-  let mut hash_val = HashMap::new();
+  let mut hash_val = HashMap::default();
   hash_val.insert(s!("a"), Stored::Bool(true));
   let hash_store = Stored::HashStored(hash_val);
 

--- a/rtx_math_parser/Cargo.toml
+++ b/rtx_math_parser/Cargo.toml
@@ -15,4 +15,5 @@ regex = "1.7.1"
 log = "0.4"
 marpa = { git = "https://github.com/dginev/marpa", branch = "abstract_syntax_forests" }
 lazy_static = "1.4"
+rustc-hash = "1.1.0"
 rtx_core = { path= "../rtx_core" }

--- a/rtx_math_parser/src/lib.rs
+++ b/rtx_math_parser/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate rustc_hash;
+
 #[macro_use]
 mod grammar;
 mod data;

--- a/rtx_math_parser/src/parser.rs
+++ b/rtx_math_parser/src/parser.rs
@@ -2,7 +2,7 @@ use lazy_static::lazy_static;
 use libxml::tree::{Node, NodeType};
 use regex::Regex;
 use std::borrow::Cow;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 use std::io::Cursor;
 
 use rtx_core::common::error::{note_begin, note_end, note_progress, Result};
@@ -72,12 +72,12 @@ impl Default for MathParser {
       builder,
       expert_pragmatics: ValidationPragmatics::expert_defaults(),
       student_pragmatics: ValidationPragmatics::student_defaults(),
-      passed: HashMap::new(),
-      failed: HashMap::new(),
-      unknowns: HashMap::new(),
-      maybe_functions: HashMap::new(),
-      // punctuation: HashMap::new(),
-      // lostnodes: HashMap::new(),
+      passed: HashMap::default(),
+      failed: HashMap::default(),
+      unknowns: HashMap::default(),
+      maybe_functions: HashMap::default(),
+      // punctuation: HashMap::default(),
+      // lostnodes: HashMap::default(),
       // idrefs: Vec::new(),
       n_parsed: 0,
       // strict: true,
@@ -180,8 +180,8 @@ impl MathParser {
   pub fn clear(&mut self) {
     self.passed = map!("ltx:XMath" => 0, "ltx:XMArg" => 0, "ltx:XMWrap" => 0);
     self.failed = map!("ltx:XMath" => 0, "ltx:XMArg" => 0, "ltx:XMWrap" => 0 );
-    self.unknowns = HashMap::new();
-    self.maybe_functions = HashMap::new();
+    self.unknowns = HashMap::default();
+    self.maybe_functions = HashMap::default();
     self.n_parsed = 0;
   }
   // our %EXCLUDED_PRETTYNAME_ATTRIBUTES = (fontsize => 1, opacity => 1);

--- a/rtx_math_parser/src/pragmatics.rs
+++ b/rtx_math_parser/src/pragmatics.rs
@@ -1,5 +1,5 @@
 use lazy_static::lazy_static;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 use std::error::Error;
 
 use crate::semantics::{Operator, XM};
@@ -555,7 +555,7 @@ lazy_static! {
   static ref PRAGMATIC_BLOCK_MAP : HashMap<char, String> = {
     // generally, we can observe that the latin alphabet shares "intent" in blocks of 3 letter in mathematics,
     // as a fast-and-loose rule of thumb. a-e is an exception as a rather stable 5 letter block with shared utility.
-    let mut map = HashMap::new();
+    let mut map = HashMap::default();
     // |a b c d e | f g h |i j k| |l m n| |o p q| |r s t| |u v w| |x y z|
     let latin_blocks = [('a','e'),('f','h'),('i','k'),('l','n'),('o','q'),('r','t'),('u','w'),('x','z')];
     // |α β γ| δ | ϵ | ζ η θ | ι κ | λ μ ν ξ | ο π ρ | σ τ υ | ϕ χ ψ | ω

--- a/rtx_math_parser/src/semantics.rs
+++ b/rtx_math_parser/src/semantics.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 use std::error::Error;
 use std::sync::Arc;
 

--- a/rtx_math_parser/src/semantics/curry.rs
+++ b/rtx_math_parser/src/semantics/curry.rs
@@ -2,7 +2,7 @@
 // use minilp::{ComparisonOp, Variable};
 // use quote::ToTokens;
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 use std::collections::HashSet;
 use std::fmt::{self, Display};
 
@@ -263,7 +263,7 @@ impl CurryConstraint {
   //     },
   //     Ordering::Equal => ComparisonOp::Eq,
   //   };
-  //   let mut var_values: HashMap<&String, f64> = HashMap::new();
+  //   let mut var_values: HashMap<&String, f64> = HashMap::default();
 
   //   lhs.to_minilp(&mut var_values, &mut rhs_minilp, false);
 

--- a/rtx_math_parser/src/semantics/curry.rs
+++ b/rtx_math_parser/src/semantics/curry.rs
@@ -2,8 +2,7 @@
 // use minilp::{ComparisonOp, Variable};
 // use quote::ToTokens;
 use std::cmp::Ordering;
-use rustc_hash::{FxHashMap as HashMap};
-use std::collections::HashSet;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::fmt::{self, Display};
 
 /// A CurryConstraint is a simple linear constraint between named variables and literals
@@ -277,7 +276,7 @@ impl Default for CurryConstraints {
 }
 
 impl CurryConstraints {
-  pub fn new() -> Self { CurryConstraints(HashSet::new()) }
+  pub fn new() -> Self { CurryConstraints(HashSet::default()) }
   pub fn insert(&mut self, value: CurryConstraint) -> bool { self.0.insert(value.simplify()) }
   pub fn iter(&self) -> std::collections::hash_set::Iter<CurryConstraint> { self.0.iter() }
 

--- a/rtx_math_parser/src/semantics/tree.rs
+++ b/rtx_math_parser/src/semantics/tree.rs
@@ -6,7 +6,7 @@ use rtx_core::state::State;
 use rtx_core::Info;
 use std::borrow::Cow;
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 use std::error::Error;
 use std::fmt;
 use std::fmt::Display;
@@ -57,7 +57,7 @@ impl XProps {
   /// Consumes the `XProps` and returns the (content, font, attributes) in an arrangement suitable for using
   /// the `Document` methods
   pub fn into_attributes(mut self) -> XAttributes {
-    let mut attrs = HashMap::new();
+    let mut attrs = HashMap::default();
     if let Some(role) = self.role.take() {
       attrs.insert(String::from("role"), role.into_owned());
     }

--- a/rtx_package/Cargo.toml
+++ b/rtx_package/Cargo.toml
@@ -19,5 +19,6 @@ log = "0.4"
 libxml = "0.3.2"
 chrono = "0.4"
 unicode-normalization = "0.1.7"
+rustc-hash="1.1.0"
 rtx_codegen = {path = "../rtx_codegen"}
 rtx_core = {path = "../rtx_core"}

--- a/rtx_package/src/macros.rs
+++ b/rtx_package/src/macros.rs
@@ -85,7 +85,7 @@ macro_rules! load_model {
   ($var:expr, $name:expr) => {{
     use rtx_core::common::model::Model;
     use rtx_core::common::relaxng::Relaxng;
-    use std::collections::HashSet;
+    use rustc_hash::FxHashSet as HashSet;
     use std::iter::FromIterator;
     // use rtx_core::common::model::IndirectModel;
     #[derive(LoadModel)]

--- a/rtx_package/src/package.rs
+++ b/rtx_package/src/package.rs
@@ -4,7 +4,7 @@ pub use libxml::tree::{Namespace, Node};
 pub use log;
 pub use regex::Regex;
 pub use std::borrow::Cow;
-pub use std::collections::HashMap;
+pub use rustc_hash::{FxHashMap as HashMap};
 pub use std::collections::VecDeque;
 pub use std::sync::{Arc, RwLock};
 

--- a/rtx_package/src/package/latex_ch11_moving_information.rs
+++ b/rtx_package/src/package/latex_ch11_moving_information.rs
@@ -18,7 +18,7 @@ LoadDefinitions!(outer_stomach, outer_state, {
   // Note that latex essentially allows redundant labels, but we can record only one!!!
   DefConstructor!("\\label Semiverbatim", sub[document, _olabel, props, state] {
     if let Some(savenode) = document.float_to_label(state) {
-      let mut labels : HashMap<String,bool> = HashMap::new();
+      let mut labels : HashMap<String,bool> = HashMap::default();
       if let Some(label) = props.get("label") {
         labels.insert(label.to_string(), true);
       }

--- a/rtx_package/src/package/latex_ch6_list_and_trivlist_environments.rs
+++ b/rtx_package/src/package/latex_ch6_list_and_trivlist_environments.rs
@@ -61,10 +61,10 @@ LoadDefinitions!(state, {
           let tag = stomach.digest(tag_expanded, state)?;
           Ok(stored_map!("tag" => tag))
         } else {
-          Ok(HashMap::new())
+          Ok(HashMap::default())
         }
       } else {
-          Ok(HashMap::new())
+          Ok(HashMap::default())
       }
     }
   );

--- a/rtx_package/src/package/latex_ch6_verbatim.rs
+++ b/rtx_package/src/package/latex_ch6_verbatim.rs
@@ -79,7 +79,7 @@ LoadDefinitions!(outer_state, {
       stomach.egroup(state)?;
       lines.push("\\end{verbatim}".to_string());
       let boxes = lines.into_iter().map(|line|
-        Tbox::new(line.clone(), font.clone(), loc.clone().map(|l| l.into_owned()), T_OTHER!(line).into(), HashMap::new(), state).into()
+        Tbox::new(line.clone(), font.clone(), loc.clone().map(|l| l.into_owned()), T_OTHER!(line).into(), HashMap::default(), state).into()
       ).collect();
       whatsit.set_body(boxes, state);
     },

--- a/rtx_package/src/package/latex_ch7_math_mode_environments.rs
+++ b/rtx_package/src/package/latex_ch7_math_mode_environments.rs
@@ -42,7 +42,7 @@ fn before_equation(stomach: &mut Stomach, state: &mut State) -> Result<()> {
     tags.insert("preset".to_owned(), true.into());
     state.assign_value("EQUATIONROW_TAGS", tags, Some(Scope::Global));
   } else {
-    state.assign_value("EQUATIONROW_TAGS", Stored::HashStored(HashMap::new()), Some(Scope::Global));
+    state.assign_value("EQUATIONROW_TAGS", Stored::HashStored(HashMap::default()), Some(Scope::Global));
   }
   let gullet = stomach.get_gullet_mut();
   state.let_i(&T_CS!("\\@@ENDDISPLAYMATH"), T_CS!("\\lx@eDM@in@equation"), None, gullet);
@@ -101,7 +101,7 @@ fn after_equation(stomach: &mut Stomach, whatsit: &mut Whatsit, state: &mut Stat
   // Now install the tags in $whatsit or current Row, as appropriate.
   let props = match state.remove_value("EQUATIONROW_TAGS") {
     Some(Stored::HashStored(hs)) => hs,
-    _ => HashMap::new(),
+    _ => HashMap::default(),
   };
   if is_aligned {
     unimplemented!();

--- a/rtx_package/src/package/latex_functions.rs
+++ b/rtx_package/src/package/latex_functions.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap as HashMap};
 use crate::package::*;
 
 use libxml::tree::Node;

--- a/rtx_package/src/package/setup_binding_language.rs
+++ b/rtx_package/src/package/setup_binding_language.rs
@@ -502,7 +502,7 @@ macro_rules! DefPrimitive {
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
     let (cs, params) = parse_prototype!($proto);
     let closure : PrimitiveClosure = Arc::new(|_stomach: &mut Stomach, _args: Vec<ArgWrap>, inner_state: &mut State| {
-      Tbox::new($replacement.to_string(), None, None, Tokens!(), HashMap::new(), inner_state).into_digested_result()
+      Tbox::new($replacement.to_string(), None, None, Tokens!(), HashMap::default(), inner_state).into_digested_result()
     });
     defi_primitive!(cs, params, Some(closure), options);
   }};
@@ -1067,7 +1067,7 @@ macro_rules! DefLigature {
 #[macro_export]
 macro_rules! DefAccent {
   ($accent:literal, $combiningchar:expr, $standalonechar:expr) => {{
-    let mut empty_opts : HashMap<String, Stored> = HashMap::new();
+    let mut empty_opts : HashMap<String, Stored> = HashMap::default();
     bind_state_mut!(st);
     DefAccent!($accent, $combiningchar, $standalonechar, empty_opts, st)
   }};
@@ -1874,7 +1874,7 @@ macro_rules! MuGlue {
 macro_rules! DocType {
   ($rootelement:expr, $pubid:expr, $sysid:expr) => {
     bind_state_mut!(st);
-    let mut namespaces: HashMap<String, String> = HashMap::new();
+    let mut namespaces: HashMap<String, String> = HashMap::default();
     DocType!($rootelement, $pubid, $sysid, namespaces, st)
   };
   ($rootelement:expr, $pubid:expr, $sysid:expr, $namespaces:expr, $state_arg:ident) => {{

--- a/rtx_package/src/package/tex_accents.rs
+++ b/rtx_package/src/package/tex_accents.rs
@@ -40,7 +40,7 @@ pub fn apply_accent(
     font,
     locator.map(|l| l.into_owned()),
     reversion.unwrap_or(Tokens!()),
-    HashMap::new(),
+    HashMap::default(),
     state,
   ))
 }

--- a/rtx_package/src/package/tex_appendix_b_p359.rs
+++ b/rtx_package/src/package/tex_appendix_b_p359.rs
@@ -17,7 +17,7 @@ LoadDefinitions!(state, {
           .specialize("\u{2026}"));
         Ok(map!("font" => Stored::Font(Arc::new(new_font)))) // Since not DefMath!
       } else {
-        Ok(HashMap::new())
+        Ok(HashMap::default())
       }
   });
 

--- a/rtx_package/src/package/tex_ch24_primitives.rs
+++ b/rtx_package/src/package/tex_ch24_primitives.rs
@@ -23,7 +23,7 @@ LoadDefinitions!(state, {
   // remain in the constructed tree.
   DefPrimitive!("{", sub[stomach, (), state] {
     stomach.bgroup(state);
-    let open = Tbox::new(String::new(), None, None, Tokens!(T_BEGIN!()), HashMap::new(), state);
+    let open = Tbox::new(String::new(), None, None, Tokens!(T_BEGIN!()), HashMap::default(), state);
     let mode = if state.lookup_bool("IN_MATH") {
       Some(TexMode::Math)
     } else {
@@ -44,7 +44,7 @@ LoadDefinitions!(state, {
       mode,
       font,
       locator: Locator::default(),
-      properties: HashMap::new()
+      properties: HashMap::default()
     }
   });
 
@@ -53,7 +53,7 @@ LoadDefinitions!(state, {
     sub[stomach, (), state] {
       let f = LookupFont!();
       stomach.egroup(state)?;
-      Tbox::new(String::new(), f, None, Tokens!(T_END!()), HashMap::new(), state)
+      Tbox::new(String::new(), f, None, Tokens!(T_END!()), HashMap::default(), state)
     }
   );
 

--- a/rtx_package/src/package/tex_fonts.rs
+++ b/rtx_package/src/package/tex_fonts.rs
@@ -457,7 +457,7 @@ LoadDefinitions!(outer_state, {
      None,
      None,
      invoked,
-     HashMap::new(),
+     HashMap::default(),
      p_state)
   });
 
@@ -477,7 +477,7 @@ LoadDefinitions!(outer_state, {
         // in the Invocation!() call, so we provide it explicitly instead.
         // if this becomes a common problem, we would have to improve the infrastructure
         Invocation!(T_CS!("\\char"), vec![value], gullet, i_state)?,
-        HashMap::new(),
+        HashMap::default(),
         i_state)
     });
 
@@ -513,7 +513,7 @@ LoadDefinitions!(outer_state, {
     let internalcs_opt = glyph.map(|_| T_CS!(s!("\\@mathchardef@{}", csname)));
     let internalcs_2 = internalcs_opt.clone();
     if let Some(internalcs) = internalcs_opt {
-      let mut glyph_props: HashMap<String, Stored> = HashMap::new();
+      let mut glyph_props: HashMap<String, Stored> = HashMap::default();
       glyph_props.insert(s!("role"), role.unwrap_or_default().into());
       let glyph_c = glyph.unwrap();
       let glyph_str = glyph_c.to_string();

--- a/rtx_package/src/package/tex_frontmatter.rs
+++ b/rtx_package/src/package/tex_frontmatter.rs
@@ -25,7 +25,7 @@ const FRONTMATTER_ELEMENTS: &[&str] = &[
 ];
 
 LoadDefinitions!(state, {
-  AssignValue!("frontmatter", Stored::HashTagData(HashMap::new()), Some(Scope::Global));
+  AssignValue!("frontmatter", Stored::HashTagData(HashMap::default()), Some(Scope::Global));
 
   // // Add a new frontmatter item that will be enclosed in <$tag %attr>...</$tag>
   // // The content is the result of digesting $tokens.
@@ -111,7 +111,7 @@ LoadDefinitions!(state, {
       Some(Stored::HashTagData(frnt)) => frnt,
       _ => fatal!(TexPool, Expected, "Global TeX Frontmatter hash was not available, should never happen"),
     };
-    state.assign_value("frontmatter", Stored::HashTagData(HashMap::new()), Some(Scope::Global));
+    state.assign_value("frontmatter", Stored::HashTagData(HashMap::default()), Some(Scope::Global));
 
     // order is important here, first go through frontmatter_elements, then any leftover keys.
     let custom_keys: Vec<String> = frontmatter
@@ -127,7 +127,7 @@ LoadDefinitions!(state, {
         // Dubious, but assures that frontmatter appears in text mode...
         // TODO:
         //local $LaTeXML::BOX = Box('', $STATE->lookupValue('font'), '', T_SPACE);
-        document.set_box_to_absorb(Tbox::new(String::new(), state.lookup_font(), None, Tokens!(T_SPACE!()), HashMap::new(), state).into());
+        document.set_box_to_absorb(Tbox::new(String::new(), state.lookup_font(), None, Tokens!(T_SPACE!()), HashMap::default(), state).into());
         for (tag, attr, stuff) in list {
           document.open_element(&tag, attr, None, state)?; // TODO:  (scalar(@stuff) && $document->canHaveAttribute($tag, 'font')
                                                            //        ? (font => $stuff[0]->getFont, _force_font => 'true') : ()));

--- a/rtx_package/src/package/tex_frontmatter.rs
+++ b/rtx_package/src/package/tex_frontmatter.rs
@@ -11,7 +11,7 @@
 // (ie. frontmatter for each sectional unit)
 
 use crate::package::*;
-use std::collections::HashSet;
+use rustc_hash::FxHashSet as HashSet;
 const FRONTMATTER_ELEMENTS: &[&str] = &[
   "ltx:title",
   "ltx:toctitle",

--- a/rtx_package/src/package/tex_functions.rs
+++ b/rtx_package/src/package/tex_functions.rs
@@ -802,7 +802,7 @@ pub fn dimension_to_spaces(dimen: &Dimension, state: &State) -> Cow<'static, str
 pub fn aligning_environment(align: &str, class: &str, document: &mut Document, props: &HashMap<String,Stored>, state: &mut State) -> Result<()> {
   if let Some(Stored::Digested(body)) = props.get("body") {
     // Add class attribute to new nodes.
-    for mut node in insert_block(document, body, HashMap::new(), state)?.into_iter() {
+    for mut node in insert_block(document, body, HashMap::default(), state)?.into_iter() {
       set_align_or_class(document, &mut node, align, class, state)?;
     }
   }

--- a/rtx_package/src/package/tex_para.rs
+++ b/rtx_package/src/package/tex_para.rs
@@ -35,7 +35,7 @@ LoadDefinitions!(state, {
 
   // Remember; \par _closes_, not opens, paragraphs!
   // Here, we want to close both an open p and para (if either are open).
-  let mut skippable_props: HashMap<String, Stored> = HashMap::new();
+  let mut skippable_props: HashMap<String, Stored> = HashMap::default();
   skippable_props.insert(s!("alignmentSkippable"), true.into());
 
   DefConstructor!("\\normal@par",

--- a/rtx_package/src/package/tex_rtx_specific.rs
+++ b/rtx_package/src/package/tex_rtx_specific.rs
@@ -184,7 +184,7 @@ DefConstructor!("\\lx@add@Preamble@PI Undigested", "<?latexml preamble='#1'?>");
 DefConstructor!("\\lx@dual OptionalKeyVals:XMath {}{}",
   "<ltx:XMDual role='#role' name='#name' meaning='#meaning' omcd='#omcd' width='#width' height='#height' xoffset='#xoffset' yoffset='#yoffset' lpadding='#lpadding' rpadding='#rpadding'>#2<ltx:XMWrap>#3</ltx:XMWrap></ltx:XMDual>",
   before_digest => sub[_stomach,state] {
-    state.push_value("PENDING_DUAL_XMARGS", Stored::HashStored(HashMap::new()));
+    state.push_value("PENDING_DUAL_XMARGS", Stored::HashStored(HashMap::default()));
   },
   after_digest => sub[_stomach,whatsit,state] {
     let kv     = whatsit.get_arg(1);
@@ -303,7 +303,7 @@ Tag!("ltx:*", after_open_late => sub[document,node,state] {
 });
 
 Tag!("ltx:XMDual", after_close_late => sub[document,node,state] {
-  let mut ids  = HashMap::new();
+  let mut ids  = HashMap::default();
   let mut refs = Vec::new();
   // Collect all children with _xmkey attribute
   for mut n in document.findnodes("descendant::*[@_xmkey]", Some(node), state) {

--- a/rtx_package/src/package/tex_scripts.rs
+++ b/rtx_package/src/package/tex_scripts.rs
@@ -211,7 +211,7 @@ fn script_handler(stomach: &mut Stomach, cc: Catcode, state: &mut State) -> Resu
       None,
       None,
       Tokens!(placeholder),
-      HashMap::new(),
+      HashMap::default(),
       state,
     ))])
   }


### PR DESCRIPTION
I was taking a break from documentation, and played around with benchmarking a file I hadn't before (the expansion/etex test). I noticed a high footprint (relative to how fast everything is) of the `core::hash::BuildHasher::hash_one` calls, which are used whenever we interface with the HashMap contents (e.g. in the usual lookups `hashmap.get(key)`). 
We use a *lot* of hashmap access, given that 
1. almost all data management happens in the State tables and 
2. we're coming from a Perl context, where most structured data is a hashmap or an array

So, I searched around for some discussion on the Rust hashing, and indeed there is quite a bit written. I quite enjoyed "[A brutally effective hash function in Rust](https://nnethercote.github.io/2021/12/08/a-brutally-effective-hash-function-in-rust.html)", which went into some detail about which trade-offs are chosen and why.

Since latexml isn't interfacing with any security-critical applications, and we are never intentionally exposing the internal hashes to the world, there was a good case to be made that the default `HashMap` isn't the perfect trade-off for `State` - it does too much in trying to remain as secure and HashDoS-resilient as possible. In turn, `FxHasher` tries to stay as quick as possible by doing as little as possible - and offers no extra guarantees. I took 30 minutes and refactored into using `FxHashMap` and `FxHashSet`, then compared a simple test run:

```
$ time cargo test --release --tests
```

<table><thead>
<th>rustc_hash</th><th>std::collections</th>
</thead><tbody>
<tr><td>

```
real	0m2.026s
user	0m1.798s
sys	0m0.226s
```

</td><td>

```
real	0m2.309s
user	0m2.082s
sys	0m0.229s
```

</td>
</tr></tbody></table>

And wow, a 10% speedup! 

Analyzing some perf visualizations confirms this, so I'm tentatively opening a PR. It would be nice to study a big test in some extra detail (e.g. the 3000 primes perf charts), but - in theory - FxHasher intentionally does less work than the standard rust HashMap hasher, so the speedup ought to be visible in various other tests.

It would be a rather nice win if 10% can be gained so easily, with this much infrastructure already fleshed out.