### PR TITLE
fix(post): faithful MakeIndex port — see/seeonly, ref styles, anchors, placement

### DIFF
--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -2367,24 +2367,29 @@ fn process_index_phrases(tokens: Tokens) -> Result<Tokens> {
           .map(|t| t.with_str(|s| s.to_string()))
           .collect();
         if extra.starts_with("see{") || extra.starts_with("see {") {
-          // \@indexsee{content}
-          // Skip "see{", collect until "}"
+          // \@indexsee{content} — pass the ORIGINAL tokens (Perl:
+          // @tokens[3..]) rather than a re-Exploded string, so macros
+          // and math inside the see-phrase keep their catcodes and
+          // expand normally (e.g. \index{X|see{\foo $n$-cube}}).
+          // The brace tokens ride along as the constructor's argument
+          // delimiters.
           expansion.push(T_CS!("\\@indexsee"));
-          // Find the content between { and }
-          let content = extra.trim_start_matches("see").trim();
-          let content = content.strip_prefix('{').unwrap_or(content);
-          let content = content.strip_suffix('}').unwrap_or(content);
-          expansion.push(T_BEGIN!());
-          expansion.extend(Explode!(content));
-          expansion.push(T_END!());
+          expansion.extend(toks[i + 3..].iter().cloned());
         } else if extra.starts_with("seealso{") || extra.starts_with("seealso {") {
           expansion.push(T_CS!("\\@indexseealso"));
-          let content = extra.trim_start_matches("seealso").trim();
-          let content = content.strip_prefix('{').unwrap_or(content);
-          let content = content.strip_suffix('}').unwrap_or(content);
-          expansion.push(T_BEGIN!());
-          expansion.extend(Explode!(content));
-          expansion.push(T_END!());
+          expansion.extend(toks[i + 7..].iter().cloned());
+        } else if extra.starts_with("seeonly{") || extra.starts_with("seeonly {") {
+          // DEVIATION from Perl LaTeXML, which lets `|seeonly{...}`
+          // fall through to the style branch below: the raw string
+          // (catcode-mangled) ends up as a font attribute and renders
+          // as a garbage ltx_font_* class (98 occurrences in the AoBF
+          // book, 181 validation errors). The makeindex idiom means
+          // "print ONLY the see-reference, no locators" — treating it
+          // as \@indexsee both renders it correctly and suppresses
+          // this mark's locator refs (Scan skips referrer recording
+          // when ltx:indexsee children are present).
+          expansion.push(T_CS!("\\@indexsee"));
+          expansion.extend(toks[i + 7..].iter().cloned());
         } else if extra == "(" {
           style = Some("rangestart".to_string());
         } else if extra == ")" {
@@ -8284,7 +8289,7 @@ LoadDefinitions!({
   );
 
   // \@indexphrase[sortkey]{phrase} → <ltx:indexphrase>
-  DefConstructor!("\\@indexphrase[]{}", "<ltx:indexphrase key='#key'>#2</ltx:indexphrase>",
+  DefConstructor!("\\@indexphrase[]{}", "<ltx:indexphrase key='#key' _standalone_font='true'>#2</ltx:indexphrase>",
     properties => sub[args] {
       let key = args[0].as_ref()
         .map(|a| clean_index_key(&a.to_string()))
@@ -8298,22 +8303,32 @@ LoadDefinitions!({
   );
 
   // \@indexsee{key} → <ltx:indexsee>
-  DefConstructor!("\\@indexsee{}", "<ltx:indexsee key='#key'>#1</ltx:indexsee>",
+  // Perl carries name => DigestIf('\seename') so the post-processor can
+  // print the italic "see" word in front of the cross-reference.
+  DefConstructor!("\\@indexsee{}", "<ltx:indexsee key='#key' name='#name' _standalone_font='true'>#1</ltx:indexsee>",
     properties => sub[args] {
       let key = args[0].as_ref()
         .map(|a| clean_index_key(&a.to_string()))
         .unwrap_or_default();
-      Ok(stored_map!("key" => key))
+      let mut props = stored_map!("key" => key);
+      if let Some(name) = DigestIf!("\\seename")? {
+        props.insert("name", name.into());
+      }
+      Ok(props)
     }
   );
 
   // \@indexseealso{key} → <ltx:indexsee>
-  DefConstructor!("\\@indexseealso{}", "<ltx:indexsee key='#key'>#1</ltx:indexsee>",
+  DefConstructor!("\\@indexseealso{}", "<ltx:indexsee key='#key' name='#name' _standalone_font='true'>#1</ltx:indexsee>",
     properties => sub[args] {
       let key = args[0].as_ref()
         .map(|a| clean_index_key(&a.to_string()))
         .unwrap_or_default();
-      Ok(stored_map!("key" => key))
+      let mut props = stored_map!("key" => key);
+      if let Some(name) = DigestIf!("\\alsoname")? {
+        props.insert("name", name.into());
+      }
+      Ok(props)
     }
   );
 
@@ -8326,8 +8341,40 @@ LoadDefinitions!({
   });
 
   DefMacro!("\\indexname", "Index");
+  // Perl latex_constructs.pool.ltxml L4567-4585: theindex generates the
+  // "Index" title, computes a document-relative xml:id (the root the
+  // post-processor's per-entry idx.* anchors chain off — without it,
+  // see-refs have nothing to resolve to), and registers as a backmatter
+  // element so a \printindex inside the last open section relocates to
+  // the document/backmatter level instead of nesting (the BACKMATTER_ELEMENT
+  // mapping for ltx:index already exists alongside ltx:bibliography's).
   DefEnvironment!("{theindex}",
-    "<ltx:index xml:id='#id'>#body</ltx:index>");
+    "<ltx:index xml:id='#id'><ltx:title font='#titlefont' _force_font='true'>#title</ltx:title>#body</ltx:index>",
+    before_digest => {
+      Let!("\\item", "\\index@item");
+      Let!("\\subitem", "\\index@subitem");
+      Let!("\\subsubitem", "\\index@subsubitem");
+    },
+    before_digest_end => { stomach::digest(Tokens!(T_CS!("\\index@done")))?; },
+    after_digest_begin => sub[whatsit] {
+      note_backmatter_element(whatsit, "ltx:index");
+      let docid: String = Expand!(T_CS!("\\thedocument@ID")).to_string();
+      let id = if docid.is_empty() {
+        "idx".to_string()
+      } else {
+        s!("{docid}.idx")
+      };
+      whatsit.set_property("id", id);
+      if let Some(title) = DigestIf!("\\indexname")? {
+        if let Some(titlefont) = title.get_font()? {
+          whatsit.set_property("titlefont", titlefont);
+        }
+        whatsit.set_property("title", title);
+      }
+    },
+    before_construct => sub[doc, whatsit] {
+      adjust_backmatter_element(doc, whatsit)?;
+    });
 
   def_primitive_noop("\\indexspace")?;
   def_primitive_noop("\\makeindex")?;

--- a/latexml_oxide/tests/alignment/listing.xml
+++ b/latexml_oxide/tests/alignment/listing.xml
@@ -2182,6 +2182,8 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <p><text font="bold italic">bfit</text>
 <text font="bold italic">itbf</text></p>
     </para>
-    <index/>
   </section>
+  <index xml:id="idx">
+    <title>Index</title>
+  </index>
 </document>

--- a/latexml_post/src/make_index.rs
+++ b/latexml_post/src/make_index.rs
@@ -6,13 +6,34 @@
 //! Supports permuted indexes, splitting by initial, see-also references,
 //! range-style page references, and glossary entry formatting.
 
-use libxml::tree::Node;
+use libxml::tree::{Node, NodeType};
 use rustc_hash::FxHashMap as HashMap;
 use unicode_normalization::UnicodeNormalization;
 
 use crate::document::{NodeData, PostDocument};
 use crate::object_db::{ObjectDB, Value};
 use crate::processor::{ProcessResult, Processor};
+
+/// A see/see-also cross reference extracted from an `ltx:indexsee` node.
+#[derive(Debug)]
+struct SeeAlso {
+  /// The cross-reference word from the `name` attribute ("see", "see also").
+  name: Option<String>,
+  /// Normalized text content, used to resolve the target entry.
+  text: String,
+  /// The original node, for re-rendering the phrase with its markup.
+  node: Option<Node>,
+}
+
+/// One level of an index phrase, as collected by Scan: the sort/merge
+/// key plus the original `ltx:indexphrase` node (when available) for
+/// markup-preserving rendering.
+#[derive(Debug, Clone)]
+struct PhraseRef {
+  key:  String,
+  text: String,
+  node: Option<Node>,
+}
 
 /// Index tree node.
 #[derive(Debug)]
@@ -21,11 +42,12 @@ struct IndexTree {
   key:              Option<String>,
   full_key:         Option<String>,
   phrase:           Option<String>,
+  phrase_node:      Option<Node>,
   phrase_text:      Option<String>,
   full_phrase_text: Option<String>,
   subtrees:         HashMap<String, IndexTree>,
   referrers:        HashMap<String, HashMap<String, bool>>,
-  see_also:         Vec<String>,
+  see_also:         Vec<SeeAlso>,
 }
 
 impl IndexTree {
@@ -35,6 +57,7 @@ impl IndexTree {
       key:              None,
       full_key:         None,
       phrase:           None,
+      phrase_node:      None,
       phrase_text:      None,
       full_phrase_text: None,
       subtrees:         HashMap::default(),
@@ -89,44 +112,80 @@ impl MakeIndex {
 
     let mut all_phrases: HashMap<String, String> = HashMap::default();
     let mut tree = IndexTree::new(index_id);
+    // Perl's final rescan runs every generated id through uniquifyID;
+    // we dedup inline. Distinct phrases can strip to the same
+    // alphanumeric key id (e.g. "probability density, ε-biased" with
+    // and without the space → idx.probabilitydensityepsilonbiased),
+    // which would otherwise emit a duplicate HTML id. Seeded with the
+    // index root id so children can't collide with it.
+    let mut used_ids: HashMap<String, u32> = HashMap::default();
+    used_ids.insert(index_id.to_string(), 0);
 
     for key in &keys {
       if let Some(entry) = self.db.lookup(key) {
-        let phrase_keys: Vec<&str> = key
-          .strip_prefix("INDEX:")
-          .unwrap_or("")
-          .split(':')
-          .filter(|s| !s.is_empty())
-          .collect();
-        if phrase_keys.is_empty() {
+        // Perl drives the tree off the scanned ltx:indexphrase NODES
+        // (`$entry->getValue('phrases')`): the `key` attribute is the
+        // sort/merge key, the node itself re-renders the phrase with
+        // its markup. Fall back to splitting the DB key for entries
+        // scanned without nodes.
+        let mut phrase_refs: Vec<PhraseRef> = Vec::new();
+        if let Some(Value::List(phrase_nodes)) = entry.get_value("phrases") {
+          for item in phrase_nodes {
+            if let Value::Xml(node) = item {
+              let nkey = node.get_attribute("key").unwrap_or_else(|| {
+                get_index_content_key(&node.get_content())
+              });
+              phrase_refs.push(PhraseRef {
+                key:  nkey,
+                text: get_index_content_key(&node.get_content()),
+                node: Some(node.clone()),
+              });
+            }
+          }
+        }
+        if phrase_refs.is_empty() {
+          phrase_refs = key
+            .strip_prefix("INDEX:")
+            .unwrap_or("")
+            .split(':')
+            .filter(|s| !s.is_empty())
+            .map(|s| PhraseRef {
+              key:  s.to_string(),
+              text: s.to_string(),
+              node: None,
+            })
+            .collect();
+        }
+        if phrase_refs.is_empty() {
+          Warn!("expected", key, "Missing phrases in indexmark: '{}'", key);
           continue;
         }
 
         if self.permuted {
           // Cyclic permutations of phrase keys
-          for perm in cyclic_permute(&phrase_keys) {
+          for perm in cyclic_permute(&phrase_refs) {
             if self.split {
-              let init = initial_letter(perm[0]);
+              let init = initial_letter(&perm[0].key);
               let subtree = tree.subtrees.entry(init.clone()).or_insert_with(|| {
                 let mut st = IndexTree::new(&tree.id);
                 st.phrase = Some(init);
                 st
               });
-              add_tree_rec(subtree, &perm, &mut all_phrases, entry);
+              add_tree_rec(subtree, &perm, &mut all_phrases, &mut used_ids, entry);
             } else {
-              add_tree_rec(&mut tree, &perm, &mut all_phrases, entry);
+              add_tree_rec(&mut tree, &perm, &mut all_phrases, &mut used_ids, entry);
             }
           }
         } else if self.split {
-          let init = initial_letter(phrase_keys[0]);
+          let init = initial_letter(&phrase_refs[0].key);
           let subtree = tree.subtrees.entry(init.clone()).or_insert_with(|| {
             let mut st = IndexTree::new(&tree.id);
             st.phrase = Some(init);
             st
           });
-          add_tree_rec(subtree, &phrase_keys, &mut all_phrases, entry);
+          add_tree_rec(subtree, &phrase_refs, &mut all_phrases, &mut used_ids, entry);
         } else {
-          add_tree_rec(&mut tree, &phrase_keys, &mut all_phrases, entry);
+          add_tree_rec(&mut tree, &phrase_refs, &mut all_phrases, &mut used_ids, entry);
         }
       }
     }
@@ -134,10 +193,15 @@ impl MakeIndex {
   }
 
   /// Generate XML for an index list from a tree.
+  ///
+  /// `ancestor_phrases` carries the full_phrase_text of each enclosing
+  /// entry (outermost first) — Perl reaches the same context by walking
+  /// the tree's parent pointers in `lookupSeealsoPhrase`.
   fn make_index_list(
     &self,
     all_phrases: &HashMap<String, String>,
     tree: &IndexTree,
+    ancestor_phrases: &[String],
   ) -> Option<NodeData> {
     if tree.subtrees.is_empty() {
       return None;
@@ -151,7 +215,7 @@ impl MakeIndex {
         tree
           .subtrees
           .get(*key)
-          .map(|st| self.make_index_entry(all_phrases, st))
+          .map(|st| self.make_index_entry(all_phrases, st, ancestor_phrases))
       })
       .collect();
     if entries.is_empty() {
@@ -167,47 +231,105 @@ impl MakeIndex {
   /// Generate a single index entry with sub-entries, references, and see-also.
   ///
   /// Port of `MakeIndex::makeIndexEntry`.
-  fn make_index_entry(&self, all_phrases: &HashMap<String, String>, tree: &IndexTree) -> NodeData {
+  fn make_index_entry(
+    &self,
+    all_phrases: &HashMap<String, String>,
+    tree: &IndexTree,
+    ancestor_phrases: &[String],
+  ) -> NodeData {
     let mut children = Vec::new();
 
-    // Phrase
-    if let Some(ref phrase) = tree.phrase {
+    // Phrase: re-render the scanned ltx:indexphrase node when we have
+    // one (math and styled text inside the phrase survive); plain text
+    // otherwise. Perl: `$doc->trimChildNodes($$tree{phrase})`.
+    if tree.phrase.is_some() || tree.phrase_node.is_some() {
+      let phrase_children: Vec<NodeData> = match tree.phrase_node {
+        Some(ref n) => trimmed_child_nodes(n),
+        None => vec![NodeData::Text(tree.phrase.clone().unwrap_or_default())],
+      };
       children.push(NodeData::Element {
         tag:        "ltx:indexphrase".to_string(),
         attributes: tree
           .key
           .as_ref()
           .map(|k| HashMap::from_iter([("key".to_string(), k.clone())])),
-        children:   vec![NodeData::Text(phrase.clone())],
+        children:   phrase_children,
       });
     }
 
-    // Referrer links (combined with range handling)
+    // Referrer links (combined with range handling). Perl prefixes
+    // them with a one-space ltx:text separating phrase from refs.
     let mut links = Vec::new();
     if !tree.referrers.is_empty() {
+      links.push(NodeData::Element {
+        tag:        "ltx:text".to_string(),
+        attributes: None,
+        children:   vec![NodeData::Text(" ".to_string())],
+      });
       links.extend(self.combine_index_entries(&tree.referrers));
     }
 
-    // See-also links
-    for see_text in &tree.see_also {
-      if !links.is_empty() {
-        links.push(NodeData::Text(", ".to_string()));
+    // See/see-also cross references (Perl makeIndexEntry): each gets
+    // a ", " separator, the italic name word ("see", "see also") when
+    // present, and the phrase — resolved to a linked target entry via
+    // seealsoSearch when possible, with its original markup.
+    //
+    // Lookup context, innermost first (Perl walks parent pointers):
+    // this entry's full phrase, each ancestor's, then bare top-level.
+    let mut see_context: Vec<String> = Vec::new();
+    if let Some(ref fpt) = tree.full_phrase_text {
+      see_context.push(fpt.clone());
+    }
+    see_context.extend(ancestor_phrases.iter().rev().cloned());
+    see_context.push(String::new());
+
+    for see in &tree.see_also {
+      links.push(NodeData::Text(", ".to_string()));
+      if let Some(ref name) = see.name {
+        if !name.is_empty() {
+          links.push(NodeData::Element {
+            tag:        "ltx:text".to_string(),
+            attributes: Some(HashMap::from_iter([(
+              "font".to_string(),
+              "italic".to_string(),
+            )])),
+            children:   vec![NodeData::Text(format!("{} ", name))],
+          });
+        }
       }
-      // Try to find the referenced phrase in allphrases
-      if let Some(target_id) = all_phrases
-        .get(see_text)
-        .or_else(|| all_phrases.get(&see_text.to_lowercase()))
-      {
-        links.push(NodeData::Element {
-          tag:        "ltx:ref".to_string(),
-          attributes: Some(HashMap::from_iter([("idref".to_string(), target_id.clone())])),
-          children:   vec![NodeData::Text(see_text.clone())],
-        });
+      let parts: Vec<SeeChunk> = match see.node {
+        Some(ref n) => seealso_partition(n),
+        None => vec![SeeChunk {
+          key: see.text.clone(),
+          xml: vec![NodeData::Text(see.text.clone())],
+        }],
+      };
+      if let Some(see_links) = seealso_search_rec(&parts, all_phrases, &see_context) {
+        links.extend(see_links);
       } else {
+        // Perl warns unless the see phrase already contains refs of
+        // its own, then falls back to the phrase's own markup.
+        let already_linked = see
+          .node
+          .as_ref()
+          .map(node_has_ref_descendant)
+          .unwrap_or(false);
+        if !already_linked {
+          Warn!(
+            "expected", &see.text,
+            "Missing index see-also term '{}' (seen under {})",
+            see.text,
+            tree.full_key.as_deref().unwrap_or("?")
+          );
+        }
+        let content: Vec<NodeData> = match see.node {
+          Some(ref n) => n.get_child_nodes().into_iter().map(NodeData::XmlNode).collect(),
+          None => vec![NodeData::Text(see.text.clone())],
+        };
         links.push(NodeData::Element {
           tag:        "ltx:text".to_string(),
-          attributes: Some(HashMap::from_iter([("font".to_string(), "italic".to_string())])),
-          children:   vec![NodeData::Text(see_text.clone())],
+          attributes: None,
+          children:   content,
         });
       }
     }
@@ -220,8 +342,12 @@ impl MakeIndex {
       });
     }
 
-    // Sub-entries
-    if let Some(sublist) = self.make_index_list(all_phrases, tree) {
+    // Sub-entries: this entry's full phrase joins the ancestor context.
+    let mut child_ancestors: Vec<String> = ancestor_phrases.to_vec();
+    if let Some(ref fpt) = tree.full_phrase_text {
+      child_ancestors.push(fpt.clone());
+    }
+    if let Some(sublist) = self.make_index_list(all_phrases, tree, &child_ancestors) {
       children.push(sublist);
     }
 
@@ -230,9 +356,39 @@ impl MakeIndex {
       attributes: if tree.id.is_empty() {
         None
       } else {
-        Some(HashMap::from_iter([("xml:id".to_string(), tree.id.clone())]))
+        // fragid mirrors xml:id so the XSLT add_id template emits an
+        // HTML id for the <li> — same workaround as glossaryentry:
+        // these nodes are created after Scan ran, so CrossRef's
+        // fill_in_frags has no DB entry to source fragid from.
+        Some(HashMap::from_iter([
+          ("xml:id".to_string(), tree.id.clone()),
+          ("fragid".to_string(), tree.id.clone()),
+        ]))
       },
       children,
+    }
+  }
+
+  /// Register an `ID:` entry for every index entry just created, so
+  /// CrossRef can resolve the see/see-also `ltx:ref idref=idx.*` links
+  /// to hrefs. Perl gets this for free from `$self->rescan($doc)` at
+  /// the end of MakeIndex::process; we register the minimum CrossRef
+  /// needs (location + fragid) directly.
+  fn register_entry_ids(&mut self, tree: &IndexTree, location: &str) {
+    for subtree in tree.subtrees.values() {
+      if !subtree.id.is_empty() {
+        let entry = self.db.register(&format!("ID:{}", subtree.id), vec![]);
+        entry.set_value("location", Value::from(location));
+        entry.set_value("fragid", Value::from(subtree.id.as_str()));
+        entry.set_value("id", Value::from(subtree.id.as_str()));
+        // Parent chain feeds CrossRef's generate_title context walk
+        // (a see-ref's tooltip becomes the enclosing index's title,
+        // as with Perl's rescan-built entries).
+        if !tree.id.is_empty() {
+          entry.set_value("parent", Value::from(tree.id.as_str()));
+        }
+      }
+      self.register_entry_ids(subtree, location);
     }
   }
 
@@ -252,7 +408,11 @@ impl MakeIndex {
       let id = ids[i];
       let styles = refs.get(id).unwrap();
 
-      // Check for range start
+      // Check for range start. Perl pairs the start with the NEXT
+      // range marker of either kind ($lvl-- for rangestart AND
+      // rangeend): since ids are sorted alphabetically rather than
+      // by document order, no real nesting is possible, and a stray
+      // second start terminates the range rather than extending it.
       if styles.contains_key("rangestart") {
         let start_id = id;
         let mut end_id = id;
@@ -262,7 +422,7 @@ impl MakeIndex {
           end_id = ids[i];
           if let Some(s) = refs.get(end_id) {
             if s.contains_key("rangestart") {
-              level += 1;
+              level -= 1;
             }
             if s.contains_key("rangeend") {
               level -= 1;
@@ -292,10 +452,14 @@ impl MakeIndex {
   ///
   /// Port of `makeIndexRefs`.
   fn make_index_ref(&self, id: &str, styles: &HashMap<String, bool>) -> NodeData {
-    let style: Vec<&String> = styles
+    // Perl: `sort keys %$entry` then take the first — "sorted styles
+    // gives bold, italic, normal; let's just do the first". The sort
+    // is what makes the pick deterministic (and prefers bold).
+    let mut style: Vec<&String> = styles
       .keys()
       .filter(|s| *s != "rangestart" && *s != "rangeend")
       .collect();
+    style.sort();
     let primary_style = style.first().map(|s| s.as_str()).unwrap_or("normal");
 
     let ref_node = NodeData::Element {
@@ -448,13 +612,18 @@ impl Processor for MakeIndex {
   fn process(&mut self, mut doc: PostDocument, nodes: Vec<Node>) -> ProcessResult {
     for node in &nodes {
       let tag = doc.get_qname(node).unwrap_or_default();
-      let id = node.get_attribute("xml:id").unwrap_or_default();
+      // xml:id is namespace-bound: plain get_attribute misses it on
+      // engine-constructed nodes (it only happens to work on nodes
+      // round-tripped through serialization).
+      let id = crate::document::get_xml_id(node).unwrap_or_default();
 
       if tag == "ltx:index" {
         if let Some((tree, all_phrases)) = self.build_tree(&id) {
-          if let Some(index_list) = self.make_index_list(&all_phrases, &tree) {
+          if let Some(index_list) = self.make_index_list(&all_phrases, &tree, &[]) {
             let mut node_mut = node.clone();
             doc.add_nodes(&mut node_mut, &[index_list]);
+            let location = doc.site_relative_destination().unwrap_or_default();
+            self.register_entry_ids(&tree, &location);
           }
         }
       } else if tag == "ltx:glossary" {
@@ -478,27 +647,55 @@ impl Processor for MakeIndex {
 
 fn add_tree_rec(
   tree: &mut IndexTree,
-  phrase_keys: &[&str],
+  phrases: &[PhraseRef],
   all_phrases: &mut HashMap<String, String>,
+  used_ids: &mut HashMap<String, u32>,
   entry: &crate::object_db::Entry,
 ) {
-  if phrase_keys.is_empty() {
-    // Leaf: record referrers and see_also
+  if phrases.is_empty() {
+    // Leaf: record referrers and see_also.
+    // Scan's note_association(["referrers", pid, style]) nests THREE
+    // levels: referrers → {pid → {style → true}} (mirroring Perl's
+    // $$entry{referrers}{$id}{$style}). The inner value is a Hash of
+    // styles, not a scalar — reading it with to_string() used to
+    // collapse every style to "" (Value's Display renders hashes as
+    // the empty string), silently dropping bold/italic/etc. and
+    // wrapping every index ref in an empty-font ltx:text.
     if let Some(Value::Hash(refs)) = entry.get_value("referrers") {
       for (k, v) in refs {
         let styles = tree.referrers.entry(k.clone()).or_default();
-        styles.insert(v.to_string(), true);
+        if let Value::Hash(style_map) = v {
+          for style in style_map.keys() {
+            styles.insert(style.clone(), true);
+          }
+        }
       }
     }
     if let Some(Value::List(see_items)) = entry.get_value("see_also") {
       for item in see_items {
-        tree.see_also.push(item.to_string());
+        // Stored as Value::Xml(ltx:indexsee) by Scan; keep the node
+        // for markup-preserving rendering, plus its name attribute
+        // ("see"/"see also") and normalized text for target lookup.
+        if let Value::Xml(node) = item {
+          tree.see_also.push(SeeAlso {
+            name: node.get_attribute("name"),
+            text: get_index_content_key(&node.get_content()),
+            node: Some(node.clone()),
+          });
+        } else {
+          tree.see_also.push(SeeAlso {
+            name: None,
+            text: get_index_content_key(&item.to_string()),
+            node: None,
+          });
+        }
       }
     }
     return;
   }
-  let key = phrase_keys[0];
-  let rest = &phrase_keys[1..];
+  let phrase = &phrases[0];
+  let rest = &phrases[1..];
+  let key = &phrase.key;
   let key_id = get_index_key_id(key);
   let parent_key = tree.full_key.clone().unwrap_or_default();
   let full_key = if parent_key.is_empty() {
@@ -506,16 +703,29 @@ fn add_tree_rec(
   } else {
     format!("{}.{}", parent_key, key)
   };
+  // Perl: phrasetext (the normalized CONTENT, not the key) feeds the
+  // see/see-also lookup table; multi-level phrases join with a space.
+  let phrase_text = phrase.text.clone();
   let parent_phrase = tree.full_phrase_text.clone().unwrap_or_default();
   let full_phrase = if parent_phrase.is_empty() {
-    key.to_string()
+    phrase_text.clone()
   } else {
-    format!("{} {}", parent_phrase, key)
+    format!("{} {}", parent_phrase, phrase_text)
   };
 
   let tree_id = tree.id.clone();
+  // Allocate the id BEFORE or_insert_with so we can uniquify against
+  // ids already used by sibling phrases that strip to the same
+  // key_id. Only done when the subtree is new (an existing subtree
+  // keeps its id). Perl: uniquifyID appends radix_alpha(clashes).
+  let needs_id = !tree.subtrees.contains_key(key.as_str());
+  let id = if needs_id {
+    Some(uniquify_id(&format!("{}.{}", tree_id, key_id), used_ids))
+  } else {
+    None
+  };
   let subtree = tree.subtrees.entry(key.to_string()).or_insert_with(|| {
-    let id = format!("{}.{}", tree_id, key_id);
+    let id = id.unwrap();
     all_phrases.insert(full_key.clone(), id.clone());
     all_phrases.insert(full_key.to_lowercase(), id.clone());
     all_phrases.insert(full_phrase.clone(), id.clone());
@@ -523,12 +733,31 @@ fn add_tree_rec(
     let mut st = IndexTree::new(&id);
     st.key = Some(key.to_string());
     st.full_key = Some(full_key.clone());
-    st.phrase = Some(key.to_string());
-    st.phrase_text = Some(key.to_string());
+    st.phrase = Some(phrase_text.clone());
+    st.phrase_node = phrase.node.clone();
+    st.phrase_text = Some(phrase_text);
     st.full_phrase_text = Some(full_phrase);
     st
   });
-  add_tree_rec(subtree, rest, all_phrases, entry);
+  add_tree_rec(subtree, rest, all_phrases, used_ids, entry);
+}
+
+/// Perl Post::uniquifyID: return `base` if unused, else append
+/// radix_alpha(n) (a, b, …) for the next free clash counter.
+fn uniquify_id(base: &str, used: &mut HashMap<String, u32>) -> String {
+  if !used.contains_key(base) {
+    used.insert(base.to_string(), 0);
+    return base.to_string();
+  }
+  loop {
+    let n = used.get_mut(base).unwrap();
+    *n += 1;
+    let candidate = format!("{}{}", base, crate::radix::radix_alpha(*n));
+    if !used.contains_key(&candidate) {
+      used.insert(candidate.clone(), 0);
+      return candidate;
+    }
+  }
 }
 
 fn initial_letter(key: &str) -> String {
@@ -539,13 +768,408 @@ fn initial_letter(key: &str) -> String {
   }
 }
 
+/// Perl getIndexKeyID: NFD-decompose, transliterate Greek letters to
+/// their names (so math-bearing keys don't collapse to nothing), then
+/// strip everything but ASCII alphanumerics.
 fn get_index_key_id(key: &str) -> String {
-  key
-    .nfd()
-    .collect::<String>()
-    .chars()
-    .filter(|c| c.is_ascii_alphanumeric())
-    .collect()
+  let decomposed: String = key.trim().nfd().collect();
+  let mut out = String::with_capacity(decomposed.len());
+  for c in decomposed.chars() {
+    if let Some(name) = greek_ascii(c) {
+      out.push_str(name);
+    } else if c.is_ascii_alphanumeric() {
+      out.push(c);
+    }
+  }
+  out
+}
+
+/// Perl %GREEK_ASCII_MAP.
+fn greek_ascii(c: char) -> Option<&'static str> {
+  Some(match c {
+    '\u{03B1}' => "alpha",
+    '\u{03B2}' => "beta",
+    '\u{03B3}' => "gamma",
+    '\u{03B4}' => "delta",
+    '\u{03F5}' => "epsilon",
+    '\u{03B5}' => "varepsilon",
+    '\u{03B6}' => "zeta",
+    '\u{03B7}' => "eta",
+    '\u{03B8}' => "theta",
+    '\u{03D1}' => "vartheta",
+    '\u{03B9}' => "iota",
+    '\u{03BA}' => "kappa",
+    '\u{03BB}' => "lambda",
+    '\u{03BC}' => "mu",
+    '\u{03BD}' => "nu",
+    '\u{03BE}' => "xi",
+    '\u{03C0}' => "pi",
+    '\u{03D6}' => "varpi",
+    '\u{03C1}' => "rho",
+    '\u{03F1}' => "varrho",
+    '\u{03C3}' => "sigma",
+    '\u{03C2}' => "varsigma",
+    '\u{03C4}' => "tau",
+    '\u{03C5}' => "upsilon",
+    '\u{03D5}' => "phi",
+    '\u{03C6}' => "varphi",
+    '\u{03C7}' => "chi",
+    '\u{03C8}' => "psi",
+    '\u{03C9}' => "omega",
+    '\u{0393}' => "Gamma",
+    '\u{0394}' => "Delta",
+    '\u{0398}' => "Theta",
+    '\u{039B}' => "Lambda",
+    '\u{039E}' => "Xi",
+    '\u{03A0}' => "Pi",
+    '\u{03A3}' => "Sigma",
+    '\u{03A5}' => "Upsilon",
+    '\u{03A6}' => "Phi",
+    '\u{03A8}' => "Psi",
+    '\u{03A9}' => "Omega",
+    _ => return None,
+  })
+}
+
+/// Perl getIndexContentKey: trim, collapse internal whitespace,
+/// strip trailing punctuation.
+fn get_index_content_key(s: &str) -> String {
+  let collapsed = s.split_whitespace().collect::<Vec<_>>().join(" ");
+  collapsed
+    .trim_end_matches(['.', ',', ';'])
+    .trim_end()
+    .to_string()
+}
+
+/// Perl `$doc->trimChildNodes`: the node's children minus pure-whitespace
+/// text nodes at either end (whitespace INSIDE the sequence is kept).
+fn trimmed_child_nodes(node: &Node) -> Vec<NodeData> {
+  let children = node.get_child_nodes();
+  let is_ws = |n: &Node| {
+    n.get_type() == Some(NodeType::TextNode) && n.get_content().trim().is_empty()
+  };
+  let start = children.iter().position(|n| !is_ws(n));
+  let end = children.iter().rposition(|n| !is_ws(n));
+  match (start, end) {
+    (Some(s), Some(e)) => children[s..=e].iter().cloned().map(NodeData::XmlNode).collect(),
+    _ => vec![],
+  }
+}
+
+/// Does the node contain an ltx:ref descendant? (Perl checks
+/// `descendant-or-self::ltx:ref` before warning about an unresolved
+/// see-also phrase.)
+fn node_has_ref_descendant(node: &Node) -> bool {
+  if node.get_type() == Some(NodeType::ElementNode) && node.get_name() == "ref" {
+    return true;
+  }
+  node.get_child_nodes().iter().any(node_has_ref_descendant)
+}
+
+// ======================================================================
+// See & see-also resolution (Perl MakeIndex.pm "A LOTTA work, for such
+// a little thing!"). A see phrase is partitioned into alternating
+// candidate-term and candidate-delimiter chunks; the search then tries
+// interpreting each delimiter as part of a longer phrase or as a
+// separator between independent targets.
+
+/// One partition chunk: the normalized lookup key plus the XML pieces
+/// it came from (used to fill the resulting ltx:ref).
+#[derive(Debug, Clone)]
+struct SeeChunk {
+  key: String,
+  xml: Vec<NodeData>,
+}
+
+/// Perl seealsoPartition: chunk the phrase, then (pass 1) combine
+/// adjacent chunks that are both-or-neither delimiters, and (pass 2)
+/// fold pure-space chunks into their neighbours.
+fn seealso_partition(see: &Node) -> Vec<SeeChunk> {
+  let parts = seealso_partition_aux(see);
+  if parts.is_empty() {
+    return parts;
+  }
+  // Pass 1: combine adjacent conjunction/punctuation chunks.
+  let mut iter = parts.into_iter();
+  let mut result: Vec<SeeChunk> = vec![iter.next().unwrap()];
+  for next in iter {
+    let prev_is = is_delimiter_key(&result.last().unwrap().key);
+    let next_is = starts_with_delimiter(&next.key);
+    if prev_is == next_is {
+      let last = result.last_mut().unwrap();
+      last.key.push_str(&next.key);
+      last.xml.extend(next.xml);
+    } else {
+      result.push(next);
+    }
+  }
+  // Pass 2: a pure-space chunk merges its neighbours into one phrase.
+  let mut iter = result.into_iter();
+  let mut merged: Vec<SeeChunk> = vec![iter.next().unwrap()];
+  let mut rest: Vec<SeeChunk> = iter.collect();
+  let mut i = 0;
+  while i < rest.len() {
+    let next = rest[i].clone();
+    if !next.key.is_empty() && next.key.trim().is_empty() && i + 1 < rest.len() {
+      let after = rest[i + 1].clone();
+      let last = merged.last_mut().unwrap();
+      last.key.push_str(&next.key);
+      last.key.push_str(&after.key);
+      last.xml.extend(next.xml);
+      last.xml.extend(after.xml);
+      i += 2;
+    } else {
+      merged.push(next);
+      i += 1;
+    }
+  }
+  merged
+}
+
+/// Perl seealsoPartition_aux: split into pure phrase/delimiter chunks.
+fn seealso_partition_aux(node: &Node) -> Vec<SeeChunk> {
+  let mut result = Vec::new();
+  for ch in node.get_child_nodes() {
+    match ch.get_type() {
+      Some(NodeType::TextNode) => {
+        let mut s = ch.get_content();
+        while !s.is_empty() {
+          if let Some((delim, rest)) = take_delimiter(&s) {
+            result.push(SeeChunk {
+              key: delim.clone(),
+              xml: vec![NodeData::Text(delim)],
+            });
+            s = rest;
+          } else {
+            // ^([^,\.\s]+)
+            let end = s
+              .find(|c: char| c == ',' || c == '.' || c.is_whitespace())
+              .unwrap_or(s.len());
+            let (tok, rest) = s.split_at(end);
+            result.push(SeeChunk {
+              key: get_index_content_key(tok),
+              xml: vec![NodeData::Text(tok.to_string())],
+            });
+            s = rest.to_string();
+          }
+        }
+      },
+      Some(NodeType::ElementNode) => {
+        let name = ch.get_name();
+        if name == "text" || name == "emph" {
+          // Recurse, re-wrapping each sub-chunk in the styling element
+          // so delimiters can split styled phrases (Perl does the same).
+          let attrs: HashMap<String, String> = ch.get_properties().into_iter().collect();
+          for sub in seealso_partition_aux(&ch) {
+            result.push(SeeChunk {
+              key: sub.key,
+              xml: vec![NodeData::Element {
+                tag:        format!("ltx:{}", name),
+                attributes: if attrs.is_empty() { None } else { Some(attrs.clone()) },
+                children:   sub.xml,
+              }],
+            });
+          }
+        } else {
+          // Opaque element (math etc.): one phrase chunk.
+          result.push(SeeChunk {
+            key: get_index_content_key(&ch.get_content()),
+            xml: vec![NodeData::XmlNode(ch.clone())],
+          });
+        }
+      },
+      _ => {},
+    }
+  }
+  result
+}
+
+/// Leading delimiter per Perl: `^(,|\.|\s+|and\s+also\b|and\b|or\b)`.
+fn take_delimiter(s: &str) -> Option<(String, String)> {
+  if s.starts_with(',') || s.starts_with('.') {
+    return Some((s[..1].to_string(), s[1..].to_string()));
+  }
+  let ws_len = s.len() - s.trim_start().len();
+  if ws_len > 0 {
+    return Some((s[..ws_len].to_string(), s[ws_len..].to_string()));
+  }
+  for kw in ["and also", "and", "or"] {
+    if let Some(rest) = strip_keyword(s, kw) {
+      return Some((s[..s.len() - rest.len()].to_string(), rest.to_string()));
+    }
+  }
+  None
+}
+
+/// Match a keyword (with internal `\s+` flexibility for "and also")
+/// at the start of `s`, requiring a word boundary after it.
+fn strip_keyword<'a>(s: &'a str, kw: &str) -> Option<&'a str> {
+  let mut rest = s;
+  for (i, word) in kw.split(' ').enumerate() {
+    if i > 0 {
+      let trimmed = rest.trim_start();
+      if trimmed.len() == rest.len() {
+        return None; // needed \s+ between words
+      }
+      rest = trimmed;
+    }
+    rest = rest.strip_prefix(word)?;
+  }
+  // \b: next char must not be a word character
+  match rest.chars().next() {
+    Some(c) if c.is_alphanumeric() || c == '_' => None,
+    _ => Some(rest),
+  }
+}
+
+/// Is this chunk key delimiter-shaped?
+/// Perl: `^,?\s*(?:,|\.|\s+|\band\s+also|\band|\bor)\s*$`.
+fn is_delimiter_key(key: &str) -> bool {
+  let k = key.strip_prefix(',').unwrap_or(key).trim();
+  if k.is_empty() || k == "," || k == "." || k == "and" || k == "or" {
+    return true;
+  }
+  let words: Vec<&str> = k.split_whitespace().collect();
+  words == ["and", "also"]
+}
+
+/// Does this chunk key START with a delimiter?
+/// Perl: `^(?:,|\.|\s+|and\b|or\b)`.
+fn starts_with_delimiter(key: &str) -> bool {
+  key.starts_with(',')
+    || key.starts_with('.')
+    || key.starts_with(|c: char| c.is_whitespace())
+    || strip_keyword(key, "and").is_some()
+    || strip_keyword(key, "or").is_some()
+}
+
+/// Perl seealsoJoin: reassemble consecutive chunks into one candidate.
+fn seealso_join(parts: &[SeeChunk]) -> SeeChunk {
+  let key = get_index_content_key(&parts.iter().map(|p| p.key.as_str()).collect::<String>());
+  let xml = parts.iter().flat_map(|p| p.xml.clone()).collect();
+  SeeChunk { key, xml }
+}
+
+/// Perl seealsoSearch_rec: parts alternate (potential) term and
+/// (potential) delimiter. Try each delimiter first as phrase-internal
+/// (joining its neighbours), then as a separator between targets.
+fn seealso_search_rec(
+  parts: &[SeeChunk],
+  all_phrases: &HashMap<String, String>,
+  context: &[String],
+) -> Option<Vec<NodeData>> {
+  if parts.is_empty() {
+    return None;
+  }
+  if parts.len() < 3 {
+    // Single term (with possible trailing punctuation): just look it up.
+    let link = lookup_seealso_phrase(&parts[0], all_phrases, context)?;
+    let mut out = vec![link];
+    if parts.len() > 1 {
+      out.extend(parts[1].xml.clone());
+    }
+    return Some(out);
+  }
+  // Try the first delimiter "literally" (term+delim+term as one phrase).
+  let mut joined: Vec<SeeChunk> = vec![seealso_join(&parts[0..3])];
+  joined.extend_from_slice(&parts[3..]);
+  if let Some(links) = seealso_search_rec(&joined, all_phrases, context) {
+    return Some(links);
+  }
+  // Try the delimiter as a separator between individual entries.
+  if let Some(link) = lookup_seealso_phrase(&parts[0], all_phrases, context) {
+    if let Some(rest) = seealso_search_rec(&parts[2..], all_phrases, context) {
+      let mut out = vec![link];
+      out.extend(parts[1].xml.clone());
+      out.extend(rest);
+      return Some(out);
+    }
+  }
+  None
+}
+
+/// Perl lookupSeealsoPhrase: try the phrase as-is, ignoring commas,
+/// plurals, case, or treating commas as level separators — first within
+/// the current entry's context (innermost first), then at top level.
+fn lookup_seealso_phrase(
+  chunk: &SeeChunk,
+  all_phrases: &HashMap<String, String>,
+  context: &[String],
+) -> Option<NodeData> {
+  let phrase = chunk.key.trim().to_string();
+  if phrase.is_empty() {
+    return None;
+  }
+  let pnc = comma_to_space(&phrase);
+  let ps = strip_plurals(&phrase);
+  let psnc = comma_to_space(&ps);
+  let pnlvl = comma_to(&phrase, ".");
+  let mut trials: Vec<String> = Vec::new();
+  for t in [&phrase, &pnc, &ps, &psnc, &pnlvl] {
+    trials.push((*t).clone());
+    trials.push(t.to_lowercase());
+  }
+  for trial in &trials {
+    for prefix in context {
+      let lookup_key = if prefix.is_empty() {
+        trial.clone()
+      } else {
+        format!("{} {}", prefix, trial)
+      };
+      if let Some(id) = all_phrases.get(&lookup_key) {
+        return Some(NodeData::Element {
+          tag:        "ltx:ref".to_string(),
+          attributes: Some(HashMap::from_iter([("idref".to_string(), id.clone())])),
+          children:   chunk.xml.clone(),
+        });
+      }
+    }
+  }
+  None
+}
+
+/// `s/,\s*/ /g`
+fn comma_to_space(s: &str) -> String { comma_to(s, " ") }
+
+fn comma_to(s: &str, repl: &str) -> String {
+  let mut out = String::with_capacity(s.len());
+  let mut chars = s.chars().peekable();
+  while let Some(c) = chars.next() {
+    if c == ',' {
+      out.push_str(repl);
+      while chars.peek().is_some_and(|c| c.is_whitespace()) {
+        chars.next();
+      }
+    } else {
+      out.push(c);
+    }
+  }
+  out
+}
+
+/// `s/(\w+)s\b/$1/g` — strip a trailing "s" from every word.
+fn strip_plurals(s: &str) -> String {
+  let mut out = String::with_capacity(s.len());
+  let mut word = String::new();
+  for c in s.chars() {
+    if c.is_alphanumeric() || c == '_' {
+      word.push(c);
+    } else {
+      push_depluraled(&mut out, &word);
+      word.clear();
+      out.push(c);
+    }
+  }
+  push_depluraled(&mut out, &word);
+  out
+}
+
+fn push_depluraled(out: &mut String, word: &str) {
+  if word.len() > 1 && word.ends_with('s') {
+    out.push_str(&word[..word.len() - 1]);
+  } else {
+    out.push_str(word);
+  }
 }
 
 /// Generate cyclic permutations of a slice.

--- a/latexml_post/src/scan.rs
+++ b/latexml_post/src/scan.rs
@@ -582,6 +582,14 @@ impl Scan {
     let exists = self.db.lookup(&key).is_some();
     if !exists {
       let mut props = vec![];
+      // Perl registers `phrases => [@phrases]` — the ltx:indexphrase
+      // NODES — so MakeIndex can key the tree off their `key`
+      // attributes and re-render the phrases with their markup
+      // (math inside an index phrase survives into the index).
+      props.push((
+        "phrases",
+        Value::List(phrases.iter().map(|n| Value::from(n.clone())).collect()),
+      ));
       if let Some(il) = inlist {
         props.push(("inlist", il));
       }
@@ -590,10 +598,10 @@ impl Scan {
 
     if !see_also.is_empty() {
       if let Some(entry) = self.db.lookup_mut(&key) {
-        let nodes: Vec<Value> = see_also
-          .iter()
-          .map(|n| Value::from(n.get_content()))
-          .collect();
+        // Store the ltx:indexsee NODES (not their flattened text):
+        // MakeIndex needs the `name` attribute ("see"/"see also") and
+        // the phrase's inline markup to render the cross-reference.
+        let nodes: Vec<Value> = see_also.iter().map(|n| Value::from(n.clone())).collect();
         entry.push_new("see_also", nodes);
       }
     } else if let Some(pid) = parent_id {


### PR DESCRIPTION
## Summary

A faithful port of `LaTeXML::Post::MakeIndex` semantics, fixing four interacting index-pipeline bugs surfaced by validating the *Analysis of Boolean Functions* book (a 481-page document with a large index using 98 `\seeonly` marks). The oxide conversion masked these as benign-looking degradation, but they diverged sharply from Perl LaTeXML, producing **181 HTML validation errors** and a structurally broken index.

After the fix: **181 → 0 validation errors**, 98 → 0 garbage `ltx_font_*` classes, 0 → 507 index-entry anchors. Verified against a minimal reproducer (byte-for-byte with Perl's intermediate XML) and the full book.

## The four bugs

1. **Ref-style drop** (`make_index.rs`). `Scan` writes referrers as a 3-level hash `{pid → {style → true}}` (Perl `$$entry{referrers}{$id}{$style}`), but `add_tree_rec` read the inner hash with `to_string()`, which `Value`'s `Display` renders as `""` — silently dropping every bold/italic/seeonly style and wrapping each locator in an empty-font `ltx:text`. Now reads the nested style map; `makeIndexRefs` sorts styles before picking the first (Perl `sort keys`), restoring determinism + bold preference.

2. **See-phrase tokens** (`latex_constructs.rs`). `\index{X|see{...}}` re-`Explode!`'d the see content into inert characters, so math and macros never expanded. Now passes the original tokens (Perl `@tokens[3..]`/`[7..]`) and carries the `name` attribute (`see`/`see also`) via `DigestIf(\seename/\alsoname)`. A new `\seeonly` arm routes the makeindex "see-only, no locators" idiom to `\@indexsee` instead of letting it fall through to the style branch, where its catcode-mangled string became a garbage `ltx_font_*` class — the AoBF 181-error source. (Perl LaTeXML 0.8.8 shares this `\seeonly` fall-through bug; will report upstream.)

3. **Anchors + see resolution** (`make_index.rs`, `scan.rs`). `indexentry` nodes now carry `xml:id` + `fragid` and register `ID:` DB entries (with parent chain) so `CrossRef` resolves see-refs to real `href`s with titles — Perl gets this from its end-of-pass `rescan`. Full port of the `seealsoPartition` / `seealsoSearch_rec` / `lookupSeealsoPhrase` search (comma/plural/case/level trials, context walk up the tree), plus `getIndexContentKey`, the Greek→ASCII key map, `trimChildNodes`, and markup-preserving phrase rendering off the scanned `indexphrase` nodes.

4. **Index placement + title** (`theindex` env). `\printindex` nested an empty, idless `<index/>` inside the last open section. Now generates the "Index" title, a document-relative `xml:id` (the root the `idx.*` anchors chain off), and registers as a backmatter element so it relocates to document level — matching Perl's `noteBackmatterElement`/`adjustBackmatterElement` pair.

Plus `uniquify_id` (Perl `Post::uniquifyID`, `radix_alpha` clash suffixes) for sibling phrases that strip to the same alphanumeric key id (AoBF: "probability density, ε-biased" with vs. without the space).

## Example

An AoBF index entry with math in both the phrase and the see-reference now renders as proper MathML with the italic "see" word — previously a garbage `ltx_font_seeonly–…` class:

```html
<li id="idx.2qhypercontractivity" class="ltx_indexentry">
  <span class="ltx_indexphrase"><math …>(2,q)</math>-hypercontractivity</span>
  <span class="ltx_indexrefs">, <span class="ltx_text ltx_font_italic">see </span>
  <span class="ltx_text">hypercontractivity, <math …>(2,q)</math>…</span></span></li>
```

## Tests

- `53_alignment/listing` golden updates to the corrected structure (index at backmatter level with id + title; was an empty `<index/>` in-section) — now byte-for-byte with Perl's intermediate XML.
- Full `latexml` + `latexml_post` + `latexml_engine` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
