### PR TITLE
adjust Unicode chars for triangles

### DIFF
--- a/rtx/tests/alignment/algx.xml
+++ b/rtx/tests/alignment/algx.xml
@@ -31,7 +31,7 @@
       <listingline xml:id="algx1.l2"><tags>
           <tag><text fontsize="80%">2:</text></tag>
           <tag role="refnum">2</tag>
-        </tags>     <text font="bold">return</text> 7
+        </tags>  <text font="bold">return</text> 7
 </listingline>
       <listingline xml:id="algx1.l3"><tags>
           <tag><text fontsize="80%">3:</text></tag>
@@ -68,14 +68,14 @@
           </XMath>
         </Math>)<text cssstyle="float:right"><Math mode="inline" tex="\triangleright" text="triangleright" xml:id="alg1.l1.m2">
             <XMath>
-              <XMTok name="triangleright" role="ADDOP">▷</XMTok>
+              <XMTok name="triangleright" role="ADDOP">⊳</XMTok>
             </XMath>
           </Math> The g.c.d. of a and b
 </text></listingline>
       <listingline xml:id="alg1.l2"><tags>
           <tag><text fontsize="80%">2:</text></tag>
           <tag role="refnum">2</tag>
-        </tags>     <Math mode="inline" tex="r\leftarrow a\bmod b" text="r leftarrow modulo@(a, b)" xml:id="alg1.l2.m1">
+        </tags>  <Math mode="inline" tex="r\leftarrow a\bmod b" text="r leftarrow modulo@(a, b)" xml:id="alg1.l2.m1">
           <XMath>
             <XMApp>
               <XMTok name="leftarrow" role="ARROW">←</XMTok>
@@ -92,7 +92,7 @@
       <listingline xml:id="alg1.l3"><tags>
           <tag><text fontsize="80%">3:</text></tag>
           <tag role="refnum">3</tag>
-        </tags>     <text font="bold">while</text> <Math mode="inline" tex="r\not=0" text="r not-equals 0" xml:id="alg1.l3.m1">
+        </tags>  <text font="bold">while</text> <Math mode="inline" tex="r\not=0" text="r not-equals 0" xml:id="alg1.l3.m1">
           <XMath>
             <XMApp>
               <XMTok meaning="not-equals" name="not-=" role="RELOP">≠</XMTok>
@@ -102,14 +102,14 @@
           </XMath>
         </Math> <text font="bold">do<text cssstyle="float:right" font="medium"><Math mode="inline" tex="\triangleright" text="triangleright" xml:id="alg1.l3.m2">
               <XMath>
-                <XMTok name="triangleright" role="ADDOP">▷</XMTok>
+                <XMTok name="triangleright" role="ADDOP">⊳</XMTok>
               </XMath>
             </Math> We have the answer if r is 0
 </text></text></listingline>
       <listingline xml:id="alg1.l4"><tags>
           <tag><text fontsize="80%">4:</text></tag>
           <tag role="refnum">4</tag>
-        </tags>         <Math mode="inline" tex="a\leftarrow b" text="a leftarrow b" xml:id="alg1.l4.m1">
+        </tags>   <Math mode="inline" tex="a\leftarrow b" text="a leftarrow b" xml:id="alg1.l4.m1">
           <XMath>
             <XMApp>
               <XMTok name="leftarrow" role="ARROW">←</XMTok>
@@ -122,7 +122,7 @@
       <listingline xml:id="alg1.l5"><tags>
           <tag><text fontsize="80%">5:</text></tag>
           <tag role="refnum">5</tag>
-        </tags>         <Math mode="inline" tex="b\leftarrow r" text="b leftarrow r" xml:id="alg1.l5.m1">
+        </tags>   <Math mode="inline" tex="b\leftarrow r" text="b leftarrow r" xml:id="alg1.l5.m1">
           <XMath>
             <XMApp>
               <XMTok name="leftarrow" role="ARROW">←</XMTok>
@@ -135,7 +135,7 @@
       <listingline xml:id="alg1.l6"><tags>
           <tag><text fontsize="80%">6:</text></tag>
           <tag role="refnum">6</tag>
-        </tags>         <Math mode="inline" tex="r\leftarrow a\bmod b" text="r leftarrow modulo@(a, b)" xml:id="alg1.l6.m1">
+        </tags>   <Math mode="inline" tex="r\leftarrow a\bmod b" text="r leftarrow modulo@(a, b)" xml:id="alg1.l6.m1">
           <XMath>
             <XMApp>
               <XMTok name="leftarrow" role="ARROW">←</XMTok>
@@ -152,18 +152,18 @@
       <listingline labels="LABEL:euclidendwhile" xml:id="alg1.l7"><tags>
           <tag><text fontsize="80%">7:</text></tag>
           <tag role="refnum">7</tag>
-        </tags>     <text font="bold">end</text> <text font="bold">while</text>
+        </tags>  <text font="bold">end</text> <text font="bold">while</text>
 </listingline>
       <listingline xml:id="alg1.l8"><tags>
           <tag><text fontsize="80%">8:</text></tag>
           <tag role="refnum">8</tag>
-        </tags>     <text font="bold">return</text> <Math mode="inline" tex="b" text="b" xml:id="alg1.l8.m1">
+        </tags>  <text font="bold">return</text> <Math mode="inline" tex="b" text="b" xml:id="alg1.l8.m1">
           <XMath>
             <XMTok font="italic" role="UNKNOWN">b</XMTok>
           </XMath>
         </Math><text cssstyle="float:right"><Math mode="inline" tex="\triangleright" text="triangleright" xml:id="alg1.l8.m2">
             <XMath>
