### PR TITLE
feat(whatsout): full --whatsin/--whatsout port + fix(test-mem): per-test thread-local engine leak

### DIFF
--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -150,6 +150,112 @@ reconvert MVP) → ar5iv-editor + VSCode-extension clients. Deferred to
 post-MVP: columns/`data-srcmap` (§6 rung 2), in-equation/math-parser
 provenance (§7 A.3), Tier B expansion provenance.
 
+---
+
+## `--whatsin` / `--whatsout` full port — LANDED 2026-05-29
+
+Faithful port of Perl `LaTeXML::Util::Pack` + the `LaTeXML.pm` driver
+whatsin/whatsout logic (`Common/Config.pm` L399-454, `LaTeXML.pm`
+L165-197, `Pack.pm` L320-345, `Pack/Zip.pm` `get_archive`). Built
+red/green TDD. The headline asks — `--whatsout=archive` and
+`--whatsout=fragment` — now work end to end, with the rest of the
+matrix wired faithfully.
+
+**Whatsin** (input chunk → core preamble/postamble):
+* `document` (default), `fragment`, `math`, `archive`, `directory`.
+* `--whatsin` now maps to the core `DataSize` in the binary (was hard-
+  coded `Document`, silently dropping `--preamble`/`--postamble`).
+* Perl default ported: a supplied `--preamble`/`--postamble` with no
+  `--whatsin` implies `fragment` (`Config.pm` L399-404).
+* `archive`/`directory` resolve a main `.tex` (sandbox-unpack /
+  detect via `main_tex::find_main_tex`) and digest it as a document.
+
+**Whatsout** (output chunk → packed result):
+* `document` (default), `fragment`, `math`, `archive`.
+* New `Whatsout::Archive` variant (`latexml_post::extract`).
+  `from_cli("archive"|"archive::zip"|…)` → `Archive` (Perl matches
+  `/^archive/`). `is_archive()` / `requires_post()` helpers.
+* `--whatsout=archive` is now honoured as the zip trigger; a `.zip`
+  `--dest` extension also implies it (`Config.pm` L421-426). With no
+  `--dest`, a placeholder `<source-name>.zip` is written
+  (`LaTeXML.pm` L185-187) instead of dumping HTML to stdout.
+* Any non-`document` whatsout forces post-processing (`Config.pm`
+  L454) so `--whatsout=fragment`/`math` work even with `--format=xml`.
+
+**Bug fixed en route.** The core converter keyed `current_postamble`
+on `whatsout` while Perl keys *both* ambles on `whatsin`
+(`LaTeXML.pm` L166-172) — fragment/math inputs lost their closing
+`\end{document}` / `\ensuremathpreceeds`. Resolution extracted into
+the pure, unit-tested `converter::resolve_amble`.
+
+**Archive bundling** (`latexml_post::pack`): applied Perl
+`ARCHIVE_EXT_EXCLUDE` (skip dotfiles, editor `~` backups, and
+`.zip/.gz/.epub/.tex/.bib/.mobi/.cache`) per-basename, plus
+`SOURCE_DATE_EPOCH` reproducible member timestamps (`Pack/Zip.pm`
+L113-115) via a dependency-free civil-date helper. `.css`/images
+still bundle (not in the exclude set).
+
+**Tests** (all green): `extract.rs` (Archive variant / `from_cli` /
+`serialize`/`is_archive`/`requires_post`), `pack.rs` (exclusion
+predicate, end-to-end bundle membership, SOURCE_DATE_EPOCH timestamp),
+`converter.rs` (`resolve_amble` math/fragment/document/archive),
+`91_whatsinout.rs` (CLI end-to-end: document=full page,
+fragment=no chrome, archive=zip bundle + placeholder dest).
+
+**Known remaining gaps (minor, documented):** epub/mobi output
+formats are unsupported, so the `format ∈ {epub,mobi} ⇒ archive`
+default (`Config.pm` L439) and `get_archive`'s mimetype-first / EPUB
+byte-38 ordering are not ported. `get_embeddable` namespace-decl
+re-binding is still the pre-existing libxml-rs FFI gap (RDFa copy is
+done). The Rust binary additionally treats `.tar.gz`/`.tgz`/`.tar`
+sources as archives (Perl's `is_archive` is `.zip`-only) — a
+deliberate convenience superset.
+
+---
+
+## Test-suite memory leak — ROOT-CAUSED + FIXED 2026-05-29
+
+The long-standing "test suite uses too much RAM / OOMs"
+(`12_grouping`/`22_fonts`, and `50_structure` glossary/report/paralists)
+is fixed. Full story in memory `[[wisdom_thread_local_no_drop_leak]]`.
+
+**Root cause.** The engine's per-thread roots (`arena::ARENA`,
+`STATE`/`STD_STATE`/`STY_STATE`, `MODEL`, …) use the **`#[thread_local]`
+attribute**, which — unlike the `thread_local!` macro — does **not** run
+`Drop` on thread exit. libtest spawns a **fresh thread per test**, so
+each test leaked its entire ~110 MB engine; 47 `50_structure` tests
+accumulated ~4.9 GB, tripping the per-process 4.5 GB RSS fuse in
+`stomach::check_timeout`. The glossary/report/paralists "failures" were
+that fuse firing mid-conversion (RSS is process-wide), **not** content
+regressions — they pass in isolation. Ruled out: concurrency
+(−j1 ≈ −j20 ≈ 4.9 GB) and glibc per-thread arenas (`MALLOC_ARENA_MAX=1`
+no effect — memory genuinely leaked, not freed-but-retained).
+
+**Fix.** New `latexml_core::reset_thread_engine()` (resets the three
+`State` singletons via `state::reset_thread_state` + the interner via
+`arena::reset`), called at the end of each conversion in the shared test
+harness `latexml_oxide/src/util/test.rs::process_texfile`. Frees the
+engine before the per-test thread exits.
+
+**Result.** `50_structure` 47/47 (was 4 OOM-induced failures);
+`12_grouping`/`22_fonts` green; −j20 peak fell **4.9 GB → ~2.9 GB**
+(State-only reset also passes 47/47, so margin either way). Production
+RSS cap stays at its original **4.5 GB** — the single-conversion binary
+never accumulates, so production is untouched. Residual ~24 MB/test is
+libxml2 process-global C state (parser dictionaries), left as-is rather
+than risk the global `xmlCleanupParser`.
+
+**Scope / non-goals.** TEST-ONLY in practice: no shipping path is
+multi-conversion-per-process (binary = 1 conv/process; `cortex_worker
+--standalone` = 1 conv/process, canvas forks per paper). So the Perl
+daemon-frame mechanism (`pushDaemonFrame`/`popDaemonFrame`, `LaTeXML.pm`
+L235/L308; commented stubs in `state.rs`) stays **unported** — wiring it
+into `Converter::convert` would tax every single-conversion run for zero
+benefit. A future thread-reusing daemon should keep the interner (call
+`state::reset_thread_state()` alone). The full `--tests` sweep no longer
+OOM-halts; the remaining reason to avoid it blindly is the separate
+tikz/pgf infinite-loop issue, not memory.
+
 ## Round-27 parity clusters
 
 ### Handoff — `ar5iv.sty` package-option keyvals (`tokenlimit` etc.)

