### PR TITLE
fix(post): copy & follow CLI --css/--javascript resources to the destination

### DIFF
--- a/latexml_oxide/bin/cortex_worker.rs
+++ b/latexml_oxide/bin/cortex_worker.rs
@@ -283,6 +283,7 @@ impl LatexmlWorker {
       stylesheet:                Some("resources/XSLT/LaTeXML-html5.xsl"),
       destination:               Some(&dest_html_str),
       source_directory:          Some(&source_dir),
+      search_paths:              &[],
       nodefaultresources:        self.profile.nodefaultresources,
       css_files:                 &[],
       js_files:                  &[],

--- a/latexml_oxide/bin/latexml_oxide.rs
+++ b/latexml_oxide/bin/latexml_oxide.rs
@@ -801,6 +801,7 @@ fn real_main() -> Result<(), Box<dyn Error>> {
           stylesheet: effective_stylesheet.as_deref(),
           destination: dest_for_post.as_deref(),
           source_directory: Some(&source_dir),
+          search_paths: &cli.search_paths,
           nodefaultresources: cli.nodefaultresources,
           css_files: &cli.css_files,
           js_files: &cli.js_files,

--- a/latexml_oxide/src/lsp_server/document.rs
+++ b/latexml_oxide/src/lsp_server/document.rs
@@ -131,6 +131,7 @@ pub(crate) fn post_process_html(core_xml: &str, uri: &str) -> String {
     stylesheet: Some("resources/XSLT/LaTeXML-html5.xsl"),
     destination: None,
     source_directory: source_dir.as_deref(),
+    search_paths: &[],
     // The server returns HTML as a string with no destination — it must never
     // write CSS/JS resource files to disk (would pollute the cwd). The client
     // supplies its own preview styling.

--- a/latexml_oxide/src/post.rs
+++ b/latexml_oxide/src/post.rs
@@ -22,6 +22,11 @@ pub struct PostOptions<'a> {
   pub stylesheet:                Option<&'a str>,
   pub destination:               Option<&'a str>,
   pub source_directory:          Option<&'a str>,
+  /// Extra resource search paths (the `--path` flag): directories searched
+  /// for `--css`/`--javascript` files (and other post resources) to copy into
+  /// the destination, in addition to the document's own paths, the current
+  /// directory, and the binary's embedded resource table.
+  pub search_paths:              &'a [String],
   pub nodefaultresources:        bool,
   pub css_files:                 &'a [String],
   pub js_files:                  &'a [String],
@@ -57,6 +62,7 @@ pub fn run_post_processing(xml: &str, opts: &PostOptions) -> String {
     stylesheet,
     destination,
     source_directory,
+    search_paths,
     nodefaultresources,
     css_files,
     js_files,
@@ -318,6 +324,12 @@ pub fn run_post_processing(xml: &str, opts: &PostOptions) -> String {
       {
         searchpaths.insert(0, project_root.display().to_string());
       }
+    }
+    // Prepend the user's `--path` directories so `--css`/`--javascript`
+    // resources are found there (and take priority over `.`/project root)
+    // when copy_param_resources searches for them.
+    for p in search_paths.iter().rev() {
+      searchpaths.insert(0, p.clone());
     }
     let mut xslt_params = rustc_hash::FxHashMap::default();
 

--- a/latexml_oxide/tests/002_cli_css_resource_copy.rs
+++ b/latexml_oxide/tests/002_cli_css_resource_copy.rs
@@ -1,0 +1,176 @@
+//! Regression test: CLI `--css` resources are searched on `--path` and
+//! COPIED into the destination directory.
+//!
+//! Before the fix, `--css=foo.css --path=DIR` emitted a `<link>` to `foo.css`
+//! in the HTML but never searched `--path` for the file nor copied it, so the
+//! page rendered unstyled (the file simply wasn't there next to the HTML).
+//!
+//! `--nodefaultresources` is orthogonal and must NOT suppress CLI-specified
+//! resources — it only drops the bundled defaults (`LaTeXML.css` /
+//! `ltx-article.css`). This test pins both halves: with
+//! `--nodefaultresources` set, the custom `--css` file is still copied, while
+//! the bundled defaults are not.
+//!
+//! Faithful to Perl `LaTeXML::Post::XSLT::process` L71-78 (the CSS/JAVASCRIPT
+//! param copy, which sits OUTSIDE the `noresources` guard).
+
+use std::path::Path;
+use std::process::Command;
+
+const HELLO_TEX: &str = "\\documentclass{article}\n\
+                         \\begin{document}\n\
+                         Hello World!\n\
+                         \\end{document}\n";
+
+const CUSTOM_CSS: &str = "/* oxide-test-marker */\nbody { color: rebeccapurple; }\n";
+
+#[test]
+fn cli_css_is_searched_on_path_and_copied_even_with_nodefaultresources() {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+
+  let workdir = tempfile::tempdir().expect("create tempdir");
+  // The custom CSS lives in a subdirectory reachable ONLY via `--path`.
+  let cssdir = workdir.path().join("styles");
+  std::fs::create_dir(&cssdir).expect("mkdir styles");
+  std::fs::write(cssdir.join("mystyle.css"), CUSTOM_CSS).expect("write mystyle.css");
+
+  let tex_path = workdir.path().join("hello.tex");
+  let html_path = workdir.path().join("hello.html");
+  std::fs::write(&tex_path, HELLO_TEX).expect("write hello.tex");
+
+  let output = Command::new(bin)
+    .arg(tex_path.file_name().unwrap())
+    .arg("--dest")
+    .arg(html_path.file_name().unwrap())
+    .arg("--format")
+    .arg("html5")
+    .arg("--css")
+    .arg("mystyle.css")
+    .arg("--path")
+    .arg(&cssdir)
+    .arg("--nodefaultresources")
+    .current_dir(workdir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+
+  assert!(
+    output.status.success(),
+    "binary exited {:?}\nstderr:\n{}",
+    output.status.code(),
+    String::from_utf8_lossy(&output.stderr),
+  );
+
+  // The HTML links the custom CSS.
+  let html = std::fs::read_to_string(&html_path).expect("read hello.html");
+  assert!(
+    html.contains("mystyle.css"),
+    "expected mystyle.css link in HTML, got:\n{html}",
+  );
+
+  // THE FIX: the file is searched on `--path` and copied into the destination
+  // directory (next to the HTML), even though `--nodefaultresources` is set.
+  let copied = workdir.path().join("mystyle.css");
+  assert!(
+    copied.is_file(),
+    "expected mystyle.css copied next to hello.html (the --css/--path copy), \
+     missing at {}\nstderr:\n{}",
+    copied.display(),
+    String::from_utf8_lossy(&output.stderr),
+  );
+  assert_eq!(
+    std::fs::read_to_string(&copied).expect("read copied css"),
+    CUSTOM_CSS,
+    "copied CSS content should match the source on --path",
+  );
+
+  // The custom file came from `--path`, NOT the embedded table, so there must
+  // be no `missing_file` warning for it.
+  let stderr = String::from_utf8_lossy(&output.stderr);
+  assert!(
+    !stderr.contains("missing_file") || !stderr.contains("mystyle.css"),
+    "unexpected missing_file warning for mystyle.css:\n{stderr}",
+  );
+
+  // `--nodefaultresources` must still suppress the bundled defaults.
+  assert!(
+    !workdir.path().join("LaTeXML.css").exists(),
+    "--nodefaultresources should suppress bundled LaTeXML.css",
+  );
+}
+
+/// The copied CSS's LOCAL `@import` targets are followed recursively, with
+/// their subdirectory structure recreated under the destination so the
+/// cascade still resolves (the ar5iv "glowup" pattern: `ar5iv.css` →
+/// `@import "./ar5iv/*.css"`). Remote (`https://…`) imports are left alone.
+#[test]
+fn cli_css_local_imports_are_recursively_copied_with_subdirs() {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+
+  let workdir = tempfile::tempdir().expect("create tempdir");
+  let styles = workdir.path().join("styles");
+  std::fs::create_dir_all(styles.join("layer")).expect("mkdir styles/layer");
+  // main.css imports a LOCAL sub-file (in a subdir) and a REMOTE sheet.
+  std::fs::write(
+    styles.join("main.css"),
+    "@import url(\"./layer/part.css\") layer(base);\n\
+     @import url('https://example.invalid/remote.css');\n\
+     body { color: red; }\n",
+  )
+  .expect("write main.css");
+  let part_css = "/* part marker */\np { margin: 0; }\n";
+  std::fs::write(styles.join("layer").join("part.css"), part_css).expect("write part.css");
+
+  let tex_path = workdir.path().join("hello.tex");
+  std::fs::write(&tex_path, HELLO_TEX).expect("write hello.tex");
+
+  let output = Command::new(bin)
+    .arg("hello.tex")
+    .arg("--dest")
+    .arg("hello.html")
+    .arg("--format")
+    .arg("html5")
+    .arg("--css")
+    .arg("main.css")
+    .arg("--path")
+    .arg(&styles)
+    .arg("--nodefaultresources")
+    .current_dir(workdir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+
+  assert!(
+    output.status.success(),
+    "binary exited {:?}\nstderr:\n{}",
+    output.status.code(),
+    String::from_utf8_lossy(&output.stderr),
+  );
+
+  // Top-level CSS copied next to the HTML (flattened to its basename)...
+  assert!(
+    workdir.path().join("main.css").is_file(),
+    "main.css not copied next to hello.html",
+  );
+
+  // ...and the LOCAL @import target was followed AND its subdirectory was
+  // recreated under the destination, so `./layer/part.css` resolves.
+  let imported = workdir.path().join("layer").join("part.css");
+  assert!(
+    imported.is_file(),
+    "expected @import target recreated at {} (subdir structure preserved)\nstderr:\n{}",
+    imported.display(),
+    String::from_utf8_lossy(&output.stderr),
+  );
+  assert_eq!(
+    std::fs::read_to_string(&imported).expect("read imported part.css"),
+    part_css,
+    "recursively-copied @import content should match the source",
+  );
+
+  // The remote @import must NOT have been fetched/written locally.
+  assert!(
+    !workdir.path().join("remote.css").exists(),
+    "remote @import should be left untouched, not copied locally",
+  );
+}

--- a/latexml_oxide/tests/52_source_map.rs
+++ b/latexml_oxide/tests/52_source_map.rs
@@ -55,6 +55,7 @@ fn html_from(xml: &str) -> String {
     stylesheet:                Some("resources/XSLT/LaTeXML-html5.xsl"),
     destination:               None,
     source_directory:          Some("tests/structure"),
+    search_paths:              &[],
     nodefaultresources:        true,
     css_files:                 &[],
     js_files:                  &[],

--- a/latexml_post/src/xslt.rs
+++ b/latexml_post/src/xslt.rs
@@ -7,8 +7,12 @@
 use libxml::tree::Node;
 use rustc_hash::FxHashMap as HashMap;
 use std::cell::RefCell;
+use std::collections::HashSet;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+use regex::Regex;
 
 use crate::document::{PostDocument, PostDocumentOptions};
 use crate::processor::{PostError, ProcessResult, Processor};
@@ -232,6 +236,95 @@ impl XSLT {
     }
   }
 
+  /// Copy each resource named in a `"a|b|c"` quoted pipe-list stylesheet
+  /// parameter (`CSS`, `JAVASCRIPT`, `ICON`) to the destination so the
+  /// `<link>`/`<script>` the stylesheet emits actually resolve.
+  ///
+  /// Port of `XSLT::process` L71-78 (the param-resource copy, distinct from the
+  /// embedded `<ltx:resource>` handling): every `--css` / `--javascript` /
+  /// icon entry is searched on the path (then the embedded table), copied, and
+  /// a missing entry warns `missing_file`. This runs **regardless of
+  /// `no_resources`** — `--nodefaultresources` only governs embedded
+  /// `<ltx:resource>` nodes, not CLI-specified resources (Perl L62-78: the CSS/
+  /// JAVASCRIPT/ICON copies sit *outside* the `noresources` guard).
+  ///
+  /// The copy targets the **site directory** (the root the relativized links in
+  /// [`relativize_resource_params`] point at, via `../` for split sub-pages),
+  /// falling back to the destination directory when no site dir is set. Link
+  /// relativization itself stays in `relativize_resource_params`; this method
+  /// only performs the copy, so split/`--splitat` link paths are unchanged.
+  fn copy_param_resources(&self, doc: &PostDocument, value: &str, info: Option<&ResourceInfo>) {
+    let dest_root = match doc
+      .get_site_directory()
+      .or_else(|| doc.get_destination_directory())
+    {
+      Some(d) => d.to_string(),
+      None => return,
+    };
+    let search_paths: Vec<&str> = doc
+      .get_search_paths()
+      .iter()
+      .chain(self.searchpaths.iter())
+      .map(String::as_str)
+      .collect();
+    // Only CSS recurses into its `@import`-ed sub-resources (below).
+    let is_css = info.is_some_and(|i| i.extension == "css");
+    // Cycle/dedup guard shared across every entry's @import graph.
+    let mut seen: HashSet<PathBuf> = HashSet::new();
+    for entry in value.trim_matches('"').split('|') {
+      let entry = entry.trim();
+      // Skip empties and URLs (nothing to copy — same guard as copy_resource).
+      if entry.is_empty()
+        || entry.starts_with("http://")
+        || entry.starts_with("https://")
+        || entry.starts_with("//")
+      {
+        continue;
+      }
+      let basename = Path::new(entry)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or(entry);
+      let dest = format!("{}/{}", dest_root, basename);
+      let ensure_parent = || {
+        if let Some(parent) = Path::new(&dest).parent() {
+          let _ = fs::create_dir_all(parent);
+        }
+      };
+      match find_resource_file(entry, info, &search_paths) {
+        Some(path) => {
+          if path != dest {
+            ensure_parent();
+            if let Err(e) = fs::copy(&path, &dest) {
+              Warn!("I/O", dest, "Couldn't copy {} to {}: {}", path, dest, e);
+            }
+          }
+          // Beyond Perl: follow the copied CSS's local @import chain so split
+          // stylesheets (e.g. ar5iv.css -> ./ar5iv/*.css layer files) bring
+          // their sub-files along. Gated to CSS; no-op for JS/icon.
+          if is_css {
+            copy_css_imports(Path::new(&path), Path::new(&dest), &mut seen);
+          }
+        },
+        None => {
+          // Not on the path — try the binary's embedded resource table
+          // (same fallback as copy_resource, so bundled CSS/JS still land).
+          if let Some(bytes) = embedded_resources::lookup(basename) {
+            ensure_parent();
+            if let Err(e) = fs::write(&dest, bytes) {
+              Warn!("I/O", dest, "Couldn't write embedded resource {} to {}: {}", basename, dest, e);
+            }
+          } else {
+            Warn!(
+              "missing_file", entry,
+              "Couldn't find resource file {} in paths {:?}", entry, search_paths
+            );
+          }
+        },
+      }
+    }
+  }
+
   /// Build a per-doc parameter map with `CSS`, `JAVASCRIPT`, and `ICON`
   /// relativized so each split sub-page references the resource at the
   /// correct relative path.
@@ -297,6 +390,93 @@ fn relativize_quoted_pipe_list(value: &str, prefix: &str) -> String {
   format!("\"{}\"", parts.join("|"))
 }
 
+/// Extract the targets of CSS `@import` rules from stylesheet source.
+///
+/// Block comments are stripped first (so a commented-out `@import` is ignored),
+/// then the common forms are matched: `@import "x.css";`, `@import url("x");`,
+/// `@import url('x');`, and bare `@import url(x);`, each with an optional
+/// trailing `layer(...)` / media / `supports(...)` tail (only the URL token is
+/// captured). One target per `@import` (CSS allows a single URL per rule).
+fn parse_css_imports(css: &str) -> Vec<String> {
+  static COMMENT: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?s)/\*.*?\*/").unwrap());
+  static IMPORT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?i)@import\s+(?:url\(\s*)?["']?([^"')\s;]+)"#).unwrap());
+  let stripped = COMMENT.replace_all(css, "");
+  IMPORT
+    .captures_iter(&stripped)
+    .filter_map(|c| c.get(1).map(|m| m.as_str().to_string()))
+    .collect()
+}
+
+/// After a CSS file is copied from `src` to `dest`, recursively copy the LOCAL
+/// resources it `@import`s, preserving each import's relative subpath so the
+/// cascade still resolves at the destination.
+///
+/// BEYOND PERL: `copyResource` copies only the named file. ar5iv-style
+/// stylesheets split themselves across `@import url("./layer/part.css")`
+/// sub-files; without following those, the copied top-level CSS renders
+/// unstyled. Each target is resolved relative to the importing file — for both
+/// the on-disk source and the destination, so the same relative path is
+/// recreated under the destination — copied, and (if itself a `.css`) recursed
+/// into. Remote (`http(s)://`, `//`, `data:`, any `scheme://`) and absolute
+/// (`/…`) targets are left untouched. `seen` (keyed on the absolute source
+/// path) guards against import cycles and redundant copies.
+fn copy_css_imports(src: &Path, dest: &Path, seen: &mut HashSet<PathBuf>) {
+  let content = match fs::read_to_string(src) {
+    Ok(c) => c,
+    Err(_) => return,
+  };
+  let (Some(src_dir), Some(dest_dir)) = (src.parent(), dest.parent()) else {
+    return;
+  };
+  for target in parse_css_imports(&content) {
+    let t = target.trim();
+    // Skip remote / non-copyable targets — only local relative paths are ours.
+    if t.is_empty()
+      || t.starts_with('/')
+      || t.starts_with("//")
+      || t.starts_with("data:")
+      || t.contains("://")
+    {
+      continue;
+    }
+    let import_src = src_dir.join(t);
+    let import_dest = dest_dir.join(t);
+    // Skip if already handled (shared import or cycle).
+    if !seen.insert(import_src.clone()) {
+      continue;
+    }
+    if !import_src.is_file() {
+      Warn!(
+        "missing_file", t,
+        "Couldn't find @import target {} referenced by {}", t, src.display()
+      );
+      continue;
+    }
+    if import_src != import_dest {
+      if let Some(parent) = import_dest.parent() {
+        let _ = fs::create_dir_all(parent);
+      }
+      if let Err(e) = fs::copy(&import_src, &import_dest) {
+        Warn!(
+          "I/O", t,
+          "Couldn't copy @import {} to {}: {}",
+          import_src.display(), import_dest.display(), e
+        );
+        continue;
+      }
+    }
+    // Recurse into nested CSS imports only (not imported fonts/images).
+    if import_src
+      .extension()
+      .and_then(|e| e.to_str())
+      .is_some_and(|e| e.eq_ignore_ascii_case("css"))
+    {
+      copy_css_imports(&import_src, &import_dest, seen);
+    }
+  }
+}
+
 impl Processor for XSLT {
   fn get_name(&self) -> &str { &self.name }
 
@@ -322,6 +502,23 @@ impl Processor for XSLT {
           let _path = self.copy_resource(&doc, &src, resource_type.as_deref());
         }
       }
+    }
+
+    // Copy CLI-specified --css/--javascript/icon resources to the destination
+    // and warn on any that can't be found. Port of XSLT::process L71-78 — the
+    // param-resource copy that the binary's `--css`/`--javascript` flow needs
+    // (those flags only set the CSS/JAVASCRIPT stylesheet params; without this
+    // the link is emitted but the file is never searched on --path or copied).
+    // Deliberately OUTSIDE the `no_resources` guard above: --nodefaultresources
+    // suppresses only the bundled defaults' <ltx:resource> nodes, not these.
+    if let Some(css) = self.parameters.get("CSS") {
+      self.copy_param_resources(&doc, css, Some(&RESOURCE_CSS));
+    }
+    if let Some(js) = self.parameters.get("JAVASCRIPT") {
+      self.copy_param_resources(&doc, js, Some(&RESOURCE_JS));
+    }
+    if let Some(icon) = self.parameters.get("ICON") {
+      self.copy_param_resources(&doc, icon, None);
     }
 
     // Register EXSLT extension functions (str:tokenize, math:*, etc.)


### PR DESCRIPTION
## Problem

`latexml_oxide … --css X --path Y` emitted a `<link>` to `X` in the HTML but the page rendered **unstyled** — `X` was never copied next to the output, so the link 404'd. Two gaps:

1. **CLI `--css`/`--javascript` were never copied.** They only set the XSLT `CSS`/`JAVASCRIPT` params (which emit the `<link>`/`<script>`); they never went through `copy_resource`, so the file was neither searched on `--path` nor copied. (Bundled defaults *were* copied, via `<ltx:resource>` nodes — which is why this was easy to miss.)
2. **`--path` never reached the post pipeline.** `cli.search_paths` flowed only to the core converter; `PostOptions` had no search-paths field, so even once we tried to copy, the file couldn't be *found*.

`--nodefaultresources` is orthogonal: per Perl it suppresses only the bundled defaults, not CLI-specified resources.

## Fix

- **Faithful to Perl `LaTeXML::Post::XSLT::process` L71–78** (the CSS/JAVASCRIPT/ICON param copy, which sits **outside** the `noresources` guard): each `--css`/`--js`/icon entry is now searched on the path (then the embedded table), copied to the site directory, and warns `missing_file` when absent.
- Threaded `--path` into the post search paths via a new `PostOptions.search_paths` (updated the bin, LSP, cortex_worker, and `52_source_map` call sites).

## Beyond Perl: recursive `@import`

A copied CSS's **local `@import` chain is followed recursively**, recreating each import's **subdirectory structure** under the destination so the cascade still resolves. This handles the ar5iv "glowup" pattern (`ar5iv.css` → `@import "./ar5iv/{tokens,a11y,dark-mode,print}.css"`). Remote (`http(s)://`, `//`, `data:`) imports are left untouched; cycles are guarded.

## Tests

`tests/002_cli_css_resource_copy.rs` — (1) `--css X --path Y --nodefaultresources` copies `X` to the dest while still suppressing bundled defaults; (2) local `@import` targets are recursively copied with their subdirs recreated, remote imports skipped.

Full suite **1454/0/0**. Verified end-to-end against the real ar5iv `main` and `glowup` branches.

Independent of the frontmatter work (#241); touches only the post-processing resource path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)