### PR TITLE
rtx_math refresh

### DIFF
--- a/rtx/bin/rtx_math.rs
+++ b/rtx/bin/rtx_math.rs
@@ -1,12 +1,12 @@
 #[macro_use]
 extern crate rtx_core;
 use libxml::tree::SaveOptions;
-use rtx::util::test::lex_single_tex_formula;
-use rtx_core::common::error::Result;
-use rtx_core::state::{State, StateOptions};
-use rtx_math_parser::*;
 use std::env;
 use std::process;
+
+use rtx::util::test::{new_test_engine,lex_single_tex_formula};
+use rtx_core::common::error::Result;
+use rtx_math_parser::*;
 
 fn main() -> Result<()> {
   if rtx_core::util::logger::init(log::LevelFilter::Info).is_err() {
@@ -34,22 +34,24 @@ fn main() -> Result<()> {
       process::exit(1);
     },
   };
-
-  let (lexemes, mut lex_nodes, xmath_opt, mut doc) = lex_single_tex_formula(&source);
+  let mut core_engine = new_test_engine();
+  let (lexemes, mut lex_nodes, xmath_opt, mut doc) = lex_single_tex_formula(&source, &mut core_engine);
   assert!(!lexemes.is_empty());
-  eprintln!("lexemes: {lexemes:?}");
-  let mut state = State::new(StateOptions::default());
+  eprintln!("\n\nlexemes: {lexemes:?}\n");
+
+  let state = core_engine.get_state_mut();
+  state.nomathparse = false; // nomathparse is "true" while lexing, but "false" while parsing
   let mut parser = MathParser::default();
-  if let Ok(Some(parse_tree)) = parser.parse_lexemes(lexemes, &lex_nodes, &mut doc, &mut state) {
+  if let Ok(Some(parse_tree)) = parser.parse_lexemes(lexemes, &lex_nodes, &mut doc, state) {
     let mut xmath = xmath_opt.unwrap();
     for mut node in xmath.get_child_nodes() {
       node.unlink();
     }
-    let xml_tree = parse_tree.into_xmath(&mut xmath, &mut lex_nodes, &mut doc, &mut state)?;
+    let xml_tree = parse_tree.into_xmath(&mut xmath, &mut lex_nodes, &mut doc, state)?;
     xmath
       .get_parent()
       .unwrap()
-      .set_attribute("text", &text_form(&xml_tree, &mut doc, &mut state))
+      .set_attribute("text", &text_form(&xml_tree, &mut doc, state))
       .unwrap();
 
     println!(

--- a/rtx/src/util/test.rs
+++ b/rtx/src/util/test.rs
@@ -12,7 +12,8 @@ use rtx_core::document::Document;
 use rtx_core::state::State;
 use rtx_core::{s, Core, CoreOptions};
 use rtx_math_parser::node_to_grammar_lexemes;
-use rtx_package::package;
+use rtx_package::{package,load_model};
+use rtx_codegen::LoadModel;
 
 pub fn rtx_tests(
   dirpath: &str,
@@ -173,22 +174,29 @@ fn process_dom(dom: XmlDoc, _name: &str) -> Vec<String> {
     .collect()
 }
 
-/// Simple tokenization of a single formula, without any custom preloads
-/// byond latex and amsmath
-pub fn lex_single_tex_formula(tex: &str) -> (Vec<String>, Vec<Node>, Option<Node>, Document) {
-  let mut latexml = Core::new(CoreOptions {
-    verbosity: Some(-2),
-    search_paths: None,
+/// Provide a default test `Core` engine for simple operations
+pub fn new_test_engine() -> Core {
+  let mut core_engine = Core::new(CoreOptions {
     preload: Some(
       ["article.cls", "amsmath.sty"]
         .map(|x| x.to_string())
         .to_vec(),
     ),
+    verbosity: Some(-2),
+    search_paths: None,
     nomathparse: Some(true),
     include_comments: Some(false),
     ..CoreOptions::default()
   });
-  latexml.get_state_mut().bindings_dispatch = Some(Rc::new(package::dispatch));
+  let state = core_engine.get_state_mut();
+  load_model!(state,"LaTeXML");
+  state.bindings_dispatch = Some(Rc::new(package::dispatch));
+  core_engine
+}
+
+/// Simple tokenization of a single formula, without any custom preloads
+/// beyond latex and amsmath
+pub fn lex_single_tex_formula(tex: &str, latexml: &mut Core) -> (Vec<String>, Vec<Node>, Option<Node>, Document) {
   let xml_result = latexml.convert_file(format!("literal:\\[ {tex} \\]"));
   assert!(xml_result.is_ok(), "{:?}", xml_result.err());
   let mut doc = xml_result.unwrap();

--- a/rtx/tests/700_unit_parse.rs
+++ b/rtx/tests/700_unit_parse.rs
@@ -1,11 +1,12 @@
-use rtx::util::test::lex_single_tex_formula;
+use rtx::util::test::{lex_single_tex_formula, new_test_engine};
 use rtx_core::state::{State, StateOptions};
 use rtx_math_parser::MathParser;
 
 #[test]
 fn basic_1() {
   let tex = "1+1=2";
-  let (lexemes, mut nodes, xmath_opt, mut doc) = lex_single_tex_formula(tex);
+  let mut latexml = new_test_engine();
+  let (lexemes, mut nodes, xmath_opt, mut doc) = lex_single_tex_formula(tex, &mut latexml);
   assert!(!lexemes.is_empty());
   let expected_lexemes = &[
     "NUMBER:1:1",

--- a/rtx_core/src/common/model.rs
+++ b/rtx_core/src/common/model.rs
@@ -380,8 +380,8 @@ impl Model {
         codeprefix,
         self,
         None,
-        "No namespace has been registered for prefix '$codeprefix' (in code)",
-        "Using '$ns' isntead"
+        s!("No namespace has been registered for prefix '{codeprefix}' (in code)"),
+        s!("Using '{example_namespace}' instead")
       );
     }
     ns

--- a/rtx_math_parser/src/semantics/tree.rs
+++ b/rtx_math_parser/src/semantics/tree.rs
@@ -106,6 +106,7 @@ pub enum XM {
   Dual(Box<XM>, Box<XM>, XProps, Meta),
   Ref(XProps),
   Wrap(Vec<XM>, XProps, Meta),
+  Arg(Vec<XM>),
   Choices(Vec<XM>),
 }
 impl From<XProps> for XM {
@@ -238,7 +239,7 @@ impl XM {
       XM::Dual(_, _, _, ref meta) => meta,
       XM::Wrap(_, _, ref meta) => meta,
       XM::Choices(cs) => cs[0].get_meta(), // Should we return a none type instead?
-      XM::Ref(_) => unimplemented!(),
+      XM::Ref(_) | XM::Arg(_) => unimplemented!(),
     }
   }
   pub fn get_meta_mut(&mut self) -> &mut Meta {
@@ -249,7 +250,7 @@ impl XM {
       XM::Dual(_, _, _, ref mut meta) => meta,
       XM::Wrap(_, _, ref mut meta) => meta,
       XM::Choices(cs) => cs[0].get_meta_mut(), // Should we return a none type instead?
-      XM::Ref(_) => unimplemented!(),
+      XM::Ref(_)| XM::Arg(_) => unimplemented!(),
     }
   }
   pub fn get_inner_meta(&self) -> Vec<&Meta> {
@@ -292,7 +293,7 @@ impl XM {
           .collect::<Vec<_>>()
           .join("")
       )),
-      XM::Choices(_) => unimplemented!(),
+      XM::Choices(_)| XM::Arg(_)=> unimplemented!(),
       XM::Dual(content, pres, _, _) => Cow::Owned(format!(
         "{}{}",
         content.get_value(nodes).expect("inner"),
@@ -408,6 +409,7 @@ impl XM {
       },
       XM::Dual(_, _, _, _) => unimplemented!(),
       XM::Wrap(_, _, _) => unimplemented!(),
+      XM::Arg(_) => unimplemented!(),
       XM::Choices(_) => Err("can not specialize choices".into()),
     }
   }
@@ -478,6 +480,7 @@ impl XM {
       },
       XM::Dual(_, _, _, _) => unimplemented!(),
       XM::Wrap(_inner, _, _) => unimplemented!(),
+      XM::Arg(_) => unimplemented!(),
       XM::Choices(args) => args.first().unwrap().get_baseline(),
     }
   }
@@ -514,7 +517,7 @@ impl XM {
           c.unconstrain_recursive();
         }
       },
-      XM::Choices(args) => {
+      XM::Choices(args) | XM::Arg(args) => {
         for tree in args {
           tree.unconstrain_recursive();
         }
@@ -561,6 +564,22 @@ impl XM {
         let mut arg_level: Vec<bool> = level.to_vec();
         arg_level.push(true);
         let mut peekable = content.iter().peekable();
+        while let Some(arg) = peekable.next() {
+          if peekable.peek().is_none() {
+            arg_level.pop();
+            arg_level.push(false);
+            arg.fmt_indented(&arg_level, f)?
+          } else {
+            arg.fmt_indented(&arg_level, f)?
+          }
+        }
+        writeln!(f)
+      },
+      XM::Arg(args) => {
+        writeln!(f, "\n{indent}Arg")?;
+        let mut arg_level: Vec<bool> = level.to_vec();
+        arg_level.push(true);
+        let mut peekable = args.iter().peekable();
         while let Some(arg) = peekable.next() {
           if peekable.peek().is_none() {
             arg_level.pop();
@@ -667,6 +686,14 @@ impl XM {
           document.set_attribute(&mut ref_node, "_xmkey", &xmkey, state)?;
         }
         Ok(ref_node)
+      },
+      XM::Arg(inner_list) => {
+        let mut arg_node = Node::new("XMArg", None, document.get_document()).unwrap();
+        for inner_item in inner_list {
+          let mut inner_node = inner_item.into_xmath(&mut arg_node, nodes, document, state)?;
+          add_child_guard_xmarg(&mut arg_node, &mut inner_node)?;
+        }
+        Ok(arg_node)
       },
       XM::Choices(mut choices) => {
         Info!(
@@ -823,8 +850,13 @@ impl From<&Node> for XM {
         let args: Args = children.iter().map(XM::from).collect::<Vec<_>>().into();
         XM::Apply((&op).into(), args, XProps::from(n), Meta::default())
       },
+      "XMArg" => {
+        let children = element_nodes(n);
+        let inner_xm = children.iter().map(XM::from).collect::<Vec<_>>();
+        XM::Arg(inner_xm)
+      },
       // TODO: continue for the other cases
-      _ => unimplemented!(),
+      missing_case => {dbg!(missing_case); unimplemented!()},
     }
   }
 }


### PR DESCRIPTION
Some initialization pieces had moved, which made the rtx_math binary encounter some namespace declaration issues.

Cleaned that up, and also added the `XM::Arg` variant, so that the following parsing test succeeds with this PR:

```bash
cargo run --release --bin rtxmath 'x^2=0'
```

Adding the log + XML snippet from running the command, for archival:

```bash
$ cargo run --release --bin rtxmath 'x^2=0'
    Finished release [optimized + debuginfo] target(s) in 0.05s
     Running `target/release/rtxmath 'x^2=0'`

(Digesting TeX Anonymous String...
(Loading "TeX.pool" definitions... )
(Loading "article.cls" definitions...
(Loading "LaTeX.pool" definitions...
(Loading "TeX.pool" definitions... ) ) )
(Loading "amsmath.sty" definitions... ) ) )
(Building... )
(Rewriting... )
(Finalizing... )

lexemes: ["UNKNOWN:x:1", "start_POSTSUPERSCRIPT:start:2", "ATOM:2:3", "end_POSTSUPERSCRIPT:end:4", "RELOP:equals:5", "NUMBER:0:6"]
```
```xml
<?xml version="1.0" encoding="UTF-8"?>
<?latexml class="article.cls"?>
<?latexml package="amsmath.sty"?>
<?latexml RelaxNGSchema="LaTeXML"?>
<document xmlns="http://dlmf.nist.gov/LaTeXML">
  <resource src="LaTeXML.css" type="text/css"/>
  <resource src="ltx-article.css" type="text/css"/>
  <para xml:id="p1">
    <equation xml:id="S0.Ex1">
      <Math mode="display" xml:id="S0.Ex1.m1" tex="x^{2}=0" text="x ^ 2 = 0">
        <XMath>
          <XMApp _font="17619975978160646265">
            <XMTok meaning="equals" role="RELOP">=</XMTok>
            <XMApp _font="16506438761460840919">
              <XMTok role="SUPERSCRIPTOP" scriptpos="post1" _font="425520478969073180"/>
              <XMTok role="UNKNOWN" font="italic">x</XMTok>
              <XMTok meaning="2" role="NUMBER" _font="11183222680203488361">2</XMTok>
            </XMApp>
            <XMTok meaning="0" role="NUMBER">0</XMTok>
          </XMApp>
        </XMath>
      </Math>
    </equation>
  </para>
</document>
```

I see there are some leftover `_font` attributes on some XMApp and XMTok nodes, so there's likely more cleanup to come.