--- a/latexml_core/src/common/arena.rs
+++ b/latexml_core/src/common/arena.rs
@@ -238,6 +238,33 @@ pub fn join(syms: &[SymStr], sep: &str) -> String { with_many(syms, |strs| strs.
 
 pub fn len() -> usize { with_arena_mut(|arena| arena.len()) }
 
+/// Free every interned string on this thread, returning the arena to a
+/// fresh, empty state.
+///
+/// **Danger:** this invalidates *every* outstanding [`SymStr`] on the
+/// thread — they become dangling indices that may resolve to unrelated
+/// strings after re-interning. It is only sound when **nothing on the
+/// thread will read a pre-reset `SymStr` again**: i.e. between fully
+/// independent conversions in a reused process (the test harness, where
+/// each test has already serialized its output to owned `String`s and
+/// the thread is about to exit or be re-initialized) or a future daemon
+/// that re-initializes the engine afterward. The single-conversion
+/// `latexml_oxide` binary never calls this — it exits instead.
+///
+/// Needed because the engine's roots are `#[thread_local]` *attribute*
+/// statics, which (unlike the `thread_local!` macro) do **not** run
+/// destructors on thread exit. Without an explicit reset, every reused
+/// thread leaks its interner (~tens of MB for a full document). See
+/// `latexml_core::reset_thread_engine`.
+pub fn reset() {
+  with_arena_mut(|arena| {
+    *arena = StringInterner::with_capacity_and_hasher(
+      131_072,
+      BuildHasherDefault::<FxHasher>::default(),
+    );
+  });
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -281,6 +308,20 @@ mod tests {
     let sym = pin("arena_test_predicate");
     let starts_with = with(sym, |s| s.starts_with("arena"));
     assert!(starts_with);
+  }
+
+  #[test]
+  fn reset_empties_interner_and_stays_usable() {
+    // Each `#[test]` runs on its own thread, so this thread's arena
+    // starts empty and the reset is isolated from sibling tests.
+    let _ = pin("arena_reset_alpha");
+    let _ = pin("arena_reset_beta");
+    assert!(len() >= 2, "expected the two pins to be interned");
+    reset();
+    assert_eq!(len(), 0, "reset must return the interner to empty");
+    // Interning still works after a reset (fresh backend installed).
+    let s = pin("arena_reset_gamma");
+    assert_eq!(to_string(s), "arena_reset_gamma");
   }
 
   #[test]

--- a/latexml_core/src/lib.rs
+++ b/latexml_core/src/lib.rs
@@ -88,6 +88,48 @@ use std::rc::Rc;
 /// See: <https://dev.w3.org/XInclude-Test-Suite/libxml2-2.4.24/doc/threads.html>
 pub fn ensure_libxml_init() { libxml::init_parser(); }
 
+/// Free this thread's accumulated engine state — the three `State`
+/// singletons (`STATE`, `STD_STATE`, `STY_STATE`) **and** the
+/// string-interner arena — returning them to a fresh baseline.
+///
+/// **Why this exists.** The engine's roots (`STATE`, `arena::ARENA`, …)
+/// are `#[thread_local]` *attribute* statics. Unlike the `thread_local!`
+/// macro, the attribute does **not** run destructors on thread exit, so a
+/// thread that builds a full engine and then exits *leaks* it (~110 MB
+/// for a typical document). The single-conversion `latexml_oxide` binary
+/// never notices — it runs one conversion and the process exits. But any
+/// process that runs **many** conversions across **many** threads
+/// (notably the test harness, where libtest spawns a fresh thread per
+/// test) accumulates one leaked engine per conversion (measured: ~4.9 GB
+/// across `50_structure`, which then trips the per-process RSS fuse in
+/// `stomach::check_timeout`). Resetting between conversions frees that
+/// memory before the thread exits (peak fell ~4.9 GB → ~2.9 GB at -j20).
+///
+/// **Why reset the interner here.** The interner *could* be kept across
+/// conversions — that is the faithful daemon design (Perl keeps its
+/// symbol table and resets only the binding stack via
+/// `pushDaemonFrame`/`popDaemonFrame` in `LaTeXML.pm`), and re-interning
+/// the same ~110k base symbols next conversion is deduped. But that only
+/// pays off when the **same thread** handles multiple conversions. The
+/// test harness gets a **fresh thread per test**, so its interner can
+/// never be reused — keeping it would just leak it on thread exit. So we
+/// reset it too. A future *thread-reusing* daemon should instead keep the
+/// interner by calling [`state::reset_thread_state`] alone (State only).
+///
+/// **Soundness.** Resetting the interner invalidates *every* live
+/// `SymStr` on the thread, so this is sound only between fully
+/// independent conversions — when the prior conversion's output has
+/// already been serialized to owned data and nothing will read a
+/// pre-reset symbol again. The test harness satisfies this (each test
+/// serializes to owned `String`s, then resets before its thread exits).
+/// It does **not** reclaim libxml2's process-global C state (parser
+/// dictionaries) — that residual (~24 MB/test) is left as-is rather than
+/// risk the global `xmlCleanupParser`.
+pub fn reset_thread_engine() {
+  crate::state::reset_thread_state();
+  crate::common::arena::reset();
+}
+
 use crate::common::arena::SymHashMap as HashMap;
 use crate::common::dimension::Dimension;
 pub use crate::common::error::*;

--- a/latexml_core/src/state.rs
+++ b/latexml_core/src/state.rs
@@ -1024,6 +1024,37 @@ pub fn use_main_state() {
   };
 }
 
+/// Free every definition/register/box this thread accumulated, returning
+/// all three `State` singletons (`STATE`, `STD_STATE`, `STY_STATE`) to a
+/// fresh, empty baseline and the rotation to `Main`.
+///
+/// **Danger:** this invalidates all live definitions/`SymStr`-keyed data
+/// on the thread. Sound only between fully independent conversions in a
+/// reused process — the test harness (each test serializes to owned
+/// `String`s, then resets before its thread exits) or a future daemon
+/// that re-initializes afterward. The single-conversion binary never
+/// calls this; it exits instead. Pairs with [`crate::common::arena::reset`]
+/// — see [`crate::reset_thread_engine`] for the combined entry point and
+/// the `#[thread_local]`-no-drop rationale.
+pub fn reset_thread_state() {
+  // Make sure STATE holds the main state (not swapped out with std/sty)
+  // before we replace it, so all three slots are freed for real.
+  use_main_state();
+  *STATE.borrow_mut() = State::new(StateOptions {
+    catcodes: Some(Catcodes::Standard),
+    ..StateOptions::default()
+  });
+  *STD_STATE.borrow_mut() = State::new(StateOptions {
+    catcodes: Some(Catcodes::Standard),
+    ..StateOptions::default()
+  });
+  *STY_STATE.borrow_mut() = State::new(StateOptions {
+    catcodes: Some(Catcodes::Style),
+    ..StateOptions::default()
+  });
+  STATE_IN_USE.set(RotateState::Main);
+}
+
 /// A shorthand for installing definitions
 pub fn install_definition<T: Into<Stored>>(definition: T, scope: Option<Scope>) {
   let definition = definition.into();

--- a/latexml_core/src/stomach.rs
+++ b/latexml_core/src/stomach.rs
@@ -75,6 +75,14 @@ pub fn check_timeout() -> Result<()> {
           // already in pathological territory. Real documents in
           // the wp5 / canvas3 corpus stay below 1 GB peak RSS.
           // Override via LATEXML_RSS_CAP_BYTES env.
+          //
+          // This is a *per-process* fuse for the single-conversion
+          // binary (one paper per process under the sandbox ulimit).
+          // The multi-conversion test harness used to trip it by
+          // *accumulating* ~110 MB/test in undropped `#[thread_local]`
+          // engine state; it now calls `reset_thread_engine()` between
+          // conversions (peak fell 4.9 GB → ~2.9 GB at -j20), so the
+          // cap stays at its production value.
           let cap = std::env::var("LATEXML_RSS_CAP_BYTES")
             .ok()
             .and_then(|v| v.parse::<u64>().ok())

--- a/latexml_oxide/bin/cortex_worker.rs
+++ b/latexml_oxide/bin/cortex_worker.rs
@@ -325,14 +325,17 @@ impl LatexmlWorker {
     let output_path =
       std::env::temp_dir().join(format!("cortex_output_{}.zip", std::process::id()));
     latexml_post::pack::pack_archive(&latexml_post::pack::PackOptions {
-      zip_path:       &output_path.to_string_lossy(),
-      html_filename:  &html_filename,
-      html:           &html,
-      log_filename:   Some("cortex.log"),
-      log:            &log,
-      status:         &status_str,
-      resource_dir:   Some(dest_dir.path()),
-      telemetry_json: Some(&telemetry_json),
+      zip_path:          &output_path.to_string_lossy(),
+      html_filename:     &html_filename,
+      html:              &html,
+      log_filename:      Some("cortex.log"),
+      log:               &log,
+      status:            &status_str,
+      resource_dir:      Some(dest_dir.path()),
+      telemetry_json:    Some(&telemetry_json),
+      // Canvas bundles are ephemeral (extracted then discarded); leave
+      // member timestamps at the crate default.
+      source_date_epoch: None,
     })?;
 
     Ok(output_path)

--- a/latexml_oxide/bin/latexml_oxide.rs
+++ b/latexml_oxide/bin/latexml_oxide.rs
@@ -122,7 +122,7 @@ struct Cli {
   )]
   graphics_svg_threshold_kb: u32,
 
-  /// Output extraction mode (Perl Pack.pm `whatsout`):
+  /// Output chunk to pack (Perl Pack.pm `whatsout`):
   ///   `document` (default) → full post-processed HTML;
   ///   `fragment`           → embeddable inline snippet
   ///                          (`<div class="ltx_document">` unwrapped,
@@ -131,10 +131,11 @@ struct Cli {
   ///                          the document root);
   ///   `math`               → math subtree (least common ancestor of all
   ///                          `<math>` nodes, or math-image fallback,
-  ///                          or `fragment` if no math present).
-  ///
-  /// `archive` is accepted for backward-compat and treated as `document` —
-  /// the zip output mode is decided independently by `--dest *.zip`.
+  ///                          or `fragment` if no math present);
+  ///   `archive`            → bundle the full document + resources into a
+  ///                          zip. With no `--dest`, writes
+  ///                          `<source-name>.zip`. A `--dest *.zip`
+  ///                          implies `archive` even without this flag.
   #[arg(long, value_name = "TYPE")]
   whatsout: Option<String>,
 
@@ -187,7 +188,18 @@ struct Cli {
   #[arg(long, value_name = "PATH")]
   log: Option<String>,
 
-  /// Input type: "document" or "directory"
+  /// Input chunk (Perl Pack.pm `whatsin`):
+  ///   `document` (default) → a standalone TeX document;
+  ///   `fragment`           → a snippet wrapped in `standard_preamble.tex`
+  ///                          / `standard_postamble.tex` (or `--preamble`
+  ///                          / `--postamble`); implied when either is
+  ///                          given;
+  ///   `math`               → a bare formula (math-mode wrapped);
+  ///   `archive`            → a zip bundle; unpacked to a sandbox and the
+  ///                          main TeX auto-detected (also implied by a
+  ///                          `.zip` source);
+  ///   `directory`          → a source directory; main TeX auto-detected
+  ///                          (also implied by a trailing `/`).
   #[arg(long, value_name = "TYPE")]
   whatsin: Option<String>,
 
@@ -375,6 +387,22 @@ fn real_main() -> Result<(), Box<dyn Error>> {
   };
   let target = cli.dest.clone();
 
+  // Resolve `--whatsout <mode>` (Perl Pack.pm `whatsout` option +
+  // Config.pm L421-439). Explicit `--whatsout` wins; otherwise a `.zip`
+  // destination extension implies `archive` (Config.pm L421-426).
+  // Unknown explicit values fall back to `document`, like Perl
+  // `pack_collection`. Hoisted here (rather than inside the post block)
+  // so both the post stage and the post-run `--log` guard can see it.
+  let dest_ext_is_zip = target
+    .as_deref()
+    .is_some_and(|t| t.to_ascii_lowercase().ends_with(".zip"));
+  let whatsout_mode = match cli.whatsout.as_deref() {
+    Some(s) => latexml_post::extract::Whatsout::from_cli(s).unwrap_or_default(),
+    None if dest_ext_is_zip => latexml_post::extract::Whatsout::Archive,
+    None => latexml_post::extract::Whatsout::Document,
+  };
+  let is_archive_out = whatsout_mode.is_archive();
+
   // --whatsin=archive: extract archive to temp directory, find main .tex file
   let mut path_flags = cli.search_paths.clone();
   let _archive_tempdir; // hold tempdir alive for the duration of processing
@@ -459,10 +487,24 @@ fn real_main() -> Result<(), Box<dyn Error>> {
     None
   };
 
+  // Map `--whatsin` to the core input-chunk size (Perl Config.pm
+  // L399-404 + LaTeXML.pm:165-194). `archive`/`directory` have already
+  // been resolved to a concrete main `.tex` above, so the core digests
+  // them as a plain document; only `math`/`fragment` change the core's
+  // preamble/postamble wrapping. When `--whatsin` is unset, a supplied
+  // `--preamble`/`--postamble` implies a `fragment` input.
+  let whatsin_size = match cli.whatsin.as_deref() {
+    Some("math") => DataSize::Math,
+    Some("fragment") => DataSize::Fragment,
+    Some("document") | Some("archive") | Some("directory") => DataSize::Document,
+    None if cli.preamble.is_some() || cli.postamble.is_some() => DataSize::Fragment,
+    _ => DataSize::Document,
+  };
+
   let opts = Config {
     verbosity,
     format: OutputFormat::HTML5,
-    whatsin: DataSize::Document,
+    whatsin: whatsin_size,
     whatsout: DataSize::Document,
     preamble: cli.preamble.clone(),
     postamble: cli.postamble.clone(),
@@ -600,7 +642,11 @@ fn real_main() -> Result<(), Box<dyn Error>> {
               }
             })
         })
-      });
+      })
+      // `--whatsout=archive` with no `--dest`/`--format` still wants a
+      // web bundle — default it to html5, matching the `--dest *.zip`
+      // inference above (a `.zip` dest already maps to html5).
+      .or_else(|| if is_archive_out { Some("html5".to_string()) } else { None });
 
       // Auto-select stylesheet from format (Perl Config.pm L543-551)
       let effective_stylesheet =
