### PR TITLE
allow raising a Fatal on 100 Errors; thread-scoped LogState

### DIFF
--- a/rtx/bin/rtx.rs
+++ b/rtx/bin/rtx.rs
@@ -13,13 +13,14 @@ use std::result::Result;
 
 fn main() -> Result<(), Box<dyn Error>> {
   if rtx_core::util::logger::init(log::LevelFilter::Info).is_err() {
+    let err = || {
     Error!(
       "rtx",
       "logger",
       None,
-      None,
       "Failed to load logger. Please check rtx_core::util::logger installed correctly."
-    );
+    ); Ok(()) };
+    err().ok();
   }
   let mut argv = env::args();
   argv.next();
@@ -27,13 +28,13 @@ fn main() -> Result<(), Box<dyn Error>> {
   let source = match argv.next() {
     Some(s) => s,
     None => {
-      Error!(
+      let err = || {Error!(
         "rtx",
         "",
         None,
-        None,
         "Please provide a source document! Exiting..."
-      );
+      ); Ok(()) };
+      err().ok();
       process::exit(1);
     },
   };
@@ -53,7 +54,8 @@ fn main() -> Result<(), Box<dyn Error>> {
   let mut converter = Converter::from_config(opts.clone());
   if let Err(e) = converter.prepare_session(&opts) {
     let message = s!("Could not prepare converter session! : {}", e);
-    Error!("rtx", "session", None, None, message);
+    let err = || {Error!("rtx", "session", None, message); Ok(())};
+    err().ok();
     process::exit(1);
   }
   // Perform the conversion:

--- a/rtx/bin/rtx_math.rs
+++ b/rtx/bin/rtx_math.rs
@@ -14,7 +14,6 @@ fn main() -> Result<()> {
       "rtx",
       "logger",
       None,
-      None,
       "Failed to load logger, aborting. Please check rtx_core::util::logger installed correctly."
     );
   }
@@ -27,7 +26,6 @@ fn main() -> Result<()> {
       Error!(
         "rtx",
         "",
-        None,
         None,
         "Please provide a TeX formula on input! Exiting..."
       );
@@ -65,7 +63,6 @@ fn main() -> Result<()> {
     Warn!(
       "math",
       "parse",
-      None,
       None,
       "Grammar did not recognize expression."
     );

--- a/rtx/src/converter.rs
+++ b/rtx/src/converter.rs
@@ -5,7 +5,7 @@ use rtx_core::digested::Digested;
 use rtx_core::document::Document;
 use rtx_core::list::List;
 use rtx_core::state::State;
-use rtx_core::{generate_message, s, Core, CoreOptions, Error, Info};
+use rtx_core::{s, Core, CoreOptions, Error, Fatal, fatal, Info};
 use rtx_package::package;
 use std::rc::Rc;
 
@@ -212,9 +212,9 @@ impl Converter {
           Ok(dom) => dom.serialize_to_string(self.state_mut()),
           Err(e) => {
             let message = s!("{:?}", e);
-            let error_state = &self.core.get_state();
             let error_where = &self.core;
-            Error!("document", "convert", error_where, error_state, message);
+            let err = || {Error!("document", "convert", error_where, message); Ok(()) };
+            err().ok();
             String::new()
           },
         }
@@ -323,7 +323,7 @@ impl Converter {
     // else { $serialized = $result; }                              // Compressed case
 
     // 5.2 Finalize logging and return a response containing the document result, log and status
-    Info!("status", "conversion", None, None, self.runtime.status_code);
+    Info!("status", "conversion", None, self.runtime.status_code);
     let log = self.flush_log();
     // self->sanitize($log) if ($$runtime{status_code} == 3);
 

--- a/rtx/src/core_interface.rs
+++ b/rtx/src/core_interface.rs
@@ -187,7 +187,7 @@ impl DigestionAPI for Core {
         load_model!(state, "LaTeXML");
       } else {
         // Eager-load at runtime
-        state.model.load_schema(schema_paths.as_slice()); // If needed?
+        state.model.load_schema(schema_paths.as_slice())?; // If needed?
       }
 
       if !state.search_paths.is_empty() {
@@ -234,7 +234,7 @@ impl DigestionAPI for Core {
     if has_rewrites {
       note_begin("Rewriting");
       document.mark_xmnode_visibility(state)?;
-      document.load_labels_for_rewrite(state);
+      document.load_labels_for_rewrite(state)?;
       // TODO: What is the right way to do rewrites in a daemon-safe manner?
       if let Some(Stored::VecDequeStored(rules)) = state.remove_value("DOCUMENT_REWRITE_RULES") {
         if let Some(root) = document.get_document().get_root_element() {
@@ -324,7 +324,7 @@ impl DigestionAPI for Core {
       // ext = pathname::extension(&request);
       } else {
         let message = s!("Can't find {} file {} ", mode, request);
-        fatal!(Core, MissingFile, self, None, message);
+        fatal!(Core, MissingFile, self, message);
       }
     }
     note_begin(&s!("Digesting {} {}", mode, name));

--- a/rtx/tests/700_unit_parse.rs
+++ b/rtx/tests/700_unit_parse.rs
@@ -36,7 +36,7 @@ fn basic_1() {
   let mut parser = MathParser::default();
   let mut state = State::new(StateOptions::default());
   // need to load the model schema by hand in the unit test, to get the "ltx" namespace working
-  state.model.load_schema(&[]);
+  assert!(state.model.load_schema(&[]).is_ok());
   let parse_tree_opt = parser.parse_lexemes(lexemes, &nodes, &mut doc, &mut state);
 
   assert!(parse_tree_opt.is_ok());

--- a/rtx_codegen/src/tokenizeable.rs
+++ b/rtx_codegen/src/tokenizeable.rs
@@ -28,7 +28,7 @@ pub fn compile_expansion(input: DeriveInput) -> TokenStream {
       quote!(None)
     } else {
       // rescan for match tokens and unwrap dont_expand...
-      let expansion = performed_expansion.pack_parameters();
+      let expansion = performed_expansion.pack_parameters().unwrap();
       // println!("expanded into: {:?} tokens: {:?}", performed_expansion.len(),
       // performed_expansion);
       //

--- a/rtx_core/src/alignment.rs
+++ b/rtx_core/src/alignment.rs
@@ -203,20 +203,20 @@ impl Alignment {
     }
   }
 
-  pub fn next_column(&mut self) -> Option<&mut Cell> {
-    self.current_row?;
+  pub fn next_column(&mut self) -> Result<Option<&mut Cell>> {
+    if self.current_row.is_none() { return Ok(None); }
     self.current_column += 1;
     let current_row = self.rows.get_mut(self.current_row.unwrap()).unwrap();
     if let Some(colspec) = current_row.get_column_mut(self.current_column) {
-      Some(colspec)
+      Ok(Some(colspec))
     } else {
-      Error!("unexpected", "&", None, None, "Extra alignment tab '&'");
+      Error!("unexpected", "&", None, "Extra alignment tab '&'");
       // DG: Mutability issue, should we do an alternative recovery?
       //     or change the call interface?
       //
       // let fallback_cell = Cell{align: Some(Align::Center),..Cell::default()};
       // current_row.add_column(fallback_cell);
-      None
+      Ok(None)
     }
   }
 
@@ -511,7 +511,7 @@ impl BoxOps for Alignment {
             }
           }
         }
-        let empty = cell.empty || cell.boxes.is_none() || cell.boxes.as_ref().unwrap().is_empty();
+        let empty = cell.empty || cell.boxes.is_none() || cell.boxes.as_ref().unwrap().is_empty()?;
         let open_column_fn = &self.open_column;
         let mut cell_attrs = HashMap::default();
         if let Some(align) = cell.align {
@@ -676,7 +676,7 @@ pub fn read_alignment_template(gullet: &mut Gullet, state: &mut State) -> Result
         break;
       }
       gullet.unread_one(last_op);
-    } else if let Some(defn) = state.lookup_expandable(&T_CS!(s!("\\NC@rewrite@{op}")), true) {
+    } else if let Some(defn) = state.lookup_expandable(&T_CS!(s!("\\NC@rewrite@{op}")), true)? {
       let invoked = defn.invoke(gullet, true, state)?;
       gullet.unread(invoked);
     } else if cc == Catcode::BEGIN {
@@ -688,7 +688,6 @@ pub fn read_alignment_template(gullet: &mut Gullet, state: &mut State) -> Result
         "unexpected",
         op,
         gullet,
-        state,
         s!("Unrecognized tabular template {op:?}")
       );
     }
@@ -766,7 +765,7 @@ fn guess_alignment_headers(
     if rows.is_empty() {
       return Ok(());
     }
-    alignment_characterize_lines(document, Axis::Row, false, rows.as_mut_slice(), state)?;
+    alignment_characterize_lines(document, Axis::Row, false, rows.as_mut_slice())?;
   }
   // Flip the rows around to produce a column view.
   {
@@ -775,7 +774,7 @@ fn guess_alignment_headers(
       return Ok(());
     }
     // This usually does something unpleasant
-    alignment_characterize_lines(document, Axis::Column, false, cols.as_mut_slice(), state)?;
+    alignment_characterize_lines(document, Axis::Column, false, cols.as_mut_slice())?;
   }
 
   // Did we go overboard?
@@ -813,7 +812,7 @@ fn guess_alignment_headers(
   }
   if n_h > 0 {
     // Found some headers?
-    document.add_class(table, "ltx_guessed_headers", state)?;
+    document.add_class(table, "ltx_guessed_headers")?;
   }
 
   //   # Debugging report!
@@ -1238,8 +1237,7 @@ fn alignment_characterize_lines(
   document: &mut Document,
   axis: Axis,
   reversed: bool,
-  lines: &mut [Vec<&mut Cell>],
-  state: &State,
+  lines: &mut [Vec<&mut Cell>]
 ) -> Result<()> {
   let n = lines.len();
   if n < 2 {
@@ -1323,7 +1321,7 @@ fn alignment_characterize_lines(
                   })))
             {
             } else {
-              document.add_ss_values(xcell, "thead", axis.marker_name(), state)?;
+              document.add_ss_values(xcell, "thead", axis.marker_name())?;
             }
           }
         }

--- a/rtx_core/src/binding/content.rs
+++ b/rtx_core/src/binding/content.rs
@@ -77,13 +77,13 @@ pub fn input_definitions(
   // Note: we always need a gullet to expand, and we sometimes need a stomach to load_definitions...
   // so let's make stomach a mandatory option.
   let prevname =
-    if options.handleoptions && state.lookup_definition(&T_CS!("\\@currname")).is_some() {
+    if options.handleoptions && state.lookup_definition(&T_CS!("\\@currname"))?.is_some() {
       let gullet = stomach.get_gullet_mut();
       gullet.do_expand(T_CS!("\\@currname"), state)?.to_string()
     } else {
       String::new()
     };
-  let prevext = if options.handleoptions && state.lookup_definition(&T_CS!("\\@currext")).is_some()
+  let prevext = if options.handleoptions && state.lookup_definition(&T_CS!("\\@currext"))?.is_some()
   {
     let gullet = stomach.get_gullet_mut();
     gullet.do_expand(T_CS!("\\@currext"), state)?.to_string()
@@ -136,7 +136,7 @@ pub fn input_definitions(
           current_options,
           prevoptions
         );
-        Info!("unexpected", "options", stomach, state, message);
+        Info!("unexpected", "options", stomach, message);
       }
     }
   }
@@ -152,14 +152,14 @@ pub fn input_definitions(
     Tokens!(Explode!(name)),
     None,
     state,
-  );
+  )?;
   def_macro(
     T_CS!("\\@currext"),
     None,
     Tokens!(Explode!(as_type)),
     None,
     state,
-  );
+  )?;
 
   // TODO: Is this inaccurate with latexml? It only sets the macros if the file is found, we set
   // them *always*, as a matter of course TODO: This *IS* inaccurate with the Package.pm
@@ -181,7 +181,7 @@ pub fn input_definitions(
       options.after,
       None,
       state,
-    );
+    )?;
   }
 
   if !current_options.is_empty() {
@@ -226,7 +226,6 @@ pub fn input_definitions(
         "missing_file",
         name,
         stomach,
-        state,
         s!("Can't find file for {name}")
       );
       // STATE.note_status(missing => $name . ($options{type} ? '.' . $options{type} : ''));
@@ -252,7 +251,7 @@ pub fn input_definitions(
         Tokens!(Explode!(prevname)),
         None,
         state,
-      );
+      )?;
     }
     if !prevext.is_empty() {
       def_macro(
@@ -261,7 +260,7 @@ pub fn input_definitions(
         Tokens!(Explode!(prevext)),
         None,
         state,
-      );
+      )?;
     }
     stomach.digest(T_CS!("\\@popfilename"), state)?;
     reset_options(stomach.get_gullet_mut(), state)?; // And reset options afterwards, too.
@@ -356,7 +355,7 @@ fn before_input_handle_options(
           }
         }
         if !topass.is_empty() {
-          pass_options(name, as_type, topass, state)
+          pass_options(name, as_type, topass, state)?;
         }
       }
     }
@@ -367,22 +366,22 @@ fn before_input_handle_options(
     Tokens!(Explode!(name)),
     None,
     state,
-  );
+  )?;
   def_macro(
     T_CS!("\\@currext"),
     None,
     Tokens!(Explode!(as_type)),
     None,
     state,
-  );
+  )?;
   // reset options (Note reset & pass were in opposite order in LoadClass ????)
   let gullet = stomach.get_gullet_mut();
   reset_options(gullet, state)?;
-  pass_options(name, as_type, options.options.clone(), state);
+  pass_options(name, as_type, options.options.clone(), state)?;
 
   // Note which packages are pretending to be classes.
   if options.as_class {
-    state.push_value("@masquerading@as@class", arena::pin(name));
+    state.push_value("@masquerading@as@class", arena::pin(name))?;
   }
   let current_opt_val = match state.lookup_vecdeque(&s!("opt@{}.{}", name, as_type)) {
     Some(vdq) => {
@@ -404,7 +403,7 @@ fn before_input_handle_options(
     Tokens!(Explode!(current_opt_val)),
     None,
     state,
-  );
+  )?;
   Ok(())
 }
 
@@ -509,7 +508,7 @@ pub fn input(
   //   }
   } else {
     // Couldn't find anything?
-    state.note_status("missing", request);
+    note_status(LogStatus::Missing, Some(request));
 
     // We presumably are trying to input Content; an error if we can't find it (contrast to
     // Definitions)
@@ -518,7 +517,6 @@ pub fn input(
       "missing_file",
       request,
       gullet,
-      state,
       s!("Can't find TeX file {}", request)
     );
     //  maybeReportSearchPaths());
@@ -639,20 +637,20 @@ pub fn load_tex_content(
 
 /// Pass the sequence of @options to the package $name (if $ext is 'sty'),
 /// or class $name (if $ext is 'cls').
-fn pass_options(name: &str, ext: &str, options: Vec<String>, state: &mut State) {
-  state.push_value(&s!("opt@{}.{}", name, ext), options);
+fn pass_options(name: &str, ext: &str, options: Vec<String>, state: &mut State) -> Result<()> {
+  state.push_value(&s!("opt@{}.{}", name, ext), options)
 }
 
 pub fn process_options(stomach: &mut Stomach, state: &mut State) -> Result<()> {
   let currname_token = T_CS!("\\@currname");
   let currext_token = T_CS!("\\@currext");
   let gullet = stomach.get_gullet_mut();
-  let name = if state.lookup_definition(&currname_token).is_some() {
+  let name = if state.lookup_definition(&currname_token)?.is_some() {
     do_expand(currname_token, gullet, state)?.to_string()
   } else {
     String::new()
   };
-  let ext = if state.lookup_definition(&currext_token).is_some() {
+  let ext = if state.lookup_definition(&currext_token)?.is_some() {
     do_expand(currext_token, gullet, state)?.to_string()
   } else {
     String::new()
@@ -748,14 +746,14 @@ pub fn process_options(stomach: &mut Stomach, state: &mut State) -> Result<()> {
 
 fn execute_option_internal(option: &str, stomach: &mut Stomach, state: &mut State) -> Result<bool> {
   let cs = T_CS!(s!("\\ds@{}", option));
-  if state.lookup_definition(&cs).is_some() {
+  if state.lookup_definition(&cs)?.is_some() {
     def_macro(
       T_CS!("\\CurrentOption"),
       None,
       Tokens!(T_OTHER!(option)),
       None,
       state,
-    );
+    )?;
 
     let unused = match state.remove_vecdeque("@unusedoptionlist") {
       Some(list) => list
@@ -789,7 +787,7 @@ fn execute_default_option_internal(
     Tokens!(T_OTHER!(option)),
     None,
     state,
-  );
+  )?;
   stomach.digest(T_CS!("\\default@ds"), state)?;
   Ok(true)
 }
@@ -885,7 +883,6 @@ pub fn require_resource(mut resource: Resource, state: &mut State) {
       "expected",
       "resource",
       None,
-      state,
       "Resource must have a resource pathname or content; skipping"
     );
     return;
@@ -899,7 +896,6 @@ pub fn require_resource(mut resource: Resource, state: &mut State) {
       "expected",
       "mime-type",
       None,
-      state,
       "Resource must have a mime-type; skipping"
     );
     return;
@@ -1155,7 +1151,7 @@ pub fn digest_if(
   stomach: &mut Stomach,
   state: &mut State,
 ) -> Result<Option<Digested>> {
-  if let Some(_defn) = state.lookup_definition(&token) {
+  if state.lookup_definition(&token)?.is_some() {
     match stomach.digest(Tokens!(token), state) {
       Ok(t) => Ok(Some(t)),
       Err(e) => Err(e),
@@ -1173,7 +1169,7 @@ pub fn build_invocation<T: Into<Token>>(
 ) -> Result<Tokens> {
   let token: Token = token.into();
   // Note: token may have been \let to another defn!
-  if let Some(defn) = state.lookup_definition(&token) {
+  if let Some(defn) = state.lookup_definition(&token)? {
     let mut invoked_tokens = vec![token];
     let mut reverted_args = if let Some(params) = defn.get_parameters() {
       params.revert_arguments(args, state)?
@@ -1184,7 +1180,7 @@ pub fn build_invocation<T: Into<Token>>(
     Ok(Tokens::new(invoked_tokens))
   } else {
     let message = s!("Can't invoke {:?}; it is undefined", token.stringify());
-    token.with_cs_name(|csname| Error!("undefined", csname, gullet, state, message));
+    token.with_cs_name(|csname| { Error!("undefined", csname, gullet, message); Ok(()) })?;
     let mut invoked_tokens = vec![token];
     // DefConstructor!(token, convert_latex_args(args.len(), 0),
     // sub { LaTeXML::Core::Stomach::makeError($_[0], 'undefined', token); });

--- a/rtx_core/src/binding/counter/dialect.rs
+++ b/rtx_core/src/binding/counter/dialect.rs
@@ -132,9 +132,9 @@ pub fn new_counter(
       ..ExpandableOptions::default()
     }),
     state,
-  );
+  )?;
   let p_ctr_cs = T_CS!(&s!("\\p@{}", ctr));
-  if state.lookup_definition(&p_ctr_cs).is_none() {
+  if state.lookup_definition(&p_ctr_cs)?.is_none() {
     def_macro(
       p_ctr_cs,
       None,
@@ -144,7 +144,7 @@ pub fn new_counter(
         ..ExpandableOptions::default()
       }),
       state,
-    );
+    )?;
   }
 
   let mut prefix = match options_opt {
@@ -201,7 +201,7 @@ pub fn new_counter(
           ..ExpandableOptions::default()
         }),
         state,
-      )
+      )?;
     } else {
       def_macro(
         T_CS!(thectrid),
@@ -220,7 +220,7 @@ pub fn new_counter(
           ..ExpandableOptions::default()
         }),
         state,
-      );
+      )?;
     }
     def_macro(
       T_CS!(s!("\\@{}@ID", ctr)),
@@ -231,7 +231,7 @@ pub fn new_counter(
         ..ExpandableOptions::default()
       }),
       state,
-    );
+    )?;
   }
 
   Ok(())
@@ -241,14 +241,14 @@ pub fn counter_value(ctr: &str, state: &mut State) -> Number {
   match state.lookup_number(&s!("\\c@{}", ctr)) {
     None => {
       let message = s!("Counter {} was not defined; assuming 0", ctr);
-      Warn!("undefined", ctr, None, state, message);
+      Warn!("undefined", ctr, None, message);
       Number::new(0)
     },
     Some(value) => value,
   }
 }
 /// increments a named counter by a `Number`
-pub fn add_to_counter(ctr: &str, value: Number, gullet: &mut Gullet, state: &mut State) {
+pub fn add_to_counter(ctr: &str, value: Number, gullet: &mut Gullet, state: &mut State) -> Result<()> {
   let v = counter_value(ctr, state).add(value);
   state.assign_value(&s!("\\c@{}", ctr), v, Some(Scope::Global));
   state.after_assignment(gullet);
@@ -262,7 +262,7 @@ pub fn add_to_counter(ctr: &str, value: Number, gullet: &mut Gullet, state: &mut
       ..ExpandableOptions::default()
     }),
     state,
-  );
+  )
 }
 
 /// Analog of `\stepcounter`, steps the counter and returns the expansion of
@@ -293,13 +293,13 @@ pub fn step_counter(
       ..ExpandableOptions::default()
     }),
     state,
-  );
+  )?;
 
   // and reset any within counters!
   if !noreset {
     if let Some(nested) = state.lookup_tokens(&s!("\\cl@{}", ctr)) {
       for c in nested.unlist() {
-        reset_counter(&c, state);
+        reset_counter(&c, state)?;
       }
     }
   }
@@ -335,13 +335,13 @@ pub fn step_counter_gullet(
       ..ExpandableOptions::default()
     }),
     state,
-  );
+  )?;
 
   // and reset any within counters!
   if !noreset {
     if let Some(nested) = state.lookup_tokens(&s!("\\cl@{}", ctr)) {
       for c in nested.unlist() {
-        reset_counter(&c, state);
+        reset_counter(&c, state)?;
       }
     }
   }
@@ -367,7 +367,7 @@ pub fn ref_step_counter(
   step_counter(&ctr, noreset, stomach, state)?;
   maybe_preempt_refnum(&ctr, false, stomach.get_gullet_mut(), state);
 
-  let has_id: bool = if let Some(iddef) = state.lookup_definition(&T_CS!(s!("\\the{ctr}@ID"))) {
+  let has_id: bool = if let Some(iddef) = state.lookup_definition(&T_CS!(s!("\\the{ctr}@ID")))? {
     if let Some(params) = iddef.get_parameters() {
       params.get_num_args() == 0
     } else {
@@ -388,7 +388,7 @@ pub fn ref_step_counter(
       ..ExpandableOptions::default()
     }),
     state,
-  );
+  )?;
   if has_id {
     def_macro(
       T_CS!("\\@currentID"),
@@ -399,7 +399,7 @@ pub fn ref_step_counter(
         ..ExpandableOptions::default()
       }),
       state,
-    );
+    )?;
   }
 
   let id = if has_id {
@@ -565,16 +565,16 @@ pub fn ref_step_id(
       ..ExpandableOptions::default()
     }),
     state,
-  );
+  )?;
 
   let thectr = s!("\\the{ctr}@ID");
-  def_macro(T_CS!("\\@currentID"), None, T_CS!(&thectr), None, state);
+  def_macro(T_CS!("\\@currentID"), None, T_CS!(&thectr), None, state)?;
   Ok(stored_map!("id" =>
     clean_id(&digest_literal(T_CS!(thectr), stomach, state)?.to_string())))
 }
 
 /// Resets the counter `ctr` to zero.
-pub fn reset_counter(ctr: &Token, state: &mut State) {
+pub fn reset_counter(ctr: &Token, state: &mut State) -> Result<()> {
   let (c_ctr, c_un_ctr, ctr_id) =
     ctr.with_str(|ctr| (s!("\\c@{ctr}"), s!("\\c@UN{ctr}"), s!("\\@{}@ID", ctr)));
   state.assign_value(&c_ctr, Number::new(0), Some(Scope::Global));
@@ -591,12 +591,13 @@ pub fn reset_counter(ctr: &Token, state: &mut State) {
       ..ExpandableOptions::default()
     }),
     state,
-  );
+  )?;
   // and reset any within counters!
   let nested = state.lookup_tokens(&s!("\\cl@{ctr}")).unwrap_or_default();
   for c in nested.unlist() {
-    reset_counter(&c, state);
+    reset_counter(&c, state)?;
   }
+  Ok(())
 }
 
 /// Create id, and tags for an itemize type \item
@@ -673,7 +674,7 @@ pub fn ref_step_item_counter(
     tag_tokens.push(T_END!());
 
     let tags = stomach.digest(tag_tokens, state)?;
-    if !tags.is_empty() {
+    if !tags.is_empty()? {
       props.insert("tags".to_string(), tags.into());
     }
     props
@@ -751,7 +752,7 @@ pub fn begin_itemize(
     Tokens!(Explode!(usecounter)),
     None,
     state,
-  );
+  )?;
   // Now arrange that this list's id's are relative to the current (outer) item (if any)
   // And that the items within this list's id's are relative to this (new) list.
   state.assign_value("itemcounter", Stored::String(arena::pin(&usecounter)), None);
@@ -771,7 +772,7 @@ pub fn begin_itemize(
       mouth::tokenize_internal(&theexpansion),
       None,
       state,
-    );
+    )?;
 
     // AND reset this list's counter when the outer item is stepped
     let mut cl_toks = vec![T_CS!(&listcounter)];
