### PR TITLE
math: scripts on fenced factors; square-root

### DIFF
--- a/rtx_core/src/alignment.rs
+++ b/rtx_core/src/alignment.rs
@@ -108,15 +108,15 @@ pub struct Alignment {
 impl Alignment {
   /// Create a new Alignment.
   /// `config` can contain:
-  ///    template : an Alignment::Template object
-  ///    openContainer  = sub($doc,%attrib); creates the container element with given attributes
-  ///    closeContainer = sub($doc); closes the container
-  ///    openRow        = sub($doc,%attrib); creates the row element with given attributes
-  ///    closeRow       = closes the row
-  ///    openColumn     = sub($doc,%attrib); creates the column element with given attributes
-  ///    closeColumn    = closes the column
-  ///    properties     = hashmap containing extra attributes for the container element.
-  ///    xml_attributes = hashmap containing attributes for the main XML node
+  ///   - template: an Alignment::Template object
+  ///   - openContainer: creates the container element with given attributes
+  ///   - closeContainer = sub($doc); closes the container
+  ///   - openRow        = sub($doc,%attrib); creates the row element with given attributes
+  ///   - closeRow       = closes the row
+  ///   - openColumn     = sub($doc,%attrib); creates the column element with given attributes
+  ///   - closeColumn    = closes the column
+  ///   - properties     = hashmap containing extra attributes for the container element.
+  ///   - xml_attributes = hashmap containing attributes for the main XML node
   pub fn new(config: AlignmentConfig) -> Self {
     let template = config.template.unwrap_or_default();
     Alignment {

--- a/rtx_math_parser/src/grammar/builder.rs
+++ b/rtx_math_parser/src/grammar/builder.rs
@@ -71,7 +71,9 @@ pub fn init_grammar() -> Result<(MarpaGrammar, Actions, TreeBuilder)> {
     factor = factor_base;
     // Terms
     tight_term = factor
-      | tight_term factor => apply_invisible_times;
+      | tight_term factor => apply_invisible_times
+      // TODO: develop this further
+      | function factor => prefix_apply;
 
     term = tight_term
       | term mulop tight_term => infix_apply_nary
@@ -124,10 +126,12 @@ pub fn init_grammar() -> Result<(MarpaGrammar, Actions, TreeBuilder)> {
 
     scripted_factor_r11 = factor_base postsuperarg => postfix_script
       | scripted_factor_l1 postsuperarg => postfix_script
-      | scripted_factor_l2 postsuperarg => postfix_script;
+      | scripted_factor_l2 postsuperarg => postfix_script
+      | fenced_factor postsuperarg => postfix_script;
     scripted_factor_r12 = factor_base postsubarg => postfix_script
       | scripted_factor_l1 postsubarg => postfix_script
-      | scripted_factor_l2 postsubarg => postfix_script;
+      | scripted_factor_l2 postsubarg => postfix_script
+      | fenced_factor postsubarg => postfix_script;
     scripted_factor_r1 = scripted_factor_r11 | scripted_factor_r12;
     scripted_factor_r2 = scripted_factor_r12 postsuperarg => postfix_script
       | scripted_factor_r11 postsubarg => postfix_script;

--- a/rtx_package/src/package/tex_appendix_b_p361.rs
+++ b/rtx_package/src/package/tex_appendix_b_p361.rs
@@ -6,9 +6,7 @@ LoadDefinitions!(state, {
   DefConstructor!(
     "\\sqrt OptionalInScriptStyle Digested",
     "?#1(<ltx:XMApp><ltx:XMTok meaning='nth-root'/>\
-    <ltx:XMArg>#1</ltx:XMArg><ltx:XMArg>#2</ltx:XMArg>\
-    </ltx:XMApp>)\
-    (<ltx:XMApp><ltx:XMTok meaning='square-root'/>\
-    <ltx:XMArg>#2</ltx:XMArg></ltx:XMApp>)"
+    <ltx:XMArg>#1</ltx:XMArg><ltx:XMArg>#2</ltx:XMArg></ltx:XMApp>)\
+    (<ltx:XMApp><ltx:XMTok role='FUNCTION' meaning='square-root'/><ltx:XMArg>#2</ltx:XMArg></ltx:XMApp>)"
   );
 });

--- a/rtx_package/src/package/tex_setup.rs
+++ b/rtx_package/src/package/tex_setup.rs
@@ -1044,14 +1044,22 @@ LoadDefinitions!(state, {
   DefParameterType!(OptionalInScriptStyle, sub[gullet, _inner, _extra, state] {
       gullet.read_optional(None, state)
     },
-    // before_digest => sub [stomach,state] {
-    //   gullet.bgroup(state);
+    // before_digest => sub[stomach,state] {
+    //   stomach.bgroup(state);
     //   MergeFont!("scripted" => true);
     // },
     // after_digest => sub[stomach,state] {
     //   stomach.egroup(state); },
-    optional => true
-    // reversion => sub { ($_[0] ? (T_OTHER('['), Revert($_[0]), T_OTHER(']')) : ()); }
+    optional => true,
+    reversion => reversion!(_gullet,arg,_inner,_extra,_state, {
+      if arg.is_empty() { Ok(Tokens!()) }
+      else {
+        let mut tks = vec![T_OTHER!("[")];
+        tks.extend(arg.into_iter().map(|t| t.revert()));
+        tks.push(T_OTHER!("]"));
+        Ok(Tokens::new(tks))
+      }
+    })
   );
   // DefParameterType!(InFractionStyle, sub[gullet, inner, _extra, state] {
   //     $_[0]->readArg; },


### PR DESCRIPTION
A couple of basic upgrades, to dust off the math parsing code flows.

Two examples needing this PR are:
```
cargo run --release --bin rtxmath '(x+y)^2 = x^2 + 2xy + y^2'
cargo run --release --bin rtxmath '\sqrt{\sqrt{x}} = 0'
```