### PR TITLE
feat: ProcessOptions keysets => [...] + raise ar5iv pushback/iflimit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 Strict Perl parity at the format/dump and package-loading boundary is
 the current top priority, followed by sandbox long-tail cleanup.
 Current local verification in `docs/SYNC_STATUS.md`: `cargo test
---tests` is **1328/0/0** and `cargo clippy --workspace --all-targets`
+--tests` is **1334/0/0** and `cargo clippy --workspace --all-targets`
 is **14 warnings (all in `latexml_math_parser`, residual clippy
 cleanup of post-ASF-migration code — collaborator's lane)**. The latest sandbox result for
 the 100k `next_warning_papers` corpus is ~99.4% OK; the latest 10k

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -43,6 +43,73 @@ outward to individual bindings. Open clusters are described below;
 closed clusters are dropped from this doc once their fix lands and
 generalizes.
 
+### Handoff — `ar5iv.sty` package-option keyvals (`tokenlimit` etc.)
+
+**Status:** LANDED 2026-05-22. Keyset plumbing wired through; ar5iv
+limit constants raised after empirical bisect on the witness. Witness
+arXiv:2605.16752v1 now converts end-to-end with just
+`--preload=ar5iv.sty` (905,021 B HTML, 25.0s wall, 2.86 GB RSS, "No
+obvious problems").
+
+**Original Rust gap (now fixed).** `\usepackage[tokenlimit=...]{latexml}`
+(passed indirectly via `ar5iv.sty`) silently dropped the keyval
+because Rust's `ProcessOptions!` macro only supported plain / star
+ordering; there was no `keysets => ['LTXML']` equivalent. Perl
+`Package.pm::executeOption_internal` handles any `key=value`
+package option in the supplied keysets *before* normal `\ds@...`
+lookup by digesting `\KV@<keyset>@<key>{<value>}`. Without that
+branch, `KV@LTXML@tokenlimit` was never populated and
+`gullet::set_token_limit` never ran. Reference Perl source:
+`~/git/arxiv-latexml/lib/LaTeXML/Package/latexml.sty.ltxml`
+(`ProcessOptions(inorder => 1, keysets => ['LTXML'])`).
+
+**Fix landed.** Generic keyset branch ported faithfully:
+
+1. `latexml_core::binding::content::process_options` now takes a
+   `keysets: &[&str]` parameter.
+2. New `keyval_option_qname` helper detects `key=value` options and,
+   for each keyset, checks the keyval type registry via
+   `crate::keyval::keyval_get`. On hit, it stashes the value under
+   the qname via `assign_value(.., Scope::Global)` and digests
+   `\KV@<keyset>@<key>{<value>}` so DefKeyVal-style closures still
+   fire.
+3. `ProcessOptions!(keysets => ["LTXML"])` macro arm added in
+   `latexml_engine/src/setup_binding_language.rs`.
+4. `latexml_package/src/package/latexml_sty.rs` now calls
+   `ProcessOptions!(keysets => ["LTXML"])`; existing per-key
+   `state::lookup_value("KV@LTXML@<key>")` blocks below it
+   (`bibconfig`, `tokenlimit`, `iflimit`, `absorblimit`,
+   `pushbacklimit`, image scaling) consume the populated keyset
+   state unchanged.
+
+Regression coverage: `latexml_oxide/tests/keyval_options/keysetopt*`
+(`a` exercises `value=42` via the keyset path; `b` exercises the
+no-option fallback). Tiny fixture binding at
+`latexml_contrib/src/keysetopt_sty.rs`.
+
+**Witness bisect (2026-05-22).** After the keyset patch the witness
+exposed two ar5iv ceilings the Rust port trips where Perl does not:
+`pushbacklimit=599999` and `iflimit=3999999`. With both pinned at
+100M the witness converts cleanly, so it's a tight-ceiling case, not
+a true infinite loop. Empirical bisect (env-var-tunable bisect
+scaffolding temporarily in `ar5iv_sty.rs`, removed once chosen):
+
+| Knob | Perl default | Rust max-fail | Rust min-pass | Chosen |
+|---|---:|---:|---:|---:|
+| `pushbacklimit` | 599999 | 625000 | 630000 | **650000** |
+| `iflimit` | 3999999 | 7000000 | 8000000 | **8000000** |
+
+Headroom on pushback (~20K above min-pass) is intentional; iflimit
+sits exactly at the min-pass boundary because the next finer probe
+wasn't taken (acceptable since the failure mode is graceful — a
+clean "limit exceeded" diagnostic, not silent corruption).
+
+**Follow-up (open).** The Rust port consumes ≈1.04× Perl's pushbacks
+and ≈2× Perl's conditionals on this `IEEEtran` + `tikz` + `pgfplots`
+input. The iflimit gap especially smells like a real over-evaluation
+somewhere; root-causing it would let us tighten the ar5iv constants
+back toward Perl's defaults. Not blocking, tracked here.
+
 ### Cluster A — Catcode-leak through optional-arg digestion (math-mode-as-symptom)
 
 **Status:** OPEN, in progress 2026-05-13. First fix landed
@@ -443,7 +510,7 @@ assertion (not just code == 0; the bug had code == 0).
 
 | Gate | Current (2026-05-20) | Target |
 |---|---|---|
-| `cargo test --tests` | **1328/0/0** | unchanged |
+| `cargo test --tests` | **1334/0/0** (was 1328 + 2×2 keysetopt fixtures from the 2026-05-22 keyset option-plumbing landing) | unchanged |
 | `cargo clippy --workspace --all-targets` | 14 warnings (all in `latexml_math_parser`, residual clippy cleanup of post-ASF-migration code — collaborator's lane) | 0 warnings (clippy cleanup landed) |
 | `latexml_oxide --init=plain.tex` | 0 errors (dump + `LATEXML_NODUMP=1` paths) | 0 errors |
 | `latexml_oxide --init=latex.ltx` | 0 errors (dump + `LATEXML_NODUMP=1` paths) | 0 errors |

--- a/latexml_contrib/src/ar5iv_sty.rs
+++ b/latexml_contrib/src/ar5iv_sty.rs
@@ -11,6 +11,16 @@ LoadDefinitions!({
   // (colonequals, comment, gnuplot, …) loaded fine in Perl but errored
   // in Rust with `\<missing-cs> undefined`. Switch back to `rawstyles`
   // for Perl-baseline parity (cf. feedback_sandbox_perl_baseline.md).
+  // Perl ar5iv.sty.ltxml ships `pushbacklimit=599999, iflimit=3999999`
+  // but the Rust port hits both ceilings on real ar5iv-profile papers
+  // (witness arXiv:2605.16752v1). Empirical bisect (2026-05-22) on that
+  // witness pinned the actual minima at: pushback ≈ 630000, iflimit
+  // ≈ 8000000. We pick 650000 / 8000000 with a small safety margin over
+  // the minimum-pass bracket. The gap to Perl's defaults suggests our
+  // pushback / conditional accounting is roughly 1.1× Perl's (pushback)
+  // and 2× Perl's (iflimit) on heavily macro-driven IEEEtran + tikz +
+  // pgfplots input; root-causing those is tracked as a follow-up but
+  // would let us tighten the constants back toward the Perl defaults.
   latexml_core::binding::content::pass_options("latexml", "sty", vec![
     s!("ids"),
     s!("rawstyles"),
@@ -19,9 +29,9 @@ LoadDefinitions!({
     s!("magnify=1.2"),
     s!("zoomout=1.2"),
     s!("tokenlimit=249999999"),
-    s!("iflimit=3999999"),
+    s!("iflimit=8000000"),
     s!("absorblimit=1299999"),
-    s!("pushbacklimit=599999"),
+    s!("pushbacklimit=650000"),
   ])?;
   RequirePackage!("latexml");
 

--- a/latexml_contrib/src/keysetopt_sty.rs
+++ b/latexml_contrib/src/keysetopt_sty.rs
@@ -1,0 +1,22 @@
+use latexml_package::prelude::*;
+
+// Focused regression for `ProcessOptions(keysets => ['...'])` plumbing.
+// Mirrors the Perl `Package.pm::executeOption_internal` keyset branch and
+// the Rust `keyval_option_qname` helper added alongside the ar5iv
+// `tokenlimit` fix (2026-05-22). Counterpart test pair lives at
+// `latexml_oxide/tests/keyval_options/keysetopt[ab].{tex,xml}`.
+LoadDefinitions!({
+  DefKeyVal!("KSO", "value", "");
+
+  ProcessOptions!(keysets => ["KSO"]);
+
+  let captured = state::lookup_value("KV@KSO@value")
+    .map(|v| v.to_string())
+    .unwrap_or_else(|| "unset".to_string());
+  def_macro(
+    T_CS!("\\keysetoptvalue"),
+    None,
+    Tokens!(ExplodeText!(&captured)),
+    None,
+  )?;
+});

--- a/latexml_contrib/src/lib.rs
+++ b/latexml_contrib/src/lib.rs
@@ -20,6 +20,7 @@ pub mod apackage_sty;
 pub mod discard_env;
 pub mod filelistclass_cls;
 pub mod myclass_cls;
+pub mod keysetopt_sty;
 pub mod mykeyval_sty;
 pub mod mytemplate_sty;
 pub mod myxkeyval_sty;
@@ -218,6 +219,7 @@ pub const BINDINGS: &[(&str, &str, BindingLoader)] = &[
   ("apackage", "sty", apackage_sty::load_definitions),
   ("filelistclass", "cls", filelistclass_cls::load_definitions),
   ("myclass", "cls", myclass_cls::load_definitions),
+  ("keysetopt", "sty", keysetopt_sty::load_definitions),
   ("mykeyval", "sty", mykeyval_sty::load_definitions),
   ("mytemplate", "sty", mytemplate_sty::load_definitions),
   ("myxkeyval", "sty", myxkeyval_sty::load_definitions),

--- a/latexml_core/src/binding/content.rs
+++ b/latexml_core/src/binding/content.rs
@@ -485,16 +485,13 @@ pub fn input_definitions(raw_file: &str, mut options: InputDefinitionOptions) ->
     //
     // Two flavors are recorded via [`FallbackKind`] for informational
     // log messages only — both always fire when the binding exists:
-    //   - Versioned: suffix/prefix actually stripped (Perl-faithful).
-    //     Drivers: 1206.0536 (mysvjour3 → svjour3),
-    //     astro-ph0005021 (./aaspp4 → ./aaspp — aaspp4.sty ships
-    //     locally with plain-TeX `\startdata`; the engine's
-    //     alignment-aware binding still wins, matching Perl).
-    //   - BasenameOnly: only directory prefix removed. Rust-specific
-    //     extension keyed to our contrib-binding registry. Drivers:
-    //     2105.02087 (misc/ieeetran → IEEEtran binding);
-    //     2405.18387 (assets/equations → equations binding, because
-    //     we ship a tuned binding for this name).
+    //   - Versioned: suffix/prefix actually stripped (Perl-faithful). Drivers: 1206.0536 (mysvjour3
+    //     → svjour3), astro-ph0005021 (./aaspp4 → ./aaspp — aaspp4.sty ships locally with plain-TeX
+    //     `\startdata`; the engine's alignment-aware binding still wins, matching Perl).
+    //   - BasenameOnly: only directory prefix removed. Rust-specific extension keyed to our
+    //     contrib-binding registry. Drivers: 2105.02087 (misc/ieeetran → IEEEtran binding);
+    //     2405.18387 (assets/equations → equations binding, because we ship a tuned binding for
+    //     this name).
     let found_raw = if found_raw.is_some() {
       found_raw
     } else if !options.noltxml {
@@ -562,9 +559,7 @@ pub fn input_definitions(raw_file: &str, mut options: InputDefinitionOptions) ->
     } else if lookup_bool(&s!("{filename}_loaded")) {
       // Fallback ltxml binding already loaded — don't double-load the raw.
       None
-    } else if !options.notex
-      && (options.reloadable || !lookup_bool(&s!("{filename}_raw_loaded")))
-    {
+    } else if !options.notex && (options.reloadable || !lookup_bool(&s!("{filename}_raw_loaded"))) {
       // Perl Package.pm L2121-2125 + L2131-2136: combined raw-search
       // step. Tries local paths first, then kpsewhich. Mirrors Perl's
       // Step 4 (`!interpreting` local raw) PLUS Step 5 (kpsewhich
@@ -591,7 +586,13 @@ pub fn input_definitions(raw_file: &str, mut options: InputDefinitionOptions) ->
       // The raw load itself sets `<filename>_raw_loaded` via
       // load_tex_definitions (per OXIDIZED_DESIGN #23). Read sites
       // check `_loaded || _raw_loaded` to detect "any load happened".
-      load_tex_definitions(&filename, &file, options.reloadable, options.at_letter, grandparent_in_expl3)?;
+      load_tex_definitions(
+        &filename,
+        &file,
+        options.reloadable,
+        options.at_letter,
+        grandparent_in_expl3,
+      )?;
     } else if !lookup_bool(&s!("{filename}_loaded")) && !lookup_bool(&s!("{filename}_raw_loaded")) {
       if options.noerror {
         // With noerror: don't mark as loaded and return Err so callers can
@@ -657,7 +658,12 @@ pub fn input_definitions(raw_file: &str, mut options: InputDefinitionOptions) ->
       )?;
     }
     if !prevext.is_empty() {
-      def_macro(T_CS!("\\@currext"), None, Tokens!(ExplodeText!(prevext)), None)?;
+      def_macro(
+        T_CS!("\\@currext"),
+        None,
+        Tokens!(ExplodeText!(prevext)),
+        None,
+      )?;
     }
     // Perl-faithful: Package.pm:2637 —
     //   Digest(($pushpop ? T_CS('\@popfilename') : T_CS('\lx@popfilename')));
@@ -781,12 +787,16 @@ fn _load_binding(internal: bool, request: &str, reloadable: bool) -> Result<bool
       // (locked) definitions. The guard auto-pops on drop.
       let _unlock_guard = crate::common::local_assignments::local_state_unlocked_guard(true);
       // Mark in-progress for the duration of this dispatcher call.
-      IN_PROGRESS.with(|s| { s.borrow_mut().insert(request_key.clone()); });
+      IN_PROGRESS.with(|s| {
+        s.borrow_mut().insert(request_key.clone());
+      });
       struct InProgressGuard(String);
       impl Drop for InProgressGuard {
         fn drop(&mut self) {
           let key = self.0.clone();
-          IN_PROGRESS.with(|s| { s.borrow_mut().remove(&key); });
+          IN_PROGRESS.with(|s| {
+            s.borrow_mut().remove(&key);
+          });
         }
       }
       let _in_progress_guard = InProgressGuard(request_key.clone());
@@ -894,8 +904,18 @@ fn before_input_handle_options(
   // for packages only}` then fired on every package that uses kvoptions
   // (rerunfilecheck reaches this via the hyperref backend `.def` chain).
   // Witnesses: arXiv:cond-mat/9611206, math/9904040, math/9904041.
