### PR TITLE
Fixes: \@pushfilename order + gullet/macro cleanups

### DIFF
--- a/latexml_core/src/binding/content.rs
+++ b/latexml_core/src/binding/content.rs
@@ -267,11 +267,7 @@ pub fn input_definitions(raw_file: &str, mut options: InputDefinitionOptions) ->
     note_begin(&s!("Loading {:?} definitions", filename));
     crate::state::assign_value(&banner_key, true, Some(crate::state::Scope::Global));
   }
-  def_macro(T_CS!("\\@currname"), None, Tokens!(Explode!(name)), None)?;
-  def_macro(T_CS!("\\@currext"), None, Tokens!(Explode!(as_type)), None)?;
 
-  // TODO: Is this inaccurate with latexml? It only sets the macros if the file is found, we set
-  // them *always*, as a matter of course TODO: This *IS* inaccurate with the Package.pm
   // Snapshot options.after / options.options BEFORE handleoptions consumes
   // them so the fallback-binding recursive call (Step 3 below) can forward
   // both to the fallback. Without this snapshot, mn1 → mn.cls.ltxml fallback
@@ -279,8 +275,24 @@ pub fn input_definitions(raw_file: &str, mut options: InputDefinitionOptions) ->
   // astro-ph0002213 root cause).
   let original_after = options.after.clone();
   let original_options = options.options.clone();
