### PR TITLE
compile-time TeX macro

### DIFF
--- a/rtx_package/src/package/amsgen_sty.rs
+++ b/rtx_package/src/package/amsgen_sty.rs
@@ -7,7 +7,7 @@ LoadDefinitions!({
   Let!("\\@nx", "\\noexpand");
   DefRegister!("\\@emptytoks" => Tokens!());
   DefMacro!("\\@ifempty {}", r"\@xifempty#1@@..\@nil");
-  RawTeX!(r"
+  TeX!(r"
   \def\@oparg#1[#2]{\@ifnextchar[{#1}{#1[#2]}}
   \long\def\@ifempty#1{\@xifempty#1@@..\@nil}
   \long\def\@xifempty#1#2@#3#4#5\@nil{%

--- a/rtx_package/src/package/article_cls.rs
+++ b/rtx_package/src/package/article_cls.rs
@@ -56,7 +56,7 @@ LoadDefinitions!( {
   AddToMacro!("\\maketitle", "\\ltx@authors@oneline");
 
   DefMacro!("\\@ptsize", "0"); // should depend on options...
-  RawTeX!(r"
+  TeX!(r"
   \newif\if@restonecol
   \newif\if@titlepage
   \@titlepagefalse

--- a/rtx_package/src/package/etoolbox_sty.rs
+++ b/rtx_package/src/package/etoolbox_sty.rs
@@ -1,6 +1,6 @@
 use crate::package::*;
 LoadDefinitions!({
-  RawTeX!(
+  TeX!(
     r"
 \def\etb@catcodes{\do\&\do\|\do\:\do\-\do\=\do\<\do\>}
 \def\do#1{\catcode\number`#1=\the\catcode`#1\relax}
@@ -45,7 +45,7 @@ LoadDefinitions!({
     DefMacro!(cs, args, body, protected => true, long => true); }
   Tokens!() });
 
-  RawTeX!(
+  TeX!(
     r"
 % {<csname>}
 
@@ -188,7 +188,7 @@ LoadDefinitions!({
     tfalse
   } }, protected => true);
 
-  RawTeX!(
+  TeX!(
     r"
 
 % {<csname>}{<true>}{<false>}
@@ -1162,7 +1162,7 @@ LoadDefinitions!({
   // returns the "true" case in all intended correct uses. Hence:
   DefMacro!("\\etb@ifpattern DefToken {}", "\\begingroup\\@firstoftwo", protected => true);
 
-  RawTeX!(
+  TeX!(
     r"
 % {<string>}{<true}{<false>}
 
@@ -1299,7 +1299,7 @@ LoadDefinitions!({
   }
 }, protected => true);
 
-  RawTeX!(
+  TeX!(
     r"
 \newcommand{\etb@patchcmd}[4][########1]{%
   \etb@ifpatchable#2{#3}
@@ -1704,7 +1704,7 @@ LoadDefinitions!({
   DefMacro!("\\AfterEndDocument{}", sub[(arg)] {
   push_value("@after@end@document", arg.unlist())?; });
 
-  RawTeX!(r"\AtEndDocument{\let\AfterEndPreamble\@gobble}");
+  TeX!(r"\AtEndDocument{\let\AfterEndPreamble\@gobble}");
   //======================================================================
   // 2.6 Environment Hooks
 

--- a/rtx_package/src/package/hyperref_sty.rs
+++ b/rtx_package/src/package/hyperref_sty.rs
@@ -407,7 +407,7 @@ LoadDefinitions!({
   DefConditional!("\\ifHy@pdfwindowui");
   DefConditional!("\\ifHy@pdfdisplaydoctitle");
   DefConditional!("\\ifHy@pdfa");
-  RawTeX!(
+  TeX!(
     r"\Hy@backreffalse
 \Hy@bookmarksnumberedfalse
 \Hy@bookmarksopenfalse
@@ -650,7 +650,7 @@ LoadDefinitions!({
   //     elsif (my ($key, $value) = $option =~ /^(.*?)\s*=\s*(.*?)$/) {
   //       hyperref_setoption($key, $value); } } }
 
-  RawTeX!(
+  TeX!(
     r#"
 \def\HyLang@afrikaans{%
   \def\equationautorefname{Vergelyking}%

--- a/rtx_package/src/package/latex_ch1_fragile_commands.rs
+++ b/rtx_package/src/package/latex_ch1_fragile_commands.rs
@@ -1,7 +1,7 @@
 use crate::package::*;
 
 LoadDefinitions!({
-  RawTeX!(r"
+  TeX!(r"
 \def\@ignorefalse{\global\let\if@ignore\iffalse}
 \def\@ignoretrue {\global\let\if@ignore\iftrue}
 \def\zap@space#1 #2{%

--- a/rtx_package/src/package/latex_ch5_page_styles.rs
+++ b/rtx_package/src/package/latex_ch5_page_styles.rs
@@ -33,7 +33,7 @@ LoadDefinitions!({
   DefRegister!("\\linewidth"       => Dimension!("6in"));
   DefRegister!("\\baselinestretch" => Dimension::new(0));
 
-  RawTeX!(r"\def\@ifl@t@r#1#2{%
+  TeX!(r"\def\@ifl@t@r#1#2{%
   \ifnum\expandafter\@parse@version@#1//00\@nil<%
         \expandafter\@parse@version@#2//00\@nil
     \expandafter\@secondoftwo

--- a/rtx_package/src/package/latex_ch8_defining_commands.rs
+++ b/rtx_package/src/package/latex_ch8_defining_commands.rs
@@ -234,7 +234,7 @@ LoadDefinitions!({
   DefPrimitive!("\\addtoversion{}{}", None);
   DefPrimitive!("\\TextSymbolUnavailable{}", None);
 
-  RawTeX!(
+  TeX!(
     r#"""
   \DeclareSymbolFont{operators}   {OT1}{cmr} {m}{n}
   \DeclareSymbolFont{letters}     {OML}{cmm} {m}{it}

--- a/rtx_package/src/package/latex_other_in_appendices.rs
+++ b/rtx_package/src/package/latex_other_in_appendices.rs
@@ -5,7 +5,7 @@
 
 use crate::package::*;
 LoadDefinitions!({
-  RawTeX!(
+  TeX!(
     r"
     \def\@namedef#1{\expandafter\def\csname #1\endcsname}
     \def\@nameuse#1{\csname #1\endcsname}
@@ -31,7 +31,7 @@ LoadDefinitions!({
   );
 
   // PORT: continue here... \noexpand is passed in as an argument, which seems wrong - it should be #1 ?
-  RawTeX!(r"\DeclareRobustCommand{\MakeUppercase}[1]{{%
+  TeX!(r"\DeclareRobustCommand{\MakeUppercase}[1]{{%
   \def\i{I}\def\j{J}%
   \def\reserved@a##1##2{\let##1##2\reserved@a}%
   \expandafter\reserved@a\@uclclist\reserved@b{\reserved@b\@gobble}%
@@ -87,14 +87,14 @@ LoadDefinitions!({
     assign_catcode(arg_c, Catcode::OTHER, Some(Scope::Local));
   });
 
-  RawTeX!(
+  TeX!(
     r"{\catcode`\^^M=13 \gdef\obeycr{\catcode`\^^M13 \def^^M{\\\relax}%
     \@gobblecr}%
     {\catcode`\^^M=13 \gdef\@gobblecr{\@ifnextchar
     \@gobble\ignorespaces}}%
     \gdef\restorecr{\catcode`\^^M5 }}"
   );
-  RawTeX!(
+  TeX!(
     r"\begingroup
   \catcode`P=12
   \catcode`T=12
@@ -151,7 +151,7 @@ LoadDefinitions!({
   });
 
   Let!("\\MessageBreak", "\\relax");
-  RawTeX!(
+  TeX!(
     r"\gdef\PackageError#1#2#3{%
        \GenericError{%
            (#1)\@spaces\@spaces\@spaces\@spaces
@@ -243,7 +243,7 @@ LoadDefinitions!({
     r"\GenericWarning{(Font)\@spaces\@spaces\@spaces\space\space}{LaTeX Font Warning: #1}"
   );
   //======================================================================
-  RawTeX!(
+  TeX!(
     r"\chardef\@xxxii=32
     \mathchardef\@Mi=10001
     \mathchardef\@Mii=10002
@@ -270,7 +270,7 @@ LoadDefinitions!({
   DefMacro!("\\@tempc", None);
   DefMacro!("\\@gtempa", None);
 
-  RawTeX!(
+  TeX!(
     r"
     \long\def\loop#1\repeat{%
       \def\iterate{#1\relax\expandafter\iterate\fi}%

--- a/rtx_package/src/package/latex_semi_undocumented.rs
+++ b/rtx_package/src/package/latex_semi_undocumented.rs
@@ -71,7 +71,7 @@ LoadDefinitions!({
       Ok(Tokens!(cmd.unlist(), T_OTHER!("["), option.unlist(), T_OTHER!("]")))
     }
   });
-  RawTeX!(
+  TeX!(
     r"
   \def\@protected@testopt#1{%%
     \ifx\protect\@typeset@protect
@@ -88,7 +88,7 @@ LoadDefinitions!({
   );
 
   // maybe this is easiest just to punt.
-  RawTeX!(
+  TeX!(
     r"
   \def\in@#1#2{%
   \def\in@@##1#1##2##3\in@@{%

--- a/rtx_package/src/package/setup_binding_language.rs
+++ b/rtx_package/src/package/setup_binding_language.rs
@@ -1528,6 +1528,15 @@ macro_rules! RawTeX {
 }
 
 #[macro_export]
+macro_rules! TeX {
+  ($text:literal) => {
+    let tokenized;
+    compile_tokenize_internal!(tokenized, $text);
+    ::rtx_core::stomach::digest(tokenized)?;
+  }
+}
+
+#[macro_export]
 macro_rules! Dimension {
   ($number:expr) => {
     Dimension::new_f64(Dimension::spec_to_f64($number)?)

--- a/rtx_package/src/package/tex_appendix_b_p350_to_p355.rs
+++ b/rtx_package/src/package/tex_appendix_b_p350_to_p355.rs
@@ -5,7 +5,7 @@ LoadDefinitions!({
   // TeX Book, Appendix B, p. 350
 
   // Font stuff ...
-  RawTeX!(
+  TeX!(
     r"\font\tenrm=cmr10
   \font\tenrm=cmr10
   \font\sevenrm=cmr7
@@ -115,7 +115,7 @@ LoadDefinitions!({
 
   DefConstructor!("\\@break", "<ltx:break/>");
 
-  RawTeX!(
+  TeX!(
     r"
   \def\loop#1\repeat{\def\body{#1}\iterate}
   \def\iterate{\body \let\next=\iterate \else\let\next=\relax\fi \next}
@@ -228,7 +228,7 @@ LoadDefinitions!({
 
   // \strutbox
   DefMacro!("\\strut", None);
-  RawTeX!("\\newbox\\strutbox");
+  TeX!("\\newbox\\strutbox");
 
   //======================================================================
   // TeX Book, Appendix B. p. 354

--- a/rtx_package/src/package/tex_appendix_b_to_p349.rs
+++ b/rtx_package/src/package/tex_appendix_b_to_p349.rs
@@ -26,7 +26,7 @@ LoadDefinitions!({
   //======================================================================
   // TeX Book, Appendix B, p. 344
   //======================================================================
-  RawTeX!(r"\outer\def^^L{\par}");
+  TeX!(r"\outer\def^^L{\par}");
   DefMacro!("\\dospecials", r"\do\ \do\\\do\{\do\}\do\$\do\&\do\#\do\^\do\^^K\do\_\do\^^A\do\%\do\~");
 
   //
@@ -258,7 +258,7 @@ LoadDefinitions!({
   //======================================================================
   // TeX Book, Appendix B, p. 345
 
-  RawTeX!(
+  TeX!(
     r"\chardef\active=13
     \chardef\@ne=1
     \chardef\tw@=2
@@ -275,7 +275,7 @@ LoadDefinitions!({
 
   //======================================================================
   // TeX Book, Appendix B, p. 346
-  RawTeX!(
+  TeX!(
     r"\countdef\count@=255
   \toksdef\toks@=0
   \skipdef\skip@=0
@@ -390,7 +390,7 @@ LoadDefinitions!({
   DefRegister!("\\z@skip", Glue::new(0));
 
   // First approximation. till I figure out \newbox
-  RawTeX!(r"\newbox\voidb@x");
+  TeX!(r"\newbox\voidb@x");
   //======================================================================
   // TeX Book, Appendix B, p. 348
 


### PR DESCRIPTION
fixes #111 , insofar as the tokenization step of RawTeX now happens during compilation. 

For now I kept the old runtime macro and introduced a shorter `TeX!` macro, so that one can quickly compare the behaviors in tricky cases.

Does this have any visible impact on performance? Let's see... not really!

The times of cargo test are quite comparable. It's naturally less compute work, but maybe the work was fast enough that a small test won't really showcase it sufficiently.

But there is quite a lot more of RawTeX to come as bindings get ported over so, it may be worth merging?