### PR TITLE
Care about stray comments in insert_block

### DIFF
--- a/rtx_core/src/common/xml.rs
+++ b/rtx_core/src/common/xml.rs
@@ -93,7 +93,17 @@ pub fn element_nodes(node: &Node) -> Vec<Node> {
   node
     .get_child_nodes()
     .into_iter()
-    .filter(|n| n.get_type() == Some(NodeType::ElementNode))
+    .filter(|n| matches!(n.get_type(), Some(NodeType::ElementNode)))
+    .collect()
+}
+
+/// obtains all content children of `node` (`Element` and `Text`), ignoring all other node types
+pub fn content_nodes(node: &Node) -> Vec<Node> {
+  node
+    .get_child_nodes()
+    .into_iter()
+    .filter(|n| matches!(n.get_type(), 
+        Some(NodeType::ElementNode) | Some(NodeType::TextNode)))
     .collect()
 }
 

--- a/rtx_core/src/util/pathname.rs
+++ b/rtx_core/src/util/pathname.rs
@@ -29,7 +29,7 @@ static PATHNAME_IS_NASTY_RE: Lazy<Regex> =
 // TODO: This is very pragmatic for now, we ought to use a real URL path library long-term
 static URL_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^\w+://(.+)/([^/]+)$").unwrap());
 
-static KPSE: Lazy<Mutex<Kpaths>> = Lazy::new(|| Mutex::new(Kpaths::new().unwrap()));
+static KPSE: Lazy<Mutex<Option<Kpaths>>> = Lazy::new(|| Mutex::new(Kpaths::new().ok()));
 
 // static ref INSTALLDIRS : Vec<String> = match env::current_exe() {
 //     Ok(exe_path) => {
@@ -330,9 +330,11 @@ pub fn extension(pathname: &str) -> String {
 /// search for a list of candidate names via the external `kpsewhich` utility
 /// returning the first path that is found
 pub fn kpsewhich(candidates: &[&str]) -> Option<String> {
-  for candidate in candidates {
-    if let Some(path) = KPSE.lock().unwrap().find_file(candidate) {
-      return Some(path);
+  if let Some(ref kpse) = *KPSE.lock().unwrap() {
+    for candidate in candidates {
+      if let Some(path) = kpse.find_file(candidate) {
+        return Some(path);
+      }
     }
   }
   None

--- a/rtx_package/src/engine/base_functions.rs
+++ b/rtx_package/src/engine/base_functions.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use rtx_core::common::xml::content_nodes;
 use std::char::{decode_utf16, REPLACEMENT_CHARACTER};
 
 pub fn reenter_text_mode(vertical_mode: bool) {
@@ -350,7 +351,7 @@ pub fn insert_block(
   let container = document.open_element("ltx:_CaptureBlock_", Some(container_attr), None)?;
   document.absorb(contents, None)?;
 
-  let mut nodes = container.get_child_nodes();
+  let mut nodes = content_nodes(&container);
   let node_tags = nodes.iter().map(document::get_node_qname)
     .collect::<Vec<_>>();
   let nnodes = nodes.len();


### PR DESCRIPTION
Tracks latexml [PR 2420](https://github.com/brucemiller/LaTeXML/pull/2420).

Not yet fully ported over, as the various advanced alignment and subfigure tests haven't landed in Rust.

I also ran tests on a laptop without kpsewhich and made the port be a little more resilient in those situations. Notably tests continue to fail without texlive (for now), as the toggle to disable the `texlive_min` test directive isn't ported yet.