@@ -787,7 +788,7 @@ pub fn begin_itemize(
   }
   // format the id of \item's relative to the id of this list
   let useexp = mouth::tokenize_internal(&s!("\\the{listcounter}@ID.i\\@{usecounter}@ID"));
-  def_macro(T_CS!(s!("\\the{usecounter}@ID")), None, useexp, None, state);
+  def_macro(T_CS!(s!("\\the{usecounter}@ID")), None, useexp, None, state)?;
 
   let mut series = if let Some(s) = options.series {
     s.to_string()
@@ -797,7 +798,7 @@ pub fn begin_itemize(
   if let Some(start) = options.start {
     SetCounter!(usecounter, start, stomach, state);
     let gullet = stomach.get_gullet_mut();
-    add_to_counter(&usecounter, Number(-1), gullet, state);
+    add_to_counter(&usecounter, Number(-1), gullet, state)?;
   } else if let Some(s) = match options.resume {
     Some(s) => Some(s),
     None => options.resume_star,
@@ -810,7 +811,7 @@ pub fn begin_itemize(
       //   state);
     }
   } else {
-    reset_counter(&T_OTHER!(&usecounter), state);
+    reset_counter(&T_OTHER!(&usecounter), state)?;
   }
 
   let mut rsc = ref_step_counter(&s!("@itemize{listpostfix}"), false, stomach, state)?;

--- a/rtx_core/src/binding/def/dialect.rs
+++ b/rtx_core/src/binding/def/dialect.rs
@@ -119,7 +119,7 @@ pub fn def_conditional(
   options: ConditionalOptions,
   gullet: &mut Gullet,
   state: &mut State,
-) {
+) -> Result<()> {
   let locked_key = if let Some(true) = options.locked {
     arena::with(cs.get_sym(), |cs_name| s!("{cs_name}:locked"))
   } else {
@@ -157,14 +157,14 @@ pub fn def_conditional(
           Tokens!(T_CS!("\\let"), cs.clone(), T_CS!("\\iftrue")),
           None,
           state,
-        );
+        )?;
         def_macro(
           T_CS!(s!("\\{}false", name)),
           None,
           Tokens!(T_CS!("\\let"), cs.clone(), T_CS!("\\iffalse")),
           None,
           state,
-        );
+        )?;
         state.let_i(&cs, &T_CS!("\\iffalse"), None, gullet);
       } else {
         //  For \ifcase, the parameter list better be a single Number !!
@@ -184,13 +184,14 @@ pub fn def_conditional(
         "The conditional {} is being defined but doesn't start with \\if",
         cs
       );
-      Error!("misdefined", cs, None, state, message);
+      Error!("misdefined", cs, None, message);
     }
   }
 
   if let Some(true) = options.locked {
     state.assign_value(&locked_key, true, None);
   }
+  Ok(())
 }
 
 /// Defines the macro expansion for a `cs`: a macro control sequence that reads parameters
@@ -202,7 +203,7 @@ pub fn def_macro<T: Into<Option<ExpansionBody>>>(
   expansion: T,
   options_opt: Option<ExpandableOptions>,
   state: &mut State,
-) {
+) -> Result<()> {
   let expansion_opt: Option<ExpansionBody> = expansion.into();
   // TODO: The None case could be refactored to feel much cleaner.
   // For now it's equivalent to Tokens!()
@@ -222,17 +223,18 @@ pub fn def_macro<T: Into<Option<ExpansionBody>>>(
     None
   };
   let defcs = if options.robust {
-    def_robust_cs(cs, options.locked, options.scope.clone(), state)
+    def_robust_cs(cs, options.locked, options.scope.clone(), state)?
   } else {
     cs
   };
   state.install_definition(
-    Expandable::new(defcs, paramlist, expansion, Some(options), state),
+    Expandable::new(defcs, paramlist, expansion, Some(options), state)?,
     scope,
   );
   if let Some(locked_key) = locked_key_opt {
     state.assign_value(&locked_key, true, Some(Scope::Global));
   }
+  Ok(())
 }
 
 /// configuration for creating a new Register
@@ -294,9 +296,9 @@ pub fn def_register<T: Into<RegisterValue>>(
     Some(setter) => setter.clone(),
     None => {
       if readonly {
-        Rc::new(move |_value, _args, state| {
+        Rc::new(move |_value, _args, _state| {
           let message = s!("Can't assign to register {}", setter_name);
-          Warn!("unexpected", setter_name, None, state, message);
+          Warn!("unexpected", setter_name, None, message);
         })
       } else {
         Rc::new(move |value, args, state| {
@@ -347,7 +349,7 @@ pub fn def_primitive(
   compiled_replacement: Option<PrimitiveClosure>,
   options: PrimitiveOptions,
   state: &mut State,
-) {
+) -> Result<()> {
   let options_locked = options.locked;
   let scope = options.scope;
   let mut before_digest_env: Vec<BeforeDigestClosure> = Vec::new();
@@ -403,7 +405,7 @@ pub fn def_primitive(
   }
   //  Not sure robust entirely makes sense for Primitives, other than LaTeXML vs LaTeX mismatch
   let defcs = if options.robust {
-    def_robust_cs(cs, options.locked, scope.clone(), state)
+    def_robust_cs(cs, options.locked, scope.clone(), state)?
   } else {
     cs
   };
@@ -425,6 +427,7 @@ pub fn def_primitive(
   if options_locked {
     state.assign_value(&s!("{}:locked", cs_name), true, None);
   }
+  Ok(())
 }
 
 /// Advanced math replacements require a XMDual representation
@@ -434,13 +437,13 @@ pub fn def_math_dual(
   presentation: String,
   options: MathPrimitiveOptions,
   state: &mut State,
-) {
+) -> Result<()> {
   let (cont_cs_str, pres_cs_str) =
     cs.with_str(|csname| (s!("{csname}@content"), s!("{csname}@presentation")));
   let cont_cs = T_CS!(cont_cs_str);
   let pres_cs = T_CS!(pres_cs_str);
   let defcs = if options.robust {
-    def_robust_cs(cs.clone(), options.locked, options.scope.clone(), state)
+    def_robust_cs(cs.clone(), options.locked, options.scope.clone(), state)?
   } else {
     cs.clone()
   };
@@ -512,7 +515,7 @@ pub fn def_math_dual(
         ..ExpandableOptions::default()
       }),
       state,
-    ),
+    )?,
     options.scope.clone(),
   );
 
@@ -527,7 +530,7 @@ pub fn def_math_dual(
         ..ExpandableOptions::default()
       }),
       state,
-    ),
+    )?,
     options.scope.clone(),
   );
 
@@ -598,6 +601,7 @@ pub fn def_math_dual(
   let scope = options.scope.clone();
   transfer_common_constructor_options(&cs, &presentation, options, &mut content_constructor);
   state.install_definition(content_constructor, scope);
+  Ok(())
 }
 
 /// EXPERIMENT: Introduce an intermediate case for simple symbols
@@ -654,7 +658,7 @@ pub fn def_math_constructor(
   presentation: String,
   mut options: MathPrimitiveOptions,
   state: &mut State,
-) {
+) -> Result<()> {
   // TODO: do we need to do anything about digesting the presentation?
   let nargs = paramlist
     .as_ref()
@@ -666,7 +670,7 @@ pub fn def_math_constructor(
   //   None
   // };
   let defcs = if options.robust {
-    def_robust_cs(cs.clone(), options.locked, options.scope.clone(), state)
+    def_robust_cs(cs.clone(), options.locked, options.scope.clone(), state)?
   } else {
     cs.clone()
   };
@@ -829,6 +833,7 @@ pub fn def_math_constructor(
   let scope = options.scope.clone();
   transfer_common_constructor_options(&cs, &presentation, options, &mut constructor);
   state.install_definition(constructor, scope);
+  Ok(())
 }
 
 fn infer_sizer(
@@ -844,7 +849,7 @@ fn infer_sizer(
   }
 }
 
-fn def_robust_cs(cs: Token, locked: bool, scope: Option<Scope>, state: &mut State) -> Token {
+fn def_robust_cs(cs: Token, locked: bool, scope: Option<Scope>, state: &mut State) -> Result<Token> {
   let cs_str = cs.with_str(|cstr| format!("{} ", cstr));
   let defcs = T_CS!(cs_str);
   let return_cs = defcs.clone();
@@ -855,10 +860,10 @@ fn def_robust_cs(cs: Token, locked: bool, scope: Option<Scope>, state: &mut Stat
   };
   // scope should be \x@protect?
   state.install_definition(
-    Expandable::new(cs, None, expansion, Some(options), state),
+    Expandable::new(cs, None, expansion, Some(options), state)?,
     scope,
   );
-  return_cs
+  Ok(return_cs)
 }
 
 /// The Constructor is where LaTeXML really starts getting interesting;
@@ -1037,7 +1042,7 @@ pub fn def_environment(
       Some(ExpansionBody::Tokens(Tokens!(body))),
       None,
       state,
-    );
+    )?;
   });
   before_digest_env.push(current_environment_closure);
 
@@ -1112,7 +1117,6 @@ pub fn def_environment(
         "unexpected",
         end_name_clone,
         stomach,
-        state,
         message1,
         message2
       );
@@ -1225,7 +1229,7 @@ pub fn get_xmarg_id(gullet: &mut Gullet, state: &mut State) -> Result<Tokens> {
     T_CS!("\\@@XMARG@ID"),
     None,
     Tokens!(Explode!(state
-      .lookup_register("\\c@@XMARG", Vec::new())
+      .lookup_register("\\c@@XMARG", Vec::new())?
       .unwrap()
       .value_of())),
     Some(ExpandableOptions {
@@ -1233,7 +1237,7 @@ pub fn get_xmarg_id(gullet: &mut Gullet, state: &mut State) -> Result<Tokens> {
       ..ExpandableOptions::default()
     }),
     state,
-  );
+  )?;
   gullet.do_expand(T_CS!("\\the@XMARG@ID"), state)
 }
 
@@ -1339,7 +1343,7 @@ pub fn def_math(
   presentation: String,
   mut options: MathPrimitiveOptions,
   state: &mut State,
-) {
+) -> Result<()> {
   // Can't defer parsing parameters since we need to know number of args!
   // $paramlist = parseParameters($paramlist, $cs) if defined $paramlist && !ref $paramlist;
 
@@ -1412,18 +1416,19 @@ pub fn def_math(
     //((ref presentation eq "CODE")
     // || ((ref presentation) && grep { $_->equals(T_PARAM) } presentation->unlist)
     // || ((ref presentation) && (grep { $_->isExecutable } presentation->unlist)))
-    def_math_dual(cs, paramlist, presentation, options, state);
+    def_math_dual(cs, paramlist, presentation, options, state)?;
   }
   // EXPERIMENT: Introduce an intermediate case for simple symbols
   // Define a primitive that will create a Box with the appropriate set of XMTok attributes.
   else if nargs == 0 && !options.has_complex_option() {
     def_math_primitive(cs, paramlist, presentation, options, state);
   } else {
-    def_math_constructor(cs, paramlist, presentation, options, state);
+    def_math_constructor(cs, paramlist, presentation, options, state)?;
   }
   if locked {
     state.assign_value(&format!("{csname}:locked"), true, None);
   }
+  Ok(())
 }
 
 /// Transfers the common MathPrimitive options to a (ideally freshly instantiated) Constructor.

--- a/rtx_core/src/binding/def/macros.rs
+++ b/rtx_core/src/binding/def/macros.rs
@@ -487,7 +487,7 @@ macro_rules! requireMath {
   ($cs_name:expr, $state_arg:ident) => {
     if !$state_arg.lookup_bool("IN_MATH") {
       let message = s!("{} should only appear in math mode", $cs_name);
-      Warn!("unexpected", "mode", None, $state_arg, message);
+      Warn!("unexpected", "mode", None, message);
     }
   };
 }
@@ -500,7 +500,7 @@ macro_rules! forbidMath {
   ($cs_name:expr, $state_arg:ident) => {
     if $state_arg.lookup_bool("IN_MATH") {
       let message = s!("{} should not appear in math mode", $cs_name);
-      Warn!("unexpected", "mode", None, $state_arg, message);
+      Warn!("unexpected", "mode", None, message);
     }
   };
 }
@@ -517,7 +517,7 @@ macro_rules! AssignRegister {
       (*defn).set_value($value, $args, $state_arg);
     } else {
       let message = s!("The control sequence {} is not a register", $cs);
-      Warn!("expected", "register", None, $state_arg, message);
+      Warn!("expected", "register", None, message);
     }
   }};
   ($cs:literal, $value:expr, $args:expr, $state_arg: ident) => {{
@@ -547,6 +547,6 @@ macro_rules! SetCounter {
     def_macro(T_CS!(s!("\\@{}@ID",$ctr)), None,
       Tokens::new(Explode!($value.value_of())),
       Some(ExpandableOptions{ scope: Some(Scope::Global),
-         ..ExpandableOptions::default()}), $state_arg);
+         ..ExpandableOptions::default()}), $state_arg)?;
   }
 }

--- a/rtx_core/src/binding/def/traits.rs
+++ b/rtx_core/src/binding/def/traits.rs
@@ -69,7 +69,7 @@ impl IntoOption<Option<Reversion>> for &str {
       Some(Reversion::Tokens(Tokens!()))
     } else {
       Some(Reversion::Tokens(
-        mouth::tokenize_internal(self).pack_parameters(),
+        mouth::tokenize_internal(self).pack_parameters().ok().unwrap(),
       ))
     }
   }
