### PR TITLE
auto-generate #[test] functions for each .tex file we are testing

### DIFF
--- a/rtx/Cargo.toml
+++ b/rtx/Cargo.toml
@@ -36,3 +36,4 @@ rtx_core = {path = "../rtx_core"}
 rtx_package = {path = "../rtx_package"}
 rtx_contrib = {path = "../rtx_contrib"}
 rtx_math_parser = {path = "../rtx_math_parser"}
+phf = { version = "0.11.1", features = ["macros"] }

--- a/rtx/src/util.rs
+++ b/rtx/src/util.rs
@@ -1,2 +1,3 @@
 /// text-related utility functions
+#[macro_use]
 pub mod test;

--- a/rtx/src/util/test.rs
+++ b/rtx/src/util/test.rs
@@ -2,7 +2,7 @@ use glob::glob;
 use libxml::parser::Parser;
 use libxml::tree::Document as XmlDoc;
 use libxml::tree::{Node, SaveOptions};
-use rustc_hash::FxHashMap as HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::core_interface::DigestionAPI;
@@ -15,15 +15,15 @@ use rtx_package::package;
 
 pub fn rtx_tests(
   dirpath: &str,
-  requires: Option<HashMap<&str, &str>>,
+  requires: Option<&phf::Map<&str, &str>>,
   dispatcher_opt: Option<BindingDispatcher>,
 ) {
   rtx_tests_internal(dirpath, requires, dispatcher_opt)
 }
 pub fn rtx_tests_internal(
   dirpath: &str,
-  requires: Option<HashMap<&str, &str>>,
-  extra_bindings_dispatcher: Option<BindingDispatcher>,
+  requires: Option<&phf::Map<&str, &str>>,
+  dispatcher_opt: Option<BindingDispatcher>,
 ) {
   rtx_core::util::logger::init(log::LevelFilter::Warn).unwrap();
   if !validate_requirements(dirpath, requires) {
@@ -40,7 +40,7 @@ pub fn rtx_tests_internal(
         tex_file_string,
         xml_file_str,
         name,
-        extra_bindings_dispatcher.clone(),
+        dispatcher_opt.clone(),
       );
     } else {
       // Skip, these could be tex fragment files.
@@ -48,7 +48,26 @@ pub fn rtx_tests_internal(
   }
 }
 
-fn validate_requirements(_dirpath: &str, _requires: Option<HashMap<&str, &str>>) -> bool {
+pub fn rtx_test_single(tex_file_str:&str, name:&str, dirpath:&str, requires:Option<&phf::Map<&str, &str>>, dispatcher_opt: Option<BindingDispatcher>) {
+  if !validate_requirements(dirpath, requires) {
+    return; // test group only if required files are found.
+  }
+  let tex_file = PathBuf::from(tex_file_str);
+  let xml_file = tex_file.with_extension("xml");
+  if xml_file.exists() {
+    rtx_ok_internal(
+      tex_file_str,
+      &xml_file.to_string_lossy(),
+      name,
+      dispatcher_opt,
+    );
+  } else {
+    // Skip, these could be tex fragment files.
+  }
+
+}
+
+fn validate_requirements(_dirpath: &str, _requires: Option<&phf::Map<&str, &str>>) -> bool {
   // TODO
   true
 }
@@ -169,4 +188,22 @@ pub fn lex_single_tex_formula(tex: &str) -> (Vec<String>, Vec<Node>, Option<Node
     },
     None => (Vec::new(), Vec::new(), None, doc),
   }
+}
+
+/// Build a test function for each "*.tex" source found in a given directory path.
+/// The path should be absolute, or relative to the root rtx checkout.
+#[macro_export]
+macro_rules! tex_tests {
+    ($dir:literal, $requires:expr, $dispatch:expr) => {
+      macro_rules! this_test_requires {
+        () => {$requires}
+      }
+      macro_rules! this_test_dispatch {
+        () => {$dispatch};
+      }
+      use rtx_codegen::GlobTeXTests;
+      #[derive(GlobTeXTests)]
+      #[directory=$dir]
+      struct _TestDirective;
+    };
 }