-  def_macro(T_CS!("\\@currname"), None, Tokens!(ExplodeText!(name)), None)?;
-  def_macro(T_CS!("\\@currext"),  None, Tokens!(ExplodeText!(as_type)), None)?;
+  def_macro(
+    T_CS!("\\@currname"),
+    None,
+    Tokens!(ExplodeText!(name)),
+    None,
+  )?;
+  def_macro(
+    T_CS!("\\@currext"),
+    None,
+    Tokens!(ExplodeText!(as_type)),
+    None,
+  )?;
   // reset options (Note reset & pass were in opposite order in LoadClass ????)
   reset_options()?;
   pass_options(name, as_type, options.options.clone())?;
@@ -1336,7 +1356,7 @@ pub fn pass_options(name: &str, ext: &str, options: Vec<String>) -> Result<()> {
 /// Perl Package.pm L2430-2465: ProcessOptions / ProcessOptions*
 /// `inorder=false` (\ProcessOptions) — execute in declared order, default handler for undeclared
 /// `inorder=true` (\ProcessOptions*) — execute in order passed, class options silently skipped
-pub fn process_options(inorder: bool) -> Result<()> {
+pub fn process_options(inorder: bool, keysets: &[&str]) -> Result<()> {
   let currname_token = T_CS!("\\@currname");
   let currext_token = T_CS!("\\@currext");
   let name = if lookup_definition(&currname_token)?.is_some() {
@@ -1378,11 +1398,11 @@ pub fn process_options(inorder: bool) -> Result<()> {
     // Perl L2447-2453: ProcessOptions* — execute in the order passed
     // Class options: try executeOption_internal only (no default fallback)
     for option in &cls_options_list {
-      let _ = execute_option_internal(*option)?;
+      let _ = execute_option_internal(*option, keysets)?;
     }
     // Current options: try executeOption, then default handler
     for option in &cur_options_list {
-      if !execute_option_internal(*option)? {
+      if !execute_option_internal(*option, keysets)? {
         execute_default_option_internal(*option)?;
       }
     }
@@ -1394,12 +1414,12 @@ pub fn process_options(inorder: bool) -> Result<()> {
     for option in declared_options.iter() {
       match option {
         Stored::String(content) if cur_set.remove(content) || cls_set.remove(content) => {
-          execute_option_internal(*content)?;
+          execute_option_internal(*content, keysets)?;
         },
         Stored::Strings(contents) => {
           for content in contents.iter() {
             if cur_set.remove(content) || cls_set.remove(content) {
-              execute_option_internal(*content)?;
+              execute_option_internal(*content, keysets)?;
             }
           }
         },
@@ -1428,7 +1448,27 @@ pub fn process_options(inorder: bool) -> Result<()> {
   Ok(())
 }
 
-fn execute_option_internal(option: SymStr) -> Result<bool> {
+fn execute_option_internal(option: SymStr, keysets: &[&str]) -> Result<bool> {
+  if let Some((qname, value)) = keyval_option_qname(option, keysets) {
+    // Perl Package.pm handles `key=value` package options before normal
+    // `\ds@...` lookup when ProcessOptions was given keysets. It digests
+    // `\KV@<keyset>@<key>{<value>}`. Rust DefKeyVal entries without code
+    // are ordinary macros, so also store the value under the qname for
+    // package bindings that apply keyvals after ProcessOptions.
+    assign_value(
+      &qname,
+      Stored::String(arena::pin(value.trim())),
+      Some(Scope::Global),
+    );
+    digest(Tokens!(
+      T_CS!(s!("\\{qname}")),
+      T_BEGIN!(),
+      ExplodeText!(&value),
+      T_END!()
+    ))?;
+    return Ok(true);
+  }
+
   let cs = T_CS!(arena::with(option, |opt| s!("\\ds@{opt}")));
   if lookup_definition(&cs)?.is_some() {
     // Perl Package.pm L2482: `DefMacroI('\CurrentOption', undef, $option)` —
@@ -1466,6 +1506,27 @@ fn execute_option_internal(option: SymStr) -> Result<bool> {
   }
 }
 
+fn keyval_option_qname(option: SymStr, keysets: &[&str]) -> Option<(String, String)> {
+  if keysets.is_empty() {
+    return None;
+  }
+  let (key, value) = arena::with(option, |opt| {
+    opt
+      .split_once('=')
+      .map(|(key, value)| (key.trim().to_string(), value.trim().to_string()))
+  })?;
+  if key.is_empty() {
+    return None;
+  }
+  for keyset in keysets {
+    let qname = crate::keyval::keyval_qname("KV", keyset, &key);
+    if crate::keyval::keyval_get(&qname, "type").is_some() {
+      return Some((qname, value));
+    }
+  }
+  None
+}
+
 fn execute_default_option_internal(option: SymStr) -> Result<bool> {
   // Perl Package.pm L2494: `DefMacroI('\CurrentOption', undef, $option)`.
   // Same catcode-faithful tokenization as execute_option_internal.
@@ -1500,7 +1561,7 @@ pub fn execute_options(options: &[&str]) -> Result<()> {
   let mut unhandled = Vec::new();
   for option in options {
     let sym = arena::pin(*option);
-    if !execute_option_internal(sym)? {
+    if !execute_option_internal(sym, &[])? {
       unhandled.push(*option);
     }
   }

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -1034,7 +1034,11 @@ pub fn eqnarray_bindings() -> Result<()> {
   // noalign-deferred `\lx@eqnarray@save@label{#1}` expansion still resolves
   // if it fires AFTER the eqnarray group pops (witness 2404.19499 align
   // case).
-  state::let_i(&T_CS!("\\lx@eqnarray@save@label"), &T_CS!("\\label"), Some(Scope::Global));
+  state::let_i(
+    &T_CS!("\\lx@eqnarray@save@label"),
+    &T_CS!("\\label"),
+    Some(Scope::Global),
+  );
   // Perl: Let('\label', '\lx@eqnarray@label');
   // Redirect \label to the noalign version so it runs at the equation (row) level
   state::let_i(&T_CS!("\\label"), &T_CS!("\\lx@eqnarray@label"), None);
@@ -4128,7 +4132,7 @@ LoadDefinitions!({
   DefPrimitive!("\\ProcessOptions OptionalMatch:*", sub[(star)] {
     // Perl: ProcessOptions(($star ? (inorder => 1) : ()));
     let inorder = star.is_some();
-    process_options(inorder)?;
+    process_options(inorder, &[])?;
     Ok(Vec::new())
   });
   DefMacro!("\\@options", "\\ProcessOptions*");

--- a/latexml_engine/src/setup_binding_language.rs
+++ b/latexml_engine/src/setup_binding_language.rs
@@ -1707,11 +1707,16 @@ macro_rules! DeclareOption {
 macro_rules! ProcessOptions {
   // ProcessOptions!() — non-star, declared order (inorder=false)
   () => {
-    process_options(false)?;
+    process_options(false, &[])?;
   };
   // ProcessOptions!(*) — star variant, in-order processing (inorder=true)
   (*) => {
-    process_options(true)?;
+    process_options(true, &[])?;
+  };
+  // ProcessOptions!(keysets => ["LTXML"]) — Perl
+  // ProcessOptions(inorder => 1, keysets => ['LTXML'])
+  (keysets => [$($keyset:expr),+ $(,)?]) => {
+    process_options(true, &[$($keyset),+])?;
   };
 }
 

--- a/latexml_oxide/tests/keyval_options/keysetopta.tex
+++ b/latexml_oxide/tests/keyval_options/keysetopta.tex
@@ -1,0 +1,5 @@
+\documentclass{article}
+\usepackage[value=42]{keysetopt}
+\begin{document}
+\keysetoptvalue
+\end{document}

--- a/latexml_oxide/tests/keyval_options/keysetopta.xml
+++ b/latexml_oxide/tests/keyval_options/keysetopta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article"?>
+<?latexml package="keysetopt" options="value=42"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <para xml:id="p1">
+    <p>42</p>
+  </para>
+</document>

--- a/latexml_oxide/tests/keyval_options/keysetoptb.tex
+++ b/latexml_oxide/tests/keyval_options/keysetoptb.tex
@@ -1,0 +1,5 @@
+\documentclass{article}
+\usepackage{keysetopt}
+\begin{document}
+\keysetoptvalue
+\end{document}

--- a/latexml_oxide/tests/keyval_options/keysetoptb.xml
+++ b/latexml_oxide/tests/keyval_options/keysetoptb.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article"?>
+<?latexml package="keysetopt"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <para xml:id="p1">
+    <p>unset</p>
+  </para>
+</document>

--- a/latexml_package/src/package/latexml_sty.rs
+++ b/latexml_package/src/package/latexml_sty.rs
@@ -239,7 +239,6 @@ fn parse_subscript_literal(body_text: &str) -> Option<(String, String)> {
   Some((base, sub.to_string()))
 }
 
-
 LoadDefinitions!({
   // Perl latexml.sty.ltxml L31-35: ids/noids and comments/nocomments expose
   // two well-known boolean knobs to the document author. Both state keys
@@ -368,12 +367,12 @@ LoadDefinitions!({
     AssignValue!("SUPPRESS_UNTEX_LINEBREAKS" => true, Scope::Global);
   });
 
-  ProcessOptions!();
+  ProcessOptions!(keysets => ["LTXML"]);
 
   // Process bibconfig keyval from options passed to latexml.sty.
   // Perl handles this via \setkeys{LTXML}{...} in the default option handler.
-  // We specifically extract bibconfig=... since it controls bibliography source selection.
-  // Other keyvals (tokenlimit, iflimit, etc.) are handled via CLI flags or ar5iv defaults.
+  // ProcessOptions with the LTXML keyset now stores package keyvals here;
+  // keep the legacy extraction as a fallback for older call paths.
   if let Some(opts) = state::lookup_vecdeque("opt@latexml.sty") {
     for opt in opts.iter() {
       let opt_str = opt.to_string();


### PR DESCRIPTION
## Highlights (Deyan)

This PR gets a very large pgfplots figure to pass without problems in arXiv:2605.16752v1.

In the process of lifting the max-limits to fit it, it was unearthed that the keyset-option plumbing wasn't fully ready yet. It is now.

## Summary

- **Keyset-options plumbing** (`feat: ProcessOptions keysets => [...]`) — port the Perl `Package.pm::executeOption_internal` keyset branch so `key=value` package options digest `\KV@<keyset>@<key>{<value>}` (and stash the value at the same qname for binding-side lookup) before normal `\ds@...` lookup. Matches upstream `latexml.sty.ltxml`'s `ProcessOptions(inorder => 1, keysets => ['LTXML'])`. Driver: ar5iv.sty's `PassOptions('latexml', 'sty', ..., 'tokenlimit=...')` chain was silently dropping every keyval-shaped option in Rust because `ProcessOptions!` only supported plain/star ordering.
- **ar5iv limit raise** (`chore(ar5iv): ...`) — once the keyset path activated, witness `arXiv:2605.16752v1` (`IEEEtran` + `tikz` + `pgfplots`) tripped both `pushbacklimit=599999` and `iflimit=3999999` where Perl LaTeXML doesn't. Empirical bisect (both knobs pinned high confirms convergence) gave: `pushbacklimit 650000` (was 599999), `iflimit 8000000` (was 3999999). Witness now converts end-to-end with just `--preload=ar5iv.sty`.

| Knob            | Perl default | Rust max-fail | Rust min-pass | Chosen  |
|-----------------|-------------:|--------------:|--------------:|--------:|
| `pushbacklimit` |       599999 |        625000 |        630000 |  650000 |
| `iflimit`       |      3999999 |       7000000 |       8000000 | 8000000 |

Open follow-up tracked in `SYNC_STATUS.md`: the iflimit ~2× gap vs Perl likely points at a real over-evaluation worth root-causing; doing so would let us tighten back toward Perl's defaults.

## Test plan

- [x] `cargo test --tests --workspace`: **1334 / 0 / 0** (1328 baseline + 2 keyval-option fixtures `keysetopt{a,b}` discovered through both `33_keyval_options` and `00_contrib`).
- [x] `cargo clippy --workspace --all-targets`: 14 warnings, all pre-existing in `latexml_math_parser`. No new warnings.
- [x] Witness conversion `--preload=ar5iv.sty` (no `--token-limit` override): 905,021 B HTML, 24.97s wall, 2.86 GB RSS, "Conversion complete: No obvious problems".
- [ ] Recommend a 10k canvas re-spot-check before merge to confirm the limit raise doesn't regress other ar5iv-profile papers (none expected — raising ceilings is monotonic for pass/fail, but worth confirming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)