### PR TITLE
A medley of add-ons needed for a first arXiv conversion

### DIFF
--- a/rtx_codegen/src/constructable.rs
+++ b/rtx_codegen/src/constructable.rs
@@ -134,7 +134,7 @@ fn compile_replacement_tokens(mut replacement: String) -> Vec<proc_macro2::Token
   let mut floats: String = String::new();
   let mut has_floats: bool = false;
   let float_res = FLOAT_RE.replace(&replacement, |refs: &Captures| -> String {
-    floats = refs.get(1).map_or("", |m| m.as_str()).to_string();
+    floats = refs.get(1).map_or("", |m| m.as_str()).trim().to_string();
     has_floats = true;
     String::new()
   });
@@ -213,9 +213,9 @@ fn compile_replacement_tokens(mut replacement: String) -> Vec<proc_macro2::Token
       if has_floats {
         let float_type = floats.len();
         if float_type == 1 {
-          operations.push(quote!(savenode = document.float_to_element(#current_tag, false);));
+          operations.push(quote!(savenode = document.float_to_element(#current_tag, false, state)?;));
         } else if float_type == 2 {
-          operations.push(quote!(savenode = document.float_to_element(#current_tag, true);));
+          operations.push(quote!(savenode = document.float_to_element(#current_tag, true, state)?;));
         }
         has_floats = false;
         floats = String::new();

--- a/rtx_core/src/alignment/normalize.rs
+++ b/rtx_core/src/alignment/normalize.rs
@@ -367,8 +367,7 @@ pub fn normalize_sum_sizes(alignment: &mut Alignment) -> Result<()> {
         rowd = rowd.max(d);
         rowt = rowt.max(t as i64);
         rowb = rowb.max(b as i64);
-      } else {
-      } // Ditto spanned rows
+      } //else {} // Ditto spanned rows
       colwidths.push(colwidths_j);
       collefts.push(collefts_j);
       colrights.push(colrights_j);

--- a/rtx_core/src/binding/def/dialect.rs
+++ b/rtx_core/src/binding/def/dialect.rs
@@ -486,22 +486,21 @@ pub fn def_math_dual(
         dtks.push(T_BEGIN!());
         dtks.push(captured_cont_cs.clone());
         dtks.push(T_BEGIN!());
-        for carg_opt in cargs.into_iter() {
-          if let Some(carg) = carg_opt {
+        for carg in cargs.into_iter().flatten() {
+          // if let Some(carg) = carg_opt {
             dtks.extend(carg.unlist());
-          } else {
-          } // TODO: we can't push an empty tokens in the flat setup. Is this a problem?
+          //} else {}
+          // TODO: we can't push an empty tokens in the flat setup. Is this a problem?
         }
         dtks.push(T_END!());
         dtks.push(T_END!());
         dtks.push(T_BEGIN!());
         dtks.push(captured_pres_cs.clone());
         dtks.push(T_BEGIN!());
-        for parg_opt in pargs.into_iter() {
-          if let Some(parg) = parg_opt {
+        for parg in pargs.into_iter().flatten() {
+          // if let Some(parg) = parg_opt {
             dtks.extend(parg.unlist());
-          } else {
-          } // TODO: we can't push an empty tokens in the flat setup. Is this a problem?
+          //} else {} // TODO: we can't push an empty tokens in the flat setup. Is this a problem?
         }
         dtks.push(T_END!());
         dtks.push(T_END!());

--- a/rtx_core/src/binding/def/macros.rs
+++ b/rtx_core/src/binding/def/macros.rs
@@ -262,7 +262,7 @@ macro_rules! reader {
 }
 
 #[macro_export]
-macro_rules! reader_predigest {
+macro_rules! predigest {
   ($stomach:ident, $arg:ident, $state:ident, $body:block) => {
     Some(Rc::new(
       |$stomach: &mut Stomach, $arg: ArgWrap, $state: &mut State| -> Result<Option<Digested>> {
@@ -290,21 +290,6 @@ macro_rules! setter {
     Some(Rc::new(
       move |$value: RegisterValue, mut $args: Vec<ArgWrap>, $state: &mut State| {
         WithInnerState!($body, $state)
-      },
-    ))
-  };
-}
-
-#[macro_export]
-macro_rules! undigested {
-  () => {
-    Some(Rc::new(
-      |stomach: &mut Stomach, arg: ArgWrap, state: &mut State| -> Result<Option<Digested>> {
-        if arg.is_none() {
-          Ok(None)
-        } else {
-          Ok(Some(Digested::from(arg.owned_tokens().unwrap_or_default())))
-        }
       },
     ))
   };

--- a/rtx_core/src/common/font.rs
+++ b/rtx_core/src/common/font.rs
@@ -267,6 +267,7 @@ pub struct Font {
   pub name: Option<Cow<'static, str>>,
   pub emph: Option<bool>,
   pub scripted: Option<bool>,
+  pub fraction: Option<bool>,
   // Note: forcefamily, forceseries, forceshape (& forcebold for compatibility)
   // are only useful for fonts in math; See the specialize method below.
   pub forceseries: Option<bool>,
@@ -386,6 +387,7 @@ impl Font {
       emph: None,
       name: None,
       scripted: None,
+      fraction: None,
       forceseries: None,
       forcefamily: None,
       forceshape: None,
@@ -410,6 +412,7 @@ impl Font {
       emph: None,
       name: None,
       scripted: None,
+      fraction: None,
       forceseries: None,
       forcefamily: None,
       forceshape: None,

--- a/rtx_core/src/common/font.rs
+++ b/rtx_core/src/common/font.rs
@@ -272,6 +272,7 @@ pub struct Font {
   pub forceseries: Option<bool>,
   pub forcefamily: Option<bool>,
   pub forceshape: Option<bool>,
+  pub forcebold: Option<bool>,
   pub scale: Option<f64>,
   pub flags: Option<u8>,
 }
@@ -388,6 +389,7 @@ impl Font {
       forceseries: None,
       forcefamily: None,
       forceshape: None,
+      forcebold: None,
       scale: None,
       flags: None,
     }
@@ -411,6 +413,7 @@ impl Font {
       forceseries: None,
       forcefamily: None,
       forceshape: None,
+      forcebold: None,
       scale: None,
       flags: None,
     }

--- a/rtx_core/src/common/store.rs
+++ b/rtx_core/src/common/store.rs
@@ -213,6 +213,7 @@ impl fmt::Display for Stored {
       Token(ref s) => write!(f, "{s}"),
       Conditional(ref s) => write!(f, "{s}"),
       Constructor(ref c) => write!(f, "Constructor[{}]", c.get_cs_name()),
+      None => write!(f, "Stored::None"),
       ref variant => {
         panic!("TODO: implement Display for Stored variant {variant:?}");
         // write!(f, "{:?}", self)

--- a/rtx_core/src/definition/argument.rs
+++ b/rtx_core/src/definition/argument.rs
@@ -149,6 +149,13 @@ impl ArgWrap {
       Err(e) => panic!("{e}"),
     }
   }
+  pub fn undigested(self) -> Option<Digested> {
+    if self.is_none() {
+      None
+    } else {
+      Some(Digested::from(self.owned_tokens().unwrap_or_default()))
+    }
+  }
 
   pub fn as_tokens<'a>(&'a self, state: &mut State) -> Result<Option<Cow<'a, Tokens>>> {
     use ArgWrap::*;

--- a/rtx_core/src/document.rs
+++ b/rtx_core/src/document.rs
@@ -3106,9 +3106,6 @@ impl Document {
 
   /// Find a node in the document that can contain an element `qname`
   pub fn float_to_element(&mut self, qname: &str, closeifpossible: bool, state: &mut State) -> Result<Option<Node>> {
-    // TODO:
-    dbg!(qname);
-    dbg!(closeifpossible);
     let mut candidates : VecDeque<Node> = VecDeque::from(self.get_insertion_candidates(&self.node));
     let mut closeable  = true;
     // If the current node can contain already, we're fine right here - just return

--- a/rtx_core/src/document.rs
+++ b/rtx_core/src/document.rs
@@ -1422,9 +1422,9 @@ impl Document {
     }
   }
 
-  pub fn can_contain_node_somehow(&self, tag: &Node, child: &str, state: &mut State) -> bool {
+  pub fn can_contain_node_somehow(&self, node: &Node, child: &str, state: &mut State) -> bool {
     let child_sym = arena::pin(child);
-    self.sym_can_contain_somehow(state.model.get_node_qname(tag), child_sym, state)
+    self.sym_can_contain_somehow(state.model.get_node_qname(node), child_sym, state)
   }
 
   pub fn can_contain_somehow(&self, tag: &str, child: &str, state: &mut State) -> bool {
@@ -3077,7 +3077,7 @@ impl Document {
 
   pub fn make_error(&mut self, error_class: &str, _content: &str, state: &mut State) -> Result<()> {
     let savenode_opt = if !self.is_openable("ltx:ERROR", state) {
-      self.float_to_element("ltx:ERROR", false)
+      self.float_to_element("ltx:ERROR", false, state)?
     } else {
       None
     };
@@ -3105,43 +3105,42 @@ impl Document {
   // to reset the insertion point to where it had been.
 
   /// Find a node in the document that can contain an element `qname`
-  pub fn float_to_element(&mut self, _qname: &str, _closeifpossible: bool) -> Option<Node> {
+  pub fn float_to_element(&mut self, qname: &str, closeifpossible: bool, state: &mut State) -> Result<Option<Node>> {
     // TODO:
-
-    // let candidates = get_insertion_candidates(self.node);
-    // let mut closeable  = true;
-    // // If the current node can contain already, we're fine right here - just return
-    // if !candidates.is_empty() && self.can_contain(candidates[0], qname) {
-    //   // Edge case: Don't resume at a text node, if it is current. Don't append more to it after
-    // other insertions.   if self.node.get_type() == NodeType::TextNode {
-    //     self.set_node(candidates[0]);
-    //   }
-    //   return Some(candidates[0]);
-    // }
-    // while !candidates.is_empty() && !self.can_contain(candidates[0], qname) {
-    //   if closeable {
-    //     closeable = self.can_auto_close(candidates[0]);
-    //   }
-    //   candidates.pop_front();
-    // }
-    // if let Some(n) = candidates.pop_front() {
-    //   if closeifpossible && closeable {
-    //     self.close_to_node(n);
-    //   } else {
-    //     let savenode = self.node;
-    //     self.set_node(n);
-    //     // Debug!("Floating from " . Stringify($savenode) . " to " . Stringify($n) . " for
-    // $qname")     //   if ($$savenode ne $$n) && $LaTeXML::DEBUG{document};
-    //     Some(savenode)
-    //   }
-    // } else {
-    //   if !self.can_contain_somehow(self.node, qname) {
-    //     Warn!("malformed", qname, self, "No open node can contain element '{}'", qname
-    //       $self->getInsertionContext())
-    //     }
-    //   None
-    // }
-    None
+    dbg!(qname);
+    dbg!(closeifpossible);
+    let mut candidates : VecDeque<Node> = VecDeque::from(self.get_insertion_candidates(&self.node));
+    let mut closeable  = true;
+    // If the current node can contain already, we're fine right here - just return
+    if !candidates.is_empty() && self.can_contain(&candidates[0], qname, state) {
+      // Edge case: Don't resume at a text node, if it is current.
+      // Don't append more to it after other insertions.
+      if self.node.get_type() == Some(NodeType::TextNode) {
+        self.set_node(&candidates[0]);
+      }
+      return Ok(candidates.pop_front());
+    }
+    while !candidates.is_empty() && !self.can_contain(&candidates[0], qname, state) {
+      if closeable {
+        closeable = self.can_auto_close(&candidates[0], state);
+      }
+      candidates.pop_front();
+    }
+    if let Some(n) = candidates.pop_front() {
+      if closeifpossible && closeable {
+        self.close_to_node(&n, false, state)?;
+      } else {
+        let savenode = self.node.clone();
+        self.set_node(&n);
+        // Debug!("Floating from " . Stringify($savenode) . " to " . Stringify($n) . " for $qname")
+        //   if ($$savenode ne $$n) && $LaTeXML::DEBUG{document};
+        return Ok(Some(savenode));
+      }
+    } else if !self.can_contain_node_somehow(&self.node, qname, state) {
+        Warn!("malformed", qname, self, state, s!("No open node can contain element '{}'", qname));
+        // self.get_insertion_context())
+    }
+    Ok(None)
   }
 
   // find a node that can accept a label.

--- a/rtx_core/src/lib.rs
+++ b/rtx_core/src/lib.rs
@@ -223,6 +223,9 @@ pub trait BoxOps: Object {
       }
     })
   }
+  fn get_property_string(&self, key: &str) -> String {
+    self.get_property(key).map(|v| v.to_string()).unwrap_or_default()
+  }
   /// get a mutable reference to a single named property (does NOT have the "isSpace" check)
   fn get_property_mut(&mut self, key: &str) -> Option<&mut Stored> {
     self.get_properties_mut().get_mut(key)

--- a/rtx_core/src/parameter.rs
+++ b/rtx_core/src/parameter.rs
@@ -52,7 +52,7 @@ pub struct Parameter {
   pub extra: Vec<Tokens>,
   pub inner: Option<Parameters>,
   pub reader: ReaderClosure,
-  pub reader_predigest: Option<ReaderPredigestClosure>,
+  pub predigest: Option<ReaderPredigestClosure>,
   pub reversion: Option<ReversionClosure>,
   pub before_digest: Vec<BeforeDigestClosure>,
   pub after_digest: Vec<DigestionClosure>,
@@ -78,7 +78,7 @@ impl Default for Parameter {
         );
         Ok(ArgWrap::None)
       }),
-      reader_predigest: None,
+      predigest: None,
       reversion: None,
       before_digest: Vec::new(),
       after_digest: Vec::new(),
@@ -213,7 +213,7 @@ impl Parameter {
         self.reversion = descriptor.reversion.clone();
         self.before_digest = descriptor.before_digest.clone();
         self.after_digest = descriptor.after_digest.clone();
-        self.reader_predigest = descriptor.reader_predigest.clone();
+        self.predigest = descriptor.predigest.clone();
         self.pack_parameters = descriptor.pack_parameters;
       },
       None => fatal!(
@@ -309,7 +309,7 @@ impl Parameter {
 
     let checked_value = if !self.optional
       && !self.novalue
-      && (value_arg.is_none() && self.reader_predigest.is_none())
+      && (value_arg.is_none() && self.predigest.is_none())
     {
       // Deyan: Special exception, which may motivate switching the reader type to Option<Tokens> in
       // the long-run        Until *may* have a value, but it also may *not*, both OK. So...
@@ -376,7 +376,7 @@ impl Parameter {
       // Done for effect only.
       pre(stomach, state)?; // maybe pass extras?
     }
-    let digested_value = if let Some(ref closure) = &self.reader_predigest {
+    let digested_value = if let Some(ref closure) = &self.predigest {
       closure(stomach, value_arg, state)?
     } else {
       // Note: we have an open question for the type interface.
@@ -498,7 +498,7 @@ impl Parameters {
     gullet.setup_scan();
     for parameter in &self.0 {
       let values = parameter.read(gullet, fordefn, state)?;
-      if parameter.reader_predigest.is_some() {
+      if parameter.predigest.is_some() {
         // TODO: Sometimes we legitimately want to use e.g. Number parameters without the predigest
         // closure... so this shouldn't be an error, not even an info -- but leaving it here
         // if something changes in the future. error!(

--- a/rtx_package/src/package.rs
+++ b/rtx_package/src/package.rs
@@ -172,6 +172,8 @@ pub mod pdftex;
 // Supported package bindings
 pub mod alltt_sty;
 pub mod amsmath_sty;
+pub mod amsbsy_sty;
+pub mod amsgen_sty;
 pub mod amsfonts_sty;
 pub mod amssymb_sty;
 pub mod amsthm_sty;
@@ -212,6 +214,8 @@ pub fn dispatch(filename: &str, stomach: &mut Stomach, state: &mut State) -> Opt
     "amsfonts.sty" => amsfonts_sty::load_definitions(stomach, state),
     "amssymb.sty" => amssymb_sty::load_definitions(stomach, state),
     "amsthm.sty" => amsthm_sty::load_definitions(stomach, state),
+    "amsbsy.sty" => amsbsy_sty::load_definitions(stomach, state),
+    "amsgen.sty" => amsgen_sty::load_definitions(stomach, state),
     "fullpage.sty" => fullpage_sty::load_definitions(stomach, state),
     "comment.sty" => comment_sty::load_definitions(stomach, state),
     "IEEEtran.cls" => ieeetran_cls::load_definitions(stomach, state),

--- a/rtx_package/src/package.rs
+++ b/rtx_package/src/package.rs
@@ -175,6 +175,7 @@ pub mod amsmath_sty;
 pub mod amsfonts_sty;
 pub mod amssymb_sty;
 pub mod amsthm_sty;
+pub mod fullpage_sty;
 pub mod article_cls;
 pub mod cite_sty;
 pub mod comment_sty;
@@ -211,6 +212,7 @@ pub fn dispatch(filename: &str, stomach: &mut Stomach, state: &mut State) -> Opt
     "amsfonts.sty" => amsfonts_sty::load_definitions(stomach, state),
     "amssymb.sty" => amssymb_sty::load_definitions(stomach, state),
     "amsthm.sty" => amsthm_sty::load_definitions(stomach, state),
+    "fullpage.sty" => fullpage_sty::load_definitions(stomach, state),
     "comment.sty" => comment_sty::load_definitions(stomach, state),
     "IEEEtran.cls" => ieeetran_cls::load_definitions(stomach, state),
     "url.sty" => url_sty::load_definitions(stomach, state),

--- a/rtx_package/src/package/amsbsy_sty.rs
+++ b/rtx_package/src/package/amsbsy_sty.rs
@@ -1,0 +1,16 @@
+//**********************************************************************
+// See amsldoc
+//**********************************************************************
+use crate::package::*;
+LoadDefinitions!(state, {
+
+  RequirePackage!("amsgen");
+
+  DefConstructor!("\\boldsymbol{}", "#1", bounded => true, require_math => true, font => { forcebold => true });
+
+  // I think the intent is that you use \pmb to get bold, but your current font doesn't supply
+  // a bold for those glyphs.  Since we're just forcing the glyph to be bold,
+  // \pmb is probably \boldsymbol. or... ??
+  Let!("\\pmb", "\\boldsymbol");
+
+});

--- a/rtx_package/src/package/amsgen_sty.rs
+++ b/rtx_package/src/package/amsgen_sty.rs
@@ -1,0 +1,35 @@
+use crate::package::*;
+LoadDefinitions!(state, {
+
+  DefMacro!("\\@saveprimitive{}{}", "\\let#2#1");
+
+  Let!("\\@xp", "\\expandafter");
+  Let!("\\@nx", "\\noexpand");
+  DefRegister!("\\@emptytoks" => Tokens!());
+  DefMacro!("\\@ifempty {}", r"\@xifempty#1@@..\@nil");
+  RawTeX!(r###"
+  \def\@oparg#1[#2]{\@ifnextchar[{#1}{#1[#2]}}
+  \long\def\@ifempty#1{\@xifempty#1@@..\@nil}
+  \long\def\@xifempty#1#2@#3#4#5\@nil{%
+    \ifx#3#4\@xp\@firstoftwo\else\@xp\@secondoftwo\fi}
+  \long\def\@ifnotempty#1{\@ifempty{#1}{}}
+  "###);
+
+  DefMacro!("\\FN@", "\\futurelet\\@let@token");
+  DefMacro!("\\DN@", "\\def\\next@");
+  DefMacro!("\\RifM@", "\\relax\\ifmmode");
+  DefMacro!("\\setboxz@h", "\\setbox\\z@\\hbox");
+  DefMacro!("\\wdz@", "\\wd\\z@");
+  DefMacro!("\\boxz@", "\\box\\z@");
+  DefMacro!("\\relaxnext@", "\\let\\@let@token\\relax");
+
+  // Do we need to worry about the skip space issues...?
+  Let!("\\new@ifnextchar", "\\@ifnextchar");
+  // \@ifstar already in LaTeX.pool
+  DefRegister!("\\ex@" => Dimension::from_str("1pt", state)?);    // Just fake it...
+  // Hmm.... how should we detect whether there"\s already punctuation?
+  DefMacro!("\\@addpunct{}", "#1");
+
+  DefMacro!("\\mathhexbox{}{}{}", r###"\text{$\m@th\mathchar"#1#2#3$}"###);
+
+});

--- a/rtx_package/src/package/amsmath_sty.rs
+++ b/rtx_package/src/package/amsmath_sty.rs
@@ -1,7 +1,25 @@
 use crate::package::*;
 use rtx_core::state::State;
+//**********************************************************************
+// See amsldoc
+//
+// Currently only a random collection of things I (Bruce) need for DLMF chapters.
+// Eventually, go through the doc and implement it all.
+//**********************************************************************
+
+// DG:
+// TODO: Most of this binding is not ported yet.
 
 LoadDefinitions!(state, {
+  Let!("\\@xp", "\\expandafter");
+  Let!("\\@nx", "\\noexpand");
+  // sub-packages:
+  RequirePackage!("amsbsy");
+  // RequirePackage!("amstext");
+  // RequirePackage!("amsopn");
+
+
+
   //======================================================================
   // Section 4.2 Math spacing commands
   // \, == \thinspace

--- a/rtx_package/src/package/article_cls.rs
+++ b/rtx_package/src/package/article_cls.rs
@@ -44,7 +44,7 @@ LoadDefinitions!(stomach, state, {
   // }); DeclareOption!("fleqn", || { state.assign_mapping("DOCUMENT_CLASSES", "ltx_fleqn": 1);
   // });
 
-  ProcessOptions!(stomach);
+  ProcessOptions!();
 
   //**********************************************************************
   // Document structure.

--- a/rtx_package/src/package/fullpage_sty.rs
+++ b/rtx_package/src/package/fullpage_sty.rs
@@ -1,0 +1,14 @@
+use crate::package::*;
+use rtx_core::state::State;
+
+LoadDefinitions!(stomach, state, {
+
+  // Ignore the options
+  for option in ["in","cm","plain", "empty", "headings", "myheadings"] {
+    DeclareOption!(option, None);
+  }
+  ProcessOptions!();
+
+  // Nothing else to do....
+
+});

--- a/rtx_package/src/package/latex_ch5_title_page_and_abstract.rs
+++ b/rtx_package/src/package/latex_ch5_title_page_and_abstract.rs
@@ -18,8 +18,8 @@ LoadDefinitions!(state, {
   );
 
   // TODO: ^
-  // DefConstructor!("\\person@thanks{}", "^ <ltx:contact role='thanks'>#1</ltx:contact>",
-  //   alias => "\\thanks".into_option(), mode => "text".into_option());
+  DefConstructor!("\\person@thanks{}", "^ <ltx:contact role='thanks'>#1</ltx:contact>",
+    alias => "\\thanks", mode => "text");
   DefConstructor!("\\@personname{}", "<ltx:personname>#1</ltx:personname>",
     before_digest => { Let!("\\thanks", "\\person@thanks"); },
     bounded => true,
@@ -120,7 +120,7 @@ LoadDefinitions!(state, {
   );
 
   DefMacro!("\\@thanks", "\\@empty");
-  DefMacro!("\\thanks{}", "\\def\\@thanks{#1}\\lx@make@thanks{#1}");
+  DefMacro!("\\thanks{}", r"\def\@thanks{#1}\lx@make@thanks{#1}");
   DefConstructor!(
     "\\lx@make@thanks{}",
     "<ltx:note role='thanks'>#1</ltx:note>"

--- a/rtx_package/src/package/latex_ch7_math_common_structures.rs
+++ b/rtx_package/src/package/latex_ch7_math_common_structures.rs
@@ -1,2 +1,17 @@
 use crate::package::*;
-LoadDefinitions!(_state, {});
+//======================================================================
+// C.7.2 Common Structures
+//======================================================================
+// sub, superscript and prime are in TeX.pool
+// Underlying support in TeX.pool.ltxml
+LoadDefinitions!(_state, {
+  DefConstructor!("\\frac InFractionStyle InFractionStyle",
+    "<ltx:XMApp>\
+      <ltx:XMTok meaning='divide' role='FRACOP' mathstyle='#mathstyle'/>\
+      <ltx:XMArg>#1</ltx:XMArg><ltx:XMArg>#2</ltx:XMArg>\
+      </ltx:XMApp>"
+      // TODO
+    // sizer      => sub[whatsit,state] { frac_sizer(whatsit.get_arg(1), whatsit.get_arg(2), state) },
+    // properties => { "mathstyle" => state.lookup_font().get_mathstyle() }
+  );
+});

--- a/rtx_package/src/package/latex_delimiters.rs
+++ b/rtx_package/src/package/latex_delimiters.rs
@@ -5,6 +5,61 @@ use crate::package::*;
 // The meaning of OPEN/CLOSE tends to depend upon the pairing,
 // rather than the individual tokens.
 // This meaning is handled in MathParser (for now)
+
+/// A shorthand data structure for delimiter metadata
+pub struct DelimeterMeta {
+  char: char,
+  left_role: &'static str,
+  right_role: &'static str,
+  name: Option<&'static str>,
+
+}
+/// This duplicates in slightly different way what DefMath has put together.
+pub static DELIMITER_MAP : Lazy<HashMap<&'static str, DelimeterMeta>> = Lazy::new(|| raw_map!(
+  "(" => DelimeterMeta{char: '(', left_role: "OPEN", right_role: "CLOSE", name:None},
+  ")" => DelimeterMeta{char: ')', left_role: "OPEN", right_role: "CLOSE", name:None},
+  "[" => DelimeterMeta{char: '[', left_role: "OPEN", right_role: "CLOSE", name:None},
+  "]" => DelimeterMeta{ char: ']', left_role: "OPEN", right_role: "CLOSE", name:None},
+  "\\{" => DelimeterMeta{ char: '{', left_role: "OPEN", right_role: "CLOSE", name:None},
+  "\\}" => DelimeterMeta{ char: '}', left_role: "OPEN", right_role: "CLOSE", name:None},
+  "\\lfloor"=> DelimeterMeta{ char: '\u{230A}',
+                left_role: "OPEN", right_role: "CLOSE", name: Some("lfloor") },
+  "\\rfloor"=> DelimeterMeta{ char: '\u{230B}',
+                left_role: "OPEN", right_role: "CLOSE", name: Some("rfloor") },
+  "\\lceil" => DelimeterMeta{ char: '\u{2308}',
+                left_role: "OPEN", right_role: "CLOSE", name: Some("lceil") },
+  "\\rceil" => DelimeterMeta{ char: '\u{2309}',
+                left_role: "OPEN", right_role: "CLOSE", name: Some("rceil") },
+  "\\langle"=> DelimeterMeta{ char: '\u{27E8}',
+                left_role: "OPEN", right_role: "CLOSE", name: Some("langle") },
+  "\\rangle"=> DelimeterMeta{ char: '\u{27E9}',
+                left_role: "OPEN",  right_role: "CLOSE", name: Some("rangle") },
+  "<"      => DelimeterMeta{ char: '\u{27E8}',
+                left_role: "OPEN", right_role: "CLOSE", name: Some("langle") },
+  ">"      => DelimeterMeta{ char: '\u{27E9}',
+                left_role: "OPEN", right_role: "CLOSE", name: Some("rangle") },
+  "/"      => DelimeterMeta{ char: '/', left_role: "MULOP",   right_role: "MULOP", name: None },
+  "\\backslash" => DelimeterMeta{ char: '\u{005C}',
+                left_role: "MULOP",   right_role: "MULOP", name: Some("backslash") },
+  "|"      => DelimeterMeta{ char: '|',
+                left_role: "VERTBAR", right_role: "VERTBAR", name: None },
+  "\\|"     => DelimeterMeta{ char: '\u{2225}',
+                left_role: "VERTBAR", right_role: "VERTBAR", name: None },
+  "\\uparrow"   => DelimeterMeta{ char: '\u{2191}',
+                    left_role: "OPEN", right_role: "CLOSE", name: Some("uparrow") },
+  "\\Uparrow"   => DelimeterMeta{ char: '\u{21D1}',
+                    left_role: "OPEN", right_role: "CLOSE", name: Some("Uparrow") },
+  "\\downarrow" => DelimeterMeta{ char: '\u{2193}',
+                    left_role: "OPEN", right_role: "CLOSE", name: Some("downarrow") },
+  "\\Downarrow" =>  DelimeterMeta{ char: '\u{21D3}',
+                    left_role: "OPEN", right_role: "CLOSE", name: Some("Downarrow") },
+  "\\updownarrow" => DelimeterMeta{ char: '\u{2195}',
+                    left_role: "OPEN", right_role: "CLOSE", name: Some("updownarrow") },
+  "\\Updownarrow" => DelimeterMeta{ char: '\u{21D5}',
+                    left_role: "OPEN", right_role: "CLOSE", name: Some("Updownarrow") }
+));
+
+
 LoadDefinitions!(state, {
   DefMacro!("\\{", r"\ifmmode\lx@math@lbrace\else\lx@text@lbrace\fi", protected => true);
   DefMacro!("\\}", r"\ifmmode\lx@math@rbrace\else\lx@text@rbrace\fi", protected => true);
@@ -38,35 +93,6 @@ LoadDefinitions!(state, {
   // Short of setting up TeX's complicated encoding machinery, I need an explicit
   // mapping.  Unfortunately, this doesn't (yet) support people declaring thier own delimiters!
 
-  // # This duplicates in slightly different way what DefMath has put together.
-  // our %DELIMITER_MAP =
-  //   ('(' => { char => "(", lrole => 'OPEN', rrole => 'CLOSE' },
-  //   ')'          => { char => ")",        lrole => 'OPEN',    rrole => 'CLOSE' },
-  //   '['          => { char => "[",        lrole => 'OPEN',    rrole => 'CLOSE' },
-  //   ']'          => { char => "]",        lrole => 'OPEN',    rrole => 'CLOSE' },
-  //   '\{'         => { char => "{",        lrole => 'OPEN',    rrole => 'CLOSE' },
-  //   '\}'         => { char => "}",        lrole => 'OPEN',    rrole => 'CLOSE' },
-  //   '\lfloor'    => { char => "\u{230A}", lrole => 'OPEN',    rrole => 'CLOSE', name => 'lfloor'
-  // },   '\rfloor'    => { char => "\u{230B}", lrole => 'OPEN',    rrole => 'CLOSE', name =>
-  // 'rfloor' },   '\lceil'     => { char => "\u{2308}", lrole => 'OPEN',    rrole => 'CLOSE',
-  // name => 'lceil' },   '\rceil'     => { char => "\u{2309}", lrole => 'OPEN',    rrole =>
-  // 'CLOSE', name => 'rceil' },   '\langle'    => { char => "\u{27E8}", lrole => 'OPEN',    rrole
-  // => 'CLOSE', name => 'langle' },   '\rangle'    => { char => "\u{27E9}", lrole => 'OPEN',
-  // rrole => 'CLOSE', name => 'rangle' },   '<'          => { char => "\u{27E8}", lrole =>
-  // 'OPEN',    rrole => 'CLOSE', name => 'langle' },   '>'          => { char => "\u{27E9}",
-  // lrole => 'OPEN',    rrole => 'CLOSE', name => 'rangle' },   '/'          => { char => "/",
-  // lrole => 'MULOP',   rrole => 'MULOP' },   '\backslash' => { char => UTF(0x5C),  lrole =>
-  // 'MULOP',   rrole => 'MULOP', name => 'backslash' },   '|'          => { char => "|",
-  // lrole => 'VERTBAR', rrole => 'VERTBAR' },   '\|'         => { char => "\u{2225}", lrole =>
-  // 'VERTBAR', rrole => 'VERTBAR' },   '\uparrow'   => { char => "\u{2191}", lrole => 'OPEN',
-  // rrole => 'CLOSE', name => 'uparrow' },   # ??   '\Uparrow'   => { char => "\u{21D1}", lrole
-  // => 'OPEN', rrole => 'CLOSE', name => 'Uparrow' },   # ??   '\downarrow' => { char =>
-  // "\u{2193}", lrole => 'OPEN', rrole => 'CLOSE', name => 'downarrow' }, # ??   '\Downarrow' =>
-  // { char => "\u{21D3}", lrole => 'OPEN', rrole => 'CLOSE', name => 'Downarrow' }, # ??
-  //   '\updownarrow' => { char => "\u{2195}", lrole => 'OPEN', rrole => 'CLOSE', name =>
-  // 'updownarrow' }, # ??   '\Updownarrow' => { char => "\u{21D5}", lrole => 'OPEN', rrole =>
-  // 'CLOSE', name => 'Updownarrow' }, # ??   );
-
   // # With new treatment of Simple Symbols as just Box's with assigned attributes,
   // # we're not getting whatsits, and so we're not looking them up the same way!!!
   // # TEMPORARILY (?) hack the Delimiter map
@@ -86,61 +112,72 @@ LoadDefinitions!(state, {
   // HOWEVER, an additional complication is that it is a common mistake to omit the balancing
   // \right! Using an \egroup (or hidden) makes it hard to recover, so use a special egroup
   DefMacro!("\\left XToken", r"\@left #1\@hidden@bgroup");
-  // # Like \@hidden@egroup, but softer about missing \left
-  // DefConstructor('\right@hidden@egroup', '',
-  //   afterDigest => sub {
-  //     my ($stomach) = @_;
-  //     if ($STATE->isValueBound('MODE', 0)    # Last stack frame was a mode switch!?!?!
-  //       || $STATE->lookupValue('groupNonBoxing')) {    # or group was opened with \begingroup
-  //       Error('unexpected', '\right', undef, "Unbalanced \\right, no balancing \\left."); }
-  //     else {
-  //       $stomach->egroup; } },
-  //   reversion => '');
+  // Like \@hidden@egroup, but softer about missing \left
+  DefConstructor!("\\right@hidden@egroup", "",
+    after_digest => sub[stomach,_args,state] {
+      if state.is_value_bound("MODE", Some(0)) // Last stack frame was a mode switch!?!?!
+        || state.lookup_value("groupNonBoxing").is_some() { // or group was opened with \begingroup
+        Error!("unexpected", "\\right", stomach, state, "Unbalanced \\right, no balancing \\left."); }
+      else {
+        stomach.egroup(state)?;
+      }
+    },
+    reversion => None);
 
   DefMacro!("\\right XToken", r"\right@hidden@egroup\@right #1");
 
-  // DefConstructor('\@left Token',
-  //   "?#char(<ltx:XMTok role='#role' name='#name' stretchy='#stretchy'>#char</ltx:XMTok>)"
-  //     . "(?#hint(<ltx:XMHint/>)(#1))",
-  //   afterDigest => sub { my ($stomach, $whatsit) = @_;
-  //     my $arg   = $whatsit->getArg(1);
-  //     my $delim = ToString($arg);
-  //     if ($delim eq '.') {
-  //       $whatsit->setProperty(hint => 1); }
-  //     elsif (my $entry = $DELIMITER_MAP{$delim}) {
-  //       $whatsit->setProperties(role => $$entry{lrole},
-  //         char     => $$entry{char},
-  //         name     => $$entry{name},
-  //         stretchy => 'true');
-  //       $whatsit->setFont($arg->getFont()); }
-  //     elsif (($arg->getProperty('role') || '') eq 'OPEN') {
-  //       $arg->setProperty(stretchy => 'true'); }
-  //     else {
-  //       Warn('unexpected', $delim, $stomach,
-  //         "Missing delimiter; '.' inserted"); }
-  //     return; },
-  //   alias => '\left');
-  // DefConstructor('\@right Token',
-  //   "?#char(<ltx:XMTok role='#role' name='#name' stretchy='#stretchy'>#char</ltx:XMTok>)"
-  //     . "(?#hint(<ltx:XMHint/>)(#1))",
-  //   afterDigest => sub { my ($stomach, $whatsit) = @_;
-  //     my $arg   = $whatsit->getArg(1);
-  //     my $delim = ToString($arg);
-  //     if ($delim eq '.') {
-  //       $whatsit->setProperty(hint => 1); }
-  //     elsif (my $entry = $DELIMITER_MAP{$delim}) {
-  //       $whatsit->setProperties(role => $$entry{rrole},
-  //         char     => $$entry{char},
-  //         name     => $$entry{name},
-  //         stretchy => 'true');
-  //       $whatsit->setFont($arg->getFont()); }
-  //     elsif (($arg->getProperty('role') || '') eq 'CLOSE') {
-  //       $arg->setProperty(stretchy => 'true'); }
-  //     else {
-  //       Warn('unexpected', $delim, $stomach,
-  //         "Missing delimiter; '.' inserted)"); }
-  //     return; },
-  //   alias => '\right');
+  DefConstructor!("\\@left Token",
+    "?#char(<ltx:XMTok role='#role' name='#name' stretchy='#stretchy'>#char</ltx:XMTok>)\
+      (?#hint(<ltx:XMHint/>)(#1))",
+    after_digest => sub[stomach,whatsit,state] {
+      let delim = whatsit.get_arg(1).map(ToString::to_string).unwrap_or_default();
+      if delim == "." {
+        whatsit.set_property("hint", true); }
+      else if let Some(entry) = DELIMITER_MAP.get(delim.as_str()) {
+        whatsit.set_property("role", entry.left_role);
+        whatsit.set_property("char", entry.char);
+        whatsit.set_property("name", entry.name);
+        whatsit.set_property("stretchy", true);
+        // TODO: Should we have more Rc<> wrappers over Font?
+        whatsit.set_font(Rc::new(
+          whatsit.get_arg(1).unwrap().get_font(state)?.unwrap().into_owned()
+        ));
+      }
+      else if whatsit.get_arg(1).unwrap().get_property_string("role") == "OPEN" {
+        whatsit.get_arg_mut(1).unwrap().set_property("stretchy", true);
+      } else {
+        Warn!("unexpected", delim, stomach, state,
+          "Missing delimiter; '.' inserted");
+      }
+      Ok(Vec::new())
+    },
+    alias => "\\left");
+  DefConstructor!("\\@right Token",
+    "?#char(<ltx:XMTok role='#role' name='#name' stretchy='#stretchy'>#char</ltx:XMTok>)\
+      (?#hint(<ltx:XMHint/>)(#1))",
+    after_digest => sub[stomach,whatsit,state] {
+      let delim = whatsit.get_arg(1).map(ToString::to_string).unwrap_or_default();
+      if delim == "." {
+        whatsit.set_property("hint", true); }
+      else if let Some(entry) = DELIMITER_MAP.get(delim.as_str()) {
+        whatsit.set_property("role", entry.right_role);
+        whatsit.set_property("char", entry.char);
+        whatsit.set_property("name", entry.name);
+        whatsit.set_property("stretchy", true);
+        // TODO: Should we have more Rc<> wrappers over Font?
+        whatsit.set_font(Rc::new(
+          whatsit.get_arg(1).unwrap().get_font(state)?.unwrap().into_owned()
+        ));
+      }
+      else if whatsit.get_arg(1).unwrap().get_property_string("role") == "CLOSE" {
+        whatsit.get_arg_mut(1).unwrap().set_property("stretchy", true);
+      } else {
+        Warn!("unexpected", delim, stomach, state,
+          "Missing delimiter; '.' inserted");
+      }
+      Ok(Vec::new())
+    },
+    alias => "\\right");
 
   // These originally had Token as parameter, rather than {}..... Why?
   // Note that in TeX, \big{((} will only enlarge the 1st paren!!!

--- a/rtx_package/src/package/latex_delimiters.rs
+++ b/rtx_package/src/package/latex_delimiters.rs
@@ -116,7 +116,7 @@ LoadDefinitions!(state, {
   DefConstructor!("\\right@hidden@egroup", "",
     after_digest => sub[stomach,_args,state] {
       if state.is_value_bound("MODE", Some(0)) // Last stack frame was a mode switch!?!?!
-        || state.lookup_value("groupNonBoxing").is_some() { // or group was opened with \begingroup
+        || state.lookup_bool("groupNonBoxing") { // or group was opened with \begingroup
         Error!("unexpected", "\\right", stomach, state, "Unbalanced \\right, no balancing \\left."); }
       else {
         stomach.egroup(state)?;

--- a/rtx_package/src/package/setup_binding_language.rs
+++ b/rtx_package/src/package/setup_binding_language.rs
@@ -1803,30 +1803,25 @@ macro_rules! DefMath(
 
 #[macro_export]
 macro_rules! DefParameterType {
-  ($name:ident) => (DefParameterTypeWO!($name,
-    NewDefault!(Parameter, name => stringify!($name).to_string())));
-  ($name:ident, $state_arg:ident) => (DefParameterTypeWO!($name,
-    NewDefault!(Parameter, name => stringify!($name.to_string())), $state_arg));
   ($name:ident, $($key:ident => $value:expr),*)=>(
     DefParameterTypeWO!($name, NewDefault!(Parameter, name => Cow::Borrowed(stringify!($name)),
     $($key=>$value),*)));
-  ($name:ident, $($key:ident => $value:expr),*, $state_arg:ident)=>
-    (DefParameterTypeWO!($name, NewDefault!(Parameter, name => Cow::Borrowed(stringify!($name)),
-    $($key=>$value),*), $state_arg));
   // with reader as explicit sub
   ($name:ident, sub[$gullet:ident, $inner:ident, $extra:ident, $inner_state:ident] $body:block) => (
     DefParameterTypeWO!($name, NewDefault!(Parameter, reader =>
       reader!($gullet, $inner, $extra, $inner_state, $body))));
+  // ($name:ident, sub[$gullet:ident, $inner:ident, $extra:ident, $inner_state:ident]
+  //   $body:block, $($key:ident => $value:expr),*) => (
+  //     DefParameterTypeWO!($name, NewDefault!(Parameter, reader =>
+  //       reader!($gullet, $inner, $extra, $inner_state, $body),
+  //     name => Cow::Borrowed(stringify!($name)),  $($key=>$value),*)));
+  // fully advanced version, including e.g. inner sub[] patterns for before_digest, after_digest,...
   ($name:ident, sub[$gullet:ident, $inner:ident, $extra:ident, $inner_state:ident]
-    $body:block, $($key:ident => $value:expr),*) => (
-      DefParameterTypeWO!($name, NewDefault!(Parameter, reader =>
-        reader!($gullet, $inner, $extra, $inner_state, $body),
-      name => Cow::Borrowed(stringify!($name)),  $($key=>$value),*)));
-  ($name:ident, sub[$gullet:ident, $inner:ident, $extra:ident, $inner_state:ident]
-    $body:block, $($key:ident => $value:expr),*) => (
-    DefParameterTypeWO!($name, NewDefault!(Parameter, reader =>
-      reader!($gullet, $inner, $extra, $inner_state, $body),
-      name => Cow::Borrowed($name),  $($key=>$value),*), $state_arg));
+    $body:block, $($input:tt)+) => (
+      let mut paramtype_options = defi_opts!(@munch ($($input)*) -> {Parameter,});
+      paramtype_options.reader = reader!($gullet, $inner, $extra, $inner_state, $body);
+      paramtype_options.name = Cow::Borrowed(stringify!($name));
+      DefParameterTypeWO!($name, paramtype_options));
 }
 
 #[macro_export]
@@ -2532,6 +2527,34 @@ macro_rules! defi_opts {
     defi_opts!(@munch ($($next)*) -> {$kind, $( [ $key @ $val ] )* [ auto_close @ $auto.into() ]})
   };
 
+  // DefParameterType options
+  // predigest: Vec<ReaderPredigestClosure>
+  (@munch ( $(,)? predigest $(:)?$(=>)? sub $($next:tt)*)
+    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    defi_opts!(@predigest (sub $($next)*) -> {$kind, $( [ $key @ $val ] )*})
+  };
+  (@munch ( $(,)? predigest $(:)?$(=>)? $body:block $($next:tt)*)
+    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    defi_opts!(@predigest ($body $($next)*) -> {$kind, $( [ $key @ $val ] )*})
+  };
+  // reversion
+
+  // semiverbatim
+  (@munch ( $(,)? semiverbatim $(:)?$(=>)? Some($value:expr))
+    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    defi_opts!(@munch () -> {$kind, $( [ $key @ $val ] )*
+      [ semiverbatim @ Some($value) ] })
+  };
+  (@munch ( $(,)? semiverbatim $(:)?$(=>)? None)
+    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    defi_opts!(@munch () -> {$kind, $( [ $key @ $val ] )*
+      [ semiverbatim @ None ] })
+  };
+  (@munch ( $(,)? semiverbatim $(:)?$(=>)? $value:expr, $($next:tt)*)
+    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    defi_opts!(@munch ($($next)*) -> {$kind, $( [ $key @ $val ] )*
+      [ semiverbatim @ $value ] })
+};
   // ligature options
   // role: literal string
   (@munch ( $(,)? role $(:)?$(=>)? $literal:literal, $($next:tt)*)
@@ -2765,5 +2788,21 @@ macro_rules! defi_opts {
                   -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [reversion @ reversion_digested!($stomach, $args, $state_arg, $body)]})
+  };
+  (@reversion (sub [$gullet:ident, $args:ident, $inner:ident, $extra:ident, $state_arg: ident] $body:block $($next:tt)*)
+                  -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
+      [reversion @ reversion!($gullet, $args, $inner, $extra, $state_arg, $body)]})
+  };
+  (@predigest (
+    sub[$stomach_arg:ident, $whatsit:ident, $state_arg: ident] $body:block $($next:tt)* )
+      -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
+      [predigest @ predigest!($stomach_arg, $whatsit, $state_arg, $body)]})
+  };
+  (@predigest (
+    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
+      [predigest @ predigest!(_stomach, _whatsit, _state, $body)]})
   };
 }

--- a/rtx_package/src/package/setup_binding_language.rs
+++ b/rtx_package/src/package/setup_binding_language.rs
@@ -2168,6 +2168,10 @@ macro_rules! DeclareOption {
 
 #[macro_export]
 macro_rules! ProcessOptions {
+  () => {{
+    bind_state_mut!(stomach,st);
+    process_options(stomach, st)?;
+  }};
   ($stomach:ident) => {{
     bind_state_mut!(st);
     process_options($stomach, st)?;

--- a/rtx_package/src/package/tex_appendix_b_p357.rs
+++ b/rtx_package/src/package/tex_appendix_b_p357.rs
@@ -62,9 +62,9 @@ LoadDefinitions!(state, {
   //       Warn('unexpected', "accent$n", $stomach, "Accent '$n' not recognized");
   //       Box(ToString($letter), undef, undef, $reversion); } });
 
-  // // Note that these two apparently work in Math? BUT the argument is treated as text!!!
-  // DefMacro('\d{}', '\ifmmode\@math@daccent{#1}\else\@text@daccent{#1}\fi');
-  // DefMacro('\b{}', '\ifmmode\@math@baccent{#1}\else\@text@baccent{#1}\fi');
+  // Note that these two apparently work in Math? BUT the argument is treated as text!!!
+  DefMacro!("\\d{}", r"\ifmmode\@math@daccent{#1}\else\@text@daccent{#1}\fi");
+  DefMacro!("\\b{}", r"\ifmmode\@math@baccent{#1}\else\@text@baccent{#1}\fi");
 
   // DefConstructor('\@math@daccent {}',
   //   "<ltx:XMApp><ltx:XMTok role='UNDERACCENT'>\x{22c5}</ltx:XMTok>"
@@ -109,39 +109,38 @@ LoadDefinitions!(state, {
   Let!("\\sp", T_SUPER!());
   Let!("\\sb", T_SUB!());
 
+  DefPrimitive!("\\lx@thinmuskip", sub[stomach,(),state] {
+    Tbox::new(arena::pin_static("\u{2009}"), None, None, Tokens!(T_CS!("\\,")),
+      stored_map!("name"  => "thinspace", "isSpace" => true,
+      "width" => state.lookup_value("\\thinmuskip")), state)
+  });
+  DefPrimitive!("\\lx@thinspace", sub[stomach,(),state] {
+    Tbox::new(arena::pin_static("\u{2009}"), None, None, Tokens!(T_CS!("\\,")),
+      stored_map!("name" => "thinspace", "width" => Dimension::from_str("0.16667em",state)?,
+       "isSpace" => true), state)
+  });
   DefMacro!(
     "\\,",
     r"\ifmmode\lx@thinmuskip\else\lx@thinspace\fi",
     protected => true
   );
-  // DefConstructor!("\\@math@thinmuskip",
-  //   "<ltx:XMHint name='thinspace' width='#width'/>",
-  //   alias => '\,',
-  //   properties => { isSpace => 1, width => sub { LookupValue('\thinmuskip'); } });
-  // DefPrimitiveI('\@text@thinmuskip', undef, "\x{2009}", alias => '\,');
 
   DefMacro!(
     "\\!",
     "\\ifmmode\\@math@negthinmuskip\\else\\@text@negthinmuskip\\fi"
   );
-  // DefConstructor('\@math@negthinmuskip', undef,
-  //   "<ltx:XMHint name='negthinspace' width='#width'/>",
-  //   alias => '\!',
-  //   properties => { isSpace => 1,
-  //     width => sub { LookupValue('\thinmuskip')->negate; } });
-  // DefPrimitiveI('\@text@negthinmuskip', undef, "", alias => '\!');
 
-  DefMacro!(
-    "\\>",
-    "\\ifmmode\\@math@medmuskip\\else\\@text@medmuskip\\fi"
-  );
-  // DefConstructor('\@math@medmuskip', undef,
-  //   "<ltx:XMHint name='medspace' width='#width'/>",
-  //   alias => '\>',
-  //   properties => { isSpace => 1,
-  //     width => sub { LookupValue('\medmuskip'); } });
-  // DefPrimitiveI('\@text@medmuskip', undef, "", alias => '\>');
+  DefPrimitive!("\\!", sub[stomach,(),state] {
+    Tbox::new(arena::pin_static("\u{200B}"), None, None, Tokens!(T_CS!("\\!")),  // zero width space
+      stored_map!("name"  => "negthinspace", "isSpace" => true,
+      "width" => state.lookup_dimension("\\thinmuskip").unwrap().negate()), state)
+  });
 
+  DefPrimitive!("\\>", sub[stomach,(),state] {
+    Tbox::new(arena::pin_static("\u{2005}"), None, None, Tokens!(T_CS!("\\>")),
+      stored_map!("name"  => "medspace", "isSpace" => true,
+      "width" => state.lookup_value("\\medmuskip")), state)
+  });
   DefPrimitive!("\\;", sub[stomach, (), state] {
     Tbox::new(arena::pin_static("\u{2004}"), None, None, Tokens!(T_CS!("\\;")),
       stored_map!("name"  => "thickspace", "isSpace" => true,
@@ -149,34 +148,21 @@ LoadDefinitions!(state, {
   });
 
   Let!("\\:", "\\>");
-  DefMacro!("\\ ", "\\ifmmode\\@math@nbspace\\else\\@text@nbspace\\fi");
-  // DefConstructor('\@math@nbspace', undef,
-  //   "<ltx:XMHint name='medspace' width='#width'/>",
-  //   alias => '\ ',
-  //   properties => { isSpace => 1,
-  //     width => sub { Dimension('0.5em'); } });
-  DefMacro!(T_CS!("\\@text@nbspace"), None, T_OTHER!("\u{00A0}"), alias => "\\ ");
 
-  DefMacro!("\\\t", "\\ifmmode\\@math@tab\\else\\@text@tab\\fi");
-  // DefConstructor('\@math@tab', undef,    # Tab!!
-  //   "<ltx:XMHint name='medspace' width='#width'/>",
-  //   alias => "\\\t",                      # TAB
-  //   properties => { isSpace => 1,
-  //     width => sub { Dimension('1em'); } });
-  // DefPrimitiveI('\@text@tab', undef, UTF(0xA0), alias => "\\\t");    # TAB!!! What else?
+  DefPrimitive!("\\ ", sub[stomach,(),state] {
+    Tbox::new(arena::pin_static("\u{00A0}"), None, None, Tokens!(T_CS!("\\ ")),
+      stored_map!("name" => "space", "isSpace" => true,
+      "width" => Dimension::from_str("0.5em", state)?), state)
+  });
 
-  DefMacro!(
-    "\\/",
-    "\\ifmmode\\@math@italiccorr\\else\\@text@italiccorr\\fi"
-  );
-  // DefConstructor("\@math@italiccorr", undef,
-  //   "<ltx:XMHint name='italiccorr'/>",
-  //   alias => '\/',
-  //   properties => { isSpace => 1 });
-  // DefPrimitiveI('\@text@italiccorr', undef, "", alias => '\/');
+  DefPrimitive!("\\\t", sub[stomach,(),state] {
+    Tbox::new(arena::pin_static("\u{00A0}"), None, None, Tokens!(T_CS!("\\\t")),
+      stored_map!("isSpace" => true, "width" => Dimension::from_str("1em",state)?), state)
+  });
 
-  // // What kind of magic might allow \mskip to translate these back into the above?
-  // DefRegister!("\\thinmuskip"  , MuGlue::new("3mu"));
-  // DefRegister!("\\medmuskip"   , MuGlue::new("4mu plus 2mu minus 4mu"));
-  // DefRegister!("\\thickmuskip" , MuGlue::new("5mu plus 5mu"));
+  DefPrimitive!("\\/", sub[stomach,(),state] {
+    Tbox::new(arena::pin_static(""), None, None, Tokens!(T_CS!("\\/")),
+      stored_map!("isSpace" => true, "name" => "italiccorr", "width" => Dimension::default()),state)
+  });
+
 });

--- a/rtx_package/src/package/tex_boxes.rs
+++ b/rtx_package/src/package/tex_boxes.rs
@@ -54,24 +54,24 @@ LoadDefinitions!(state, {
     }
   });
 
-  DefParameterType!(BoxSpecification,  reader => reader!(gullet, _inner, _extra, state, {
+  DefParameterType!(BoxSpecification, sub[gullet, _inner, _extra, state] {
       if let Some(key) = gullet.read_keyword(&["to", "spread"], state)? {
         Ok(Tokens!(T_OTHER!(key)))
       } else {
         Ok(Tokens!())
       }
-    }),
+    },
     // The predigest closure is new for rtx, as it was a single closure in Perl
     // The key problem is that in rtx the parameter type interfaces are well-typed,
     // so it is not possible to remain elegant while at the same time
     // have access to the stomach AND digest.
     // Hence, the `reader` is exclusively responsible for using the gullet to obtain tokens,
     // while early/immediate digestion via the stomach can be achieved
-    // by using the separate `reader_predigest` interface
-    // Importantly, reader_predigest forces the parameter to be usable
+    // by using the separate `predigest` interface
+    // Importantly, predigest forces the parameter to be usable
     // only for stomach-capable bindings,
     // namely DefConstructor, DefPrimitive or DefEnvironment
-    reader_predigest => reader_predigest!(stomach, key, state, {
+    predigest => sub[stomach, key, state] {
       if !key.is_empty() {
         let mut keyvals = KeyVals::new(
           KeyvalsConfig{skip_missing: true, ..KeyvalsConfig::default()}, state);
@@ -81,22 +81,22 @@ LoadDefinitions!(state, {
       } else {
         Ok(None)
       }
-    }),
+    },
     optional => true);
 
-  DefParameterType!(HBoxContents, reader => reader!(gullet, _inner, _extra, state, {
+  DefParameterType!(HBoxContents, sub[gullet, _inner, _extra, state] {
       read_box_contents(gullet, state.lookup_tokens("\\everyhbox"), state)
-    }),
-    reader_predigest=>reader_predigest!(stomach, arg, state, {
-      predigest_box_contents(stomach, arg, state) })
-  );
+    },
+    predigest => sub[stomach, arg, state] {
+      predigest_box_contents(stomach, arg, state)
+    });
 
-  DefParameterType!(VBoxContents, reader=>reader!(gullet, _inner, _extra, state, {
+  DefParameterType!(VBoxContents, sub[gullet, _inner, _extra, state] {
       read_box_contents(gullet, state.lookup_tokens("\\everyvbox"), state)
-    }),
-    reader_predigest=>reader_predigest!(stomach, arg, state, {
-      predigest_box_contents(stomach, arg, state) })
-  );
+    },
+    predigest => sub[stomach, arg, state] {
+      predigest_box_contents(stomach, arg, state)
+    });
 
   // This re-binds a number of important control sequences to their default text binding.
   // This is useful within common boxing or footnote macros that can appear within
@@ -210,15 +210,16 @@ LoadDefinitions!(state, {
     }
   );
 
-  DefParameterType!(RuleSpecification, reader=>reader!(gullet, _inner, _extra, state, {
-    let mut keyvals = KeyVals::new(
-      KeyvalsConfig{ skip_missing: true, .. KeyvalsConfig::default()}, state);
-    while let Some(key) = gullet.read_keyword(&["width", "height", "depth"], state)? {
-      keyvals.set_value(&key, Stored::Dimension(gullet.read_dimension(state)?), false, state);
-    }
-    keyvals }),
+  DefParameterType!(RuleSpecification, sub[gullet, _inner, _extra, state] {
+      let mut keyvals = KeyVals::new(
+        KeyvalsConfig{ skip_missing: true, .. KeyvalsConfig::default()}, state);
+      while let Some(key) = gullet.read_keyword(&["width", "height", "depth"], state)? {
+        keyvals.set_value(&key, Stored::Dimension(gullet.read_dimension(state)?), false, state);
+      }
+      keyvals
+    },
     optional => true,
-    reader_predigest => undigested!()
+    predigest => sub[_stomach,arg,_state] { Ok(arg.undigested()) }
   );
 
   DefConstructor!("\\vrule RuleSpecification","",

--- a/rtx_package/src/package/tex_setup.rs
+++ b/rtx_package/src/package/tex_setup.rs
@@ -94,7 +94,7 @@ LoadDefinitions!(state, {
       }
       Ok(value)
     },
-    reversion => reversion!(gullet, arg, inner, _extra, state, {
+    reversion => sub[gullet, arg, inner, _extra, state] {
       // let mut reverted_inner;
       let mut read_tokens: Vec<Token> = vec![T_BEGIN!()];
       if let Some(inner_ps) = inner {
@@ -106,8 +106,7 @@ LoadDefinitions!(state, {
       }
       read_tokens.push(T_END!());
       Ok(Tokens::new(read_tokens))
-    })
-  );
+    });
 
   DefParameterType!(DefPlain, sub[gullet, inner, _extra, state] {
       let mut value = ArgWrap::Tokens(gullet.read_arg(state)?);
@@ -117,7 +116,7 @@ LoadDefinitions!(state, {
       Ok(value)
     },
     pack_parameters => true,
-    reversion => reversion!(gullet, arg, inner, _extra, state, {
+    reversion => sub[gullet, arg, inner, _extra, state] {
      // let mut reverted_inner;
      let mut read_tokens: Vec<Token> = vec![T_BEGIN!()];
      if let Some(inner_ps) = inner {
@@ -129,8 +128,7 @@ LoadDefinitions!(state, {
      }
      read_tokens.push(T_END!());
      Ok(Tokens::new(read_tokens))
-    })
-  );
+    });
 
   DefParameterType!(Optional, sub[gullet, inner, default, state] {
       let value = gullet.read_optional(None, state)?;
@@ -149,7 +147,7 @@ LoadDefinitions!(state, {
       Ok(value_2)
     },
     optional => true,
-    reversion => reversion!(gullet, arg, inner, _extra, state, {
+    reversion => sub[gullet, arg, inner, _extra, state] {
       if !arg.is_empty() {
         let mut read_tokens: Vec<Token> = vec![T_OTHER!("[")];
         let mut reverted_arg = match inner {
@@ -162,8 +160,7 @@ LoadDefinitions!(state, {
       } else {
         Ok(Tokens!())
       }
-    })
-  );
+    });
 
   // This is a peculiar type of argument of the form
   //   <general text> = <filler>{<balanced text><right brace>
@@ -187,7 +184,7 @@ LoadDefinitions!(state, {
     // TODO: how many tokens are in extra?
     gullet.read_until(&until_extra[0], state)
   },
-  reversion => reversion!(gullet, arg, _inner, until, _state, {
+  reversion => sub[gullet, arg, _inner, until, _state] {
     let mut rev = Vec::new();
     for t in arg.into_iter() {
       rev.push(t.revert());
@@ -196,7 +193,7 @@ LoadDefinitions!(state, {
       rev.extend(ts.clone().revert());
     }
     Ok(Tokens::new(rev))
-  }));
+  });
 
   // Skip any spaces, but don't contribute an argument.
   DefParameterType!(SkipSpaces, sub[gullet, _inner, _extra, state] {
@@ -316,14 +313,13 @@ LoadDefinitions!(state, {
       Ok(Tokens!())
     }
   },
-  reversion => reversion!(gullet, arg, _inner, _extra, _state, {
+  reversion => sub[gullet, arg, _inner, _extra, _state] {
     let arg_rev : Vec<Token> = arg.into_iter().map(Token::revert).collect();
     let mut tks = vec![T_BEGIN!()];
     tks.extend(arg_rev);
     tks.push(T_END!());
     Ok(Tokens::new(tks))
-  })
-  );
+  });
 
   // Set state.smuggle_the=true whenever you want to handle special TeX neutralization of
   // tokens created by \the-like primitives.
@@ -350,8 +346,8 @@ LoadDefinitions!(state, {
       Ok(expanded)
     },
     pack_parameters => true,
-    reversion      => reversion!(gullet, arg, _inner, _extra, _state, {
-      Ok(Tokens!(T_BEGIN!(), Tokens!(arg).revert(), T_END!())) })
+    reversion      => sub[gullet, arg, _inner, _extra, _state] {
+      Ok(Tokens!(T_BEGIN!(), Tokens!(arg).revert(), T_END!())) }
   );
 
   // Read a matching keyword, eg. Match:=
@@ -383,7 +379,7 @@ LoadDefinitions!(state, {
   // Read a Semiverbatim argument; ie w/ most catcodes neutralized.
   DefParameterType!(Semiverbatim,
     sub[gullet, _inner, _extra, state] { gullet.read_arg(state) },
-    reversion => reversion!(gullet, arg, inner, _extra, state, {
+    reversion => sub[gullet, arg, inner, _extra, state] {
       // let mut reverted_inner;
       let mut read_tokens: Vec<Token> = vec![T_BEGIN!()];
       if let Some(inner_ps) = inner {
@@ -395,7 +391,7 @@ LoadDefinitions!(state, {
       }
       read_tokens.push(T_END!());
       Ok(Tokens::new(read_tokens))
-    }),
+    },
     semiverbatim => Some(Vec::new()));
 
   // Read a LaTeX-style optional argument (ie. in []), but the contents read as Semiverbatim.
@@ -403,7 +399,7 @@ LoadDefinitions!(state, {
     sub[gullet, _inner, _extra, state] { gullet.read_optional(None, state) },
     semiverbatim => Some(Vec::new()),
     optional => true,
-    reversion => reversion!(gullet, arg, _inner, _extra, _state, {
+    reversion => sub[gullet, arg, _inner, _extra, _state] {
      if !arg.is_empty() {
        let mut read_tokens = vec![T_OTHER!(s!("["))];
        let mut reverted_arg = arg.into_iter().map(Token::revert).collect();
@@ -413,7 +409,7 @@ LoadDefinitions!(state, {
      } else {
        Ok(Tokens!())
      }
-    })
+    }
   );
 
   // Be careful here: if % appears before the initial {, it's still a comment!
@@ -426,20 +422,20 @@ LoadDefinitions!(state, {
       state.end_semiverbatim()?;
       Ok(arg)
     },
-    before_digest => before_digest!(stomach, state, {
+    before_digest => sub[stomach, state] {
       stomach.bgroup(state);
       MergeFont!(family => "typewriter", state);
-    }),
-    after_digest => after_digest!(stomach, _args, state, {
+    },
+    after_digest => sub[stomach, _args, state] {
       stomach.egroup(state)?;
-    }),
-    reversion => reversion!(gullet, arg, _inner, _extra, _state, {
+    },
+    reversion => sub[gullet, arg, _inner, _extra, _state] {
       let mut reverted = vec![T_BEGIN!()];
       let reverted_arg : Vec<Token> = arg.into_iter().map(Token::revert).collect();
       reverted.extend(reverted_arg);
       reverted.push(T_END!());
       Ok(Tokens::new(reverted))
-    })
+    }
   );
 
   // Read Verbatim, but allows expanding command sequences
@@ -460,23 +456,23 @@ LoadDefinitions!(state, {
       state.end_semiverbatim()?;
       arg
     },
-    before_digest => before_digest!(stomach, state, {
+    before_digest => sub[stomach, state] {
       stomach.bgroup(state);
-      MergeFont!(family => "typewriter", state); }),
-    after_digest => after_digest!(stomach, _args, state, {
-      stomach.egroup(state)?; }),
-    reversion => reversion!(gullet, arg, _inner, _extra, _state, {
+      MergeFont!(family => "typewriter", state); },
+    after_digest => sub[stomach, _args, state] {
+      stomach.egroup(state)?; },
+    reversion => sub[gullet, arg, _inner, _extra, _state] {
       let mut reverted = vec![T_BEGIN!()];
       let reverted_arg : Vec<Token> = arg.into_iter().map(Token::revert).collect();
       reverted.extend(reverted_arg);
       reverted.push(T_END!());
       Ok(Tokens::new(reverted))
-    })
+    }
   );
   // Read an argument that will not be digested.
   DefParameterType!(Undigested, sub[gullet, _inner, _extra, state] { gullet.read_arg(state)},
-  reader_predigest => undigested!(),
-  reversion => reversion!(gullet, arg, _inner, _extra, _state, {
+  predigest => sub[_stomach,arg,_state] { Ok(arg.undigested()) }
+  reversion => sub[gullet, arg, _inner, _extra, _state] {
     if arg.is_empty() {
       Ok(Tokens!())
     } else {
@@ -486,14 +482,14 @@ LoadDefinitions!(state, {
       read_tokens.push(T_END!());
       Ok(Tokens::new(read_tokens))
     }
-  }));
+  });
 
   // Read a LaTeX-style optional argument (ie. in []), but it will not be digested.
   DefParameterType!(OptionalUndigested,
     sub[gullet, _inner, _extra, state] { gullet.read_optional(None, state) },
-    reader_predigest => undigested!(),
+    predigest => sub[_stomach,arg,_state] { Ok(arg.undigested()) }
     optional => true,
-    reversion => reversion!(gullet, arg, _inner, _extra, _state, {
+    reversion => sub[gullet, arg, _inner, _extra, _state] {
       if arg.is_empty() {
         Ok(Tokens!())
       } else {
@@ -503,13 +499,13 @@ LoadDefinitions!(state, {
         read_tokens.push(T_OTHER!("]"));
         Ok(Tokens::new(read_tokens))
       }
-  }));
+  });
 
   // Read a keyword value (KeyVals), that will not be digested.
   DefParameterType!(UndigestedKey, sub[gullet, _inner, _extra, state] {
     gullet.read_arg(state)
   },
-  reader_predigest => undigested!());
+  predigest => sub[_stomach,arg,_state] { Ok(arg.undigested()) });
 
   // Read a token as used when defining it, ie. it may be enclosed in braces.
   DefParameterType!(DefToken, sub[gullet, _inner, _extra, state] {
@@ -536,7 +532,8 @@ LoadDefinitions!(state, {
         Ok(Tokens!())
       }
     }
-  }, reader_predigest => undigested!());
+  },
+  predigest => sub[_stomach,arg,_state] { Ok(arg.undigested()) });
 
   // Read a variable, ie. a token (after expansion) that is a writable register.
   DefParameterType!(Variable, sub[gullet, _inner, _extra, state] {
@@ -564,7 +561,7 @@ LoadDefinitions!(state, {
       Ok(ArgWrap::Tokens(Tokens!()))
     }
   },
-  reversion => reversion!(gullet,args, _inner, _extra, _state, {
+  reversion => sub[gullet,args, _inner, _extra, _state] {
     let _defn = args.remove(0);
     // my ($defn, @args) = @$var;
     unimplemented!()
@@ -577,7 +574,7 @@ LoadDefinitions!(state, {
     // };
     // reverted.extend(reverted_args);
     // Ok(Tokens::new(reverted))
-  }));
+  });
 
   // Same, but not necessarily writable
   DefParameterType!(Register, sub[gullet, _inner, _extra, state] {
@@ -602,13 +599,13 @@ LoadDefinitions!(state, {
     }
     Ok(Tokens!())
   },
-  reversion => reversion!(gullet, _arg, _inner, _extra, _state, {
+  reversion => sub[gullet, _arg, _inner, _extra, _state] {
     // my ($var) = @_;
     // my ($defn, @args) = @$var;
     // my $params = $defn->getParameters;
     // return Tokens($defn->getCS, ($params ? $params->revertArguments(@args) : ()));
     Ok(Tokens!())
-  }));
+  });
 
   DefParameterType!(TeXFileName, sub[gullet, _inner, _extra, state] {
     use Catcode::*;
@@ -684,7 +681,7 @@ LoadDefinitions!(state, {
     } else {
       Tokens!()
     }
-  }, reader_predigest => reader_predigest!(stomach, arg, state, {
+  }, predigest => sub[stomach, arg, state] {
     let token = arg.unlist().remove(0);
     let mut stuff = stomach.invoke_token(&token, state)?;
     if !stuff.is_empty() {
@@ -706,7 +703,7 @@ LoadDefinitions!(state, {
       Error!("expected","<box>", stomach, state, message);
       None
     }
-  }));
+  });
 
   // Read a parenthesis delimited argument.
   // Note that this does NOT balance () within the argument.
@@ -725,11 +722,11 @@ LoadDefinitions!(state, {
       Ok(None)
     }
   },
-  reversion => reversion!(gullet, args, _inner, _extra, _state, {
+  reversion => sub[gullet, args, _inner, _extra, _state] {
     Ok(Tokens!(
       T_OTHER!("("), Tokens::new(args).revert(), T_OTHER!(")")
     ))
-  }));
+  });
 
   // Read a digested argument, digesting as it is being read.
   // The usual macro parameter (generally written as {}) gets tokenized and digested
@@ -743,7 +740,7 @@ LoadDefinitions!(state, {
       gullet.skip_spaces(state)?;
       Ok(Tokens!())
     }),
-    reader_predigest => reader_predigest!(stomach, _arg, state, {
+    predigest => predigest!(stomach, _arg, state, {
       let ismath = state.lookup_bool("IN_MATH");
       let mut list = Vec::new();
       let mut next_token = None;
@@ -797,7 +794,7 @@ LoadDefinitions!(state, {
   DefParameterType!(DigestedBody, reader => reader!(_gullet, _inner, _extra, _state, {
       Ok(Tokens!()) // all done in predigestion
     }),
-    reader_predigest => reader_predigest!(stomach, _arg, state, {
+    predigest => predigest!(stomach, _arg, state, {
       let ismath   = state.lookup_bool("IN_MATH");
       let mut list     = stomach.digest_next_body(None, state)?;
       // In most (all?) cases, we're really looking for a single Whatsit here...
@@ -1030,28 +1027,31 @@ LoadDefinitions!(state, {
   // current.
   DefParameterType!(InScriptStyle, sub[gullet, _inner, _extra, state] {
       gullet.read_arg(state) },
-  //   beforeDigest => sub {
-  //     $_[0]->bgroup;
-  //     MergeFont(scripted => 1); },
-  //   afterDigest => sub {
-  //     $_[0]->egroup; },
-      reversion => reversion!(gullet, arg, _inner, _extra, _state, {
-        Ok(Tokens!(T_BEGIN!(), Tokens::new(arg).revert(), T_END!())) })
-    );
+    before_digest => sub[stomach,state] {
+      stomach.bgroup(state);
+      MergeFont!(scripted => true);
+    },
+    after_digest => sub[stomach,_args,state] {
+      stomach.egroup(state)?;
+    },
+    reversion => sub[gullet, arg, _inner, _extra, _state] {
+        Ok(Tokens!(T_BEGIN!(), Tokens::new(arg).revert(), T_END!()))
+    });
   // # NOTE: the various parameter features don't combine easily!!
   // # I need a ScriptStyleUntil for \root!!!
   // # I also need to redo fractions using these new types....
   DefParameterType!(OptionalInScriptStyle, sub[gullet, _inner, _extra, state] {
       gullet.read_optional(None, state)
     },
-    // before_digest => sub[stomach,state] {
-    //   stomach.bgroup(state);
-    //   MergeFont!("scripted" => true);
-    // },
-    // after_digest => sub[stomach,state] {
-    //   stomach.egroup(state); },
+    before_digest => sub[stomach,state] {
+      stomach.bgroup(state);
+      MergeFont!(scripted => true);
+    },
+    after_digest => sub[stomach,_args,state] {
+      stomach.egroup(state)?;
+    },
     optional => true,
-    reversion => reversion!(_gullet,arg,_inner,_extra,_state, {
+    reversion => sub[_gullet,arg,_inner,_extra,_state] {
       if arg.is_empty() { Ok(Tokens!()) }
       else {
         let mut tks = vec![T_OTHER!("[")];
@@ -1059,26 +1059,23 @@ LoadDefinitions!(state, {
         tks.push(T_OTHER!("]"));
         Ok(Tokens::new(tks))
       }
-    })
-  );
+    });
   DefParameterType!(InFractionStyle, sub[gullet, _inner, _extra, state] {
       gullet.read_arg(state)
     },
-    // TODO
-    // before_digest => sub[gullet,state] {
-    //   gullet.bgroup(state);
-    //   MergeFont!("fraction" => true);
-    // },
-    // after_digest => sub[stomach,state] {
-    //   gullet.egroup(state)?;
-    // },
-    reversion => reversion!(_gullet,arg,_inner,_extra,_state, {
+    before_digest => sub[stomach,state] {
+      stomach.bgroup(state);
+      MergeFont!(fraction => true);
+    },
+    after_digest => sub[stomach,_args,state] {
+      stomach.egroup(state)?;
+    },
+    reversion => sub[_gullet,arg,_inner,_extra,_state] {
       let mut reverted = vec![T_BEGIN!()];
       reverted.extend(arg.into_iter().map(Token::revert));
       reverted.push(T_END!());
       Ok(Tokens::new(reverted))
-    })
-  );
+    });
 
   //**********************************************************************
   // LaTeX has a very particular notion of "Undefined",

--- a/rtx_package/src/package/tex_setup.rs
+++ b/rtx_package/src/package/tex_setup.rs
@@ -1061,14 +1061,24 @@ LoadDefinitions!(state, {
       }
     })
   );
-  // DefParameterType!(InFractionStyle, sub[gullet, inner, _extra, state] {
-  //     $_[0]->readArg; },
-  //   beforeDigest => sub {
-  //     $_[0]->bgroup;
-  //     MergeFont(fraction => 1); },
-  //   afterDigest => sub {
-  //     $_[0]->egroup; },
-  //   reversion => sub { (T_BEGIN, Revert($_[0]), T_END); });
+  DefParameterType!(InFractionStyle, sub[gullet, _inner, _extra, state] {
+      gullet.read_arg(state)
+    },
+    // TODO
+    // before_digest => sub[gullet,state] {
+    //   gullet.bgroup(state);
+    //   MergeFont!("fraction" => true);
+    // },
+    // after_digest => sub[stomach,state] {
+    //   gullet.egroup(state)?;
+    // },
+    reversion => reversion!(_gullet,arg,_inner,_extra,_state, {
+      let mut reverted = vec![T_BEGIN!()];
+      reverted.extend(arg.into_iter().map(Token::revert));
+      reverted.push(T_END!());
+      Ok(Tokens::new(reverted))
+    })
+  );
 
   //**********************************************************************
   // LaTeX has a very particular notion of "Undefined",


### PR DESCRIPTION
Trying to convert the showcase article for ar5iv at [1910.06709](https://ar5iv.labs.arxiv.org/html/1910.06709)

This PR ports over:
 - `\left`, `\right`, `\frac`
 - fullpage.sty
 - support for `Document::float_to_element`
 - `^` floating marker in binding replacement strings
 - support for `\boldsymbol`
 - Some more infrastructure is needed for `DefParameterType` to execute `before_digest`, `after_digest`. 

TODO:
- support for `{align*}`
- support for `\eqref`

Maybe I can quickly add the remaining bits and have a first Rust-side showcase article... 