### PR TITLE
[parity] web showcase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ resources/dumps/
 arxiv-examples/
 *.latexml.log
 USER_OK.md
+
+# Local Claude Code settings and ad-hoc HTML conversion outputs
+.claude/
+html/

--- a/latexml_core/src/util/logger.rs
+++ b/latexml_core/src/util/logger.rs
@@ -122,8 +122,14 @@ impl log::Log for LatexmlLogger {
 }
 
 /// initialize the logger at a given verbosity `level`
+///
+/// Returns the underlying `SetLoggerError` if another `log` global logger
+/// is already installed (e.g. an embedder set up `tracing-log` first).
+/// Callers can decide whether to ignore that — the in-process `bind_log` /
+/// `flush_log` buffers are independent of the `log` crate sink and keep
+/// working either way.
 pub fn init(level: LevelFilter) -> Result<(), SetLoggerError> {
-  log::set_logger(&LOGGER).unwrap();
+  log::set_logger(&LOGGER)?;
   log::set_max_level(level);
   Ok(())
 }

--- a/latexml_oxide/src/core_interface.rs
+++ b/latexml_oxide/src/core_interface.rs
@@ -91,6 +91,34 @@ pub trait DigestionAPI {
   }
 }
 
+/// Parse a preload spec into `(name, ext, options)`.
+///
+/// Mirrors Perl `Core.pm:initializeState` (regexes
+/// `s/^\[([^\]]*)\]//` then `s/\.(\w+)$//`): the option bracket
+/// comes at the *front*, e.g. `[ids,mathlexemes]latexml.sty`.
+/// Defaults to `ext = "sty"` when the spec has no `.<ext>` suffix.
+pub(crate) fn parse_preload_spec(preload: &str) -> (String, String, Vec<String>) {
+  let (base, options) = match preload
+    .strip_prefix('[')
+    .and_then(|rest| rest.find(']').map(|end| (&rest[..end], &rest[end + 1..])))
+  {
+    Some((opts_str, rest)) => {
+      let opts: Vec<String> = opts_str
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+      (rest.to_string(), opts)
+    },
+    None => (preload.to_string(), vec![]),
+  };
+  let (name, ext) = match base.rfind('.') {
+    Some(pos) => (base[..pos].to_string(), base[pos + 1..].to_string()),
+    None => (base.clone(), String::from("sty")),
+  };
+  (name, ext, options)
+}
+
 impl DigestionAPI for Core {
   fn initialize_singletons(&mut self, preloads: Vec<String>) -> Result<()> {
     // reset the error REPORT singleton
@@ -106,39 +134,22 @@ impl DigestionAPI for Core {
     let dump_path = LATEXML_DUMP.clone();
     state::assign_value("InitialPreloads", true, Some(Scope::Global));
     for preload in preloads {
-      // Perl: initializeState extracts extension and options from "name.ext[opt1,opt2]"
-      // Parse bracket options: "latexml.sty[nobibtex]" → name="latexml", ext="sty",
-      // options=["nobibtex"]
-      let (preload_base, options) = if let Some(bracket_pos) = preload.find('[') {
-        let base = preload[..bracket_pos].to_string();
-        let opts_str = preload[bracket_pos + 1..].trim_end_matches(']');
-        let opts: Vec<String> = opts_str
-          .split(',')
-          .map(|s| s.trim().to_string())
-          .filter(|s| !s.is_empty())
-          .collect();
-        (base, opts)
-      } else {
-        (preload.clone(), vec![])
-      };
-      let (name, ext) = if let Some(pos) = preload_base.rfind('.') {
-        (
-          preload_base[..pos].to_string(),
-          preload_base[pos + 1..].to_string(),
-        )
-      } else {
-        (preload_base.clone(), String::from("sty"))
-      };
+      let (name, ext, options) = parse_preload_spec(&preload);
       let handleoptions = ext == "sty" || ext == "cls";
-      // Pass package options via state (Perl: \PassOptionsToPackage equivalent)
+      // Pass package options via state (Perl: \PassOptionsToPackage equivalent).
+      // Match `\PassOptionsToPackage` at latex_constructs.rs L3838-3842: push the
+      // `Vec<String>` through `push_value` so it lands as a `Stored::Strings`
+      // batch inside the `opt@<name>.<ext>` `VecDequeStored`. The batch shape is
+      // what `collect_syms` (binding/content.rs L1157) flattens when
+      // `\ProcessOptions*` enumerates declared options; storing a single
+      // comma-joined `Stored::String("opt1,opt2")` instead silently bypasses
+      // every `DeclareOption!` site, so e.g. dvipsnames/svgnames/x11names
+      // palettes never load — visible as `Error:unexpected:Apricot Can't find
+      // color named 'Apricot'; assuming Black` on a `[dvipsnames]color.sty`
+      // preload.
       if !options.is_empty() {
         let opt_key = format!("opt@{name}.{ext}");
-        let opt_str = options.join(",");
-        state::assign_value(
-          &opt_key,
-          latexml_core::common::store::Stored::String(latexml_core::common::arena::pin(&opt_str)),
-          Some(Scope::Global),
-        );
+        state::push_value(&opt_key, options)?;
       }
       input_definitions(&name, InputDefinitionOptions {
         extension: Some(ext.into()),
@@ -911,5 +922,94 @@ fn renumber_collect_dfs(
       continue;
     }
     renumber_collect_dfs(&child, xml_ns, id_entries, idref_entries);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::parse_preload_spec;
+
+  fn opts(v: &[&str]) -> Vec<String> { v.iter().map(|s| s.to_string()).collect() }
+
+  #[test]
+  fn preload_no_brackets_no_ext() {
+    assert_eq!(
+      parse_preload_spec("latexml"),
+      ("latexml".into(), "sty".into(), opts(&[]))
+    );
+  }
+
+  #[test]
+  fn preload_no_brackets_with_ext() {
+    assert_eq!(
+      parse_preload_spec("ar5iv.sty"),
+      ("ar5iv".into(), "sty".into(), opts(&[]))
+    );
+    assert_eq!(
+      parse_preload_spec("TeX.pool"),
+      ("TeX".into(), "pool".into(), opts(&[]))
+    );
+  }
+
+  #[test]
+  fn preload_front_brackets_with_options() {
+    // The historical-bug fixture: front-bracket form must produce a real name.
+    assert_eq!(
+      parse_preload_spec("[ids,mathlexemes]latexml.sty"),
+      (
+        "latexml".into(),
+        "sty".into(),
+        opts(&["ids", "mathlexemes"])
+      )
+    );
+    assert_eq!(
+      parse_preload_spec("[dvipsnames]color.sty"),
+      ("color".into(), "sty".into(), opts(&["dvipsnames"]))
+    );
+  }
+
+  #[test]
+  fn preload_class_with_options() {
+    assert_eq!(
+      parse_preload_spec("[twocolumn,11pt]article.cls"),
+      (
+        "article".into(),
+        "cls".into(),
+        opts(&["twocolumn", "11pt"])
+      )
+    );
+  }
+
+  #[test]
+  fn preload_options_trimmed_and_empty_stripped() {
+    assert_eq!(
+      parse_preload_spec("[ a , b ,, c ]name.sty"),
+      ("name".into(), "sty".into(), opts(&["a", "b", "c"]))
+    );
+  }
+
+  #[test]
+  fn preload_empty_brackets() {
+    assert_eq!(
+      parse_preload_spec("[]name.sty"),
+      ("name".into(), "sty".into(), opts(&[]))
+    );
+  }
+
+  #[test]
+  fn preload_unmatched_bracket_falls_through() {
+    // No closing `]` ⇒ treat the whole spec as the base, no options.
+    assert_eq!(
+      parse_preload_spec("[opt"),
+      ("[opt".into(), "sty".into(), opts(&[]))
+    );
+  }
+
+  #[test]
+  fn preload_dot_in_name_uses_last_segment_as_ext() {
+    assert_eq!(
+      parse_preload_spec("foo.bar.sty"),
+      ("foo.bar".into(), "sty".into(), opts(&[]))
+    );
   }
 }

--- a/latexml_oxide/src/core_interface.rs
+++ b/latexml_oxide/src/core_interface.rs
@@ -189,8 +189,8 @@ impl DigestionAPI for Core {
   fn digest(
     &mut self,
     request: String,
-    _preamble: Option<String>,
-    _postamble: Option<String>,
+    preamble: Option<String>,
+    postamble: Option<String>,
     mode: Option<DigestionMode>,
     _no_init: bool,
   ) -> Result<Digested> {
@@ -263,9 +263,15 @@ impl DigestionAPI for Core {
       None,
     );
 
-    // $self->loadPostamble($options{postamble}) if $options{postamble};
+    // Reverse order, since last opened is first read!
+    // (Perl: Core.pm L154-157 in `digestFile`.)
+    if let Some(postamble) = postamble {
+      self.load_postamble(postamble);
+    }
     input_content(&request, InputOptions::default())?;
-    // $self->loadPreamble($options{preamble}) if $options{preamble};
+    if let Some(preamble) = preamble {
+      self.load_preamble(preamble);
+    }
 
     // // Now for the Hacky part for BibTeX!!!
     // if ($mode eq 'BibTeX') {


### PR DESCRIPTION
We have an old showcase for latexml at https://latexml.mathweb.org/editor, with repo at [LaTeXML::Plugin::ltxmojo](https://github.com/dginev/latexml-plugin-ltxmojo). That is getting sunset in September 2026.

I had some time waiting on an evening walk last night and I tried out the Claude app's ability to self-drive a full project from scratch on a phone. It worked, I now have a Rust-based replacement for the showcase app with the new latexml-oxide. Relatively painless, but it had residual bugs that needed cleaning. New showcase repository is at [dginev/ar5iv-editor](https://github.com/dginev/ar5iv-editor)

Including this PR - the tests from the showcase catch some translation inaccuracies with handling the preload options. As well as add the preamble/postamble feature.

Here is a sneak-peek of the first MVP. Need to figure out where to host it, more on that some time later. I'll reconstitute the entire KWARC-based latexml stack without much issue I believe.

<img width="1957" height="940" alt="image" src="https://github.com/user-attachments/assets/8577e0e5-4528-4aaa-946d-317d76c7ce0f" />