@@ -634,7 +680,9 @@ fn real_main() -> Result<(), Box<dyn Error>> {
         || is_html_format
         || cli.split
         || cli.splitat.is_some()
-        || xml_input_mode;
+        || xml_input_mode
+        // Perl Config.pm L454: any non-`document` whatsout forces post.
+        || whatsout_mode.requires_post();
 
       // Build split XPath from --splitat
       let split_enabled =
@@ -653,8 +701,29 @@ fn real_main() -> Result<(), Box<dyn Error>> {
           .parent()
           .map(|p| p.to_string_lossy().to_string())
           .unwrap_or_else(|| ".".to_string());
-        let is_zip_output = target.as_ref().is_some_and(|t| t.ends_with(".zip"))
-          || cli.whatsin.as_deref() == Some("archive");
+
+        // `--whatsout=archive` (or a `.zip` destination) bundles into a
+        // zip. When `--dest` is omitted, Perl LaTeXML.pm:185-187 invents
+        // a placeholder `<source-name>.zip`; mirror that so an archive
+        // job always lands a file rather than dumping HTML to stdout.
+        let zip_dest: Option<String> = if is_archive_out {
+          Some(match &target {
+            Some(t) if t.to_ascii_lowercase().ends_with(".zip") => t.clone(),
+            Some(t) => format!(
+              "{}.zip",
+              t.trim_end_matches(".html").trim_end_matches(".xml")
+            ),
+            None => {
+              let stem = Path::new(&source_for_post)
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("document");
+              format!("{stem}.zip")
+            },
+          })
+        } else {
+          None
+        };
 
         // For zip output, route graphics conversions through a TempDir so
         // the converted PNG/SVG files can be collected and bundled into
@@ -662,34 +731,23 @@ fn real_main() -> Result<(), Box<dyn Error>> {
         // Without this, the Graphics post-processor wrote PNGs next to
         // `target` on the filesystem but the zip only carried HTML+log+status —
         // confirmed-bug 2026-05-18 on 1910.01256.
-        let resource_tempdir: Option<tempfile::TempDir> = if is_zip_output {
+        let resource_tempdir: Option<tempfile::TempDir> = if is_archive_out {
           Some(tempfile::tempdir()?)
         } else {
           None
         };
         let dest_for_post: Option<String> = if let Some(tmp) = resource_tempdir.as_ref() {
-          // Use a stable HTML filename derived from the target stem so
-          // the Graphics processor's relative paths resolve naturally.
-          let stem = target
-            .as_ref()
-            .and_then(|t| Path::new(t).file_stem())
+          // Use a stable HTML filename derived from the zip stem so the
+          // Graphics processor's relative paths resolve naturally.
+          let stem = zip_dest
+            .as_deref()
+            .and_then(|z| Path::new(z).file_stem())
             .and_then(|s| s.to_str())
             .unwrap_or("document");
           Some(tmp.path().join(format!("{stem}.html")).to_string_lossy().to_string())
         } else {
           target.clone()
         };
-
-        // Resolve `--whatsout <mode>` (Perl Pack.pm whatsout option).
-        // Unknown values silently fall back to Document — same as Perl
-        // `pack_collection`. `archive` is accepted for backward compat
-        // but maps to Document (the zip wrap is decided by --dest *.zip,
-        // not by whatsout extraction).
-        let whatsout_mode = cli
-          .whatsout
-          .as_deref()
-          .and_then(latexml_post::extract::Whatsout::from_cli)
-          .unwrap_or_default();
 
         // latexmlpost_oxide's default was "if no --pmml AND no
         // --stylesheet, default pmml = true". Apply the same rule for
@@ -718,41 +776,33 @@ fn real_main() -> Result<(), Box<dyn Error>> {
           graphics_svg_threshold_kb: cli.graphics_svg_threshold_kb,
           whatsout: whatsout_mode,
         });
-        if is_zip_output {
-          // whatsout=archive: pack output into ZIP
-          if let Some(ref target_path) = target {
-            let zip_dest = if target_path.ends_with(".zip") {
-              target_path.clone()
-            } else {
-              format!(
-                "{}.zip",
-                target_path
-                  .trim_end_matches(".html")
-                  .trim_end_matches(".xml")
-              )
-            };
-            latexml_post::writer::ensure_parent_dir(&zip_dest)?;
-            let resource_dir = resource_tempdir.as_ref().map(|t| t.path());
-            let stem = Path::new(&zip_dest)
-              .file_stem()
-              .and_then(|s| s.to_str())
-              .unwrap_or("document");
-            let html_name = format!("{stem}.html");
-            let log_name = format!("{stem}.log");
-            latexml_post::pack::pack_archive(&latexml_post::pack::PackOptions {
-              zip_path:       &zip_dest,
-              html_filename:  &html_name,
-              html:           &output,
-              log_filename:   Some(&log_name),
-              log:            &response.log,
-              status:         &response.status,
-              resource_dir,
-              telemetry_json: None,
-            })?;
-            eprintln!("Output written to {}", zip_dest);
-          } else {
-            latexml_post::writer::write_output(&output, None)?;
-          }
+        if let Some(zip_dest) = zip_dest {
+          // whatsout=archive: pack the full document + resources into a ZIP.
+          latexml_post::writer::ensure_parent_dir(&zip_dest)?;
+          let resource_dir = resource_tempdir.as_ref().map(|t| t.path());
+          let stem = Path::new(&zip_dest)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("document");
+          let html_name = format!("{stem}.html");
+          let log_name = format!("{stem}.log");
+          // Reproducible-build support: honour SOURCE_DATE_EPOCH for the
+          // zip member timestamps (Perl Pack/Zip.pm L113-115).
+          let source_date_epoch = std::env::var("SOURCE_DATE_EPOCH")
+            .ok()
+            .and_then(|s| s.trim().parse::<u64>().ok());
+          latexml_post::pack::pack_archive(&latexml_post::pack::PackOptions {
+            zip_path:          &zip_dest,
+            html_filename:     &html_name,
+            html:              &output,
+            log_filename:      Some(&log_name),
+            log:               &response.log,
+            status:            &response.status,
+            resource_dir,
+            telemetry_json:    None,
+            source_date_epoch,
+          })?;
+          eprintln!("Output written to {}", zip_dest);
         } else {
           latexml_post::writer::write_output(&output, target.as_deref())?;
         }
@@ -763,11 +813,10 @@ fn real_main() -> Result<(), Box<dyn Error>> {
       }
     }
 
-    // --log: write conversion log to file (skip if already packed into ZIP)
-    let is_zip_output = target.as_ref().is_some_and(|t| t.ends_with(".zip"))
-      || cli.whatsin.as_deref() == Some("archive");
+    // --log: write conversion log to file (skip if already packed into
+    // the ZIP by the archive output stage).
     if let Some(ref log_path) = cli.log {
-      if !is_zip_output {
+      if !is_archive_out {
         latexml_post::writer::write_output(&response.log, Some(log_path))?;
         eprintln!("Log written to {}", log_path);
       }

--- a/latexml_oxide/src/converter.rs
+++ b/latexml_oxide/src/converter.rs
@@ -129,22 +129,12 @@ impl Converter {
     // - We use a new temporary variable to avoid confusion with daemon caching
     // - Math needs to magically trigger math mode if needed
     // - Fragments need to have a default pre- and postamble, if none provided
-    let current_preamble = match self.opts.whatsin {
-      DataSize::Math => Some(s!("literal:\\begin{{document}}\\ensuremathfollows")),
-      DataSize::Fragment => match self.opts.preamble.clone() {
-        Some(p) => Some(p),
-        None => Some(s!("standard_preamble.tex")),
-      },
-      _ => None,
-    };
-    let current_postamble = match self.opts.whatsout {
-      DataSize::Math => Some(s!("literal:\\ensuremathpreceeds\\end{{document}}")),
-      DataSize::Fragment => match self.opts.postamble.clone() {
-        Some(p) => Some(p),
-        None => Some(s!("standard_postamble.tex")),
-      },
-      _ => None,
-    };
+    // Perl LaTeXML.pm:165-172 keys BOTH ambles on `whatsin`; see
+    // `resolve_amble`. (The previous inline code keyed the postamble on
+    // `whatsout`, dropping `\end{document}` / `\ensuremathpreceeds` for
+    // fragment/math inputs.)
+    let (current_preamble, current_postamble) =
+      resolve_amble(&self.opts.whatsin, &self.opts.preamble, &self.opts.postamble);
     // TODO:
     // 1.3.3 Archives need to get unpacked in a sandbox (with sufficient bookkeeping)
     //   elsif ($$opts{whatsin} =~ /^archive/) {
@@ -388,5 +378,75 @@ impl Converter {
       self.initialize_session()?
     }
     Ok(())
+  }
+}
+
+/// Resolve the `(preamble, postamble)` to wrap the source in, based on
+/// the requested input chunk size. Faithful port of Perl `LaTeXML.pm`
+/// L165-172 — note both ambles key on **`whatsin`** (not `whatsout`):
+///
+/// * `math` → `\begin{document}\ensuremathfollows` …
+///   `\ensuremathpreceeds\end{document}` (magic math-mode trigger).
+/// * `fragment` → the caller-supplied `preamble`/`postamble`, defaulting
+///   to `standard_preamble.tex` / `standard_postamble.tex`.
+/// * everything else (`document`, `archive`, …) → no wrapping.
+pub(crate) fn resolve_amble(
+  whatsin: &DataSize,
+  preamble: &Option<String>,
+  postamble: &Option<String>,
+) -> (Option<String>, Option<String>) {
+  match whatsin {
+    DataSize::Math => (
+      Some(s!("literal:\\begin{{document}}\\ensuremathfollows")),
+      Some(s!("literal:\\ensuremathpreceeds\\end{{document}}")),
+    ),
+    DataSize::Fragment => (
+      Some(preamble.clone().unwrap_or_else(|| s!("standard_preamble.tex"))),
+      Some(postamble.clone().unwrap_or_else(|| s!("standard_postamble.tex"))),
+    ),
+    _ => (None, None),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn amble_math_wraps_both_ends() {
+    // Perl LaTeXML.pm:166-168 — math sets BOTH preamble and postamble.
+    let (pre, post) = resolve_amble(&DataSize::Math, &None, &None);
+    assert_eq!(
+      pre.as_deref(),
+      Some("literal:\\begin{document}\\ensuremathfollows")
+    );
+    assert_eq!(
+      post.as_deref(),
+      Some("literal:\\ensuremathpreceeds\\end{document}")
+    );
+  }
+
+  #[test]
+  fn amble_fragment_defaults_to_standard_files() {
+    let (pre, post) = resolve_amble(&DataSize::Fragment, &None, &None);
+    assert_eq!(pre.as_deref(), Some("standard_preamble.tex"));
+    assert_eq!(post.as_deref(), Some("standard_postamble.tex"));
+  }
+
+  #[test]
+  fn amble_fragment_honors_explicit_files() {
+    let (pre, post) = resolve_amble(
+      &DataSize::Fragment,
+      &Some("my_pre.tex".into()),
+      &Some("my_post.tex".into()),
+    );
+    assert_eq!(pre.as_deref(), Some("my_pre.tex"));
+    assert_eq!(post.as_deref(), Some("my_post.tex"));
+  }
+
+  #[test]
+  fn amble_document_and_archive_have_no_wrapping() {
+    assert_eq!(resolve_amble(&DataSize::Document, &None, &None), (None, None));
+    assert_eq!(resolve_amble(&DataSize::Archive, &None, &None), (None, None));
   }
 }

--- a/latexml_oxide/src/util/test.rs
+++ b/latexml_oxide/src/util/test.rs
@@ -257,10 +257,20 @@ fn process_texfile(
   if let Some(dispatcher) = extra_bindings_dispatcher {
     state::set_extra_bindings_dispatch(dispatcher);
   }
-  match latexml.convert_file(tex_path.to_owned()) {
+  let r = match latexml.convert_file(tex_path.to_owned()) {
     Err(e) => panic!("{:?}: Couldn't convert {:?}; {:?}", name, tex_path, e),
     Ok(doc) => process_ltx_doc(doc, name),
-  }
+  };
+  // Drop the engine, then free this thread's accumulated thread-local
+  // state. libtest spawns a fresh thread per test, and the engine's
+  // roots are `#[thread_local]` *attribute* statics, which do NOT run
+  // destructors on thread exit — so without this each test would leak
+  // its ~110 MB engine, accumulating to ~4.9 GB across the suite. The
+  // output is already owned `String`s by now, so no live `SymStr`
+  // survives the reset. See `latexml_core::reset_thread_engine`.
+  drop(latexml);
+  latexml_core::reset_thread_engine();
+  r
 }
 
 /// Loads the reference XML file as raw text lines, avoiding libxml2

--- a/latexml_oxide/tests/91_whatsinout.rs
+++ b/latexml_oxide/tests/91_whatsinout.rs
@@ -1,0 +1,166 @@
+//! End-to-end `--whatsin` / `--whatsout` CLI coverage (Perl
+//! `LaTeXML::Util::Pack` + `LaTeXML.pm` driver logic).
+//!
+//! Exercises the binary the way a user invokes it, asserting the
+//! shape of the output for each `whatsout` mode:
+//!
+//! * `document` (default) → full HTML page (has `<head>`).
+//! * `fragment` → embeddable snippet (no page chrome).
+//! * `archive` → a zip bundle (HTML + status), with a placeholder
+//!   `<source>.zip` destination when `--dest` is omitted (Perl
+//!   LaTeXML.pm:185-187).
+//!
+//! Run via the prebuilt-binary harness (`CARGO_BIN_EXE_latexml_oxide`),
+//! like `001_single_binary_smoke.rs`.
+
+use std::io::Read;
+use std::path::Path;
+use std::process::Command;
+
+const HELLO_TEX: &str = "\\documentclass{article}\n\
+                         \\begin{document}\n\
+                         Hello World!\n\
+                         \\end{document}\n";
+
+/// Spawn the binary in `cwd` with `args`, returning the captured output.
+fn run(cwd: &Path, args: &[&str]) -> std::process::Output {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  Command::new(bin)
+    .args(args)
+    .current_dir(cwd)
+    .output()
+    .expect("spawn latexml_oxide")
+}
+
+fn stderr_of(out: &std::process::Output) -> String {
+  String::from_utf8_lossy(&out.stderr).to_string()
+}
+
+#[test]
+fn whatsout_document_is_full_page() {
+  let work = tempfile::tempdir().expect("tempdir");
+  std::fs::write(work.path().join("hello.tex"), HELLO_TEX).unwrap();
+  let out = run(work.path(), &["hello.tex", "--dest", "doc.html"]);
+  assert!(
+    out.status.success(),
+    "status {:?}\nstderr:\n{}",
+    out.status.code(),
+    stderr_of(&out)
+  );
+  let html = std::fs::read_to_string(work.path().join("doc.html")).expect("read doc.html");
+  assert!(html.contains("Hello World"), "missing body text:\n{html}");
+  // A full document carries the page chrome (`<head>`…`</head>`).
+  assert!(
+    html.contains("<head") && html.contains("</head>"),
+    "document output should be a full HTML page with a <head>:\n{html}"
+  );
+}
+
+#[test]
+fn whatsout_fragment_strips_page_chrome() {
+  let work = tempfile::tempdir().expect("tempdir");
+  std::fs::write(work.path().join("hello.tex"), HELLO_TEX).unwrap();
+  let out = run(work.path(), &[
+    "hello.tex",
+    "--whatsout",
+    "fragment",
+    "--dest",
+    "frag.html",
+  ]);
+  assert!(
+    out.status.success(),
+    "status {:?}\nstderr:\n{}",
+    out.status.code(),
+    stderr_of(&out)
+  );
+  let frag = std::fs::read_to_string(work.path().join("frag.html")).expect("read frag.html");
+  assert!(frag.contains("Hello World"), "missing body text:\n{frag}");
+  // An embeddable fragment must NOT carry the full-page `<head>`/`<html>`
+  // wrapper — that is the whole point of `--whatsout=fragment`.
+  assert!(
+    !frag.contains("<head") && !frag.contains("<html"),
+    "fragment output must not carry page chrome:\n{frag}"
+  );
+}
+
+#[test]
+fn whatsout_archive_writes_zip_bundle() {
+  let work = tempfile::tempdir().expect("tempdir");
+  std::fs::write(work.path().join("hello.tex"), HELLO_TEX).unwrap();
+  let out = run(work.path(), &[
+    "hello.tex",
+    "--whatsout",
+    "archive",
+    "--dest",
+    "bundle.zip",
+  ]);
+  assert!(
+    out.status.success(),
+    "status {:?}\nstderr:\n{}",
+    out.status.code(),
+    stderr_of(&out)
+  );
+  let zip_path = work.path().join("bundle.zip");
+  assert!(zip_path.is_file(), "expected bundle.zip on disk");
+
+  let f = std::fs::File::open(&zip_path).unwrap();
+  let mut archive = zip::ZipArchive::new(f).expect("valid zip");
+  let names: Vec<String> = (0..archive.len())
+    .map(|i| archive.by_index(i).unwrap().name().to_string())
+    .collect();
+  assert!(
+    names.iter().any(|n| n == "bundle.html"),
+    "zip should contain bundle.html; names: {names:?}"
+  );
+  assert!(
+    names.iter().any(|n| n == "status"),
+    "zip should contain a status entry; names: {names:?}"
+  );
+  // The bundled HTML is the full document.
+  let mut html = String::new();
+  archive
+    .by_name("bundle.html")
+    .unwrap()
+    .read_to_string(&mut html)
+    .unwrap();
+  assert!(html.contains("Hello World"), "bundled HTML missing body:\n{html}");
+}
+
+#[test]
+fn whatsout_archive_defaults_destination_to_source_zip() {
+  // Perl LaTeXML.pm:185-187: `--whatsout=archive` with no `--dest`
+  // invents `<source-name>.zip`.
+  let work = tempfile::tempdir().expect("tempdir");
+  std::fs::write(work.path().join("paper.tex"), HELLO_TEX).unwrap();
+  let out = run(work.path(), &["paper.tex", "--whatsout", "archive"]);
+  assert!(
+    out.status.success(),
+    "status {:?}\nstderr:\n{}",
+    out.status.code(),
+    stderr_of(&out)
+  );
+  let zip_path = work.path().join("paper.zip");
+  assert!(
+    zip_path.is_file(),
+    "expected placeholder paper.zip on disk; stderr:\n{}",
+    stderr_of(&out)
+  );
+  // With no --dest/--format an archive still defaults to an html5 web
+  // bundle: `paper.html` inside, carrying the body text.
+  let f = std::fs::File::open(&zip_path).unwrap();
+  let mut archive = zip::ZipArchive::new(f).expect("valid zip");
+  let names: Vec<String> = (0..archive.len())
+    .map(|i| archive.by_index(i).unwrap().name().to_string())
+    .collect();
+  assert!(
+    names.iter().any(|n| n == "paper.html"),
+    "placeholder zip should contain paper.html; names: {names:?}"
+  );
+  let mut html = String::new();
+  archive
+    .by_name("paper.html")
+    .unwrap()
+    .read_to_string(&mut html)
+    .unwrap();
+  assert!(html.contains("Hello World"), "bundled HTML missing body:\n{html}");
+}

--- a/latexml_post/Cargo.toml
+++ b/latexml_post/Cargo.toml
@@ -39,3 +39,8 @@ latexml_core = {path = "../latexml_core"}
 # grandchild on timeout instead of orphaning it for 10+ minutes.
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[dev-dependencies]
+# `pack` module tests stage resource directories in a TempDir and read
+# the produced zip back to assert membership + reproducible timestamps.
+tempfile = "3"

--- a/latexml_post/src/extract.rs
+++ b/latexml_post/src/extract.rs
@@ -4,7 +4,10 @@
 //! These are the implementations behind the `--whatsout fragment` and
 //! `--whatsout math` CLI modes. They run AFTER all post-processing on
 //! the final XML/HTML document and return the subtree the user actually
-//! wanted (an embeddable inline snippet, or just the math).
+//! wanted (an embeddable inline snippet, or just the math). The
+//! `--whatsout archive` mode keeps the full document (no extraction) but
+//! flags the caller to wrap it into a zip — see [`Whatsout::is_archive`]
+//! and [`crate::pack::pack_archive`].
 //!
 //! Companion modules:
 //! * [`crate::pack`] bundles the chosen output into a zip archive.
@@ -30,35 +33,53 @@ use libxml::tree::Node;
 use crate::document::PostDocument;
 
 /// Output extraction mode — port of Perl `LaTeXML::Util::Pack`'s
-/// `whatsout` option (Pack.pm L323-345). Selects which subtree of the
+/// `whatsout` option (Pack.pm L320-345). Selects which subtree of the
 /// post-processed document to serialize and ship to the user.
 ///
 /// * [`Whatsout::Document`] — full document, no extraction (default).
 /// * [`Whatsout::Fragment`] — embeddable HTML snippet via
 ///   [`get_embeddable`].
 /// * [`Whatsout::Math`] — math subtree (or fallback) via [`get_math`].
+/// * [`Whatsout::Archive`] — full document, but bundled into a zip by
+///   [`crate::pack::pack_archive`] (Pack.pm L326-331 +
+///   `Pack/Zip.pm::get_archive`). Extraction is a no-op; the archiving
+///   happens in the binary's output stage.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum Whatsout {
   #[default]
   Document,
   Fragment,
   Math,
+  Archive,
 }
 
 impl Whatsout {
   /// Parse a CLI string into the matching variant. Returns `None` for
   /// unrecognized values; callers typically fall back to `Document`.
-  /// Mirrors Perl `pack_collection`'s string-tag dispatch — accepts
-  /// `archive` for backward-compat but maps it to `Document` (archive
-  /// bundling is the `pack::pack_archive` concern, not extraction).
+  /// Mirrors Perl `pack_collection`'s string-tag dispatch. Perl matches
+  /// archive with `/^archive/`, so the `archive::zip` /
+  /// `archive::zip::perl` long forms (Pack/Zip.pm L118-122) also map to
+  /// [`Whatsout::Archive`].
   pub fn from_cli(s: &str) -> Option<Self> {
     match s {
-      "document" | "archive" => Some(Whatsout::Document),
+      "document" => Some(Whatsout::Document),
       "fragment" => Some(Whatsout::Fragment),
       "math" => Some(Whatsout::Math),
+      _ if s.starts_with("archive") => Some(Whatsout::Archive),
       _ => None,
     }
   }
+
+  /// Whether this mode bundles the output into a zip archive (Perl
+  /// `pack_collection` `whatsout =~ /^archive/`). The binary's output
+  /// stage branches on this to call [`crate::pack::pack_archive`].
+  pub fn is_archive(self) -> bool { matches!(self, Whatsout::Archive) }
+
+  /// Whether selecting this mode forces post-processing. Perl
+  /// `Config.pm` L454: any `whatsout` other than `document` implies
+  /// `post = 1` (fragment/math need the extraction stage; archive needs
+  /// the full post-processed document to bundle).
+  pub fn requires_post(self) -> bool { !matches!(self, Whatsout::Document) }
 }
 
 /// Apply the requested [`Whatsout`] extraction to `doc` and return the
@@ -70,7 +91,9 @@ impl Whatsout {
 /// don't have to thread the inner [`libxml::tree::Document`] through.
 pub fn serialize_whatsout(doc: &PostDocument, mode: Whatsout) -> String {
   match mode {
-    Whatsout::Document => doc.to_xml_string(),
+    // Archive ships the FULL document; the zip wrapping is a separate
+    // output-stage concern (`pack::pack_archive`), not extraction.
+    Whatsout::Document | Whatsout::Archive => doc.to_xml_string(),
     Whatsout::Fragment => get_embeddable(doc)
       .map(|n| doc.get_document().node_to_string(&n))
       .unwrap_or_else(|| doc.to_xml_string()),
@@ -346,17 +369,49 @@ mod tests {
     assert_eq!(Whatsout::from_cli("document"), Some(Whatsout::Document));
     assert_eq!(Whatsout::from_cli("fragment"), Some(Whatsout::Fragment));
     assert_eq!(Whatsout::from_cli("math"), Some(Whatsout::Math));
-    // Backward-compat: `--whatsout archive` was historically how the
-    // zip output mode was selected; now archive bundling is
-    // controlled separately (by `--dest *.zip`) so the extraction
-    // step is a no-op.
-    assert_eq!(Whatsout::from_cli("archive"), Some(Whatsout::Document));
+    // `--whatsout=archive` (Perl Pack.pm `pack_collection` `whatsout`
+    // tag): bundle the full document into a zip. The `archive::zip`
+    // / `archive::zip::perl` long forms (Zip.pm L118-122) also count
+    // as archive — Perl matches `/^archive/`.
+    assert_eq!(Whatsout::from_cli("archive"), Some(Whatsout::Archive));
+    assert_eq!(Whatsout::from_cli("archive::zip"), Some(Whatsout::Archive));
     assert_eq!(Whatsout::from_cli("nonsense"), None);
   }
 
   #[test]
   fn whatsout_default_is_document() {
     assert_eq!(Whatsout::default(), Whatsout::Document);
+  }
+
+  #[test]
+  fn whatsout_is_archive_predicate() {
+    assert!(Whatsout::Archive.is_archive());
+    assert!(!Whatsout::Document.is_archive());
+    assert!(!Whatsout::Fragment.is_archive());
+    assert!(!Whatsout::Math.is_archive());
+  }
+
+  #[test]
+  fn whatsout_requires_post_for_non_document() {
+    // Perl Config.pm L454: any non-`document` whatsout forces post=1.
+    assert!(!Whatsout::Document.requires_post());
+    assert!(Whatsout::Fragment.requires_post());
+    assert!(Whatsout::Math.requires_post());
+    assert!(Whatsout::Archive.requires_post());
+  }
+
+  #[test]
+  fn serialize_whatsout_archive_returns_full_document() {
+    // Archive bundles the FULL post-processed document into the zip;
+    // the serialized HTML payload is the whole document, identical to
+    // `Whatsout::Document`. The zip wrapping is `pack::pack_archive`'s
+    // job, not extraction's.
+    let xml = r#"<html><body><div class="ltx_document"><p>hi</p></div></body></html>"#;
+    let d = doc(xml);
+    let archive = serialize_whatsout(&d, Whatsout::Archive);
+    let full = serialize_whatsout(&d, Whatsout::Document);
+    assert_eq!(archive, full);
+    assert!(archive.contains("<html>") && archive.contains("</html>"));
   }
 
   #[test]

--- a/latexml_post/src/pack.rs
+++ b/latexml_post/src/pack.rs
@@ -59,6 +59,12 @@ pub struct PackOptions<'a> {
   /// runs; `benchmark_canvas.sh` extracts this member and appends to
   /// `<output_dir>/telemetry.jsonl`. See `docs/TELEMETRY.md`.
   pub telemetry_json: Option<&'a str>,
+  /// `SOURCE_DATE_EPOCH` (Unix seconds, UTC). When `Some`, every zip
+  /// member's last-modified time is pinned to it for reproducible
+  /// archives — Perl `Pack/Zip.pm` L113-115
+  /// (`setLastModFileDateTimeFromUnix`). `None` lets the zip crate use
+  /// its default write timestamp.
+  pub source_date_epoch: Option<u64>,
 }
 
 /// Pack the post-processing outputs into a zip archive.
@@ -75,7 +81,18 @@ pub fn pack_archive(opts: &PackOptions) -> io::Result<()> {
   let file = File::create(opts.zip_path)?;
   let buf_file = BufWriter::with_capacity(ZIP_WRITE_BUF, file);
   let mut zip = ZipWriter::new(buf_file);
-  let zip_options = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+  let mut zip_options =
+    SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+  // Reproducible archives: pin every member's mod-time to SOURCE_DATE_EPOCH
+  // when provided (Perl Pack/Zip.pm L113-115). DOS/zip timestamps only
+  // span 1980-2107, so out-of-range epochs are silently left at the
+  // crate default — matching the spirit of `setLastModFileDateTimeFromUnix`
+  // (which would clamp) without failing the whole archive.
+  if let Some(epoch) = opts.source_date_epoch {
+    if let Some(dt) = epoch_to_zip_datetime(epoch) {
+      zip_options = zip_options.last_modified_time(dt);
+    }
+  }
 
   // HTML first, so `unzip -l` shows the main artifact at the top.
   zip
@@ -115,8 +132,16 @@ pub fn pack_archive(opts: &PackOptions) -> io::Result<()> {
 }
 
 /// Recursively add files from `dir` to a ZIP archive, preserving the
-/// directory structure relative to `base`. Skips `.html` files because
-/// the post-processed HTML is added separately by [`pack_archive`].
+/// directory structure relative to `base`.
+///
+/// Two skip rules apply:
+///  * `.html` files — the post-processed HTML is added separately by
+///    [`pack_archive`] (and the staging dir may hold a stray copy
+///    written there for the Graphics processor's relative paths).
+///  * [`is_excluded_archive_entry`] — Perl `Pack/Zip.pm`'s
+///    `ARCHIVE_EXT_EXCLUDE` (source `.tex`/`.bib`, nested archives,
+///    dotfiles, editor backups). Applied per-basename, matching Perl's
+///    `addTree` filter `sub { !/$ext_exclude/ }`.
 ///
 /// Each source file is wrapped in a 64 KiB `BufReader` to amortise
 /// `read()` syscalls on the input side (the `io::copy` 8 KiB default
@@ -132,10 +157,16 @@ fn add_dir_to_zip<W: Write + io::Seek>(
     let path = entry.path();
     let rel = path.strip_prefix(base).unwrap_or(&path);
     let name = rel.to_string_lossy().to_string();
+    let basename = entry.file_name().to_string_lossy().to_string();
 
     if path.is_dir() {
-      add_dir_to_zip(zip, &path, base, options)?;
-    } else if !name.ends_with(".html") {
+      // Perl's `addTree` filter excludes whole subtrees whose *directory*
+      // name matches (e.g. a nested `.git`); honour the same per-basename
+      // rule before recursing.
+      if !is_excluded_archive_entry(&basename) {
+        add_dir_to_zip(zip, &path, base, options)?;
+      }
+    } else if !name.ends_with(".html") && !is_excluded_archive_entry(&basename) {
       zip.start_file(&name, *options).map_err(io_err)?;
       let f = File::open(&path)?;
       let mut buf_reader = io::BufReader::with_capacity(ZIP_WRITE_BUF, f);
@@ -145,6 +176,60 @@ fn add_dir_to_zip<W: Write + io::Seek>(
   Ok(())
 }
 
+/// Whether a bundle entry should be excluded from the archive — port of
+/// Perl `Pack/Zip.pm` `$ARCHIVE_EXT_EXCLUDE`
+/// (`qr/(?:^\.)|(?:\.(?:zip|gz|epub|tex|bib|mobi|cache)$)|(?:~$)/`),
+/// applied to the file's basename:
+///  * hidden dotfiles (`^\.`),
+///  * editor backups (`~$`),
+///  * nested archives / source / cache files
+///    (`.zip`, `.gz`, `.epub`, `.tex`, `.bib`, `.mobi`, `.cache`).
+fn is_excluded_archive_entry(basename: &str) -> bool {
+  if basename.starts_with('.') || basename.ends_with('~') {
+    return true;
+  }
+  // Suffix test on the lowercase extension (Perl anchors `$`, i.e. the
+  // final extension). `rsplit('.')` yields the extension before any dot.
+  match basename.rsplit_once('.') {
+    Some((_, ext)) => matches!(
+      ext.to_ascii_lowercase().as_str(),
+      "zip" | "gz" | "epub" | "tex" | "bib" | "mobi" | "cache"
+    ),
+    None => false,
+  }
+}
+
+/// Convert a Unix epoch (seconds, UTC) into a zip [`zip::DateTime`].
+///
+/// DOS/zip timestamps only represent 1980-01-01..=2107; epochs outside
+/// that window return `None` (caller falls back to the crate default).
+/// Pure civil-date arithmetic (Howard Hinnant's `civil_from_days`) so we
+/// don't pull in a date-time crate just for `SOURCE_DATE_EPOCH`.
+fn epoch_to_zip_datetime(epoch: u64) -> Option<zip::DateTime> {
+  let days = (epoch / 86_400) as i64;
+  let secs_of_day = (epoch % 86_400) as u32;
+  let (hour, minute, second) = (
+    (secs_of_day / 3600) as u8,
+    ((secs_of_day % 3600) / 60) as u8,
+    (secs_of_day % 60) as u8,
+  );
+  // civil_from_days: days since 1970-01-01 → (year, month, day).
+  let z = days + 719_468;
+  let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+  let doe = z - era * 146_097; // [0, 146096]
+  let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365; // [0, 399]
+  let year = yoe + era * 400;
+  let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+  let mp = (5 * doy + 2) / 153; // [0, 11]
+  let day = (doy - (153 * mp + 2) / 5 + 1) as u8; // [1, 31]
+  let month = (if mp < 10 { mp + 3 } else { mp - 9 }) as u8; // [1, 12]
+  let year = year + i64::from(month <= 2);
+  if !(1980..=2107).contains(&year) {
+    return None;
+  }
+  zip::DateTime::from_date_and_time(year as u16, month, day, hour, minute, second).ok()
+}
+
 /// Convert a `zip::result::ZipError` into an `io::Error` so the caller
 /// signature can stay `io::Result`. The zip crate wraps `io::Error`
 /// already; we just re-wrap unrecognized kinds as `Other`.
@@ -152,5 +237,142 @@ fn io_err(e: zip::result::ZipError) -> io::Error {
   match e {
     zip::result::ZipError::Io(inner) => inner,
     other => io::Error::other(other.to_string()),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use std::io::Read;
+
+  /// Read back the set of entry names from a zip on disk.
+  fn zip_entry_names(zip_path: &Path) -> Vec<String> {
+    let f = File::open(zip_path).expect("open zip");
+    let mut archive = zip::ZipArchive::new(f).expect("parse zip");
+    (0..archive.len())
+      .map(|i| archive.by_index(i).expect("entry").name().to_string())
+      .collect()
+  }
+
+  #[test]
+  fn excludes_perl_archive_ext_set() {
+    // Perl Zip.pm ARCHIVE_EXT_EXCLUDE = qr/(?:^\.)|(?:\.(?:zip|gz|epub|
+    // tex|bib|mobi|cache)$)|(?:~$)/ — applied to the basename.
+    assert!(is_excluded_archive_entry("paper.tex"));
+    assert!(is_excluded_archive_entry("refs.bib"));
+    assert!(is_excluded_archive_entry("bundle.zip"));
+    assert!(is_excluded_archive_entry("page.gz"));
+    assert!(is_excluded_archive_entry("book.epub"));
+    assert!(is_excluded_archive_entry("book.mobi"));
+    assert!(is_excluded_archive_entry("LaTeXML.cache"));
+    assert!(is_excluded_archive_entry(".hidden"));
+    assert!(is_excluded_archive_entry("backup~"));
+    // Kept: real bundle resources.
+    assert!(!is_excluded_archive_entry("fig1.png"));
+    assert!(!is_excluded_archive_entry("diagram.svg"));
+    assert!(!is_excluded_archive_entry("LaTeXML.css"));
+    assert!(!is_excluded_archive_entry("logo.jpg"));
+  }
+
+  #[test]
+  fn pack_archive_bundles_resources_minus_excluded() {
+    let staging = tempfile::tempdir().expect("tempdir");
+    let p = staging.path();
+    // Resources that SHOULD be bundled.
+    std::fs::write(p.join("fig1.png"), b"PNGDATA").unwrap();
+    std::fs::write(p.join("LaTeXML.css"), b"body{}").unwrap();
+    std::fs::create_dir(p.join("sub")).unwrap();
+    std::fs::write(p.join("sub").join("img.svg"), b"<svg/>").unwrap();
+    // Resources that must be EXCLUDED.
+    std::fs::write(p.join("paper.tex"), b"\\documentclass{article}").unwrap();
+    std::fs::write(p.join("refs.bib"), b"@book{x}").unwrap();
+    std::fs::write(p.join("LaTeXML.cache"), b"cache").unwrap();
+    std::fs::write(p.join(".hidden"), b"secret").unwrap();
+    std::fs::write(p.join("backup~"), b"old").unwrap();
+    // The HTML is added separately by pack_archive; a stray copy in
+    // the staging dir must not be double-added.
+    std::fs::write(p.join("doc.html"), b"<html>staging copy</html>").unwrap();
+
+    let out = tempfile::tempdir().expect("out dir");
+    let zip_path = out.path().join("bundle.zip");
+    let zip_path_str = zip_path.to_string_lossy().to_string();
+
+    pack_archive(&PackOptions {
+      zip_path:         &zip_path_str,
+      html_filename:    "doc.html",
+      html:             "<html>real document</html>",
+      log_filename:     Some("doc.log"),
+      log:              "log line",
+      status:           "Status:conversion:0",
+      resource_dir:     Some(p),
+      telemetry_json:   None,
+      source_date_epoch: None,
+    })
+    .expect("pack archive");
+
+    let names = zip_entry_names(&zip_path);
+    // Bundled resources present.
+    assert!(names.iter().any(|n| n == "fig1.png"), "names: {names:?}");
+    assert!(names.iter().any(|n| n == "LaTeXML.css"), "names: {names:?}");
+    assert!(
+      names.iter().any(|n| n == "sub/img.svg"),
+      "subdir resource missing; names: {names:?}"
+    );
+    // Core entries present.
+    assert!(names.iter().any(|n| n == "doc.html"));
+    assert!(names.iter().any(|n| n == "doc.log"));
+    assert!(names.iter().any(|n| n == "status"));
+    // Excluded resources absent.
+    for forbidden in ["paper.tex", "refs.bib", "LaTeXML.cache", ".hidden", "backup~"] {
+      assert!(
+        !names.iter().any(|n| n == forbidden),
+        "{forbidden} must be excluded; names: {names:?}"
+      );
+    }
+    // Exactly one doc.html (the real one), not the staging copy too.
+    assert_eq!(
+      names.iter().filter(|n| n.as_str() == "doc.html").count(),
+      1,
+      "doc.html must not be double-added; names: {names:?}"
+    );
+    // And the real HTML, not the staging copy, is what got stored.
+    let f = File::open(&zip_path).unwrap();
+    let mut archive = zip::ZipArchive::new(f).unwrap();
+    let mut html_entry = archive.by_name("doc.html").unwrap();
+    let mut body = String::new();
+    html_entry.read_to_string(&mut body).unwrap();
+    assert_eq!(body, "<html>real document</html>");
+  }
+
+  #[test]
+  fn source_date_epoch_sets_member_timestamp() {
+    // Perl Zip.pm L113-115: when SOURCE_DATE_EPOCH is set, every member
+    // gets that fixed mod-time for reproducible archives. 2021-01-01
+    // 00:00:00 UTC = 1609459200.
+    let staging = tempfile::tempdir().expect("tempdir");
+    std::fs::write(staging.path().join("fig.png"), b"x").unwrap();
+    let out = tempfile::tempdir().expect("out");
+    let zip_path = out.path().join("ts.zip");
+    let zip_path_str = zip_path.to_string_lossy().to_string();
+    pack_archive(&PackOptions {
+      zip_path:          &zip_path_str,
+      html_filename:     "d.html",
+      html:              "<html/>",
+      log_filename:      None,
+      log:               "",
+      status:            "ok",
+      resource_dir:      Some(staging.path()),
+      telemetry_json:    None,
+      source_date_epoch: Some(1_609_459_200),
+    })
+    .expect("pack");
+
+    let f = File::open(&zip_path).unwrap();
+    let mut archive = zip::ZipArchive::new(f).unwrap();
+    let entry = archive.by_name("fig.png").unwrap();
+    let dt = entry.last_modified().expect("has mod time");
+    assert_eq!(dt.year(), 2021, "year");
+    assert_eq!(dt.month(), 1, "month");
+    assert_eq!(dt.day(), 1, "day");
   }
 }


### PR DESCRIPTION
## Summary

Two related commits from one session on this branch:

### 1. `feat(whatsout)` — full `--whatsin` / `--whatsout` port
Faithful port of `LaTeXML::Util::Pack` + the `LaTeXML.pm` driver logic. The headline asks — `--whatsout=archive` and `--whatsout=fragment` — now work end to end, with the rest of the matrix wired faithfully.

- **`latexml_post::extract`**: new `Whatsout::Archive` variant + `is_archive()` / `requires_post()`; `from_cli` accepts `archive` / `archive::zip` (Perl matches `/^archive/`).
- **`latexml_post::pack`**: apply Perl `ARCHIVE_EXT_EXCLUDE` (skip dotfiles, `~` backups, `.tex/.bib/.zip/.gz/.epub/.mobi/.cache`) + `SOURCE_DATE_EPOCH` reproducible member timestamps (`Pack/Zip.pm::get_archive`).
- **converter bug fix**: key *both* preamble and postamble on `whatsin` (`LaTeXML.pm:166-172`), extracted to the unit-tested `resolve_amble`. Previously the postamble keyed on `whatsout`, dropping `\end{document}` / `\ensuremathpreceeds` for fragment/math inputs.
- **`bin/latexml_oxide`**: map `--whatsin` to the core `DataSize` (`--preamble`/`--postamble` ⇒ `fragment` default); derive `--whatsout` (explicit wins, else a `.zip` dest ⇒ archive); honor `--whatsout=archive` with placeholder `<source>.zip` destination (`LaTeXML.pm:185-187`); force post-processing for any non-`document` whatsout (`Config.pm:454`).

### 2. `fix(test-mem)` — free per-test thread-local engine
**Root cause:** the engine's per-thread roots (`arena::ARENA`, `STATE`/`STD_STATE`/`STY_STATE`, `MODEL`, …) use the `#[thread_local]` *attribute*, which — unlike the `thread_local!` macro — does **not** run `Drop` on thread exit. libtest spawns a fresh thread per test, so each test leaked its whole ~110 MB engine → ~4.9 GB across `50_structure`, tripping the per-process 4.5 GB RSS fuse in `stomach::check_timeout`. The `glossary`/`report`/`paralists` "failures" were that fuse firing mid-conversion (RSS is process-wide), **not** content bugs. Ruled out by measurement: concurrency (`-j1 ≈ -j20 ≈ 4.9 GB`) and glibc per-thread arenas (`MALLOC_ARENA_MAX=1` changed nothing).

**Fix:** new `latexml_core::reset_thread_engine()` (`state::reset_thread_state` + `arena::reset`), called at the end of each conversion in the shared test harness (`util/test.rs::process_texfile`). Frees `State` + interner before the per-test thread exits.

| | before | after |
|---|---|---|
| `50_structure` -j20 | 4 OOM failures | **47/47** |
| `12_grouping` / `22_fonts` | OOM | **green** |
| peak RSS -j20 | 4.97 GB | **~2.9 GB** |
| production RSS cap | — | unchanged (4.5 GB) |

**Scope:** test-only in practice — no shipping path is multi-conversion-per-process (binary = 1 conv/process; `cortex_worker --standalone` = 1 conv/process, canvas forks per paper). So Perl's daemon frame (`pushDaemonFrame`/`popDaemonFrame`) stays unported; a future thread-reusing daemon should keep the interner (`state::reset_thread_state` alone). Residual ~24 MB/test is libxml2 process-global C state, left as-is.

## Test plan
- Red/green TDD throughout. `latexml_post` lib **211/0**, converter `resolve_amble` **4/0**, `91_whatsinout` CLI e2e **4/0** (document=full page, fragment=no chrome, archive=zip bundle + placeholder dest).
- Memory fix verified: `50_structure` **47/47**, `12_grouping`/`22_fonts` green, regression batch `53/55/56/70/80` green, `latexml_core` clippy clean.
- Not run: full `cargo test --tests` to completion (the OOM-halt is gone, but the separate tikz/pgf infinite-loop binaries `85_pgf`/`86_tikz` remain a hazard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