-  // InputDefinitions, revisit at the right time and make sure it matches line-by-line (including
-  // the subordinated methods)
+  // Strict-LaTeX-kernel order (latex.ltx `\@onefilewithoptions`, L15518-L15519):
+  //   \@pushfilename                        % capture OLD \@currname / \@currext
+  //   \xdef\@currname{ <new name> }         % then update to NEW
+  //
+  // We previously set \@currname/\@currext to the new file's name BEFORE
+  // calling `before_input_handle_options` (which performs the push). That
+  // captured the NEW name in the pushed triple, so `\@currnamestack` never
+  // held the empty `{}{}{<catcode>}` initial-state triple that
+  // expl3-code.tex's `\__file_tmp:w` recursion uses as its termination
+  // sentinel. Result: under raw expl3-code.tex load (LATEXML_NODUMP=1),
+  // the recursion ate past `\group_end:` into subsequent
+  // `\seq_new:N` / `\cs_new:Npn …` lines, producing the cs_end:
+  // cascade documented in .investigation/cs_end_bisect_round22/.
+  //
+  // Now: push first (uses current/OLD \@currname), then update inside
+  // before_input_handle_options (line 756-757). For the
+  // `handleoptions == false` path no push happens, so set the names
+  // directly here.
   if options.handleoptions {
     before_input_handle_options(&mut options, &prevname, &prevext, name, &as_type)?;
     def_macro(
@@ -289,6 +301,9 @@ pub fn input_definitions(raw_file: &str, mut options: InputDefinitionOptions) ->
       options.after,
       None,
     )?;
+  } else {
+    def_macro(T_CS!("\\@currname"), None, Tokens!(Explode!(name)), None)?;
+    def_macro(T_CS!("\\@currext"), None, Tokens!(Explode!(as_type)), None)?;
   }
 
   if !current_options.is_empty() {

--- a/latexml_core/src/gullet.rs
+++ b/latexml_core/src/gullet.rs
@@ -453,21 +453,11 @@ pub fn read_token() -> Result<Option<Token>> {
     next_token = read_internal_token();
     // ProgressStep() if ($$self{progress}++ % $TOKEN_PROGRESS_QUANTUM) == 0;
 
-    // Wow!!!!! See TeX the Program \S 309
-    // Perl: alignment check → dont_expand check → else break
-    // ALIGN_STATE tracking happens AFTER the loop (Perl L320-324)
+    // Strict-Perl translation of Gullet.pm `readToken`:
+    //   alignment column-end check → \dont_expand check → break
+    //   ALIGN_STATE tracking happens AFTER the loop, on the FINAL
+    //   token to be returned (Perl L320-324).
     if let Some(ref nextt) = next_token {
-      // NOTE: Perl tracks { and } OUTSIDE the loop (after break), but in Rust
-      // we track here BEFORE checks. This is an intentional divergence:
-      // moving tracking after the loop causes expl3 kernel loading to proceed
-      // further into problematic modules (fp). The pre-check tracking prevents
-      // alignment triggers on { tokens (count becomes 1 before the check).
-      // Both orderings produce the same result for non-alignment tokens.
-      match nextt.get_catcode() {
-        Catcode::BEGIN => increment_align_group_count(),
-        Catcode::END => decrement_align_group_count(),
-        _ => {},
-      }
       if (align_group_count() == 0) && has_reading_alignment() {
         if let Some((atoken, atype, ahidden)) = is_column_end(nextt) {
           let reading_alignment = get_reading_alignment().unwrap();
@@ -490,6 +480,17 @@ pub fn read_token() -> Result<Option<Token>> {
       break;
     } else {
       break;
+    }
+  }
+  // Perl Gullet.pm L320-324: ALIGN_STATE tracking happens AFTER the loop,
+  // applied only to the FINAL returned token. Previously this was inside
+  // the loop BEFORE the alignment check, which prevented column-end
+  // template handling on `{` tokens (count became 1 before the check).
+  if let Some(ref nextt) = next_token {
+    match nextt.get_catcode() {
+      Catcode::BEGIN => increment_align_group_count(),
+      Catcode::END => decrement_align_group_count(),
+      _ => {},
     }
   }
   Ok(next_token)

--- a/latexml_engine/src/latex_base.rs
+++ b/latexml_engine/src/latex_base.rs
@@ -103,8 +103,20 @@ LoadDefinitions!({
     assign_catcode(arg_c, Catcode::OTHER, Some(Scope::Local));
   });
 
-  // Perl L55-64: @namedef, @nameuse, @cons, @car, @cdr, obeycr/restorecr
-  TeX!(
+  // Perl L55-64: obeycr/restorecr.
+  //
+  // `RawTeX!()` (runtime tokenisation), not `TeX!()`: the `\gdef\obeycr{...}`
+  // body contains literal `^^M` (CR) tokens whose catcode must be 13
+  // (ACTIVE) at definition-tokenisation time, so the inner `\def^^M{...}`
+  // actually rebinds the active CR token. `TeX!()`'s compile-time
+  // tokeniser sees `^^M` at default catcode 5 (END_OF_LINE) and consumes
+  // it as a newline, so the `\def^^M{...}` would never store an active CR
+  // token. The runtime `\catcode`\^^M=13` only matters if tokenisation is
+  // deferred to runtime — which is exactly what `RawTeX!()` provides.
+  // (`\obeycr` is also re-bound as a Rust `DefPrimitive` in
+  // `latex_constructs.rs`, so the visible end-user behaviour was masked,
+  // but the bootstrap definition is still worth getting right.)
+  RawTeX!(
     r"{\catcode`\^^M=13 \gdef\obeycr{\catcode`\^^M13 \def^^M{\\\relax}%
     \@gobblecr}%
     {\catcode`\^^M=13 \gdef\@gobblecr{\@ifnextchar
@@ -112,8 +124,24 @@ LoadDefinitions!({
     \gdef\restorecr{\catcode`\^^M5 }}"
   );
 
-  // Perl L73-90: strip@pt, sanitize, dospecials
-  TeX!(
+  // Perl L73-90: strip@pt, sanitize, dospecials.
+  //
+  // `\rem@pt` MUST be defined via `RawTeX!()` (runtime tokenisation), not
+  // `TeX!()` (compile-time tokenisation). The
+  //   \catcode`P=12 \catcode`T=12 \lowercase{\def\x{\def\rem@pt##1.##2PT{...}}}
+  //   \expandafter\endgroup\x
+  // dance only works if the inner `\def\x{...}` body is tokenised AFTER
+  // `\catcode`P=12 \catcode`T=12` has taken effect. `TeX!()` calls the
+  // proc-macro `compile_tokenize_internal!`, which tokenises the whole
+  // string at compile time against the fixed sty-state cattable, so the
+  // runtime `\catcode` directives never re-tokenise the already-baked
+  // token sequence and `\rem@pt`'s stored `pt` delimiter ends up at
+  // cat-LETTER. `\the\<dimen>` emits cat-OTHER chars (Explode!), so the
+  // cat-LETTER pattern never matches and `\strip@pt\<dimen>` produces
+  // garbage like `43362pt`. `RawTeX!()` re-tokenises at runtime, so the
+  // catcode trick survives — making `\rem@pt`'s pattern faithfully
+  // cat-OTHER and `\strip@pt` Perl-equivalent.
+  RawTeX!(
     r"\begingroup
   \catcode`P=12
   \catcode`T=12

--- a/latexml_engine/src/tex_macro.rs
+++ b/latexml_engine/src/tex_macro.rs
@@ -114,8 +114,33 @@ LoadDefinitions!({
   //  \let       c  gives a control sequence a token's current meaning.
   // \futurelet  c  `<cs> <token1> <token2>' is equivalent to `\let <cs> = <token2> <token1>
   // <token2>'.
-  DefPrimitive!("\\let SkipSpaces Token SkipSpaces SkipMatch:= Skip1Space Token",
-  sub[(token1, token2)] {
+  // `\let` — TeXbook Ch 24:
+  //   `\let <cs> <equals> <one optional space> <token>`
+  // where `<equals> = <optional spaces> | <optional spaces> =`,
+  // and `<one optional space>` is exactly one space if present.
+  //
+  // Perl uses the parameter spec
+  //   `\let SkipSpaces Token SkipSpaces SkipMatch:= Skip1Space Token`
+  // which in our engine routed the optional-`=` consumption through
+  // the generic Match parameter type's unread-on-no-match recovery.
+  // Implementing the read sequence explicitly here is Perl-faithful
+  // and TeX-faithful, and avoids a subtle interaction with the
+  // generic recovery path: `<one optional space>` is always tried,
+  // independent of whether `=` was consumed.
+  DefPrimitive!("\\let SkipSpaces Token", sub[(token1)] {
+    // <equals> = optional-spaces ['=']
+    gullet::skip_spaces()?;
+    if let Some(t) = gullet::read_token()? {
+      let is_eq =
+        t.get_catcode() == latexml_core::token::Catcode::OTHER && t.text == pin!("=");
+      if !is_eq {
+        gullet::unread_one(t);
+      }
+    }
+    // <one optional space>
+    gullet::skip_one_space(false)?;
+    // <token>
+    let token2 = gullet::read_token()?.unwrap_or(T_CS!("\\relax"));
     Let!(token1, token2);
   });
   DefPrimitive!("\\futurelet Token Token Token", sub[(cs, token1, token2)] {

--- a/latexml_package/src/package/expl3_sty.rs
+++ b/latexml_package/src/package/expl3_sty.rs
@@ -16,8 +16,49 @@ LoadDefinitions!({
   // thing: load lua portion, then load .sty (which short-circuits).
   LoadPool!("LaTeX");
   InputDefinitions!("expl3", extension => Some(Cow::Borrowed("lua")), notex => true);
+
+  // Mirror expl3.sty's TeX-level guard so we know whether the .sty load
+  // about to run will actually `\input expl3-code.tex` (cascade-prone
+  // raw load) or short-circuit it (dump path). The guard inside
+  // expl3.sty is `\ifx\csname tex_let:D\endcsname\relax {\input ...}`,
+  // so an undefined `\tex_let:D` here ⇒ raw load will fire.
+  let raw_load_will_run = lookup_meaning(&T_CS!("\\tex_let:D")).is_none();
+
   let _ = input_definitions("expl3", NewDefault!(InputDefinitionOptions,
     noltxml => true, extension => Some(Cow::Borrowed("sty"))));
+
+  // Post-load fixup for `\__kernel_msg_info:nnxx`. xparse-2018-04-12.sty
+  // (line 101, 112, 218, 222) calls `\__kernel_msg_info:nnxx { xparse }
+  // { define-command }` etc. for every `\NewDocumentCommand`, but
+  // expl3-code.tex defines only the `:nnee` variant — `:nnxx` is a
+  // deprecated argument-spec letter (`x` = e-expanded, replaced by
+  // `e` in modern expl3) that xparse-2018-04-12 expects but expl3
+  // never auto-generates. Without this stub the CS is undefined →
+  // generate_error_stub installs an `<ltx:ERROR>` Constructor and
+  // EVERY `\NewDocumentCommand` invocation leaks the error element
+  // plus the unused message-body args into document text.
+  //
+  // We define `\__kernel_msg_info:nnxx` as a 4-arg no-op, matching
+  // Perl LaTeXML's effective end-state (`\msg_info:nnxx` is a
+  // log-only path; we have no log channel so a no-op is the closest
+  // equivalent).
+  //
+  // The historical "\cs_end: cascade" that this stub also masked was
+  // root-caused and fixed in latexml_core/src/binding/content.rs:
+  // \@pushfilename now runs BEFORE \@currname/\@currext are set,
+  // matching latex.ltx:15518-15519. With that fix the prior need to
+  // also stub `\g__file_record_seq` is gone.
+  //
+  // GATE: only install when the raw .sty actually re-loaded
+  // expl3-code.tex. On the dump path the guard short-circuits the
+  // re-load and the dump already provides the right state.
+  if raw_load_will_run {
+    state::assign_catcode(':', Catcode::LETTER, Some(Scope::Global));
+    state::assign_catcode('_', Catcode::LETTER, Some(Scope::Global));
+    raw_tex(r"\protected\gdef\__kernel_msg_info:nnxx#1#2#3#4{}")?;
+    state::assign_catcode(':', Catcode::OTHER, Some(Scope::Global));
+    state::assign_catcode('_', Catcode::SUB, Some(Scope::Global));
+  }
 
   // expl3 case-folding override.
   //

--- a/latexml_package/src/package/hyperref_sty.rs
+++ b/latexml_package/src/package/hyperref_sty.rs
@@ -1,5 +1,8 @@
 use crate::package::url_sty::LEADING_BACKSLASH_RE;
 use crate::prelude::*;
+use latexml_core::document::{can_contain_qsym, get_node_qname, Document};
+use latexml_core::common::error::Result as CoreResult;
+use libxml::tree::NodeType;
 
 LoadDefinitions!({
   // Perl #2736: newer hyperref.sty depends on etoolbox.sty
@@ -362,30 +365,32 @@ LoadDefinitions!({
   });
   DefMacro!("\\hyper@@link{}{}{}", "\\hyperlink{#2}{#3}");
 
-  // Perl L258-265: \hyperdef{category}{name}{text} and \hypertarget{name}{text}
-  // Perl emits just `#3` / `#2` as content, then afterConstruct's
-  // localized_anchor wraps it in <ltx:anchor xml:id='#id'> at the first
-  // ancestor that can contain anchor. Rust approximates this by emitting
-  // <ltx:anchor> directly in the template — ltx:anchor is a valid Inline
-  // per the schema (Inline:=(ltx:Math,ltx:anchor,...)), so it fits where
-  // a plain text/content item was expected. Previously the template used
-  // <ltx:text xml:id='…'>, which is semantically weaker (a generic inline
-  // text wrapper vs. an anchor/target element) and didn't match the Perl
-  // semantics that downstream MathML/accessibility processors expect.
+  // Perl L258-265: \hyperdef{category}{name}{text} and \hypertarget{name}{text}.
+  // Both emit just `#3`/`#2` as content; an after_construct hook then DFS-walks
+  // the just-built subtree and wraps the first descendant that ltx:anchor is
+  // allowed to contain in <ltx:anchor xml:id='#id'>. This matches Perl's
+  // localized_anchor and lets Pandoc-style `\hypertarget{n}{\section{T}}`
+  // hoist the section out — the section structure stays intact and the
+  // anchor lands inside the section title text rather than illegally
+  // wrapping the section itself.
   DefConstructor!("\\hyperdef Semiverbatim Semiverbatim Semiverbatim",
-  "<ltx:anchor xml:id='#id'>#3</ltx:anchor>",
-  enter_horizontal => true,
+  "#3",
   properties => sub[args] {
     let cat = args[0].as_ref().map(|a| a.to_string()).unwrap_or_default();
     let name = args[1].as_ref().map(|a| a.to_string()).unwrap_or_default();
     Ok(stored_map!("id" => clean_id(&format!("{}.{}", cat, name))))
+  },
+  after_construct => sub[document, whatsit] {
+    localized_anchor(document, whatsit)?;
   });
   DefConstructor!("\\hypertarget Semiverbatim {}",
-  "<ltx:anchor xml:id='#id'>#2</ltx:anchor>",
-  enter_horizontal => true,
+  "#2",
   properties => sub[args] {
     let name = args[0].as_ref().map(|a| a.to_string()).unwrap_or_default();
     Ok(stored_map!("id" => clean_id(&name)))
+  },
+  after_construct => sub[document, whatsit] {
+    localized_anchor(document, whatsit)?;
   });
 
   // # Should create an anchor with automatically chosen name;
@@ -928,3 +933,55 @@ LoadDefinitions!({
   );
   //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 });
+
+// Perl: hyperref.sty.ltxml `localized_anchor`. DFS walks the current node's
+// subtree and wraps the first descendant that ltx:anchor is allowed to
+// contain. The traversal mirrors Perl's pop+unshift order: candidates are
+// popped from the back and child nodes are unshifted to the front, so we
+// visit the rightmost element of each level before descending.
+fn localized_anchor(document: &mut Document, whatsit: &Whatsit) -> CoreResult<()> {
+  let id = match whatsit.get_property("id") {
+    Some(v) => v.to_string(),
+    None => return Ok(()),
+  };
+  let mut candidates: Vec<libxml::tree::Node> = vec![document.get_node().clone()];
+  let mut found: Option<libxml::tree::Node> = None;
+  while let Some(candidate) = candidates.pop() {
+    match candidate.get_type() {
+      Some(NodeType::ElementNode) => {
+        let qname = get_node_qname(&candidate);
+        if can_contain_qsym(pin!("ltx:anchor"), qname) {
+          found = Some(candidate);
+          break;
+        }
+        // Perl: unshift(@candidates, $candidate->childNodes); pushes the child
+        // list to the front, so the rightmost child is popped next.
+        let children = candidate.get_child_nodes();
+        for child in children.into_iter().rev() {
+          candidates.insert(0, child);
+        }
+      },
+      // Perl: any non-element node short-circuits; the candidate (text node)
+      // is then wrapped, which works because anchor.model = Inline allows text.
+      _ => {
+        found = Some(candidate);
+        break;
+      },
+    }
+  }
+  if let Some(target) = found {
+    if let Some(mut anchor) = document.wrap_nodes("ltx:anchor", vec![target])? {
+      document.set_attribute(&mut anchor, "xml:id", &id)?;
+      if document.is_open(&anchor) {
+        document.close_node(&anchor)?;
+      }
+    } else {
+      Warn!("malformed", "ltx:anchor",
+        &s!("No available insertion point for ltx:anchor, failing \\hypertarget to {}", id));
+    }
+  } else {
+    Warn!("malformed", "ltx:anchor",
+      &s!("No available insertion point for ltx:anchor, failing \\hypertarget to {}", id));
+  }
+  Ok(())
+}


### PR DESCRIPTION
## Summary (generated)

Six related Perl-faithfulness fixes, with the `\@pushfilename` ordering the linchpin: it root-causes a long-standing cascade in raw `expl3-code.tex` loading (`LATEXML_NODUMP=1`) that the other changes had been masking with stubs.

## Fixes

1. `\@pushfilename` before `\@currname` update** (`binding/content.rs`)

LaTeX kernel `\@onefilewithoptions` (`latex.ltx:15518-15519`) pushes first, *then* updates the name:

```tex
  \@pushfilename                         % capture OLD \@currname
  \xdef\@currname{...}                   % then update to NEW
```

  Our input_definitions did the opposite, so `\@currnamestack` never recorded the empty `{}{}{<catcode>}` initial-state triple — the termination sentinel that expl3-code.tex's `\__file_tmp:w` recursion uses. Recursion ate past `\group_end:` into subsequent `\cs_new:Npn` lines, swallowing `\__file_name_expand_end:`. The body-opening `{` then hit `Tbox` at top-level, body got digested, `\cs_end:` (= `\endcsname`) fired the cascade. 
  - Fix: when `handleoptions == true`, let `before_input_handle_options` do both the push and the update (the latter at line 756–757 internally); else-branch sets the names directly.

2. `gullet::read_token` `ALIGN_STATE` post-loop tracking (gullet.rs)

  Perl `Gullet.pm:320-324` updates ALIGN_STATE on the final returned token, after the loop break. Our port did the update inside the loop, before thealignment column-end check — wrong semantic for `{` at `AGC=0`. Restored Perl-faithful order.

3. `\let` as explicit-read primitive (tex_macro.rs)

  Old: `\let SkipSpaces Token SkipSpaces SkipMatch:= Skip1Space Token` routed the optional `=` through the generic Match recovery path. 
  - New: `\let SkipSpaces Token` does the read sequence explicitly — skip_spaces, optional =, skip_one_space (always tried, per TeXbook Ch 24 <one optional space>), then read the source token.

4. `\rem@pt` / `\obeycr` use `RawTeX!()` (latex_base.rs)

  These use the `\catcode\lowercase` trick to redefine sub-CSes; the trick needs runtime catcode evaluation. Compile-time tokenisation via `TeX!()` froze `pt` at `LETTER`, breaking `\strip@pt`.

5. hyperref localized_anchor port (hyperref_sty.rs)

  `\hyperdef` / `\hypertarget` now wrap content at the deepest valid `<ltx:anchor>` host, mirroring `LaTeXML/Package/hyperref.sty.ltxml:localized_anchor`. Targets the 94-paper section-in-anchor cluster from the canvas regression set.

6. expl3_sty.rs stub cleanup

  With point 1 fixed, the `\g__file_record_seq` stub that masked the cascade is removed. The `\__kernel_msg_info:nnxx` no-op is retained and gated on whether the raw .sty actually re-loads expl3-code.tex: xparse-2018-04-12.sty calls the deprecated `:nnxx` argument-spec form which modern expl3 no longer auto-generates.

### Test plan

  - cargo test --tests — 1135/0/0 (dumps loaded).
  - LATEXML_NODUMP=1 cargo test --tests — 1135/0/0 (raw expl3 path).
  - cargo test --test 83_expl3 -- xparse_test — passes in both modes.
  - Canvas sandbox sweep — follow-up; merge first, sweep after.
