### PR TITLE
Fix/regression reports html feedback

### DIFF
--- a/latexml_core/src/stomach.rs
+++ b/latexml_core/src/stomach.rs
@@ -679,6 +679,17 @@ pub fn end_mode_opt(mode: &str, noframe: bool) -> Result<()> {
     if !bound_on_top || current_bound != bound_mode {
       // Last stack frame was NOT a mode switch, or was a switch to a different mode.
       // Perl: Don't pop if there's an error; maybe we'll recover?
+      if *TRACE_BOUND_MODE {
+        let cur_tok = get_current_token()
+          .map(|t| t.to_string())
+          .unwrap_or_default();
+        eprintln!(
+          "[trace] end_mode ERROR: mode={mode} cur_tok={cur_tok} bound_on_top={bound_on_top} current_bound={current_bound} depth={}\n  {}\n{}",
+          crate::state::get_frame_depth(),
+          current_frame_message(),
+          std::backtrace::Backtrace::force_capture()
+        );
+      }
       let (category, message) = make_mode_error();
       Error!("unexpected", category, &message);
     } else {

--- a/latexml_oxide/src/post.rs
+++ b/latexml_oxide/src/post.rs
@@ -99,6 +99,14 @@ pub fn run_post_processing(xml: &str, opts: &PostOptions) -> String {
 
   telemetry::phase_enter(Phase::PostXmlParse);
   let t_parse = audit_start("PostDocument::new_from_string");
+  // Perl LaTeXML.pm L330-336: a completely empty core-conversion result
+  // (e.g. after a Fatal abort) is still post-processed — Perl sets a bare
+  // <document/> root first, "important for utility features such as
+  // packing .zip archives for output". Mirror that for the empty-string
+  // serialization instead of failing the parse with a libxml "Got a Null
+  // pointer" and echoing the empty input through (witness: cortex_worker
+  // on any Fatal paper produced a 0-byte .html).
+  let xml = if xml.trim().is_empty() { "<document/>" } else { xml };
   let doc = match PostDocument::new_from_string(xml, doc_opts) {
     Ok(d) => d,
     Err(e) => {

--- a/latexml_package/src/package/xy_sty.rs
+++ b/latexml_package/src/package/xy_sty.rs
@@ -298,11 +298,16 @@ LoadDefinitions!({
         _ => String::from("matrix(1 0 0 1 0 0)"),
       };
       let g_attrs = string_map!("transform" => transform);
-      document.open_element("svg:g", Some(g_attrs), None)?;
-      if let Some(Some(content)) = args.first() {
-        document.absorb(content, None)?;
+      if crate::package::xylatexml_tex::svg_insertion_hopeless(document, "svg:g") {
+        // Orphaned nested xy picture (outer \xy wrapper aborted) — skip,
+        // see xylatexml_tex::svg_empty_element for witness/rationale.
+      } else {
+        document.open_element("svg:g", Some(g_attrs), None)?;
+        if let Some(Some(content)) = args.first() {
+          document.absorb(content, None)?;
+        }
+        document.close_element("svg:g")?;
       }
-      document.close_element("svg:g")?;
     },
     after_digest => sub[whatsit] {
       let range_str = state::lookup_string("saved_xy_range");

--- a/latexml_package/src/package/xylatexml_tex.rs
+++ b/latexml_package/src/package/xylatexml_tex.rs
@@ -118,12 +118,39 @@ fn svg_empty_element(
   attrs: HashMap<String, String>,
 ) -> Result<()> {
   let savenode = document.float_to_element(tag, false)?;
+  if savenode.is_none()
+    && latexml_core::document::can_contain_node_somehow(document.get_node(), tag).is_none()
+  {
+    // Hopeless insertion point: float_to_element found no ancestor that
+    // can host `tag` — not even via auto-open — and already issued the
+    // "No open node can contain element" Warn. This state is reached by
+    // orphaned xy drawing ops whose enclosing \xy wrapper was aborted
+    // (witness 2501.02222: real xy rejects \Qcircuit's matrix setup with
+    // "\xymatrix<setup>{<rows>} expected"; the leftover ops surface at
+    // the \end{document} unwind inside a stale <ltx:text>). Perl never
+    // reaches this state — its emulated xy discards the aborted diagram
+    // body — so degrade the same way: drop the orphaned drawing op and
+    // keep the document. Without this guard each op cascades one
+    // malformed-insert Error (83x on the witness) into
+    // Fatal:TooManyErrors and the paper ships nothing.
+    return Ok(());
+  }
   document.open_element(tag, Some(attrs), None)?;
   document.close_element(tag)?;
   if let Some(saved) = savenode {
     document.set_node(&saved);
   }
   Ok(())
+}
+
+/// Companion guard to [`svg_empty_element`] for the non-empty SVG wrappers
+/// (`svg:g`, `svg:text`) that follow the float->open->absorb->close pattern.
+/// Call after a `float_to_element` that returned `None`: when the current
+/// insertion point cannot host `tag` even via auto-open, the wrapper and its
+/// SVG-internal content are orphaned drawing ops (same witness/rationale as
+/// `svg_empty_element`) and the caller should skip emission entirely.
+pub(crate) fn svg_insertion_hopeless(document: &Document, tag: &str) -> bool {
+  latexml_core::document::can_contain_node_somehow(document.get_node(), tag).is_none()
 }
 
 /// Helper: capture common xy SVG element properties at digest time.
@@ -446,11 +473,16 @@ LoadDefinitions!({
       let ypx = dim_to_px(y);
       let transform = s!("translate({},{})", fmt2(xpx), fmt2(ypx));
       let g_attrs = string_map!("transform" => transform);
-      document.open_element("svg:g", Some(g_attrs), None)?;
-      if let Some(Some(content)) = args.get(2) {
-        document.absorb(content, None)?;
+      if svg_insertion_hopeless(document, "svg:g") {
+        // Orphaned xy positioning op — skip wrapper AND content
+        // (see svg_empty_element for witness/rationale).
+      } else {
+        document.open_element("svg:g", Some(g_attrs), None)?;
+        if let Some(Some(content)) = args.get(2) {
+          document.absorb(content, None)?;
+        }
+        document.close_element("svg:g")?;
       }
-      document.close_element("svg:g")?;
     }
   );
 
@@ -1108,12 +1140,16 @@ LoadDefinitions!({
       let transform = s!("translate({},{}) rotate({}) scale({},{})", x, y, angle, xscale, yscale);
       let attrs = string_map!("transform" => transform, "stroke" => stroke);
       let savenode = document.float_to_element("svg:text", false)?;
-      document.open_element("svg:text", Some(attrs), None)?;
-      if let Some(Some(content)) = args.first() {
-        document.absorb(content, None)?;
+      if savenode.is_none() && svg_insertion_hopeless(document, "svg:text") {
+        // Orphaned xy wrapper — skip (see svg_empty_element).
+      } else {
+        document.open_element("svg:text", Some(attrs), None)?;
+        if let Some(Some(content)) = args.first() {
+          document.absorb(content, None)?;
+        }
+        document.close_element("svg:text")?;
+        if let Some(saved) = savenode { document.set_node(&saved); }
       }
-      document.close_element("svg:text")?;
-      if let Some(saved) = savenode { document.set_node(&saved); }
     },
     properties => sub[args] {
       let (stroke, _fill) = xy_fill_stroke();
@@ -1180,12 +1216,16 @@ LoadDefinitions!({
       };
       let attrs = string_map!("transform" => transform);
       let savenode = document.float_to_element("svg:g", false)?;
-      document.open_element("svg:g", Some(attrs), None)?;
-      if let Some(Stored::Digested(box_d)) = props.get("xy_box") {
-        document.absorb(box_d, None)?;
+      if savenode.is_none() && svg_insertion_hopeless(document, "svg:g") {
+        // Orphaned xy wrapper — skip (see svg_empty_element).
+      } else {
+        document.open_element("svg:g", Some(attrs), None)?;
+        if let Some(Stored::Digested(box_d)) = props.get("xy_box") {
+          document.absorb(box_d, None)?;
+        }
+        document.close_element("svg:g")?;
+        if let Some(saved) = savenode { document.set_node(&saved); }
       }
-      document.close_element("svg:g")?;
-      if let Some(saved) = savenode { document.set_node(&saved); }
     },
     properties => sub[args] {
       let xscale = args.first().and_then(|a| a.as_ref())
@@ -1212,12 +1252,16 @@ LoadDefinitions!({
       };
       let attrs = string_map!("transform" => transform);
       let savenode = document.float_to_element("svg:g", false)?;
-      document.open_element("svg:g", Some(attrs), None)?;
-      if let Some(Stored::Digested(box_d)) = props.get("xy_box") {
-        document.absorb(box_d, None)?;
+      if savenode.is_none() && svg_insertion_hopeless(document, "svg:g") {
+        // Orphaned xy wrapper — skip (see svg_empty_element).
+      } else {
+        document.open_element("svg:g", Some(attrs), None)?;
+        if let Some(Stored::Digested(box_d)) = props.get("xy_box") {
+          document.absorb(box_d, None)?;
+        }
+        document.close_element("svg:g")?;
+        if let Some(saved) = savenode { document.set_node(&saved); }
       }
-      document.close_element("svg:g")?;
-      if let Some(saved) = savenode { document.set_node(&saved); }
     },
     properties => sub[args] {
       let kangle: i64 = args.first().and_then(|a| a.as_ref())
@@ -1253,12 +1297,16 @@ LoadDefinitions!({
       };
       let attrs = string_map!("transform" => transform);
       let savenode = document.float_to_element("svg:g", false)?;
-      document.open_element("svg:g", Some(attrs), None)?;
-      if let Some(Stored::Digested(box_d)) = props.get("xy_box") {
-        document.absorb(box_d, None)?;
+      if savenode.is_none() && svg_insertion_hopeless(document, "svg:g") {
+        // Orphaned xy wrapper — skip (see svg_empty_element).
+      } else {
+        document.open_element("svg:g", Some(attrs), None)?;
+        if let Some(Stored::Digested(box_d)) = props.get("xy_box") {
+          document.absorb(box_d, None)?;
+        }
+        document.close_element("svg:g")?;
+        if let Some(saved) = savenode { document.set_node(&saved); }
       }
-      document.close_element("svg:g")?;
-      if let Some(saved) = savenode { document.set_node(&saved); }
     },
     properties => sub[_args] {
       let lc = xy_reg_dim("\\L@c"); let up = xy_reg_dim("\\U@p"); let rp = xy_reg_dim("\\R@p");


### PR DESCRIPTION
This PR comes from a dev demo we did today, and likely needs more review than usual 
(discussing while claude-ing lowers my focus).

### Summary(generated)

1. 05905ad — fix(xy): drop orphaned SVG drawing ops at hopeless insertion points
    - Problem: When raw-xy aborts a diagram (e.g. `\Qcircuit` matrix setup rejected — same rejection in Perl), 
      already-digested drawing whatsits resurface at the `\end{document}` unwind inside a stale `<ltx:text>`.
      Every `svg:path`/`svg:g` insert then fails → 83 malformed-insert errors → Fatal:TooManyErrors → paper ships nothing, while Perl ships a degraded document.
    - **Fix**: svg_empty_element and the svg wrapper constructors (`\xyscale@@`, `\xyRotate@@`, `\lx@xy@svgtext`, `\lx@xy@move@to`, `\lx@xy@svgnested`)
        now skip emission in the "hopeless orphan" state (no float host and `can_contain_node_somehow` is `None`) — unreachable for healthy diagrams.
    - Witness: arXiv:2501.02222 goes from 102 errors + fatal + zero output → 28 errors with 588KB XML shipped (Perl: 22 errors). Healthy `\xymatrix` output
    - Also adds an env-gated `LXML_TRACE_BOUND_MODE` diagnostic in end_mode_opt.

2. deb2b57 — fix(post): give empty core-conversion results a `<document/>` root

    - Problem: Perl (LaTeXML.pm L330-336) post-processes even fatally-aborted conversions by substituting a bare `<document/>` root.
        Rust fed the empty serialization straight to libxml → "Got a Null pointer" parse error, and cortex_worker shipped a 0-byte `.html` plus the spurious error on every Fatal paper.
    - **Fix:** Mirror Perl — substitute `<document/>` for empty/whitespace-only input in `run_post_processing` (latexml_oxide/src/post.rs, +8 lines).
        XSLT output is then byte-identical to xsltproc, so the archive shape matches the Perl toolchain.
    - Witness: 2403.19758 (tikz-cd fatal) — clean empty html, no parse noise; 2501.02222 (with fix 1.) now ships 264KB of real HTML end-to-end.