-              <XMTok name="triangleright" role="ADDOP">▷</XMTok>
+              <XMTok name="triangleright" role="ADDOP">⊳</XMTok>
             </XMath>
           </Math> The gcd is b
 </text></listingline>

--- a/rtx/tests/fonts/abxtest.xml
+++ b/rtx/tests/fonts/abxtest.xml
@@ -102,7 +102,7 @@
           <tr>
             <td align="left" thead="row"><Math mode="inline" tex="*" text="*" xml:id="S0.SS0.SSS0.Px2.p2.m7">
                 <XMath>
-                  <XMTok meaning="times" role="MULOP">*</XMTok>
+                  <XMTok meaning="times" role="MULOP">∗</XMTok>
                 </XMath>
               </Math></td>
             <td align="left"><text font="typewriter">*</text></td>
@@ -638,7 +638,7 @@
           <tr>
             <td align="left" thead="row"><Math mode="inline" tex="\neg" text="not" xml:id="S0.SS0.SSS0.Px6.p2.m1">
                 <XMath>
-                  <XMTok meaning="not" name="neg" role="FUNCTION">¬</XMTok>
+                  <XMTok meaning="not" name="neg" role="BIGOP">¬</XMTok>
                 </XMath>
               </Math></td>
             <td align="left"><text font="typewriter">\neg</text></td>
@@ -1435,7 +1435,7 @@
           <tr>
             <td align="left" thead="row"><Math mode="inline" tex="\partial" text="partial-differential" xml:id="S0.SS0.SSS0.Px11.p2.m3">
                 <XMath>
-                  <XMTok meaning="partial-differential" name="partial" role="OPERATOR">∂</XMTok>
+                  <XMTok meaning="partial-differential" name="partial" role="DIFFOP">∂</XMTok>
                 </XMath>
               </Math></td>
             <td align="left"><text font="typewriter">\partial</text></td>
@@ -2151,7 +2151,7 @@
           <tr>
             <td align="left" thead="row"><Math mode="inline" tex="\triangleleft" text="triangleleft" xml:id="S0.SS0.SSS0.Px15.p2.m1">
                 <XMath>
-                  <XMTok name="triangleleft" role="ADDOP">◁</XMTok>
+                  <XMTok name="triangleleft" role="ADDOP">⊲</XMTok>
                 </XMath>
               </Math></td>
             <td align="left"><text font="typewriter">\triangleleft</text></td>
@@ -2167,7 +2167,7 @@
           <tr>
             <td align="left" thead="row"><Math mode="inline" tex="\triangleright" text="triangleright" xml:id="S0.SS0.SSS0.Px15.p2.m3">
                 <XMath>
-                  <XMTok name="triangleright" role="ADDOP">▷</XMTok>
+                  <XMTok name="triangleright" role="ADDOP">⊳</XMTok>
                 </XMath>
               </Math></td>
             <td align="left"><text font="typewriter">\triangleright</text></td>
@@ -4481,9 +4481,9 @@
             <td align="left"><text font="typewriter">|</text></td>
           </tr>
           <tr>
-            <td align="left" thead="row"><Math mode="inline" tex="\|" text="parallel-to" xml:id="S0.SS0.SSS0.Px26.p2.m15">
+            <td align="left" thead="row"><Math mode="inline" tex="\|" text="||" xml:id="S0.SS0.SSS0.Px26.p2.m15">
                 <XMath>
-                  <XMTok meaning="parallel-to" name="||" role="VERTBAR">∥</XMTok>
+                  <XMTok name="||" role="VERTBAR">∥</XMTok>
                 </XMath>
               </Math></td>
             <td align="left"><text font="typewriter">\Vert</text></td>

--- a/rtx/tests/fonts/acc.xml
+++ b/rtx/tests/fonts/acc.xml
@@ -97,7 +97,7 @@
               </XMApp>
               <XMTok role="PUNCT" rpadding="20.0pt">,</XMTok>
               <XMApp xml:id="S0.Ex3.m1.3">
-                <XMTok fontsize="70%" name="triangleright" role="UNDERACCENT">▷</XMTok>
+                <XMTok fontsize="70%" name="triangleright" role="UNDERACCENT">⊳</XMTok>
                 <XMTok font="italic" role="UNKNOWN">q</XMTok>
               </XMApp>
               <XMTok role="PUNCT" rpadding="20.0pt">,</XMTok>

--- a/rtx_package/src/engine/plain.rs
+++ b/rtx_package/src/engine/plain.rs
@@ -1036,8 +1036,8 @@ LoadDefinitions!({
   DefMath!("\\diamond",         None, "\u{22C4}", role => "ADDOP");
   DefMath!("\\bigtriangleup",   None, "\u{25B3}", role => "ADDOP");
   DefMath!("\\bigtriangledown", None, "\u{25BD}", role => "ADDOP");
-  DefMath!("\\triangleleft",    None, "\u{25C1}", role => "ADDOP");
-  DefMath!("\\triangleright",   None, "\u{25B7}", role => "ADDOP");
+  DefMath!("\\triangleleft",    None, "\u{22B2}", role => "ADDOP");
+  DefMath!("\\triangleright",   None, "\u{22B3}", role => "ADDOP");
   DefMath!("\\lhd",           None, "\u{22B2}", role => "ADDOP", meaning => "subgroup-of");
   DefMath!("\\rhd",           None, "\u{22B3}", role => "ADDOP", meaning => "contains-as-subgroup");
   DefMath!("\\unlhd", None, "\u{22B4}", role => "ADDOP", meaning => "subgroup-of-or-equals");


### PR DESCRIPTION
Tracks latexml [PR 2422](https://github.com/brucemiller/LaTeXML/pull/2422/)

Note that I updated the test files here, but none of them actually runs at the moment - more infrastructure is needed in place first.