--- a/rtx/src/util/test.rs
+++ b/rtx/src/util/test.rs
@@ -194,6 +194,7 @@ pub fn lex_single_tex_formula(tex: &str) -> (Vec<String>, Vec<Node>, Option<Node
 /// The path should be absolute, or relative to the root rtx checkout.
 #[macro_export]
 macro_rules! tex_tests {
+    ($dir:literal) => {tex_tests!($dir,None,None);};
     ($dir:literal, $requires:expr, $dispatch:expr) => {
       macro_rules! this_test_requires {
         () => {$requires}

--- a/rtx/tests/00_tokenize.rs
+++ b/rtx/tests/00_tokenize.rs
@@ -1,10 +1,6 @@
 ///**********************************************************************
 /// Test cases for rtx
 ///**********************************************************************
-use rtx::util::test::*;
+use rtx::tex_tests;
 
-#[test]
-fn can_tokenize() {
-  let requires = None;
-  rtx_tests("tests/tokenize", requires, None);
-}
+tex_tests!("tests/tokenize", None, None);

--- a/rtx/tests/00_tokenize.rs
+++ b/rtx/tests/00_tokenize.rs
@@ -3,4 +3,4 @@
 ///**********************************************************************
 use rtx::tex_tests;
 
-tex_tests!("tests/tokenize", None, None);
+tex_tests!("tests/tokenize");

--- a/rtx/tests/10_expansion.rs
+++ b/rtx/tests/10_expansion.rs
@@ -5,7 +5,6 @@ extern crate rtx_package;
 
 mod helpers;
 
-use rustc_hash::FxHashMap as HashMap;
 ///**********************************************************************
 /// Test cases for rtx
 ///**********************************************************************
@@ -15,21 +14,13 @@ use rtx_core::common::error::Result;
 use rtx_core::state::State;
 use rtx_core::stomach::Stomach;
 use rtx_package::package;
+use rtx::tex_tests;
 
-use rtx::util::test::*;
+use phf::{phf_map};
+static REQUIRES: phf::Map<&'static str, &'static str> = phf_map! {
+  "meaning" => "t1enc.def",
+  "ifthen" => "ifthen.sty"};
 
-#[test]
-fn can_expand() {
-  let mut requires = HashMap::default();
-  requires.insert("meaning", "t1enc.def");
-  requires.insert("ifthen", "ifthen.sty");
-
-  rtx_tests(
-    "tests/expansion",
-    Some(requires),
-    Some(Arc::new(expansion_tests_dispatch)),
-  );
-}
 pub fn expansion_tests_dispatch(
   filename: &str,
   stomach: &mut Stomach,
@@ -41,3 +32,8 @@ pub fn expansion_tests_dispatch(
     other => package::dispatch(other, stomach, state),
   }
 }
+
+tex_tests!(
+  "tests/expansion",
+  Some(&REQUIRES),
+  Some(Arc::new(expansion_tests_dispatch)));

--- a/rtx/tests/12_grouping.rs
+++ b/rtx/tests/12_grouping.rs
@@ -1,14 +1,9 @@
 ///**********************************************************************
 /// Test cases for rtx
 ///**********************************************************************
-use rtx::util::test::*;
+use rtx::tex_tests;
 use std::sync::Arc;
 
-#[test]
-fn can_group() {
-  rtx_tests(
-    "tests/grouping",
+tex_tests!("tests/grouping",
     None,
-    Some(Arc::new(rtx_contrib::dispatch)),
-  );
-}
+    Some(Arc::new(rtx_contrib::dispatch)));

--- a/rtx/tests/20_digestion.rs
+++ b/rtx/tests/20_digestion.rs
@@ -13,20 +13,11 @@ mod helpers;
 ///**********************************************************************
 use std::sync::Arc;
 
-use rtx::util::test::*;
+use rtx::tex_tests;
 use rtx_core::common::error::Result;
 use rtx_core::state::State;
 use rtx_core::stomach::Stomach;
 use rtx_package::package;
-
-#[test]
-fn can_digest() {
-  rtx_tests(
-    "tests/digestion",
-    None,
-    Some(Arc::new(digestion_tests_dispatch)),
-  );
-}
 
 fn digestion_tests_dispatch(
   filename: &str,
@@ -38,3 +29,5 @@ fn digestion_tests_dispatch(
     other => package::dispatch(other, stomach, state),
   }
 }
+
+tex_tests!("tests/digestion",None,Some(Arc::new(digestion_tests_dispatch)));

--- a/rtx/tests/22_fonts.rs
+++ b/rtx/tests/22_fonts.rs
@@ -1,8 +1,6 @@
 ///**********************************************************************
 /// Test cases for rtx
 ///**********************************************************************
-use rtx::util::test::*;
+use rtx::tex_tests;
 
-#[test]
-#[ignore]
-fn can_group() { rtx_tests("tests/fonts", None, None); }
+tex_tests!("tests/fonts", None, None);

--- a/rtx/tests/22_fonts.rs
+++ b/rtx/tests/22_fonts.rs
@@ -3,4 +3,4 @@
 ///**********************************************************************
 use rtx::tex_tests;
 
-tex_tests!("tests/fonts", None, None);
+tex_tests!("tests/fonts");

--- a/rtx/tests/30_encoding.rs
+++ b/rtx/tests/30_encoding.rs
@@ -2,39 +2,41 @@
 /// Test cases for rtx
 ///**********************************************************************
 use rtx::util::test::*;
-use rustc_hash::FxHashMap as HashMap;
+use phf::{phf_map};
+
+static REQUIRES: phf::Map<&'static str, &'static str> = phf_map! {
+  "ansinew"=> "ansinew.def",
+  "applemac"=> "applemac.def",
+  "cp437"=> "cp437.def",
+  "cp437de"=> "cp437de.def",
+  "cp850"=> "cp850.def",
+  "cp852"=> "cp852.def",
+  "cp858"=> "cp858.def",
+  "cp865"=> "cp865.def",
+  "cp1250"=> "cp1250.def",
+  "cp1252"=> "cp1252.def",
+  "decmulti"=> "decmulti.def",
+  "macce"=> "macce.def",
+  "next"=> "next.def",
+  "latin1"=> "latin1.def",
+  "latin2"=> "latin2.def",
+  "latin3"=> "latin3.def",
+  "latin4"=> "latin4.def",
+  "latin5"=> "latin5.def",
+  "latin9"=> "latin9.def",
+  "latin10"=> "latin10.def",
+  "ot1"=> "ot1enc.def",
+  "t1"=> "t1enc.def",
+  "t2a"=> "t2aenc.def",
+  "t2b"=> "t2benc.def",
+  "t2c"=> "t2cenc.def",
+  "ts1"=> "ts1enc.def",
+  "ly1"=> "ly1enc.def"
+};
 
 #[test]
 #[ignore]
+// TODO: use tex_tests!() once enabled
 fn can_encode() {
-  let mut requires = HashMap::default();
-  requires.insert("ansinew", "ansinew.def");
-  requires.insert("applemac", "applemac.def");
-  requires.insert("cp437", "cp437.def");
-  requires.insert("cp437de", "cp437de.def");
-  requires.insert("cp850", "cp850.def");
-  requires.insert("cp852", "cp852.def");
-  requires.insert("cp858", "cp858.def");
-  requires.insert("cp865", "cp865.def");
-  requires.insert("cp1250", "cp1250.def");
-  requires.insert("cp1252", "cp1252.def");
-  requires.insert("decmulti", "decmulti.def");
-  requires.insert("macce", "macce.def");
-  requires.insert("next", "next.def");
-  requires.insert("latin1", "latin1.def");
-  requires.insert("latin2", "latin2.def");
-  requires.insert("latin3", "latin3.def");
-  requires.insert("latin4", "latin4.def");
-  requires.insert("latin5", "latin5.def");
-  requires.insert("latin9", "latin9.def");
-  requires.insert("latin10", "latin10.def");
-  requires.insert("ot1", "ot1enc.def");
-  requires.insert("t1", "t1enc.def");
-  requires.insert("t2a", "t2aenc.def");
-  requires.insert("t2b", "t2benc.def");
-  requires.insert("t2c", "t2cenc.def");
-  requires.insert("ts1", "ts1enc.def");
-  requires.insert("ly1", "ly1enc.def");
-
-  rtx_tests("tests/encoding", Some(requires), None);
+  rtx_tests("tests/encoding", Some(&REQUIRES), None);
 }

--- a/rtx/tests/50_structure.rs
+++ b/rtx/tests/50_structure.rs
@@ -1,12 +1,9 @@
-use rtx::util::test::*;
+use rtx::tex_tests;
 ///**********************************************************************
 /// Test cases for rtx
 ///**********************************************************************
-use rustc_hash::FxHashMap as HashMap;
+use phf::{phf_map};
+static REQUIRES: phf::Map<&'static str, &'static str> = phf_map! {
+  "csquotes" => "csquotes.sty" };
 
-#[test]
-fn can_structure() {
-  let mut requires = HashMap::default();
-  requires.insert("csquotes", "csquotes.sty");
-  rtx_tests("tests/structure", Some(requires), None);
-}
+tex_tests!("tests/structure", Some(&REQUIRES), None);

--- a/rtx/tests/53_alignment.rs
+++ b/rtx/tests/53_alignment.rs
@@ -2,12 +2,14 @@
 /// Test cases for rtx
 ///**********************************************************************
 use rtx::util::test::*;
-use rustc_hash::FxHashMap as HashMap;
+use phf::{phf_map};
+
+static REQUIRES: phf::Map<&'static str, &'static str> = phf_map! {
+  "listing" => "listings.cfg"
+};
 
 #[test]
 #[ignore]
 fn can_align() {
-  let mut requires = HashMap::default();
-  requires.insert("listing", "listings.cfg");
-  rtx_tests("tests/alignment", Some(requires), None);
+  rtx_tests("tests/alignment", Some(&REQUIRES), None);
 }

--- a/rtx/tests/55_theorem.rs
+++ b/rtx/tests/55_theorem.rs
@@ -2,12 +2,12 @@
 /// Test cases for rtx
 ///**********************************************************************
 use rtx::util::test::*;
-use rustc_hash::FxHashMap as HashMap;
 
+use phf::{phf_map};
+static REQUIRES: phf::Map<&'static str, &'static str> = phf_map! {
+  "ntheorem" => "ntheorem.std" };
 #[test]
 #[ignore]
 fn can_theorem() {
-  let mut requires = HashMap::default();
-  requires.insert("ntheorem", "ntheorem.std");
-  rtx_tests("tests/theorem", Some(requires), None);
+  rtx_tests("tests/theorem", Some(&REQUIRES), None);
 }

--- a/rtx/tests/65_graphics.rs
+++ b/rtx/tests/65_graphics.rs
@@ -2,13 +2,13 @@
 /// Test cases for rtx
 ///**********************************************************************
 use rtx::util::test::*;
-use rustc_hash::FxHashMap as HashMap;
+use phf::{phf_map};
+static REQUIRES: phf::Map<&'static str, &'static str> = phf_map! {
+  "colors" => "dvipsnam.def",
+  "xcolors" => "dvipsnam.def" };
 
 #[test]
 #[ignore]
 fn can_graphics() {
-  let mut requires = HashMap::default();
-  requires.insert("colors", "dvipsnam.def");
-  requires.insert("xcolors", "dvipsnam.def");
-  rtx_tests("tests/graphics", Some(requires), None);
+  rtx_tests("tests/graphics", Some(&REQUIRES), None);
 }

--- a/rtx/tests/81_babel.rs
+++ b/rtx/tests/81_babel.rs
@@ -2,18 +2,17 @@
 /// Test cases for rtx
 ///**********************************************************************
 use rtx::util::test::*;
-use rustc_hash::FxHashMap as HashMap;
+use phf::{phf_map};
+static REQUIRES: phf::Map<&'static str, &'static str> = phf_map! {
+  "*" => "babel.sty",
+  "numprints" => "numprint.sty",
+  "german" => "germanb.ldf",
+  "greek" => "greek.ldf",
+  "french" => "frenchb.ldf",
+  "page545" => "germanb.ldf"};
 
 #[test]
 #[ignore]
 fn can_babel() {
-  let mut requires = HashMap::default();
-  requires.insert("*", "babel.sty");
-  requires.insert("numprints", "numprint.sty");
-  requires.insert("german", "germanb.ldf");
-  requires.insert("greek", "greek.ldf");
-  requires.insert("french", "frenchb.ldf");
-  requires.insert("page545", "germanb.ldf");
-
-  rtx_tests("tests/babel", Some(requires), None);
+  rtx_tests("tests/babel", Some(&REQUIRES), None);
 }

--- a/rtx_codegen/Cargo.toml
+++ b/rtx_codegen/Cargo.toml
@@ -16,4 +16,5 @@ proc-macro2 = "1.0.0"
 quote = "1.0"
 lazy_static = "1.0.0"
 regex = "1.7.1"
+glob = "0.3"
 rtx_core= { path = "../rtx_core" }

--- a/rtx_codegen/src/lib.rs
+++ b/rtx_codegen/src/lib.rs
@@ -9,6 +9,7 @@ mod constructable;
 mod modelable;
 mod parametrizeable;
 mod tokenizeable;
+mod testable;
 
 #[proc_macro_derive(CompileReplacement, attributes(replacement))]
 pub fn derive_compile_replacement(input: TokenStream) -> TokenStream {
@@ -125,4 +126,10 @@ pub fn start_state_frame(_input: TokenStream) -> TokenStream {
 pub fn end_state_frame(_input: TokenStream) -> TokenStream {
   unsafe { CONTEXT_DEPTH -= 1 };
   TokenStream::new()
+}
+
+#[proc_macro_derive(GlobTeXTests, attributes(directory))]
+pub fn derive_tex_tests(input: TokenStream) -> TokenStream {
+  let item = parse_macro_input!(input as DeriveInput);
+  testable::compile_tests_at(item)
 }

--- a/rtx_codegen/src/testable.rs
+++ b/rtx_codegen/src/testable.rs
@@ -1,0 +1,40 @@
+use glob::glob;
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{DeriveInput, Lit, Meta};
+
+/// The only purpose of doing the glob for "*.tex" tests at compile-time is to
+/// make sure each TeX entry gets a dedicated #[test] header, and respectively
+/// increments the counter for the number of tests which have been run.
+/// In addition, this allows running more tests in parallel.
+pub fn compile_tests_at(input: DeriveInput) -> TokenStream {
+  let directory: String = match input.attrs[0].parse_meta().unwrap() {
+    Meta::NameValue(v) => match v.lit {
+      Lit::Str(v) => v.value(),
+      _ => {
+        panic!("only accepts #[directory = \"value\"] attribute, mandatory double-quotes (Lit)")
+      },
+    },
+    _ => panic!(
+      "only accepts #[directory = \"value\"] attribute, mandatory double-quotes (parse_meta)"
+    ),
+  };
+  // TODO: How do we best manage the relative directories changing from compile-time to test-time?
+  let test_functions: Vec<_> = glob(&format!("rtx/{directory}/*.tex")).unwrap().flatten().map(|pb| {
+    let filebase = pb.file_stem().unwrap().to_string_lossy();
+    let file = pb.to_string_lossy();
+    let fn_filename = filebase
+      .replace(['-', ' ', '.'], "_");
+    let fn_name = format_ident!("{fn_filename}_test");
+    quote!(
+      #[test]
+      fn #fn_name() {
+        rtx::util::test::rtx_test_single(#file, #filebase, #directory, this_test_requires!(), this_test_dispatch!())
+      }
+    )
+  }).collect();
+
+  quote!(
+    #(#test_functions)*
+  ).into()
+}


### PR DESCRIPTION
This PR adds a quality-of-life improvement which I hope will make @brucemiller a little excited!

- Introduce `rtx_codegen::testable` which collects the ".tex" files available for a given test sub-suite (tokenize, expandable, digested, ...) at _compile-time_ and generates a `#[test]` function for each individual file
- Add a `tex_tests!` macro to leverage that compile-time extension

This allows to write e.g. in `tests/00_tokenize.rs`:
```rust
tex_tests!("tests/tokenize");
```

With that change there are two major benefits:
 - each file is reported _separately_ in `cargo test` so one can see individual failures quickly
 - cargo is able to execute each `#[test]` function on a separate thread. Which really speeds up the tests on a modern CPU.

Here is a full test run of the current state of the project with this PR (showing the second run, after the full project has already been compiled):

<details>

```
$ time cargo test --release --tests
    Finished release [optimized] target(s) in 0.08s
     Running unittests src/lib.rs (target/release/deps/rtx-931c24d611cc23d6)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/main.rs (target/release/deps/rtx-aa74e5dc775503af)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests bin/rtx_math.rs (target/release/deps/rtxmath-90519d2012af579b)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/000_hello.rs (target/release/deps/000_hello-265deee2d132a2e2)

running 1 test
test can_convert_hello ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s

     Running tests/00_contrib.rs (target/release/deps/00_contrib-d5ee9660a9f16828)

running 1 test
test can_contrib ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s

     Running tests/00_tokenize.rs (target/release/deps/00_tokenize-5b9cd3b6329bcb2f)

running 15 tests
test alltt_test ... ok
test badchars_test ... ok
test comment_test ... ok
test file_read_test ... ok
test equality_test ... ok
test ligatures_test ... ok
test mathtokens_test ... ok
test newlines_input_test ... ok
test newlines_test ... ok
test percent_test ... ok
test snippet_test ... ok
test trailingspaces_test ... ok
test url_test ... ok
test verb_test ... ok
test verbata_test ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/10_expansion.rs (target/release/deps/10_expansion-bed390c789fbbbc4)

running 39 tests
test definedness_test ... ok
test endinput_test ... ok
test aftergroup_test ... ok
test endinputinner_test ... ok
test endinputinner2_test ... ok
test env_test ... ok
test environments_test ... ok
test etex_mydim_test ... ok
test etex_test ... ok
test etoolbox_test ... ok
test for_test ... ok
test fragment1_test ... ok
test fragment2_test ... ok
test hyperurls_test ... ok
test ifthen_test ... ok
test keywords_test ... ok
test lettercase_test ... ok
test meaning_test ... ok
test multi_escaped_param_test ... ok
test noexpand_conditional_test ... ok
test noexpand_test ... ok
test numexpr_test ... ok
test parindent_test ... ok
test pass_param_toks_in_gen_macros_test ... ok
test pdftex_expanded_test ... ok
test simple_dimen_test ... ok
test testchar_test ... ok
test testexpand_test ... ok
test testif_test ... ok
test testinput_test ... ok
test testmultido_test ... ok
test textcase_test ... ok
test toks_test ... ok
test urls_test ... ok
test utflettercase_test ... ok
test whichcache_test ... ok
test whichfrag1_test ... ok
test whichfrag2_test ... ok
test whichinput_test ... ok

test result: ok. 39 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/12_grouping.rs (target/release/deps/12_grouping-1abd2fc1a7442109)

running 2 tests
test mathgroup_test ... ok
test scopemacro_test ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/20_digestion.rs (target/release/deps/20_digestion-8c019d1f15da5b8b)

running 9 tests
test chardefs_test ... ok
test box_test ... ok
test def_test ... ok
test defaultunits_test ... ok
test dollar_test ... ok
test io_test ... ok
test primes_test ... ok
test rebox_test ... ok
test testctr_test ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/22_fonts.rs (target/release/deps/22_fonts-444c99a8d6a6167e)

running 22 tests
test acc_test ... ok
test abxtest_test ... ok
test accents_test ... ok
test cancels_test ... ok
test bbold_test ... ok
test ding_test ... ok
test emph_test ... ok
test esint_test ... ok
test fonts_test ... ok
test marvosym_test ... ok
test mathaccents_test ... ok
test mathbbol_test ... ok
test mathcolor_test ... ok
test mixed_test ... ok
test omencodings_test ... ok
test sizes_test ... ok
test soul_test ... ok
test stmaryrd_test ... ok
test textcomp_test ... ok
test textsymbols_test ... ok
test ulem_test ... ok
test wasysym_test ... ok

test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/30_encoding.rs (target/release/deps/30_encoding-1ec88e521853c6b4)

running 1 test
test can_encode ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/40_math.rs (target/release/deps/40_math-95dc9a46b96e9183)

running 1 test
test can_math ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/50_structure.rs (target/release/deps/50_structure-ab16c5e32f0ee2f8)

running 5 tests
test abstract_test ... ok
test itemize_test ... ok
test badabstract_test ... ok
test sec_test ... ok
test asubfile_test ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/52_namespace.rs (target/release/deps/52_namespace-3519ffb573eb81e4)

running 1 test
test can_namespace ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/53_alignment.rs (target/release/deps/53_alignment-fc68b0a183bce77d)

running 1 test
test can_align ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/55_theorem.rs (target/release/deps/55_theorem-c4c853e20c4da62b)

running 1 test
test can_theorem ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/56_ams.rs (target/release/deps/56_ams-59798e4e4e8f1033)

running 1 test
test can_theorem ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/65_graphics.rs (target/release/deps/65_graphics-b9fa06b1746e1e69)

running 1 test
test can_graphics ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/700_unit_parse.rs (target/release/deps/700_unit_parse-86684a4619ccabc9)

running 1 test
test basic_1 ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s

     Running tests/70_parse.rs (target/release/deps/70_parse-2e90a61fa53317b7)

running 1 test
test can_parse ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/80_complex.rs (target/release/deps/80_complex-7ffc947e075fe9d8)

running 1 test
test can_complex ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s

     Running tests/81_babel.rs (target/release/deps/81_babel-0bf4bb090f6cd02e)

running 1 test
test can_babel ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/lib.rs (target/release/deps/rtx_codegen-30e084d3e4115099)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/lib.rs (target/release/deps/rtx_contrib-b5b04b51dc1fea40)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/lib.rs (target/release/deps/rtx_core-0003c41f3a71b851)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/00_unit_state.rs (target/release/deps/00_unit_state-e3f4540403e8028e)

running 9 tests
test assign_lookup_mapping ... ok
test push_pop_daemon_frames ... ok
test texy_ops ... ok
test assign_lookup_arrays ... ok
test scoped_assign_lookup_value ... ok
test assign_lookup_value ... ok
test install_definition_and_meaning ... ok
test semiverbatim ... ok
test basic_state_init ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/01_unit_tokens.rs (target/release/deps/01_unit_tokens-1b0634e58272a0a8)

running 1 test
test unit_examples ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/lib.rs (target/release/deps/rtx_math_parser-e7f992674c954bd0)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/lib.rs (target/release/deps/rtx_package-db8c1ec0df0f6804)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


real	0m0.452s
user	0m0.314s
sys	0m0.144s
```

</details>

So on my 32-thread CPU the what I think are ~110 individual tests run in 0.4 seconds, now that each `.tex` test is allowed to execute in parallel.