### PR TITLE
[nightly] refactor to lightweight #[thread_local] annotations

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           override: true
       - name: run tests
         uses: actions-rs/cargo@v1

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ There is demonstrable need for LaTeXML in the domain of academic writing, as wel
 
 ### Installation
 
-Requires Rust `stable` v1.32, and newer.
+Requires Rust `nightly` v1.72, and newer.
 
 ### Sample use
 

--- a/rtx_core/src/binding/def/dialect.rs
+++ b/rtx_core/src/binding/def/dialect.rs
@@ -92,7 +92,7 @@ pub fn is_defined_token(cs: &Token, state: &State) -> bool {
 pub fn is_definable(token: &Token, state: &State) -> bool {
   let meaning = state.lookup_meaning(token);
   token.with_str(|name| name != "\\relax" && !name.starts_with("\\end"))
-    && (meaning.is_none() || (meaning == TOKEN_RELAX.with(|tr| state.lookup_meaning(tr)))
+    && (meaning.is_none() || (meaning == state.lookup_meaning(&TOKEN_RELAX))
         || state.lookup_bool("2.09_COMPATIBILITY"))
 }
 

--- a/rtx_core/src/common/arena.rs
+++ b/rtx_core/src/common/arena.rs
@@ -12,54 +12,71 @@ use std::hash::BuildHasherDefault;
 use string_interner::backend::BufferBackend;
 use string_interner::symbol::SymbolU32;
 use string_interner::StringInterner;
+use once_cell::sync::Lazy;
 
-thread_local! {
-  static T: RefCell<StringInterner<BufferBackend, BuildHasherDefault<FxHasher>>> = RefCell::new(
-    StringInterner::with_capacity_and_hasher(32_768, BuildHasherDefault::<FxHasher>::default()));
-  /// the unique symbol for str value "ANY"
-  pub static ANY_SYM: SymbolU32 = pin_static("ANY");
-  /// the unique symbol for str value "#PCDATA"
-  pub static H_PCDATA_SYM: SymbolU32 = pin_static("#PCDATA");
-  /// the unique symbol for str value "#COMMENT"
-  pub static H_COMMENT_SYM: SymbolU32 = pin_static("#Comment");
-  /// the unique symbol for the empty str value ""
-  pub static EMPTY_SYM: SymbolU32 = pin_static("");
-  /// the unique symbol for str value "ltx:*"
-  pub static LTX_STAR_SYM: SymbolU32 = pin_static("ltx:*");
-  /// the unique symbol for str value "ltx:p"
-  pub static LTX_P_SYM: SymbolU32 = pin_static("ltx:p");
-  /// the unique symbol for str value "\globaldefs"
-  pub static GLOBAL_DEFS_SYM : SymbolU32 = pin_static("\\globaldefs");
-  /// the unique symbol for str value "_WildCard_"
-  pub static WILD_CARD_SYM : SymbolU32 = pin_static("_WildCard_");
-  /// the unique symbol for str value "#ProcessingInstruction"
-  pub static H_PI_SYM : SymbolU32 = pin_static("#ProcessingInstruction");
-  /// the unique symbol for str value "#DTD"
-  pub static H_DTD_SYM : SymbolU32 = pin_static("#DTD");
-  /// the unique symbol for str value "#Document"
-  pub static H_DOC_SYM : SymbolU32 = pin_static("#Document");
-  /// the unique symbol for str value "#default"
-  pub static H_DEFAULT_SYM : SymbolU32 = pin_static("#default");
-  /// the unique symbol for str value "ltx:_Capture_"
-  pub static CAPTURE_SYM : SymbolU32 = pin_static("ltx:_Capture_");
-  /// the unique symbol for str value "font"
-  pub static FONT_SYM : SymbolU32 = pin_static("font");
-  /// the unique symbol for str value "xml:id"
-  pub static XML_ID_SYM : SymbolU32 = pin_static("xml:id");
-  /// the unique symbol for str value "DTD"
-  pub static DTD_SYM : SymbolU32 = pin_static("DTD");
-  /// the unique symbol for str value "RelaxNG"
-  pub static RELAXNG_SYM : SymbolU32 = pin_static("RelaxNG");
-}
+#[thread_local]
+static ARENA: Lazy<RefCell<StringInterner<BufferBackend, BuildHasherDefault<FxHasher>>>> = Lazy::new(|| RefCell::new(
+  StringInterner::with_capacity_and_hasher(32_768, BuildHasherDefault::<FxHasher>::default())));
+/// the unique symbol for str value "ANY"
+#[thread_local]
+pub static ANY_SYM: Lazy<SymbolU32> = Lazy::new(|| pin_static("ANY"));
+/// the unique symbol for str value "#PCDATA"
+#[thread_local]
+pub static H_PCDATA_SYM: Lazy<SymbolU32> = Lazy::new(|| pin_static("#PCDATA"));
+/// the unique symbol for str value "#COMMENT"
+#[thread_local]
+pub static H_COMMENT_SYM: Lazy<SymbolU32> = Lazy::new(|| pin_static("#Comment"));
+/// the unique symbol for the empty str value ""
+#[thread_local]
+pub static EMPTY_SYM: Lazy<SymbolU32> = Lazy::new(|| pin_static(""));
+/// the unique symbol for str value "ltx:*"
+#[thread_local]
+pub static LTX_STAR_SYM: Lazy<SymbolU32> = Lazy::new(|| pin_static("ltx:*"));
+/// the unique symbol for str value "ltx:p"
+#[thread_local]
+pub static LTX_P_SYM: Lazy<SymbolU32> = Lazy::new(|| pin_static("ltx:p"));
+/// the unique symbol for str value "\globaldefs"
+#[thread_local]
+pub static GLOBAL_DEFS_SYM : Lazy<SymbolU32> = Lazy::new(|| pin_static("\\globaldefs"));
+/// the unique symbol for str value "_WildCard_"
+#[thread_local]
+pub static WILD_CARD_SYM : Lazy<SymbolU32> = Lazy::new(|| pin_static("_WildCard_"));
+/// the unique symbol for str value "#ProcessingInstruction"
+#[thread_local]
+pub static H_PI_SYM : Lazy<SymbolU32> = Lazy::new(|| pin_static("#ProcessingInstruction"));
+/// the unique symbol for str value "#DTD"
+#[thread_local]
+pub static H_DTD_SYM : Lazy<SymbolU32> = Lazy::new(|| pin_static("#DTD"));
+/// the unique symbol for str value "#Document"
+#[thread_local]
+pub static H_DOC_SYM : Lazy<SymbolU32> = Lazy::new(|| pin_static("#Document"));
+/// the unique symbol for str value "#default"
+#[thread_local]
+pub static H_DEFAULT_SYM : Lazy<SymbolU32> = Lazy::new(|| pin_static("#default"));
+/// the unique symbol for str value "ltx:_Capture_"
+#[thread_local]
+pub static CAPTURE_SYM : Lazy<SymbolU32> = Lazy::new(|| pin_static("ltx:_Capture_"));
+/// the unique symbol for str value "font"
+#[thread_local]
+pub static FONT_SYM : Lazy<SymbolU32> = Lazy::new(|| pin_static("font"));
+/// the unique symbol for str value "xml:id"
+#[thread_local]
+pub static XML_ID_SYM : Lazy<SymbolU32> = Lazy::new(|| pin_static("xml:id"));
+/// the unique symbol for str value "DTD"
+#[thread_local]
+pub static DTD_SYM : Lazy<SymbolU32> = Lazy::new(|| pin_static("DTD"));
+/// the unique symbol for str value "RelaxNG"
+#[thread_local]
+pub static RELAXNG_SYM : Lazy<SymbolU32> = Lazy::new(|| pin_static("RelaxNG"));
 
 /// Assign a static str into the arena, returning a unique symbol associated with it
 pub fn pin_static(text: &'static str) -> SymbolU32 {
-  T.with(|arena| arena.borrow_mut().get_or_intern_static(text))
+  ARENA.borrow_mut().get_or_intern_static(text)
 }
 
 /// Assign a string into the arena, returning a unique symbol associated with it
 pub fn pin<S: AsRef<str>>(text: S) -> SymbolU32 {
-  T.with(|arena| arena.borrow_mut().get_or_intern(text))
+  ARENA.borrow_mut().get_or_intern(text)
 }
 
 pub fn pin_char(c: char) -> SymbolU32 {
@@ -70,36 +87,29 @@ pub fn pin_char(c: char) -> SymbolU32 {
 
 pub fn with<R, FnR>(sym: SymbolU32, caller: FnR) -> R
 where FnR: FnOnce(&str) -> R {
-  T.with(|arena| {
     caller(
-      arena
+      ARENA
         .borrow()
         .resolve(sym)
         .expect("arena::with should only be called when the string is guaranteed to be allocated."),
     )
-  })
 }
 
 pub fn to_string(sym: SymbolU32) -> String {
-  T.with(|arena| {
-    arena
-      .borrow()
-      .resolve(sym)
-      .expect(
-        "arena::to_string should only be called when the string is guaranteed to be allocated.",
-      )
-      .to_owned()
-  })
+  ARENA.borrow()
+    .resolve(sym)
+    .expect(
+      "arena::to_string should only be called when the string is guaranteed to be allocated.",
+    )
+    .to_owned()
 }
 
 // TODO: Is this needed? The tighter call would guarantee the T lock is released early.
 pub fn chars(sym: SymbolU32) -> Vec<char> {
-  T.with(|arena| {
-    arena
-      .borrow()
-      .resolve(sym)
-      .expect("arena::chars should only be called when the string is guaranteed to be allocated.")
-      .chars()
-      .collect()
-  })
+  ARENA
+    .borrow()
+    .resolve(sym)
+    .expect("arena::chars should only be called when the string is guaranteed to be allocated.")
+    .chars()
+    .collect()
 }

--- a/rtx_core/src/common/dimension.rs
+++ b/rtx_core/src/common/dimension.rs
@@ -62,7 +62,7 @@ impl Dimension {
       let unit = cap.get(2).map_or(String::new(), |m| m.as_str().to_string());
       let converted_unit = match state_opt {
         Some(state) => state.convert_unit(&unit),
-        None => STD_STATE.with(|state_rw| state_rw.borrow().convert_unit(&unit)),
+        None => STD_STATE.borrow().convert_unit(&unit),
       };
       Ok(fixpoint(num, Some(converted_unit)) as f64)
     } else {

--- a/rtx_core/src/common/font.rs
+++ b/rtx_core/src/common/font.rs
@@ -1156,7 +1156,7 @@ pub fn decode_string(
   stomach: &mut Stomach,
   state: &mut State,
 ) -> SymbolU32 {
-  let empty_sym = EMPTY_SYM.with(|sym| *sym);
+  let empty_sym = *EMPTY_SYM;
   if string == empty_sym {
     return empty_sym;
   }

--- a/rtx_core/src/common/model.rs
+++ b/rtx_core/src/common/model.rs
@@ -75,7 +75,7 @@ impl Model {
 
   pub fn set_doc_type(&mut self, roottag: &str, publicid: &str, systemid: &str) {
     self.schema_data = Some(vec![
-      DTD_SYM.with(|sym| *sym),
+      *DTD_SYM,
       arena::pin(roottag),
       arena::pin(publicid),
       arena::pin(systemid),
@@ -83,7 +83,7 @@ impl Model {
   }
 
   pub fn set_relaxng_schema(&mut self, schema: &str) {
-    self.schema_data = Some(vec![RELAXNG_SYM.with(|sym| *sym), arena::pin(schema)]);
+    self.schema_data = Some(vec![*RELAXNG_SYM, arena::pin(schema)]);
   }
   pub fn add_schema_declaration(&self, document: &mut Document) {
     if let Some(ref schema) = self.schema {
@@ -112,12 +112,12 @@ impl Model {
       self.register_namespace("xhtml", Some("http://www.w3.org/1999/xhtml"));
       self.permissive = true;
     } // Actually, they could have declared all sorts of Tags....
-    let mut schema_type = EMPTY_SYM.with(|sym| *sym);
+    let mut schema_type = *EMPTY_SYM;
     match self.schema_data {
       None => {},
       Some(ref data) => {
         schema_type = data[0];
-        if schema_type == DTD_SYM.with(|sym| *sym) {
+        if schema_type == *DTD_SYM {
           // NOTE: This is a hack, as DTD should be deprecated, just making xii test work for now
           // ($roottag, $publicid, $systemid) = @data;
           name = arena::with(*data.last().unwrap(), |data_str| {
@@ -128,7 +128,7 @@ impl Model {
             ..Relaxng::default()
           });
           // $systemid);
-        } else if schema_type == RELAXNG_SYM.with(|sym| *sym) {
+        } else if schema_type == *RELAXNG_SYM {
           name = arena::to_string(data[1]);
           self.schema = Some(Relaxng {
             name: name.clone(),
@@ -195,7 +195,7 @@ impl Model {
     namespace_opt: Option<SymbolU32>,
   ) {
     // double-check empty strings are None
-    let namespace_opt_checked = namespace_opt.filter(|val| *val != EMPTY_SYM.with(|sym| *sym));
+    let namespace_opt_checked = namespace_opt.filter(|val| *val != *EMPTY_SYM);
     match namespace_opt_checked {
       Some(namespace) => {
         self.code_namespace_prefixes.insert(namespace, codeprefix);
@@ -212,7 +212,7 @@ impl Model {
   }
 
   pub fn register_document_namespace(&mut self, docprefix: &str, namespace_opt: Option<&str>) {
-    let default_sym = H_DEFAULT_SYM.with(|sym| *sym);
+    let default_sym = *H_DEFAULT_SYM;
     let docprefix_sym = if docprefix.is_empty() {
       default_sym
     } else {
@@ -284,12 +284,12 @@ impl Model {
         message2
       );
     }
-    let default_sym = H_DEFAULT_SYM.with(|sym| *sym);
+    let default_sym = *H_DEFAULT_SYM;
     docprefix.filter(|p| p != &default_sym)
   }
 
   pub fn get_document_namespace(&mut self, docprefix: &str, probe: bool) -> Option<String> {
-    let h_default_sym = H_DEFAULT_SYM.with(|sym| *sym);
+    let h_default_sym = *H_DEFAULT_SYM;
     let docprefix_sym = if docprefix.is_empty() {
       h_default_sym
     } else {
@@ -462,7 +462,7 @@ impl Model {
       NamespaceDecl => arena::pin_static("xmlns"),
 
       ElementNode | AttributeNode => {
-        let empty_sym = EMPTY_SYM.with(|sym| *sym);
+        let empty_sym = *EMPTY_SYM;
         let mut prefix = empty_sym;
         if let Some(ns) = node.get_namespace() {
           let href = ns.get_href();
@@ -518,12 +518,12 @@ impl Model {
 
   pub fn can_contain_sym(&mut self, tag: SymbolU32, child: SymbolU32) -> bool {
     // Handle obvious cases explicitly.
-    if H_PCDATA_SYM.with(|sym| tag == *sym)
-      || H_COMMENT_SYM.with(|sym| tag == *sym)
-      || EMPTY_SYM.with(|sym| tag == *sym)
+    if tag == *H_PCDATA_SYM
+      || tag == *H_COMMENT_SYM
+      || tag == *EMPTY_SYM
     {
       return false;
-    } else if WILD_CARD_SYM.with(|sym| tag == *sym) {
+    } else if tag == *WILD_CARD_SYM {
       return true;
     };
     if arena::with(tag, |tag_str| CAPTURE_TAG_RE.is_match(tag_str))
@@ -533,17 +533,17 @@ impl Model {
       return true;
     }
 
-    if WILD_CARD_SYM.with(|sym| child == *sym)
-      || H_COMMENT_SYM.with(|sym| child == *sym)
-      || H_PI_SYM.with(|sym| child == *sym)
-      || H_DTD_SYM.with(|sym| child == *sym)
+    if child == *WILD_CARD_SYM
+      || child == *H_COMMENT_SYM
+      || child == *H_PI_SYM
+      || child == *H_DTD_SYM
     {
       return true;
     }
 
     if self.permissive
-      && H_DOC_SYM.with(|sym| tag == *sym)
-      && H_PCDATA_SYM.with(|sym| child != *sym)
+      && tag == *H_DOC_SYM
+      && child != *H_PCDATA_SYM
     {
       return true; // No DTD? Punt!
     }
@@ -554,7 +554,7 @@ impl Model {
       .entry(tag)
       .or_insert_with(TagFrame::default)
       .model;
-    ANY_SYM.with(|sym| model.contains(sym)) || model.contains(&child)
+    model.contains(&ANY_SYM) || model.contains(&child)
   }
 
   /// Can an element with (qualified name) `tag` contain a `child` element?
@@ -584,7 +584,7 @@ impl Model {
       .get(&arena::pin(tag))
       .unwrap_or(&*DEFAULT_TAG_FRAME)
       .model;
-    ANY_SYM.with(|sym| model.contains(sym)) || model.contains(&arena::pin(child))
+    model.contains(&ANY_SYM) || model.contains(&arena::pin(child))
   }
 
   pub fn can_have_attribute(&self, tag: SymbolU32, attrib: SymbolU32) -> bool {

--- a/rtx_core/src/document.rs
+++ b/rtx_core/src/document.rs
@@ -81,11 +81,14 @@ static MERGE_ATTRIBUTE_SUMLENGTH: Lazy<HashSet<&'static str>> = Lazy::new(|| {
 pub static FONT_ELEMENT_NAME: &str = "ltx:text";
 pub static MATH_TOKEN_NAME: &str = "ltx:XMTok";
 pub static MATH_HINT_NAME: &str = "ltx:XMHint";
-thread_local! {
-  pub static FONT_ELEMENT_SYM: SymbolU32 = arena::pin_static("ltx:text");
-  pub static MATH_TOKEN_SYM: SymbolU32 = arena::pin_static("ltx:XMTok");
-  pub static MATH_HINT_SYM: SymbolU32 = arena::pin_static("ltx:XMHint");
-}
+
+#[thread_local]
+pub static FONT_ELEMENT_SYM: Lazy<SymbolU32> = Lazy::new(|| arena::pin_static("ltx:text"));
+#[thread_local]
+pub static MATH_TOKEN_SYM: Lazy<SymbolU32> = Lazy::new(|| arena::pin_static("ltx:XMTok"));
+#[thread_local]
+pub static MATH_HINT_SYM: Lazy<SymbolU32> = Lazy::new(|| arena::pin_static("ltx:XMHint"));
+
 pub struct Document {
   pub document: XmlDoc,
   pub pending: Vec<Node>,
@@ -987,8 +990,7 @@ impl Document {
       .clone();
     // let ns_hash  = ((defined $p) && $STATE->lookupMapping('TAG_PROPERTIES', $p .
     // ':*')) || {};
-    let all_hash = LTX_STAR_SYM
-      .with(|sym| state.tag_properties.entry(*sym))
+    let all_hash = state.tag_properties.entry(*LTX_STAR_SYM)
       .or_insert_with(TagOptions::default)
       .clone();
 
@@ -1115,7 +1117,7 @@ impl Document {
           let node_qname = self.get_node_qname(node, state);
           state
             .model
-            .can_contain_sym(node_qname, H_PCDATA_SYM.with(|sym| *sym))
+            .can_contain_sym(node_qname, *H_PCDATA_SYM)
         };
 
         if !noindent {
@@ -1226,7 +1228,7 @@ impl Document {
     } else {
       text
     };
-    if qname == MATH_TOKEN_NAME && cur_qname == MATH_TOKEN_SYM.with(|sym| *sym) {
+    if qname == MATH_TOKEN_NAME && cur_qname == *MATH_TOKEN_SYM {
       // Already INSIDE a token!
       if !text.is_empty() {
         self.open_math_text_internal(text, state)?;
@@ -1513,15 +1515,15 @@ impl Document {
   /// a single FONT_ELEMENT_NAME node; pull it up.
   fn auto_collapse_children(&mut self, node: &mut Node, state: &mut State) -> Result<()> {
     let qname = state.model.get_node_qname(node);
-    if CAPTURE_SYM.with(|sym| qname != *sym) {
+    if qname != *CAPTURE_SYM {
       let mut c = node.get_child_nodes();
       // with single child, AND, $node can have all the attributes that the child has (but at least
       // "font") BUT, it isn"t being forced somehow
       if c.len() == 1
-        && (state.model.get_node_qname(&c[0]) == FONT_ELEMENT_SYM.with(|sym| *sym))
+        && (state.model.get_node_qname(&c[0]) == *FONT_ELEMENT_SYM)
         && state
           .model
-          .can_have_attribute(qname, FONT_SYM.with(|sym| *sym))
+          .can_have_attribute(qname, *FONT_SYM)
         && c[0]
           .get_attributes()
           .keys()
@@ -1871,7 +1873,7 @@ impl Document {
       while (node.get_type() != Some(NodeType::DocumentNode)) && self.can_auto_close(&node, state) {
         let parent_opt = node.get_parent();
         let parent_name = match parent_opt {
-          None => EMPTY_SYM.with(|sym| *sym),
+          None => *EMPTY_SYM,
           Some(ref p) => state.model.get_node_qname(p),
         };
         if self.sym_can_contain_somehow(parent_name, qsym, state) {
@@ -2769,7 +2771,7 @@ impl Document {
               .model
               .get_document_namespace_prefix(&ns_uri, false, false)
             {
-              if prefix != EMPTY_SYM.with(|sym| *sym) {
+              if prefix != *EMPTY_SYM {
                 let mut root = self.document.get_root_element().unwrap();
                 match arena::with(prefix, |prefix_str| {
                   Namespace::new(prefix_str, &ns_uri, &mut root)
@@ -3247,8 +3249,8 @@ impl Document {
     let model = &state.model;
     let qname = model.get_node_qname(node);
     if !node.has_attribute_ns("id", XML_NS)
-      && model.can_have_attribute(qname, XML_ID_SYM.with(|sym| *sym))
-      && (qname != CAPTURE_SYM.with(|sym| *sym))
+      && model.can_have_attribute(qname, *XML_ID_SYM)
+      && (qname != *CAPTURE_SYM)
     {
       let mut ancestor = self
         .findnode("ancestor::*[@xml:id][1]", Some(node), state)

--- a/rtx_core/src/keyvals.rs
+++ b/rtx_core/src/keyvals.rs
@@ -447,7 +447,7 @@ impl KeyVals {
     let value = if use_default {
       headset
         .get_default(state)
-        .unwrap_or_else(|| Stored::String(EMPTY_SYM.with(|sym| *sym)))
+        .unwrap_or_else(|| Stored::String(*EMPTY_SYM))
     } else {
       value
     };

--- a/rtx_core/src/lib.rs
+++ b/rtx_core/src/lib.rs
@@ -1,5 +1,5 @@
 //! The Core of rtx - roughly the equivalent of TeX conversion.
-
+#![feature(thread_local)]
 #![allow(missing_docs)]
 extern crate rustc_hash;
 

--- a/rtx_core/src/mouth.rs
+++ b/rtx_core/src/mouth.rs
@@ -804,12 +804,12 @@ pub fn tokenize(text: &str, state_opt: Option<&mut State>) -> Tokens {
     return NO_TOKENS;
   }
   match state_opt {
-    None => STD_STATE.with(|state_rw| {
-      let mut state = state_rw.borrow_mut();
+    None => {
+      let mut state = STD_STATE.borrow_mut();
       Mouth::new(text, None, &mut state)
         .unwrap()
         .read_tokens(&mut state)
-    }),
+    },
     Some(s) => Mouth::new(text, None, s).unwrap().read_tokens(s),
   }
 }
@@ -818,10 +818,8 @@ pub fn tokenize_internal(text: &str) -> Tokens {
   if text.is_empty() {
     return NO_TOKENS;
   }
-  STY_STATE.with(|state_rw| {
-    let mut state = state_rw.borrow_mut();
-    Mouth::new(text, None, &mut state)
-      .unwrap()
-      .read_tokens(&mut state)
-  })
+  let mut state = STY_STATE.borrow_mut();
+  Mouth::new(text, None, &mut state)
+    .unwrap()
+    .read_tokens(&mut state)
 }

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -336,16 +336,17 @@ impl Default for State {
   }
 }
 
-thread_local! {
-  pub static STY_STATE: RefCell<State> = RefCell::new(State::new(StateOptions {
-    catcodes: Some(Catcodes::Style),
-    ..StateOptions::default()
-  }));
-  pub static STD_STATE: RefCell<State> = RefCell::new(State::new(StateOptions {
-    catcodes: Some(Catcodes::Standard),
-    ..StateOptions::default()
-  }));
-}
+#[thread_local]
+pub static STY_STATE: Lazy<RefCell<State>> = Lazy::new(|| RefCell::new(State::new(StateOptions {
+  catcodes: Some(Catcodes::Style),
+  ..StateOptions::default()
+})));
+#[thread_local]
+pub static STD_STATE: Lazy<RefCell<State>> = Lazy::new(|| RefCell::new(State::new(StateOptions {
+  catcodes: Some(Catcodes::Standard),
+  ..StateOptions::default()
+})));
+
 
 /// State fields allowed for customization during construction
 #[derive(Default)]
@@ -505,7 +506,7 @@ impl State {
   ) {
     // hotcode lookupDefinition for \globaldefs,
     // since this is called extremely often and should be highly standardized
-    if let Some(globaldefs) = GLOBAL_DEFS_SYM.with(|sym| self.value.get(sym)) {
+    if let Some(globaldefs) = self.value.get(&GLOBAL_DEFS_SYM) {
       if let Some(global_value) = globaldefs.front() {
         // magic TeX register override: \globaldefs
         match *global_value {
@@ -802,7 +803,7 @@ impl State {
   ///  (`EMPTY_SYM` if None)
   pub fn lookup_string_sym(&self, key: &str) -> SymbolU32 {
     match self.lookup_value(key) {
-      None => EMPTY_SYM.with(|sym| *sym),
+      None => *EMPTY_SYM,
       Some(Stored::String(v)) => *v,
       Some(other) => arena::pin(other.to_string()),
     }
@@ -844,7 +845,7 @@ impl State {
   }
   /// convenience method to lookup the current value at the "font" key
   pub fn lookup_font(&self) -> Option<Rc<Font>> {
-    match self.lookup_value_sym(&FONT_SYM.with(|sym| *sym)) {
+    match self.lookup_value_sym(&FONT_SYM) {
       None | Some(Stored::None) => None,
       Some(f) => f.into(),
     }
@@ -964,7 +965,7 @@ impl State {
     // (but not \let to a token)
     if token.get_catcode().is_active_or_cs() {
       let lookupname = token.text;
-      if lookupname != EMPTY_SYM.with(|sym| *sym) {
+      if lookupname != *EMPTY_SYM {
         match self.meaning.get(&lookupname) {
           Some(entry) => {
             if let Some(def) = entry.front() {
@@ -1277,7 +1278,7 @@ impl State {
   pub fn lookup_meaning(&self, token: &Token) -> Option<Cow<Stored>> {
     if token.get_catcode().is_active_or_cs()
       && !token.has_smuggled()
-      && token.text != EMPTY_SYM.with(|sym| *sym)
+      && token.text != *EMPTY_SYM
     {
       match self.meaning.get(&token.text) {
         Some(entry) => match entry.front() {
@@ -1315,7 +1316,7 @@ impl State {
     let cc = key.get_catcode();
     let name = key.get_sym();
     let lookupname: Option<SymbolU32> = if (cc == Catcode::ACTIVE) || (cc == Catcode::CS) {
-      if name == EMPTY_SYM.with(|sym| *sym) {
+      if name == *EMPTY_SYM {
         None
       } else {
         Some(name)
@@ -1416,7 +1417,7 @@ impl State {
     };
     // Debug!("Looking up digestable {:?}", lookupname);
     let entry_opt = self.meaning.get(&lookup_sym);
-    if lookup_sym != EMPTY_SYM.with(|sym| *sym)
+    if lookup_sym != *EMPTY_SYM
       && entry_opt.is_some()
       && !entry_opt.as_ref().unwrap().is_empty()
     {
@@ -1902,7 +1903,7 @@ impl State {
       imodel
         .entry(arena::pin_static("#Document"))
         .or_insert_with(HashMap::default)
-        .insert(H_PCDATA_SYM.with(|sym| *sym), LTX_P_SYM.with(|sym| *sym));
+        .insert(*H_PCDATA_SYM, *LTX_P_SYM);
     }
 
     imodel
@@ -1918,7 +1919,7 @@ impl State {
   ) {
     let start = match start_opt {
       Some(s) => s,
-      None => EMPTY_SYM.with(|sym| *sym),
+      None => *EMPTY_SYM,
     };
 
     // A bit tricky here, we need to release the state.model borrow immediately, which is why we
@@ -1935,15 +1936,15 @@ impl State {
         continue;
       } // Already solved
 
-      if start != EMPTY_SYM.with(|sym| *sym) {
+      if start != *EMPTY_SYM {
         desc
           .entry(kid)
           .or_insert_with(HashMap::default)
           .insert(start, desirability);
       }
 
-      if kid != H_PCDATA_SYM.with(|sym| *sym) && openable.contains(&kid) {
-        let inner = if start != EMPTY_SYM.with(|sym| *sym) {
+      if kid != *H_PCDATA_SYM && openable.contains(&kid) {
+        let inner = if start != *EMPTY_SYM {
           start
         } else {
           kid

--- a/rtx_core/src/tbox.rs
+++ b/rtx_core/src/tbox.rs
@@ -82,7 +82,7 @@ impl Tbox {
     };
     // let locator = $STATE->getStomach->getGullet->getLocator unless defined $locator;
     let _locator = locator_opt;
-    let empty_sym = EMPTY_SYM.with(|sym| *sym);
+    let empty_sym = *EMPTY_SYM;
     let tokens = if text != empty_sym && tokens_opt.is_empty() {
       Tokens!(Token {
         text,

--- a/rtx_core/src/token.rs
+++ b/rtx_core/src/token.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::fmt::Display;
 use std::rc::Rc;
+use once_cell::sync::Lazy;
 use string_interner::symbol::SymbolU32;
 
 use crate::common::arena;
@@ -310,99 +311,107 @@ impl PartialEq for Token {
 //  a known token than it is to build a new one
 //  (as the arena lookup is a hair slower than copying a u32)
 
-thread_local! {
-  /// constant for an END "}" token
-  pub static TOKEN_BEGIN: Token = Token {
-    text: arena::pin_static("{"),
-    code: Catcode::BEGIN,
-    smuggled: None,
-  };
-  /// constant for a BEGIN "{" token
-  pub static TOKEN_END: Token = Token {
-    text: arena::pin_static("}"),
-    code: Catcode::END,
-    smuggled: None,
-  };
-  /// constant for a MATH "$" token
-  pub static TOKEN_MATH: Token = Token {
-    text: arena::pin_static("$"),
-    code: Catcode::MATH,
-    smuggled: None,
-  };
-  /// constant for an ALIGN "&" token
-  pub static TOKEN_ALIGN: Token = Token {
-    text: arena::pin_static("&"),
-    code: Catcode::ALIGN,
-    smuggled: None,
-  };
-  /// constant for a PARAM "#" token
-  pub static TOKEN_PARAM: Token = Token {
-    text: arena::pin_static("#"),
-    code: Catcode::PARAM,
-    smuggled: None,
-  };
-  /// constant for a SUPER "^" token
-  pub static TOKEN_SUPER: Token = Token {
-    text: arena::pin_static("^"),
-    code: Catcode::SUPER,
-    smuggled: None,
-  };
-  /// constant for a SUB "_" token
-  pub static TOKEN_SUB: Token = Token {
-    text: arena::pin_static("_"),
-    code: Catcode::SUB,
-    smuggled: None,
-  };
-  /// constant for a SPACE " " token
-  pub static TOKEN_SPACE: Token = Token {
-    text: arena::pin_static(" "),
-    code: Catcode::SPACE,
-    smuggled: None,
-  };
-  /// constant for a CR "\n" token
-  pub static TOKEN_CR: Token = Token {
-    text: arena::pin_static("\n"),
-    code: Catcode::SPACE,
-    smuggled: None,
-  };
-  /// constant for T_CS("\relax")
-  pub static TOKEN_RELAX: Token = Token {
-    text: arena::pin_static("\\relax"),
-    code: Catcode::CS,
-    smuggled: None,
-  };
-}
+/// constant for an END "}" token
+#[thread_local]
+pub static TOKEN_BEGIN: Lazy<Token> = Lazy::new(|| Token {
+  text: arena::pin_static("{"),
+  code: Catcode::BEGIN,
+  smuggled: None,
+});
+/// constant for a BEGIN "{" token
+#[thread_local]
+pub static TOKEN_END: Lazy<Token> = Lazy::new(|| Token {
+  text: arena::pin_static("}"),
+  code: Catcode::END,
+  smuggled: None,
+});
+/// constant for a MATH "$" token
+#[thread_local]
+pub static TOKEN_MATH: Lazy<Token> = Lazy::new(|| Token {
+  text: arena::pin_static("$"),
+  code: Catcode::MATH,
+  smuggled: None,
+});
+/// constant for an ALIGN "&" token
+#[thread_local]
+pub static TOKEN_ALIGN: Lazy<Token> = Lazy::new(|| Token {
+  text: arena::pin_static("&"),
+  code: Catcode::ALIGN,
+  smuggled: None,
+});
+/// constant for a PARAM "#" token
+#[thread_local]
+pub static TOKEN_PARAM: Lazy<Token> = Lazy::new(|| Token {
+  text: arena::pin_static("#"),
+  code: Catcode::PARAM,
+  smuggled: None,
+});
+/// constant for a SUPER "^" token
+#[thread_local]
+pub static TOKEN_SUPER: Lazy<Token> = Lazy::new(|| Token {
+  text: arena::pin_static("^"),
+  code: Catcode::SUPER,
+  smuggled: None,
+});
+/// constant for a SUB "_" token
+#[thread_local]
+pub static TOKEN_SUB: Lazy<Token> = Lazy::new(|| Token {
+  text: arena::pin_static("_"),
+  code: Catcode::SUB,
+  smuggled: None,
+});
+/// constant for a SPACE " " token
+#[thread_local]
+pub static TOKEN_SPACE: Lazy<Token> = Lazy::new(|| Token {
+  text: arena::pin_static(" "),
+  code: Catcode::SPACE,
+  smuggled: None,
+});
+/// constant for a CR "\n" token
+#[thread_local]
+pub static TOKEN_CR: Lazy<Token> = Lazy::new(|| Token {
+  text: arena::pin_static("\n"),
+  code: Catcode::SPACE,
+  smuggled: None,
+});
+/// constant for T_CS("\relax")
+#[thread_local]
+pub static TOKEN_RELAX: Lazy<Token> = Lazy::new(|| Token {
+  text: arena::pin_static("\\relax"),
+  code: Catcode::CS,
+  smuggled: None,
+});
 
 #[macro_export]
 /// macro for a BEGIN "{" token
-macro_rules! T_BEGIN(() => { $crate::token::TOKEN_BEGIN.with(|t| t.clone()) });
+macro_rules! T_BEGIN(() => { $crate::token::TOKEN_BEGIN.clone() });
 #[macro_export]
 /// macro for a new END "{" token
-macro_rules! T_END(() => { $crate::token::TOKEN_END.with(|t| t.clone()) });
+macro_rules! T_END(() => { $crate::token::TOKEN_END.clone() });
 /// macro for a MATH "$" token
 #[macro_export]
-macro_rules! T_MATH(() => { $crate::token::TOKEN_MATH.with(|t| t.clone()) });
+macro_rules! T_MATH(() => { $crate::token::TOKEN_MATH.clone() });
 /// macro for an ALIGN "&" token
 #[macro_export]
-macro_rules! T_ALIGN(() => { $crate::token::TOKEN_ALIGN.with(|t| t.clone()) });
+macro_rules! T_ALIGN(() => { $crate::token::TOKEN_ALIGN.clone() });
 /// macro for a PARAM "#" token
 #[macro_export]
-macro_rules! T_PARAM(() => { $crate::token::TOKEN_PARAM.with(|t| t.clone()) });
+macro_rules! T_PARAM(() => { $crate::token::TOKEN_PARAM.clone() });
 /// macro for a SUPER "^" token
 #[macro_export]
-macro_rules! T_SUPER(() => { $crate::token::TOKEN_SUPER.with(|t| t.clone()) });
+macro_rules! T_SUPER(() => { $crate::token::TOKEN_SUPER.clone() });
 /// macro for a SUB "_" token
 #[macro_export]
-macro_rules! T_SUB(() => { $crate::token::TOKEN_SUB.with(|t| t.clone()) });
+macro_rules! T_SUB(() => { $crate::token::TOKEN_SUB.clone() });
 /// macro for a SPACE token (default " ")
 #[macro_export]
-macro_rules! T_SPACE(() => { $crate::token::TOKEN_SPACE.with(|t| t.clone()) };
+macro_rules! T_SPACE(() => { $crate::token::TOKEN_SPACE.clone() };
 ($text:literal) => {
   Token { text: $crate::common::arena::pin($text), code: Catcode::SPACE, smuggled: None}
 });
 /// macro for a CR "\n" token
 #[macro_export]
-macro_rules! T_CR(() => { $crate::token::TOKEN_CR.with(|t| t.clone()) });
+macro_rules! T_CR(() => { $crate::token::TOKEN_CR.clone() });
 /// macro for a LETTER token
 #[macro_export]
 macro_rules! T_LETTER {
@@ -495,7 +504,7 @@ macro_rules! T_CS {
 
 /// macro for T_CS("\\relax")
 #[macro_export]
-macro_rules! T_RELAX(() => { $crate::token::TOKEN_RELAX.with(|t| t.clone()) });
+macro_rules! T_RELAX(() => { $crate::token::TOKEN_RELAX.clone() });
 
 /// macro for a tracing MARKER token
 #[macro_export]

--- a/rtx_core/src/whatsit.rs
+++ b/rtx_core/src/whatsit.rs
@@ -228,10 +228,8 @@ impl fmt::Debug for Whatsit {
 
 impl fmt::Display for Whatsit {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    STD_STATE.with(|state_rw| {
-      let state = state_rw.borrow(); // TODO: is this really the way?
-      write!(f, "{}", self.revert(&state).unwrap())
-    }) // What else??
+    let state = STD_STATE.borrow(); // TODO: is this really the way?
+    write!(f, "{}", self.revert(&state).unwrap())
   }
 }
 

--- a/rtx_package/src/package/etex.rs
+++ b/rtx_package/src/package/etex.rs
@@ -187,7 +187,7 @@ LoadDefinitions!(outer_state, {
     let value = etex_readexpr_i(gullet, rtype, 0, state)?;
     if let Some(token) = gullet.read_token(state)? {
       // Skip \relax
-      if TOKEN_RELAX.with(|tr| token != *tr) {
+      if token != *TOKEN_RELAX {
         gullet.unread_one(token);
       }
     }
@@ -223,7 +223,7 @@ LoadDefinitions!(outer_state, {
 
     // Now check for a following operator(s) & operand(s) (respecting precedence)
     while let Some(next) = gullet.read_x_non_space(state)? {
-      if TOKEN_RELAX.with(|tr| next == *tr) {
+      if next == *TOKEN_RELAX {
         gullet.unread_one(next); // leave the \relax for top-level to strip off.
         break;
       } else if next == T_OTHER!("+") && prec < 1 {

--- a/rtx_package/src/package/latex_ch11_moving_information.rs
+++ b/rtx_package/src/package/latex_ch11_moving_information.rs
@@ -158,7 +158,7 @@ LoadDefinitions!(outer_stomach, outer_state, {
       // It's ignorable for latexml anyway, so we'll just read it if its there.
       let gullet = stomach.get_gullet_mut();
       gullet.skip_spaces(state)?;
-      if TOKEN_BEGIN.with(|tb| gullet.if_next(tb, state))? {
+      if gullet.if_next(&TOKEN_BEGIN, state)? {
         gullet.read_arg(state)?;
       }
       begin_bibliography(stomach, whatsit, state)?;

--- a/rtx_package/src/package/latex_ch2_document.rs
+++ b/rtx_package/src/package/latex_ch2_document.rs
@@ -24,7 +24,7 @@ LoadDefinitions!(state, {
     let id = prop_str!(props,"id");
     // Already (auto) created?
     if let Some(mut docel) = document.findnode("/ltx:document", None, state) {
-      if id != EMPTY_SYM.with(|sym| *sym) {
+      if id != *EMPTY_SYM {
         arena::with(id, |id_str|
           document.set_attribute(&mut docel, "xml:id", id_str, state))?;
       }

--- a/rtx_package/src/package/latex_ch5_title_page_and_abstract.rs
+++ b/rtx_package/src/package/latex_ch5_title_page_and_abstract.rs
@@ -178,7 +178,7 @@ LoadDefinitions!(state, {
   // If we get a plain \abstract, instead of an environment, look for \abstract{the abstract}
   AssignValue!("\\abstract:locked" => false); // REDEFINE the above locked definition!
   DefMacro!("\\abstract", sub[gullet, _args, state] {
-    if TOKEN_BEGIN.with(|tb| gullet.if_next(tb, state))? {
+    if gullet.if_next(&TOKEN_BEGIN, state)? {
       T_CS!("\\abstract@onearg")
     } else {
       T_CS!("\\begin{abstract}")

--- a/rtx_package/src/package/latex_semi_undocumented.rs
+++ b/rtx_package/src/package/latex_semi_undocumented.rs
@@ -10,7 +10,7 @@ LoadDefinitions!(outer_stomach, state, {
     // use \egroup for $next, if we've fallen off end?
     let next_test = match next {
       Some(ref n) => XEquals!(&token, n),
-      None => TOKEN_END.with(|te| XEquals!(&token, te))
+      None => XEquals!(&token, &*TOKEN_END)
     };
     let which = if next_test {
       t_if

--- a/rtx_package/src/package/tex_assignment.rs
+++ b/rtx_package/src/package/tex_assignment.rs
@@ -335,8 +335,7 @@ LoadDefinitions!(outer_state, {
 });
 
 pub fn shorthand_def(cs: Token, address_type: &str, init: RegisterValue, stomach: &mut Stomach, state: &mut State) -> Result<()> {
-  state.assign_meaning(&cs, TOKEN_RELAX.with(|tr|
-    state.lookup_meaning(tr)).unwrap().into_owned(),None);
+  state.assign_meaning(&cs, state.lookup_meaning(&TOKEN_RELAX).unwrap().into_owned(),None);
   let num = stomach.get_gullet_mut().read_number(state)?;
   let name = s!("{address_type}{}", num.value_of());
   def_register(cs, None, init,

--- a/rtx_package/src/package/tex_expandable_primitives.rs
+++ b/rtx_package/src/package/tex_expandable_primitives.rs
@@ -278,8 +278,8 @@ LoadDefinitions!(outer_state, {
 
   DefMacro!("\\csname CSName", sub[gullet, (token), state] {
     if state.lookup_meaning(&token).is_none() {
-      state.assign_meaning(&token, TOKEN_RELAX.with(|t_relax|
-        state.lookup_meaning(t_relax)).unwrap().into_owned(), None);
+      state.assign_meaning(&token,
+        state.lookup_meaning(&TOKEN_RELAX).unwrap().into_owned(), None);
     }
     token
   });

--- a/rtx_package/src/package/tex_fonts.rs
+++ b/rtx_package/src/package/tex_fonts.rs
@@ -370,7 +370,7 @@ LoadDefinitions!(outer_state, {
   DefPrimitive!("\\char Number", sub[stomach, (number), p_state] {
     let number_tks = number.revert(p_state).unwrap_or_default().unlist();
     let decoded = match font::decode(number.value_of() as u8, None, false, stomach, p_state) {
-      None => EMPTY_SYM.with(|sym| *sym),
+      None => *EMPTY_SYM,
       Some(c) => arena::pin_char(c)
     };
     Tbox::new(
@@ -386,15 +386,14 @@ LoadDefinitions!(outer_state, {
   // (including the preassignment to \relax!)
   DefPrimitive!("\\chardef Token SkipMatch:=", sub[stomach, (newcs), state] {
     // Let w/o AfterAssignment
-    state.assign_meaning(&newcs, TOKEN_RELAX.with(|tr|
-      state.lookup_meaning(tr)).unwrap().into_owned(), None);
+    state.assign_meaning(&newcs, state.lookup_meaning(&TOKEN_RELAX).unwrap().into_owned(), None);
     let value = stomach.get_gullet_mut().read_number(state)?;
     // TODO: DG: This needs to be revised and updated once CharDef is clear as a datastructure
     let internalcs_str = newcs.with_cs_name(|csname| s!("\\@chardef@{}", csname));
     let internalcs = T_CS!(internalcs_str);
     DefPrimitive!(internalcs.clone(), None, sub[stomach,args,i_state] {
       let decoded = font::decode(value.value_of() as u8, None, false, stomach, i_state)
-        .map(arena::pin_char).unwrap_or_else(|| EMPTY_SYM.with(|sym| *sym));
+        .map(arena::pin_char).unwrap_or_else(|| *EMPTY_SYM);
       let gullet = stomach.get_gullet_mut();
       Tbox::new(decoded,
         None,
@@ -448,8 +447,7 @@ LoadDefinitions!(outer_state, {
   // Almost like a register, but different...
   DefPrimitive!("\\mathchardef Token SkipMatch:=", sub[stomach, (newcs), state] {
     // Let w/o AfterAssignment
-    state.assign_meaning(&newcs, TOKEN_RELAX.with(|tr|
-      state.lookup_meaning(tr)).unwrap().into_owned(), None);
+    state.assign_meaning(&newcs, state.lookup_meaning(&TOKEN_RELAX).unwrap().into_owned(), None);
     let value  = stomach.get_gullet_mut().read_number(state).unwrap();
     // eprintln!(" ** {} + {}", value,csname);
     let (role, glyph) = decode_math_char(value.value_of() as u16, stomach, state);

--- a/rtx_package/src/package/tex_math_mode.rs
+++ b/rtx_package/src/package/tex_math_mode.rs
@@ -22,7 +22,7 @@ LoadDefinitions!(state, {
         let mode = state.lookup_string("MODE");
         Debug!("T_MATH primitive current mode: {:?}", mode);
         if mode == "display_math" {
-          if TOKEN_MATH.with(|tm| gullet.if_next(tm, state))? {
+          if gullet.if_next(&TOKEN_MATH, state)? {
             gullet.read_token(state)?;
             op = "\\@@ENDDISPLAYMATH";
           } else {
@@ -40,7 +40,7 @@ LoadDefinitions!(state, {
           }
         } else if mode == "inline_math" {
           op = "\\@@ENDINLINEMATH";
-        } else if TOKEN_MATH.with(|tm| gullet.if_next(tm, state))? {
+        } else if gullet.if_next(&TOKEN_MATH, state)? {
           gullet.read_token(state)?;
           op = "\\@@BEGINDISPLAYMATH";
         }

--- a/rtx_package/src/package/tex_scripts.rs
+++ b/rtx_package/src/package/tex_scripts.rs
@@ -423,7 +423,7 @@ LoadDefinitions!(state, {
     // Combine with any following superscript!
     // However, this is semantically screwed up!
     // We really need to set up separate superscripts, but at same level!
-    if TOKEN_SUPER.with(|ts| gullet.if_next(ts, state))? {
+    if gullet.if_next(&TOKEN_SUPER, state)? {
       gullet.read_token(state)?;
       sup.extend(gullet.read_arg(state)?.unlist());
     }

--- a/rtx_package/src/package/tex_stray_math_style.rs
+++ b/rtx_package/src/package/tex_stray_math_style.rs
@@ -11,19 +11,19 @@ LoadDefinitions!(_state, {
   // Also record that this explicitly sets the mathstyle (support for \over, etal)
   DefPrimitive!("\\displaystyle", sub[_stomach,_args,state] {
     MergeFont!(mathstyle => "display");
-    Tbox::new(EMPTY_SYM.with(|sym| *sym), None, None, Tokens!(T_CS!("\\displaystyle")),
+    Tbox::new(*EMPTY_SYM, None, None, Tokens!(T_CS!("\\displaystyle")),
       stored_map!("explicit_mathstyle" => true), state) });
   DefPrimitive!("\\textstyle", sub[_stomach,_args,state] {
     MergeFont!(mathstyle => "text");
-    Tbox::new(EMPTY_SYM.with(|sym| *sym), None, None, Tokens!(T_CS!("\\textstyle")),
+    Tbox::new(*EMPTY_SYM, None, None, Tokens!(T_CS!("\\textstyle")),
       stored_map!("explicit_mathstyle" => true), state) });
   DefPrimitive!("\\scriptstyle", sub[_stomach,_args,state] {
     MergeFont!(mathstyle => "script");
-    Tbox::new(EMPTY_SYM.with(|sym| *sym), None, None, Tokens!(T_CS!("\\scriptstyle")),
+    Tbox::new(*EMPTY_SYM, None, None, Tokens!(T_CS!("\\scriptstyle")),
       stored_map!("explicit_mathstyle" => true), state) });
   DefPrimitive!("\\scriptscriptstyle", sub[_stomach,_args,state] {
     MergeFont!(mathstyle => "scriptscript");
-    Tbox::new(EMPTY_SYM.with(|sym| *sym), None, None, Tokens!(T_CS!("\\scriptscriptstyle")),
+    Tbox::new(*EMPTY_SYM, None, None, Tokens!(T_CS!("\\scriptscriptstyle")),
       stored_map!("explicit_mathstyle" => true), state) });
 
 });


### PR DESCRIPTION
This PR enacts the suggestion in #143 , using the `cargo +nightly` release channel. It is not usable on `stable` Rust, until `#[thread_local]` annotations are stabilized.

I am indeed seeing the expected speedups on tests an examples, varying anywhere between 10%-60% in runtime, depending on example. For the arXiv example mentioned in #153 , this PR lowers the runtime from 250 ms to 150 ms, a whopping 60% speedup.