@@ -181,6 +181,15 @@ impl IntoTokensResult<Result<Tokens>> for Tokens {
 
 impl IntoTokensResult<Result<Tokens>> for Result<Tokens> {
   fn into_tokens_result(self) -> Result<Tokens> { self }
+}
+
+impl IntoTokensResult<Result<Tokens>> for Result<()> {
+  fn into_tokens_result(self) -> Result<Tokens> {
+    match self {
+      Ok(()) => Ok(Tokens!()),
+      Err(e) => Err(e)
+    }
+  }
 }
 
 impl IntoTokensResult<Result<Tokens>> for () {

--- a/rtx_core/src/common/def_parser.rs
+++ b/rtx_core/src/common/def_parser.rs
@@ -54,7 +54,7 @@ pub fn parse_prototype(
       "Definition prototype doesn't have proper control sequence: \"{}\"",
       proto
     );
-    fatal!(Prototype, Misdefined, None, state, message);
+    fatal!(Prototype, Misdefined, None, message);
   };
   let final_proto = normalized_proto.trim();
   let paramlist = parse_parameters(final_proto, &cs, state_opt)?;

--- a/rtx_core/src/common/error.rs
+++ b/rtx_core/src/common/error.rs
@@ -3,35 +3,90 @@ use std::fmt;
 use std::io;
 use std::num::{ParseFloatError, ParseIntError};
 use std::result;
+use std::cell::RefCell;
+use once_cell::sync::Lazy;
+use crate::common::arena::{self,EMPTY_SYM};
+
+use rustc_hash::{FxHashMap as HashMap};
+use string_interner::symbol::SymbolU32;
+
+#[derive(Debug,Clone,Default)]
+pub struct LogState {
+  pub undefined: HashMap<SymbolU32,usize>,
+  pub missing: HashMap<SymbolU32,usize>,
+  pub debug: usize,
+  pub info: usize,
+  pub warning: usize,
+  pub error: usize,
+  pub fatal: bool,
+}
+pub enum LogStatus {
+  Debug,
+  Info,
+  Warning,
+  Error,
+  Fatal,
+  Undefined,
+  Missing,
+}
+
+#[thread_local]
+pub static REPORT : Lazy<RefCell<LogState>> = Lazy::new(|| RefCell::new(LogState::default()));
+
+pub fn note_status(status: LogStatus, what:Option<&str>) {
+  let mut state = REPORT.borrow_mut();
+  use LogStatus::*;
+  match status {
+    Debug => {state.debug += 1},
+    Info => {state.info += 1},
+    Warning => {state.warning += 1},
+    Error => {state.error += 1},
+    Fatal => {state.fatal = true},
+    Undefined => {
+      let entry = state.undefined.entry(
+        what.map(arena::pin).unwrap_or(*EMPTY_SYM)).or_insert(0);
+      *entry +=1;
+    },
+    Missing => {
+      let entry = state.missing.entry(
+        what.map(arena::pin).unwrap_or(*EMPTY_SYM)).or_insert(0);
+      *entry +=1;
+    },
+  }
+}
+
+pub fn get_status(status: LogStatus) -> usize {
+  let state = REPORT.borrow();
+  use LogStatus::*;
+  match status {
+    Debug => state.debug,
+    Info => state.info,
+    Warning => state.warning,
+    Error => state.error,
+    Fatal => if state.fatal {1} else {0},
+    _ => unimplemented!()
+  }
+}
 
 #[macro_export]
 macro_rules! Debug {
-  ($category:expr, $object:expr, $where:ident, None, $message:expr) => {{
-    // $state.note_status("debug"); // TODO: We're losing the info count this way...
+  ($category:expr, $object:expr, $where:ident, $message:expr) => {{
+    $crate::common::error::note_status(
+      $crate::common::error::LogStatus::Debug, None);
     use log::debug;
     debug!(target: &s!("{}:{}", $category, $object), "{}",
-      generate_message!($where, $message, -1))
+      $crate::generate_message!($where, $message, -1))
   }};
- ($category:expr, $object:expr, $where:ident, None, $message:expr, $($details:expr),*) => {{
-    // $state.note_status("debug"); // TODO: We're losing the debug count this way...
+ ($category:expr, $object:expr, $where:ident, $message:expr, $($details:expr),*) => {{
+    $crate::common::error::note_status(
+      $crate::common::error::LogStatus::Debug, None);
     use log::debug;
     debug!(target: &s!("{}:{}", $category, $object), "{}",
-      generate_message!($where, $message, -1, $($details),*))
-  }};
-  ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr) => {{
-    use log::debug;
-    $state.note_status("debug","");
-    debug!(target: &s!("{}:{}", $category, $object), "{}",
-      generate_message!($where, $message, -1))
-  }};
- ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr, $($details:expr),*) => {{
-    use log::debug;
-    $state.note_status("debug","");
-    debug!(target: &s!("{}:{}", $category, $object), "{}",
-      generate_message!($where, $message, -1, $($details),*))
+      $crate::generate_message!($where, $message, -1, $($details),*))
   }};
   ($($simple:expr),*) => {{
-    // $state.note_status("debug"); // TODO: We're losing the info count this way...
+    $crate::common::error::note_status(
+      $crate::common::error::LogStatus::Debug, None);
     use log::debug;
     debug!($($simple),*);
   }};
@@ -40,108 +95,78 @@ macro_rules! Debug {
 
 #[macro_export]
 macro_rules! Info {
-  ($category:expr, $object:expr, $where:ident, None, $message:expr) => {{
+  ($category:expr, $object:expr, $where:ident, $message:expr) => {{
+    $crate::common::error::note_status(
+      $crate::common::error::LogStatus::Info, None);
     use log::info;
-    // $state.note_status("info"); // TODO: We're losing the info count this way...
-    info!(target: &s!("{}:{}", $category, $object), "{}",
-      generate_message!($where, $message, -1))
+    info!(target: &format!("{}:{}", $category, $object), "{}",
+      $crate::generate_message!($where, $message, -1))
   }};
- ($category:expr, $object:expr, $where:ident, None, $message:expr, $($details:expr),*) => {{
-    // $state.note_status("info"); // TODO: We're losing the info count this way...
+ ($category:expr, $object:expr, $where:ident, $message:expr, $($details:expr),*) => {{
+  $crate::common::error::note_status(
+    $crate::common::error::LogStatus::Info, None);
     use log::info;
-    info!(target: &s!("{}:{}", $category, $object), "{}",
-       generate_message!($where, $message, -1, $($details),*))
-  }};
-  ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr) => {{
-    $state.note_status("info","");
-    use log::info;
-    info!(target: &s!("{}:{}", $category, $object), "{}",
-      generate_message!($where, $message, -1))
-  }};
- ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr, $($details:expr),*) => {{
-    $state.note_status("info","");
-    use log::info;
-    info!(target: &s!("{}:{}", $category, $object), "{}",
-      generate_message!($where, $message, -1, $($details),*))
+    info!(target: &format!("{}:{}", $category, $object), "{}",
+    $crate::generate_message!($where, $message, -1, $($details),*))
   }};
   ($($simple:expr),*) => {{
-    // $state.note_status("debug"); // TODO: We're losing the info count this way...
+    $crate::common::error::note_status(
+      $crate::common::error::LogStatus::Info, None);
     use log::info;
     info!($($simple),*);
   }};
+
 }
 
 #[macro_export]
 macro_rules! Warn {
-  ($category:expr, $object:expr, $where:ident, None, $message:expr) => {{
-    // $state.note_status("warn"); // TODO: We're losing the warn count this way...
+  ($category:expr, $object:expr, $where:ident, $message:expr) => {{
+    $crate::common::error::note_status(
+      $crate::common::error::LogStatus::Warning, None);
     use log::warn;
     warn!(target: &format!("{}:{}", $category, $object), "{}",
-      generate_message!($where, $message, -1))
+      $crate::generate_message!($where, $message, -1))
   }};
- ($category:expr, $object:expr, $where:ident, None, $message:expr, $($details:expr),*) => {{
-    // $state.note_status("warn"); // TODO: We're losing the warn count this way...
+ ($category:expr, $object:expr, $where:ident, $message:expr, $($details:expr),*) => {{
+    $crate::common::error::note_status(
+      $crate::common::error::LogStatus::Warning, None);
     use log::warn;
     warn!(target: &format!("{}:{}", $category, $object), "{}",
-      generate_message!($where, $message, -1, $($details),*))
-  }};
-  ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr) => {{
-    $state.note_status("warn","");
-    use log::warn;
-    warn!(target: &format!("{}:{}", $category, $object), "{}",
-      generate_message!($where, $message, -1))
-  }};
- ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr, $($details:expr),*) => {{
-    $state.note_status("warn","");
-    use log::warn;
-    warn!(target: &format!("{}:{}", $category, $object), "{}",
-      generate_message!($where, $message, -1, $($details),*))
+      $crate::generate_message!($where, $message, -1, $($details),*))
   }}
 }
 
 #[macro_export]
 macro_rules! Error {
-  ($category:expr, $object:expr, $where:ident, None, $message:expr) => {{
-    // $state.note_status("error"); // TODO: We're losing the error count this way...
-    use log::error;
-    use $crate::generate_message;
-    error!(target: &format!("{}:{}", $category, $object), "{}",
-      generate_message!($where, $message, -1))
+  ($category:expr, $object:expr, $where:ident, $message:expr) => {{
+    $crate::Error!($category,$object,$where,$message,"")
   }};
- ($category:expr, $object:expr, $where:ident, None, $message:expr, $($details:expr),*) => {{
-    // $state.note_status("error"); // TODO: We're losing the error count this way...
+ ($category:expr, $object:expr, $where:ident, $message:expr, $($details:expr),*) => {{
+    $crate::common::error::note_status(
+      $crate::common::error::LogStatus::Error, None);
     use log::error;
-    use $crate::generate_message;
     error!(target: &format!("{}:{}", $category, $object), "{}",
-      generate_message!($where, $message, -1, $($details),*))
-  }};
-  ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr) => {{
-    use log::error;
-    use $crate::generate_message;
-    $state.note_status("error","");
-    error!(target: &format!("{}:{}", $category, $object), "{}",
-      generate_message!($where, $message, -1))
-  }};
- ($category:expr, $object:expr, $where:ident, $state:expr, $message:expr, $($details:expr),*) => {{
-    use log::error;
-    use $crate::generate_message;
-    $state.note_status("error","");
-    error!(target: &format!("{}:{}", $category, $object), "{}",
-      generate_message!($where, $message, -1, $($details),*))
+      $crate::generate_message!($where, $message, -1, $($details),*));
+    let maxerrors = 100; //TODO: ($state ? $state->lookupValue('MAX_ERRORS') : 100);
+    if $crate::common::error::get_status($crate::common::error::LogStatus::Error) > maxerrors {
+      Fatal!(TooManyErrors, MaxLimit(maxerrors), $where, format!("Too many errors (> {maxerrors})!"));
+    }
   }}
 }
 
 // TODO: flesh out the messages
 #[macro_export]
 macro_rules! Fatal {
-  ($target:tt, $category:tt, $where:expr, $state: expr, $message:expr) => {{
+  ($target:expr, $category:expr, $where:expr, $message:expr) => {{
+    $crate::common::error::note_status(
+      $crate::common::error::LogStatus::Fatal, None);
     fatal!($target, $category, $message);
   }};
 }
 
 #[macro_export]
 macro_rules! fatal {
-  ($target:tt, $category:tt, $message:expr) => {{
+  ($target:expr, $category:expr, $message:expr) => {{
     use $crate::common::error::Error as RtxError;
     use $crate::common::error::ErrorCategory::*;
     use $crate::common::error::ErrorTarget::*;
@@ -151,7 +176,7 @@ macro_rules! fatal {
       message: $message.to_string(),
     });
   }};
-  ($target:tt, $category:expr, $where: ident, $state: ident, $message:expr) => {{
+  ($target:tt, $category:expr, $where: ident, $message:expr) => {{
     use $crate::common::error::Error as RtxError;
     use $crate::common::error::ErrorCategory::*;
     use $crate::common::error::ErrorTarget::*;
@@ -199,6 +224,18 @@ macro_rules! generate_message {
       column!()
     )
   };
+  ($where:ident, $message:expr, $level:literal, $detail:expr, $detail2:expr) => {
+    format!(
+      "{}\n\t{}\n\t{}\n\t{}\n\tIn {}:{}:{}\n",
+      $message,
+      $where.get_location(),
+      $detail,
+      $detail2,
+      file!(),
+      line!(),
+      column!()
+    )
+  };
 }
 
 pub type Result<T> = result::Result<T, Error>;
@@ -230,6 +267,7 @@ pub enum ErrorCategory {
   EoF,
   Endgroup,
   FailedParse,
+  MaxLimit(usize),
   Generic(Box<dyn ErrorTrait>),
   Filename(String),
 }
@@ -255,6 +293,7 @@ pub enum ErrorTarget {
   Internal,
   TargetUnexpected,
   SmuggledCatcode,
+  TooManyErrors,
 }
 
 impl fmt::Display for Error {
@@ -276,6 +315,7 @@ impl fmt::Display for Error {
       Convert => write!(f, "conversion"),
       Endgroup => write!(f, "<endgroup>"),
       FailedParse => write!(f, "failed to parse"),
+      MaxLimit(num) => write!(f, "{}", num),
       Generic(ref err) => err.fmt(f),
       Filename(ref name) => write!(f, "file:{name}"),
     }

--- a/rtx_core/src/common/font.rs
+++ b/rtx_core/src/common/font.rs
@@ -946,7 +946,7 @@ impl Font {
   ) -> Result<(Dimension, Dimension, Dimension)> {
     let fillwidth = match options.get("width") {
       Some(Stored::Int(fw)) => Some(*fw),
-      None => match state.lookup_definition(&T_CS!("\\textwidth")) {
+      None => match state.lookup_definition(&T_CS!("\\textwidth"))? {
         Some(def) => def.value_of(Vec::new(), state).map(|x| x.value_of()),
         None => None,
       },
@@ -955,13 +955,13 @@ impl Font {
     let _maxwidth = fillwidth.unwrap_or_default();
     //   # baselineskip, lineskip ??
     let _baseline = state
-      .lookup_definition(&T_CS!("\\baselineskip"))
+      .lookup_definition(&T_CS!("\\baselineskip"))?
       .expect("baseline skip should aways be defined")
       .value_of(Vec::new(), state)
       .expect("\\baselineskip should always have a value.")
       .value_of();
     let _lineskip = state
-      .lookup_definition(&T_CS!("\\lineskip"))
+      .lookup_definition(&T_CS!("\\lineskip"))?
       .expect("lineskip should always be defined")
       .value_of(Vec::new(), state)
       .expect("\\lineskip should always have a value.")

--- a/rtx_core/src/common/glue.rs
+++ b/rtx_core/src/common/glue.rs
@@ -247,7 +247,7 @@ pub fn spec_setup(
         "You should not create {} with both units and stretch",
         if is_mu { "MuGlue" } else { "Glue" }
       );
-      Warn!("unexpected", "fill", None, state, msg);
+      Warn!("unexpected", "fill", None, msg);
     }
 
     if let Some(cs) = GLUE_RE.captures(spec) {
@@ -269,7 +269,7 @@ pub fn spec_setup(
         f.trunc() as i64
       } else if is_mu {
         if unit != "mu" {
-          Warn!("unexpected", unit, None, state, "Assumed mu");
+          Warn!("unexpected", unit, None, "Assumed mu");
         }
         fixpoint(f, None) // in mu
       } else {
@@ -285,7 +285,7 @@ pub fn spec_setup(
       } else if is_mu {
         pfill = None;
         if punit != "mu" {
-          Warn!("unexpected", punit, None, state, "Assumed mu");
+          Warn!("unexpected", punit, None, "Assumed mu");
         }
         Some(fixpoint(p, None))
       } else {
@@ -302,7 +302,7 @@ pub fn spec_setup(
       } else if is_mu {
         mfill = None; // 0
         if munit != "mu" {
-          Warn!("unexpected", munit, None, state, "Assumed mu");
+          Warn!("unexpected", munit, None, "Assumed mu");
         }
         Some(fixpoint(m, None))
       } else {
@@ -332,7 +332,7 @@ pub fn spec_setup(
         "Missing {} specification assuming 0pt",
         if is_mu { "MuGlue" } else { "Glue" }
       );
-      Warn!("unexpected", spec, None, state, msg);
+      Warn!("unexpected", spec, None, msg);
       (0, None, None, None, None)
     }
   }

--- a/rtx_core/src/common/model.rs
+++ b/rtx_core/src/common/model.rs
@@ -91,15 +91,15 @@ impl Model {
     }
   }
 
-  pub fn load_schema(&mut self, search_paths: &[&str]) -> &Option<Relaxng> {
+  pub fn load_schema(&mut self, search_paths: &[&str]) -> Result<&Option<Relaxng>> {
     // Only load once
     if self.schema.is_some() {
-      return &self.schema;
+      return Ok(&self.schema);
     }
     let mut name = String::new();
     if self.schema_data.is_none() {
       // TODO: Return this code path to normal once we properly load schemas
-      Warn!("expected", "<model>", None, None, "TODO");
+      Warn!("expected", "<model>", None, "TODO");
       // Warn('expected', '<model>', undef, "No Schema Model has been declared; assuming LaTeXML");
       // // article ??? or what ? undef gives problems!
 
@@ -138,7 +138,7 @@ impl Model {
           let message = arena::with(schema_type, |schema_type_str| {
             s!("Can't load a schema of type {schema_type_str:?}")
           });
-          Error!("unknown", "schematype", self, None, message)
+          Error!("unknown", "schematype", self, message)
         }
       },
     };
@@ -168,7 +168,7 @@ impl Model {
       self.describe_model()
     }
 
-    &self.schema
+    Ok(&self.schema)
   }
   pub fn describe_model(&self) {}
 
@@ -279,7 +279,6 @@ impl Model {
         "malformed",
         namespace,
         self,
-        None,
         "No prefix has been registered for namespace (in document)",
         message2
       );
@@ -317,7 +316,8 @@ impl Model {
         s!("No namespace has been registered for prefix '{dp_str}' (in document)")
       });
       let msg2 = s!("Using '{ns_str}' instead");
-      Error!("malformed", docprefix, self, None, msg1, msg2);
+      let err = || {Error!("malformed", docprefix, self, msg1, msg2); Ok(()) };
+      err().ok();
     }
     if ns_str.is_empty() {
       None
@@ -365,7 +365,7 @@ impl Model {
     codeprefix
   }
 
-  pub fn get_namespace(&mut self, codeprefix: &str, probe: bool) -> Option<SymbolU32> {
+  pub fn get_namespace(&mut self, codeprefix: &str, probe: bool) -> Result<Option<SymbolU32>> {
     let mut ns: Option<SymbolU32> = self.code_namespaces.get(&arena::pin(codeprefix)).copied();
     if ns.is_none() && !probe {
       self.namespace_errors += 1;
@@ -379,12 +379,11 @@ impl Model {
         "malformed",
         codeprefix,
         self,
-        None,
         s!("No namespace has been registered for prefix '{codeprefix}' (in code)"),
         s!("Using '{example_namespace}' instead")
       );
     }
-    ns
+    Ok(ns)
   }
 
   /// Get the node's qualified name in standard form
@@ -490,22 +489,22 @@ impl Model {
   /// Given a Qualified name, possibly prefixed with a namespace prefix,
   /// as defined by the code namespace mapping,
   /// return the NamespaceURI and localname.
-  pub fn decode_qname(&mut self, codetag: &str) -> (Option<String>, String) {
+  pub fn decode_qname(&mut self, codetag: &str) -> Result<(Option<String>, String)> {
     match PREFIXED_LOCALNAME_RE.captures(codetag) {
       Some(captures) => {
         let prefix = captures.get(1).map_or("", |m| m.as_str());
         let localname = captures.get(2).map_or("", |m| m.as_str());
 
         if prefix == "xml" {
-          (None, codetag.to_string())
+          Ok((None, codetag.to_string()))
         } else {
-          (
-            self.get_namespace(prefix, false).map(arena::to_string),
+          Ok((
+            self.get_namespace(prefix, false)?.map(arena::to_string),
             localname.to_string(),
-          )
+          ))
         }
       },
-      None => (None, codetag.to_string()),
+      None => Ok((None, codetag.to_string())),
     }
   }
 

--- a/rtx_core/src/common/store.rs
+++ b/rtx_core/src/common/store.rs
@@ -1022,7 +1022,7 @@ impl<'a> From<&'a Stored> for Token {
       },
       t => {
         let message = s!("dangerous cast to CS for {:?}", t);
-        Warn!("Stored", "cast", None, None, message);
+        Warn!("Stored", "cast", None, message);
         T_CS!(t.to_string())
       }, /* TODO, is this the right place to default to CS? Do we need a
           * custom method instead? */

--- a/rtx_core/src/common/xml.rs
+++ b/rtx_core/src/common/xml.rs
@@ -1,6 +1,7 @@
 use libxml::tree::{Document, Node, NodeType};
 use libxml::xpath::Context;
 use rustc_hash::FxHashMap as HashMap;
+use crate::common::error::Result;
 
 pub const XMLNS_NS: &str = "http://www.w3.org/2000/xmlns/";
 pub const XML_NS: &str = "http://www.w3.org/XML/1998/namespace";
@@ -16,7 +17,7 @@ impl XPath {
     XPath { context }
   }
 
-  pub fn register_namespace(&mut self, codeprefix: &str, namespace: &str) {
+  pub fn register_namespace(&mut self, codeprefix: &str, namespace: &str) -> Result<()> {
     match self.context.register_namespace(codeprefix, namespace) {
       Ok(()) => {},
       Err(_) => {
@@ -25,9 +26,10 @@ impl XPath {
           codeprefix,
           namespace
         );
-        Error!("expected", "XPath", None, None, message);
+        Error!("expected", "XPath", None, message);
       },
     };
+    Ok(())
   }
 
   pub fn findnodes(&mut self, xpath: &str, node: Option<&Node>) -> Vec<Node> {
@@ -35,7 +37,8 @@ impl XPath {
       Ok(nodes) => nodes,
       Err(e) => {
         let message = s!("{:?}", e);
-        Error!("xpath", "findnodes", None, None, message);
+        let err = || {Error!("xpath", "findnodes", None, message); Ok(()) };
+        err().ok();
         panic!("this is an external libxml2 error; unwinding...");
       },
     }
@@ -46,7 +49,8 @@ impl XPath {
       Ok(vals) => vals,
       Err(e) => {
         let message = s!("{:?}", e);
-        Error!("xpath", "findvalues", None, None, message);
+        let err = || {Error!("xpath", "findvalues", None, message); Ok(())};
+        err().ok();
         Vec::new()
       },
     }

--- a/rtx_core/src/definition.rs
+++ b/rtx_core/src/definition.rs
@@ -127,7 +127,7 @@ impl PartialEq for Reversion {
 }
 
 impl From<&str> for Reversion {
-  fn from(t: &str) -> Reversion { Reversion::Tokens(mouth::tokenize_internal(t).pack_parameters()) }
+  fn from(t: &str) -> Reversion { Reversion::Tokens(mouth::tokenize_internal(t).pack_parameters().ok().unwrap()) }
 }
 impl From<Tokens> for Reversion {
   fn from(ts: Tokens) -> Reversion { Reversion::Tokens(ts) }

--- a/rtx_core/src/definition/conditional.rs
+++ b/rtx_core/src/definition/conditional.rs
@@ -132,7 +132,7 @@ impl Definition for Conditional {
           "Unknown conditional control sequence {}",
           state.get_current_token().unwrap().stringify()
         );
-        Error!("unexpected", self.cs, gullet, state, message);
+        Error!("unexpected", self.cs, gullet, message);
         Ok(Tokens!())
       },
     }
@@ -319,7 +319,6 @@ impl Conditional {
       "expected",
       "\\fi",
       self,
-      state,
       "Missing \\fi or \\else, conditional fell off end"
     );
     Ok(Tokens!())
@@ -351,7 +350,7 @@ impl Conditional {
           stack_frame.borrow().start
         );
         let local_token_str = local_token.to_string();
-        Error!("unexpected", local_token_str, gullet, state, message);
+        Error!("unexpected", local_token_str, gullet, message);
         Ok(Tokens!())
       } else {
         state.set_ifframe(Some(Rc::clone(&stack_frame)));
@@ -370,7 +369,7 @@ impl Conditional {
         local_token.stringify()
       );
       let local_token_str = local_token.to_string();
-      Error!("unexpected", local_token_str, gullet, state, message);
+      Error!("unexpected", local_token_str, gullet, message);
       Ok(Tokens!())
     }
   }
@@ -394,7 +393,7 @@ impl Conditional {
       } else {
         // "expand" by removing the stack entry for this level
         state.set_ifframe(Some(stack_frame));
-        state.shift_value("if_stack"); // Done with this frame
+        state.shift_value("if_stack")?; // Done with this frame
 
         //     print STDERR '{' . ToString($LaTeXML::CURRENT_TOKEN) . '}'
         // . " [for " . Stringify($$LaTeXML::IFFRAME{token}) . " #" . $$LaTeXML::IFFRAME{ifid} .
@@ -407,7 +406,7 @@ impl Conditional {
         "Didn't expect a {:?} since we seem not to be in a conditional",
         state.get_current_token().unwrap().stringify()
       );
-      Error!("unexpected", "fi", gullet, state, message);
+      Error!("unexpected", "fi", gullet, message);
       Ok(Tokens!())
     }
   }

--- a/rtx_core/src/definition/expandable.rs
+++ b/rtx_core/src/definition/expandable.rs
@@ -221,12 +221,12 @@ impl Expandable {
     expansion: T,
     traits: Option<ExpandableOptions>,
     state: &State,
-  ) -> Self {
+  ) -> Result<Self> {
     let mut expansion: ExpansionBody = expansion.into();
     let traits = traits.unwrap_or_default();
     if !traits.nopack_parameters {
       if let ExpansionBody::Tokens(expansion_tokens) = expansion {
-        expansion = ExpansionBody::Tokens(Tokens::pack_parameters(expansion_tokens));
+        expansion = ExpansionBody::Tokens(Tokens::pack_parameters(expansion_tokens)?);
       }
     }
     // simplify: treat empty tokens as None
@@ -234,7 +234,7 @@ impl Expandable {
       ExpansionBody::Tokens(tks) if tks.is_empty() => None,
       other => Some(other),
     };
-    Expandable {
+    Ok(Expandable {
       cs,
       paramlist,
       expansion,
@@ -243,6 +243,6 @@ impl Expandable {
       is_outer: traits.outer || state.get_prefix("outer"),
       is_long: traits.long || state.get_prefix("long"),
       ..Expandable::default()
-    }
+    })
   }
 }

--- a/rtx_core/src/definition/register.rs
+++ b/rtx_core/src/definition/register.rs
@@ -113,12 +113,12 @@ impl NumericOps for RegisterValue {
       RegisterValue::MuGlue(v) => v.value_of(),
       RegisterValue::Token(v) => {
         let message = s!(".value_of called on Token {:?}", v);
-        Warn!("register", "value_of", None, None, message);
+        Warn!("register", "value_of", None, message);
         -1
       },
       RegisterValue::Tokens(v) => {
         let message = s!(".value_of called on Tokens {:?}", v);
-        Warn!("register", "value_of", None, None, message);
+        Warn!("register", "value_of", None, message);
         -1
       },
     }
@@ -274,7 +274,10 @@ impl<'a> From<&'a RegisterValue> for Dimension {
           "Token register can not be cast into a dimension: {:?}",
           other
         );
-        Error!("expected", "dimension", None, None, message);
+        // silence a potential Fatal from 100 errors,
+        // until a better place is reached in the high-level conversion logic
+        let err = || {Error!("expected", "dimension", None, message); Ok(()) };
+        err().ok();
         Dimension::new(0)
       },
     }
@@ -290,8 +293,11 @@ impl<'a> From<&'a RegisterValue> for Glue {
       RegisterValue::MuGlue(other) => Glue::new(other.value_of()),
       RegisterValue::Token(other) => other.to_number().into(),
       RegisterValue::Tokens(other) => {
-        let message = s!("Token register can not be cast into a Glue: {:?}", other);
-        Error!("expected", "dimension", None, None, message);
+        let message = s!("Token register can not be cast into a Glue: {other:?}");
+        // silence a potential Fatal from 100 errors,
+        // until a better place is reached in the high-level conversion logic
+        let err = || { Error!("expected", "dimension", None, message); Ok(()) };
+        err().ok();
         Glue::new(0)
       },
     }
@@ -315,7 +321,8 @@ impl<'a> From<&'a RegisterValue> for MuGlue {
       RegisterValue::Token(other) => other.to_number().into(),
       RegisterValue::Tokens(other) => {
         let message = s!("Token register can not be cast into a Glue: {:?}", other);
-        Error!("expected", "dimension", None, None, message);
+        let err = || {Error!("expected", "dimension", None, message); Ok(())};
+        err().ok();
         MuGlue::new(0)
       },
     }
@@ -529,7 +536,8 @@ impl Register {
       let message = self
         .cs
         .with_cs_name(|cs_str| s!("Can't assign to chardef {}", cs_str));
-      Error!("unexpected", "chardef", None, state, message);
+      let err = || {Error!("unexpected", "chardef", None, message); Ok(()) };
+      err().ok();
     } else {
       (self.setter)(value, args, state);
     }

--- a/rtx_core/src/digested.rs
+++ b/rtx_core/src/digested.rs
@@ -391,7 +391,7 @@ impl BoxOps for Digested {
       _ => unimplemented!(),
     }
   }
-  fn get_body(&self) -> Option<Digested> {
+  fn get_body(&self) -> Result<Option<Digested>> {
     use DigestedData::*;
     match *self.0 {
       TBox(ref b) => {
@@ -399,20 +399,18 @@ impl BoxOps for Digested {
           "digested",
           "get_body",
           self,
-          None,
           s!("Called get_body on Box: {:?}", b)
         );
-        None
+        Ok(None)
       },
       List(ref l) => {
         Error!(
           "digested",
           "get_body",
           self,
-          None,
           s!("Called get_body on List: {:?}", l)
         );
-        None
+        Ok(None)
       },
       Whatsit(ref w) => w.borrow().get_body(),
       _ => unimplemented!(),
@@ -515,15 +513,15 @@ impl Digested {
   }
 
   /// Predicate check - delegates to `.is_empty()` of the underlying data
-  pub fn is_empty(&self) -> bool {
+  pub fn is_empty(&self) -> Result<bool> {
     use DigestedData::*;
-    match *self.0 {
+    Ok(match *self.0 {
       TBox(ref b) => b.borrow().is_empty(),
       List(ref l) => l.borrow().is_empty(),
-      Whatsit(ref w) => w.borrow().is_empty(),
+      Whatsit(ref w) => w.borrow().is_empty()?,
       Postponed(ref tks) => tks.is_empty(),
       _ => unimplemented!(),
-    }
+    })
   }
 
   /// Provide a way of emulating an `Undigested` argument, by requesting

--- a/rtx_core/src/document.rs
+++ b/rtx_core/src/document.rs
@@ -187,7 +187,7 @@ impl Document {
         // alternative
         arena::with(*prefix, |p_str| {
           arena::with(*ns, |ns_str| context.register_namespace(p_str, ns_str))
-        });
+        }).unwrap();
       }
       self.context = Some(context);
       self.context.as_mut().unwrap()
@@ -311,7 +311,7 @@ impl Document {
           }
           arena::with(key, |key_str| {
             arena::with(value, |value_str| {
-              self.set_attribute(node, key_str, value_str, state)
+              self.set_attribute(node, key_str, value_str)
             })
           })?;
         }
@@ -372,7 +372,7 @@ impl Document {
           // Too late to do wrapNodes?
           if let Some(mut text) = self.wrap_nodes(FONT_ELEMENT_NAME, vec![child], state)? {
             for (key, (value, _properties)) in &pending_declaration {
-              self.set_attribute(&mut text, key, value, state)?;
+              self.set_attribute(&mut text, key, value)?;
             }
             self.finalize_rec(&mut text, state)?; // Now have to clean up the new node!
           }
@@ -716,9 +716,9 @@ impl Document {
       let message = s!(
         "Attempt to close {}, which isn't open. Currently in {}",
         qname_msg,
-        self.get_insertion_context(None, state)
+        self.get_insertion_context(None, state)?
       );
-      Error!("malformed", qname, self, state, message);
+      Error!("malformed", qname, self, message);
       Ok(None)
     } else {
       // Found node.
@@ -733,7 +733,7 @@ impl Document {
             .collect::<Vec<String>>()
             .join(",")
         );
-        Error!("malformed", qname, self, state, message);
+        Error!("malformed", qname, self, message);
       }
       // So, now close up to the desired node.
       self.close_node_internal(&node, state)?;
@@ -833,9 +833,9 @@ impl Document {
     if n_type == Some(NodeType::DocumentNode) {
       // Didn't find $node at all!!
       let message = s!("Attempt to close {:?}, which isn't open", node.get_name());
-      arena::with(state.model.get_node_qname(node), |qname_str| {
-        Error!("malformed", qname_str, self, state, message)
-      });
+      arena::with(state.model.get_node_qname(node), |qname_str| Ok({
+        Error!("malformed", qname_str, self, message)
+      }))?;
     //     "Currently in " . $self->getInsertionContext()) unless $ifopen;
     } else {
       // Found node.
@@ -851,9 +851,9 @@ impl Document {
             .collect::<Vec<String>>()
             .join(",")
         );
-        arena::with(qname, |qname_str| {
-          Error!("malformed", qname_str, self, state, message)
-        });
+        arena::with(qname, |qname_str| Ok({
+          Error!("malformed", qname_str, self, message)
+        }))?;
       }
       if let Some(lastopen_node) = lastopen {
         self.close_node_internal(&lastopen_node, state)?;
@@ -893,14 +893,14 @@ impl Document {
       // Didn't find $qname at all!!
       if strict {
         let qname = state.model.get_node_qname(node);
-        arena::with(qname, |qname_str| {
+        arena::with(qname, |qname_str| Ok({
           let message = s!(
             "Attempt to close {}, which isn't open. Currently in {:?}",
             qname_str,
-            self.get_insertion_context(None, state)
+            self.get_insertion_context(None, state)?
           );
-          Error!("malformed", qname_str, self, state, message)
-        });
+          Error!("malformed", qname_str, self, message)
+        }))?;
       }
     } else {
       // Found node.
@@ -917,11 +917,12 @@ impl Document {
               .join(", ")
           );
           if strict {
-            Error!("malformed", qname, self, state, message);
+            Error!("malformed", qname, self, message);
           } else {
-            Info!("malformed", qname, self, state, message);
+            Info!("malformed", qname, self, message);
           }
-        });
+          Ok(())
+        })?;
       }
       self.close_node_internal(node, state)?;
     }
@@ -1781,7 +1782,7 @@ impl Document {
 
   /// Return a string indicating the path to the current insertion point in the document.
   /// if $levels is defined, show only that many levels
-  pub fn get_insertion_context(&self, levels_opt: Option<usize>, state: &mut State) -> String {
+  pub fn get_insertion_context(&self, levels_opt: Option<usize>, state: &mut State) -> Result<String> {
     let mut levels = match levels_opt {
       None => {
         // Default depth is based on verbosity
@@ -1803,8 +1804,8 @@ impl Document {
         "Insertion point is not an element, document or text: {:?}",
         self.document.node_to_string(&node)
       );
-      Error!("internal", "context", self, state, message);
-      return String::new();
+      Error!("internal", "context", self, message);
+      return Ok(String::new());
     }
     let mut path = s!("TODO"); //TODO: Stringify($node);
     while let Some(parent_node) = node.get_parent() {
@@ -1818,7 +1819,7 @@ impl Document {
       }
       // TODO: $path = Stringify($node) . $path; }
     }
-    path
+    Ok(path)
   }
 
   /// Find the node where an element with qualified name $qname can be inserted.
@@ -1853,17 +1854,16 @@ impl Document {
 
     if let Some(has_opened) = has_opened_opt {
       // out of options if already inside an auto-open chain
-      let message = arena::with(has_opened, |has_opened_str| {
-        arena::with(cur_qname, |cur_qname_str| {
-          s!(
+      let message: String = arena::with(has_opened, |has_opened_str|
+        arena::with(cur_qname, |cur_qname_str| Ok::<String,crate::common::error::Error>(
+          format!(
             "failed auto-open through <{}> at inadmissible <{}>. Currently in {}",
             has_opened_str,
             cur_qname_str,
-            self.get_insertion_context(None, state)
-          )
-        })
-      });
-      Error!("malformed", qname, self, state, message);
+            self.get_insertion_context(None, state)?
+          ))
+      ))?;
+      Error!("malformed", qname, self, message);
       Ok(self.node.clone()) // But we'll do it anyway, unless Error => Fatal.
     } else {
       // Now we're getting more desparate...
@@ -1894,7 +1894,7 @@ impl Document {
           s!("{:?} isn't allowed in <{}>", qname, cur_qname_str)
         });
         //"Currently in " self.getInsertionContext());
-        Error!("malformed", qname, self, state, message);
+        Error!("malformed", qname, self, message);
 
         // But we'll do it anyway, unless Error => Fatal.
         Ok(self.node.clone())
@@ -2033,7 +2033,6 @@ impl Document {
     node: &mut Node,
     key: &str,
     value: &str,
-    state: &State,
   ) -> Result<()> {
     if value.is_empty() {
       return Ok(()); // skip if empty
@@ -2041,7 +2040,7 @@ impl Document {
     if key == "xml:id" || key == "id" {
       // If it's an ID attribute
       // Do id book keeping
-      self.record_id_with_node(value, node, state);
+      self.record_id_with_node(value, node);
       // TODO: Need to improve Namespace ergonomics, also in rust-libxml
       // let node_ns = self
       //   .document
@@ -2105,7 +2104,6 @@ impl Document {
     node: &mut Node,
     key: &str,
     values_str: &str,
-    state: &State,
   ) -> Result<()> {
     // $values = $values->toAttribute if ref $values;
     if !values_str.is_empty() {
@@ -2120,17 +2118,17 @@ impl Document {
           }
         }
         old.sort_unstable();
-        self.set_attribute(node, key, &old.join(" "), state)?;
+        self.set_attribute(node, key, &old.join(" "))?;
       } else {
         values.sort_unstable();
-        self.set_attribute(node, key, &values.join(" "), state)?;
+        self.set_attribute(node, key, &values.join(" "))?;
       }
     }
     Ok(())
   }
 
-  pub fn add_class(&mut self, node: &mut Node, class: &str, state: &State) -> Result<()> {
-    self.add_ss_values(node, "class", class, state)
+  pub fn add_class(&mut self, node: &mut Node, class: &str) -> Result<()> {
+    self.add_ss_values(node, "class", class)
   }
 
   //**********************************************************************
@@ -2161,7 +2159,7 @@ impl Document {
   /// which should be the `xml:id` attribute of the `node`.
   /// Usually this association will be maintained by the methods
   /// that create nodes or set attributes.
-  fn record_id_with_node(&mut self, id: &str, node: &Node, state: &State) -> String {
+  fn record_id_with_node(&mut self, id: &str, node: &Node) -> String {
     let prev_opt = if let Some(prev) = self.idstore.get(id) {
       // Whoops! Already assigned!!!
       // Can we recover?
@@ -2183,7 +2181,7 @@ impl Document {
         badid,
         self.document.node_to_string(&prev)
       );
-      Info!("malformed", "id", self, state, message);
+      Info!("malformed", "id", self, message);
     }
     self.idstore.insert(id.to_string(), node.clone());
     id.to_string()
@@ -2195,7 +2193,7 @@ impl Document {
   pub fn record_node_ids(&mut self, node: &Node, state: &mut State) -> Result<()> {
     for mut idnode in self.findnodes("descendant-or-self::*[@xml:id]", Some(node), state) {
       if let Some(id) = idnode.get_attribute_ns("id", XML_NS) {
-        let newid = self.record_id_with_node(&id, &idnode, state);
+        let newid = self.record_id_with_node(&id, &idnode);
         if newid != id {
           idnode.set_attribute("xml:id", &newid)?;
         }
@@ -2305,7 +2303,6 @@ impl Document {
             "expected",
             "id",
             self,
-            state,
             "Missing idref on ltx:XMRef",
             s!("_xmkey is `{}`", key.unwrap_or_default())
           );
@@ -2316,7 +2313,6 @@ impl Document {
               "expected",
               "node",
               self,
-              state,
               s!("No node found with id='{id}' (referred to from ltx:XMRef)")
             );
           },
@@ -2456,7 +2452,7 @@ impl Document {
         } // Change dualid refs to branchid
       } else {
         branch.set_attribute("xml:id", &dualid)?; // Just use same ID on the branch
-        self.record_id_with_node(&dualid, &branch, state);
+        self.record_id_with_node(&dualid, &branch);
       }
     }
     self.replace_tree(branch, dual, state)?;
@@ -2663,7 +2659,7 @@ impl Document {
         }
       }
     }
-    let (decoded_ns, tag) = state.model.decode_qname(qname);
+    let (decoded_ns, tag) = state.model.decode_qname(qname)?;
     let mut newnode;
     // box = self.node_boxes.get(box);    // may already be the string key
     // If this will be the document root node, things are slightly more involved.
@@ -2716,7 +2712,7 @@ impl Document {
         if key == "font" || key == "locator" {
           continue;
         }
-        self.set_attribute(&mut newnode, key, &attrs[key], state)?;
+        self.set_attribute(&mut newnode, key, &attrs[key])?;
       }
     }
     if let Some(font) = font_opt {
@@ -2779,7 +2775,7 @@ impl Document {
                   Ok(ns) => Some(ns),
                   Err(_) => {
                     let message = s!("failed to create namespace: {:?}", prefix);
-                    Error!("document", "open_element_internal", self, state, message);
+                    Error!("document", "open_element_internal", self, message);
                     None
                   },
                 }
@@ -2799,7 +2795,7 @@ impl Document {
                 Ok(ns) => Some(ns),
                 Err(_) => {
                   let message = s!("failed to create namespace: {:?}", prefix);
-                  Error!("document", "open_element_internal", self, state, message);
+                  Error!("document", "open_element_internal", self, message);
                   None
                 },
               }
@@ -2921,7 +2917,7 @@ impl Document {
               "xml:id" | "id" => {
                 // Use the replacement id
                 let mapped_id = id_map.get(&val).unwrap();
-                let newid = self.record_id_with_node(mapped_id, &new, state);
+                let newid = self.record_id_with_node(mapped_id, &new);
                 new.set_attribute(&key, &newid)?;
               },
               "idref" => {
@@ -2966,7 +2962,7 @@ impl Document {
     }
     let first_node = &nodes[0];
     let mut parent = first_node.get_parent().unwrap();
-    let (ns, tag) = state.model.decode_qname(qname);
+    let (ns, tag) = state.model.decode_qname(qname)?;
     let mut new = self.open_element_internal(&mut parent, ns, &tag, state)?;
     self.after_open(&mut new, state)?;
     parent.replace_child_node(new.clone(), first_node.clone())?;
@@ -3136,7 +3132,7 @@ impl Document {
         return Ok(Some(savenode));
       }
     } else if !self.can_contain_node_somehow(&self.node, qname, state) {
-        Warn!("malformed", qname, self, state, s!("No open node can contain element '{}'", qname));
+        Warn!("malformed", qname, self, s!("No open node can contain element '{}'", qname));
         // self.get_insertion_context())
     }
     Ok(None)
@@ -3190,7 +3186,7 @@ impl Document {
       Some(savenode)
     } else {
       let message = s!("No open node with an xml:id can get attribute {:?}", key);
-      Warn!("malformed", key, self, state, message);
+      Warn!("malformed", key, self, message);
       //  $self->getInsertionContext());
       None
     }
@@ -3204,7 +3200,7 @@ impl Document {
     self.box_to_absorb = self.localized_boxes.pop().unwrap();
   }
 
-  pub fn load_labels_for_rewrite(&mut self, state: &mut State) {
+  pub fn load_labels_for_rewrite(&mut self, state: &mut State) -> Result<()> {
     for node in self.findnodes("//*[@labels]", None, state) {
       if let Some(labels) = node.get_attribute("labels") {
         if let Some(id) = node.get_attribute("id") {
@@ -3218,12 +3214,12 @@ impl Document {
             "malformed",
             "label",
             None,
-            None,
             format!("Node {} has labels but no xml:id", node.get_name())
           );
         }
       }
     }
+    Ok(())
   }
 
   fn set_local_font(&mut self, arg: Rc<Font>) { self.localized_fonts.push(arg); }
@@ -3278,7 +3274,7 @@ impl Document {
         + &ctr;
 
       ancestor.set_attribute(&ctrkey, &ctr)?;
-      self.set_attribute(node, "xml:id", &id, state)?;
+      self.set_attribute(node, "xml:id", &id)?;
     }
     Ok(())
   }

--- a/rtx_core/src/document/helpers.rs
+++ b/rtx_core/src/document/helpers.rs
@@ -14,7 +14,7 @@ pub fn prune_empty_para(document: &mut Document, node: &mut Node, state: &mut St
       || document.get_node_qname(&prev_opt.unwrap(), state) != arena::pin_static("ltx:para")
     {
       // If `node` WAS the 1st child
-      document.add_class(&mut node.get_parent().unwrap(), "ltx_pruned_first", state)?;
+      document.add_class(&mut node.get_parent().unwrap(), "ltx_pruned_first")?;
     }
     node.unlink();
   }

--- a/rtx_core/src/gullet.rs
+++ b/rtx_core/src/gullet.rs
@@ -156,7 +156,7 @@ impl Gullet {
         None => String::from("Empty"),
       };
       let message = s!("Closing mouth with input remaining '{}'", next);
-      Error!("unexpected", next, self, state, message);
+      Error!("unexpected", next, self, message);
     }
     if let Some(ref mut runtime) = self.mouth {
       runtime.mouth.finish(state);
@@ -416,7 +416,7 @@ impl Gullet {
         }
         // And *then* continue the main loop checks
       } else if token.get_catcode().is_active_or_cs() {
-        if let Some(defn) = state.lookup_definition(&token) {
+        if let Some(defn) = state.lookup_definition(&token)? {
           if (toplevel || !defn.is_protected()) && defn.is_expandable() {
             // is this the right logic here? don't expand unless digesting?
             state.local_current_token(token);
@@ -602,7 +602,6 @@ impl Gullet {
         "expected",
         "}",
         self,
-        state,
         "Gullet->readBalanced ran out of input in an unbalanced state."
       );
     }
@@ -976,7 +975,7 @@ impl Gullet {
         state.get_current_token().unwrap(),
         next
       );
-      Warn!("expected", "<number>", self, state, message);
+      Warn!("expected", "<number>", self, message);
       if let Some(next) = next {
         self.unread_one(next);
       }
@@ -1103,7 +1102,6 @@ impl Gullet {
             "expected",
             "<unit>",
             self,
-            state,
             "Illegal unit of measure (pt inserted)."
           );
           65536.0
@@ -1116,7 +1114,7 @@ impl Gullet {
         "Missing number, treated as zero. while processing {:?}",
         state.get_current_token().unwrap()
       );
-      Warn!("expected", "<number>", self, state, message);
+      Warn!("expected", "<number>", self, message);
       Ok(Dimension::new(0))
     }
   }
@@ -1218,7 +1216,6 @@ impl Gullet {
                   "expected",
                   "<unit>",
                   self,
-                  state,
                   "Illegal unit of measure (mu inserted)."
                 );
                 None
@@ -1232,7 +1229,6 @@ impl Gullet {
                   "expected",
                   "<unit>",
                   self,
-                  state,
                   "Illegal unit of measure (pt inserted)."
                 );
                 None
@@ -1292,7 +1288,6 @@ impl Gullet {
           "expected",
           "<unit>",
           self,
-          state,
           "Illegal unit of measure (mu inserted)."
         );
       }
@@ -1308,7 +1303,6 @@ impl Gullet {
         "expected",
         "<mudimen>",
         self,
-        state,
         "Expecting mudimen; assuming 0"
       );
       Ok(MuDimension::new(0))
@@ -1357,7 +1351,7 @@ impl Gullet {
             },
             _ => Ok(Tokens!(token)),
           }
-        } else if let Some(defn) = state.lookup_definition(&token) {
+        } else if let Some(defn) = state.lookup_definition(&token)? {
           // TODO: we are doing two lookups to avoid the type restriction of .read_arguments, any
           // way to circumvent? Is it slow in the first place?
           if defn.is_expandable() {
@@ -1436,7 +1430,6 @@ impl Gullet {
             "unexpected",
             "<closed>",
             self,
-            state,
             "Mouth is unexpectedly already closed",
             message
           );
@@ -1459,7 +1452,6 @@ impl Gullet {
               "unexpected",
               "next",
               self,
-              state,
               "TODO: unexpected input remaining"
             );
             // Error('unexpected', $next, $gullet, "Unexpected input remaining: '$next'",
@@ -1481,7 +1473,6 @@ impl Gullet {
           "unexpected",
           "runtime",
           self,
-          state,
           "TODO: gullet had no active runtime"
         );
         break;

--- a/rtx_core/src/keyval.rs
+++ b/rtx_core/src/keyval.rs
@@ -169,7 +169,6 @@ pub fn define(options: KeyvalConfig, gullet: &mut Gullet, state: &mut State) -> 
         "unexpected",
         "keyval",
         None,
-        state,
         s!(
           "No parameters in keyval {key} (in set {keyset} with prefix {prefix}) taking only first"
         )
@@ -181,7 +180,6 @@ pub fn define(options: KeyvalConfig, gullet: &mut Gullet, state: &mut State) -> 
           "unexpected",
           "keyval",
           None,
-          state,
           "Too many parameters in keyval {key} (in set {keyset} with prefix {prefix})\
           taking only first"
         );
@@ -214,7 +212,7 @@ pub fn define(options: KeyvalConfig, gullet: &mut Gullet, state: &mut State) -> 
       )),
       None,
       state,
-    );
+    )?;
   }
 
   // figure out the kind of key-val parameter we are defining
@@ -257,7 +255,6 @@ pub fn define(options: KeyvalConfig, gullet: &mut Gullet, state: &mut State) -> 
       "unknown",
       "undef",
       None,
-      state,
       s!(
         "Unknown KeyVals kind {kind} should be one of\
      'ordinary', 'command', 'choice', 'boolean'. "
@@ -275,8 +272,7 @@ fn define_ordinary(
 ) -> Result<()> {
   let qname_cs = T_CS!(s!("\\{qname}"));
   let plain_params = parse_parameters("{}", &qname_cs, Some(state))?;
-  def_macro(qname_cs, plain_params, code_expansion, None, state);
-  Ok(())
+  def_macro(qname_cs, plain_params, code_expansion, None, state)
 }
 
 /// Helper function to define state neccesary for a command key.
@@ -292,7 +288,7 @@ fn define_command(
   let orig = s!("\\ltxml@orig@{qname}");
   let macroname_cs = s!("\\{macroname}");
   let closure: ExpansionClosure = Rc::new(move |_gullet, value: Vec<ArgWrap>, istate| {
-    def_macro(T_CS!(&orig), plainp.clone(), code.clone(), None, istate);
+    def_macro(T_CS!(&orig), plainp.clone(), code.clone(), None, istate)?;
     let value_tks: Vec<Token> = value
       .into_iter()
       .flat_map(|v| {
@@ -321,8 +317,7 @@ fn define_command(
     ExpansionBody::Closure(closure),
     None,
     state,
-  );
-  Ok(())
+  )
 }
 
 /// Helper function to define state neccesary for an choice key.
@@ -359,7 +354,7 @@ fn define_choice(
         ExpansionBody::Tokens(Tokens::new(Explode!(nvalue))),
         None,
         istate,
-      );
+      )?;
     }
     // iterate over the possible choices and store them
     let mut index = 0;
@@ -374,7 +369,7 @@ fn define_choice(
             ExpansionBody::Tokens(Tokens::new(Explode!(index))),
             None,
             istate,
-          );
+          )?;
         }
         index += 1;
       }
@@ -390,7 +385,7 @@ fn define_choice(
           code.clone(),
           None,
           istate,
-        );
+        )?;
         tokens.push(orig.clone());
         tokens.push(T_BEGIN!());
         tokens.extend(value.unlist());
@@ -404,7 +399,7 @@ fn define_choice(
         mismatch.clone(),
         None,
         istate,
-      );
+      )?;
       tokens.push(orig.clone());
       tokens.push(T_BEGIN!());
       tokens.extend(value.unlist());
@@ -418,8 +413,7 @@ fn define_choice(
     ExpansionBody::Closure(closure),
     None,
     state,
-  );
-  Ok(())
+  )
 }
 
 /// Helper function to define state neccesary for a boolean key.
@@ -438,7 +432,7 @@ fn define_boolean(
     ConditionalOptions::default(),
     gullet,
     state,
-  ); // We might need to $scope here
+  )?; // We might need to $scope here
   let orig = s!("\\ltxml@@rig@{qname}");
   let orig_cs = T_CS!(orig);
   let plain_params = parse_parameters("{}", &orig_cs, Some(state))?;
@@ -462,7 +456,7 @@ fn define_boolean(
         code.clone(),
         None,
         istate,
-      );
+      )?;
       tokens.push(orig_cs.clone());
       tokens.push(T_BEGIN!());
       tokens.extend(value.unlist());

--- a/rtx_core/src/keyvals.rs
+++ b/rtx_core/src/keyvals.rs
@@ -89,7 +89,6 @@ impl Object for KeyVals {
         "ignore",
         "keyvals",
         stomach,
-        state,
         "Skipping digestion of \\setkeys as requested (did you digest a KeyVals twice?) "
       );
     } else {
@@ -564,7 +563,7 @@ impl KeyVals {
           until.stringify()
         );
         let message2 = s!("key started at {}", startloc.to_string());
-        Error!("expected", until, gullet, state, message, message2);
+        Error!("expected", until, gullet, message, message2);
       }
 
       // turn the key tokens into a string and normalize

--- a/rtx_core/src/lib.rs
+++ b/rtx_core/src/lib.rs
@@ -239,15 +239,14 @@ pub trait BoxOps: Object {
     self.with_properties(|props| matches!(props.get(key), Some(Stored::Bool(true))))
   }
   /// obtains the "body" of a digested object which captured it
-  fn get_body(&self) -> Option<Digested> {
+  fn get_body(&self) -> Result<Option<Digested>> {
     Error!(
       "boxops",
       "get_body",
       self,
-      None,
       "Generic BoxOps::get_body should never be called!"
     );
-    None
+    Ok(None)
   }
   /// gets the associated font, if any
   fn get_font(&self, state: &mut State) -> Result<Option<Cow<Font>>>;

--- a/rtx_core/src/list.rs
+++ b/rtx_core/src/list.rs
@@ -150,7 +150,7 @@ impl List {
     // 2. empty contents
     self.get_property_bool("isEmpty")
       || self.get_property_bool("isSpace")
-      || self.boxes.iter().all(|item| item.is_empty())
+      || self.boxes.iter().all(|item| item.is_empty().unwrap_or(false))
   }
 }
 

--- a/rtx_core/src/mouth.rs
+++ b/rtx_core/src/mouth.rs
@@ -320,7 +320,7 @@ impl Mouth {
           Ok(count) => count,
           Err(e) => {
             let message = s!("BufReader::read_to_end returned an error: {:?}", e);
-            Warn!("mouth", "io", self, state, message);
+            Warn!("mouth", "io", self, message);
             0
           },
         };
@@ -345,7 +345,7 @@ impl Mouth {
             Ok(fstr) => fstr,
             Err(e) => {
               let message = s!("input isn't valid under encoding utf8: {:?}", e);
-              Info!("misdefined", "utf8", self, state, message);
+              Info!("misdefined", "utf8", self, message);
               unsafe { str::from_utf8_unchecked(&file_bytes) }
             },
           };
@@ -426,7 +426,7 @@ impl Mouth {
         let line_opt = self.get_next_line(state);
         // For \read, we have to return something for EOL, and handle implicit final newline
         let read_mode = state.lookup_int("PRESERVE_NEWLINES") > 1;
-        let eolch = if let Some(defn) = state.lookup_definition(&CS_ENDLINECHAR) {
+        let eolch = if let Some(defn) = state.lookup_definition(&CS_ENDLINECHAR).unwrap() {
           if defn.is_register() {
             if let Some(eol) = defn.value_of(Vec::new(), state) {
               let eol = eol.value_of() as i16;

--- a/rtx_core/src/parameter.rs
+++ b/rtx_core/src/parameter.rs
@@ -73,7 +73,6 @@ impl Default for Parameter {
           "Parameter",
           "mock_reader",
           None,
-          None,
           "Please define a real reader, this is a mock fallback!"
         );
         Ok(ArgWrap::None)
@@ -282,7 +281,7 @@ impl Parameter {
             value = value.neutralize(semi_chars, state);
           }
           if self.pack_parameters {
-            value = value.pack_parameters();
+            value = value.pack_parameters()?;
           }
           if wants_option {
             if value.is_empty() {
@@ -320,7 +319,6 @@ impl Parameter {
           "expected",
           self,
           gullet,
-          state,
           s!("Missing argument {} for {}", self.stringify(), fordefn_str)
         );
         ArgWrap::Tokens(Tokens!(T_OTHER!("missing")))

--- a/rtx_core/src/state.rs
+++ b/rtx_core/src/state.rs
@@ -715,7 +715,7 @@ impl State {
   }
 
   /// manage a (global) list of values
-  pub fn push_value<T: Into<Stored>>(&mut self, key: &str, value: T) {
+  pub fn push_value<T: Into<Stored>>(&mut self, key: &str, value: T) -> Result<()> {
     let key_sym = arena::pin(key);
     let value = value.into();
     if !self.value.contains_key(&key_sym) {
@@ -737,13 +737,14 @@ impl State {
       other => {
         let message =
           s!("BUG: Tried to push_value into an unsupported Stored field! Field was: {other:?}");
-        Error!("state", "Stored", None, self, message);
+        Error!("state", "Stored", None, message);
       },
     }
+    Ok(())
   }
 
   /// pops the last value in a named `Stored::VecDequeStored` queue, if any
-  pub fn pop_value(&mut self, key: &str) -> Option<Stored> {
+  pub fn pop_value(&mut self, key: &str) -> Result<Option<Stored>> {
     let key_sym = arena::pin(key);
     if !self.value.contains_key(&key_sym) {
       self.assign_internal(
@@ -756,16 +757,15 @@ impl State {
     if let Some(&mut Stored::VecDequeStored(ref mut front)) =
       self.value.get_mut(&key_sym).unwrap().front_mut()
     {
-      front.pop_back()
+      Ok(front.pop_back())
     } else {
       Error!(
         "state",
         "Stored",
         None,
-        self,
         "BUG: Tried to pop_value from a non-vecdeque value key!"
       );
-      None
+      Ok(None)
     }
   }
 
@@ -934,29 +934,30 @@ impl State {
     self.assign_value("Alignment", alignment, scope);
   }
 
-  pub fn lookup_register(&mut self, cs: &str, parameters: Vec<ArgWrap>) -> Option<RegisterValue> {
+  pub fn lookup_register(&mut self, cs: &str, parameters: Vec<ArgWrap>) -> Result<Option<RegisterValue>> {
     let cs = T_CS!(cs);
-    if let Some(defn) = self.lookup_definition(&cs) {
+    Ok(
+    if let Some(defn) = self.lookup_definition(&cs)? {
       if defn.is_register() {
         defn.value_of(parameters, self)
       } else {
         let message = s!("The control sequence {:?} is not a register", cs);
-        Warn!("expected", "register", None, self, message);
+        Warn!("expected", "register", None, message);
         None
       }
     } else {
       let message = s!("The control sequence {:?} is not defined", cs);
-      Warn!("expected", "register", None, self, message);
+      Warn!("expected", "register", None, message);
       None
-    }
+    })
   }
 
-  pub fn lookup_expandable(&self, token: &Token, toplevel: bool) -> Option<Rc<dyn Definition>> {
+  pub fn lookup_expandable(&self, token: &Token, toplevel: bool) -> Result<Option<Rc<dyn Definition>>> {
     // Can only be a token or definition; we want defns!
     // is this the right logic here? don't expand unless digesting?
-    self
-      .lookup_definition(token)
-      .filter(|defn| (*defn).is_expandable() && (toplevel || !(*defn).is_protected()))
+    Ok(self
+      .lookup_definition(token)?
+      .filter(|defn| (*defn).is_expandable() && (toplevel || !(*defn).is_protected())))
   }
 
   /// Whether token must be wrapped as dont_expand
@@ -1033,7 +1034,7 @@ impl State {
     }
   }
 
-  pub fn shift_value(&mut self, key: &str) -> Option<Stored> {
+  pub fn shift_value(&mut self, key: &str) -> Result<Option<Stored>> {
     let key_sym = arena::pin(key);
     if !self.value.contains_key(&key_sym) {
       self.assign_internal(
@@ -1043,6 +1044,7 @@ impl State {
         Some(Scope::Global),
       )
     }
+    Ok(
     if let Some(&mut Stored::VecDequeStored(ref mut front)) =
       self.value.get_mut(&key_sym).unwrap().front_mut()
     {
@@ -1052,11 +1054,10 @@ impl State {
         "state",
         "Stored",
         None,
-        self,
         "BUG: Tried to shift_value from a non-vecdeque value key!"
       );
       None
-    }
+    })
   }
 
   /// manage a (global) hash of values
@@ -1336,7 +1337,7 @@ impl State {
   /// Since we're not doing digestion here, we don't need to handle mathactive,
   /// nor cs let to executable tokens
   /// This returns a definition object, or undef
-  pub fn lookup_definition<'def>(&'def self, key: &'def Token) -> Option<Rc<dyn Definition>> {
+  pub fn lookup_definition<'def>(&'def self, key: &'def Token) -> Result<Option<Rc<dyn Definition>>> {Ok(
     if let Some(defs) = self.lookup_definition_internal(key) {
       match defs.front() {
         Some(Stored::Conditional(entry)) => Some(entry.clone()),
@@ -1348,19 +1349,19 @@ impl State {
         Some(Stored::None) | Some(Stored::Token(_)) | None => None,
         Some(v) => {
           let message = s!("in lookup_definition for {:?}. Value was: {:?}", key, v);
-          Error!("unexpected", "value", None, self, message);
+          Error!("unexpected", "value", None, message);
           None
         },
       }
     } else {
       None
-    }
+    })
   }
 
   /// Returns a definition as `Stored` so that one can call `.read_arguments`,
   /// which can't be specialized during compile-time over a trait object
   /// Instead we'll dispatch via `Stored` at runtime, to allow generic calls
-  pub fn lookup_definition_stored<'def>(&'def self, key: &'def Token) -> Option<Stored> {
+  pub fn lookup_definition_stored<'def>(&'def self, key: &'def Token) -> Result<Option<Stored>> {Ok(
     match self.lookup_definition_internal(key) {
       Some(defs) => match defs.front() {
         // Still, good time to handle the Token case and catch weird storage errors
@@ -1378,13 +1379,13 @@ impl State {
         }))),
         Some(v) => {
           let message = s!("in lookup_definition for {:?}. Value was: {:?}", key, v);
-          Error!("unexpected", "value", None, self, message);
+          Error!("unexpected", "value", None, message);
           None
         },
         None => None,
       },
       _ => None,
-    }
+    })
   }
 
   /// A specialized version of `lookup_definition` for registers, since we can't adequately perform
@@ -1752,7 +1753,7 @@ impl State {
         });
         let stomach = self.stomach.borrow();
         arena::with(key, |key_str| {
-          Warn!("internal", key_str, stomach, self, message)
+          Warn!("internal", key_str, stomach, message)
         });
       }
     }
@@ -1781,30 +1782,14 @@ impl State {
         Some(sp) => *sp,
         None => {
           let message = s!("Illegal unit of measure {:?}, assuming pt.", u);
-          Warn!("expected", "<unit>", None, self, message);
+          Warn!("expected", "<unit>", None, message);
           *UNITS.get("pt").unwrap()
         },
       },
     }
   }
 
-  // #======================================================================
-  /// TODO
-  pub fn note_status(&self, _category: &str, _what: &str) {
-    // Ok, note status is *EXTREMELY* localized
-    // it only touches the status field of state,
-    // and has NO side-effects to any of the other stateful machinery.
-    // So. Let's make it possible to call it from any context, including immutable state borrows,
-    // by using interiror mutability.
-    // "Proof by commenting intent"
-
-    // if ($type eq 'undefined') {
-    //   map { $$self{status}{undefined}{$_}++ } @data; }
-    // elsif ($type eq 'missing') {
-    //   map { $$self{status}{missing}{$_}++ } @data; }
-    // else {
-    //   $$self{status}{$type}++;
-  }
+  // ======================================================================
 
   // sub getStatus {
   //   my ($self, $type) = @_;
@@ -2010,7 +1995,7 @@ impl State {
   /// along with appropriate error messge.
   pub fn generate_error_stub(&mut self, caller: &mut Gullet, token: &Token) -> Result<Token> {
     let cs = token.with_cs_name(ToString::to_string);
-    self.note_status("undefined", &cs); // TODO: Undefined:cs
+    note_status(LogStatus::Undefined, Some(&cs));
                                         // To minimize chatter, go ahead and define it...
     if cs.starts_with("\\if") {
       // Apparently an \ifsomething ???
@@ -2019,7 +2004,6 @@ impl State {
         "undefined",
         token,
         caller,
-        self,
         s!(
           "The token {} is not defined. Defining it now as with \\newif",
           token.stringify()
@@ -2032,7 +2016,7 @@ impl State {
           s!("\\let{}\\iftrue", cs),
           None,
           self,
-        ),
+        )?,
         Some(Scope::Global),
       );
       self.install_definition(
@@ -2042,7 +2026,7 @@ impl State {
           s!("\\let{}\\iffalse", cs),
           None,
           self,
-        ),
+        )?,
         Some(Scope::Global),
       );
       self.let_i(token, &T_CS!("\\iffalse"), Some(Scope::Global), caller);
@@ -2051,7 +2035,6 @@ impl State {
         "undefined",
         token,
         caller,
-        self,
         s!(
           "The token {} is not defined. Defining it now as <ltx:ERROR/>",
           token.stringify()

--- a/rtx_core/src/stomach.rs
+++ b/rtx_core/src/stomach.rs
@@ -128,7 +128,7 @@ impl<'t> Stomach {
           terminal,
           start_location
         );
-        Warn!("expected", terminal, self, state, message);
+        Warn!("expected", terminal, self, message);
       }
     }
     // and add a Dummy `trailer' if none explicit.
@@ -280,7 +280,7 @@ impl<'t> Stomach {
               token,
               cc
             );
-            Error!("misdefined", token, self, state, &message);
+            Error!("misdefined", token, self, &message);
             if let Some(digested) = self.invoke_token_simple(meaning, state)? {
               result.push(digested);
             }
@@ -365,7 +365,7 @@ impl<'t> Stomach {
     state: &mut State,
   ) -> Result<Vec<Digested>> {
     let cs = token.with_cs_name(|cs| String::from(cs));
-    state.note_status("undefined", &cs);
+    note_status(LogStatus::Undefined, Some( &cs));
 
     // To minimize chatter, go ahead and define it...
     if cs.starts_with("\\if") {
@@ -376,7 +376,6 @@ impl<'t> Stomach {
         "undefined",
         token,
         self,
-        state,
         &message,
         "Defining it now as with \\newif"
       );
@@ -388,7 +387,7 @@ impl<'t> Stomach {
           Tokens!(T_CS!("\\let"), T_CS!(&cs), T_CS!("\\iftrue")),
           None,
           state,
-        ),
+        )?,
         None,
       );
       state.install_definition(
@@ -398,7 +397,7 @@ impl<'t> Stomach {
           Tokens!(T_CS!("\\let"), T_CS!(cs), T_CS!("\\iffalse")),
           None,
           state,
-        ),
+        )?,
         None,
       );
 
@@ -412,7 +411,6 @@ impl<'t> Stomach {
         "undefined",
         token,
         self,
-        state,
         &message,
         "Defining it now as <ltx:ERROR/>"
       );
@@ -511,7 +509,6 @@ impl<'t> Stomach {
             "unexpected",
             "runtime",
             self,
-            state,
             "TODO: gullet had no active runtime"
           );
           break;
@@ -525,7 +522,6 @@ impl<'t> Stomach {
           "unexpected",
           "<closed>",
           self,
-          state,
           "TODO: Mouth is unexpectedly already closed"
         );
         // Error('unexpected', '<closed>', $gullet, "Mouth is unexpectedly already closed",
@@ -550,7 +546,7 @@ impl<'t> Stomach {
             "Finished reading from {}, but it still has input.",
             stringify_mouth
           );
-          Error!("unexpected", "next", gullet, state, message, detail);
+          Error!("unexpected", "next", gullet, message, detail);
           {
             if let Some(ref mut runtime) = gullet.mouth {
               runtime.mouth.finish(state);
@@ -690,7 +686,6 @@ impl<'t> Stomach {
         "unexpected",
         state.get_current_token().unwrap(),
         self,
-        state,
         "Attempt to close boxing group"
       );
     } else {
@@ -711,7 +706,6 @@ impl<'t> Stomach {
         "unexpected",
         state.get_current_token().unwrap().to_string(),
         self,
-        state,
         s!(
           "Attempt to close non-boxing group; {}",
           self.current_frame_message(state)
@@ -798,7 +792,7 @@ impl<'t> Stomach {
         Some(ref token) => token.to_string(),
         None => String::from("mode"),
       };
-      Error!("unexpected", category, self, state, &message); // self.currentFrameMessage);
+      Error!("unexpected", category, self, &message); // self.currentFrameMessage);
     } else {
       // Don"t pop if there"s an error; maybe we'll recover?
       self.pop_stack_frame(false, state)?;

--- a/rtx_core/src/token.rs
+++ b/rtx_core/src/token.rs
@@ -811,7 +811,7 @@ impl Token {
            Illegal: {}",
           &self.stringify()
         );
-        Fatal!(Parameter, Unexpected, None, state, msg);
+        Fatal!(Parameter, Unexpected, None, msg);
       },
       Catcode::CS | Catcode::ACTIVE => {
         if state.is_dont_expandable(&self) {

--- a/rtx_core/src/tokens.rs
+++ b/rtx_core/src/tokens.rs
@@ -438,7 +438,7 @@ impl Tokens {
   // Collapses PARAM+PARAM token pair into a single PARAM
   // B book suggests running this
   // and remove dont_expand markers.
-  pub fn pack_parameters(self) -> Self {
+  pub fn pack_parameters(self) -> Result<Self> {
     let mut rescanned = Vec::new();
     let mut toks = self.unlist().into_iter().collect::<VecDeque<_>>();
     while let Some(mut t) = toks.pop_front() {
@@ -462,7 +462,6 @@ impl Tokens {
             "misdefined",
             "expansion",
             None,
-            None,
             "Parameter has a malformed arg, should be #1-#9 or ##. In expansion {}",
             Tokens::new(toks.clone().into_iter().collect()).to_string()
           );
@@ -477,7 +476,7 @@ impl Tokens {
         rescanned.push(t);
       }
     }
-    Tokens::new(rescanned)
+    Ok(Tokens::new(rescanned))
   }
 }
 

--- a/rtx_core/src/whatsit.rs
+++ b/rtx_core/src/whatsit.rs
@@ -78,17 +78,18 @@ impl Whatsit {
   }
 
   /// A Whatsit is empty if it is marked empty, or space-like, or has an empty body.
-  pub fn is_empty(&self) -> bool {
+  pub fn is_empty(&self) -> Result<bool> {
+    Ok(
     // 1. A space-like thing
     // 2. An environment-like structure with an empty body
     // TODO: For now it is difficult to pass in a State with an initialized TeX.pool.
     self.get_property_bool("isEmpty")
       || self.get_property_bool("isSpace")
       || (self.get_definition().get_cs_name() == "Begin"
-        && match self.get_body() {
-          Some(b) => b.unlist_ref().iter().all(|inner| inner.is_empty()),
-          None => true,
-        })
+        && match self.get_body()? {
+            Some(b) => b.unlist_ref().iter().all(|inner| inner.is_empty().unwrap_or(false)),
+            None => true,
+        }))
   }
   /// sets a pre-assembled HashMap of properties
   pub fn set_properties(&mut self, props: HashMap<String, Stored>) {
@@ -321,7 +322,7 @@ impl Object for Whatsit {
     };
 
     if !is_closure {
-      if let Some(body) = self.get_body() {
+      if let Some(body) = self.get_body()? {
         tokens.extend(body.revert(state)?.unlist());
         if let Some(trailer) = self.get_trailer() {
           tokens.extend(trailer.revert(state)?.unlist());
@@ -373,11 +374,11 @@ impl BoxOps for Whatsit {
     self.definition.do_absorbtion(document, self, state)
     // LaTeXML::Definition::stopProfiling($profiled, 'absorb') if $profiled;
   }
-  fn get_body(&self) -> Option<Digested> {
-    match self.properties.get("body") {
+  fn get_body(&self) -> Result<Option<Digested>> {
+    Ok(match self.properties.get("body") {
       Some(Stored::Digested(body)) => Some(body.clone()),
       _ => None,
-    }
+    })
   }
 
   fn get_font(&self, state: &mut State) -> Result<Option<Cow<Font>>> {

--- a/rtx_core/tests/00_unit_state.rs
+++ b/rtx_core/tests/00_unit_state.rs
@@ -144,7 +144,7 @@ fn assign_lookup_arrays() {
     "empty_key",
     vec![Stored::String(arena::pin_static("mydir"))],
   );
-  let shifted = state.shift_value("empty_key");
+  let shifted = state.shift_value("empty_key").unwrap();
   if let Some(Stored::String(shifted)) = shifted {
     arena::with(shifted, |shifted_str| {
       assert_eq!(shifted_str, "mydir", "shift/unshift new key")
@@ -165,31 +165,31 @@ fn assign_lookup_arrays() {
   }
 
   assert_eq!(
-    state.shift_value("SEARCHPATHS"),
+    state.shift_value("SEARCHPATHS").unwrap(),
     Some(Stored::String(arena::pin_static("d"))),
     "shift searchpaths"
   );
   assert_eq!(
-    state.pop_value("SEARCHPATHS"),
+    state.pop_value("SEARCHPATHS").unwrap(),
     Some(Stored::String(arena::pin_static("c"))),
     "pop searchpaths"
   );
   assert_eq!(
-    state.shift_value("SEARCHPATHS"),
+    state.shift_value("SEARCHPATHS").unwrap(),
     Some(Stored::String(arena::pin_static("a"))),
     "shift searchpaths"
   );
   assert_eq!(
-    state.pop_value("SEARCHPATHS"),
+    state.pop_value("SEARCHPATHS").unwrap(),
     Some(Stored::String(arena::pin_static("b"))),
     "pop searchpaths"
   );
   assert_eq!(
-    state.shift_value("SEARCHPATHS"),
+    state.shift_value("SEARCHPATHS").unwrap(),
     None,
     "shift searchpaths None"
   );
-  assert_eq!(state.pop_value("SEARCHPATHS"), None, "pop searchpaths None");
+  assert_eq!(state.pop_value("SEARCHPATHS").unwrap(), None, "pop searchpaths None");
   assert_eq!(
     state.lookup_value("SEARCHPATHS"),
     Some(&Stored::VecDequeStored(VecDeque::new())),
@@ -202,7 +202,7 @@ fn assign_lookup_arrays() {
     .collect::<VecDeque<Stored>>();
   state.assign_value("SEARCHPATHS", Stored::VecDequeStored(vdq.clone()), None);
   let new_d = Stored::String(arena::pin_static("d"));
-  state.push_value("SEARCHPATHS", new_d.clone());
+  assert!(state.push_value("SEARCHPATHS", new_d.clone()).is_ok());
   vdq.push_back(new_d.clone());
   assert_eq!(
     state.lookup_value("SEARCHPATHS"),
@@ -210,31 +210,31 @@ fn assign_lookup_arrays() {
     "push works as intended"
   );
   assert_eq!(
-    state.pop_value("SEARCHPATHS"),
+    state.pop_value("SEARCHPATHS").unwrap(),
     Some(new_d),
     "pop searchpaths"
   );
   assert_eq!(
-    state.shift_value("SEARCHPATHS"),
+    state.shift_value("SEARCHPATHS").unwrap(),
     Some(Stored::String(arena::pin_static("a"))),
     "shift searchpaths"
   );
   assert_eq!(
-    state.pop_value("SEARCHPATHS"),
+    state.pop_value("SEARCHPATHS").unwrap(),
     Some(Stored::String(arena::pin_static("c"))),
     "pop searchpaths"
   );
   assert_eq!(
-    state.pop_value("SEARCHPATHS"),
+    state.pop_value("SEARCHPATHS").unwrap(),
     Some(Stored::String(arena::pin_static("b"))),
     "pop searchpaths"
   );
   assert_eq!(
-    state.shift_value("SEARCHPATHS"),
+    state.shift_value("SEARCHPATHS").unwrap(),
     None,
     "shift searchpaths None"
   );
-  assert_eq!(state.pop_value("SEARCHPATHS"), None, "pop searchpaths None");
+  assert_eq!(state.pop_value("SEARCHPATHS").unwrap(), None, "pop searchpaths None");
   assert_eq!(
     state.lookup_value("SEARCHPATHS"),
     Some(&Stored::VecDequeStored(VecDeque::new())),
@@ -257,7 +257,7 @@ fn install_definition_and_meaning() {
   };
   // Install a Definition
   state.install_definition(job_definition.clone(), None);
-  if let Some(stored_definition) = state.lookup_definition(&T_CS!("\\jobname")) {
+  if let Ok(Some(stored_definition)) = state.lookup_definition(&T_CS!("\\jobname")) {
     assert_eq!(stored_definition.get_cs().into_owned(), T_CS!("\\jobname"));
   } else {
     panic!("Failed to lookup installed definition!");

--- a/rtx_core/tests/01_unit_tokens.rs
+++ b/rtx_core/tests/01_unit_tokens.rs
@@ -79,7 +79,7 @@ fn unit_examples() {
     T_END!(),
     T_LETTER!("z")
   )
-  .pack_parameters();
+  .pack_parameters().unwrap();
   let subst = pattern.substitute_parameters(&[
     T_LETTER!("u").into(),
     T_LETTER!("v").into(),

--- a/rtx_math_parser/src/parser.rs
+++ b/rtx_math_parser/src/parser.rs
@@ -11,7 +11,7 @@ use rtx_core::common::error::{note_begin, note_end, note_progress, Result};
 use rtx_core::common::xml::*;
 use rtx_core::document::Document;
 use rtx_core::state::State;
-use rtx_core::{fatal, map, raw_map, s, static_map, Error};
+use rtx_core::{map, raw_map, s, static_map, Error, Fatal, fatal};
 
 use crate::grammar::builder::init_grammar;
 use crate::pragmatics::ValidationPragmatics;
@@ -375,7 +375,7 @@ impl MathParser {
           }
           // TODO: is the array/XM case still relevant?
           // if ($isarr) { $$result[1]{$key} = $value; } else {
-          document.set_attribute(&mut result, &key, &value, state)?;
+          document.set_attribute(&mut result, &key, &value)?;
           // }
         }
         result = document
@@ -883,7 +883,8 @@ pub fn realize_xmnode<'a>(node: &'a Node, document: &'a Document, state: &State)
         // LaTeXML::MathParser::IDREFS{$idref}
         // ? "Previously bound to " .
         // ToString($LaTeXML::MathParser::IDREFS{$idref})           : ()));
-        Error!("expected", "id", None, state, message);
+        let err = || {Error!("expected", "id", None, message); Ok(()) };
+        err().ok();
         //       return ['ltx:ERROR', {}, "Missing XMRef idref=$idref"]; } }
       }
     }

--- a/rtx_math_parser/src/semantics/tree.rs
+++ b/rtx_math_parser/src/semantics/tree.rs
@@ -2,6 +2,7 @@ use libxml::tree::Node;
 use rtx_core::common::font::Font;
 use rtx_core::common::xml::element_nodes;
 use rtx_core::document::Document;
+use rtx_core::common::object::Object;
 use rtx_core::state::State;
 use rtx_core::Info;
 use rustc_hash::FxHashMap as HashMap;
@@ -680,10 +681,10 @@ impl XM {
       XM::Ref(refprops) => {
         let mut ref_node = Node::new("XMRef", None, document.get_document()).unwrap();
         if let Some(id) = refprops.id {
-          document.set_attribute(&mut ref_node, "idref", &id, state)?;
+          document.set_attribute(&mut ref_node, "idref", &id)?;
         }
         if let Some(xmkey) = refprops.xmkey {
-          document.set_attribute(&mut ref_node, "_xmkey", &xmkey, state)?;
+          document.set_attribute(&mut ref_node, "_xmkey", &xmkey)?;
         }
         Ok(ref_node)
       },
@@ -696,10 +697,13 @@ impl XM {
         Ok(arg_node)
       },
       XM::Choices(mut choices) => {
-        Info!(
-          "to_xmath handler discarded {} parse choices.",
-          choices.len() - 1
-        );
+        {
+          let stomach = &state.stomach.borrow();
+          Info!("math_parser","choices", stomach,
+            "to_xmath handler discarded {} parse choices.",
+            choices.len() - 1
+          );
+        }
         choices.remove(0).into_xmath(owner, nodes, document, state)
       },
     }

--- a/rtx_package/src/package/etex.rs
+++ b/rtx_package/src/package/etex.rs
@@ -38,7 +38,7 @@ LoadDefinitions!(outer_state, {
       let mut raw_line = mouth.borrow_mut().read_raw_line(false, state).unwrap_or_default();
       // DG: Can't we do this \endlinechar check in readRawLine ?!
       // DG:  and can't we make it *faster* ?
-      if let Some(eol) = state.lookup_definition(&T_CS!("\\endlinechar")) {
+      if let Some(eol) = state.lookup_definition(&T_CS!("\\endlinechar"))? {
         let eolv   = eol.value_of(Vec::new(), state).unwrap_or_default().value_of();
         if (eolv > 0) && (eolv <= 255) {
           raw_line.push(eolv as u8 as char);
@@ -159,7 +159,7 @@ LoadDefinitions!(outer_state, {
 
   // \unless someif
   DefConditional!("\\unless Token", sub[gullet, (if_token), state] {
-    if let Some(Stored::Conditional(defn)) = state.lookup_definition_stored(&if_token) {
+    if let Some(Stored::Conditional(defn)) = state.lookup_definition_stored(&if_token)? {
       if defn.conditional_type == ConditionalType::If {
         if let Some(ref test) = defn.test {
           // Invert the if's test!
@@ -169,7 +169,7 @@ LoadDefinitions!(outer_state, {
       }
     }
     let msg = s!("\\unless should not be followed by {}",if_token.stringify());
-    Error!("unexpected", if_token, gullet, state, msg);
+    Error!("unexpected", if_token, gullet, msg);
     false
   });
 

--- a/rtx_package/src/package/etoolbox_sty.rs
+++ b/rtx_package/src/package/etoolbox_sty.rs
@@ -26,7 +26,7 @@ LoadDefinitions!(state, {
   DefMacro!("\\newrobustcmd OptionalMatch:* DefToken [Number][]{}", sub[stomach,(_star,cs,nargs,opt,body),state] {
   if !is_definable(&cs, state) {
     if !state.lookup_bool(&s!("{cs}:locked")) {
-      Info!("ignore", cs, stomach, state,
+      Info!("ignore", cs, stomach,
         "Ignoring redefinition (\\newcommand) of '{cs}'"); }
   } else {
     let args = convert_latex_args(nargs.value_of() as usize, opt, state)?;
@@ -170,7 +170,7 @@ LoadDefinitions!(state, {
   // Hence we need to lock them, to avoid the native redefinition.
 
   DefMacro!("\\ifdefprotected DefToken {} {}", sub[gullet,(cs,ttrue,tfalse),state] {
-  let definition = state.lookup_definition(&cs);
+  let definition = state.lookup_definition(&cs)?;
   if definition.is_none() || !definition.as_ref().unwrap().is_expandable() {
     // Undefined, or not an expandable definition, therefore not protected
     return Ok(tfalse);
@@ -1275,11 +1275,11 @@ LoadDefinitions!(state, {
   // Need to be able to examine a Macro's replacement for a match (and then replace)
   // we can only do this for token expansions, and should return failure for all else.
   DefMacro!("\\patchcmd [] DefToken {}{}{}{}", sub[gullet,(_prefix,cs,search,replace,success,failure), state] {
-  let definition = state.lookup_definition(&cs);
+  let definition = state.lookup_definition(&cs)?;
   if definition.is_some() && definition.as_ref().unwrap().is_expandable() {
     let expansion = definition.as_ref().unwrap().get_expansion();
     if matches!(expansion,Some(ExpansionBody::Closure(_))) {
-      Info!("unexpected", "patchcmd", gullet, state, "Patchcmd is not supported on LaTeXML-native definitions, will not patch {}",cs);
+      Info!("unexpected", "patchcmd", gullet, "Patchcmd is not supported on LaTeXML-native definitions, will not patch {}",cs);
       return Ok(failure)
     }
     let string        = expansion.unwrap().to_string();
@@ -1293,13 +1293,13 @@ LoadDefinitions!(state, {
       let replace_string = replace.to_string();
       let patched = string.replace(&search_string, &replace_string);
       // New definition in local scope
-      state.install_definition(Expandable::new(cs, definition.unwrap().get_parameters().cloned(), patched, None, state), None);
+      state.install_definition(Expandable::new(cs, definition.unwrap().get_parameters().cloned(), patched, None, state)?, None);
       Ok(success)
     } else {
       Ok(failure)
     }
   } else {
-    Info!("unexpected", "patchcmd", gullet, state, "Patchcmd is not supported on non-expandable definitions, will not patch {}", cs);
+    Info!("unexpected", "patchcmd", gullet, "Patchcmd is not supported on non-expandable definitions, will not patch {}", cs);
     Ok(failure)
   }
 }, protected => true);
@@ -1698,17 +1698,17 @@ LoadDefinitions!(state, {
   // \AfterEndDocument
   DefMacro!("\\AfterPreamble{}", sub[gullet,(arg),state] {
   if state.lookup_bool("inPreamble") {
-    state.push_value("@at@begin@document", arg.unlist());
+    state.push_value("@at@begin@document", arg.unlist())?;
     Tokens!()
   } else {
     arg
   }});
   DefMacro!("\\AtEndPreamble{}", sub[gullet,(arg),state] {
-  state.push_value("@document@preamble@atend", arg.unlist()); });
+  state.push_value("@document@preamble@atend", arg.unlist())?; });
   DefMacro!("\\AfterEndPreamble{}", sub[gullet,(arg),state] {
-  state.push_value("@document@preamble@afterend", arg.unlist()); });
+  state.push_value("@document@preamble@afterend", arg.unlist())?; });
   DefMacro!("\\AfterEndDocument{}", sub[gullet,(arg),state] {
-  state.push_value("@after@end@document", arg.unlist()); });
+  state.push_value("@after@end@document", arg.unlist())?; });
 
   RawTeX!(
     r###"
@@ -1719,11 +1719,11 @@ LoadDefinitions!(state, {
   // 2.6 Environment Hooks
 
   DefMacro!("\\AtBeginEnvironment{}{}", sub[gullet,(arg1,arg2),state] {
-    state.push_value(&format!("@environment@{arg1}@atbegin"), arg2.unlist()); });
+    state.push_value(&format!("@environment@{arg1}@atbegin"), arg2.unlist())?; });
   DefMacro!("\\AtEndEnvironment{}{}", sub[gullet,(arg1,arg2),state] {
-    state.push_value(&format!("@environment@{arg1}@atend"), arg2.unlist()); });
+    state.push_value(&format!("@environment@{arg1}@atend"), arg2.unlist())?; });
   DefMacro!("\\BeforeBeginEnvironment{}{}", sub[gullet,(arg1,arg2),state] {
-    state.push_value(&format!("@environment@{arg1}@beforebegin"), arg2.unlist()); });
+    state.push_value(&format!("@environment@{arg1}@beforebegin"), arg2.unlist())?; });
   DefMacro!("\\AfterEndEnvironment{}{}", sub[gullet,(arg1,arg2),state] {
-    state.push_value(&format!("@environment@{arg1}@afterend"), arg2.unlist()); });
+    state.push_value(&format!("@environment@{arg1}@afterend"), arg2.unlist())?; });
 });

--- a/rtx_package/src/package/fontenc_sty.rs
+++ b/rtx_package/src/package/fontenc_sty.rs
@@ -137,7 +137,7 @@ LoadDefinitions!(stomach, state, {
             "Only strings should be stored as font encoding names, at: {:?}",
             encoding_stored
           );
-          Error!("fontenc", "font_encodings", stomach, state, message);
+          Error!("fontenc", "font_encodings", stomach, message);
         }
       }
     }

--- a/rtx_package/src/package/hyperref_sty.rs
+++ b/rtx_package/src/package/hyperref_sty.rs
@@ -440,7 +440,7 @@ LoadDefinitions!(state, {
 
   DefMacro!("\\lx@autorefnum@@{}", sub[gullet,(ttype),state] {
     let type_s  = ttype.unwrap().to_string();
-    let mut tokens = if state.lookup_definition(&T_CS!(s!("\\{type_s}autorefname"))).is_some() {
+    let mut tokens = if state.lookup_definition(&T_CS!(s!("\\{type_s}autorefname")))?.is_some() {
       vec![T_CS!(format!("\\{type_s}autorefname")), T_CS!("\\nobreakspace")]
     } else {
       Vec::new()
@@ -453,7 +453,7 @@ LoadDefinitions!(state, {
     };
     let pcounter = T_CS!(s!("\\p@{counter_str}",));
     let thecounter = T_CS!(s!("\\the{counter_str}"));
-    if state.lookup_definition(&pcounter).is_some() {
+    if state.lookup_definition(&pcounter)?.is_some() {
       tokens.push(pcounter);
     }
     tokens.push(thecounter);

--- a/rtx_package/src/package/inputenc_sty.rs
+++ b/rtx_package/src/package/inputenc_sty.rs
@@ -33,8 +33,7 @@ fn set_input_encoding(encoding: &str, stomach: &mut Stomach, state: &mut State) 
     encoding_tokenized,
     None,
     state,
-  );
-  Ok(())
+  )
 }
 
 LoadDefinitions!(outer_stomach, state, {
@@ -56,7 +55,7 @@ LoadDefinitions!(outer_stomach, state, {
   DefMacro!("\\@inpenc@undefined", sub[gullet, (), state] {
     let message = s!("Keyboard character used is undefined in inputencoding {}",
       state.input_encoding.as_ref().unwrap());
-    Error!("unexpected", "<char>", gullet, state, message);
+    Error!("unexpected", "<char>", gullet,  message);
   });
 
   DefPrimitive!("\\inputencoding{}", sub[stomach, (encoding), state] {

--- a/rtx_package/src/package/latex_ch11_moving_information.rs
+++ b/rtx_package/src/package/latex_ch11_moving_information.rs
@@ -244,7 +244,6 @@ LoadDefinitions!(outer_stomach, outer_state, {
     let mut tokens = Vec::new();
     // If we're in some sort of list environment, maybe we can recover
     if tag == "enumerate" || tag == "itemize" || tag == "description" {
-      Info!("\nDamn! We're in a list {}; try to close it!", tag);
       tokens.extend(Invocation!("\\end", vec![env], gullet)?.unlist());
       tokens.extend(vec![
         T_CS!("\\let"),

--- a/rtx_package/src/package/latex_ch13_boxes.rs
+++ b/rtx_package/src/package/latex_ch13_boxes.rs
@@ -26,16 +26,16 @@ LoadDefinitions!(state, {
   DefMacro!("\\stretch{}", "0pt plus #1fill\\relax");
 
   DefPrimitive!("\\@check@length DefToken", sub[stomach, (cs), state] {
-    match state.lookup_definition(&cs) {
+    match state.lookup_definition(&cs)? {
       None => {
         let message = s!("'{}' is not a length; defining it now", cs.stringify());
-        Warn!("undefined", cs, stomach, state, message);
+        Warn!("undefined", cs, stomach, message);
         DefRegister!(cs, None, Dimension::new(0));
       },
       Some(defn) => if !defn.is_register() {
         let message = s!("'{}' length was expected, got {:?} instead of register.",
           cs.to_string(), defn.register_type());
-        Error!("misdefined", cs, stomach, state, message);
+        Error!("misdefined", cs, stomach, message);
       }
     };
   });

--- a/rtx_package/src/package/latex_ch15_font_selection.rs
+++ b/rtx_package/src/package/latex_ch15_font_selection.rs
@@ -42,7 +42,7 @@ LoadDefinitions!(outer_state, {
     if inner_state.lookup_bool("IN_MATH") {
       let c = c.to_string();
       let message = s!("Command {:?} invalid in math mode", c);
-      Warn!("unexpected", c, stomach, inner_state, message);
+      Warn!("unexpected", c, stomach, message);
     }
     Ok(vec![])
   });
@@ -106,15 +106,15 @@ LoadDefinitions!(outer_state, {
     if let Some(sh) = font::lookup_font_family(&family) { MergeFont!(sh.clone()); }
     else {
       let message = s!("Unrecognized font family {:?}.", family);
-      Info!("unexpected", family, stomach, inner_state, message); }
+      Info!("unexpected", family, stomach, message); }
     if let Some(sh) = font::lookup_font_series(&series) { MergeFont!(sh.clone()); }
     else {
       let message = s!("Unrecognized font series {:?}.", series);
-      Info!("unexpected", series, stomach, inner_state, message); }
+      Info!("unexpected", series, stomach, message); }
     if let Some(sh) = font::lookup_font_shape(&shape) { MergeFont!(sh.clone()); }
     else {
       let message = s!("Unrecognized font shape {:?}.", shape);
-      Info!("unexpected",shape, stomach, inner_state, message); }
+      Info!("unexpected",shape, stomach, message); }
     Ok(Vec::new())
   });
 

--- a/rtx_package/src/package/latex_ch1_documentclass.rs
+++ b/rtx_package/src/package/latex_ch1_documentclass.rs
@@ -39,7 +39,7 @@ LoadDefinitions!(state, {
   DefPrimitive!("\\warn@unusedclassoptions", sub[stomach,_args,state] {
     if let Some(Stored::VecString(unused)) = state.lookup_value("@unusedoptionlist") {
       if !unused.is_empty() {
-        Info!("unexpected", "options", stomach, state,
+        Info!("unexpected", "options", stomach,
               "Unused global options: {}",unused.join(","));
         state.assign_value("@unusedoptionlist", Stored::VecString(Vec::new()), None);
       }

--- a/rtx_package/src/package/latex_ch1_environments.rs
+++ b/rtx_package/src/package/latex_ch1_environments.rs
@@ -46,8 +46,8 @@ LoadDefinitions!(state, {
         // this creates {name} , {{ and }} are escapes in Rust's `format` macro
         let undef = format!("{{{name}}}");
         let message = s!("The environment {} is not defined.", undef);
-        Error!("undefined", undef, gullet, state, message);
-        state.note_status("undefined", &undef);
+        Error!("undefined", undef, gullet, message);
+        note_status(LogStatus::Undefined, Some(&undef));
         // TODO:
         // state.install_definition(LaTeXML::Core::Definition::Constructor->new($token, undef,
         //       sub { LaTeXML::Core::Stomach::makeError($_[0], "undefined", $undef); })); }

--- a/rtx_package/src/package/latex_ch2_document.rs
+++ b/rtx_package/src/package/latex_ch2_document.rs
@@ -11,10 +11,10 @@ LoadDefinitions!(state, {
   //   \end{document}
 
   DefMacro!("\\AtBeginDocument{}", sub[gullet,(rules),state] {
-    state.push_value("@at@begin@document", rules);
+    state.push_value("@at@begin@document", rules)
   });
   DefMacro!("\\AtEndDocument{}", sub[gullet,(rules),state] {
-    state.push_value("@at@end@document", rules);
+    state.push_value("@at@end@document", rules)
   });
 
   // Like  "<ltx:document xml:id='#id'>#body</ltx:document>",
@@ -26,7 +26,7 @@ LoadDefinitions!(state, {
     if let Some(mut docel) = document.findnode("/ltx:document", None, state) {
       if id != *EMPTY_SYM {
         arena::with(id, |id_str|
-          document.set_attribute(&mut docel, "xml:id", id_str, state))?;
+          document.set_attribute(&mut docel, "xml:id", id_str))?;
       }
     } else {
       let props = arena::with(id, |id_str| string_map!("xml:id" => id_str));

--- a/rtx_package/src/package/latex_ch5_packages.rs
+++ b/rtx_package/src/package/latex_ch5_packages.rs
@@ -23,7 +23,7 @@ LoadDefinitions!(outer_stomach, state, {
 
   DefConstructor!("\\usepackage OptionalSemiverbatim Semiverbatim []",
                   "<?latexml package='#2' ?#1(options='#1')?>",
-    before_digest => sub[stomach, state] { only_preamble("\\usepackage", stomach, state); },
+    before_digest => sub[stomach, state] { only_preamble("\\usepackage", stomach, state) },
     after_digest => sub[stomach, whatsit, state] {
       let options: Option<&Digested> = whatsit.get_arg(1);
       let packages: Option<&Digested> = whatsit.get_arg(2);
@@ -48,7 +48,7 @@ LoadDefinitions!(outer_stomach, state, {
 
   DefConstructor!("\\RequirePackage OptionalSemiverbatim Semiverbatim []",
   "<?latexml package='#2' ?#1(options='#1')?>",
-  before_digest =>  sub[stomach, state] { only_preamble("\\RequirePackage", stomach, state); },
+  before_digest =>  sub[stomach, state] { only_preamble("\\RequirePackage", stomach, state) },
   after_digest => sub[stomach, whatsit, state] {
     let options  = whatsit.get_arg(1);
     let packages = whatsit.get_arg(2).unwrap();
@@ -164,7 +164,7 @@ LoadDefinitions!(outer_stomach, state, {
   DefPrimitive!("\\ExecuteOptions{}", sub[gullet, (options), state] {
     // TODO!
     // ExecuteOptions!(split(/\s*,\s*/, ToString(Expand($options))));
-    Info!("TODO","\\ExecuteOptions",gullet,state,"implement fully, it's an empty stub.");
+    Info!("TODO","\\ExecuteOptions",gullet,"implement fully, it's an empty stub.");
     Ok(Vec::new())
   });
 
@@ -174,7 +174,7 @@ LoadDefinitions!(outer_stomach, state, {
     //   "inorder"
     // }
     // ProcessOptions!(($star ? (inorder => 1) : ()));
-    Info!("TODO","\\ProcessOptions",stomach,state,"implement fully, missing 'inorder'");
+    Info!("TODO","\\ProcessOptions",stomach,"implement fully, missing 'inorder'");
     process_options(stomach, state)?;
     Ok(Vec::new())
   });

--- a/rtx_package/src/package/latex_ch5_title_page_and_abstract.rs
+++ b/rtx_package/src/package/latex_ch5_title_page_and_abstract.rs
@@ -88,11 +88,11 @@ LoadDefinitions!(state, {
     if i <= 1 { }
     else if i == nauthors {
       let author_conj = Digest!(T_CS!("\\lx@author@conj"), state)?;
-      document.set_attribute(&mut node, "before", &author_conj.to_string(), state)?;
+      document.set_attribute(&mut node, "before", &author_conj.to_string())?;
 
     } else {
       let author_sep = Digest!(T_CS!("\\lx@author@sep"), state)?;
-      document.set_attribute(&mut node, "before", &author_sep.to_string(), state)?;
+      document.set_attribute(&mut node, "before", &author_sep.to_string())?;
     }
   });
 
@@ -164,7 +164,7 @@ LoadDefinitions!(state, {
       let regurgitated = List::new(stomach.box_list.clone(), state);
       let frontmatter = match state.lookup_value_mut("frontmatter") {
         Some(&mut Stored::HashTagData(ref mut frnt)) => frnt,
-        _ => Fatal!(TexPool, Expected, stomach, state,
+        _ => Fatal!(TexPool, Expected, stomach,
              "Global TeX Frontmatter hash was not available, should never happen"),
       };
       let abstr = frontmatter.entry("ltx:abstract".to_string()).or_insert_with(Vec::new);

--- a/rtx_package/src/package/latex_ch6_verbatim.rs
+++ b/rtx_package/src/package/latex_ch6_verbatim.rs
@@ -147,7 +147,7 @@ LoadDefinitions!(outer_state, {
       result.push(T_CS!("\\@hidden@egroup"));
       Ok(Tokens::new(result))
     } else { // typically something read too far got \verb and the content is somewhere else..?
-      Error!("expected", "delimiter", gullet, state,
+      Error!("expected", "delimiter", gullet,
         "Verbatim argument lost\n Bindings for preceding code is probably broken");
       state.end_semiverbatim()?;
       Ok(Tokens!())

--- a/rtx_package/src/package/latex_ch7_math_mode_environments.rs
+++ b/rtx_package/src/package/latex_ch7_math_mode_environments.rs
@@ -154,13 +154,13 @@ LoadDefinitions!(state, {
   alias        => "$$",
   before_digest => sub[stomach, state] {
     stomach.begin_mode("display_math", state)?;
-    if let Some(RegisterValue::Tokens(everymath_toks)) = state.lookup_register("\\everymath", Vec::new()) {
+    if let Some(RegisterValue::Tokens(everymath_toks)) = state.lookup_register("\\everymath", Vec::new())? {
       let everymath_toks = everymath_toks.unlist();
       if !everymath_toks.is_empty() {
         stomach.get_gullet_mut().unread(Tokens::new(everymath_toks));
       }
     }
-    if let Some(RegisterValue::Tokens(everydisplay_toks)) = state.lookup_register("\\everydisplay", Vec::new()) {
+    if let Some(RegisterValue::Tokens(everydisplay_toks)) = state.lookup_register("\\everydisplay", Vec::new())? {
       let everydisplay_toks = everydisplay_toks.unlist();
       if !everydisplay_toks.is_empty() {
         stomach.get_gullet_mut().unread(Tokens::new(everydisplay_toks));

--- a/rtx_package/src/package/latex_ch8_defining_commands.rs
+++ b/rtx_package/src/package/latex_ch8_defining_commands.rs
@@ -16,7 +16,7 @@ LoadDefinitions!(state, {
     if !IsDefinable!(&cs_token) {
       if !state.has_value(&s!("{}:locked", cs_token.to_string())) { // not locked, inform.
         let message = s!("Ignoring redefinition (\\newcommand) of {}", cs_token.stringify());
-        Info!("ignore", cs_token, stomach, state, message);
+        Info!("ignore", cs_token, stomach, message);
       }
       return Ok(vec![]);
     }

--- a/rtx_package/src/package/latex_ch8_defining_environments.rs
+++ b/rtx_package/src/package/latex_ch8_defining_environments.rs
@@ -16,7 +16,7 @@ LoadDefinitions!(outer_state, {
        state.lookup_bool(&s!("\\begin{{{}}}:locked",name));
       if !is_locked {
         let message = s!("Ignoring redefinition (\\newenvironment) of Environment {:?}", name);
-        Info!("ignore", name, stomach, state, message);
+        Info!("ignore", name, stomach, message);
       }
     } else {
       // TODO: can we convince DefMacro! this is not a second mutable borrow of state?

--- a/rtx_package/src/package/latex_ch9_figures_and_tables.rs
+++ b/rtx_package/src/package/latex_ch9_figures_and_tables.rs
@@ -90,8 +90,8 @@ LoadDefinitions!(state, {
   });
 
   DefConstructor!("\\@@generic@caption[]{}", "<ltx:text class='ltx_caption'>#2</ltx:text>",
-  before_digest => sub[stomach, state] {
-    Error!("unexpected", "\\caption", stomach, state,
+  before_digest => sub[stomach, _state] {
+    Error!("unexpected", "\\caption", stomach,
       "Use of \\caption outside any known float"); });
 
   // Note that even without \caption, we'd probably like to have xml:id.

--- a/rtx_package/src/package/latex_delimiters.rs
+++ b/rtx_package/src/package/latex_delimiters.rs
@@ -117,7 +117,7 @@ LoadDefinitions!(state, {
     after_digest => sub[stomach,_args,state] {
       if state.is_value_bound("MODE", Some(0)) // Last stack frame was a mode switch!?!?!
         || state.lookup_bool("groupNonBoxing") { // or group was opened with \begingroup
-        Error!("unexpected", "\\right", stomach, state, "Unbalanced \\right, no balancing \\left."); }
+        Error!("unexpected", "\\right", stomach, "Unbalanced \\right, no balancing \\left."); }
       else {
         stomach.egroup(state)?;
       }
@@ -146,7 +146,7 @@ LoadDefinitions!(state, {
       else if whatsit.get_arg(1).unwrap().get_property_string("role") == "OPEN" {
         whatsit.get_arg_mut(1).unwrap().set_property("stretchy", true);
       } else {
-        Warn!("unexpected", delim, stomach, state,
+        Warn!("unexpected", delim, stomach,
           "Missing delimiter; '.' inserted");
       }
       Ok(Vec::new())
@@ -172,7 +172,7 @@ LoadDefinitions!(state, {
       else if whatsit.get_arg(1).unwrap().get_property_string("role") == "CLOSE" {
         whatsit.get_arg_mut(1).unwrap().set_property("stretchy", true);
       } else {
-        Warn!("unexpected", delim, stomach, state,
+        Warn!("unexpected", delim, stomach,
           "Missing delimiter; '.' inserted");
       }
       Ok(Vec::new())

--- a/rtx_package/src/package/latex_functions.rs
+++ b/rtx_package/src/package/latex_functions.rs
@@ -143,24 +143,24 @@ fn relocate_footnote_aux(
   // textnote.get_parent().unwrap().remove_child(textnote);
   textnote.unlink();
   document.append_clone(marknote, textnote.get_child_nodes(), state)?;
-  document.set_attribute(marknote, "role", notetype, state)?;
+  document.set_attribute(marknote, "role", notetype)?;
   if let Some(labels) = textnote.get_attribute("labels") {
     document.generate_id(marknote, "", state)?;
-    document.set_attribute(marknote, "labels", &labels, state)?;
+    document.set_attribute(marknote, "labels", &labels)?;
   }
   Ok(())
 }
 
-pub fn only_preamble(cs: &str, stomach: &mut Stomach, state: &mut State) {
+pub fn only_preamble(cs: &str, stomach: &mut Stomach, state: &mut State) -> Result<()> {
   if !state.lookup_bool("inPreamble") {
     Error!(
       "unexpected",
       cs,
       stomach,
-      state,
       "The current command '{cs}' can only appear in the preamble"
     );
   }
+  Ok(())
 }
 
 pub fn tabular_bindings(
@@ -205,7 +205,7 @@ pub fn tabular_bindings(
     properties.insert(
       String::from("strut"),
       state
-        .lookup_register("\\baselineskip", Vec::new())
+        .lookup_register("\\baselineskip", Vec::new())?
         .unwrap()
         .multiply(Float::new_f64(1.5))
         .into(),
@@ -230,10 +230,10 @@ pub fn tabular_bindings(
     "@column@after",
   ] {
     let cs = T_CS!(s!("\\{name}"));
-    let cs_def = state.lookup_definition(&cs).unwrap();
+    let cs_def = state.lookup_definition(&cs)?.unwrap();
     let mut expansion = cs_def.get_expansion().cloned().unwrap_or_default();
     expansion.push(T_CS!(s!("\\@tabular{name}")));
-    def_macro(cs, None, expansion, None, state);
+    def_macro(cs, None, expansion, None, state)?;
   }
   Ok(())
 }

--- a/rtx_package/src/package/latex_hook.rs
+++ b/rtx_package/src/package/latex_hook.rs
@@ -8,7 +8,7 @@ LoadDefinitions!(state, {
   RelaxNGSchema!("LaTeXML");
   Tag!("ltx:section", auto_close => true);
   Tag!("ltx:document", auto_close => true, auto_open => true);
-  Tag!("ltx:document", after_open => sub[document,root,state] {
+  Tag!("ltx:document", after_open => sub[document,root,_state] {
     let mut bg_to_set = None;
     if let Some(bg) = document.get_node_font(root).get_background() {
       if bg != "white" {
@@ -16,7 +16,7 @@ LoadDefinitions!(state, {
       }
     }
     if let Some(bg) = bg_to_set {
-      document.set_attribute(root, "backgroundcolor", &bg, state)?;
+      document.set_attribute(root, "backgroundcolor", &bg)?;
     }
   });
 

--- a/rtx_package/src/package/latex_other_in_appendices.rs
+++ b/rtx_package/src/package/latex_other_in_appendices.rs
@@ -83,7 +83,7 @@ LoadDefinitions!(state, {
       Some('\\') => arg_chars.next().unwrap(),
       Some(other) => other,
       None => {
-        Warn!("expected","character",gullet,state,"\\@makeother called on empty argument?");
+        Warn!("expected","character",gullet ,"\\@makeother called on empty argument?");
         return Ok(Tokens!());
       }};
     state.assign_catcode(arg_c, Catcode::OTHER, Some(Scope::Local));
@@ -143,7 +143,7 @@ LoadDefinitions!(state, {
   DefMacro!("\\ltx@hard@MessageBreak", None, "^^J");
 
   DefPrimitive!("\\@onlypreamble{}", sub[stomach,(arg),state] {
-    only_preamble("\\@onlypreamble", stomach, state); }); // Don't bother enforcing this.
+    only_preamble("\\@onlypreamble", stomach, state)?; }); // Don't bother enforcing this.
   DefPrimitive!("\\GenericError{}{}{}{}", sub[stomach,(arg1,arg2,arg3,arg4),state] {
     make_generic_message("\\GenericError", vec![arg2, arg3, arg4], "error", stomach, state)?;
   });

--- a/rtx_package/src/package/multido_sty.rs
+++ b/rtx_package/src/package/multido_sty.rs
@@ -50,7 +50,7 @@ LoadDefinitions!(state, {
         if let Some(cap) = DNIR_REX.captures(&csname) {
           let vtype = cap.get(1).map_or(String::new(), |m| m.as_str().to_lowercase());
           if gullet.read_keyword(&["="], state)?.is_none() {
-            Error!("expected", "=", gullet, state, "Missing = in multido variables");
+            Error!("expected", "=", gullet, "Missing = in multido variables");
           }
           let init = match vtype.as_str() {
             "d" => Tokens!(Explode!(s!("{}sp", gullet.read_dimension(state)?.value_of()))),
@@ -65,7 +65,7 @@ LoadDefinitions!(state, {
           inits.extend(init.unlist());
           inits.push(T_END!());
           if gullet.read_keyword(&["+"], state)?.is_none() {
-            Error!("expected", "+", gullet, state, "Missing + in multido variables");
+            Error!("expected", "+", gullet, "Missing + in multido variables");
           }
           let needs_negate = state.lookup_int("\\multido@count") < 0;
           let step = match vtype.as_str() {
@@ -100,7 +100,7 @@ LoadDefinitions!(state, {
             break;
           }
         }  else {
-          Error!("unexpected", var, gullet, state,
+          Error!("unexpected", var, gullet,
             format!("Wrong format for multido variable {var:?}"));
         }
         gullet.skip_spaces(state)?;

--- a/rtx_package/src/package/rtx_math_macros.rs
+++ b/rtx_package/src/package/rtx_math_macros.rs
@@ -172,11 +172,11 @@ LoadDefinitions!(_state, {
   DefConstructor!("\\lx@dual OptionalKeyVals:XMath {}{}",
   "<ltx:XMDual role='#role' name='#name' meaning='#meaning' omcd='#omcd' width='#width' height='#height' xoffset='#xoffset' yoffset='#yoffset' lpadding='#lpadding' rpadding='#rpadding'>#2<ltx:XMWrap>#3</ltx:XMWrap></ltx:XMDual>",
   before_digest => sub[_stomach,state] {
-    state.push_value("PENDING_DUAL_XMARGS", Stored::HashStored(HashMap::default()));
+    state.push_value("PENDING_DUAL_XMARGS", Stored::HashStored(HashMap::default()))
   },
   after_digest => sub[_stomach,whatsit,state] {
     let kv     = whatsit.get_arg(1);
-    if let Some(Stored::HashStored(xmargs)) = state.pop_value("PENDING_DUAL_XMARGS") { // Really SHOULD be a hash
+    if let Some(Stored::HashStored(xmargs)) = state.pop_value("PENDING_DUAL_XMARGS")? { // Really SHOULD be a hash
       whatsit.set_properties(xmargs);  // Hopefully no name class with XM<digits>
     }
     // TODO:
@@ -312,7 +312,7 @@ LoadDefinitions!(_state, {
     }
     for mut r in refs {                        // Now fill in the references
       let r_xmkey = r.get_attribute("_xmkey").unwrap();
-      document.set_attribute(&mut r, "idref", ids.get(&r_xmkey).unwrap(), state)?;
+      document.set_attribute(&mut r, "idref", ids.get(&r_xmkey).unwrap())?;
       r.remove_attribute("_xmkey")?;
     }
   });

--- a/rtx_package/src/package/setup_binding_language.rs
+++ b/rtx_package/src/package/setup_binding_language.rs
@@ -459,7 +459,7 @@ macro_rules! TypedConditional {
           let $var: parameter_rust_type!($ptype) = match $var.try_into() {
             Ok(v) => v,
             Err(e) => {
-              Error!("expected", "argument", $gullet, None, e);
+              Error!("expected", "argument", $gullet, e);
               <parameter_rust_type!($ptype)>::default()
             }
           };
@@ -479,7 +479,7 @@ macro_rules! defi_conditional {
     defi_conditional!($cs, $paramlist, $test, $options, gullet, st);
   }};
   ($cs:expr, $paramlist:expr, $test:expr, $options:expr, $gullet:ident, $state_arg:ident) => {{
-    def_conditional($cs, $paramlist, $test, $options, $gullet, $state_arg);
+    def_conditional($cs, $paramlist, $test, $options, $gullet, $state_arg)?;
   }};
 }
 
@@ -610,7 +610,7 @@ macro_rules! TypedPrimitive {
           let $var: parameter_rust_type!($ptype) = match $var.try_into() {
             Ok(v) => v,
             Err(e) => {
-              Error!("expected", "argument", $stomach_arg, None, e);
+              Error!("expected", "argument", $stomach_arg, e);
               <parameter_rust_type!($ptype)>::default()
             }
           };
@@ -628,7 +628,7 @@ macro_rules! defi_primitive(
     defi_primitive!($cs, $params, $compiled_replacement, $options, st)
   }};
   ($cs:expr, $params:expr, $compiled_replacement:expr, $options:expr, $state_arg:ident) => {{
-    def_primitive($cs, $params, $compiled_replacement, $options, $state_arg);
+    def_primitive($cs, $params, $compiled_replacement, $options, $state_arg)?;
   }};
 );
 
@@ -646,7 +646,7 @@ macro_rules! LookupRegister {
       defn.value_of($parameters, $state_arg).unwrap_or_default()
     } else {
       let message = s!("The control sequence {:?} is not a register", $cs);
-      Warn!("expected", "register", None, $state_arg, message);
+      Warn!("expected", "register", None, message);
       RegisterValue::default()
     }
   };
@@ -927,7 +927,7 @@ macro_rules! defi_math {
     let cs = T_CS!($cstext.to_string());
     let presentation = $presentation.to_string();
     let paramlist: Option<Parameters> = $paramlist;
-    def_math(cs, paramlist, presentation, options, $state_arg);
+    def_math(cs, paramlist, presentation, options, $state_arg)?;
   }};
 }
 
@@ -986,7 +986,7 @@ macro_rules! CounterValue {
 macro_rules! AddToCounter {
   ($ctr:expr, $value:expr, $gullet:ident) => {{
     bind_state_mut!(st);
-    add_to_counter($ctr, $value, $gullet, st)
+    add_to_counter($ctr, $value, $gullet, st)?
   }};
   ($ctr:expr, $value:expr, $gullet:ident, $state_arg:ident) => {
     add_to_counter($ctr, $value, $gullet, $state_arg)
@@ -1034,14 +1034,14 @@ macro_rules! RefStepID {
 macro_rules! ResetCounter {
   ($ctr:literal) => {{
     bind_state_mut!(st);
-    reset_counter(&T_OTHER!($ctr), st)
+    reset_counter(&T_OTHER!($ctr), st)?
   }};
   ($ctr:expr) => {{
     bind_state_mut!(st);
-    reset_counter($ctr, st)
+    reset_counter($ctr, st)?
   }};
   ($ctr:expr, $state_arg: ident) => {
-    reset_counter($ctr, $state_arg)
+    reset_counter($ctr, $state_arg)?
   };
 }
 
@@ -1159,7 +1159,7 @@ macro_rules! DefAccent {
         T_CS!("\\lx@applyaccent"), T_OTHER!($accent),
         T_OTHER_CHAR!($combiningchar), T_OTHER!($standalonechar),
         T_BEGIN!(), T_ARG!(1), T_END!())),
-      Some(ExpandableOptions{protected: true, ..ExpandableOptions::default()}), $state);
+      Some(ExpandableOptions{protected: true, ..ExpandableOptions::default()}), $state)?;
   }};
 }
 
@@ -1261,14 +1261,14 @@ macro_rules! RemoveValue {
 macro_rules! PushValue {
   ($name:expr => $values:expr) => {{
     bind_state_mut!(st);
-    st.push_value($name, $values)
+    st.push_value($name, $values)?
   }};
   ($name:expr, $values:expr) => {{
     bind_state_mut!(st);
-    st.push_value($name, $values)
+    st.push_value($name, $values)?
   }};
   ($name:expr, $values:expr, $state_arg:ident) => {
-    $state_arg.push_value($name, $values)
+    $state_arg.push_value($name, $values)?
   };
 }
 #[macro_export]
@@ -1389,7 +1389,7 @@ macro_rules! LookupDefinition {
     LookupDefinition!($name, st)
   }};
   ($name:expr, $state_arg:ident) => {
-    $state_arg.lookup_definition($name)
+    $state_arg.lookup_definition($name)?
   };
 }
 #[macro_export]
@@ -1613,7 +1613,7 @@ macro_rules! DefMacro {
   }};
   // explicit state, for nested macro factories
   ($cs:expr, None, $expansion:expr, $state_arg:ident) => {{
-    def_macro($cs, None, $expansion, None, $state_arg);
+    def_macro($cs, None, $expansion, None, $state_arg)?;
   }};
   ($cs:expr, None, $expansion:literal, $($input:tt)+) => {{
     let compiled_expansion;
@@ -1656,7 +1656,7 @@ macro_rules! TypedMacro {
           let $var: parameter_rust_type!($ptype) = match $var.try_into() {
             Ok(v) => v,
             Err(e) => {
-              Error!("expected", "argument", $gullet, None, e);
+              Error!("expected", "argument", $gullet, e);
               <parameter_rust_type!($ptype)>::default()
             }
           };
@@ -1677,7 +1677,7 @@ macro_rules! defi_macro {
     defi_macro!($cs, $paramlist, $compiled_replacement, $options, st);
   }};
   ($cs:expr, $paramlist:expr, $compiled_replacement:expr, $options:expr, $state_arg:ident) => {
-    def_macro($cs, $paramlist, $compiled_replacement, $options, $state_arg);
+    def_macro($cs, $paramlist, $compiled_replacement, $options, $state_arg)?;
   };
 }
 
@@ -1859,12 +1859,11 @@ macro_rules! DefColumnType {
         $expansion_closure,
         None,
         st,
-      );
+      )?;
     } else {
       Warn!(
         "expected",
         "character",
-        None,
         None,
         "Expected Column specifier"
       );
@@ -2085,7 +2084,7 @@ macro_rules! DocType {
 macro_rules! Today {
   () => {{
     bind_state_mut!(st);
-    today(st)
+    today(st)?
   }};
 }
 
@@ -2105,7 +2104,7 @@ macro_rules! DeclareOption {
   };
   (None, $tokenized:ident, $outer_state: ident) => {
     let cs = String::from("\\default@ds");
-    def_macro(T_CS!(cs), None, $tokenized, None, $outer_state);
+    def_macro(T_CS!(cs), None, $tokenized, None, $outer_state)?;
   };
   (None, sub $body:block) => {
     bind_state_mut!(st);
@@ -2125,7 +2124,7 @@ macro_rules! DeclareOption {
     let code: PrimitiveClosure = Rc::new(move |$stomach, _args, $inner_state|
       WithInnerState!($body, $stomach, $inner_state).into_digested_result()
     );
-    def_primitive(T_CS!(cs), None, Some(code), PrimitiveOptions::default(), $outer_state);
+    def_primitive(T_CS!(cs), None, Some(code), PrimitiveOptions::default(), $outer_state)?;
   };
   ($option:expr, None) => {
     bind_state_mut!(st);
@@ -2135,17 +2134,17 @@ macro_rules! DeclareOption {
     bind_state_mut!(st);
     let tokenized;
     compile_tokenize_internal!(tokenized, $tex);
-    st.push_value("@declaredoptions", $option);
+    st.push_value("@declaredoptions", $option)?;
     let cs = s!("\\ds@{}", $option);
     // literal case, create a macro
-    def_macro(T_CS!(cs),None,tokenized,None,st);
+    def_macro(T_CS!(cs),None,tokenized,None,st)?;
   };
   ($option:expr, $tokenized:ident) => {
     bind_state_mut!(st);
-    st.push_value("@declaredoptions", $option.to_string());
+    st.push_value("@declaredoptions", $option.to_string())?;
     let cs = s!("\\ds@{}", $option);
     // literal case, create a macro
-    def_macro(T_CS!(cs),None, $tokenized, None, st);
+    def_macro(T_CS!(cs),None, $tokenized, None, st)?;
   };
   ($option:expr, sub $body:block) => {
     bind_state_mut!(st);
@@ -2160,13 +2159,13 @@ macro_rules! DeclareOption {
     DeclareOption!($option, sub[$stomach, $state] $body, st)
   };
   ($option:expr, sub[$stomach:ident, $inner_state:ident] $body:block, $outer_state: ident) => {
-    $outer_state.push_value("@declaredoptions", $option);
+    $outer_state.push_value("@declaredoptions", $option)?;
     let cs = s!("\\ds@{}", $option);
     // block case, create a primitive
     let code: PrimitiveClosure = Rc::new(move |$stomach, _args, $inner_state|
       WithInnerState!($body, $stomach, $inner_state).into_digested_result()
     );
-    def_primitive(T_CS!(cs), None, Some(code), PrimitiveOptions::default(), $outer_state);
+    def_primitive(T_CS!(cs), None, Some(code), PrimitiveOptions::default(), $outer_state)?;
   }
 }
 
@@ -2192,11 +2191,11 @@ macro_rules! AddToMacro {
   }};
   ($cs:ident, $tokens:ident, $organ:ident, $state:ident) => {{
     // Needs error checking!
-    let defn = $state.lookup_definition(&$cs);
+    let defn = $state.lookup_definition(&$cs)?;
     if defn.is_none() || !defn.as_ref().unwrap().is_expandable() {
       let message = s!("{} is not an expandable control sequence", $cs);
       let message2 = "Ignoring addition";
-      Warn!("unexpected", $cs, $organ, $state, message, message2);
+      Warn!("unexpected", $cs, $organ, message, message2);
     } else {
       let mut expansion = match defn.unwrap().get_expansion() {
         // the .clone() call is again avoidable with a careful refactor via e.g. using
@@ -2213,7 +2212,6 @@ macro_rules! AddToMacro {
             "unexpected",
             "ExpandableBody::Closure",
             $organ,
-            $state,
             message
           );
           Vec::new()
@@ -2231,7 +2229,7 @@ macro_rules! AddToMacro {
           ..ExpandableOptions::default()
         }),
         $state,
-      );
+      )?;
     }
   }};
 }

--- a/rtx_package/src/package/tex_alignment.rs
+++ b/rtx_package/src/package/tex_alignment.rs
@@ -104,13 +104,13 @@ LoadDefinitions!(outer_state, {
   // Handled directly in alignments, but must be defined as non-macros
   DefPrimitive!("\\noalign", sub[stomach,_args,state] {
       stomach.bgroup(state);
-      Error!("unexpected", "\\noalign", stomach, state, "\\noalign cannot be used here");
+      Error!("unexpected", "\\noalign", stomach, "\\noalign cannot be used here");
       Let!(&T_ALIGN!(),          T_RELAX!());
       Let!(&T_CS!("\\noalign"), T_RELAX!());
       Let!(&T_CS!("\\omit"),    T_RELAX!());
       Let!(&T_CS!("\\span"),    T_RELAX!()); });
   DefPrimitive!("\\omit", sub[stomach,_args,state] {
-      Error!("unexpected", "\\omit", stomach, state, "\\omit cannot be used here");
+      Error!("unexpected", "\\omit", stomach, "\\omit cannot be used here");
       stomach.bgroup(state);
       Let!(&T_ALIGN!(),          T_RELAX!());
       Let!(&T_CS!("\\noalign"), T_RELAX!());
@@ -118,7 +118,7 @@ LoadDefinitions!(outer_state, {
       Let!(&T_CS!("\\span"),    T_RELAX!()); });
   DefPrimitive!("\\span", sub[stomach,_args,state] {
       stomach.bgroup(state);
-      Error!("unexpected", "\\span", stomach, state, "\\span cannot be used here");
+      Error!("unexpected", "\\span", stomach, "\\span cannot be used here");
       Let!(&T_ALIGN!(),          T_RELAX!());
       Let!(&T_CS!("\\noalign"), T_RELAX!());
       Let!(&T_CS!("\\omit"),    T_RELAX!());
@@ -335,7 +335,7 @@ LoadDefinitions!(outer_state, {
       if tbox.get_property_bool("alignmentSkippable")
         || tbox.get_property_bool("isFill") {
         save.push(tbox);
-      } else if !tbox.is_empty() {
+      } else if !tbox.is_empty()? {
         stomach.box_list.push(tbox);
         break;
       }
@@ -425,7 +425,6 @@ pub fn digest_alignment_body(
       "missing",
       "alignment",
       stomach,
-      state,
       "There is no open alignment structure here"
     );
     return Ok(());
@@ -456,7 +455,7 @@ pub fn digest_alignment_body(
           .unlist()
           .into_iter(),
       );
-      extract_alignment_column(alignment_cell.borrow_mut(), cell, state);
+      extract_alignment_column(alignment_cell.borrow_mut(), cell, state)?;
     } else {
       // Debug("Halign $alignment: BODY DONE!") if $LaTeXML::DEBUG{halign};
       break;
@@ -495,7 +494,6 @@ pub fn digest_alignment_body(
         "unexpected",
         next_tok,
         stomach,
-        state,
         s!("Column ended with {next_tok}")
       );
     }
@@ -588,7 +586,7 @@ pub fn digest_alignment_column(
     // Next column, unless spanning (then combine columns)
     if spanning {
       spanning = false;
-      alignment.borrow_mut().next_column();
+      alignment.borrow_mut().next_column()?;
     } else {
       alignment.borrow_mut().start_column(false, stomach, state)?;
     }
@@ -689,7 +687,7 @@ pub fn extract_alignment_column(
   mut alignment: RefMut<Alignment>,
   in_box: Digested,
   state: &mut State,
-) -> Digested {
+) -> Result<Digested> {
   let mut boxes = VecDeque::new();
   boxes.extend(in_box.unlist());
   let is_math = state.lookup_bool("IN_MATH");
@@ -723,7 +721,7 @@ pub fn extract_alignment_column(
           || front_box.get_property("alignmentSkippable").is_some()
           || front_box.get_property("isSpace").is_some()
           || matches!(item, DigestedData::Comment(_))
-          || front_box.is_empty() =>
+          || front_box.is_empty()? =>
       {
         saveleft.push_front(front_box)
       },
@@ -755,7 +753,7 @@ pub fn extract_alignment_column(
           || last_box.get_property("alignmentSkippable").is_some()
           || last_box.get_property("isSpace").is_some()
           || matches!(item, DigestedData::Comment(_))
-          || last_box.is_empty() =>
+          || last_box.is_empty()? =>
       {
         saveright.push_front(last_box);
       },
@@ -793,5 +791,5 @@ pub fn extract_alignment_column(
   //     $$c{skipped} = 1 if $c; }
   //   Debug("Halign $alignment: INSTALL column " . join(',', map { $_ . "=" .
   // ToString($$colspec{$_}); } sort keys %$colspec)) if $LaTeXML::DEBUG{halign};
-  digested_out
+  Ok(digested_out)
 }

--- a/rtx_package/src/package/tex_appendix_b_p358.rs
+++ b/rtx_package/src/package/tex_appendix_b_p358.rs
@@ -352,7 +352,7 @@ LoadDefinitions!(state, {
       if let Some(id) = not_node.get_attribute_ns("id",XML_NS) {
         not_node.remove_attribute("xml:id")?;
         document.unrecord_id(&id);
-        document.set_attribute(&mut strike, "xml:id", &id, state)?;
+        document.set_attribute(&mut strike, "xml:id", &id)?;
         document.get_node_mut().add_child(thing)?;
         document.close_element("ltx:XMApp", state)?;
       }
@@ -364,11 +364,11 @@ LoadDefinitions!(state, {
       }
 
       if let Some(meaning) = thing.get_attribute("meaning") {
-        document.set_attribute(thing, "meaning",  &format!("not-{meaning}"), state)?; }
+        document.set_attribute(thing, "meaning",  &format!("not-{meaning}"))?; }
       if let Some(name) = thing.get_attribute("name") {
-        document.set_attribute(thing, "name", &format!("not-{name}"), state)?; }
+        document.set_attribute(thing, "name", &format!("not-{name}"))?; }
       else if !text.is_empty() {
-        document.set_attribute(thing, "name", &format!("not-{text}"), state)?; }
+        document.set_attribute(thing, "name", &format!("not-{text}"))?; }
 
       let known_c = MATH_CHAR_NEGATIONS.get(&text);
       let new : Cow<'_, str> = match known_c {

--- a/rtx_package/src/package/tex_appendix_b_to_p349.rs
+++ b/rtx_package/src/package/tex_appendix_b_to_p349.rs
@@ -18,7 +18,7 @@ LoadDefinitions!(state, {
   //
   // & gives an error except within the right context
   // (which should redefine it!)
-  DefConstructor!("&", sub[doc,_a,state] { Error!("unexpected", "&", doc, state, "Stray alignment \"&\""); });
+  DefConstructor!("&", sub[doc,_a,state] { Error!("unexpected", "&", doc, "Stray alignment \"&\""); });
 
   //**********************************************************************
   // Plain;  Extracted from Appendix B.
@@ -400,7 +400,7 @@ LoadDefinitions!(state, {
   // TeX Book, Appendix B, p. 348
 
   DefMacro!("\\newif DefToken", sub[gullet, (cs), state] {
-    def_conditional(cs, None,None,ConditionalOptions::default(),gullet,state);
+    def_conditional(cs, None,None,ConditionalOptions::default(),gullet,state)
   });
 
   // See the section Registers & Parameters, above for setting default values.

--- a/rtx_package/src/package/tex_assignment.rs
+++ b/rtx_package/src/package/tex_assignment.rs
@@ -78,7 +78,7 @@ LoadDefinitions!(outer_state, {
     } else { // Failed?
       let message = s!("Unrecognized font name {:?} Font switch macro {:?}
       will have no effect", name, cs.stringify());
-      Info!("unexpected", name, gullet, state, message);
+      Info!("unexpected", name, gullet, message);
       None
     };
     gullet.skip_spaces(state)?;
@@ -124,7 +124,7 @@ LoadDefinitions!(outer_state, {
         } else {
           let message = s!("\\advance expected a defined variable for {:?}, found no definition",
           defn_token_str);
-          Error!("expected","definition", stomach, state, message);
+          Error!("expected","definition", stomach, message);
         }
         state.expire_current_token();
       }
@@ -142,11 +142,11 @@ LoadDefinitions!(outer_state, {
       } else {
         let message =
           s!("\\multiply expected a defined variable for {:?}, found no definition", varname);
-        Error!("expected","definition", stomach, state, message);
+        Error!("expected","definition", stomach, message);
       }
     } else {
       let message = s!("\\multiply expected a Variable argument, but got nothing.");
-      Error!("expected","variable", stomach, state, message);
+      Error!("expected","variable", stomach, message);
     }
   });
 
@@ -159,18 +159,18 @@ LoadDefinitions!(outer_state, {
         let defn_value = defn.value_of(inner, state).unwrap_or_default();
         let mut denominator = scale.value_f64();
         if denominator == 0.0 {
-          Error!("misdefined", scale, stomach, state, "Illegal \\divide by 0; assuming 1");
+          Error!("misdefined", scale, stomach, "Illegal \\divide by 0; assuming 1");
           denominator = 1.0;
         }
         defn.set_value(defn_value.divide(Float::new_f64(denominator)), defn_args, state);
       } else {
         let message =
           s!("\\divide expected a defined variable for {:?}, found no definition", varname);
-        Error!("expected","definition", stomach, state, message);
+        Error!("expected","definition", stomach, message);
       }
     } else {
       let message = s!("\\divide expected a Variable argument, but got nothing.");
-      Error!("expected","variable", stomach, state, message);
+      Error!("expected","variable", stomach, message);
     }
   });
 

--- a/rtx_package/src/package/tex_boxes.rs
+++ b/rtx_package/src/package/tex_boxes.rs
@@ -63,7 +63,7 @@ LoadDefinitions!(state, {
     let box_key   = s!("box{}", number.value_of());
     if let Some(Stored::Digested(ref stuff)) = state.lookup_value(&box_key) {
       adjust_box_color(stuff, state)?;
-      if stuff.is_empty() { Digested::from(List::default()) } else { stuff.clone() }
+      if stuff.is_empty()? { Digested::from(List::default()) } else { stuff.clone() }
     } else {
       Digested::from(List::default())
     }

--- a/rtx_package/src/package/tex_ch24_primitives.rs
+++ b/rtx_package/src/package/tex_ch24_primitives.rs
@@ -64,7 +64,7 @@ LoadDefinitions!(state, {
     before_digest => sub[stomach,state] { stomach.bgroup(state); },
     capture_body => true,
     reversion=> sub[whatsit, _args,state] {
-      if let Some(body) = whatsit.get_body() {
+      if let Some(body) = whatsit.get_body()? {
         body.revert(state)
       } else { Ok(Tokens!()) }
     }
@@ -147,7 +147,7 @@ LoadDefinitions!(state, {
   // \aftergroup saves ALL tokens (from repeated calls) to be executed IN ORDER after the next
   // egroup or }
   DefPrimitive!("\\aftergroup Token", sub[stomach, (t), state] {
-    state.push_value("afterGroup", t);
+    state.push_value("afterGroup", t)
   });
 
   // \uppercase<general text>, \lowercase<general text>
@@ -322,7 +322,7 @@ LoadDefinitions!(state, {
       gullet.unread_vec(kv);
       gullet.unread_one(T_CS!("\\ltx@special@graphics"));
     } else {
-      Info!("ignored", "special", stomach, state, s!("Unrecognized TeX Special: {arg}"));
+      Info!("ignored", "special", stomach, s!("Unrecognized TeX Special: {arg}"));
     }
   });
 
@@ -405,7 +405,7 @@ LoadDefinitions!(state, {
         parent.set_attribute("transform", &transform)?;
       }
     } else if in_svg(document,state) {
-      Warn!("unexpected", "kern", document, state, s!("Lost kern in SVG {length}"));
+      Warn!("unexpected", "kern", document, s!("Lost kern in SVG {length}"));
     }
   });
   DefMacro!(
@@ -418,7 +418,7 @@ LoadDefinitions!(state, {
   DefPrimitive!("\\unskip", sub[stomach,(),state] {
     // pop until a non-empty box is found
     while let Some(last_box) = stomach.box_list.pop() {
-      if !last_box.is_empty() {
+      if !last_box.is_empty()? {
         stomach.box_list.push(last_box);
         break;
       }

--- a/rtx_package/src/package/tex_expandable_primitives.rs
+++ b/rtx_package/src/package/tex_expandable_primitives.rs
@@ -38,10 +38,13 @@ LoadDefinitions!(outer_state, {
       } else {
         t
       }});
-    let token = token_opt.unwrap_or_else(|| {
-      Error!("expected", "ExpandedIfToken", gullet, state,
-        "conditional expected a token argument, came back empty. Falling back to \\@empty");
-      T_CS!("\\@empty") });
+    let token = match token_opt {
+      Some(t) => t,
+      None => {
+        Error!("expected", "ExpandedIfToken", gullet,
+          "conditional expected a token argument, came back empty. Falling back to \\@empty");
+        T_CS!("\\@empty")
+      }};
     if token.has_smuggled() {    // marked dont_expand
       let smuggled = token.get_dont_expand().as_ref().unwrap();
       if smuggled.get_catcode() == Catcode::ACTIVE {
@@ -67,9 +70,9 @@ LoadDefinitions!(outer_state, {
     state.x_equals(&left, &right)
   });
 
-  DefConditional!("\\ifvoid Number", sub[_g, (arg), state] { classify_box(arg, state).is_empty() });
-  DefConditional!("\\ifhbox Number", sub[_g, (arg), state] { classify_box(arg, state) == "hbox" });
-  DefConditional!("\\ifvbox Number", sub[_g, (arg), state] { classify_box(arg, state) == "vbox" });
+  DefConditional!("\\ifvoid Number", sub[_g, (arg), state] { classify_box(arg, state)?.is_empty() });
+  DefConditional!("\\ifhbox Number", sub[_g, (arg), state] { classify_box(arg, state)? == "hbox" });
+  DefConditional!("\\ifvbox Number", sub[_g, (arg), state] { classify_box(arg, state)? == "vbox" });
 
   DefConditional!("\\iftrue", { true });
   DefConditional!("\\iffalse", { false });
@@ -255,14 +258,14 @@ LoadDefinitions!(outer_state, {
       }
       match token.get_catcode() {
         Catcode::CS => {
-          if let Some(defn) = state.lookup_definition(&token) {
+          if let Some(defn) = state.lookup_definition(&token)? {
             let message =
               s!("The control sequence {:?} should not appear between \\csname and \\endcsname",
                 token);
-            Error!("unexpected", token, gullet, state, message);
+            Error!("unexpected", token, gullet, message);
           } else {
             let message = s!("The token {:?} is not defined", token);
-            Error!("undefined", token, gullet, state, message);
+            Error!("undefined", token, gullet, message);
           }
         },
         Catcode::SPACE => {  // Keep newlines from having \n!
@@ -285,12 +288,12 @@ LoadDefinitions!(outer_state, {
   });
 
   DefPrimitive!("\\endcsname", sub[stomach, (), state] {
-    Error!("unexpected" ,"\\endcsname", stomach, state, "Extra \\endcsname");
+    Error!("unexpected" ,"\\endcsname", stomach, "Extra \\endcsname");
   });
 
   DefMacro!("\\expandafter Token Token", sub[gullet, (tok, xtok), state] {
     let mut tokens : Vec<Token> = vec![tok];
-    if let Some(defn) = state.lookup_expandable(&xtok, false) {
+    if let Some(defn) = state.lookup_expandable(&xtok, false)? {
       state.local_current_token(xtok);
       let invoked = defn.invoke(gullet, true, state)?;
       if !invoked.is_empty() {
@@ -375,7 +378,7 @@ LoadDefinitions!(outer_state, {
       };
       tokens
     } else {
-      Error!("expected", "<register>", gullet, state, "a register was expected to be here");
+      Error!("expected", "<register>", gullet, "a register was expected to be here");
       Vec::new()
     }
   });
@@ -383,7 +386,7 @@ LoadDefinitions!(outer_state, {
 
 // Hmm... I wonder, should getString itself be dealing with escapechar?
 fn escapechar(state: &mut State) -> String {
-  let code: i64 = match state.lookup_register("\\escapechar", Vec::new()) {
+  let code: i64 = match state.lookup_register("\\escapechar", Vec::new()).unwrap() {
     Some(RegisterValue::Number(v)) => v.value_of(),
     _ => -1,
   };
@@ -413,7 +416,8 @@ fn compare(u: i64, rel: Token, v: i64) -> bool {
       rel,
       rel.get_catcode()
     );
-    Error!("expected", "<relationaltoken>", None, None, message);
+    let err = || {Error!("expected", "<relationaltoken>", None, message); Ok(())};
+    err().ok();
     false
   }
 }

--- a/rtx_package/src/package/tex_fonts.rs
+++ b/rtx_package/src/package/tex_fonts.rs
@@ -72,8 +72,10 @@ LoadDefinitions!(outer_state, {
       match thebox.get_width(None, state) {
         Ok(v) => v,
         Err(e) => {
-          Error!("method", "get_width", None, state, format!("{e}"));
-          None }
+          let err = || {Error!("method", "get_width", None, format!("{e}")); Ok(()) };
+          err().ok();
+          None
+        }
       }
     } else {
       Some(RegisterValue::Dimension(Dimension::default()))
@@ -168,7 +170,7 @@ LoadDefinitions!(outer_state, {
     if LoadFontMap!(&encoding).is_some() {
       MergeFont!(encoding => encoding);
     } else {
-      Info!("missing_font_encoding", encoding, stomach, state,
+      Info!("missing_font_encoding", encoding, stomach,
         "Couldn't find font encoding, falling back to OT1");
       // Default to OT1 encoding if no map found
       MergeFont!(encoding => "OT1");

--- a/rtx_package/src/package/tex_frontmatter.rs
+++ b/rtx_package/src/package/tex_frontmatter.rs
@@ -155,7 +155,7 @@ LoadDefinitions!(state, {
   Tag!("ltx:document", after_open_late => sub[document, root, state] {
     let classes = LookupMappingKeys!("DOCUMENT_CLASSES").join(" ");
     if !classes.is_empty()  {
-      document.add_class(root, &classes, state)?;
+      document.add_class(root, &classes)?;
     }
   });
 

--- a/rtx_package/src/package/tex_functions.rs
+++ b/rtx_package/src/package/tex_functions.rs
@@ -42,7 +42,7 @@ pub fn neutralize_font(state: &mut State) {
   state.assign_value("mathfont", Font::math_default(), Some(Scope::Local));
 }
 
-pub fn today(state: &mut State) -> String {
+pub fn today(state: &mut State) -> Result<String> {
   let month_names = [
     "January",
     "February",
@@ -58,10 +58,10 @@ pub fn today(state: &mut State) -> String {
     "December",
   ];
   let month =
-    month_names[state.lookup_register("\\month", vec![]).unwrap().value_of() as usize - 1];
-  let day = state.lookup_register("\\day", vec![]).unwrap().value_of();
-  let year = state.lookup_register("\\year", vec![]).unwrap().value_of();
-  s!("{} {}, {}", month, day, year)
+    month_names[state.lookup_register("\\month", vec![])?.unwrap().value_of() as usize - 1];
+  let day = state.lookup_register("\\day", vec![])?.unwrap().value_of();
+  let year = state.lookup_register("\\year", vec![])?.unwrap().value_of();
+  Ok(s!("{} {}, {}", month, day, year))
 }
 
 pub fn parse_def_parameters(
@@ -70,7 +70,7 @@ pub fn parse_def_parameters(
   state: &mut State,
 ) -> Result<Option<Parameters>> {
   let mut tokens: VecDeque<Token> =
-    VecDeque::from(params_in.pack_parameters().unlist());
+    VecDeque::from(params_in.pack_parameters()?.unlist());
   // Now, recognize parameters and delimiters.
   let mut params = Vec::new();
   let mut n = 0;
@@ -212,7 +212,7 @@ pub fn do_def(
         ..ExpandableOptions::default()
       }),
       state,
-    ),
+    )?,
     scope,
   );
   state.after_assignment(stomach.get_gullet_mut());
@@ -222,18 +222,18 @@ pub fn do_def(
 // Kinda rough: We don't really keep track of modes as carefully as TeX does.
 // We'll assume that a box is horizontal if there's anything at all,
 // but it's not a vbox (!?!?)
-pub fn classify_box(boxnum: Number, state: &State) -> &'static str {
+pub fn classify_box(boxnum: Number, state: &State) -> Result<&'static str> {Ok(
   match state.lookup_value(&s!("box{}", boxnum.value_of())) {
     Some(Stored::Digested(ref d)) => match d.data() {
       DigestedData::Whatsit(ref w)
-        if w.borrow().definition == state.lookup_definition(&T_CS!("\\vbox")).unwrap() =>
+        if w.borrow().definition == state.lookup_definition(&T_CS!("\\vbox"))?.unwrap() =>
       {
         "vbox"
       },
       _ => "hbox",
     },
     _ => "",
-  }
+  })
 }
 
 const MATH_CLASS_ROLE: [&str; 8] = ["", "BIGOP", "BINOP", "RELOP", "OPEN", "CLOSE", "PUNCT", ""];
@@ -412,7 +412,6 @@ pub fn insert_block(
     &mut document.get_element().unwrap(),
     "_vertical_mode_",
     "true",
-    state,
   )?; // HACK!!!! (see \hbox)
 
   document.absorb(contents, None, state)?;
@@ -478,7 +477,7 @@ pub fn insert_block(
       // Else only 1 item inside...which is an ltx:p with 1 item, if allowed.
       let mut cfirst = crows.pop_front().unwrap();
       for (key, val) in blockattr {
-        document.set_attribute(&mut cfirst, &key, &val, state)?;
+        document.set_attribute(&mut cfirst, &key, &val)?;
       }
       document.unwrap_nodes(rows.remove(0))?;
       document.unwrap_nodes(blocknode)?;
@@ -493,7 +492,7 @@ pub fn insert_block(
     {
       let mut first = rows.remove(0);
       for (key, val) in blockattr {
-        document.set_attribute(&mut first, &key, &val, state)?;
+        document.set_attribute(&mut first, &key, &val)?;
       }
       document.unwrap_nodes(blocknode)?;
     }
@@ -531,7 +530,7 @@ pub fn cleanup_math(document: &mut Document, mathnode: Node, state: &mut State) 
         document.wrap_nodes("ltx:text", vec![text], state)?.unwrap()
       };
       // Now record that it originally was marked as math
-      document.add_class(&mut text, "ltx_markedasmath", state)?;
+      document.add_class(&mut text, "ltx_markedasmath")?;
       texts.push(text)
     }
     document.replace_node(mathnode.clone(), texts)?; // and replace the whole Math with the pieces
@@ -991,7 +990,7 @@ pub fn set_align_or_class(
       .model
       .can_have_attribute(qname, arena::pin_static("class"))
   {
-    document.add_class(node, class, state)?;
+    document.add_class(node, class)?;
   }
   Ok(())
 }
@@ -1029,13 +1028,13 @@ pub fn make_generic_message(
   //   return ('latex', $cmd, $stomach, $message);
   match kind {
     "error" => {
-      Error!("latex", cmd, stomach, state, message);
+      Error!("latex", cmd, stomach, message);
     },
     "warn" => {
-      Warn!("latex", cmd, stomach, state, message);
+      Warn!("latex", cmd, stomach, message);
     },
     "info" => {
-      Info!("latex", cmd, stomach, state, message);
+      Info!("latex", cmd, stomach, message);
     },
     _other => panic!("Only call make_generic_message with error|warn|info message kinds."),
   };

--- a/rtx_package/src/package/tex_math_fork.rs
+++ b/rtx_package/src/package/tex_math_fork.rs
@@ -45,7 +45,7 @@ LoadDefinitions!(_state, {
         stuff.push(t);
       }
     }
-    Error!("unexpected", "\\eqno", gullet, state, "Fell of the end reading tag for \\eqno!");
+    Error!("unexpected", "\\eqno", gullet, "Fell of the end reading tag for \\eqno!");
       // s!("started {locator}"));
     Tokens::new(stuff)
   });

--- a/rtx_package/src/package/tex_math_mode.rs
+++ b/rtx_package/src/package/tex_math_mode.rs
@@ -33,7 +33,6 @@ LoadDefinitions!(state, {
               "expected",
               "$",
               stomach,
-              state,
               "Missing $ closing display math.\nIgnoring; expect to be in wrong math/text mode."
             );
             op = "";
@@ -87,7 +86,7 @@ LoadDefinitions!(state, {
     reversion    => Tokens!(T_MATH!()),
     before_digest => sub[stomach, state] {
       stomach.begin_mode("inline_math", state)?;
-      if let Some(RegisterValue::Tokens(everymath_toks)) = state.lookup_register("\\everymath", Vec::new()) {
+      if let Some(RegisterValue::Tokens(everymath_toks)) = state.lookup_register("\\everymath", Vec::new())? {
         let everymath_toks = everymath_toks.unlist();
         if !everymath_toks.is_empty() {
           stomach.get_gullet_mut().unread(Tokens::new(everymath_toks));
@@ -107,7 +106,7 @@ LoadDefinitions!(state, {
       // only do this once.
 
       let tex_opt = if let Some(ref tbox) = document.get_node_box(node) {
-        if let Some(body) = tbox.get_body() {
+        if let Some(body) = tbox.get_body()? {
           state.set_dual_branch("presentation");
           let tex = body.untex(state)?;
           state.expire_dual_branch();
@@ -115,7 +114,7 @@ LoadDefinitions!(state, {
           let ctex = body.untex(state)?;
           state.expire_dual_branch();
           if ctex != tex {
-            document.set_attribute(node, "content-tex", &ctex, state)?;
+            document.set_attribute(node, "content-tex", &ctex)?;
           }
           Some(tex)
         } else {
@@ -125,7 +124,7 @@ LoadDefinitions!(state, {
         None
       };
       if let Some(tex_string) = tex_opt {
-        document.set_attribute(node, "tex", &tex_string, state)?;
+        document.set_attribute(node, "tex", &tex_string)?;
       }
     }
   });

--- a/rtx_package/src/package/tex_misc_tweaks.rs
+++ b/rtx_package/src/package/tex_misc_tweaks.rs
@@ -93,8 +93,8 @@ LoadDefinitions!(_state, {
   //       $document->getNode->appendChild($node);
   // } });
 
-  DefMacro!("\\dump", sub[gullet,_args,state] {
-    Warn!("unexpected", "dump", gullet, state, "Do not know how to \\dump yet, sorry");
+  DefMacro!("\\dump", sub[gullet,_args,_state] {
+    Warn!("unexpected", "dump", gullet, "Do not know how to \\dump yet, sorry");
   });
 
 });

--- a/rtx_package/src/package/tex_para.rs
+++ b/rtx_package/src/package/tex_para.rs
@@ -51,7 +51,7 @@ LoadDefinitions!(state, {
           if qname == arena::pin_static("ltx:para") && node.get_attribute("class").is_none() {
             let class_sym = prop_str!(props,"class");
             arena::with(class_sym, |class_str|
-              document.set_attribute(&mut node, "class", class_str, state))?;
+              document.set_attribute(&mut node, "class", class_str))?;
           } else if qname == arena::pin_static("ltx:figure") {
             // insert breaks in figures, for vertically separating subfigures
             document.insert_element("ltx:break",Vec::new(), None, state)?;
@@ -72,7 +72,7 @@ LoadDefinitions!(state, {
           state.assign_value("next_para_class", Stored::None, None);
         }
         // Fish out flags for next ltx:para, to be used when the next \par closes:
-        if state.lookup_register("\\parindent",Vec::new()).unwrap().value_of() == 0 {
+        if state.lookup_register("\\parindent",Vec::new())?.unwrap().value_of() == 0 {
           // respect \parindent if no overrides are given
           state.assign_value("next_para_class", "ltx_noindent", None);
         }

--- a/rtx_package/src/package/tex_scripts.rs
+++ b/rtx_package/src/package/tex_scripts.rs
@@ -90,7 +90,7 @@ fn script_handler(stomach: &mut Stomach, cc: Catcode, state: &mut State) -> Resu
         prevspace = true; // a space avoids double-scripts
         putback.push_front(prev); // put back? assuming it will add rpadding to previous???
         continue;
-      } else if prev.is_empty() {
+      } else if prev.is_empty()? {
         // If empty, the script floats, can't conflict, but don't put back
         break;
       } else if let Some(prevop) = is_script(&prev, state) {
@@ -107,7 +107,6 @@ fn script_handler(stomach: &mut Stomach, cc: Catcode, state: &mut State) -> Resu
               "unexpected",
               s!("double-{}", lcode),
               stomach,
-              state,
               s!("Double {}", lcode)
             );
           }
@@ -165,14 +164,13 @@ fn script_handler(stomach: &mut Stomach, cc: Catcode, state: &mut State) -> Resu
         "expected",
         "{",
         stomach,
-        state,
         "Missing sub/superscript argument"
       ); //$gullet->showUnexpected);
       stuff.push(Digested::default());
     }
     let script = stuff.remove(0); // ONLY the first box is the script!
 
-    if !script.is_empty() {
+    if !script.is_empty()? {
       let mut properties = stored_map!(
         "isMath" => true,
         "base"        => if let Some(b) = base { Stored::Digested(b) }
@@ -187,7 +185,7 @@ fn script_handler(stomach: &mut Stomach, cc: Catcode, state: &mut State) -> Resu
         properties.insert("font".to_string(), font.into());
       }
       let mut with_script = vec![Digested::from(Whatsit {
-        definition: state.lookup_definition(&T_CS!(cs)).unwrap(),
+        definition: state.lookup_definition(&T_CS!(cs))?.unwrap(),
         args: vec![Some(script)],
         properties,
         // TODO:
@@ -205,7 +203,6 @@ fn script_handler(stomach: &mut Stomach, cc: Catcode, state: &mut State) -> Resu
       "Unexpected",
       c,
       stomach,
-      state,
       format!("Script {} can only appear in math mode", c)
     );
     let placeholder = if cc == Catcode::SUPER {
@@ -349,7 +346,7 @@ LoadDefinitions!(state, {
     )),
     PrimitiveOptions::default(),
     state,
-  );
+  )?;
   def_primitive(
     T_SUB!(),
     None,
@@ -360,7 +357,7 @@ LoadDefinitions!(state, {
     )),
     PrimitiveOptions::default(),
     state,
-  );
+  )?;
 
   // NOTE: The When reverting these, the
   DefConstructor!("\\@@POSTSUPERSCRIPT InScriptStyle",r###"

--- a/rtx_package/src/package/tex_setup.rs
+++ b/rtx_package/src/package/tex_setup.rs
@@ -171,11 +171,11 @@ LoadDefinitions!(state, {
       if open.get_catcode() == Catcode::BEGIN {
         gullet.read_balanced(false, state)?.unwrap_or_default()
       } else {
-        Error!("expected","{", gullet, state, "Expected <general text> here");
+        Error!("expected","{", gullet, "Expected <general text> here");
         Tokens!(open)
       }
     } else {
-      Error!("expected","{", gullet, state, "Expected <general text> here");
+      Error!("expected","{", gullet, "Expected <general text> here");
       Tokens!()
     }
   });
@@ -209,7 +209,7 @@ LoadDefinitions!(state, {
     match gullet.read_token(state)? {
       Some(t) => Ok(ArgWrap::Token(t)),
       None => {
-        Error!("expected", "Token", gullet, state, "Paramater <Token> found None.");
+        Error!("expected", "Token", gullet, "Paramater <Token> found None.");
         Ok(ArgWrap::Tokens(Tokens!()))
       }
     }
@@ -220,7 +220,7 @@ LoadDefinitions!(state, {
     if let Some(t) = gullet.read_x_token(None, false, state)? {
       Ok(ArgWrap::Token(t))
     } else {
-      Error!("expected","XToken", gullet, state, "Paramater <XToken> found None.");
+      Error!("expected","XToken", gullet,"Paramater <XToken> found None.");
       Ok(ArgWrap::Tokens(Tokens!()))
     }
   });
@@ -263,7 +263,8 @@ LoadDefinitions!(state, {
     gullet.read_token(state)?.map(|tok| {
       gullet.unread_one(tok.clone());
       if tok.get_catcode() != Catcode::BEGIN {
-        Error!("expected","{", gullet, state, "Expected a {{ here.");
+        let err = || {Error!("expected","{", gullet,"Expected a {{ here."); Ok(())};
+        err().ok();
       }
       tok
     })
@@ -281,7 +282,7 @@ LoadDefinitions!(state, {
         tokens.push(token);
         tokens.extend(gullet.read_balanced(false, state)?.unwrap_or_default().unlist());
         tokens.push(T_END!());
-      } else if let Some(defn) = state.lookup_definition_stored(&token) {
+      } else if let Some(defn) = state.lookup_definition_stored(&token)? {
         let args = defn.read_arguments(gullet, state)?;
         tokens.extend(Invocation!(token, args, gullet, state)?.unlist());
       } else {
@@ -302,7 +303,7 @@ LoadDefinitions!(state, {
         Tokens!(token)
       }
     } else {
-      Error!("expected","expanded", gullet, state,
+      Error!("expected","expanded", gullet,
         "was expecting an Expanded parameter value, found nothing.");
       Tokens!()
     }
@@ -331,8 +332,7 @@ LoadDefinitions!(state, {
           Tokens!(token)
         }
       } else {
-        Error!("Expected", "DefExpanded", gullet, state,
-          "Expected <DefExpanded> here");
+        Error!("Expected", "DefExpanded", gullet, "Expected <DefExpanded> here");
         Tokens!()
       };
       state.expire_smuggle_the();
@@ -511,7 +511,7 @@ LoadDefinitions!(state, {
     match token {
       Some(t) => Ok(ArgWrap::Token(t)),
       None => {
-        Error!("expected","DefToken", gullet, state,
+        Error!("expected","DefToken", gullet,
           "Expected a DefToken parameter, found nothing.");
         Ok(ArgWrap::Tokens(Tokens!()))
       }
@@ -539,12 +539,12 @@ LoadDefinitions!(state, {
           Ok(ArgWrap::RegisterDefinition(Box::new((token_opt.unwrap(), args))))
         } else {
           let message = s!("A <variable> was supposed to be here\n Got {:?}", token_opt);
-          Error!("expected","<variable>", gullet, state, message);
+          Error!("expected","<variable>", gullet,message);
           Ok(ArgWrap::Tokens(Tokens!()))
         }
     } else {
       let message = s!("A <variable> was supposed to be here\n Got {:?}", token_opt);
-      Error!("expected","<variable>", gullet, state, message);
+      Error!("expected","<variable>", gullet,message);
       Ok(ArgWrap::Tokens(Tokens!()))
     }
   },
@@ -577,7 +577,7 @@ LoadDefinitions!(state, {
       },
       None => {
         let message = s!("A <register> was supposed to be here. Got {:?}", token);
-        Error!("expected","<register>", gullet, state, message);
+        Error!("expected","<register>", gullet,message);
         if let Some(t) = token {
           if is_definable(&t, state) {
             def_register(t, None, Tokens!(), None, state);
@@ -682,14 +682,14 @@ LoadDefinitions!(state, {
       };
       if csname != "\\hbox" && csname != "\\vbox" && csname != "\\vtop" {
         let message = s!("A <box> was supposed to be here.\nGot {}", csname);
-        Error!("expected","<box>", stomach, state, message);
+        Error!("expected","<box>", stomach,message);
         None
       } else {
         Some(tbox)
       }
     } else {
       let message = s!("A <box> was supposed to be here.\nGot none.");
-      Error!("expected","<box>", stomach, state, message);
+      Error!("expected","<box>", stomach,message);
       None
     }
   });
@@ -785,10 +785,10 @@ LoadDefinitions!(state, {
   // particularly alignments (which may or may not be actual environments),
   // but which need special treatment of some of their content
   // as the expansion is carried out.
-  DefParameterType!(DigestedBody, reader => reader!(_gullet, _inner, _extra, _state, {
+  DefParameterType!(DigestedBody, sub[_gullet, _inner, _extra, _state] {
       Ok(Tokens!()) // all done in predigestion
-    }),
-    predigest => predigest!(stomach, _arg, state, {
+    },
+    predigest => sub[stomach, _arg, state] {
       let ismath   = state.lookup_bool("IN_MATH");
       let mut list     = stomach.digest_next_body(None, state)?;
       // In most (all?) cases, we're really looking for a single Whatsit here...
@@ -796,7 +796,7 @@ LoadDefinitions!(state, {
       let mut digested = List::new(list, state);
       digested.mode = if ismath { Some(TexMode::Math) } else { Some(TexMode::Text) };
       digested
-    })
+    }
   );
 
   // In addition to the standard TeX Dimension, there are various LaTeX constructs
@@ -897,7 +897,7 @@ LoadDefinitions!(state, {
         ..KVSpec::default()
       }, state)
     } else {
-      Error!("Expected","{", gullet, state, "Missing keyval arguments");
+      Error!("Expected","{", gullet, "Missing keyval arguments");
       Ok(KeyVals::default())
     }
   }

--- a/rtx_package/src/package/verbatim_sty.rs
+++ b/rtx_package/src/package/verbatim_sty.rs
@@ -105,7 +105,7 @@ LoadDefinitions!(state, {
         lines.push(pre);
         if !post.is_empty() {
           let message = s!("Characters dropped after '\\end{{{}}}'", env);
-          Info!("unexpected","stuff", gullet, state, message);
+          Info!("unexpected","stuff", gullet, message);
         }
         break;
       } else {
@@ -155,7 +155,7 @@ LoadDefinitions!(state, {
       )
     } else {
       let message = s!("\\verbatiminput found no file for {:?}, output may be incomplete", file);
-      Error!("binding", "missing_file", gullet, state, message);
+      Error!("binding", "missing_file", gullet, message);
       Ok(Tokens!())
     }
   });


### PR DESCRIPTION
Greetings from the code mines. This PR achieves something very simple:

1. There is now a new struct named `common::error::LogState` and a thread-scoped singleton `common::error::REPORT` of that type. This allows to do the status bookkeeping from `note_status` and friends from within the `common::error` module, and separately from the main State.
2. I have finally ported the behavior where 100 Errors cause a Fatal, and terminate the conversion. But since we model fatal errors through Rust's `Result` types, that means any function that may throw an `Error!` now needs to be able to return a Result, in the case where that error was the hundredth one.

And yet, there is a benefit to using Result types, as we can think about Fatals as first-class data items, and allow some flexibility. Two examples:

First, recognize the 100-error Fatal, but decide to disregard it if it happens in an inconvenient place (e.g. in a `From`/`Into` cast, which aren't well-suited for Result handling). Here's an example of casting to MuGlue from a Tokens, which I currently don't recognize:
```rust
RegisterValue::Tokens(other) => {
  let message = 
    s!("Token register can not be cast into a Glue: {:?}", other);
  // this executes the error code, 
  // but silently disregards any raised Fatal via the .ok() call
  let err = || {Error!("expected", "dimension", None, message); Ok(())};
  err().ok(); 
  MuGlue::new(0)
},
```

Another possible future use is that the Result type allows catching fatals from intermediate callers and enhancing them with more information. E.g. we could catch a Fatal raised from a binding during an absorb call and only add the locator information once it swims up to the Stomach. But that's just hand-waving, I am not planning on redesigning the error reporting setup just yet.