### PR TITLE
chore: migrate the workspace to Rust edition 2024

### DIFF
--- a/latexml_codegen/Cargo.toml
+++ b/latexml_codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "latexml_codegen"
 version = "0.4.0"
-edition = "2021"
+edition = "2024"
 license = "CC0"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
 description = "Syntax extension plugins for LaTeXML's binding language"

--- a/latexml_codegen/src/constructable.rs
+++ b/latexml_codegen/src/constructable.rs
@@ -153,7 +153,7 @@ fn emit_pi(qname: &str, attrs: &[AttrPair]) -> TokenStream2 {
 fn emit_absorb(value: &Value) -> TokenStream2 {
   let to_absorb = emit_value(value, false);
   quote!(
-    if let Some(ref stored_digested) = #to_absorb {
+    if let Some(stored_digested) = #to_absorb {
       let digested_opt : Option<Digested> = stored_digested.into();
       if let Some(ref digested) = digested_opt {
         document.absorb(digested, None)?;
@@ -228,14 +228,14 @@ fn emit_attr_value(av: &AttrValue) -> TokenStream2 {
       },
       AttrPart::Value(v) => {
         let ve = emit_value(v, false);
-        quote!(match #ve { Some(ref val) => val.to_attribute(), None => String::new() })
+        quote!(match #ve { Some(val) => val.to_attribute(), None => String::new() })
       },
       AttrPart::Conditional { test, then_val, else_val } => {
         let cond = emit_bool(test);
         let tv = emit_value(then_val, false);
         let ev = emit_value(else_val, false);
         quote!(match (if #cond { #tv } else { #ev }) {
-          Some(ref val) => val.to_attribute(),
+          Some(val) => val.to_attribute(),
           None => String::new()
         })
       },
@@ -282,7 +282,7 @@ fn emit_bool(test: &Value) -> TokenStream2 {
   let tv = emit_value(test, true);
   quote!(match #tv {
     None => false,
-    Some(ref v) => {
+    Some(v) => {
       let v_str = v.to_string();
       !v_str.is_empty() && v_str != "false"
     }

--- a/latexml_contrib/Cargo.toml
+++ b/latexml_contrib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "latexml_contrib"
 version = "0.3.0"
-edition = "2021"
+edition = "2024"
 license = "CC0"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
 description = "User-contributed bindings for personal use"

--- a/latexml_contrib/src/script_bindings/mod.rs
+++ b/latexml_contrib/src/script_bindings/mod.rs
@@ -372,7 +372,7 @@ fn font_from_rhai_map(opts: Map) -> latexml_core::common::font::Font {
 fn rhai_map_to_props(map: Map) -> SymHashMap<Stored> {
   let mut props: SymHashMap<Stored> = SymHashMap::default();
   for (k, v) in map {
-    if let Some(d) = v.clone().try_cast::<Digested>() {
+    match v.clone().try_cast::<Digested>() { Some(d) => {
       if k.as_str() == "font" {
         if let Ok(Some(f)) = d.get_font() {
           props.insert("font", Stored::Font(Rc::new(f.into_owned())));
@@ -380,9 +380,9 @@ fn rhai_map_to_props(map: Map) -> SymHashMap<Stored> {
         }
       }
       props.insert(k.as_str(), Stored::Digested(d));
-    } else {
+    } _ => {
       props.insert(k.as_str(), dynamic_to_string(v).into());
-    }
+    }}
   }
   props
 }

--- a/latexml_contrib/src/script_bindings/wire.rs
+++ b/latexml_contrib/src/script_bindings/wire.rs
@@ -189,7 +189,7 @@ pub(super) fn apply_opts<B: BindingBuilder>(
   ast: &Rc<AST>,
 ) -> Result<B> {
   for (key, val) in opts {
-    if let Some(fp) = val.clone().try_cast::<FnPtr>() {
+    match val.clone().try_cast::<FnPtr>() { Some(fp) => {
       // Closure option → typed builder setter (front-end builds the closure).
       match key.as_str() {
         "afterDigest" => {
@@ -232,7 +232,7 @@ pub(super) fn apply_opts<B: BindingBuilder>(
         // %options; the builder's set_option does the same for scalars).
         _ => {},
       }
-    } else if key.as_str() == "properties" && val.is_map() {
+    } _ => if key.as_str() == "properties" && val.is_map() {
       // Static property map (Perl's `properties => { key => value, … }`).
       let map = val.cast::<Map>();
       builder = builder.properties(Rc::new(move |_args| Ok(rhai_map_to_props(map.clone()))));
@@ -248,7 +248,7 @@ pub(super) fn apply_opts<B: BindingBuilder>(
     } else if let Some(ov) = dynamic_to_option_value(&val) {
       // Scalar option → the builder's generic, single-source `set_option`.
       builder = builder.set_option(key.as_str(), ov)?;
-    }
+    }}
   }
   Ok(builder)
 }
@@ -711,12 +711,12 @@ pub(super) fn def_math_ligature_impl(pattern: &str, replacement: &str, opts: Map
         {
           return Ok(None);
         }
-        if let Some(sibling) = node_mut.get_prev_sibling() {
+        match node_mut.get_prev_sibling() { Some(sibling) => {
           node = sibling;
           node_mut = &mut node;
-        } else {
+        } _ => {
           return Ok(None);
-        }
+        }}
       }
       if ntomatch > 0 {
         Ok(Some((ntomatch, replacement.clone(), attr.clone())))

--- a/latexml_contrib/src/siamltex_cls.rs
+++ b/latexml_contrib/src/siamltex_cls.rs
@@ -24,7 +24,7 @@ fn push_classification_to_frontmatter(
       content: vec![latexml_core::document::tag::TagContent::Box(body)],
     };
     latexml_core::state::with_value_mut("frontmatter", |val_opt| {
-      if let Some(Stored::HashTagData(ref mut frnt)) = val_opt {
+      if let Some(Stored::HashTagData(frnt)) = val_opt {
         frnt
           .entry("ltx:classification".to_string())
           .or_insert_with(Vec::new)

--- a/latexml_core/Cargo.toml
+++ b/latexml_core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "latexml_core"
 version = "0.4.0"
-edition = "2021"
+edition = "2024"
 license = "CC0"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
 description = "Core conversion capabilities of latexml_oxide"

--- a/latexml_core/src/alignment.rs
+++ b/latexml_core/src/alignment.rs
@@ -953,17 +953,17 @@ pub fn read_alignment_template() -> Result<Template> {
         break;
       }
       gullet::unread_one(last_op);
-    } else if let Some(defn) = lookup_expandable(&T_CS!(s!("\\NC@rewrite@{op}")), None)? {
+    } else { match lookup_expandable(&T_CS!(s!("\\NC@rewrite@{op}")), None)? { Some(defn) => {
       let invoked = defn.invoke(true)?;
       gullet::unread(invoked);
-    } else if cc == Catcode::BEGIN {
+    } _ => if cc == Catcode::BEGIN {
       let balanced_arg = gullet::read_balanced(ExpansionLevel::Off, false, false)?;
       if !balanced_arg.is_empty() {
         gullet::unread(balanced_arg);
       }
     } else {
       Warn!("unexpected", op, s!("Unrecognized tabular template {op:?}"));
-    }
+    }}}
     if nopens <= 0 {
       break;
     }
@@ -1008,7 +1008,7 @@ pub fn matrix_template() -> Template {
 /// for lpad/rpad; now superseded by template_has_intercol for better @{} handling.
 #[allow(dead_code)]
 fn template_has_fill(tokens: &Option<Tokens>) -> bool {
-  if let Some(ref toks) = tokens {
+  if let Some(toks) = tokens {
     for tok in toks.unlist_ref() {
       let s = tok.to_string();
       if s == "\\hfil" || s == "\\hfill" || s == "\\hskip" {
@@ -1026,7 +1026,7 @@ fn template_has_fill(tokens: &Option<Tokens>) -> bool {
 /// For `\vrule\relax\lx@intercol\hfil`: reachable (vrule is skippable).
 /// For `@{1}\lx@intercol\hfil`: NOT reachable ("1" blocks the scan).
 fn intercol_reachable_in_before(tokens: &Option<Tokens>) -> bool {
-  if let Some(ref toks) = tokens {
+  if let Some(toks) = tokens {
     for tok in toks.unlist_ref() {
       let s = tok.to_string();
       if s == "\\lx@intercol" || s.contains("intercol") {
@@ -1054,7 +1054,7 @@ fn intercol_reachable_in_before(tokens: &Option<Tokens>) -> bool {
 /// \lx@intercol indicates actual intercolumn padding; \hfil is just centering.
 /// For @{}c@{} columns, \lx@intercol is disabled but \hfil remains.
 fn template_has_intercol(tokens: &Option<Tokens>) -> bool {
-  if let Some(ref toks) = tokens {
+  if let Some(toks) = tokens {
     for tok in toks.unlist_ref() {
       let s = tok.to_string();
       if s == "\\lx@intercol" || s.contains("intercol") {

--- a/latexml_core/src/alignment/normalize.rs
+++ b/latexml_core/src/alignment/normalize.rs
@@ -59,7 +59,7 @@ pub fn normalize_cell_sizes(alignment: &mut Alignment) -> Result<()> {
   // Sets: cached_width, cached_height, cached_depth, lpadding, rpadding (per cell) & empty
   for row in &mut alignment.rows {
     for cell in row.get_columns_mut() {
-      if let Some(ref mut boxes) = &mut cell.boxes {
+      if let Some(boxes) = &mut cell.boxes {
         let (w, mut h, mut d, cw, ch, cd) = boxes.get_size(Some(stored_map!(
             "align" => cell.align.as_ref().map(|a| a.char_code()), "width" => cell.width,
             "vattach" => cell.vattach.clone() )))?;
@@ -456,7 +456,7 @@ pub fn normalize_prune_rows(alignment: &mut Alignment) -> Result<()> {
 /// Rust doesn't populate lspaces from template, so we check tokens directly.
 fn cell_has_intercol(cell: &Cell) -> bool {
   fn has_intercol(tokens: &Option<Tokens>) -> bool {
-    if let Some(ref toks) = tokens {
+    if let Some(toks) = tokens {
       for tok in toks.unlist_ref() {
         let s = tok.to_string();
         if s == "\\lx@intercol" || s.contains("intercol") {
@@ -640,9 +640,9 @@ pub fn normalize_sum_sizes(alignment: &mut Alignment) -> Result<()> {
   // Uses cell's cached_width,cached_height,cached_depth
   // Computes net row & column sizes & positions
   let strut = match alignment.get_property("strut").as_deref() {
-    Some(Stored::Dimension(ref d)) => *d,
-    Some(Stored::Glue(ref g)) => Dimension::new(g.value_of()),
-    Some(Stored::MuGlue(ref g)) => Dimension::new(g.value_of()),
+    Some(Stored::Dimension(d)) => *d,
+    Some(Stored::Glue(g)) => Dimension::new(g.value_of()),
+    Some(Stored::MuGlue(g)) => Dimension::new(g.value_of()),
     _ => Dimension::new(0),
   };
   // Perl: Glue->new($pts * 0.7) uses kround (adds 0.5 before int), not plain truncation
@@ -806,7 +806,7 @@ pub fn normalize_sum_sizes(alignment: &mut Alignment) -> Result<()> {
 
         with_value_sym(crate::pin!("font"), |v_opt| {
           v_opt.and_then(|v| {
-            if let Stored::Font(ref f) = v {
+            if let Stored::Font(f) = v {
               f.get_size().map(|s| (s * UNITY as f64) as i64 / 2)
             } else {
               None

--- a/latexml_core/src/aux_macros.rs
+++ b/latexml_core/src/aux_macros.rs
@@ -3,7 +3,7 @@
 /// A flexary macro for constructing `HashMap<&'static str, &'static str>` maps
 #[macro_export]
 macro_rules! static_map {
-  ($( $key:expr => $val:expr ),*) => {{
+  ($( $key:expr_2021 => $val:expr_2021 ),*) => {{
     let mut map : HashMap<&'static str, &'static str> = HashMap::default();
     $( map.insert($key, $val); )*
     map
@@ -13,7 +13,7 @@ macro_rules! static_map {
 /// A flexary macro for constructing `HashMap<String, T>` maps, where `T` is generic.
 #[macro_export]
 macro_rules! map {
-  ($( $key:expr => $val:expr ),*) => {{
+  ($( $key:expr_2021 => $val:expr_2021 ),*) => {{
     let mut map = HashMap::default();
     $( map.insert($key.to_string(), $val); )*
     map
@@ -23,7 +23,7 @@ macro_rules! map {
 /// A flexary macro for constructing `SymHashMap<Stored>` maps
 #[macro_export]
 macro_rules! stored_map {
-  ($( $key:expr => $val:expr ),*) => {{
+  ($( $key:expr_2021 => $val:expr_2021 ),*) => {{
     let mut map : $crate::common::arena::SymHashMap<$crate::common::store::Stored> =
       $crate::common::arena::SymHashMap::default();
     $( map.insert($key, $val.into()); )*
@@ -34,7 +34,7 @@ macro_rules! stored_map {
 /// A flexary macro for constructing `SymHashMap<T>` maps
 #[macro_export]
 macro_rules! sym_map {
-  ($( $key:expr => $val:expr ),*) => {{
+  ($( $key:expr_2021 => $val:expr_2021 ),*) => {{
     let mut map = $crate::common::arena::SymHashMap::default();
     $( map.insert($key, $val); )*
     map
@@ -44,7 +44,7 @@ macro_rules! sym_map {
 /// A flexary macro for constructing `HashMap<String, T>` maps
 #[macro_export]
 macro_rules! string_keys_map {
-  ($( $key:expr => $val:expr ),*) => {{
+  ($( $key:expr_2021 => $val:expr_2021 ),*) => {{
     let mut map = HashMap::default();
     $( map.insert($key.to_string(), $val.into()); )*
     map
@@ -54,7 +54,7 @@ macro_rules! string_keys_map {
 /// A flexary macro for constructing `HashMap<String, String>` maps
 #[macro_export]
 macro_rules! string_map {
-  ($( $key:expr => $val:expr ),*) => {{
+  ($( $key:expr_2021 => $val:expr_2021 ),*) => {{
     let mut map = HashMap::default();
     $( map.insert($key.to_string(), $val.to_string()); )*
     map
@@ -65,7 +65,7 @@ macro_rules! string_map {
 /// (inferred at time of use)
 #[macro_export]
 macro_rules! raw_map {
-  ($( $key:expr => $val:expr ),* $(,)?) => {{
+  ($( $key:expr_2021 => $val:expr_2021 ),* $(,)?) => {{
     #[allow(unused_mut)]
     let mut map = HashMap::default();
     $( map.insert($key, $val); )*
@@ -76,7 +76,7 @@ macro_rules! raw_map {
 /// A flexary macro for constructing `HashMap<char, T>` maps, where `T` is generic
 #[macro_export]
 macro_rules! raw_char_map {
-  ($( $key:literal => $val:expr ),*) => {{
+  ($( $key:literal => $val:expr_2021 ),*) => {{
     let mut map : HashMap<char,_> = HashMap::default();
     $( map.insert($key, $val); )*
     map
@@ -92,7 +92,7 @@ macro_rules! s {
 /// The `some!` macro transforms data in type `S` to `Option<Into<T>>` (always wrapping with `Some`)
 #[macro_export]
 macro_rules! some {
-  ($arg:expr) => {
+  ($arg:expr_2021) => {
     Some($arg.into())
   };
 }
@@ -107,7 +107,7 @@ macro_rules! some {
 /// ```
 #[macro_export]
 macro_rules! mixvec {
-  ($( $val:expr ),*) => {{
+  ($( $val:expr_2021 ),*) => {{
     vec![ $($val.into()),*]
   }}
 }
@@ -122,7 +122,7 @@ macro_rules! mixvec {
 /// ```
 #[macro_export]
 macro_rules! mixrc {
-  ($( $val:expr ),*) => {{
+  ($( $val:expr_2021 ),*) => {{
     Rc::new([ $($val.into()),*])
   }}
 }
@@ -131,7 +131,7 @@ macro_rules! mixrc {
 /// The specification can be partial - missing fields are taken via the `Default` trait.
 #[macro_export]
 macro_rules! fontmap {
-  ($($key:ident => $value:expr),*) => (
+  ($($key:ident => $value:expr_2021),*) => (
     Font { $($key: Some($value.into()),)* .. Font::default() })
 }
 
@@ -139,7 +139,7 @@ macro_rules! fontmap {
 /// Source: <https://riptutorial.com/rust/example/4149/create-a-hashset-macro>
 #[macro_export]
 macro_rules! set {
-    ( $( $x:expr ),* ) => {  // Match zero or more comma delimited items
+    ( $( $x:expr_2021 ),* ) => {  // Match zero or more comma delimited items
         {
             // use rustc_hash::FxHashSet as HashSet;
             use rustc_hash::FxHashSet as HashSet;

--- a/latexml_core/src/binding/content.rs
+++ b/latexml_core/src/binding/content.rs
@@ -202,7 +202,7 @@ pub fn input_definitions(raw_file: &str, mut options: InputDefinitionOptions) ->
     with_vecdeque("@masquerading@as@class", |vdq_opt| {
       if let Some(vdq) = vdq_opt {
         if vdq.iter().any(|x| {
-          if let Stored::String(ref v) = x {
+          if let Stored::String(v) = x {
             arena::with(*v, |str| str == prevname)
           } else {
             false
@@ -2955,13 +2955,13 @@ pub fn build_invocation_str(spec: &str, args: Vec<Option<Tokens>>) -> Result<Tok
 
 fn build_invocation_token(token: Token, args: Vec<Option<Tokens>>) -> Result<Tokens> {
   // Note: token may have been \let to another defn!
-  if let Some(defn) = lookup_definition(&token)? {
+  match lookup_definition(&token)? { Some(defn) => {
     let mut invoked_tokens = vec![token];
     if let Some(params) = defn.get_parameters() {
       invoked_tokens.extend(params.revert_arguments(args)?);
     }
     Ok(Tokens::new(invoked_tokens))
-  } else {
+  } _ => {
     let message = s!("Can't invoke {:?}; it is undefined", token.stringify());
     token.with_cs_name(|csname| {
       Error!("undefined", csname, message);
@@ -2983,7 +2983,7 @@ fn build_invocation_token(token: Token, args: Vec<Option<Tokens>>) -> Result<Tok
       .collect();
     invoked_tokens.extend(wrapped_args);
     Ok(Tokens::new(invoked_tokens))
-  }
+  }}
 }
 
 /// Convert a LaTeX-style argument spec to our Package form.

--- a/latexml_core/src/binding/counter/dialect.rs
+++ b/latexml_core/src/binding/counter/dialect.rs
@@ -363,15 +363,15 @@ pub fn ref_step_counter(ctype: &str, noreset: bool) -> Result<HashMap<Stored>> {
   let the_ctr_id = s!("\\the{ctr}@ID");
   let the_ctr = s!("\\the{ctr}");
 
-  let has_id: bool = if let Some(iddef) = state::lookup_definition(&T_CS!(&the_ctr_id))? {
+  let has_id: bool = match state::lookup_definition(&T_CS!(&the_ctr_id))? { Some(iddef) => {
     if let Some(params) = iddef.get_parameters() {
       params.get_num_args() == 0
     } else {
       true
     }
-  } else {
+  } _ => {
     false
-  };
+  }};
 
   let the_ctr_cs = T_CS!(&the_ctr);
   let the_ctr_id_cs = T_CS!(&the_ctr_id);

--- a/latexml_core/src/binding/def/macros.rs
+++ b/latexml_core/src/binding/def/macros.rs
@@ -5,7 +5,7 @@
 /// build a Font from key=>val pairs
 #[macro_export]
 macro_rules! Font {
-  ($($key:ident => $value:expr),*) => (
+  ($($key:ident => $value:expr_2021),*) => (
     Some(Font { $($key: $value.into_font_field(),)* .. Font::default() })
 )}
 
@@ -13,7 +13,7 @@ macro_rules! Font {
 /// (currently only FontDirective::Asset is supported in this macro)
 #[macro_export]
 macro_rules! FontDirective {
-  ($($key:ident => $value:expr),*) => (
+  ($($key:ident => $value:expr_2021),*) => (
     Some(FontDirective::Asset(Rc::new(
       Font { $($key: $value.into_font_field(),)* .. Font::default() }
     ))))
@@ -23,7 +23,7 @@ macro_rules! FontDirective {
 /// and complete the remaining entries via the Default instance
 #[macro_export]
 macro_rules! NewDefault {
-  ($name:ident, $($key:ident => $value:expr),*) => ($name {
+  ($name:ident, $($key:ident => $value:expr_2021),*) => ($name {
     $($key: $value,)*
     ..$name::default()
   })
@@ -32,7 +32,7 @@ macro_rules! NewDefault {
 /// Just like NewDefault, but adds a mandatory `.into_option()` to all values
 #[macro_export]
 macro_rules! NewDefaultV {
-  ($name:ident, $($key:ident => $value:expr),*) => ($name {
+  ($name:ident, $($key:ident => $value:expr_2021),*) => ($name {
     $($key: $value.into_option(),)*
     ..$name::default()
   })
@@ -172,7 +172,7 @@ macro_rules! properties {
       },
     )
   };
-  ($value:expr) => {
+  ($value:expr_2021) => {
     Rc::new(
       move |_args: &Vec<Option<Digested>>| -> Result<SymHashMap<Stored>> { Ok($value.clone()) },
     )
@@ -284,9 +284,9 @@ macro_rules! reversion_digested {
 
 #[macro_export]
 macro_rules! prop_digested {
-  ($props:ident, $key:expr) => {
+  ($props:ident, $key:expr_2021) => {
     match $props.get($key) {
-      Some(Stored::VecDigested(ref vd)) => vd.iter().collect::<Vec<&Digested>>(),
+      Some(Stored::VecDigested(vd)) => vd.iter().collect::<Vec<&Digested>>(),
       Some(Stored::Digested(d)) => vec![&*d],
       Some(Stored::String(s)) => panic!(
         "prop_digested! called on a string property {:?} with value {:?}.",
@@ -316,7 +316,7 @@ macro_rules! prop_digested {
 
 #[macro_export]
 macro_rules! prop_str {
-  ($props:ident, $key:expr) => {
+  ($props:ident, $key:expr_2021) => {
     match $props.get($key) {
       Some(&Stored::String(ref id)) => *id,
       _ => pin!(""),
@@ -326,7 +326,7 @@ macro_rules! prop_str {
 
 #[macro_export]
 macro_rules! prop_string {
-  ($props:ident, $key:expr) => {
+  ($props:ident, $key:expr_2021) => {
     match $props.get($key) {
       Some(&Stored::String(id)) => arena::to_string(id),
       _ => String::new(),
@@ -336,7 +336,7 @@ macro_rules! prop_string {
 
 #[macro_export]
 macro_rules! prop_whatsit {
-  ($props:ident, $key:expr) => {
+  ($props:ident, $key:expr_2021) => {
     match $props.get($key) {
       // Cloning here is OK now, as there is an Rc<> guard over the DigestedData
       Some(&Stored::Digested(ref rc)) => (**rc).clone(),
@@ -347,7 +347,7 @@ macro_rules! prop_whatsit {
 
 #[macro_export]
 macro_rules! prop_bool {
-  ($props:ident, $key:expr) => {
+  ($props:ident, $key:expr_2021) => {
     match $props.get($key) {
       Some(&Stored::Bool(v)) => v,
       _ => false,
@@ -365,10 +365,10 @@ macro_rules! unref {
 }
 #[macro_export]
 macro_rules! count_unpack_ref {
-  ($index:expr, $args:ident => $var:ident) => {
+  ($index:expr_2021, $args:ident => $var:ident) => {
     let $var = $args[$index].as_ref().unwrap();
   };
-  ($index:expr, $args:ident => $var:ident,$($tail:ident),*) => {
+  ($index:expr_2021, $args:ident => $var:ident,$($tail:ident),*) => {
     count_unpack_ref!($index,$args => $var);
     count_unpack_ref!(1usize+$index, $args => $($tail),*)
   };
@@ -417,21 +417,21 @@ macro_rules! unpack_opt_ref {
 /// Convert the number to lower case roman numerals, returning a list of LaTeXML::Core::Token
 #[macro_export]
 macro_rules! roman {
-  ($stuff:expr) => {
+  ($stuff:expr_2021) => {
     Tokens::new(ExplodeText!(roman_aux($stuff as i64)))
   };
 }
 /// Convert the number to upper case roman numerals, returning a list of LaTeXML::Core::Token
 #[macro_export]
 macro_rules! Roman {
-  ($stuff:expr) => {
+  ($stuff:expr_2021) => {
     Tokens::new(ExplodeText!(roman_aux($stuff as i64).to_ascii_uppercase()))
   };
 }
 
 #[macro_export]
 macro_rules! requireMath {
-  ($cs_name:expr) => {
+  ($cs_name:expr_2021) => {
     if !$crate::state::lookup_bool_sym($crate::pin!("IN_MATH")) {
       let message = s!("{} should only appear in math mode", $cs_name);
       Warn!("unexpected", "mode", message);
@@ -440,7 +440,7 @@ macro_rules! requireMath {
 }
 #[macro_export]
 macro_rules! forbidMath {
-  ($cs_name:expr) => {
+  ($cs_name:expr_2021) => {
     if $crate::state::lookup_bool_sym($crate::pin!("IN_MATH")) {
       let message = s!("{} should not appear in math mode", $cs_name);
       Warn!("unexpected", "mode", message);
@@ -450,10 +450,10 @@ macro_rules! forbidMath {
 
 #[macro_export]
 macro_rules! AssignRegister {
-  ($cs:literal, $value:expr) => {
+  ($cs:literal, $value:expr_2021) => {
     AssignRegister!($cs, $value, Vec::new())
   };
-  ($cs:literal, $value:expr, $args:expr) => {
+  ($cs:literal, $value:expr_2021, $args:expr_2021) => {
     let value_ident = { $value };
     if let Some(defn) = state::lookup_register_definition(&T_CS!($cs)) {
       (*defn).set_value(value_ident, None, $args);
@@ -466,10 +466,10 @@ macro_rules! AssignRegister {
 
 #[macro_export]
 macro_rules! SetCounter {
-  ($ctr:expr => $value:expr) => {
+  ($ctr:expr_2021 => $value:expr_2021) => {
     SetCounter!($ctr, $value)
   };
-  ($ctr:expr, $value:expr) => {
+  ($ctr:expr_2021, $value:expr_2021) => {
     state::assign_register(
       &s!("\\c@{}", $ctr),
       $value.into(),

--- a/latexml_core/src/binding/def/replacement.rs
+++ b/latexml_core/src/binding/def/replacement.rs
@@ -707,7 +707,7 @@ fn exec_ops(
           *savenode = document.float_to_attribute(key);
           let mut node = document.get_node().clone();
           document.set_attribute(&mut node, key, &val_str)?;
-          if let Some(ref sn) = savenode {
+          if let &mut Some(ref sn) = savenode {
             document.set_node(sn);
           }
         } else {

--- a/latexml_core/src/binding/def/traits.rs
+++ b/latexml_core/src/binding/def/traits.rs
@@ -188,11 +188,11 @@ impl IntoOption<Option<SizingClosure>> for &str {
             Dimension::default(),
           ))
         } else {
-          let font = if let Some(Stored::Font(ref font)) = w.get_property("font").as_deref() {
+          let font = match w.get_property("font").as_deref() { Some(Stored::Font(font)) => {
             font.clone()
-          } else {
+          } _ => {
             lookup_font().unwrap()
-          };
+          }};
           let options = sizer_options_from_whatsit(w);
           font.compute_boxes_size(&boxes, options)
         }
@@ -201,11 +201,11 @@ impl IntoOption<Option<SizingClosure>> for &str {
       // literal string, get its size with the current font?
       let sized_data = String::from(self);
       Some(Rc::new(move |w| {
-        let font = if let Stored::Font(ref font) = *w.get_property("font").unwrap() {
+        let font = match *w.get_property("font").unwrap() { Stored::Font(ref font) => {
           font.clone()
-        } else {
+        } _ => {
           lookup_font().unwrap()
-        };
+        }};
         let options = sizer_options_from_whatsit(w);
         font.compute_boxes_size(
           &[Digested::from(Tbox {

--- a/latexml_core/src/common/def_parser.rs
+++ b/latexml_core/src/common/def_parser.rs
@@ -125,10 +125,10 @@ pub fn parse_parameters(
     // (`delimited` advances past its opening token before failing otherwise —
     // e.g. a lone "{" from the non-nesting inner of "{{}}").
     let mut probe;
-    let mut p: Parameter = if let Ok(inner_spec) = {
+    let mut p: Parameter = match {
       probe = *input;
       group('{', '}').parse_next(&mut probe).inspect(|_| *input = probe)
-    } {
+    } { Ok(inner_spec) => {
       // Plain (possibly typed-inner) braced group, spec keeps its braces.
       let inner: Option<Parameters> = if inner_spec.is_empty() {
         None
@@ -141,10 +141,10 @@ pub fn parse_parameters(
         inner: inner.map(|ps| ps.into()).unwrap_or_default(),
         ..Parameter::default()
       }
-    } else if let Ok(inner_spec) = {
+    } _ => { match {
       probe = *input;
       group('[', ']').parse_next(&mut probe).inspect(|_| *input = probe)
-    } {
+    } { Ok(inner_spec) => {
       let spec = arena::pin(format!("[{inner_spec}]"));
       if let Some(default_str) = inner_spec.strip_prefix("Default:") {
         let extra = if default_str.is_empty() {
@@ -165,10 +165,10 @@ pub fn parse_parameters(
       } else {
         Parameter { name: arena::pin_static("Optional"), spec, ..Parameter::default() }
       }
-    } else if let Ok((word, extra_opt)) = {
+    } _ => { match {
       probe = *input;
       paramspec.parse_next(&mut probe).inspect(|_| *input = probe)
-    } {
+    } { Ok((word, extra_opt)) => {
       let spec_str = match extra_opt {
         Some(extra) => format!("{word}:{extra}"),
         None => word.to_string(),
@@ -186,7 +186,7 @@ pub fn parse_parameters(
         extra,
         ..Parameter::default()
       }
-    } else {
+    } _ => {
       // Literal single char (incl. each whitespace char) as a Token parameter.
       let ch = any.parse_next(input).map_err(|_: winnow::error::ErrMode<winnow::error::ContextError>| {
         Error::from(s!("parse_parameters: unreadable prototype tail for {:?}", cs))
@@ -198,7 +198,7 @@ pub fn parse_parameters(
         extra: vec![Tokens::new(vec![ch_token])],
         ..Parameter::default()
       }
-    };
+    }}}}}};
     if init_flag {
       p = p.init()?;
     }

--- a/latexml_core/src/common/error.rs
+++ b/latexml_core/src/common/error.rs
@@ -367,21 +367,21 @@ macro_rules! DebugFeature {
 
 #[macro_export]
 macro_rules! Debug {
-  ($category:expr, $object:expr, $message:expr) => {{
+  ($category:expr_2021, $object:expr_2021, $message:expr_2021) => {{
     $crate::common::error::note_status(
       $crate::common::error::LogStatus::Debug, None);
     use log::debug;
     debug!(target: &s!("{}:{}", $category, $object), "{}",
       $crate::generate_message!($message))
   }};
- ($category:expr, $object:expr, $message:expr, $($details:expr),*) => {{
+ ($category:expr_2021, $object:expr_2021, $message:expr_2021, $($details:expr_2021),*) => {{
     $crate::common::error::note_status(
       $crate::common::error::LogStatus::Debug, None);
     use log::debug;
     debug!(target: &s!("{}:{}", $category, $object), "{}",
       $crate::generate_message!($message, $($details),*))
   }};
-  ($($simple:expr),*) => {{
+  ($($simple:expr_2021),*) => {{
     $crate::common::error::note_status(
       $crate::common::error::LogStatus::Debug, None);
     use log::debug;
@@ -392,21 +392,21 @@ macro_rules! Debug {
 
 #[macro_export]
 macro_rules! Info {
-  ($category:expr, $object:expr, $message:expr) => {{
+  ($category:expr_2021, $object:expr_2021, $message:expr_2021) => {{
     $crate::common::error::note_status(
       $crate::common::error::LogStatus::Info, None);
     use log::info;
     info!(target: &format!("{}:{}", $category, $object), "{}",
       $crate::generate_message!($message))
   }};
- ($category:expr, $object:expr, $message:expr, $($details:expr),*) => {{
+ ($category:expr_2021, $object:expr_2021, $message:expr_2021, $($details:expr_2021),*) => {{
   $crate::common::error::note_status(
     $crate::common::error::LogStatus::Info, None);
     use log::info;
     info!(target: &format!("{}:{}", $category, $object), "{}",
     $crate::generate_message!($message, $($details),*))
   }};
-  ($($simple:expr),*) => {{
+  ($($simple:expr_2021),*) => {{
     $crate::common::error::note_status(
       $crate::common::error::LogStatus::Info, None);
     use log::info;
@@ -417,7 +417,7 @@ macro_rules! Info {
 
 #[macro_export]
 macro_rules! Warn {
-  ($category:expr, $object:expr, $message:expr) => {{
+  ($category:expr_2021, $object:expr_2021, $message:expr_2021) => {{
     $crate::common::error::note_status(
       $crate::common::error::LogStatus::Warning, None);
     if !$crate::common::error::is_log_output_suppressed() {
@@ -426,7 +426,7 @@ macro_rules! Warn {
         $crate::generate_message!($message))
     }
   }};
- ($category:expr, $object:expr, $message:expr, $($details:expr),*) => {{
+ ($category:expr_2021, $object:expr_2021, $message:expr_2021, $($details:expr_2021),*) => {{
     $crate::common::error::note_status(
       $crate::common::error::LogStatus::Warning, None);
     if !$crate::common::error::is_log_output_suppressed() {
@@ -439,10 +439,10 @@ macro_rules! Warn {
 
 #[macro_export]
 macro_rules! Error {
-  ($category:expr, $object:expr, $message:expr) => {{
+  ($category:expr_2021, $object:expr_2021, $message:expr_2021) => {{
     $crate::Error!($category,$object,$message,"")
   }};
- ($category:expr, $object:expr, $message:expr, $($details:expr),*) => {{
+ ($category:expr_2021, $object:expr_2021, $message:expr_2021, $($details:expr_2021),*) => {{
     $crate::common::error::note_status(
       $crate::common::error::LogStatus::Error, None);
     if !$crate::common::error::is_log_output_suppressed() {
@@ -490,7 +490,7 @@ macro_rules! Error {
 // TODO: flesh out the messages
 #[macro_export]
 macro_rules! Fatal {
-  ($target:expr, $category:expr, $message:expr) => {{
+  ($target:expr_2021, $category:expr_2021, $message:expr_2021) => {{
     $crate::common::error::note_status($crate::common::error::LogStatus::Fatal, None);
     {
       use $crate::common::error::Error as LatexmlError;
@@ -512,7 +512,7 @@ macro_rules! Fatal {
 
 #[macro_export]
 macro_rules! fatal {
-  ($target:expr, $category:expr, $message:expr) => {{
+  ($target:expr_2021, $category:expr_2021, $message:expr_2021) => {{
     use $crate::common::error::Error as LatexmlError;
     use $crate::common::error::ErrorCategory::*;
     use $crate::common::error::ErrorTarget::*;
@@ -526,7 +526,7 @@ macro_rules! fatal {
 
 #[macro_export]
 macro_rules! generate_message {
-  ($message:expr) => {
+  ($message:expr_2021) => {
     format!(
       "{}\n\t{}\n\tIn {}:{}:{}\n",
       $message,
@@ -536,7 +536,7 @@ macro_rules! generate_message {
       column!()
     )
   };
-  ($message:expr, $detail:expr) => {
+  ($message:expr_2021, $detail:expr_2021) => {
     format!(
       "{}\n\t{}\n\t{}\n\tIn {}:{}:{}\n",
       $message,
@@ -547,7 +547,7 @@ macro_rules! generate_message {
       column!()
     )
   };
-  ($message:expr, $detail:expr, $detail2:expr) => {
+  ($message:expr_2021, $detail:expr_2021, $detail2:expr_2021) => {
     format!(
       "{}\n\t{}\n\t{}\n\t{}\n\tIn {}:{}:{}\n",
       $message,
@@ -559,7 +559,7 @@ macro_rules! generate_message {
       column!()
     )
   };
-  ($message:expr, $detail:expr, $detail2:expr) => {
+  ($message:expr_2021, $detail:expr_2021, $detail2:expr_2021) => {
     format!(
       "{}\n\t{}\n\t{}\n\t{}\n\tIn {}:{}:{}\n",
       $message,
@@ -571,7 +571,7 @@ macro_rules! generate_message {
       column!()
     )
   };
-  ($message:expr, $detail:expr, $detail2:expr, $location:expr) => {
+  ($message:expr_2021, $detail:expr_2021, $detail2:expr_2021, $location:expr_2021) => {
     format!(
       "{}\n\t{}\n\t{}\n\t{}\n\tIn {}:{}:{}\n",
       $message,
@@ -587,7 +587,7 @@ macro_rules! generate_message {
 
 #[macro_export]
 macro_rules! Note {
-  ($input:expr) => {
+  ($input:expr_2021) => {
     if !$crate::common::error::is_log_output_suppressed()
       && log::max_level() >= log::LevelFilter::Info
     {
@@ -599,7 +599,7 @@ macro_rules! Note {
 
 #[macro_export]
 macro_rules! NoteLog {
-  ($input:expr) => {
+  ($input:expr_2021) => {
     if !$crate::common::error::is_log_output_suppressed()
       && log::max_level() >= log::LevelFilter::Debug
     {
@@ -682,7 +682,7 @@ impl fmt::Display for ErrorCategory {
     use ErrorCategory::*;
     match self {
       Init => write!(f, "Init"),
-      Io(ref err) => err.fmt(f),
+      Io(err) => err.fmt(f),
       NotFound => write!(f, "No matching cities with a population were found."),
       MissingFile => write!(f, "missing file"),
       Misdefined => write!(f, "misdefined"),
@@ -698,8 +698,8 @@ impl fmt::Display for ErrorCategory {
       Endgroup => write!(f, "<endgroup>"),
       FailedParse => write!(f, "failed to parse"),
       MaxLimit(num) => write!(f, "{}", num),
-      Generic(ref err) => err.fmt(f),
-      Filename(ref name) => write!(f, "file:{name}"),
+      Generic(err) => err.fmt(f),
+      Filename(name) => write!(f, "file:{name}"),
       TokenLimit => write!(f, "token_limit"),
       PushbackLimit => write!(f, "pushback_limit"),
       IfLimit => write!(f, "if_limit"),

--- a/latexml_core/src/common/font.rs
+++ b/latexml_core/src/common/font.rs
@@ -762,21 +762,21 @@ impl Font {
     let r0 = prevbox
       .get_property("role")
       .and_then(|s| {
-        if let Stored::String(sym) = s.into_owned() {
+        match s.into_owned() { Stored::String(sym) => {
           Some(arena::with(sym, |s| s.to_string()))
-        } else {
+        } _ => {
           None
-        }
+        }}
       })
       .unwrap_or_else(|| "ID".to_string());
     let r1 = thisbox
       .get_property("role")
       .and_then(|s| {
-        if let Stored::String(sym) = s.into_owned() {
+        match s.into_owned() { Stored::String(sym) => {
           Some(arena::with(sym, |s| s.to_string()))
-        } else {
+        } _ => {
           None
-        }
+        }}
       })
       .unwrap_or_else(|| "ID".to_string());
     let t0 = *MATH_ATOM_TYPE.get(r0.as_str()).unwrap_or(&0);
@@ -1904,7 +1904,7 @@ fn lookup_multichar_override(code: u8, encoding_opt: Option<&str>) -> Option<Str
   }
   let mapname = format!("{encoding}_fontmap_multichar");
   with_value(&mapname, |val_opt| {
-    if let Some(Stored::HashString(ref map)) = val_opt {
+    if let Some(Stored::HashString(map)) = val_opt {
       map.get(&code.to_string()).cloned()
     } else {
       None
@@ -2010,7 +2010,7 @@ pub fn decode_string(string: SymStr, encoding_opt: Option<&str>, implicit: bool)
   let multichar_map: Option<HashMap<String, String>> = if !encoding.is_empty() {
     let mapname = format!("{encoding}_fontmap_multichar");
     with_value(&mapname, |val_opt| {
-      if let Some(Stored::HashString(ref m)) = val_opt {
+      if let Some(Stored::HashString(m)) = val_opt {
         Some(m.clone())
       } else {
         None

--- a/latexml_core/src/common/local_assignments.rs
+++ b/latexml_core/src/common/local_assignments.rs
@@ -119,11 +119,11 @@ pub fn align_group_count() -> i32 {
     .unwrap_or_default()
 }
 pub fn set_align_group_count(v: i32) {
-  if let Some(gc) = locals_mut!().align_group_count.last_mut() {
+  match locals_mut!().align_group_count.last_mut() { Some(gc) => {
     *gc = v;
-  } else {
+  } _ => {
     locals_mut!().align_group_count.push(v);
-  }
+  }}
 }
 pub fn local_align_group_count(v: i32) { locals_mut!().align_group_count.push(v); }
 pub fn expire_align_group_count() -> Option<i32> { locals_mut!().align_group_count.pop() }

--- a/latexml_core/src/common/mathchar.rs
+++ b/latexml_core/src/common/mathchar.rs
@@ -809,7 +809,7 @@ pub fn decode_math_char(
       // current size comes from context (e.g. \big's font => { size => 12 }).
       let preserved_size = f.size;
       state::with_font_info(ftok, |fontinfo| {
-        if let Some(Stored::Font(ref info)) = fontinfo.unwrap_or(None) {
+        if let Some(Stored::Font(info)) = fontinfo.unwrap_or(None) {
           f = f.merge_ref(info);
         } else {
           // Perl: fallback to \lx@default@font if not found
@@ -819,7 +819,7 @@ pub fn decode_math_char(
           });
           if let Some(d_tok) = d_tok_opt {
             state::with_font_info(&d_tok, |d_info| {
-              if let Some(Stored::Font(ref d_f)) = d_info.unwrap_or(None) {
+              if let Some(Stored::Font(d_f)) = d_info.unwrap_or(None) {
                 f = f.merge_ref(d_f);
               }
             });
@@ -851,7 +851,7 @@ pub fn decode_math_char(
     // a State borrow while its closure runs — the reentrant mutation
     // panics with "RefCell already borrowed" (sandbox paper 0711.4787).
     let mut encoding_opt: Option<String> = state::with_font_info(ftok, |fontinfo| {
-      if let Some(Stored::Font(ref info)) = fontinfo? {
+      if let Some(Stored::Font(info)) = fontinfo? {
         Ok::<Option<String>, crate::common::error::Error>(
           info.encoding.as_ref().map(|s| s.to_string()),
         )

--- a/latexml_core/src/common/model.rs
+++ b/latexml_core/src/common/model.rs
@@ -852,11 +852,11 @@ pub fn is_node_in_schema_class(class_name: &str, tag: &Node) -> bool {
   is_in_schema_class(arena::pin(class_name), tag)
 }
 pub fn is_in_schema_class(class_name: SymStr, tag: SymStr) -> bool {
-  if let Some(class) = model!().schema_class.get_sym(class_name) {
+  match model!().schema_class.get_sym(class_name) { Some(class) => {
     class.contains(&tag)
-  } else {
+  } _ => {
     false
-  }
+  }}
 }
 
 //**********************************************************************

--- a/latexml_core/src/common/number.rs
+++ b/latexml_core/src/common/number.rs
@@ -37,7 +37,7 @@ impl From<Number> for Option<Tokens> {
 
 #[macro_export]
 macro_rules! Number {
-  ($number:expr) => {{ ::latexml_core::common::number::Number::new($number as i64) }};
+  ($number:expr_2021) => {{ ::latexml_core::common::number::Number::new($number as i64) }};
 }
 
 impl From<String> for Number {

--- a/latexml_core/src/common/store.rs
+++ b/latexml_core/src/common/store.rs
@@ -625,12 +625,12 @@ impl Stored {
   /// to circumvent the limitations of using trait objects with `Rc<Definition>`
   pub fn read_arguments(&self) -> Result<Vec<ArgWrap>> {
     match self {
-      Stored::Conditional(ref entry) => entry.read_arguments(),
-      Stored::Constructor(ref entry) => entry.read_arguments(),
-      Stored::Expandable(ref entry) => entry.read_arguments(),
-      Stored::MathPrimitive(ref entry) => entry.read_arguments(),
-      Stored::Primitive(ref entry) => entry.read_arguments(),
-      Stored::Register(ref entry) => entry.read_arguments(),
+      Stored::Conditional(entry) => entry.read_arguments(),
+      Stored::Constructor(entry) => entry.read_arguments(),
+      Stored::Expandable(entry) => entry.read_arguments(),
+      Stored::MathPrimitive(entry) => entry.read_arguments(),
+      Stored::Primitive(entry) => entry.read_arguments(),
+      Stored::Register(entry) => entry.read_arguments(),
       e => Err(s!(".read_arguments not defined for stored variant {:?}", e).into()),
     }
   }
@@ -638,11 +638,11 @@ impl Stored {
   /// `ToString::to_string`
   pub fn to_attribute(&self) -> String {
     match self {
-      Stored::Dimension(ref v) => v.to_attribute(),
-      Stored::Number(ref v) => v.to_attribute(),
-      Stored::MuDimension(ref v) => v.to_attribute(),
-      Stored::Glue(ref v) => v.to_attribute(),
-      Stored::MuGlue(ref v) => v.to_attribute(),
+      Stored::Dimension(v) => v.to_attribute(),
+      Stored::Number(v) => v.to_attribute(),
+      Stored::MuDimension(v) => v.to_attribute(),
+      Stored::Glue(v) => v.to_attribute(),
+      Stored::MuGlue(v) => v.to_attribute(),
       other => other.to_string(),
     }
   }
@@ -989,7 +989,7 @@ impl From<&Stored> for String {
 impl<'a> From<&'a Stored> for Option<&'a VecDeque<Stored>> {
   fn from(value: &'a Stored) -> Option<&'a VecDeque<Stored>> {
     match value {
-      Stored::VecDequeStored(ref v) => Some(v),
+      Stored::VecDequeStored(v) => Some(v),
       _ => None,
     }
   }
@@ -998,7 +998,7 @@ impl<'a> From<&'a Stored> for Option<&'a VecDeque<Stored>> {
 impl<'a> From<&'a Stored> for Option<Rc<Font>> {
   fn from(value: &'a Stored) -> Option<Rc<Font>> {
     match value {
-      Stored::Font(ref f) => Some(Rc::clone(f)),
+      Stored::Font(f) => Some(Rc::clone(f)),
       _ => None,
     }
   }
@@ -1007,11 +1007,11 @@ impl<'a> From<&'a Stored> for Option<Rc<Font>> {
 impl<'a> From<&'a Stored> for Option<Number> {
   fn from(value: &'a Stored) -> Option<Number> {
     match value {
-      Stored::Number(ref n) => Some(*n),
-      Stored::Dimension(ref n) => Some(Number::new(n.value_of())),
-      Stored::Glue(ref n) => Some(Number::new(n.value_of())),
-      Stored::MuDimension(ref n) => Some(Number::new(n.value_of())),
-      Stored::MuGlue(ref n) => Some(Number::new(n.value_of())),
+      Stored::Number(n) => Some(*n),
+      Stored::Dimension(n) => Some(Number::new(n.value_of())),
+      Stored::Glue(n) => Some(Number::new(n.value_of())),
+      Stored::MuDimension(n) => Some(Number::new(n.value_of())),
+      Stored::MuGlue(n) => Some(Number::new(n.value_of())),
       other => {
         eprintln!("TODO: auto-cast of Stored to Number attempted on {other:?}");
         None
@@ -1043,11 +1043,11 @@ fn mu_to_pt_value(mu_val: i64) -> i64 {
 impl<'a> From<&'a Stored> for Option<Dimension> {
   fn from(value: &'a Stored) -> Option<Dimension> {
     match value {
-      Stored::Dimension(ref n) => Some(*n),
-      Stored::Number(ref n) => Some(Dimension::new(n.value_of())),
-      Stored::Glue(ref n) => Some(Dimension::new(n.value_of())),
-      Stored::MuDimension(ref n) => Some(Dimension::new(mu_to_pt_value(n.value_of()))),
-      Stored::MuGlue(ref n) => Some(Dimension::new(mu_to_pt_value(n.value_of()))),
+      Stored::Dimension(n) => Some(*n),
+      Stored::Number(n) => Some(Dimension::new(n.value_of())),
+      Stored::Glue(n) => Some(Dimension::new(n.value_of())),
+      Stored::MuDimension(n) => Some(Dimension::new(mu_to_pt_value(n.value_of()))),
+      Stored::MuGlue(n) => Some(Dimension::new(mu_to_pt_value(n.value_of()))),
       _ => None,
     }
   }
@@ -1056,11 +1056,11 @@ impl<'a> From<&'a Stored> for Option<Dimension> {
 impl<'a> From<&'a Stored> for Option<Glue> {
   fn from(value: &'a Stored) -> Option<Glue> {
     match value {
-      Stored::Dimension(ref n) => Some(Glue::new(n.value_of())),
-      Stored::Number(ref n) => Some(Glue::new(n.value_of())),
-      Stored::MuDimension(ref n) => Some(Glue::new(mu_to_pt_value(n.value_of()))),
-      Stored::MuGlue(ref n) => Some(Glue::new(mu_to_pt_value(n.value_of()))),
-      Stored::Glue(ref n) => Some(*n),
+      Stored::Dimension(n) => Some(Glue::new(n.value_of())),
+      Stored::Number(n) => Some(Glue::new(n.value_of())),
+      Stored::MuDimension(n) => Some(Glue::new(mu_to_pt_value(n.value_of()))),
+      Stored::MuGlue(n) => Some(Glue::new(mu_to_pt_value(n.value_of()))),
+      Stored::Glue(n) => Some(*n),
       _ => None,
     }
   }
@@ -1102,7 +1102,7 @@ impl From<Stored> for Option<Tokens> {
 impl<'a> From<&'a Stored> for Option<Rc<Register>> {
   fn from(value: &'a Stored) -> Option<Rc<Register>> {
     match value {
-      Stored::Register(ref reg) => Some(Rc::clone(reg)),
+      Stored::Register(reg) => Some(Rc::clone(reg)),
       _ => None,
     }
   }
@@ -1111,7 +1111,7 @@ impl<'a> From<&'a Stored> for Option<Rc<Register>> {
 impl<'a> From<&'a Stored> for Option<Catcode> {
   fn from(value: &'a Stored) -> Option<Catcode> {
     match value {
-      Stored::Catcode(ref cc) => Some(*cc),
+      Stored::Catcode(cc) => Some(*cc),
       _ => None,
     }
   }
@@ -1120,7 +1120,7 @@ impl<'a> From<&'a Stored> for Option<Catcode> {
 impl<'a> From<&'a Stored> for Option<&'a [char]> {
   fn from(value: &'a Stored) -> Option<&'a [char]> {
     match value {
-      Stored::Chars(ref cc) => Some(cc),
+      Stored::Chars(cc) => Some(cc),
       _ => None,
     }
   }
@@ -1129,7 +1129,7 @@ impl<'a> From<&'a Stored> for Option<&'a [char]> {
 impl From<&Stored> for Option<Rc<[Option<char>]>> {
   fn from(value: &Stored) -> Option<Rc<[Option<char>]>> {
     match value {
-      Stored::Fontmap(ref cc) => Some(Rc::clone(cc)),
+      Stored::Fontmap(cc) => Some(Rc::clone(cc)),
       _ => None,
     }
   }

--- a/latexml_core/src/common/xml.rs
+++ b/latexml_core/src/common/xml.rs
@@ -143,12 +143,12 @@ pub fn is_descendant_or_self(child: &Node, parent: &Node) -> bool {
     if p_node == parent {
       return true;
     }
-    if let Some(parent_node) = p_node.get_parent() {
+    match p_node.get_parent() { Some(parent_node) => {
       parent_opt = Some(parent_node);
       p = parent_opt.as_ref();
-    } else {
+    } _ => {
       break;
-    }
+    }}
   }
   false
 }

--- a/latexml_core/src/definition.rs
+++ b/latexml_core/src/definition.rs
@@ -192,7 +192,7 @@ impl FontDirective {
   pub fn get_font(&self, whatsit: Option<&Whatsit>) -> Result<Rc<Font>> {
     match self {
       FontDirective::Closure(fc) => Ok(Rc::new((fc)(whatsit)?)),
-      FontDirective::Asset(ref font) => Ok(Rc::clone(font)),
+      FontDirective::Asset(font) => Ok(Rc::clone(font)),
     }
   }
   pub fn get_asset(&self) -> Option<Rc<Font>> {
@@ -364,8 +364,8 @@ impl fmt::Display for dyn Definition {
 impl fmt::Display for ExpansionBody {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
-      ExpansionBody::Tokens(ref t) => write!(f, "{t}"),
-      ExpansionBody::Closure(ref code) => {
+      ExpansionBody::Tokens(t) => write!(f, "{t}"),
+      ExpansionBody::Closure(code) => {
         write!(f, "ExpansionBody::Closure({:p})", Rc::as_ptr(code))
       }, // what is the right way to serialize this, e.g. for the \meaning macro
     }

--- a/latexml_core/src/definition/conditional.rs
+++ b/latexml_core/src/definition/conditional.rs
@@ -307,7 +307,7 @@ impl Conditional {
             // Make sure this \else is NOT for a nested \if that is part of the test clause!
             let maybe_last = with_value("if_stack", |stack_opt| {
               if let Some(Stored::VecDequeStored(stack)) = stack_opt {
-                if let Some(Stored::IfFrame(ref stack_frame)) = stack.front() {
+                if let Some(Stored::IfFrame(stack_frame)) = stack.front() {
                   if *stack_frame.borrow() == *local_frame.as_ref().unwrap().borrow() {
                     // No need to actually call elseHandler, but note that we've seen an \else!
                     stack_frame.borrow_mut().elses = true;
@@ -396,7 +396,7 @@ impl Conditional {
 
   fn invoke_fi(&self) -> Result<Tokens> {
     let stack_frame_opt: Option<Rc<RefCell<IfFrame>>> = with_value("if_stack", |stack_opt| {
-      if let Some(Stored::VecDequeStored(ref stack)) = stack_opt {
+      if let Some(Stored::VecDequeStored(stack)) = stack_opt {
         if let Some(Stored::IfFrame(frame)) = stack.front() {
           Some(Rc::clone(frame))
         } else {

--- a/latexml_core/src/definition/register.rs
+++ b/latexml_core/src/definition/register.rs
@@ -99,14 +99,14 @@ impl Object for RegisterValue {
   fn revert(&self) -> Result<Tokens> {
     match self {
       // ExplodeText($self->toString);
-      RegisterValue::Number(ref value) => Ok(Tokens::new(ExplodeText!(value))),
-      RegisterValue::Dimension(ref value) => Ok(Tokens::new(ExplodeText!(value))),
-      RegisterValue::MuDimension(ref value) => Ok(Tokens::new(ExplodeText!(value))),
-      RegisterValue::Glue(ref value) => Ok(Tokens::new(ExplodeText!(value))),
-      RegisterValue::MuGlue(ref value) => Ok(Tokens::new(ExplodeText!(value))),
-      RegisterValue::Token(ref value) => Ok(Tokens!(value.revert())),
-      RegisterValue::Tokens(ref value) => Ok(Tokens::new(value.clone().revert())), // clone?
-      RegisterValue::Pair(ref value) => value.revert(),
+      RegisterValue::Number(value) => Ok(Tokens::new(ExplodeText!(value))),
+      RegisterValue::Dimension(value) => Ok(Tokens::new(ExplodeText!(value))),
+      RegisterValue::MuDimension(value) => Ok(Tokens::new(ExplodeText!(value))),
+      RegisterValue::Glue(value) => Ok(Tokens::new(ExplodeText!(value))),
+      RegisterValue::MuGlue(value) => Ok(Tokens::new(ExplodeText!(value))),
+      RegisterValue::Token(value) => Ok(Tokens!(value.revert())),
+      RegisterValue::Tokens(value) => Ok(Tokens::new(value.clone().revert())), // clone?
+      RegisterValue::Pair(value) => value.revert(),
     }
   }
 }
@@ -732,7 +732,7 @@ impl Definition for Register {
     let params = &self.parameters;
     match params {
       None => Ok(Vec::new()),
-      Some(ref params) => params.read_arguments(Some(self)),
+      Some(params) => params.read_arguments(Some(self)),
     }
   }
 

--- a/latexml_core/src/digested.rs
+++ b/latexml_core/src/digested.rs
@@ -314,7 +314,7 @@ impl BoxOps for Digested {
       Alignment(w) => w.borrow_mut().be_absorbed_mut(document),
       KeyVals(kvs) => kvs.be_absorbed(document),
       Postponed(_) => Ok(Vec::new()), // Postponed items absorbed silently
-      RegisterValue(ref _rv) => Ok(Vec::new()), // Register values not absorbable
+      RegisterValue(_rv) => Ok(Vec::new()), // Register values not absorbable
     }
   }
 
@@ -739,17 +739,17 @@ impl Digested {
           || w.get_property_bool("alignmentSkippable")
         {
           true
-        } else if let Ok(Some(body)) = w.get_body() {
+        } else { match w.get_body() { Ok(Some(body)) => {
           body.is_skippable()
-        } else if let Some(ref prop) = w.get_property("content_box") {
+        } _ => { match w.get_property("content_box") { Some(ref prop) => {
           // Perl: $thing->getProperty('content_box') — for \hbox etc.
           match &**prop {
             Stored::Digested(cb) => cb.is_skippable(),
             _ => false,
           }
-        } else {
+        } _ => {
           false
-        }
+        }}}}}
       },
       Postponed(ref tks) => {
         // Perl checks token catcodes: letters, others, active, CS are NOT skippable

--- a/latexml_core/src/document.rs
+++ b/latexml_core/src/document.rs
@@ -236,11 +236,11 @@ impl Document {
     match node_opt {
       Some(node) => self.get_xpath().findvalues(xpath, Some(node)),
       None => {
-        if let Some(root) = self.document.get_root_element() {
+        match self.document.get_root_element() { Some(root) => {
           self.get_xpath().findvalues(xpath, Some(&root))
-        } else {
+        } _ => {
           Vec::new()
-        }
+        }}
       },
     }
   }
@@ -651,14 +651,14 @@ impl Document {
     let mut boxes = vec![Cow::Borrowed(object)];
     while let Some(front_box) = boxes.pop() {
       match front_box.data() {
-        List(ref list) => {
+        List(list) => {
           // Simply unwind Lists to avoid unneccessary recursion; This occurs quite frequently!
           for tbox in list.borrow().unlist().into_iter().rev() {
             boxes.push(Cow::Owned(tbox));
           }
         },
         // A Proper Box or Whatsit? Absorb it.
-        TBox(ref digested) => {
+        TBox(digested) => {
           self.set_box_to_absorb(Some((*front_box).clone()));
           self.init_constructed_nodes();
           digested.borrow().be_absorbed(self)?;
@@ -666,25 +666,25 @@ impl Document {
           self.close_constructed_nodes();
           self.expire_box_to_absorb();
         },
-        Whatsit(ref digested) => {
+        Whatsit(digested) => {
           self.set_box_to_absorb(Some((*front_box).clone()));
           self.init_constructed_nodes();
           digested.borrow().be_absorbed(self)?;
           self.close_constructed_nodes();
           self.expire_box_to_absorb();
         },
-        Alignment(ref alignment) => {
+        Alignment(alignment) => {
           self.set_box_to_absorb(Some((*front_box).clone()));
           self.init_constructed_nodes();
           alignment.borrow_mut().be_absorbed_mut(self)?;
           self.close_constructed_nodes();
           self.expire_box_to_absorb();
         },
-        Comment(ref comment) => {
+        Comment(comment) => {
           comment.be_absorbed(self)?;
         },
-        Postponed(ref tokens) => {
-          let text_font_opt = if let Some(Stored::Font(ref prop_font)) = props.get("font") {
+        Postponed(tokens) => {
+          let text_font_opt = if let Some(Stored::Font(prop_font)) = props.get("font") {
             Some(Rc::clone(prop_font))
           } else {
             match self.box_to_absorb {
@@ -699,7 +699,7 @@ impl Document {
             self.record_constructed_node(&new_text);
           }
         },
-        KeyVals(ref kv) => {
+        KeyVals(kv) => {
           // When KeyVals appear in body absorption (e.g. #1 for RequiredKeyVals),
           // convert them to text representation matching Perl's stringify behavior.
           let text = kv.to_string();
@@ -911,11 +911,11 @@ impl Document {
       // Perl: insertPI always places PIs before the root element.
       // Find the document root and insert before it.
       let doc_node = self.document.clone();
-      if let Some(mut root) = doc_node.get_root_element() {
+      match doc_node.get_root_element() { Some(mut root) => {
         root.add_prev_sibling(&mut pi_node)?;
-      } else {
+      } _ => {
         self.node.add_prev_sibling(&mut pi_node)?;
-      }
+      }}
     }
     Ok(())
   }
@@ -1151,12 +1151,12 @@ impl Document {
 
   // Close $qname, if it is closeable.
   pub fn maybe_close_element(&mut self, qname: &str) -> Result<Option<Node>> {
-    if let Some(node) = self.is_closeable(qname) {
+    match self.is_closeable(qname) { Some(node) => {
       self.close_node_internal(&node)?;
       Ok(Some(node))
-    } else {
+    } _ => {
       Ok(None)
-    }
+    }}
   }
 
   /// Closes all nodes until $node becomes the current point.
@@ -1171,12 +1171,12 @@ impl Document {
         cant_close.push(n.clone());
       }
       lastopen = Some(n.clone());
-      if let Some(p) = n.get_parent() {
+      match n.get_parent() { Some(p) => {
         n = p;
         n_type = n.get_type();
-      } else {
+      } _ => {
         break;
-      }
+      }}
     }
     if n_type == Some(NodeType::DocumentNode) {
       // Didn't find $node at all!!
@@ -1736,7 +1736,7 @@ impl Document {
         &comment_text,
         Placement_::AppendChild,
       );
-    } else if let Some(node) = self.get_element() {
+    } else { match self.get_element() { Some(node) => {
       // Get the nearest element node (Perl: getElement)
       let prev = node.get_last_child();
       let prevtype = prev.as_ref().and_then(|n| n.get_type());
@@ -1779,7 +1779,7 @@ impl Document {
           Placement_::AppendChild,
         );
       }
-    }
+    } _ => {}}}
     Ok(self.node.clone())
   }
 
@@ -2204,7 +2204,7 @@ impl Document {
           orig.data() as *const DigestedData,
         );
         let same_as_last = if !same_as_orig {
-          if let DigestedData::List(ref list) = orig.data() {
+          if let DigestedData::List(list) = orig.data() {
             list
               .borrow()
               .boxes
@@ -2363,14 +2363,14 @@ impl Document {
   pub fn filter_deletions(&self, nodes: Vec<Node>) -> Vec<Node> {
     // This test seems to successfully determine inclusion,
     // without requiring the (dangerous? & dubious?) unbindNode to be used.
-    if let Some(root) = self.document.get_root_element() {
+    match self.document.get_root_element() { Some(root) => {
       nodes
         .into_iter()
         .filter(|node| xml::is_descendant_or_self(node, &root))
         .collect()
-    } else {
+    } _ => {
       Vec::new()
-    }
+    }}
   }
 
   /// Given a list of nodes such as from ->absorb,
@@ -3571,11 +3571,11 @@ impl Document {
   }
 
   pub fn has_node_font(&self, node: &Node) -> bool {
-    if let Some(element) = xml::closest_element(node) {
+    match xml::closest_element(node) { Some(element) => {
       element.has_attribute("_font")
-    } else {
+    } _ => {
       false
-    }
+    }}
   }
 
   pub fn get_node_language(&self, node: &Node) -> String {
@@ -3607,12 +3607,12 @@ impl Document {
           }
         }
       }
-      if let Some(parent) = node_ref.get_parent() {
+      match node_ref.get_parent() { Some(parent) => {
         current = parent;
         node_ref = &current;
-      } else {
+      } _ => {
         break;
-      }
+      }}
     }
     String::from("en")
   }
@@ -4367,7 +4367,7 @@ impl Document {
       }
       candidates.pop_front();
     }
-    if let Some(n) = candidates.pop_front() {
+    match candidates.pop_front() { Some(n) => {
       if closeifpossible && closeable {
         self.close_to_node(&n, false)?;
       } else {
@@ -4377,14 +4377,14 @@ impl Document {
         //   if ($$savenode ne $$n) && $LaTeXML::DEBUG{document};
         return Ok(Some(savenode));
       }
-    } else if can_contain_node_somehow(&self.node, qname).is_none() {
+    } _ => if can_contain_node_somehow(&self.node, qname).is_none() {
       Warn!(
         "malformed",
         qname,
         s!("No open node can contain element '{}'", qname)
       );
       // self.get_insertion_context())
-    }
+    }}
     Ok(None)
   }
 
@@ -4581,7 +4581,7 @@ impl Document {
   //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
   pub fn replace_tree(&mut self, new: Node, old: Node) -> Result<Option<Node>> {
-    if let Some(mut parent) = old.get_parent() {
+    match old.get_parent() { Some(mut parent) => {
       let mut following = VecDeque::new(); // Collect the matching and following nodes
       while let Some(mut sib) = parent.get_last_child() {
         if sib == old {
@@ -4603,9 +4603,9 @@ impl Document {
         parent.add_child(&mut child)?; // No need for clone
       }
       Ok(inserted)
-    } else {
+    } _ => {
       Ok(None)
-    }
+    }}
   }
 
   pub fn append_tree(&mut self, node: &mut Node, data: Vec<Node>) -> Result<()> {

--- a/latexml_core/src/document/tag.rs
+++ b/latexml_core/src/document/tag.rs
@@ -123,7 +123,7 @@ impl TagOptions {
       AfterCloseLate => &mut self.after_close_late,
     };
     match field {
-      Some(ref mut vec) => std::mem::take(vec),
+      Some(vec) => std::mem::take(vec),
       None => Vec::new(),
     }
   }

--- a/latexml_core/src/dump_reader.rs
+++ b/latexml_core/src/dump_reader.rs
@@ -88,7 +88,7 @@ pub fn flush_deferred_aliases() -> (usize, usize) {
     }
     // Perl `Lt()` parity: look up target's meaning, write it at
     // alias key via `assign_internal('meaning', ..., 'global')`.
-    if let Some(meaning) = state::lookup_meaning(&target_tok) {
+    match state::lookup_meaning(&target_tok) { Some(meaning) => {
       state::assign_internal(
         TableName::Meaning,
         cs_tok.get_cs_name(),
@@ -96,9 +96,9 @@ pub fn flush_deferred_aliases() -> (usize, usize) {
         Some(Scope::Global),
       );
       applied += 1;
-    } else {
+    } _ => {
       skipped += 1;
-    }
+    }}
   }
   (applied, skipped)
 }

--- a/latexml_core/src/dump_writer.rs
+++ b/latexml_core/src/dump_writer.rs
@@ -199,7 +199,7 @@ pub fn write_dump(
     {
       // Confirm the loop pattern before dropping (don't suppress
       // valid hook contributions on engines with sound aliasing).
-      if let Stored::Tokens(ref tks) = value {
+      if let Stored::Tokens(tks) = value {
         let body = tks.unlist_ref();
         let needle_cs = key_str.clone();
         let has_self_the = body.iter().any(|t| t.with_str(|s| s == "\\the"))

--- a/latexml_core/src/gullet.rs
+++ b/latexml_core/src/gullet.rs
@@ -1130,11 +1130,11 @@ pub fn read_balanced(
           // SHOULD count nesting of { }!!! when SCANNED (not digested)
           if has_reading_alignment() && align_group_count() == 0 {
             if let Some((_atoken, atype, ahidden)) = is_column_end(&token) {
-              if let DigestedData::Alignment(data) = get_reading_alignment().unwrap().data() {
+              match get_reading_alignment().unwrap().data() { DigestedData::Alignment(data) => {
                 handle_template(data.borrow_mut(), token, atype, ahidden)?;
-              } else {
+              } _ => {
                 panic!("malformed alignmed was stored?");
-              }
+              }}
               continue;
             }
           }
@@ -1556,7 +1556,7 @@ fn read_cs_name_inner(quiet: bool) -> Result<Token> {
           if let Some(c) = standalone {
             c.with_str(|s| cs.push_str(s));
           }
-        } else if let Some(Stored::Token(letted)) = crate::state::lookup_meaning(&token) {
+        } else { match crate::state::lookup_meaning(&token) { Some(Stored::Token(letted)) => {
           // CS is \let-equivalent to a single token. If that token is
           // a character (LETTER/OTHER/SPACE), append its string repr
           // to the constructed csname — mirrors real TeX's behaviour
@@ -1581,7 +1581,7 @@ fn read_cs_name_inner(quiet: bool) -> Result<Token> {
             );
             Error!("unexpected", token, message);
           }
-        } else if !quiet {
+        } _ => if !quiet {
           if lookup_definition(&token)?.is_some() {
             let message = s!(
               "The control sequence {:?} should not appear between \\csname and \\endcsname (partial cs so far: {:?})",
@@ -1593,7 +1593,7 @@ fn read_cs_name_inner(quiet: bool) -> Result<Token> {
             let message = s!("The token {:?} is not defined", token);
             Error!("undefined", token, message);
           }
-        }
+        }}}
         // In quiet mode (ifcsname), just skip the CS token
       },
       Catcode::SPACE => cs.push(' '), // Keep newlines from having \n!
@@ -1821,7 +1821,7 @@ pub fn read_register_value_coerce(
     None => Ok(None),
     Some(token) => {
       let _is_fontdimen = token.with_str(|s| s == "\\fontdimen");
-      if let Some(defn) = lookup_register_definition(&token) {
+      match lookup_register_definition(&token) { Some(defn) => {
         if let Some(mut register_type) = defn.register_type() {
           if register_type == RegisterType::CharDef {
             // CharDefs treated as numbers here
@@ -1846,10 +1846,10 @@ pub fn read_register_value_coerce(
           unread_one(token); // Unread
           Ok(None)
         }
-      } else {
+      } _ => {
         unread_one(token); // Unread
         Ok(None)
-      }
+      }}
     },
   }
 }
@@ -2358,7 +2358,7 @@ pub fn read_tokens_value() -> Result<Tokens> {
       // Perl: $$token[1] == CC_BEGIN — direct catcode check
       if token.get_catcode() == Catcode::BEGIN {
         Ok(read_balanced(ExpansionLevel::Off, false, false)?)
-      } else if let Some(defn) = lookup_register_definition(&token) {
+      } else { match lookup_register_definition(&token) { Some(defn) => {
         match defn.register_type() {
           Some(RegisterType::Tokens) | Some(RegisterType::Token) => {
             // TODO: The mismatch between Vec<Tokens> for read_arguments and Vec<Token> for
@@ -2372,7 +2372,7 @@ pub fn read_tokens_value() -> Result<Tokens> {
           },
           _ => Ok(Tokens!(token)),
         }
-      } else if let Some(defn) = lookup_definition(&token)? {
+      } _ => { match lookup_definition(&token)? { Some(defn) => {
         // TODO: we are doing two lookups to avoid the type restriction of .read_arguments, any
         // way to circumvent? Is it slow in the first place?
         if defn.is_expandable() {
@@ -2384,9 +2384,9 @@ pub fn read_tokens_value() -> Result<Tokens> {
         } else {
           Ok(Tokens!(token))
         }
-      } else {
+      } _ => {
         Ok(Tokens!(token))
-      }
+      }}}}}
     },
   }
 }

--- a/latexml_core/src/keyvals.rs
+++ b/latexml_core/src/keyvals.rs
@@ -116,16 +116,16 @@ impl Object for KeyVals {
         // avoid accidental repeats?
         let keytype_opt = keyval_get(&keyval_qname(&self.prefix, primary_keyset, key), "type");
         let v = if let Some(Stored::Parameter(keytype)) = keytype_opt {
-          if let Some(v) = value.take() {
+          match value.take() { Some(v) => {
             keytype.digest(v, None)?
-          } else {
+          } _ => {
             None
-          }
-        } else if let Some(v) = value.take() {
+          }}
+        } else { match value.take() { Some(v) => {
           Some(v.be_digested()?)
-        } else {
+        } _ => {
           None
-        };
+        }}};
         tuple.digested_value = v;
       }
     }

--- a/latexml_core/src/lib.rs
+++ b/latexml_core/src/lib.rs
@@ -390,11 +390,11 @@ pub trait BoxOps: Object {
       None => match self.get_property("cached_height") {
         Some(val) => (&*val).into(),
         None => {
-          if let Ok((_, h, _)) = self.compute_size(HashMap::default()) {
+          match self.compute_size(HashMap::default()) { Ok((_, h, _)) => {
             Some(RegisterValue::Dimension(h))
-          } else {
+          } _ => {
             Some(RegisterValue::Dimension(Dimension::default()))
-          }
+          }}
         },
       },
     }
@@ -409,11 +409,11 @@ pub trait BoxOps: Object {
       None => match self.get_property("cached_depth") {
         Some(val) => (&*val).into(),
         None => {
-          if let Ok((_, _, d)) = self.compute_size(HashMap::default()) {
+          match self.compute_size(HashMap::default()) { Ok((_, _, d)) => {
             Some(RegisterValue::Dimension(d))
-          } else {
+          } _ => {
             Some(RegisterValue::Dimension(Dimension::default()))
-          }
+          }}
         },
       },
     }

--- a/latexml_core/src/mouth.rs
+++ b/latexml_core/src/mouth.rs
@@ -650,7 +650,7 @@ impl Mouth {
         let line_opt = self.get_next_line();
         // For \read, we have to return something for EOL, and handle implicit final newline
         let read_mode = lookup_int("PRESERVE_NEWLINES") > 1;
-        let eolch = if let Some(defn) = lookup_definition(&T_CS!("\\endlinechar")).unwrap() {
+        let eolch = match lookup_definition(&T_CS!("\\endlinechar")).unwrap() { Some(defn) => {
           if defn.is_register() {
             if let Some(eol) = defn.value_of(Vec::new()) {
               let eol = eol.value_of() as i16;
@@ -666,9 +666,9 @@ impl Mouth {
           } else {
             None
           }
-        } else {
+        } _ => {
           Some('\r')
-        };
+        }};
         if line_opt.is_none() {
           // Exhausted the input.
           let eolcc = if let Some(ch) = eolch {

--- a/latexml_core/src/parameter.rs
+++ b/latexml_core/src/parameter.rs
@@ -413,7 +413,7 @@ impl Parameter {
       // Done for effect only.
       pre()?; // maybe pass extras?
     }
-    let digested_value = if let Some(ref closure) = &self.predigest {
+    let digested_value = if let Some(closure) = &self.predigest {
       closure(value_arg, &self.extra)?
     } else {
       // Note: we have an open question for the type interface.

--- a/latexml_core/src/rewrite.rs
+++ b/latexml_core/src/rewrite.rs
@@ -530,11 +530,11 @@ impl Rewrite {
           let mut replaced = Vec::new();
           for _idx in 0..nmatched {
             // Remove the nodes to be replaced
-            if let Some(popped) = following.pop_front() {
+            match following.pop_front() { Some(popped) => {
               replaced.push(popped);
-            } else {
+            } _ => {
               break; // nmatched larger than available nodes — stop
-            }
+            }}
           }
           for rnode in replaced.iter() {
             document.unrecord_node_ids(rnode);
@@ -586,12 +586,12 @@ impl Rewrite {
               // Collect nmatched siblings
               let mut cur = tree.clone();
               for _ in 1..nmatched {
-                if let Some(sib) = cur.get_next_sibling() {
+                match cur.get_next_sibling() { Some(sib) => {
                   cur = sib.clone();
                   nodes.push(sib);
-                } else {
+                } _ => {
                   break;
-                }
+                }}
               }
               set_attributes_wild(document, attrs, nodes, nmatched)?;
             } else if nmatched > 1 {
@@ -1161,11 +1161,11 @@ pub fn set_attributes_wild(
   }
 
   // Insert content arm as first child (before presentation nodes)
-  if let Some(mut first_child) = dual_node.get_first_child() {
+  match dual_node.get_first_child() { Some(mut first_child) => {
     first_child.add_prev_sibling(&mut content_app)?;
-  } else {
+  } _ => {
     dual_node.add_child(&mut content_app)?;
-  }
+  }}
 
   // Restructure POSTSUBSCRIPT/POSTSUPERSCRIPT in the presentation children.
   // In Perl, XMWrap gets kludge_scripts'd by the math parser. Since we don't have

--- a/latexml_core/src/state.rs
+++ b/latexml_core/src/state.rs
@@ -874,7 +874,7 @@ impl State {
             Some(Scope::Global),
           );
         }
-        if let Some(Stored::Stash(ref mut stash)) =
+        if let Some(Stored::Stash(stash)) =
           self.stash.get_mut(&scope_name).as_mut().unwrap().get_mut(0)
         {
           stash.push((table_name, key, value.clone()));
@@ -941,11 +941,11 @@ impl State {
     }
   }
   pub fn lookup_font_info(&self, key: &Token) -> Result<Option<&Stored>> {
-    let key_str = if let Some(defn) = lookup_definition(key)? {
+    let key_str = match lookup_definition(key)? { Some(defn) => {
       s!("fontinfo_{}", defn.get_cs_name())
-    } else {
+    } _ => {
       s!("fontinfo_{key}")
-    };
+    }};
     Ok(self.lookup_value(&key_str))
   }
   /// manage a (global) hash of values
@@ -1398,7 +1398,7 @@ pub fn has_value(key: &str) -> bool {
 pub fn push_tokens(key: &str, value: Tokens) {
   let mut state = state_mut!();
   match state.lookup_value_mut(key) {
-    Some(Stored::Tokens(ref mut tks)) => tks.unlist_mut().extend(value.unlist()),
+    Some(Stored::Tokens(tks)) => tks.unlist_mut().extend(value.unlist()),
     None | Some(Stored::None) => state.assign_value(key, Stored::Tokens(value), None),
     Some(other) => panic!("Can only push_tokens into a Stored::Tokens, but got {other:?}"),
   }
@@ -1653,7 +1653,7 @@ pub fn lookup_register_token(
   cs: &Token,
   parameters: Vec<ArgWrap>,
 ) -> Result<Option<RegisterValue>> {
-  Ok(if let Some(defn) = lookup_definition(cs)? {
+  Ok(match lookup_definition(cs)? { Some(defn) => {
     if defn.is_register() {
       defn.value_of(parameters)
     } else {
@@ -1661,9 +1661,9 @@ pub fn lookup_register_token(
       Warn!("expected", "register", message);
       None
     }
-  } else {
+  } _ => {
     None
-  })
+  }})
 }
 
 pub fn lookup_expandable(
@@ -2187,7 +2187,7 @@ pub fn lookup_digestable_definition(token: &Token) -> Option<Stored> {
     // Debug!("Found definition for: {:?}", lookupname);
     if let Some(entry) = entry_opt {
       if let Some(front) = entry.front() {
-        if let Stored::Token(ref t) = front {
+        if let Stored::Token(t) = front {
           if let Some(lookup_name) = t.get_executable_primitive_name() {
             let lookup_sym = arena::pin(lookup_name);
             if let Some(retry_entry) = state!().meaning.get(&lookup_sym) {

--- a/latexml_core/src/tbox.rs
+++ b/latexml_core/src/tbox.rs
@@ -283,15 +283,15 @@ impl BoxOps for Tbox {
   fn get_font(&self) -> Result<Option<Cow<'_, Font>>> { Ok(Some(Cow::Borrowed(&self.font))) }
 
   fn compute_size(&self, options: HashMap<Stored>) -> Result<(Dimension, Dimension, Dimension)> {
-    if let Some(body_stored) = self.get_property("body") {
+    match self.get_property("body") { Some(body_stored) => {
       if let Stored::Digested(ref body) = *body_stored {
         body.compute_size(options)
       } else {
         panic!("the stored 'body' property should always be a Stored::Digested enum case.");
       }
-    } else {
+    } _ => {
       Ok(self.font.compute_string_size(&self.get_string()?, options))
-    }
+    }}
   }
 }
 

--- a/latexml_core/src/telemetry.rs
+++ b/latexml_core/src/telemetry.rs
@@ -332,7 +332,7 @@ impl Telemetry {
 
     let mut first = true;
     macro_rules! field {
-      ($name:literal, $val:expr) => {{
+      ($name:literal, $val:expr_2021) => {{
         if !first {
           s.push(',');
         }
@@ -344,7 +344,7 @@ impl Telemetry {
       }};
     }
     macro_rules! field_str {
-      ($name:literal, $val:expr) => {{
+      ($name:literal, $val:expr_2021) => {{
         if !first {
           s.push(',');
         }
@@ -356,7 +356,7 @@ impl Telemetry {
       }};
     }
     macro_rules! field_array_u64 {
-      ($name:literal, $arr:expr) => {{
+      ($name:literal, $arr:expr_2021) => {{
         if !first {
           s.push(',');
         }
@@ -374,7 +374,7 @@ impl Telemetry {
       }};
     }
     macro_rules! field_array_u32 {
-      ($name:literal, $arr:expr) => {{
+      ($name:literal, $arr:expr_2021) => {{
         field_array_u64!($name, $arr);
       }};
     }

--- a/latexml_core/src/token.rs
+++ b/latexml_core/src/token.rs
@@ -486,7 +486,7 @@ macro_rules! T_LETTER {
       #[cfg(feature = "token-locators")] loc: 0
     }
   };
-  ($text:expr) => {
+  ($text:expr_2021) => {
     Token {
       text: $crate::common::arena::pin($text),
       code: Catcode::LETTER,
@@ -504,7 +504,7 @@ macro_rules! T_OTHER {
       #[cfg(feature = "token-locators")] loc: 0
     }
   };
-  ($text:expr) => {
+  ($text:expr_2021) => {
     Token {
       text: $crate::common::arena::pin($text),
       code: Catcode::OTHER,
@@ -526,7 +526,7 @@ macro_rules! T_OTHER_CHAR {
 /// macro for an ACTIVE char token
 #[macro_export]
 macro_rules! T_ACTIVE {
-  ($c:expr) => {{
+  ($c:expr_2021) => {{
     let mut tmp = [0u8; 4];
     let s = $c.encode_utf8(&mut tmp);
     Token {
@@ -539,7 +539,7 @@ macro_rules! T_ACTIVE {
 /// macro for a COMMENT content token
 #[macro_export]
 macro_rules! T_COMMENT {
-  ($text:expr) => {
+  ($text:expr_2021) => {
     Token {
       text: $crate::common::arena::pin($text),
       code: Catcode::COMMENT,
@@ -557,7 +557,7 @@ macro_rules! T_CS {
       #[cfg(feature = "token-locators")] loc: 0
     }
   };
-  ($text:expr) => {
+  ($text:expr_2021) => {
     $crate::token::Token {
       text: $crate::common::arena::pin($text),
       code: $crate::token::Catcode::CS,
@@ -573,7 +573,7 @@ macro_rules! T_RELAX(() => { $crate::token::TOKEN_RELAX.clone() });
 /// macro for a tracing MARKER token
 #[macro_export]
 macro_rules! T_MARKER {
-  ($text:expr) => {
+  ($text:expr_2021) => {
     Token {
       text: $crate::common::arena::pin($text),
       code: Catcode::MARKER,
@@ -585,7 +585,7 @@ macro_rules! T_MARKER {
 /// macro for a numbered ARG token
 #[macro_export]
 macro_rules! T_ARG {
-  ($text:expr) => {
+  ($text:expr_2021) => {
     Token {
       text: $crate::common::arena::pin($text.to_string()),
       code: Catcode::ARG,
@@ -597,17 +597,17 @@ macro_rules! T_ARG {
 /// Token constructor macro (defaults to OTHER code)
 #[macro_export]
 macro_rules! Token {
-  ($text:expr) => {
+  ($text:expr_2021) => {
     Token!($text, Catcode::OTHER)
   };
-  ($text:literal, $cc:expr) => {
+  ($text:literal, $cc:expr_2021) => {
     Token {
       text: $crate::pin!($text),
       code: $cc,
       #[cfg(feature = "token-locators")] loc: 0
     }
   };
-  ($text:expr, $cc:expr) => {
+  ($text:expr_2021, $cc:expr_2021) => {
     Token {
       text: $crate::common::arena::pin($text),
       code: $cc,
@@ -619,10 +619,10 @@ macro_rules! Token {
 /// Special case: a character needs swift string conversion, so let's use a dedicated macro
 #[macro_export]
 macro_rules! CharToken {
-  ($c:expr) => {
+  ($c:expr_2021) => {
     CharToken!($c, Catcode::OTHER)
   };
-  ($c:expr, $cc:expr) => {{
+  ($c:expr_2021, $cc:expr_2021) => {{
     let mut tmp = [0u8; 4];
     let s = $c.encode_utf8(&mut tmp);
     Token!(s, $cc)
@@ -634,7 +634,7 @@ macro_rules! CharToken {
 /// ^^J in TeX decodes to CC_OTHER by default; let the tokenizer handle catcode
 /// reassignment if needed.
 #[macro_export]
-macro_rules! Explode(($text:expr) => (
+macro_rules! Explode(($text:expr_2021) => (
   $text.to_string().chars().map(|c|
     if c==' ' { T_SPACE!() }
     else {
@@ -644,7 +644,7 @@ macro_rules! Explode(($text:expr) => (
 ));
 
 #[macro_export]
-macro_rules! ExplodeChars(($text:expr) => (
+macro_rules! ExplodeChars(($text:expr_2021) => (
   $text.as_str().chars().map(|c|
     if c==' ' { T_SPACE!() }
     else {
@@ -658,7 +658,7 @@ macro_rules! ExplodeChars(($text:expr) => (
 /// Perl sync: newlines are OTHER, not SPACE (matches Perl #2700 revert of #2646).
 #[macro_export]
 macro_rules! ExplodeText(
-  ($text:expr) => ({
+  ($text:expr_2021) => ({
   use $crate::token::{Catcode,Token};
   $text.to_string().chars().map(|c|
     if c==' ' { T_SPACE!() }
@@ -673,7 +673,7 @@ macro_rules! ExplodeText(
 
 #[macro_export]
 macro_rules! SymExplodeText(
-  ($sym:expr) => ({
+  ($sym:expr_2021) => ({
   use $crate::token::{Catcode,Token};
   let chars : Vec<char> = arena::with($sym, |text| text.chars().collect());
   chars.into_iter().map(|c|
@@ -837,7 +837,7 @@ impl Token {
         }
       }
       let maybe_return = state::with_value("SPECIALS", |specials_opt| {
-        if let Some(Stored::Chars(ref specials_list)) = specials_opt {
+        if let Some(Stored::Chars(specials_list)) = specials_opt {
           for special in specials_list.iter() {
             if *special == ch {
               let mut tmp = [0u8; 4];

--- a/latexml_core/src/tokens.rs
+++ b/latexml_core/src/tokens.rs
@@ -48,7 +48,7 @@ impl PartialEq for Tokens {
 #[macro_export]
 macro_rules! Tokens(
   () => ( $crate::tokens::NO_TOKENS );
-  ($( $tokens:expr ),+) => ({
+  ($( $tokens:expr_2021 ),+) => ({
     let mut collected : Vec<$crate::token::Token> = Vec::new();
     $(
       let t_vec : Vec<$crate::token::Token> = $tokens.into();

--- a/latexml_core/src/whatsit.rs
+++ b/latexml_core/src/whatsit.rs
@@ -168,7 +168,7 @@ impl Whatsit {
       // And copy any otherwise undefined properties from the trailer
       // Perl: copies properties from trailer (typically a Whatsit for \end{...})
       match digested.data() {
-        DigestedData::Whatsit(ref trailer) => {
+        DigestedData::Whatsit(trailer) => {
           let trailer_val = trailer.borrow();
           let props = trailer_val.get_properties();
           for (prop, value) in props {
@@ -178,7 +178,7 @@ impl Whatsit {
               .or_insert_with(|| value.clone());
           }
         },
-        DigestedData::TBox(ref tbox) => {
+        DigestedData::TBox(tbox) => {
           let tbox_val = tbox.borrow();
           let props = tbox_val.get_properties();
           for (prop, value) in props {
@@ -188,7 +188,7 @@ impl Whatsit {
               .or_insert_with(|| value.clone());
           }
         },
-        DigestedData::List(ref list) => {
+        DigestedData::List(list) => {
           let list_val = list.borrow();
           let props = list_val.get_properties();
           for (prop, value) in props {
@@ -422,8 +422,8 @@ impl BoxOps for Whatsit {
     match self.properties.get("font") {
       Some(Stored::Font(font)) => Ok(Some(Cow::Owned((**font).clone()))),
       Some(Stored::FontDirective(fd)) => match fd {
-        FontDirective::Closure(ref code) => Ok(Some(Cow::Owned(code(Some(self))?))),
-        FontDirective::Asset(ref asset) => Ok(Some(Cow::Borrowed(asset))),
+        FontDirective::Closure(code) => Ok(Some(Cow::Owned(code(Some(self))?))),
+        FontDirective::Asset(asset) => Ok(Some(Cow::Borrowed(asset))),
       },
       _ => Ok(None),
     }
@@ -436,9 +436,9 @@ impl BoxOps for Whatsit {
     mut options: HashMap<Stored>,
   ) -> Result<(Dimension, Dimension, Dimension)> {
     let defn = self.get_definition();
-    if let Some(sizer) = defn.get_sizer() {
+    match defn.get_sizer() { Some(sizer) => {
       sizer(self)
-    } else if self.has_property("cached_width") || self.has_property("cached_height") {
+    } _ => if self.has_property("cached_width") || self.has_property("cached_height") {
       // Perl: when after_digest sets cached dimensions (e.g. image_graphicx_sizer),
       // compute_size should return them instead of falling through to body/args sum.
       let w = match self.get_property("cached_width").as_deref() {
@@ -480,13 +480,13 @@ impl BoxOps for Whatsit {
           boxes.extend(arg.unlist());
         }
       }
-      let font = if let Stored::Font(ref sf) = *self.get_property("font").unwrap() {
+      let font = match *self.get_property("font").unwrap() { Stored::Font(ref sf) => {
         sf.clone()
-      } else {
+      } _ => {
         lookup_font().unwrap()
-      };
+      }};
       font.compute_boxes_size(&boxes, options)
-    }
+    }}
   }
 }
 

--- a/latexml_core/tests/00_unit_state.rs
+++ b/latexml_core/tests/00_unit_state.rs
@@ -50,7 +50,7 @@ fn assign_lookup_value() {
     None => panic!("Couldn't lookup hashref_test value after assignment"),
     Some(Stored::HashStored(ref received_hash)) => match received_hash.get("a") {
       None => panic!("Assigned hash was missing key!"),
-      Some(Stored::Bool(ref b)) => assert!(b),
+      Some(Stored::Bool(b)) => assert!(b),
       Some(_) => panic!("Assigned hash had malformed key!"),
     },
     Some(_) => panic!("Looked up value of hashref_test didn't match assignment value"),
@@ -151,15 +151,15 @@ fn assign_lookup_arrays() {
   }
 
   unshift_value("SEARCHPATHS", vec![Stored::String(arena::pin_static("d"))]);
-  if let Some(vdq) = lookup_vecdeque("SEARCHPATHS") {
+  match lookup_vecdeque("SEARCHPATHS") { Some(vdq) => {
     let mut vdq_expected = VecDeque::new();
     for entry in &["d", "a", "b", "c"] {
       vdq_expected.push_back(Stored::String(arena::pin_static(entry)));
     }
     assert_eq!(vdq, vdq_expected, "shift/unshift existing key");
-  } else {
+  } _ => {
     panic!("state.lookup_vecdeque returned None");
-  }
+  }}
 
   assert_eq!(
     shift_value("SEARCHPATHS").unwrap(),
@@ -263,12 +263,12 @@ fn install_definition_and_meaning() {
 
   // Assign a Meaning
   assign_meaning(&T_CS!("\\foobar"), job_definition, Some(Scope::Local));
-  if let Some(Stored::Expandable(ref stored_meaning)) = lookup_meaning(&T_CS!("\\foobar")) {
+  match lookup_meaning(&T_CS!("\\foobar")) { Some(Stored::Expandable(ref stored_meaning)) => {
     assert_eq!(stored_meaning.cs, T_CS!("\\jobname")); // Note: meaning for \foobar still has
   // definition for CS \jobname
-  } else {
+  } _ => {
     panic!("Failed to lookup installed meaning!");
-  }
+  }}
 
   let looked_up_meaning = { lookup_meaning(&T_CS!("\\foobar")).unwrap() };
   {

--- a/latexml_engine/Cargo.toml
+++ b/latexml_engine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "latexml_engine"
 version = "0.5.0"
-edition = "2021"
+edition = "2024"
 license = "CC0"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
 description = "Core TeX/LaTeX engine bindings (Base, TeX_*, eTeX, pdfTeX, plain, latex pools). Split out of latexml_package to reduce CI compile-time RAM peaks."

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -938,11 +938,11 @@ LoadDefinitions!({
     }
     let wrapper = if let Some(point) = point {
       Some(document.insert_element_before(&point, "ltx:_Capture_", None)?)
-    } else if let Some(mut document_element) = document.get_document().get_root_element() {
+    } else { match document.get_document().get_root_element() { Some(mut document_element) => {
       Some(document.open_element_at(&mut document_element, "ltx:_Capture_", None, None)?)
-    } else {
+    } _ => {
       None
-    };
+    }}};
     if let Some(wrapper) = wrapper {
       document.set_node(&wrapper);
       insert_frontmatter(document)?;
@@ -1301,11 +1301,11 @@ pub fn digested_to_text(d: &Digested) -> Result<String> {
     },
     DigestedData::Whatsit(w) => {
       let w = w.borrow();
-      if let Some(Stored::Dimension(width)) = w.get_property("width").as_deref() {
+      match w.get_property("width").as_deref() { Some(Stored::Dimension(width)) => {
         out.push_str(&super::tex_glue::dimension_to_spaces(*width));
-      } else {
+      } _ => {
         out.push_str(&w.get_string()?);
-      }
+      }}
     },
     _ => out.push_str(&d.to_string()),
   }
@@ -2053,8 +2053,8 @@ pub fn do_def(globally: bool, cs: Token, params: Tokens, body: Tokens) -> Result
 pub fn classify_box(boxnum: Number) -> Result<&'static str> {
   with_value(&s!("box{}", boxnum.value_of()), |val_opt| {
     Ok(match val_opt {
-      Some(Stored::Digested(ref d)) => match d.data() {
-        DigestedData::Whatsit(ref w)
+      Some(Stored::Digested(d)) => match d.data() {
+        DigestedData::Whatsit(w)
           if w.borrow().definition == lookup_definition(&T_CS!("\\vbox"))?.unwrap() =>
         {
           "vbox"
@@ -2349,7 +2349,7 @@ fn simplify_vertical_list(item: Digested) -> Digested {
 /// Perl: revertSpec($whatsit, $keyword)
 /// If whatsit has property $keyword, return Explode($keyword) ++ Revert($value)
 pub fn revert_spec(whatsit: &Whatsit, keyword: &str) -> Vec<Token> {
-  if let Some(value) = whatsit.get_property(keyword) {
+  match whatsit.get_property(keyword) { Some(value) => {
     // Explode the keyword + value strings into T_OTHER tokens. `pin_char`
     // uses a stack-buffer encode_utf8 and skips the per-char
     // `c.to_string()` heap alloc the previous version did.
@@ -2370,9 +2370,9 @@ pub fn revert_spec(whatsit: &Whatsit, keyword: &str) -> Vec<Token> {
       loc: 0,
     }));
     tokens
-  } else {
+  } _ => {
     Vec::new()
-  }
+  }}
 }
 
 pub fn p_revert<T>(arg: T) -> Result<Tokens>
@@ -3427,11 +3427,11 @@ pub fn translate_attachment<T: ToString>(pos: T) -> &'static str {
 }
 
 pub fn in_svg(document: &Document) -> bool {
-  if let Some(context) = document.get_element() {
+  match document.get_element() { Some(context) => {
     document::with_node_qname(&context, |qname| qname.starts_with("svg:"))
-  } else {
+  } _ => {
     false
-  }
+  }}
 }
 
 pub fn adjust_box_color(tbox: &Digested) -> Result<()> {

--- a/latexml_engine/src/base_xmath.rs
+++ b/latexml_engine/src/base_xmath.rs
@@ -21,7 +21,7 @@ fn xmath_copy_keyvals(whatsit: &mut Whatsit) -> Result<Vec<Digested>> {
   // Use get_hash_digested() since after digestion values are in cached_hash_digested
   let pairs: Vec<(String, String)> = if let Some(arg1) = whatsit.get_arg(1) {
     match arg1.data() {
-      DigestedData::KeyVals(ref kv) => kv.get_hash_digested().into_iter().collect(),
+      DigestedData::KeyVals(kv) => kv.get_hash_digested().into_iter().collect(),
       _ => Vec::new(),
     }
   } else {
@@ -447,7 +447,7 @@ LoadDefinitions!({
       let arg = whatsit.get_arg(2);
       let reversion_key = s!("xref:{}@reversion", xmid);
       with_value_mut("PENDING_DUAL_XMARGS", |pending_opt|
-        if let Some(Stored::HashStored(ref mut pending)) = pending_opt  {
+        if let Some(Stored::HashStored(pending)) = pending_opt  {
           pending.insert(&xmid, arg.into());
         });
       // TODO: Must we store the (currently &mut) Whatsit?
@@ -673,12 +673,12 @@ LoadDefinitions!({
          }
          n+=1;
          text = node_text + &text;
-         if let Some(sibling) = node_mut.get_prev_sibling() {
+         match node_mut.get_prev_sibling() { Some(sibling) => {
            this_node = sibling;
            node_mut = &mut this_node;
-         } else {
+         } _ => {
            break;
-         }
+         }}
        }
        let has_leading_letter = match text.chars().next() {
          Some(fc) => fc.is_alphabetic(),
@@ -772,12 +772,12 @@ LoadDefinitions!({
       break;
     }
     n+=1;
-    if let Some(sibling) = node_ref.get_prev_sibling() {
+    match node_ref.get_prev_sibling() { Some(sibling) => {
       current = sibling;
       node_ref = &mut current;
-    } else {
+    } _ => {
       break;
-    }
+    }}
   }
   if n > 1 && (number.chars().any(|c| c.is_numeric())) {
     Ok(Some((n, combined, MathLigatureOptions {
@@ -960,7 +960,7 @@ LoadDefinitions!({
       // Pass all keyval pairs as properties
       let mut props = stored_map!();
       if let Some(d) = &args[0] {
-        if let DigestedData::KeyVals(ref kv) = d.data() {
+        if let DigestedData::KeyVals(kv) = d.data() {
           // Store left/right as Digested directly from digested keyvals.
           for prop_key in &["left", "right"] {
             if let Some(digested) = kv.get_value_digested(prop_key) {
@@ -1000,7 +1000,7 @@ LoadDefinitions!({
       //   (T_CS('\\' . $name), T_BEGIN, $alignment->revert, T_END); }
       let mut name = String::new();
       if let Some(d) = &args[0] {
-        if let DigestedData::KeyVals(ref kv) = d.data() {
+        if let DigestedData::KeyVals(kv) = d.data() {
           name = kv.get_value("name").map(|v| v.to_string()).unwrap_or_default();
         }
       }
@@ -1009,8 +1009,8 @@ LoadDefinitions!({
         let prop = _whatsit.get_property("alignment");
         let mut rev = None;
         if let Some(cow) = prop.as_ref() {
-          if let Stored::Digested(ref alignment) = &**cow {
-            if let DigestedData::Alignment(ref al) = alignment.data() {
+          if let Stored::Digested(alignment) = &**cow {
+            if let DigestedData::Alignment(al) = alignment.data() {
               rev = Some(al.borrow().revert()?);
             }
           }
@@ -1043,7 +1043,7 @@ LoadDefinitions!({
     properties => sub[args] {
       let mut props = stored_map!();
       if let Some(d) = &args[0] {
-        if let DigestedData::KeyVals(ref kv) = d.data() {
+        if let DigestedData::KeyVals(kv) = d.data() {
           // Store left/right as Digested directly from digested keyvals.
           // Perl's absorb() handles Tokens natively; Rust constructor templates
           // only absorb Digested. Using get_value_digested avoids the revert->re-digest
@@ -1087,7 +1087,7 @@ LoadDefinitions!({
       let mut align = String::new();
       let mut alignment_required = false;
       if let Some(d) = &args[0] {
-        if let DigestedData::KeyVals(ref kv) = d.data() {
+        if let DigestedData::KeyVals(kv) = d.data() {
           name = kv.get_value("name").map(|v| v.to_string()).unwrap_or_default();
           align = kv.get_value("alignment").map(|v| v.to_string()).unwrap_or_default();
           alignment_required = kv.has_key("alignment-required");
@@ -1228,7 +1228,7 @@ LoadDefinitions!({
     properties => sub[args] {
       let mut props = stored_map!();
       if let Some(d) = &args[0] {
-        if let DigestedData::KeyVals(ref kv) = d.data() {
+        if let DigestedData::KeyVals(kv) = d.data() {
           for prop_key in &["left", "right"] {
             if let Some(digested) = kv.get_value_digested(prop_key) {
               props.insert(prop_key, Stored::Digested(digested.clone()));
@@ -1328,7 +1328,7 @@ LoadDefinitions!({
     properties => sub[args] {
       let mut props = stored_map!();
       if let Some(d) = &args[0] {
-        if let DigestedData::KeyVals(ref kv) = d.data() {
+        if let DigestedData::KeyVals(kv) = d.data() {
           for prop_key in &["left", "right"] {
             if let Some(digested) = kv.get_value_digested(prop_key) {
               props.insert(prop_key, Stored::Digested(digested.clone()));
@@ -1740,19 +1740,19 @@ pub fn equationgroup_join_cols(
       continue;
     }
     if col.is_multiple_of(ncols) {
-      if let (Some(ref mut mf), Some(ref mut br)) = (&mut mainfork, &mut branch) {
+      if let (Some(mf), Some(br)) = (&mut mainfork, &mut branch) {
         close_math_fork(document, equation, mf, br)?;
       }
       let (mf, br) = open_math_fork(document, equation)?;
       mainfork = Some(mf);
       branch = Some(br);
     }
-    if let (Some(ref mut mf), Some(ref mut br)) = (&mut mainfork, &mut branch) {
+    if let (Some(mf), Some(br)) = (&mut mainfork, &mut branch) {
       add_column_to_math_fork(document, mf, br, &mut cell)?;
     }
     col += 1;
   }
-  if let (Some(ref mut mf), Some(ref mut br)) = (&mut mainfork, &mut branch) {
+  if let (Some(mf), Some(br)) = (&mut mainfork, &mut branch) {
     close_math_fork(document, equation, mf, br)?;
   }
   Ok(())

--- a/latexml_engine/src/bibtex.rs
+++ b/latexml_engine/src/bibtex.rs
@@ -313,19 +313,19 @@ pub fn bib_add_to_container(
     Some(&current),
   );
   let xpath = bib_container_xpath(tag, &attrs);
-  if let Some(rel) = doc.findnode(&xpath, entry.as_ref()) {
+  match doc.findnode(&xpath, entry.as_ref()) { Some(rel) => {
     doc.set_node(&rel);
     if let Some(d) = data {
       doc.absorb(d, None)?;
     }
     doc.set_node(&current);
-  } else {
+  } _ => {
     let content: Vec<&latexml_core::digested::Digested> = match data {
       Some(d) => vec![d],
       None => vec![],
     };
     doc.insert_element(tag, content, Some(attrs))?;
-  }
+  }}
   Ok(())
 }
 
@@ -846,7 +846,7 @@ LoadDefinitions!({
     sub [document, args] {
       let tag = args[0].as_ref().map(|a| a.to_string()).unwrap_or_default();
       let attrs = if let Some(kv_d) = &args[1] {
-        if let latexml_core::digested::DigestedData::KeyVals(ref kv) = kv_d.data() {
+        if let latexml_core::digested::DigestedData::KeyVals(kv) = kv_d.data() {
           kv.get_hash()
         } else {
           FxAttrMap::default()

--- a/latexml_engine/src/etex.rs
+++ b/latexml_engine/src/etex.rs
@@ -13,11 +13,11 @@ use latexml_core::common::glue::FillCode;
 /// current font. Perl: `$font = $STATE->lookupValue('font')->merge(%$fontinfo);`
 fn fontchar_lookup_font(font_tok: &Token) -> Option<Rc<Font>> {
   // Resolve through definition to get actual CS name (e.g. \font -> \tenrm)
-  let key = if let Ok(Some(defn)) = lookup_definition(font_tok) {
+  let key = match lookup_definition(font_tok) { Ok(Some(defn)) => {
     s!("fontinfo_{}", defn.get_cs_name())
-  } else {
+  } _ => {
     s!("fontinfo_{}", font_tok)
-  };
+  }};
   with_value(&key, |v| {
     if let Some(Stored::Font(f)) = v {
       Some(Rc::clone(f))
@@ -414,14 +414,14 @@ LoadDefinitions!({
     });
     if let Some(mouth) = mouth_opt {
       let mut raw_line = mouth.borrow_mut().read_raw_line(false).unwrap_or_default();
-      if let Some(eol) = lookup_definition(&T_CS!("\\endlinechar"))? {
+      match lookup_definition(&T_CS!("\\endlinechar"))? { Some(eol) => {
         let eolv   = eol.value_of(Vec::new()).unwrap_or_default().value_of();
         if (eolv > 0) && (eolv <= 255) {
           raw_line.push(eolv as u8 as char);
         }
-      } else {
+      } _ => {
         raw_line.push('\r');
-      }
+      }}
       DefMacro!(token, None, Tokens!(Explode!(raw_line)));
     }
   });

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -517,14 +517,14 @@ fn lx_read_and_change_case(req_case: &str) -> Result<Vec<Token>> {
           result.push(T_BEGIN!());
           result.extend(arg.unlist());
           result.push(T_END!());
-        } else if let Some(changed) = lookup_mapping(
+        } else { match lookup_mapping(
           if is_upper {
             "text_uppercase"
           } else {
             "text_lowercase"
           },
           &next_key_case,
-        ) {
+        ) { Some(changed) => {
           if let Stored::Token(changed_tok) = changed {
             result.push(changed_tok);
           } else {
@@ -534,7 +534,7 @@ fn lx_read_and_change_case(req_case: &str) -> Result<Vec<Token>> {
           if req_case == "sentence" || req_case == "title" {
             is_upper = false;
           }
-        } else {
+        } _ => {
           // Fall-through: not in exclude list, not in case-mapping. Pass
           // both `\protect` and the munged CS through, but mark the CS
           // un-expandable via `\dont_expand` so the OUTER `\edef`'s
@@ -548,7 +548,7 @@ fn lx_read_and_change_case(req_case: &str) -> Result<Vec<Token>> {
           result.push(tok);
           result.push(T_CS!("\\dont_expand"));
           result.push(next_tok);
-        }
+        }}}
       }
     } else {
       result.push(tok);
@@ -578,11 +578,11 @@ fn setup_aligning_context(doc: &mut Document) {
   if let Some(node) = doc.get_element() {
     // Save node and its current last child so we only apply to NEW children later
     state::assign_value("ALIGNING_NODE", Stored::Node(node.clone()), None);
-    if let Some(last) = node.get_last_child() {
+    match node.get_last_child() { Some(last) => {
       state::assign_value("ALIGNING_PREV_CHILD", Stored::Node(last), None);
-    } else {
+    } _ => {
       state::assign_value("ALIGNING_PREV_CHILD", Stored::None, None);
-    }
+    }}
   }
 }
 /// Perl: applyAligningContext — applies align/class to children added AFTER \centering.
@@ -731,7 +731,7 @@ pub fn before_equation() -> Result<()> {
   let mut is_numbered = false;
   maybe_peek_label()?;
   let ctr = with_value_mut("EQUATION_NUMBERING", |val_opt| {
-    if let Some(Stored::HashStored(ref mut numbering)) = val_opt {
+    if let Some(Stored::HashStored(numbering)) = val_opt {
       numbering.insert("in_equation", true.into());
       is_numbered = matches!(numbering.get("numbered"), Some(&Stored::Bool(true)));
       has_preset = numbering.contains_key("preset");
@@ -787,11 +787,11 @@ pub fn after_equation(whatsit: Option<&mut Whatsit>) -> Result<()> {
   let mut is_numbered_for_postset = false;
   let mut ctr = String::from("equation");
   with_value("EQUATION_NUMBERING", |eq_num_opt| {
-    if let Some(Stored::HashStored(ref numbering)) = eq_num_opt {
+    if let Some(Stored::HashStored(numbering)) = eq_num_opt {
       is_aligned = matches!(numbering.get("aligned"), Some(&Stored::Bool(true)));
       is_numbered_for_postset = matches!(numbering.get("numbered"), Some(&Stored::Bool(true)));
       with_value("EQUATIONROW_TAGS", |tags_opt| {
-        if let Some(Stored::HashStored(ref tags)) = tags_opt {
+        if let Some(Stored::HashStored(tags)) = tags_opt {
           ctr = tags
             .get("counter")
             .map_or_else(|| numbering.get("counter"), Some)
@@ -840,7 +840,7 @@ pub fn after_equation(whatsit: Option<&mut Whatsit>) -> Result<()> {
       ))])?;
       let stored_tags_update = Stored::Digested(stomach::digest(invoked_tags)?);
       with_value_mut("EQUATIONROW_TAGS", |tags_opt| {
-        if let Some(Stored::HashStored(ref mut tags)) = tags_opt {
+        if let Some(Stored::HashStored(tags)) = tags_opt {
           tags.insert("tags", stored_tags_update);
         }
       });
@@ -849,7 +849,7 @@ pub fn after_equation(whatsit: Option<&mut Whatsit>) -> Result<()> {
   }
   // Phase 3: Reset in_equation flag
   with_value_mut("EQUATION_NUMBERING", |eq_num_opt| {
-    if let Some(Stored::HashStored(ref mut numbering)) = eq_num_opt {
+    if let Some(Stored::HashStored(numbering)) = eq_num_opt {
       numbering.insert("in_equation", Stored::Bool(false));
     }
   });
@@ -1681,7 +1681,7 @@ pub fn define_new_theorem(
         T_CS!(&format_title_cs),
         T_BEGIN!(),
       ];
-      if let Some(Some(ref arg)) = args.first() {
+      if let Some(Some(arg)) = args.first() {
         title_tokens.extend(arg.revert()?.unlist());
       }
       title_tokens.push(T_END!());
@@ -2017,11 +2017,11 @@ pub fn note_backmatter_element(whatsit: &mut Whatsit, backelement: &str) {
 
 pub fn adjust_backmatter_element(document: &mut Document, whatsit: &Whatsit) -> Result<()> {
   let asif_opt =
-    if let Some(Stored::String(asif_sym)) = whatsit.get_property("backmatterelement").as_deref() {
+    match whatsit.get_property("backmatterelement").as_deref() { Some(Stored::String(asif_sym)) => {
       Some(arena::to_string(*asif_sym))
-    } else {
+    } _ => {
       None
-    };
+    }};
   // Note: We allocate a string here, since
   // it looks like arena::with can deadlock with find_insertion_point
   // we may need a find_insertion_point_sym to avoid that...
@@ -3094,15 +3094,15 @@ LoadDefinitions!({
   DefConstructor!(T_CS!("\\begin{document}"), None, sub[document, _args, props] {
     let id = prop_str!(props,"id");
     // Already (auto) created?
-    if let Some(mut docel) = document.findnode("/ltx:document", None) {
+    match document.findnode("/ltx:document", None) { Some(mut docel) => {
       if id != pin!("") {
         let id_s = arena::with(id, |s| s.to_string());
         document.set_attribute(&mut docel, "xml:id", &id_s)?;
       }
-    } else {
+    } _ => {
       let props = arena::with(id, |id_str| string_map!("xml:id" => id_str));
       document.open_element("ltx:document", Some(props), None)?;
-    }
+    }}
   },
   after_digest => sub[whatsit] {
     // Perl: beginMode('internal_vertical', 1) — noframe=1
@@ -5229,7 +5229,7 @@ LoadDefinitions!({
     // At least an empty tag! ?
     properties => sub[args] {
       if let Some(ref arg) = args[0] {
-        if let DigestedData::Postponed(ref tag_tokens) = arg.data() {
+        if let DigestedData::Postponed(tag_tokens) = arg.data() {
           let tag_expanded = Expand!(tag_tokens.clone());
           let tag = stomach::digest(tag_expanded)?;
           Ok(stored_map!("tag" => tag))
@@ -5531,7 +5531,7 @@ LoadDefinitions!({
     if in_equation {
       if defer_retract {
         with_value_mut("EQUATIONROW_TAGS", |tags_opt| {
-          if let Some(Stored::HashStored(ref mut tags)) = tags_opt {
+          if let Some(Stored::HashStored(tags)) = tags_opt {
             tags.insert("retract", true.into());
           }
         });
@@ -5553,7 +5553,7 @@ LoadDefinitions!({
       // Perl uses Digested parameter type; we manually digest here
       let digested = stomach::digest(content)?;
       with_value_mut("EQUATIONROW_TAGS", |tags_opt| {
-        if let Some(Stored::HashStored(ref mut tags)) = tags_opt {
+        if let Some(Stored::HashStored(tags)) = tags_opt {
           tags.insert("tags", Stored::Digested(digested));
         }
       });
@@ -5668,7 +5668,7 @@ LoadDefinitions!({
 
   // Perl: latex_constructs.pool.ltxml lines 2243-2247
   DefConditional!("\\if@in@firstcolumn", {
-    if let Some(alignment_digested) = lookup_alignment() {
+    match lookup_alignment() { Some(alignment_digested) => {
       if let Some(alignment_cell) = alignment_digested.alignment_cell() {
         let alignment = alignment_cell.borrow();
         !alignment.is_in_row()
@@ -5676,9 +5676,9 @@ LoadDefinitions!({
       } else {
         false
       }
-    } else {
+    } _ => {
       false
-    }
+    }}
   });
 
   // Perl: latex_constructs.pool.ltxml lines 2251-2254
@@ -6360,11 +6360,11 @@ LoadDefinitions!({
   });
   DefPrimitive!("\\DeclareSymbolFontAlphabet {Token} {}", sub[(cs, name)] {
     let fontkey = s!("fontdeclarations@{}", name.to_string());
-    let font : Option<Font> = if let Some(Stored::Font(value)) = lookup_value(&fontkey) {
+    let font : Option<Font> = match lookup_value(&fontkey) { Some(Stored::Font(value)) => {
       Some((*value).clone())
-    } else {
+    } _ => {
       None
-    };
+    }};
     DefPrimitive!(cs, None, None, font => font);
   });
 
@@ -7017,11 +7017,11 @@ LoadDefinitions!({
     // `\thefigure\par` undefined errors when captype was "figure\par".
     let captype = gullet::do_expand(T_CS!("\\@captype"))?.to_string();
     let prekey = s!("PREINCREMENTED_{captype}");
-    let props = if let Some(Stored::HashStored(pre)) = state::remove_value(&prekey) {
+    let props = match state::remove_value(&prekey) { Some(Stored::HashStored(pre)) => {
       pre
-    } else {
+    } _ => {
       ref_step_counter(&captype, false)?
-    };
+    }};
     let inlist  = stomach::digest(T_CS!(s!("\\ext@{}", captype)))?.to_string();
     state::assign_value(&s!("{}_tags", captype), props.get("tags"), Some(Scope::Global));
     state::assign_value(&s!("{}_id", captype), props.get("id"),   Some(Scope::Global));
@@ -7255,20 +7255,20 @@ LoadDefinitions!({
   );
 
   DefMacro!("\\@tabbing@start@tabs", sub [_args] {
-    if let Some(Stored::Tokens(toks)) = state::lookup_value("tabbing_start_tabs") {
+    match state::lookup_value("tabbing_start_tabs") { Some(Stored::Tokens(toks)) => {
       toks
-    } else {
+    } _ => {
       Tokens!()
-    }
+    }}
   });
 
   // \+ increments tab start by adding \> to tabbing_start_tabs
   DefPrimitive!("\\@tabbing@increment", sub [_args] {
-    let mut tabs = if let Some(Stored::Tokens(toks)) = state::lookup_value("tabbing_start_tabs") {
+    let mut tabs = match state::lookup_value("tabbing_start_tabs") { Some(Stored::Tokens(toks)) => {
       toks.unlist()
-    } else {
+    } _ => {
       Vec::new()
-    };
+    }};
     tabs.push(T_CS!("\\>"));
     state::assign_value(
       "tabbing_start_tabs",
@@ -7279,15 +7279,15 @@ LoadDefinitions!({
 
   // \- decrements tab start by removing first element from tabbing_start_tabs
   DefPrimitive!("\\@tabbing@decrement", sub [_args] {
-    let tabs = if let Some(Stored::Tokens(toks)) = state::lookup_value("tabbing_start_tabs") {
+    let tabs = match state::lookup_value("tabbing_start_tabs") { Some(Stored::Tokens(toks)) => {
       let mut v = toks.unlist();
       if !v.is_empty() {
         v.remove(0);
       }
       v
-    } else {
+    } _ => {
       Vec::new()
-    };
+    }};
     state::assign_value(
       "tabbing_start_tabs",
       Stored::Tokens(Tokens::new(tabs)),
@@ -8277,9 +8277,9 @@ LoadDefinitions!({
     let current = document.get_node().clone();
     let current_name = arena::with(get_node_qname(&current), |s| s.to_string());
     let parent_name = if current_name == "#PCDATA" {
-      if let Some(p) = current.get_parent() {
+      match current.get_parent() { Some(p) => {
         arena::with(get_node_qname(&p), |s| s.to_string())
-      } else { current_name }
+      } _ => { current_name }}
     } else { current_name };
     let in_flow = parent_name.starts_with("ltx:p") || parent_name == "ltx:text";
     if in_flow {
@@ -8656,12 +8656,12 @@ LoadDefinitions!({
             whatsit.set_property("mathframe", true);
             // Extract inner body for the XMArg template
             // For \fbox{$...$}, get the math body from the inner whatsit
-            if let Ok(Some(body)) = a.get_body() {
+            match a.get_body() { Ok(Some(body)) => {
               whatsit.set_property("inner", body);
-            } else {
+            } _ => {
               // Fallback: use the entire arg
               whatsit.set_property("inner", a.clone());
-            }
+            }}
           }
         }
       }

--- a/latexml_engine/src/macros.rs
+++ b/latexml_engine/src/macros.rs
@@ -123,7 +123,7 @@ macro_rules! load_model {
 #[macro_export]
 /// Macro for compiling string literal tokens into their usual Tokens representation
 macro_rules! compile_tokenize {
-  ($var:ident, $literal:expr) => {{
+  ($var:ident, $literal:expr_2021) => {{
     #[derive(CompileTokens)]
     #[literal=$literal]
     struct _Dummy;
@@ -135,7 +135,7 @@ macro_rules! compile_tokenize {
 #[macro_export]
 /// Macro for compiling string literal tokens into their preamble Tokens representation
 macro_rules! compile_tokenize_internal {
-  ($var:ident, $literal:expr) => {{
+  ($var:ident, $literal:expr_2021) => {{
     #[derive(CompileTokensInternal)]
     #[literal=$literal]
     struct _Dummy;

--- a/latexml_engine/src/plain_constructs.rs
+++ b/latexml_engine/src/plain_constructs.rs
@@ -453,7 +453,7 @@ LoadDefinitions!({
         for item in matrix.unlist() {
           if let Some(prop) = item.get_property("alignment") {
             if let Stored::Digested(ref alignment_d) = *prop {
-              if let DigestedData::Alignment(ref alignment_rc) = alignment_d.data() {
+              if let DigestedData::Alignment(alignment_rc) = alignment_d.data() {
                 let alignment = alignment_rc.borrow();
                 // Use row_heights from normalization
                 let row_heights = alignment.get_row_heights();

--- a/latexml_engine/src/setup_binding_language.rs
+++ b/latexml_engine/src/setup_binding_language.rs
@@ -13,7 +13,7 @@ macro_rules! LoadDefinitions {
 //======================================================================
 #[macro_export]
 macro_rules! DefParameterTypeWO {
-  ($name:ident, $param:expr) => {
+  ($name:ident, $param:expr_2021) => {
     assign_mapping(
       "PARAMETER_TYPES",
       stringify!($name),
@@ -24,7 +24,7 @@ macro_rules! DefParameterTypeWO {
 
 #[macro_export]
 macro_rules! LoadPool {
-  ($name:expr) => {{
+  ($name:expr_2021) => {{
     input_definitions($name, InputDefinitionOptions {
       extension: Some(Cow::Borrowed("pool")),
       ..InputDefinitionOptions::default()
@@ -34,10 +34,10 @@ macro_rules! LoadPool {
 
 #[macro_export]
 macro_rules! InputDefinitions {
-  ($name:expr) => {{
+  ($name:expr_2021) => {{
     input_definitions($name, InputDefinitionOptions::default())?
   }};
-  ($name: expr, $($key:ident => $value:expr),*) => {
+  ($name: expr_2021, $($key:ident => $value:expr_2021),*) => {
     input_definitions($name, NewDefault!(InputDefinitionOptions, $($key => $value),*))?
   }
 }
@@ -73,31 +73,31 @@ macro_rules! InnerPool {
 
 #[macro_export]
 macro_rules! RequirePackage {
-  ($package:expr) => {{
+  ($package:expr_2021) => {{
     require_package($package, RequireOptions::default())?
   }};
-  ($package:expr, $options:expr) => {{
+  ($package:expr_2021, $options:expr_2021) => {{
     require_package($package, $options)?
   }};
-  ($package:expr, $($key:ident => $val:expr),*) => {{
+  ($package:expr_2021, $($key:ident => $val:expr_2021),*) => {{
     let require_package_options = NewDefault!(RequireOptions, $($key=>$val),*);
     require_package($package, require_package_options)?
   }};
 }
 #[macro_export]
 macro_rules! LoadClass {
-  ($class:expr) => {{ load_class($class, Vec::new(), Tokens!())? }};
-  ($class:expr, $options:expr, $after:expr) => {{ load_class($class, $options, $after)? }};
+  ($class:expr_2021) => {{ load_class($class, Vec::new(), Tokens!())? }};
+  ($class:expr_2021, $options:expr_2021, $after:expr_2021) => {{ load_class($class, $options, $after)? }};
 }
 
 #[macro_export]
 macro_rules! DeclareFontMap {
-  ($name:expr, $map:expr, $family:expr) => {{
+  ($name:expr_2021, $map:expr_2021, $family:expr_2021) => {{
     let mapname = s!("{}_{}_fontmap", $name, $family);
     let map: Rc<[Option<char>]> = $map;
     state::assign_value(&mapname, map, Some(Scope::Global));
   }};
-  ($name:expr, $map:expr) => {{
+  ($name:expr_2021, $map:expr_2021) => {{
     let mapname = s!("{}_fontmap", $name);
     let map: Rc<[Option<char>]> = $map;
     state::assign_value(&mapname, map, Some(Scope::Global));
@@ -108,7 +108,7 @@ macro_rules! DeclareFontMap {
 /// Usage: `DeclareFontMapMultichar!("T2B", { 0x80 => "\u{04F6}\u{0336}", 0x91 => "C\u{0337}" });`
 #[macro_export]
 macro_rules! DeclareFontMapMultichar {
-  ($name:expr, { $($pos:expr => $str:expr),* $(,)? }) => {{
+  ($name:expr_2021, { $($pos:expr_2021 => $str:expr_2021),* $(,)? }) => {{
     let mapname = s!("{}_fontmap_multichar", $name);
     let map: HashMap<String, String> = [
       $( ($pos.to_string(), $str.to_string()), )*
@@ -119,10 +119,10 @@ macro_rules! DeclareFontMapMultichar {
 
 #[macro_export]
 macro_rules! FindFile {
-  ($name:expr) => {
+  ($name:expr_2021) => {
     find_file($name, None)
   };
-  ($name:expr, type => $ext:literal) => {
+  ($name:expr_2021, type => $ext:literal) => {
     find_file(
       $name,
       Some(FindFileOptions {
@@ -137,7 +137,7 @@ macro_rules! FindFile {
 // Color
 #[macro_export]
 macro_rules! LookupColor {
-  ($name:expr) => {{
+  ($name:expr_2021) => {{
     if let Some(color) = LookupValue!(&s!("color_{}", $name)) {
       color.to_string()
     } else {
@@ -386,7 +386,7 @@ macro_rules! DefPrimitive {
       $body $($input)*)
   }};
   // Case: closure pattern replacement
-  ($proto:expr, sub[$args:ident]
+  ($proto:expr_2021, sub[$args:ident]
     $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
     let (cs, params) = parse_prototype!($proto);
@@ -397,7 +397,7 @@ macro_rules! DefPrimitive {
     def_primitive(cs, params, Some(closure), options)?;
   }};
   // Case: cs-noparams with closure pattern replacement
-  ($cs:expr, None, sub[$args:ident]
+  ($cs:expr_2021, None, sub[$args:ident]
     $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
     let closure = PrimitiveBody::Closure(Rc::new(
@@ -407,7 +407,7 @@ macro_rules! DefPrimitive {
     def_primitive($cs, None, Some(closure), options)?;
   }};
   // Case: cs-noparams with closure block
-  ($cs:expr, None, $body:block $($input:tt)*) => {{
+  ($cs:expr_2021, None, $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
     let closure = PrimitiveBody::Closure(Rc::new(
       move |_args: Vec<ArgWrap>| {
@@ -416,7 +416,7 @@ macro_rules! DefPrimitive {
     def_primitive($cs, None, Some(closure), options)?;
   }};
   // Case: cs-noparams with replacement expr
-  ($cs:expr, None, $body:literal, $($input:tt)*) => {{
+  ($cs:expr_2021, None, $body:literal, $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
     let pbody = PrimitiveBody::String(arena::pin_static($body));
     def_primitive($cs, None, Some(pbody), options)?;
@@ -428,13 +428,13 @@ macro_rules! DefPrimitive {
     def_primitive(cs, params, None, options)?;
   }};
   // Case: no params, no replacement
-  ($cs:expr, None, None $($input:tt)*) => {{
+  ($cs:expr_2021, None, None $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
     def_primitive($cs, None, None, options)?;
   }};
 
   // Case: closure block with implicit arguments
-  ($proto:expr, $body:block $($input:tt)*) => {{
+  ($proto:expr_2021, $body:block $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
     let (cs, params) = parse_prototype!($proto);
     let closure = PrimitiveBody::Closure(Rc::new(
@@ -444,11 +444,11 @@ macro_rules! DefPrimitive {
     def_primitive(cs, params, Some(closure), options)?;
   }};
   // Case: direct closure provided (for reasons of reusing the same closure in several definitions)
-  ($proto:expr, $replacement_closure:expr, $($input:tt)*) => {{
+  ($proto:expr_2021, $replacement_closure:expr_2021, $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {PrimitiveOptions,});
     def_primitive($proto, $replacement_closure, options)?;
   }};
-  ($proto:expr, $replacement_closure:expr) => {{
+  ($proto:expr_2021, $replacement_closure:expr_2021) => {{
     let (cs, params) = parse_prototype!($proto);
     def_primitive(cs, params, $replacement_closure, PrimitiveOptions::default())?;
   }};
@@ -487,10 +487,10 @@ macro_rules! TypedPrimitive {
 
 #[macro_export]
 macro_rules! LookupRegister {
-  ($cs:expr) => {
+  ($cs:expr_2021) => {
     LookupRegister!($cs, Vec::new())
   };
-  ($cs:expr, $parameters:expr) => {{
+  ($cs:expr_2021, $parameters:expr_2021) => {{
     let params = { $parameters };
     let defn_opt = { state::lookup_register_definition(&T_CS!($cs)) };
     if let Some(defn) = defn_opt {
@@ -505,10 +505,10 @@ macro_rules! LookupRegister {
 
 #[macro_export]
 macro_rules! LookupRegisterOrDefault {
-  ($cs:expr) => {
+  ($cs:expr_2021) => {
     LookupRegisterOrDefault!($cs, Vec::new())
   };
-  ($cs:expr, $parameters:expr) => {
+  ($cs:expr_2021, $parameters:expr_2021) => {
     if let Some(defn) = { state::lookup_register_definition(&T_CS!($cs)) } {
       defn.value_of($parameters).unwrap_or_default()
     } else {
@@ -594,7 +594,7 @@ macro_rules! DefConstructor {
   }};
 
   // Literal replacement flavors
-  ($proto:expr, $replacement:literal) => {{
+  ($proto:expr_2021, $replacement:literal) => {{
     let (cs, params) = parse_prototype!($proto);
     let compiled_replacement;
     compile_replacement!(compiled_replacement, $replacement);
@@ -602,41 +602,41 @@ macro_rules! DefConstructor {
   }};
   // Pre-parsed prototype flavors
   // Pre-parsed prototype; Closure replacement flavors
-  ($cs:expr, $parameters:expr, sub [ $document:ident, $args:ident, $props:ident]
+  ($cs:expr_2021, $parameters:expr_2021, sub [ $document:ident, $args:ident, $props:ident]
     $body:block, $($input:tt)+) => {{
     let options = defi_opts!(@munch ($($input)*) -> {ConstructorOptions,});
     let compiled_replacement : Option<ReplacementClosure>= Some(Rc::new(
       replacement!($document, $args, $props, $body)));
     def_constructor($cs, $parameters, compiled_replacement, options);
   }};
-  ($cs:expr, $parameters:expr, sub [ $document:ident, $args:ident, $props:ident]
+  ($cs:expr_2021, $parameters:expr_2021, sub [ $document:ident, $args:ident, $props:ident]
     $body:block) => {{
     let compiled_replacement : Option<ReplacementClosure>= Some(Rc::new(
       replacement!($document, $args, $props, $body)));
     def_constructor($cs, $parameters, compiled_replacement, ConstructorOptions::default());
   }};
   //  Pre-parsed prototype; Literal replacement flavors
-  ($cs:expr, $parameters:expr, $replacement:literal) => {{
+  ($cs:expr_2021, $parameters:expr_2021, $replacement:literal) => {{
     let compiled_replacement;
     compile_replacement!(compiled_replacement, $replacement);
     def_constructor($cs, $parameters, compiled_replacement, ConstructorOptions::default());
   }};
-  ($cs:expr, $parameters:expr, None) => {{
+  ($cs:expr_2021, $parameters:expr_2021, None) => {{
     def_constructor($cs, $parameters, $replacement, ConstructorOptions::default());
   }};
 
   // Optioned flavors come last due to :tt munching
-  ($cs:expr, $parameters:expr, $replacement:literal, $($input:tt)+) => {{
+  ($cs:expr_2021, $parameters:expr_2021, $replacement:literal, $($input:tt)+) => {{
     let options = defi_opts!(@munch ($($input)*) -> {ConstructorOptions,});
     let compiled_replacement;
     compile_replacement!(compiled_replacement, $replacement);
     def_constructor($cs, $parameters, compiled_replacement, options);
   }};
-  ($cs:expr, $parameters:expr, None, $($input:tt)+) => {{
+  ($cs:expr_2021, $parameters:expr_2021, None, $($input:tt)+) => {{
     let options = defi_opts!(@munch ($($input)*) -> {ConstructorOptions,});
     def_constructor($cs, $parameters, None, options);
   }};
-  ($proto:expr, $replacement:literal, $($input:tt)+) => {{
+  ($proto:expr_2021, $replacement:literal, $($input:tt)+) => {{
     let options = defi_opts!(@munch ($($input)*) -> {ConstructorOptions,});
     let (cs, params) = parse_prototype!($proto);
     let compiled_replacement;
@@ -666,13 +666,13 @@ macro_rules! parse_prototype(
     }
   }};
   // expressions get handled at runtime
-  ($proto:expr) => {{
+  ($proto:expr_2021) => {{
     latexml_core::common::def_parser::parse_prototype($proto, true)? }};
 );
 
 #[macro_export]
 macro_rules! DefEnvironmentWO (
-  ($proto_raw:expr, $replacement:expr, $options:expr) => ({
+  ($proto_raw:expr_2021, $replacement:expr_2021, $options:expr_2021) => ({
   use latexml_core::util::text::*;
   let mut proto = $proto_raw.to_string().trim_start().to_string();
   let name = extract_bracketed(&mut proto, Some(&Delimiter::Brace)).unwrap_or_default();
@@ -692,7 +692,7 @@ macro_rules! DefEnvironmentWO (
 
 #[macro_export]
 macro_rules! DefEnvironmentIWO (
-  ($proto_raw:expr, $compiled_replacement:expr, $options:expr) => ({
+  ($proto_raw:expr_2021, $compiled_replacement:expr_2021, $options:expr_2021) => ({
   use latexml_core::util::text::*;
   let mut proto = $proto_raw.to_string().trim_start().to_string();
   let name = extract_bracketed(&mut proto, Some(&Delimiter::Brace)).unwrap_or_default();
@@ -708,34 +708,34 @@ macro_rules! DefEnvironmentIWO (
 
 #[macro_export]
 macro_rules! RelaxNGSchema {
-  ($name:expr) => {{ select_relaxng_schema($name, None) }};
+  ($name:expr_2021) => {{ select_relaxng_schema($name, None) }};
 }
 
 #[macro_export]
 macro_rules! RegisterNamespace(
-  ($prefix:expr, $namespace:expr) => {
+  ($prefix:expr_2021, $namespace:expr_2021) => {
     model::register_namespace($prefix, Some($namespace));
   };
-  ($prefix:expr => $namespace:expr) => {
+  ($prefix:expr_2021 => $namespace:expr_2021) => {
     RegisterNamespace!($prefix, $namespace)
   };
 );
 #[macro_export]
 macro_rules! RegisterDocumentNamespace(
-  ($prefix:expr, $namespace:expr) => {
+  ($prefix:expr_2021, $namespace:expr_2021) => {
     model::register_document_namespace($prefix, Some($namespace))
   }
 );
 #[macro_export]
 macro_rules! RequireResource(
-  ($resource:expr) => {
+  ($resource:expr_2021) => {
     require_resource(Resource{name: $resource.to_string(), ..Resource::default()})
   }
 );
 
 #[macro_export]
 macro_rules! defi_math {
-  ($cstext:expr, $paramlist:expr, $presentation:expr, $options:expr) => {{
+  ($cstext:expr_2021, $paramlist:expr_2021, $presentation:expr_2021, $options:expr_2021) => {{
     let options = $options;
     let cs = T_CS!($cstext.to_string());
     let presentation = $presentation.to_string();
@@ -770,21 +770,21 @@ macro_rules! defi_math {
 
 #[macro_export]
 macro_rules! CounterValue {
-  ($ctr:expr) => {{ counter_value($ctr)? }};
-  ($ctr:expr) => {
+  ($ctr:expr_2021) => {{ counter_value($ctr)? }};
+  ($ctr:expr_2021) => {
     counter_value($ctr)?
   };
 }
 
 #[macro_export]
 macro_rules! AddToCounter {
-  ($ctr:expr, $value:expr) => {
+  ($ctr:expr_2021, $value:expr_2021) => {
     add_to_counter($ctr, $value.into())?
   };
 }
 #[macro_export]
 macro_rules! StepCounter {
-  ($ctr:expr, $noreset:expr) => {
+  ($ctr:expr_2021, $noreset:expr_2021) => {
     step_counter($ctr, $noreset)
   };
 }
@@ -792,10 +792,10 @@ macro_rules! StepCounter {
 /// convenience macro for `api::counter_dialect::ref_step_counter`
 #[macro_export]
 macro_rules! RefStepCounter {
-  ($ctr:expr) => {
+  ($ctr:expr_2021) => {
     ref_step_counter($ctr, false)
   };
-  ($ctr:expr, $noreset:expr) => {
+  ($ctr:expr_2021, $noreset:expr_2021) => {
     ref_step_counter($ctr, $noreset)
   };
 }
@@ -803,7 +803,7 @@ macro_rules! RefStepCounter {
 /// convenience macro for `api::counter_dialect::ref_step_id`
 #[macro_export]
 macro_rules! RefStepID {
-  ($ctr:expr) => {
+  ($ctr:expr_2021) => {
     ref_step_id($ctr)
   };
 }
@@ -812,15 +812,15 @@ macro_rules! RefStepID {
 /// ID-ed item got pruned and we want to reuse its identifier.
 #[macro_export]
 macro_rules! RefCurrentID {
-  ($ctr:expr) => {
+  ($ctr:expr_2021) => {
     ref_current_id($ctr)
   };
 }
 #[macro_export]
 macro_rules! ResetCounter {
   ($ctr:literal) => {{ reset_counter(&T_OTHER!($ctr))? }};
-  ($ctr:expr) => {{ reset_counter($ctr)? }};
-  ($ctr:expr) => {
+  ($ctr:expr_2021) => {{ reset_counter($ctr)? }};
+  ($ctr:expr_2021) => {
     reset_counter($ctr)?
   };
 }
@@ -828,14 +828,14 @@ macro_rules! ResetCounter {
 /// Return `tokens` with all tokens expanded
 #[macro_export]
 macro_rules! Expand {
-  ($tokens:expr) => {
+  ($tokens:expr_2021) => {
     do_expand($tokens)?
   };
 }
 
 #[macro_export]
 macro_rules! Input {
-  ($arg:expr) => {
+  ($arg:expr_2021) => {
     ::latexml_core::binding::content::input($arg, InputOptions::default())?
   };
 }
@@ -856,19 +856,19 @@ macro_rules! Input {
 #[macro_export]
 macro_rules! Invocation {
   ($csname:literal) => {{ Invocation!($csname, vec![None]) }};
-  ($csname:literal, $args:expr) => {{
+  ($csname:literal, $args:expr_2021) => {{
     build_invocation_str($csname, $args.into_iter().map(Into::into).collect())?
   }};
-  ($token:expr) => {
+  ($token:expr_2021) => {
     Invocation!($token, vec![None])
   };
-  ($token:expr, $args:expr) => {
+  ($token:expr_2021, $args:expr_2021) => {
     build_invocation($token, $args.into_iter().map(Into::into).collect())?
   };
 }
 #[macro_export]
 macro_rules! DefLigature {
-  ($regex:expr, $replacement:expr, fontTest => sub[$font:ident] $body:block) => {
+  ($regex:expr_2021, $replacement:expr_2021, fontTest => sub[$font:ident] $body:block) => {
     let regex_compiled = Regex::new($regex).unwrap();
     let test_closure: Option<FontTestClosure> = Some(Rc::new(move |$font| $body));
     let new_ligature_id = generate_ligature_id();
@@ -882,7 +882,7 @@ macro_rules! DefLigature {
       matcher:   None,
     }]);
   };
-  ($regex:expr, $replacement:expr) => {
+  ($regex:expr_2021, $replacement:expr_2021) => {
     let regex_compiled = Regex::new($regex).unwrap();
     let new_ligature_id = generate_ligature_id();
     unshift_value("TEXT_LIGATURES", vec![Ligature {
@@ -901,13 +901,13 @@ macro_rules! DefLigature {
 // 1st char of the argument.  In cases where there is no argument, `standalonechar` is used.
 #[macro_export]
 macro_rules! DefAccent {
-  ($accent:literal, $combiningchar:expr, $standalonechar:expr) => {{
+  ($accent:literal, $combiningchar:expr_2021, $standalonechar:expr_2021) => {{
     DefAccent!($accent, $combiningchar, $standalonechar, HashMap::default())
   }};
-  ($accent:literal, $combiningchar:expr, $standalonechar:expr, below => true) => {{
+  ($accent:literal, $combiningchar:expr_2021, $standalonechar:expr_2021, below => true) => {{
     DefAccent!($accent, $combiningchar, $standalonechar, map!("below"=>Stored::Bool(true)))
   }};
-  ($accent:literal, $combiningchar:expr, $standalonechar:expr, $options:expr) => {{
+  ($accent:literal, $combiningchar:expr_2021, $standalonechar:expr_2021, $options:expr_2021) => {{
     let mut options : HashMap<String, Stored> = $options;
     if !options.contains_key("above") &&
       !options.get("below").map(|v| matches!(v, Stored::Bool(true))).unwrap_or(false) {
@@ -937,7 +937,7 @@ macro_rules! DefAccent {
 //
 #[macro_export]
 macro_rules! LookupBool {
-  ($name:expr) => {{ state::lookup_bool($name) }};
+  ($name:expr_2021) => {{ state::lookup_bool($name) }};
 }
 #[macro_export]
 macro_rules! LookupFont {
@@ -945,94 +945,94 @@ macro_rules! LookupFont {
 }
 #[macro_export]
 macro_rules! LookupString {
-  ($name:expr) => {{ state::lookup_string($name) }};
+  ($name:expr_2021) => {{ state::lookup_string($name) }};
 }
 #[macro_export]
 macro_rules! LookupNumber {
-  ($name:expr) => {{ state::lookup_number($name) }};
+  ($name:expr_2021) => {{ state::lookup_number($name) }};
 }
 #[macro_export]
 macro_rules! LookupTokens {
-  ($name:expr) => {{ state::lookup_tokens($name) }};
+  ($name:expr_2021) => {{ state::lookup_tokens($name) }};
 }
 #[macro_export]
 macro_rules! AssignValue {
-  ($name:expr => $value:expr) => {
+  ($name:expr_2021 => $value:expr_2021) => {
     AssignValue!($name, $value)
   };
-  ($name:expr => $value:expr, $scope:expr) => {
+  ($name:expr_2021 => $value:expr_2021, $scope:expr_2021) => {
     AssignValue!($name, $value, $scope)
   };
-  ($name:expr, $value:expr) => {{ state::assign_value($name, $value, None) }};
-  ($name:expr, $value:expr, $scope:expr) => {{ state::assign_value($name, $value, $scope) }};
-  ($name:expr, $value:expr, $scope:expr) => {
+  ($name:expr_2021, $value:expr_2021) => {{ state::assign_value($name, $value, None) }};
+  ($name:expr_2021, $value:expr_2021, $scope:expr_2021) => {{ state::assign_value($name, $value, $scope) }};
+  ($name:expr_2021, $value:expr_2021, $scope:expr_2021) => {
     state::assign_value($name, $value, $scope)
   };
 }
 
 #[macro_export]
 macro_rules! AssignMapping {
-  ($map:expr, $key:expr => $value:expr) => {
+  ($map:expr_2021, $key:expr_2021 => $value:expr_2021) => {
     assign_mapping($map, $key, $value.into())
   };
 }
 #[macro_export]
 macro_rules! AssignMeaning {
-  ($key:expr, $val:expr) => {
+  ($key:expr_2021, $val:expr_2021) => {
     AssignMeaning!($key, $val, None)
   };
-  ($key:expr, $val:expr, $scope: expr) => {{ assign_meaning($key, $val, $scope) }};
+  ($key:expr_2021, $val:expr_2021, $scope: expr_2021) => {{ assign_meaning($key, $val, $scope) }};
 }
 
 #[macro_export]
 macro_rules! LookupCatcode {
-  ($c:expr) => {{ state::lookup_catcode($c) }};
+  ($c:expr_2021) => {{ state::lookup_catcode($c) }};
 }
 #[macro_export]
 macro_rules! AssignCatcode {
-  ($name:expr => $value:expr) => {
+  ($name:expr_2021 => $value:expr_2021) => {
     AssignCatcode!($name, $value)
   };
-  ($c:expr, $catcode:expr) => {{ AssignCatcode!($c, $catcode, None) }};
-  ($c:expr, $catcode:expr, $scope:expr) => {{ assign_catcode($c, $catcode, $scope) }};
+  ($c:expr_2021, $catcode:expr_2021) => {{ AssignCatcode!($c, $catcode, None) }};
+  ($c:expr_2021, $catcode:expr_2021, $scope:expr_2021) => {{ assign_catcode($c, $catcode, $scope) }};
 }
 #[macro_export]
 macro_rules! LookupMeaning {
-  ($name:expr) => {
+  ($name:expr_2021) => {
     state::lookup_meaning($name)
   };
 }
 #[macro_export]
 macro_rules! LookupDefinition {
-  ($name:expr) => {
+  ($name:expr_2021) => {
     state::lookup_definition($name)?
   };
 }
 #[macro_export]
 macro_rules! InstallDefinition {
-  ($name:expr, $definition:expr, $scope:expr) => {
+  ($name:expr_2021, $definition:expr_2021, $scope:expr_2021) => {
     state::install_definition($name, $definition, $scope)
   };
 }
 #[macro_export]
 macro_rules! XEquals {
-  ($token1:expr, $token2:expr) => {
+  ($token1:expr_2021, $token2:expr_2021) => {
     state::x_equals($token1, $token2)
   };
 }
 #[macro_export]
 macro_rules! IsDefined {
-  ($name:expr) => {
+  ($name:expr_2021) => {
     is_defined_token($name)
   };
 }
 #[macro_export]
 macro_rules! IsDefinedToken {
-  ($name:expr) => {{ is_defined_token($name) }};
+  ($name:expr_2021) => {{ is_defined_token($name) }};
 }
 #[macro_export]
 macro_rules! IsDefinable {
-  ($token: expr) => {
+  ($token: expr_2021) => {
     is_definable($token)
   };
 }
@@ -1045,24 +1045,24 @@ macro_rules! Let {
   ($token1:literal, $token2:literal, None) => {
     state::let_i(&T_CS!($token1), &T_CS!($token2), None)
   };
-  ($token1:literal, $token2:literal, $scope:expr) => {
+  ($token1:literal, $token2:literal, $scope:expr_2021) => {
     state::let_i(&T_CS!($token1), &T_CS!($token2), Some($scope))
   };
   // half-packaged args
-  ($token1:literal, $token2:expr) => {
+  ($token1:literal, $token2:expr_2021) => {
     state::let_i(&T_CS!($token1), &$token2, None)
   };
-  ($token1:expr, $token2:literal) => {
+  ($token1:expr_2021, $token2:literal) => {
     state::let_i(&$token1, &T_CS!($token2), None)
   };
   // internal form, pre-packaged arguments
-  ($token1:expr, $token2:expr) => {
+  ($token1:expr_2021, $token2:expr_2021) => {
     state::let_i(&$token1, &$token2, None)
   };
-  ($token1:expr, $token2:expr, None) => {
+  ($token1:expr_2021, $token2:expr_2021, None) => {
     state::let_i(&$token1, &$token2, None)
   };
-  ($token1:expr, $token2:expr, $scope:expr) => {
+  ($token1:expr_2021, $token2:expr_2021, $scope:expr_2021) => {
     state::let_i(&$token1, &$token2, Some($scope))
   };
 }
@@ -1072,7 +1072,7 @@ macro_rules! DigestIf {
   ($token:literal) => {
     digest_if(T_CS!($token))
   };
-  ($token:expr) => {
+  ($token:expr_2021) => {
     digest_if($token)
   };
 }
@@ -1086,10 +1086,10 @@ macro_rules! DigestIf {
 ///   `MergeFont(family => 'math', shape => 'italic')`.
 #[macro_export]
 macro_rules! MergeFont {
-  ($kv:expr) => {
+  ($kv:expr_2021) => {
     merge_font($kv)
   };
-  ($($key:ident => $val:expr),+ $(,)?) => {
+  ($($key:ident => $val:expr_2021),+ $(,)?) => {
     merge_font(fontmap!($($key => $val),+))
   };
 }
@@ -1129,7 +1129,7 @@ macro_rules! DefMacro {
       $body $($input)*)
   };
   // closure, general form
-  ($proto:expr, sub [$args:ident]
+  ($proto:expr_2021, sub [$args:ident]
     $body:block $($input:tt)*) => {
     let options = defi_opts!(@munch ($($input)*) -> {ExpandableOptions,});
     let (cs, params) = parse_prototype!($proto);
@@ -1137,7 +1137,7 @@ macro_rules! DefMacro {
       Rc::new(move |$args| $body.into_tokens_result())));
     def_macro(cs, params, expansion_closure, Some(options))?;
   };
-  ($proto:expr, $body:block $($input:tt)*) => {
+  ($proto:expr_2021, $body:block $($input:tt)*) => {
     let options = defi_opts!(@munch ($($input)*) -> {ExpandableOptions,});
     let (cs, params) = parse_prototype!($proto);
     let expansion_closure: Option<ExpansionBody> = Some(ExpansionBody::Closure(Rc::new(
@@ -1155,7 +1155,7 @@ macro_rules! DefMacro {
     def_macro(cs, params, compiled_expansion, Some(options))?;
   };
   // Internal-level use
-  ($cs:expr, $parameters:literal, $expansion: literal) => {
+  ($cs:expr_2021, $parameters:literal, $expansion: literal) => {
     let cs = $cs;
     let params = parse_parameters($parameters, &cs, true)?;
     let compiled_expansion;
@@ -1169,7 +1169,7 @@ macro_rules! DefMacro {
   // plus a parameters string. We invoke `parse_parameters` at runtime to
   // build the Parameters from the literal — same shape as the
   // ($proto:literal, sub [$args] $body) arm.
-  ($cs:expr, $parameters:literal, sub [$args:ident]
+  ($cs:expr_2021, $parameters:literal, sub [$args:ident]
     $body:block $($input:tt)*) => {
     let options = defi_opts!(@munch ($($input)*) -> {ExpandableOptions,});
     let cs_expr = $cs;
@@ -1181,7 +1181,7 @@ macro_rules! DefMacro {
   };
   // Same as above, but with parenthesized named args:
   //   DefMacro!(T_CS!("\\__foo:nn"), "{}{}", sub[(case, cp)] { ... });
-  ($cs:expr, $parameters:literal, sub [( $($var:ident),* )]
+  ($cs:expr_2021, $parameters:literal, sub [( $($var:ident),* )]
     $body:block $($input:tt)*) => {
     let options = defi_opts!(@munch ($($input)*) -> {ExpandableOptions,});
     let cs_expr = $cs;
@@ -1195,7 +1195,7 @@ macro_rules! DefMacro {
     )));
     def_macro(cs_expr, parsed_params, expansion_closure, Some(options))?;
   };
-  ($cs:expr, $parameters:expr, sub [$args:ident]
+  ($cs:expr_2021, $parameters:expr_2021, sub [$args:ident]
     $body:block $($input:tt)*) => {
     let options = defi_opts!(@munch ($($input)*) -> {ExpandableOptions,});
     let expansion_closure: Option<ExpansionBody> = Some(ExpansionBody::Closure(Rc::new(
@@ -1217,39 +1217,39 @@ macro_rules! DefMacro {
     compile_expansion!(compiled_expansion, $expansion);
     def_macro(T_CS!($cs), None, compiled_expansion, Some(options))?;
   };
-  ($cs:literal, None, $expansion:expr) => {
+  ($cs:literal, None, $expansion:expr_2021) => {
     def_macro(T_CS!($cs), None, $expansion, None)?;
   };
-  ($cs:expr, None, $expansion:literal) => {
+  ($cs:expr_2021, None, $expansion:literal) => {
     let compiled_expansion;
     compile_expansion!(compiled_expansion, $expansion);
     def_macro($cs, None, compiled_expansion, Some(ExpandableOptions {
       nopack_parameters: true, ..ExpandableOptions::default()
     }))?;
   };
-  ($cs:expr, None, $body:block) => {
+  ($cs:expr_2021, None, $body:block) => {
     let expansion_closure: Option<ExpansionBody> = Some(ExpansionBody::Closure(Rc::new(
       move |_args| $body.into_tokens_result()
     )));
     def_macro($cs, None, expansion_closure, None)?;
   };
-  ($cs:expr, None, $expansion:expr) => {
+  ($cs:expr_2021, None, $expansion:expr_2021) => {
     def_macro($cs, None, $expansion, None)?;
   };
-  ($cs:expr, None, $expansion:literal, $($input:tt)+) => {
+  ($cs:expr_2021, None, $expansion:literal, $($input:tt)+) => {
     let compiled_expansion;
     compile_expansion!(compiled_expansion, $expansion);
     let mut options = defi_opts!(@munch ($($input)*) -> {ExpandableOptions,});
     options.nopack_parameters = true; // compile_expansion! already packs parameters
     def_macro($cs, None, compiled_expansion, Some(options))?;
   };
-  ($cs:expr, None, $expansion:expr, $($input:tt)+) => {
+  ($cs:expr_2021, None, $expansion:expr_2021, $($input:tt)+) => {
     let options = defi_opts!(@munch ($($input)*) -> {ExpandableOptions,});
     def_macro($cs, None, $expansion, Some(options))?;
   };
   // the triple expr case should be near the end, as it matches too many cases.
   // It's an internal use of DefMacro e.g. with 3 variable name arguments
-  ($cs:expr, $parameters:expr, $expansion:expr) => {{
+  ($cs:expr_2021, $parameters:expr_2021, $expansion:expr_2021) => {{
     def_macro($cs, $parameters, $expansion, None)?;
   }};
   // The least-specified option-parsing cases come last due to the TT munchers accepting any inputs
@@ -1258,7 +1258,7 @@ macro_rules! DefMacro {
     let (cs, params) = parse_prototype!($proto);
     def_macro(cs, params, None, Some(options))?;
   };
-  ($cs:expr, $replacement:expr, $expansion:expr, $($input:tt)*) => {
+  ($cs:expr_2021, $replacement:expr_2021, $expansion:expr_2021, $($input:tt)*) => {
     let options = defi_opts!(@munch ($($input)*) -> {ExpandableOptions,});
     def_macro($cs, $replacement, $expansion, Some(options))?;
   };
@@ -1300,28 +1300,28 @@ macro_rules! TypedMacro {
 /// and also defines the control sequence for assignment.
 #[macro_export]
 macro_rules! DefRegister {
-  ($proto:expr => $value:expr) => {{
+  ($proto:expr_2021 => $value:expr_2021) => {{
     let (cs, params) = parse_prototype!($proto);
     defi_register!(cs, params, $value, None);
   }};
-  ($proto:expr, $value:expr) => {{
+  ($proto:expr_2021, $value:expr_2021) => {{
     let (cs, params) = parse_prototype!($proto);
     defi_register!(cs, params, $value, None);
   }};
-  ($cs:expr, None, $value:expr) => {{
+  ($cs:expr_2021, None, $value:expr_2021) => {{
     defi_register!($cs, None, $value, None);
   }};
   // Option parsers are more lenient, should be at the end of the list of patterns
-  ($cs:expr, None, $value:expr, $($input:tt)+) => {{
+  ($cs:expr_2021, None, $value:expr_2021, $($input:tt)+) => {{
     let options = defi_opts!(@munch ($($input)*) -> {RegisterOptions,});
     defi_register!($cs, None, $value, Some(options));
   }};
-  ($proto:expr, $value:expr, $($input:tt)+) => {{
+  ($proto:expr_2021, $value:expr_2021, $($input:tt)+) => {{
     let (cs, params) = parse_prototype!($proto);
     let options = defi_opts!(@munch ($($input)*) -> {RegisterOptions,});
     defi_register!(cs, params, $value, Some(options));
   }};
-  ($proto:expr => $value:expr, $($input:tt)+) => {{
+  ($proto:expr_2021 => $value:expr_2021, $($input:tt)+) => {{
     let (cs, params) = parse_prototype!($proto);
     let options = defi_opts!(@munch ($($input)*) -> {RegisterOptions,});
     defi_register!(cs, params, $value, Some(options));
@@ -1330,7 +1330,7 @@ macro_rules! DefRegister {
 
 #[macro_export]
 macro_rules! defi_register {
-  ($cs:expr, $paramlist:expr, $value:expr, $options:expr) => {{
+  ($cs:expr_2021, $paramlist:expr_2021, $value:expr_2021, $options:expr_2021) => {{
     let value = { $value };
     def_register($cs, $paramlist, value, $options)?
   }};
@@ -1338,9 +1338,9 @@ macro_rules! defi_register {
 
 #[macro_export]
 macro_rules! NewCounter {
-  ($ctr:expr) => (new_counter($ctr, "", None)?);
-  ($ctr:expr, $within:expr) => (new_counter($ctr, $within, None)?);
-  ($ctr:expr, $within:expr, $($key:ident => $val:expr),*) => (
+  ($ctr:expr_2021) => (new_counter($ctr, "", None)?);
+  ($ctr:expr_2021, $within:expr_2021) => (new_counter($ctr, $within, None)?);
+  ($ctr:expr_2021, $within:expr_2021, $($key:ident => $val:expr_2021),*) => (
     new_counter($ctr, $within, Some(NewDefault!(NewCounterOptions, $($key=>$val),*)))?);
 }
 
@@ -1368,10 +1368,10 @@ macro_rules! DefEnvironment {
       )),
       options);
   }};
-  ($proto:literal, $replacement:expr) => {
+  ($proto:literal, $replacement:expr_2021) => {
     DefEnvironmentWO!($proto, $replacement, ConstructorOptions::default());
   };
-  ($proto:literal, $replacement:expr, $($input:tt)* ) => {{
+  ($proto:literal, $replacement:expr_2021, $($input:tt)* ) => {{
     let options = defi_opts!(@munch ($($input)*) -> {ConstructorOptions,});
     //                              ^^^^^^^^^^^^    ^^^^^^^^^^^^^^^^^^^^
     //                                 input       output
@@ -1381,7 +1381,7 @@ macro_rules! DefEnvironment {
 
 #[macro_export]
 macro_rules! Tag {
-  ($tag:expr, $($input:tt)*) => {{
+  ($tag:expr_2021, $($input:tt)*) => {{
     let options = defi_opts!(@munch ($($input)*) -> {TagOptions,});
     install_tag($tag, options);
   }}
@@ -1399,9 +1399,9 @@ macro_rules! DefMath(
     let defmath_options = defi_opts!(@munch ($($input)*) -> {MathPrimitiveOptions,});
     defi_math!(cs,paramlist, $presentation, defmath_options);
   }};
-  ($text:expr,$paramlist:expr,$presentation:expr) => (
+  ($text:expr_2021,$paramlist:expr_2021,$presentation:expr_2021) => (
     defi_math!($text,$paramlist, $presentation, MathPrimitiveOptions::default()));
-  ($text:expr,$paramlist:expr,$presentation:expr, $($input:tt)*) => {{
+  ($text:expr_2021,$paramlist:expr_2021,$presentation:expr_2021, $($input:tt)*) => {{
     let defmath_options = defi_opts!(@munch ($($input)*) -> {MathPrimitiveOptions,});
     defi_math!($text,$paramlist, $presentation, defmath_options);
   }};
@@ -1409,7 +1409,7 @@ macro_rules! DefMath(
 
 #[macro_export]
 macro_rules! DefParameterType {
-  ($name:ident, $($key:ident => $value:expr),*)=>(
+  ($name:ident, $($key:ident => $value:expr_2021),*)=>(
     DefParameterTypeWO!($name, NewDefault!(Parameter, name => arena::pin_static(stringify!($name)),
     $($key=>$value),*)));
   // with reader as explicit sub
@@ -1505,12 +1505,12 @@ macro_rules! Revert {
   ($thing:literal) => {
     Explode!($thing)
   };
-  ($thing:expr) => {{ $thing.revert()?.unlist() }};
+  ($thing:expr_2021) => {{ $thing.revert()?.unlist() }};
 }
 
 #[macro_export]
 macro_rules! GetKeyVal {
-  ($keyval_opt:expr, $key:expr) => {
+  ($keyval_opt:expr_2021, $key:expr_2021) => {
     match $keyval_opt {
       Some(digested) => match digested.data() {
         DigestedData::KeyVals(keyval) => keyval.get_value($key),
@@ -1523,7 +1523,7 @@ macro_rules! GetKeyVal {
 
 #[macro_export]
 macro_rules! GetKeyVals {
-  ($keyval:expr) => {
+  ($keyval:expr_2021) => {
     match $keyval_opt {
       Some(Digested::KeyVals(keyval)) => keyval.get_key_vals(),
       _ => None,
@@ -1536,7 +1536,7 @@ macro_rules! GetKeyVals {
 /// For descriptions of further parameters, see `keyval::define`.
 #[macro_export]
 macro_rules! DefKeyVal {
-  ($keyset:expr, $key:expr, $vtype:expr) => {{
+  ($keyset:expr_2021, $key:expr_2021, $vtype:expr_2021) => {{
     ::latexml_core::keyval::define(KeyvalConfig {
       prefix: "KV",
       keyset: $keyset,
@@ -1546,7 +1546,7 @@ macro_rules! DefKeyVal {
       ..KeyvalConfig::default()
     })?;
   }};
-  ($keyset:expr, $key:expr, $vtype:expr, $default:expr) => {{
+  ($keyset:expr_2021, $key:expr_2021, $vtype:expr_2021, $default:expr_2021) => {{
     ::latexml_core::keyval::define(KeyvalConfig {
       prefix: "KV",
       keyset: $keyset,
@@ -1556,7 +1556,7 @@ macro_rules! DefKeyVal {
       ..KeyvalConfig::default()
     })?;
   }};
-  ($keyset:expr, $key:expr, $vtype:expr, $default:expr, $options:tt) => {{
+  ($keyset:expr_2021, $key:expr_2021, $vtype:expr_2021, $default:expr_2021, $options:tt) => {{
     // TODO: explicit $options with prefix logic — for now ignore options and use default prefix
     log::warn!(
       "DefKeyVal with explicit options not fully ported, ignoring options for {}/{}",
@@ -1582,12 +1582,12 @@ macro_rules! Digest {
     stomach::digest(tokenized)
   }};
 
-  ($tokens:expr) => {{ stomach::digest($tokens) }};
+  ($tokens:expr_2021) => {{ stomach::digest($tokens) }};
 }
 
 #[macro_export]
 macro_rules! DigestText {
-  ($tokens:expr) => {{ digest_text($tokens) }};
+  ($tokens:expr_2021) => {{ digest_text($tokens) }};
 }
 
 /// Tokenize($string); Tokenizes the string using the standard cattable, returning a
@@ -1599,7 +1599,7 @@ macro_rules! Tokenize {
     compile_tokenize!(tokenized, $string);
     tokenized
   }};
-  ($string:expr) => {
+  ($string:expr_2021) => {
     mouth::tokenize($string)
   };
 }
@@ -1613,14 +1613,14 @@ macro_rules! TokenizeInternal {
     compile_tokenize_internal!(tokenized, $string);
     tokenized
   }};
-  ($string:expr) => {
+  ($string:expr_2021) => {
     mouth::tokenize_internal($string)
   };
 }
 
 #[macro_export]
 macro_rules! RawTeX {
-  ($text:expr) => {
+  ($text:expr_2021) => {
     ::latexml_core::stomach::raw_tex($text)?;
   };
 }
@@ -1636,19 +1636,19 @@ macro_rules! TeX {
 
 #[macro_export]
 macro_rules! Dimension {
-  ($number:expr) => {
+  ($number:expr_2021) => {
     Dimension::new_f64(Dimension::spec_to_f64($number)?)
   };
 }
 
 #[macro_export]
 macro_rules! Glue {
-  ($spec:expr) => {{ Glue::new_spec($spec, None, None, None, None) }};
+  ($spec:expr_2021) => {{ Glue::new_spec($spec, None, None, None, None) }};
 }
 
 #[macro_export]
 macro_rules! MuGlue {
-  ($spec:expr) => {{ MuGlue::new_spec($spec, None, None, None, None) }};
+  ($spec:expr_2021) => {{ MuGlue::new_spec($spec, None, None, None, None) }};
 }
 
 /// Register document namespaces. Replaces the old `DocType!` macro (DTD not supported in Rust
@@ -1656,10 +1656,10 @@ macro_rules! MuGlue {
 /// ignored.
 #[macro_export]
 macro_rules! RegisterDocumentNamespaces {
-  ($rootelement:expr, $pubid:expr, $sysid:expr) => {
+  ($rootelement:expr_2021, $pubid:expr_2021, $sysid:expr_2021) => {
     // No-op: DTD schema type not supported. Arguments retained for documentation/compatibility.
   };
-  ($rootelement:expr, $pubid:expr, $sysid:expr, $namespaces:expr) => {{
+  ($rootelement:expr_2021, $pubid:expr_2021, $sysid:expr_2021, $namespaces:expr_2021) => {{
     for (prefix, value) in $namespaces.iter() {
       model::register_document_namespace(prefix, Some(value));
     }
@@ -1684,7 +1684,7 @@ macro_rules! DeclareOption {
       PrimitiveBody::Closure(Rc::new(move |_args| $body.into_digested_result()));
     def_primitive(T_CS!(cs), None, Some(code), PrimitiveOptions::default())?;
   };
-  ($option:expr, $tex:literal) => {
+  ($option:expr_2021, $tex:literal) => {
     let tokenized;
     compile_tokenize_internal!(tokenized, $tex);
     state::push_value("@declaredoptions", $option)?;
@@ -1692,13 +1692,13 @@ macro_rules! DeclareOption {
     // literal case, create a macro
     def_macro(T_CS!(cs), None, tokenized, None)?;
   };
-  ($option:expr, $tokenized:ident) => {
+  ($option:expr_2021, $tokenized:ident) => {
     state::push_value("@declaredoptions", $option.to_string())?;
     let cs = s!("\\ds@{}", $option);
     // literal case, create a macro
     def_macro(T_CS!(cs), None, $tokenized, None)?;
   };
-  ($option:expr, $(sub)? $body:block) => {
+  ($option:expr_2021, $(sub)? $body:block) => {
     state::push_value("@declaredoptions", $option)?;
     let cs = s!("\\ds@{}", $option);
     // block case, create a primitive
@@ -1720,7 +1720,7 @@ macro_rules! ProcessOptions {
   };
   // ProcessOptions!(keysets => ["LTXML"]) — Perl
   // ProcessOptions(inorder => 1, keysets => ['LTXML'])
-  (keysets => [$($keyset:expr),+ $(,)?]) => {
+  (keysets => [$($keyset:expr_2021),+ $(,)?]) => {
     process_options(true, &[$($keyset),+])?;
   };
 }
@@ -1807,7 +1807,7 @@ macro_rules! defi_opts {
   (@munch ($(,)?) -> {$kind:ident,}) => {
     $kind::default()
   };
-  (@munch ($(,)?) -> {$kind:ident, $([$id:ident @ $body:expr])+ } ) => {
+  (@munch ($(,)?) -> {$kind:ident, $([$id:ident @ $body:expr_2021])+ } ) => {
     $kind {
       $($id: $body),*,
       ..$kind::default()
@@ -1817,324 +1817,324 @@ macro_rules! defi_opts {
   // DG: this is currently problematic - we seem to have two kinds of reversions, one working after
   //     digestion, and one *not*
   (@munch ( $(,)? reversion $(:)?$(=>)? sub[$whatsit:ident, $args:ident] $body:block $($next:tt)*)
-  -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@reversion (sub[$whatsit,$args] $body $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   (@munch ( $(,)? reversion $(:)?$(=>)?
     sub[$arg:ident, $inner:ident, $extra:ident] $body:block $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@reversion (sub[$arg,$inner,$extra] $body $($next)*) -> {$kind, $([ $key @ $val ])*})
   };
   (@munch ( $(,)? reversion $(:)?$(=>)? $(sub)? $body:block $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@reversion (sub $body $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   // reversion => None means "empty reversion" (disable reversion entirely)
   // Perl: reversion => Tokens() — produces empty tex= attribute
   (@munch ( $(,)? reversion $(:)?$(=>)? None, $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )*
       [ reversion @ Some(Reversion::Tokens(Tokens!())) ] })
   };
   (@munch ( $(,)? reversion $(:)?$(=>)? None)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ()
       -> {$kind, $( [ $key @ $val ] )*
         [ reversion @ Some(Reversion::Tokens(Tokens!())) ] })
   };
-  (@munch ( $(,)? reversion $(:)?$(=>)? $tokens:expr, $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  (@munch ( $(,)? reversion $(:)?$(=>)? $tokens:expr_2021, $($next:tt)*)
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )*
       [ reversion @ $tokens.into_option() ] })
   };
-  (@munch ( $(,)? reversion $(:)?$(=>)? $tokens:expr)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  (@munch ( $(,)? reversion $(:)?$(=>)? $tokens:expr_2021)
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ()  -> {$kind, $( [ $key @ $val ] )* [ reversion @ $tokens.into_option() ] })
   };
 
   // sizer: Option<SizingClosure>
   (@munch ( $(,)? sizer $(:)?$(=>)? sub[$whatsit_arg:ident]
     $body:block $($next:tt)*) ->
-  {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )* [
       sizer @ Some(sizersub!($whatsit_arg, $body)) ]})
   };
   (@munch ( $(,)? sizer $(:)?$(=>)? $body:block $($next:tt)*) ->
-  {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )* [
       sizer @ Some(sizersub!(_whatsit_arg, $body)) ]})
   };
-  (@munch ( $(,)? sizer $(:)?$(=>)? $tokens:expr, $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  (@munch ( $(,)? sizer $(:)?$(=>)? $tokens:expr_2021, $($next:tt)*)
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )*
       [ sizer @ $tokens.into_option() ] })
   };
-  (@munch ( $(,)? sizer $(:)?$(=>)? $tokens:expr)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  (@munch ( $(,)? sizer $(:)?$(=>)? $tokens:expr_2021)
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ()  -> {$kind, $( [ $key @ $val ] )* [ sizer @ $tokens.into_option() ] })
   };
   // select: literal string
-  (@munch ( $(,)? select $(:)?$(=>)? $tokens:expr, $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  (@munch ( $(,)? select $(:)?$(=>)? $tokens:expr_2021, $($next:tt)*)
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )*
       [ select @ $tokens.into_option() ] })
   };
-  (@munch ( $(,)? select $(:)?$(=>)? $tokens:expr)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  (@munch ( $(,)? select $(:)?$(=>)? $tokens:expr_2021)
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ()  -> {$kind, $( [ $key @ $val ] )* [ select @ $tokens.into_option() ] })
   };
   // select_count: literal number
-  (@munch ( $(,)? select_count $(:)?$(=>)? $tokens:expr, $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  (@munch ( $(,)? select_count $(:)?$(=>)? $tokens:expr_2021, $($next:tt)*)
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )*
       [ select_count @ $tokens.into_option() ] })
   };
-  (@munch ( $(,)? select_count $(:)?$(=>)? $tokens:expr)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  (@munch ( $(,)? select_count $(:)?$(=>)? $tokens:expr_2021)
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ()  -> {$kind, $( [ $key @ $val ] )*
       [ select_count @ $tokens.into_option() ] })
   };
   // replace: sub
   (@munch ( $(,)? replace $(:)?$(=>)? sub $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@replace (sub $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   (@munch ( $(,)? replace $(:)?$(=>)? $body:block $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@replace ($body $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   // xpath: literal string
-  (@munch ( $(,)? xpath $(:)?$(=>)? $tokens:expr, $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  (@munch ( $(,)? xpath $(:)?$(=>)? $tokens:expr_2021, $($next:tt)*)
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )*
       [ xpath @ $tokens.into_option() ] })
   };
-  (@munch ( $(,)? xpath $(:)?$(=>)? $tokens:expr)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  (@munch ( $(,)? xpath $(:)?$(=>)? $tokens:expr_2021)
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ()  -> {$kind, $( [ $key @ $val ] )* [ xpath @ $tokens.into_option() ] })
   };
 
   // mode : Option<TexMode>
   (@munch ( $(,)? mode $(:)?$(=>)? $literal:literal $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )*
       [ mode @ $literal.into_option() ] })
   };
   // alias : Option<String>
   (@munch ( $(,)? alias $(:)?$(=>)? $literal:literal $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )*
       [ alias @ $literal.into_option() ] })
   };
   // scope: Option<Scope>
-  (@munch ( $(,)? scope $(:)?$(=>)? $scope:expr)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  (@munch ( $(,)? scope $(:)?$(=>)? $scope:expr_2021)
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ()  -> {$kind, $( [ $key @ $val ] )* [ scope @ $scope.into_option() ] })
   };
-  (@munch ( $(,)? scope $(:)?$(=>)? $scope:expr, $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  (@munch ( $(,)? scope $(:)?$(=>)? $scope:expr_2021, $($next:tt)*)
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )*
       [ scope @ $scope.into_option() ] })
   };
   // font: Font
   (@munch ( $(,)? font $(:)?$(=>)? sub [ $font_whatsit:ident]
-    $body:block $($next:tt)*) -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    $body:block $($next:tt)*) -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $( [ $key @ $val ] )*
       [ font @ Some(FontDirective::Closure(Rc::new(move |$font_whatsit| $body))) ] })
   };
   (@munch ( $(,)? font $(:)?$(=>)? { $($fkey:ident => $fvalue:literal),* } $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $( [ $key @ $val ] )*
       [ font @ FontDirective!($($fkey => $fvalue),*) ] })
   };
   (@munch ( $(,)? font $(:)?$(=>)? $body:block $($next:tt)*) ->
-  {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $( [ $key @ $val ] )*
       [ font @ Some(FontDirective::Closure(Rc::new(move |_font_whatsit| $body))) ] })
   };
   (@munch ( $(,)? font $(:)?$(=>)? $props:ident $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $( [ $key @ $val ] )*
       [ font @ $props.map(|v| FontDirective::Asset(Rc::new(v))) ] })
   };
   // properties: PropertiesClosure
   (@munch ( $(,)? properties $(:)?$(=>)? $body:block $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $( [ $key @ $val ] )*
       [ properties @ properties!($body) ] })
   };
   (@munch ( $(,)? properties $(:)?$(=>)?
       sub[$args:ident] $body:block $($next:tt)*)
-      -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+      -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $( [ $key @ $val ] )*
       [ properties @ properties!($args, $body) ] })
   };
   (@munch ( $(,)? properties $(:)?$(=>)? $var:ident $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $( [ $key @ $val ] )*
       [ properties @ properties!($var) ] })
   };
 
   // before_digest_end: Vec<BeforeDigestClosure>
   (@munch ( $(,)? before_digest_end $(:)?$(=>)? sub $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@before_digest_end (sub $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   (@munch ( $(,)? before_digest_end $(:)?$(=>)? $body:block $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@before_digest_end ($body $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
 
 
   // before_digest: Vec<BeforeDigestClosure>
   (@munch ( $(,)? before_digest $(:)?$(=>)? sub $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@before_digest (sub $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   (@munch ( $(,)? before_digest $(:)?$(=>)? $body:block $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@before_digest ($body $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
 
   // after_digest: Vec<DigestionClosure>
   (@munch ( $(,)? after_digest $(:)?$(=>)? sub $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@after_digest (sub $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   (@munch ( $(,)? after_digest $(:)?$(=>)? $body:block $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@after_digest ($body $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
 
   // after_digest_begin: Vec<DigestionClosure>
   (@munch ( $(,)? after_digest_begin $(:)?$(=>)? sub $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@after_digest_begin (sub $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   (@munch ( $(,)? after_digest_begin $(:)?$(=>)? $body:block $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@after_digest_begin ($body $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
 
   // after_digest_body: Vec<DigestionClosure>
   (@munch ( $(,)? after_digest_body $(:)?$(=>)? sub $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@after_digest_body (sub $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   (@munch ( $(,)? after_digest_body $(:)?$(=>)? $body:block $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@after_digest_body ($body $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
 
   // before_construct: Vec<ConstructionClosure>
   (@munch ( $(,)? before_construct $(:)?$(=>)? sub $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@before_construct (sub $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   (@munch ( $(,)? before_construct $(:)?$(=>)? $body:block $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@before_construct ($body $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
 
 
   // after_construct: Vec<ConstructionClosure>
   (@munch ( $(,)? after_construct $(:)?$(=>)? sub $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@after_construct (sub $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   (@munch ( $(,)? after_construct $(:)?$(=>)? $body:block $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@after_construct ($body $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   (@munch ( $(,)? after_construct $(:)?$(=>)? $var:ident $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])* [after_construct @ $var]})
   };
 
   // getter: RegisterGetterClosure
   (@munch ( $(,)? getter $(:)?$(=>)? sub $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@getter (sub $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   (@munch ( $(,)? getter $(:)?$(=>)? $body:block $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@getter ($body $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   // setter: RegisterSetterClosure
   (@munch ( $(,)? setter $(:)?$(=>)? sub $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@setter (sub $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   (@munch ( $(,)? setter $(:)?$(=>)? $body:block $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@setter ($body $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   // after_open: Option<Vec<TagConstructionClosure>>
   (@munch ( $(,)? after_open $(:)?$(=>)? sub $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@after_open (sub $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   (@munch ( $(,)? after_open $(:)?$(=>)? $body:block $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@after_open ($body $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   // after_open_late: Option<Vec<TagConstructionClosure>>
   (@munch ( $(,)? after_open_late $(:)?$(=>)? sub $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@after_open_late (sub $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   (@munch ( $(,)? after_open_late $(:)?$(=>)? $body:block $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@after_open_late ($body $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   // after_close: Option<Vec<TagConstructionClosure>>
   (@munch ( $(,)? after_close $(:)?$(=>)? sub $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@after_close (sub $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   (@munch ( $(,)? after_close $(:)?$(=>)? $body:block $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@after_close ($body $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   // after_close_late: Option<Vec<TagConstructionClosure>>
   (@munch ( $(,)? after_close_late $(:)?$(=>)? sub $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@after_close_late (sub $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   (@munch ( $(,)? after_close_late $(:)?$(=>)? $body:block $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@after_close_late ($body $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   // auto_open: Option<bool>
   (@munch ( $(,)? auto_open $(:)?$(=>)? $auto:literal $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $( [ $key @ $val ] )* [ auto_open @ $auto.into() ]})
   };
   // auto_close: Option<bool>
   (@munch ( $(,)? auto_close $(:)?$(=>)? $auto:literal $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $( [ $key @ $val ] )* [ auto_close @ $auto.into() ]})
   };
 
   // DefParameterType options
   // predigest: Vec<ReaderPredigestClosure>
   (@munch ( $(,)? predigest $(:)?$(=>)? sub $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@predigest (sub $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   (@munch ( $(,)? predigest $(:)?$(=>)? $body:block $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@predigest ($body $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   // digested_reversion: Option<DigestedReversionClosure>
   // Perl equivalent: the `reversion` option on DefParameterType, which receives the raw value.
   // Allows parameter types to control reversion formatting from the structured digested data.
   (@munch ( $(,)? digested_reversion $(:)?$(=>)? sub $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@digested_reversion (sub $($next)*) -> {$kind, $( [ $key @ $val ] )*})
   };
   (@digested_reversion (sub[$arg:ident] $body:block $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $( [ $key @ $val ] )*
       [digested_reversion @ Some(Rc::new({
         move |$arg: &Digested| -> Result<Tokens> { $body }
@@ -2143,135 +2143,135 @@ macro_rules! defi_opts {
   // reversion
 
   // semiverbatim
-  (@munch ( $(,)? semiverbatim $(:)?$(=>)? Some($value:expr))
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  (@munch ( $(,)? semiverbatim $(:)?$(=>)? Some($value:expr_2021))
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch () -> {$kind, $( [ $key @ $val ] )*
       [ semiverbatim @ Some($value) ] })
   };
   (@munch ( $(,)? semiverbatim $(:)?$(=>)? None)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch () -> {$kind, $( [ $key @ $val ] )*
       [ semiverbatim @ None ] })
   };
-  (@munch ( $(,)? semiverbatim $(:)?$(=>)? $value:expr, $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  (@munch ( $(,)? semiverbatim $(:)?$(=>)? $value:expr_2021, $($next:tt)*)
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $( [ $key @ $val ] )*
       [ semiverbatim @ $value ] })
 };
   // ligature options
   // role: literal string
   (@munch ( $(,)? role $(:)?$(=>)? $literal:literal, $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )*
       [ role @ Some($literal.to_string()) ] })
   };
   (@munch ( $(,)? role $(:)?$(=>)? $literal:literal)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ()  -> {$kind, $( [ $key @ $val ] )* [ role @ Some($literal.to_string()) ] })
   };
   // meaning: literal string
   (@munch ( $(,)? meaning $(:)?$(=>)? $literal:literal, $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )*
       [ meaning @ Some($literal.to_string()) ] })
   };
   (@munch ( $(,)? meaning $(:)?$(=>)? $literal:literal)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ()  -> {$kind, $( [ $key @ $val ] )*
       [ meaning @ Some($literal.to_string()) ] })
   };
   // name: literal string
   (@munch ( $(,)? name $(:)?$(=>)? $literal:literal, $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )*
       [ name @ Some($literal.to_string()) ] })
   };
   (@munch ( $(,)? name $(:)?$(=>)? $literal:literal)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ()  -> {$kind, $( [ $key @ $val ] )* [ name @ Some($literal.to_string()) ] })
   };
   // for register
   // address: Option<String>
-  (@munch ( $(,)? address $(:)?$(=>)? $idval:expr, $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  (@munch ( $(,)? address $(:)?$(=>)? $idval:expr_2021, $($next:tt)*)
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )*
       [ address @ Some($idval.to_string()) ] })
   };
-  (@munch ( $(,)? address $(:)?$(=>)? $idval:expr)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  (@munch ( $(,)? address $(:)?$(=>)? $idval:expr_2021)
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ()  -> {$kind, $( [ $key @ $val ] )* [ name @ Some($idval.to_string()) ] })
   };
   // allocate: Option<String>
-  (@munch ( $(,)? allocate $(:)?$(=>)? $idval:expr, $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  (@munch ( $(,)? allocate $(:)?$(=>)? $idval:expr_2021, $($next:tt)*)
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )*
       [ allocate @ Some($idval.to_string()) ] })
   };
-  (@munch ( $(,)? allocate $(:)?$(=>)? $idval:expr)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  (@munch ( $(,)? allocate $(:)?$(=>)? $idval:expr_2021)
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ()  -> {$kind, $( [ $key @ $val ] )* [allocate @ Some($idval.to_string()) ]})
   };
   // for defmath
   // stretchy: bool
   (@munch ( $(,)? stretchy $(:)?$(=>)? $flag:literal, $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )* [ stretchy @ Some($flag) ] })
   };
   (@munch ( $(,)? stretchy $(:)?$(=>)? $flag:literal)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ()  -> {$kind, $( [ $key @ $val ] )* [ stretchy @ Some($flag) ] })
   };
   // operator_role: string
   (@munch ( $(,)? operator_role $(:)?$(=>)? $flag:literal, $($next:tt)*)
-  -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
   defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )*
     [ operator_role @ Some($flag.to_string()) ] })
   };
   (@munch ( $(,)? operator_role $(:)?$(=>)? $flag:literal)
-  -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
   defi_opts!(@munch ()  -> {$kind, $( [ $key @ $val ] )*
     [ operator_role @ Some($flag.to_string()) ] })
   };
   // operator_stretchy: bool
   (@munch ( $(,)? operator_stretchy $(:)?$(=>)? $flag:literal, $($next:tt)*)
-  -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
   defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )*
     [ operator_stretchy @ Some($flag) ] })
   };
   (@munch ( $(,)? operator_stretchy $(:)?$(=>)? $flag:literal)
-  -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
   defi_opts!(@munch ()  -> {$kind, $( [ $key @ $val ] )* [ operator_stretchy @ Some($flag) ] })
   };
   // scriptpos: string
   (@munch ( $(,)? scriptpos $(:)?$(=>)? $flag:literal, $($next:tt)*)
-  -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
   defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )*
     [ scriptpos @ Some($flag.to_string()) ] })
   };
   (@munch ( $(,)? scriptpos $(:)?$(=>)? $flag:literal)
-  -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
   defi_opts!(@munch ()  -> {$kind, $( [ $key @ $val ] )* [ scriptpos @ Some($flag.to_string()) ] })
   };
   // mathstyle: Option<String>
   (@munch ( $(,)? mathstyle $(:)?$(=>)? $literal:literal, $($next:tt)*)
-  -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
   defi_opts!(@munch ($($next)*)  -> {$kind, $( [ $key @ $val ] )*
     [ mathstyle @ Some($literal.to_string()) ] })
   };
   (@munch ( $(,)? mathstyle $(:)?$(=>)? $literal:literal)
-  -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+  -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
   defi_opts!(@munch ()
     -> {$kind, $( [ $key @ $val ] )*
       [ mathstyle @ Some($literal.to_string()) ] })
   };
   // misc ident with literal value
   (@munch ( $(,)? $id:ident $(:)?$(=>)? $lit:literal $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])* [$id @ $lit]})
   };
   // misc ident with block value
   (@munch ( $(,)? $id:ident $(:)?$(=>)? $body:block $($next:tt)*)
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])* [$id @ $body]})
   };
 
@@ -2279,52 +2279,52 @@ macro_rules! defi_opts {
   // Closure parsers
 
   (@before_digest_end ($body:block $($next:tt)* )
-                  -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+                  -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [before_digest_end @ before_digest!($body)]})
   };
   (@before_digest ($(sub)? $body:block $($next:tt)* )
-                  -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+                  -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [before_digest @ before_digest!($body)]})
   };
   (@before_digest ($(sub)? $body:block $($next:tt)* ) -> {$kind:ident,
-    $([$key:ident @ $val:expr])*}) => {
+    $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [before_digest @ before_digest!($body)]})
   };
   (@after_digest (
     sub[$whatsit:ident] $body:block $($next:tt)* )
-      -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+      -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_digest @ after_digest!($whatsit, $body)]})
   };
   (@after_digest (
-    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_digest @ after_digest!(_whatsit,$body)]})
   };
 
   (@after_digest_begin (
     sub[$whatsit:ident] $body:block $($next:tt)* )
-      -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+      -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_digest_begin @ after_digest!($whatsit, $body)]})
   };
   (@after_digest_begin (
-    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_digest_begin @ after_digest!(_whatsit, $body)]})
   };
 
   (@after_digest_body (
     sub[$whatsit:ident] $body:block $($next:tt)* )
-      -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+      -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_digest_body @ after_digest!($whatsit, $body)]})
   };
   (@after_digest_body (
-    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_digest_body @ after_digest!( whatsit, $body)]})
   };
@@ -2332,98 +2332,98 @@ macro_rules! defi_opts {
 
   (@before_construct (
     sub[$doc:ident, $whatsit:ident] $body:block $($next:tt)* )
-      -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+      -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [before_construct @ construct!($doc, $whatsit, $body)]})
   };
   (@before_construct (
     sub[$doc:ident] $body:block $($next:tt)* )
-      -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+      -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [before_construct @ construct!($doc, _whatsit, $body)]})
   };
   (@before_construct (
-    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [before_construct @ construct!(_document, _whatsit, $body)]})
   };
 
   (@after_construct (
     sub[$doc:ident, $whatsit:ident] $body:block $($next:tt)* )
-      -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+      -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_construct @ construct!($doc, $whatsit, $body)]})
   };
   (@after_construct (
     sub[$doc:ident] $body:block $($next:tt)* )
-      -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+      -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_construct @ construct!($doc, _whatsit, $body)]})
   };
   (@after_construct (
-    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_construct @ construct!(_document, _whatsit, $body)]})
   };
 
   (@getter (
     sub[$args:ident] $body:block $($next:tt)* )
-      -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+      -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [getter @ getter!($args, $body)]})
   };
   (@getter (
-    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [getter @ getter!(_args,$body)]})
   };
 
   (@setter (
     sub[$value:ident, $scope:ident, $args:ident] $body:block $($next:tt)* )
-      -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+      -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [setter @ setter!($value, $scope, $args, $body)]})
   };
   (@setter (
-    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [setter @ setter!(value, args, $body)]})
   };
   // 3-argument form: sub[document, node, whatsit] { ... }
   (@after_open (
     sub[$document:ident, $node:ident, $whatsit:ident] $body:block $($next:tt)* )
-      -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+      -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_open @ Some(tagsub!($document, $node, $whatsit, $body)) ]})
   };
   // 2-argument form: sub[document, node] { ... }
   (@after_open (
     sub[$document:ident, $node:ident] $body:block $($next:tt)* )
-      -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+      -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_open @ Some(tagsub!($document, $node, $body)) ]})
   };
   (@after_open (
-    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_open @ Some(tagsub!(document, node, $body)) ]})
   };
   // 3-argument form
   (@after_open_late (
     sub[$document:ident, $node:ident, $whatsit:ident] $body:block $($next:tt)* )
-      -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+      -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_open_late @ Some(tagsub!($document, $node, $whatsit, $body)) ]})
   };
   // 2-argument form
   (@after_open_late (
     sub[$document:ident, $node:ident] $body:block $($next:tt)* )
-      -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+      -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_open_late @ Some(tagsub!($document, $node, $body)) ]})
   };
   (@after_open_late (
-    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_open_late @ Some(tagsub!(document, node, $body)) ]})
   };
@@ -2431,82 +2431,82 @@ macro_rules! defi_opts {
   // Matches Perl's afterClose => sub { my ($document, $node, $whatsit) = @_; ... }
   (@after_close (
     sub[$document:ident, $node:ident, $whatsit:ident] $body:block $($next:tt)* )
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_close @ Some(tagsub!($document, $node, $whatsit, $body)) ]})
   };
   // 2-argument form: sub[document, node] { ... }
   (@after_close (
     sub[$document:ident, $node:ident] $body:block $($next:tt)* )
-    -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_close @ Some(tagsub!($document, $node, $body)) ]})
   };
   (@after_close (
-    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_close @ Some(tagsub!(document, node, $body)) ]})
   };
   // 3-argument form
   (@after_close_late (
     sub[$document:ident, $node:ident, $whatsit:ident] $body:block $($next:tt)* )
-      -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+      -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_close_late @ Some(tagsub!($document, $node, $whatsit, $body)) ]})
   };
   // 2-argument form
   (@after_close_late (
     sub[$document:ident, $node:ident] $body:block $($next:tt)* )
-      -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+      -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_close_late @ Some(tagsub!($document, $node, $body)) ]})
   };
   (@after_close_late (
-    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [after_close_late @ Some(tagsub!(document, node, $body)) ]})
   };
 
   (@replace ($body:block $($next:tt)* )
-                  -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+                  -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [replace @ rewrite_replace_sub!($body)]})
   };
   (@replace (sub [$document_arg:ident, $node_arg:ident]
     $body:block $($next:tt)* )
-                  -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+                  -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])* [replace @
       rewrite_replace_sub!($document_arg, $node_arg, $body)]})
   };
   (@reversion (sub [$whatsit:ident, $args:ident] $body:block $($next:tt)* )
-                  -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+                  -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [reversion @ reversion_digested!($whatsit, $args, $body)]})
   };
   (@reversion (sub [$args:ident, $inner:ident, $extra:ident] $body:block $($next:tt)*)
-                  -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+                  -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [reversion @ reversion!($args, $inner, $extra, $body)]})
   };
   (@reversion (sub $body:block $($next:tt)*)
-      -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+      -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [reversion @ reversion!(_args, _inner, _extra, $body)]})
   };
   (@predigest (
     sub[$whatsit:ident, $extra:ident] $body:block $($next:tt)* )
-      -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+      -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [predigest @ predigest!($whatsit, $extra, $body)]})
   };
   (@predigest (
     sub[$whatsit:ident] $body:block $($next:tt)* )
-      -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+      -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [predigest @ predigest!($whatsit, $body)]})
   };
   (@predigest (
-    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr])*}) => {
+    $body:block $($next:tt)* ) -> {$kind:ident, $([$key:ident @ $val:expr_2021])*}) => {
     defi_opts!(@munch ($($next)*) -> {$kind, $([$key @ $val])*
       [predigest @ predigest!( _whatsit,$body)]})
   };

--- a/latexml_engine/src/tex_box.rs
+++ b/latexml_engine/src/tex_box.rs
@@ -29,7 +29,7 @@ fn hack_vbox_attachment(whatsit: &mut Whatsit, valign: &'static str) {
 /// Returns false if no \halign alignment was found.
 fn set_halign_vattach(digested: &Digested, valign: &str) -> bool {
   match digested.data() {
-    DigestedData::Whatsit(ref w) => {
+    DigestedData::Whatsit(w) => {
       let w_ref = w.borrow();
       if w_ref.get_property("alignment").is_some() {
         // Check if this whatsit's definition is \halign
@@ -37,7 +37,7 @@ fn set_halign_vattach(digested: &Digested, valign: &str) -> bool {
         let is_halign = *def.get_cs_name() == *"\\halign";
         if is_halign {
           // Get the alignment property value and set vattach on it
-          if let Some(Cow::Borrowed(Stored::Digested(ref alignment_dig))) =
+          if let Some(Cow::Borrowed(Stored::Digested(alignment_dig))) =
             w_ref.get_property("alignment")
           {
             if let DigestedData::Alignment(ref alignment_cell) = *alignment_dig.data() {
@@ -54,7 +54,7 @@ fn set_halign_vattach(digested: &Digested, valign: &str) -> bool {
       }
       false
     },
-    DigestedData::List(ref list_cell) => {
+    DigestedData::List(list_cell) => {
       // Walk children to find a \halign
       let children = list_cell.borrow().unlist();
       for child in children.iter() {
@@ -96,7 +96,7 @@ fn fobj_get_size(digested: &Digested) -> (Dimension, Dimension, Dimension) {
     return dims;
   }
   // If zero dims: for Lists, sum children's dimensions
-  if let DigestedData::List(ref list_cell) = digested.data() {
+  if let DigestedData::List(list_cell) = digested.data() {
     if let Ok(list) = list_cell.try_borrow() {
       let mut total_w: i64 = 0;
       let mut max_h: i64 = 0;
@@ -344,9 +344,9 @@ LoadDefinitions!({
     before_digest => { bgroup(); },
     capture_body => true,
     reversion => sub[whatsit, _args] {
-      if let Some(body) = whatsit.get_body()? {
+      match whatsit.get_body()? { Some(body) => {
         body.revert()
-      } else { Ok(Tokens!()) }
+      } _ => { Ok(Tokens!()) }}
     }
   );
   DefConstructor!("\\lx@hidden@egroup", "",
@@ -361,9 +361,9 @@ LoadDefinitions!({
     before_digest => { bgroup(); },
     capture_body => true,
     reversion=> sub[whatsit,_args] {
-      if let Some(body) = whatsit.get_body()? {
+      match whatsit.get_body()? { Some(body) => {
         body.revert()
-      } else { Ok(Tokens!()) }
+      } _ => { Ok(Tokens!()) }}
     }
   );
   DefConstructor!("\\@hidden@egroup", "",
@@ -550,7 +550,7 @@ LoadDefinitions!({
     let newtag = if is_svg { "svg:g" }
       else if vmode { if inline { "ltx:inline-block" } else { "ltx:p" } }
       else { "ltx:text" };
-    let width : String = if let Some(Stored::Dimension(ref w)) = props.get("width") {
+    let width : String = if let Some(Stored::Dimension(w)) = props.get("width") {
       w.to_attribute()
     } else {
       String::new()
@@ -908,21 +908,21 @@ LoadDefinitions!({
   // Perl: \box does NOT call enterHorizontal (TeX_Box.pool.ltxml line 647)
   DefPrimitive!("\\box Number", sub[(number)] {
     let box_key = s!("box{}", number.value_of());
-    if let Some(Stored::Digested(stuff)) = state::remove_value(&box_key) {
+    match state::remove_value(&box_key) { Some(Stored::Digested(stuff)) => {
       Ok(vec![stuff])
-    } else {
+    } _ => {
       Ok(Vec::new())
-    }
+    }}
   });
 
   // Perl: \copy does NOT call enterHorizontal (TeX_Box.pool.ltxml line 653)
   DefPrimitive!("\\copy Number", sub[(number)] {
     let box_key = s!("box{}", number.value_of());
-    if let Some(Stored::Digested(stuff)) = lookup_value(&box_key) {
+    match lookup_value(&box_key) { Some(Stored::Digested(stuff)) => {
       Ok(vec![stuff])
-    } else {
+    } _ => {
       Ok(Vec::new())
-    }
+    }}
   });
 
   // \unhbox<8bit>, \unhcopy<8bit>
@@ -930,7 +930,7 @@ LoadDefinitions!({
   DefPrimitive!("\\unhbox Number", sub[(number)] {
     enter_horizontal();
     let box_key = s!("box{}", number.value_of());
-    if let Some(Stored::Digested(stuff)) = state::remove_value(&box_key) {
+    match state::remove_value(&box_key) { Some(Stored::Digested(stuff)) => {
       // Only unlist if box is horizontal (mode ends with "horizontal")
       let mode = stuff.get_property_string("mode");
       if mode.ends_with("horizontal") {
@@ -938,24 +938,24 @@ LoadDefinitions!({
       } else {
         Ok(vec![stuff])
       }
-    } else {
+    } _ => {
       Ok(Vec::new())
-    }
+    }}
   });
 
   DefPrimitive!("\\unhcopy Number", sub[(number)] {
     enter_horizontal();
     let box_key = s!("box{}", number.value_of());
-    if let Some(Stored::Digested(stuff)) = lookup_value(&box_key) {
+    match lookup_value(&box_key) { Some(Stored::Digested(stuff)) => {
       let mode = stuff.get_property_string("mode");
       if mode.ends_with("horizontal") {
         Ok(stuff.unlist())
       } else {
         Ok(vec![stuff])
       }
-    } else {
+    } _ => {
       Ok(Vec::new())
-    }
+    }}
   });
 
   // \unvbox<8bit>, \unvcopy<8bit>
@@ -963,7 +963,7 @@ LoadDefinitions!({
   DefPrimitive!("\\unvbox Number", sub[(number)] {
     leave_horizontal()?;
     let box_key = s!("box{}", number.value_of());
-    if let Some(Stored::Digested(stuff)) = state::remove_value(&box_key) {
+    match state::remove_value(&box_key) { Some(Stored::Digested(stuff)) => {
       // Only unlist if box is vertical (mode ends with "vertical")
       let mode = stuff.get_property_string("mode");
       if mode.ends_with("vertical") {
@@ -971,25 +971,25 @@ LoadDefinitions!({
       } else {
         Ok(vec![stuff])
       }
-    } else {
+    } _ => {
       Ok(Vec::new())
-    }
+    }}
   });
 
   // Perl: $stomach->leaveHorizontal (TeX_Box.pool.ltxml line 693)
   DefPrimitive!("\\unvcopy Number", sub[(number)] {
     leave_horizontal()?;
     let box_key = s!("box{}", number.value_of());
-    if let Some(Stored::Digested(stuff)) = lookup_value(&box_key) {
+    match lookup_value(&box_key) { Some(Stored::Digested(stuff)) => {
       let mode = stuff.get_property_string("mode");
       if mode.ends_with("vertical") {
         Ok(stuff.unlist())
       } else {
         Ok(vec![stuff])
       }
-    } else {
+    } _ => {
       Ok(Vec::new())
-    }
+    }}
   });
 
   //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1085,7 +1085,7 @@ LoadDefinitions!({
     let w_pt = width.map(|d| d.value_of() as f64 / 65536.0);
     let h_pt = height.map(|d| d.value_of() as f64 / 65536.0);
 
-    if let Some(_alignment) = lookup_alignment() {
+    match lookup_alignment() { Some(_alignment) => {
       // Perl: set isVerticalRule only if dimensions suggest a real rule
       let dominated_by_height = match (h_pt, w_pt) {
         (None, None) => true,
@@ -1096,9 +1096,9 @@ LoadDefinitions!({
       if dominated_by_height {
         whatsit.set_property("isVerticalRule", true);
       }
-    } else if w_pt == Some(0.0) {
+    } _ => if w_pt == Some(0.0) {
       whatsit.set_property("invisible", true);
-    }
+    }}
     // Set color from current font (Perl: only if NOT black)
     if let Some(font) = lookup_font() {
       if let Some(color) = font.color {
@@ -1195,13 +1195,13 @@ LoadDefinitions!({
     noautoclose_attrs.insert(String::from("_noautoclose"), String::from("1"));
     let mut container = document.open_element("ltx:text", Some(noautoclose_attrs), None)?;
 
-    if let Some(ref filler_d) = filler {
+    if let Some(filler_d) = filler {
       document.absorb(filler_d, None)?;
     }
 
     // Check if we should extend a rule to fill the requested width
     let mut unwrap = false;
-    if let (Some(_), Some(ref rw)) = (&cbox, &req_width) {
+    if let (Some(_), Some(rw)) = (&cbox, &req_width) {
       // Find the last child of the container — should be the absorbed rule
       if let Some(mut fnode) = container.get_last_child() {
         let qname = fnode.get_name();

--- a/latexml_engine/src/tex_file_io.rs
+++ b/latexml_engine/src/tex_file_io.rs
@@ -89,7 +89,7 @@ LoadDefinitions!({
     let mut finished = false;
     //   close the mouth (if any) and clear the variable
     with_value(&file_key, |mouth_opt|
-      if let Some(Stored::Mouth(ref mouth)) = mouth_opt {
+      if let Some(Stored::Mouth(mouth)) = mouth_opt {
         mouth.borrow_mut().finish();
         finished = true;
       });
@@ -299,7 +299,7 @@ LoadDefinitions!({
       // Map psfile-style options to graphicx-style. Perl L282-311.
       let mut options_vec: Vec<String> = Vec::new();
       if let Some(ref kv_digested) = args[0] {
-        if let DigestedData::KeyVals(ref kv) = kv_digested.data() {
+        if let DigestedData::KeyVals(kv) = kv_digested.data() {
           let mut h_off: f64 = 0.0;
           let mut v_off: f64 = 0.0;
           for (key, value) in kv.get_pairs() {

--- a/latexml_engine/src/tex_inserts.rs
+++ b/latexml_engine/src/tex_inserts.rs
@@ -25,12 +25,12 @@ LoadDefinitions!({
   DefPrimitive!("\\vsplit Number Match:to Dimension", sub[(number,_to,_dimension)] {
     // analog to \box for now.
     let box_key   = s!("box{}", number.value_of());
-    if let Some(Stored::Digested(stuff)) = lookup_value(&box_key) {
+    match lookup_value(&box_key) { Some(Stored::Digested(stuff)) => {
       adjust_box_color(&stuff)?;
       if stuff.is_empty()? { Digested::from(List::default()) } else { stuff }
-    } else {
+    } _ => {
       Digested::from(List::default())
-    }
+    }}
   });
   DefMacro!(T_CS!("\\splitfirstmark"), None, Tokens!());
   DefMacro!(T_CS!("\\splitbotmark"), None, Tokens!());

--- a/latexml_engine/src/tex_kern.rs
+++ b/latexml_engine/src/tex_kern.rs
@@ -89,8 +89,8 @@ LoadDefinitions!({
           if box_in_list.get_property_bool("isKern") {
             let width_stored = box_in_list.get_property("width").unwrap();
             match &*width_stored {
-              Stored::Dimension(ref width_d) => return *width_d,
-              Stored::Digested(ref d) => {
+              Stored::Dimension(width_d) => return *width_d,
+              Stored::Digested(d) => {
                 if let DigestedData::RegisterValue(RegisterValue::Dimension(dim)) = d.data() {
                   return *dim;
                 }

--- a/latexml_engine/src/tex_macro.rs
+++ b/latexml_engine/src/tex_macro.rs
@@ -168,14 +168,14 @@ LoadDefinitions!({
         Error!("expected", "expandafter", "\\expandafter wrongly used without 2 arguments.");
       }
     }
-    if let Some(defn) = lookup_expandable(&xtok, None)? {
+    match lookup_expandable(&xtok, None)? { Some(defn) => {
       state::local_current_token(xtok);
       let invoked = defn.invoke(true)?;
       if !invoked.is_empty() {
         skipped.extend(invoked.unlist()); // Expand `xtok` ONCE ONLY!
       }
       state::expire_current_token();
-    } else if !has_meaning(&xtok) {
+    } _ => if !has_meaning(&xtok) {
       // Undefined token is an error, as expansion is expected.
       // BUT The unknown token is NOT consumed, (see TeX B book, item 367)
       // since probably in a real TeX run it would have been defined.
@@ -183,7 +183,7 @@ LoadDefinitions!({
       skipped.push(xtok);
     } else {
       skipped.push(xtok);
-    };
+    }};
     Ok(Tokens::new(skipped))
   });
   // If next token is expandable, prefix it with the internal marker \dont_expand
@@ -243,7 +243,7 @@ LoadDefinitions!({
           _ => break,
         }
       }
-      if let Some(defn) = lookup_definition(&effective_token)? {
+      match lookup_definition(&effective_token)? { Some(defn) => {
         if defn.is_register() {
           // SOME kind of register is acceptable
           let args = if let Some(params) = defn.get_parameters() {
@@ -259,11 +259,11 @@ LoadDefinitions!({
           };
         } else if defn.get_cs_name() == "\\font" {
           // HACK to get the \fontcmd that would have selected the current font (see FontDef)
-          if let Some(Stored::Token(t)) = state::lookup_value("current_FontDef") {
+          match state::lookup_value("current_FontDef") { Some(Stored::Token(t)) => {
             return Ok(Tokens!(t));
-          } else {
+          } _ => {
             return Ok(Tokens!(T_CS!("\\lx@default@font")));
-          }
+          }}
         } else {
           // Perl: elsif ($defn->isFontDef) { return $defn->getCS; }
           // Check if this is a font CS defined by \font (has fontinfo in state)
@@ -272,7 +272,7 @@ LoadDefinitions!({
             return Ok(Tokens!(token));
           }
         }
-      } else {
+      } _ => {
         // the token is Undefined
         if token.get_catcode() == Catcode::CS {
           // but IS a cs \something
@@ -286,7 +286,7 @@ LoadDefinitions!({
           def_register(token, None, Number!(0), None)?; // Dimension, or what?
           return Ok(Tokens!(T_OTHER!("0")));
         }
-      }
+      }}
       // If we fall through to here, whatever $token is shouldn't have been used with \the
       let (the_t, msg) =
         token.with_str(|tstr| (s!("\\the{tstr}"), s!("You can't use {tstr} after \\the")));

--- a/latexml_engine/src/tex_math.rs
+++ b/latexml_engine/src/tex_math.rs
@@ -61,7 +61,7 @@ pub fn is_script(object: &Digested) -> Option<(String, Catcode)> {
     _ => Some(Cow::Borrowed(object)),
   };
   if let Some(boxobj) = box_opt {
-    if let DigestedData::Whatsit(ref obj) = boxobj.data() {
+    if let DigestedData::Whatsit(obj) = boxobj.data() {
       obj.borrow().get_definition().get_cs().with_cs_name(|name| {
         SCRIPT_NAME_RE.captures(name).map(|cap| {
           (
@@ -224,7 +224,7 @@ fn script_handler(cc: Catcode) -> Result<Vec<Digested>> {
       if let Some(pvs) = prevscript {
         properties.insert("prevscript", pvs.into());
       }
-      if let Some(Stored::Digested(ref b)) = properties.get("base") {
+      if let Some(Stored::Digested(b)) = properties.get("base") {
         if let Some(bsp) = b.get_property("scriptpos") {
           let bsp_str = bsp.to_string();
           if !bsp_str.is_empty() {
@@ -328,7 +328,7 @@ fn script_sizer(
     script_size.1.value_of() as f64,
     script_size.2.value_of() as f64,
   );
-  let (base_font_size, mathstyle) = if let Some(Stored::Digested(ref base)) = base_opt {
+  let (base_font_size, mathstyle) = if let Some(Stored::Digested(base)) = base_opt {
     let bfont = base.get_font()?.map(|f| f.into_owned());
     let fs = bfont.as_ref().and_then(|f| f.get_size()).unwrap_or(10.0);
     let ms = bfont
@@ -346,7 +346,7 @@ fn script_sizer(
       .unwrap_or_else(|| "text".to_string());
     (fs, ms)
   };
-  let (_wb, hb, db) = if let Some(Stored::Digested(ref base)) = base_opt {
+  let (_wb, hb, db) = if let Some(Stored::Digested(base)) = base_opt {
     let base_size = base.clone().get_size(None)?;
     (
       base_size.0.value_of() as f64,
@@ -378,7 +378,7 @@ fn script_sizer(
     lookup(&cmsy_name).or_else(|| lookup("cmsy")).unwrap_or(0.0) * base_font_size
   };
   let xheight = get_font_dimen(5);
-  let inferred_pos = if let Some(Stored::Digested(ref base)) = base_opt {
+  let inferred_pos = if let Some(Stored::Digested(base)) = base_opt {
     let base_pos = base
       .get_property("scriptpos")
       .map(|s| s.to_string())
@@ -407,7 +407,7 @@ fn script_sizer(
       d = db + hs + ds;
     }
   } else {
-    let wp = if let Some(Stored::Digested(ref prev)) = prev_opt {
+    let wp = if let Some(Stored::Digested(prev)) = prev_opt {
       prev.get_width(None)?.unwrap_or_default().value_of() as f64
     } else {
       0.0
@@ -603,8 +603,8 @@ LoadDefinitions!({
     if !node.has_attribute("tex") {
       // only do this once.
 
-      let tex_opt = if let Some(ref tbox) = document.get_node_box(node) {
-        if let Some(body) = tbox.get_body()? {
+      let tex_opt = match document.get_node_box(node) { Some(ref tbox) => {
+        match tbox.get_body()? { Some(body) => {
           set_dual_branch("presentation");
           let tex = body.untex()?;
           expire_dual_branch();
@@ -615,12 +615,12 @@ LoadDefinitions!({
             document.set_attribute(node, "content-tex", &ctex)?;
           }
           Some(tex)
-        } else {
+        } _ => {
           None
-        }
-      } else {
+        }}
+      } _ => {
         None
-      };
+      }};
       if let Some(tex_string) = tex_opt {
         document.set_attribute(node, "tex", &tex_string)?;
       }
@@ -1000,7 +1000,7 @@ LoadDefinitions!({
         // Look up math_token_attributes for the delimiter character.
         let char_str = entry.char.to_string();
         state::with_value(&format!("math_token_attributes_{}", char_str), |val| {
-          if let Some(Stored::HashString(ref attrs)) = val {
+          if let Some(Stored::HashString(attrs)) = val {
             if let Some(meaning) = attrs.get("meaning") {
               whatsit.set_property("meaning", meaning.clone());
             }
@@ -1051,7 +1051,7 @@ LoadDefinitions!({
         // Preserve meaning from DefMath
         let char_str = entry.char.to_string();
         state::with_value(&format!("math_token_attributes_{}", char_str), |val| {
-          if let Some(Stored::HashString(ref attrs)) = val {
+          if let Some(Stored::HashString(attrs)) = val {
             if let Some(meaning) = attrs.get("meaning") {
               whatsit.set_property("meaning", meaning.clone());
             }
@@ -1381,7 +1381,7 @@ LoadDefinitions!({
       // semantics) with \@left/\@right (Constructors without grouping).
       for (key, val_opt) in [("left", &left_val), ("right", &right_val)] {
         if let Some(val) = val_opt {
-          if let ArgWrap::Tokens(ref ts) = val {
+          if let ArgWrap::Tokens(ts) = val {
             // Rewrite tokens: replace any left/right CS with \@left/\@right
             let mut new_tokens = Vec::new();
             for tok in ts.unlist_ref().iter() {
@@ -2160,7 +2160,7 @@ fn adjust_mathstyle_internal(outerstyle: &str, tbox: &mut Tbox) {
 
 /// Adjust a Whatsit's font mathstyle, returning the new style if it had a mathstyle property
 fn adjust_mathstyle_internal_whatsit(outerstyle: &str, whatsit: &mut Whatsit) -> Option<String> {
-  if let Some(Stored::Font(ref font)) = whatsit.properties.get("font") {
+  if let Some(Stored::Font(font)) = whatsit.properties.get("font") {
     let origstyle = font.mathstyle.as_deref().unwrap_or("display").to_string();
     let newstyle = mathstyle_adjust(outerstyle, &origstyle);
     if newstyle != origstyle {

--- a/latexml_engine/src/tex_paragraph.rs
+++ b/latexml_engine/src/tex_paragraph.rs
@@ -174,12 +174,12 @@ LoadDefinitions!({
           { state::assign_value("next_para_class", "ltx_noindent", None); }
         }
         // Vertical adjustments
-        if let Some(Stored::Tokens(vadj)) = { state::remove_value("vAdjust") } {
+        match { state::remove_value("vAdjust") } { Some(Stored::Tokens(vadj)) => {
           state::assign_value("vAdjust", Tokens!(), Some(Scope::Global));
           Ok(vec![ Digest!(vadj)? ])
-        } else {
+        } _ => {
           Ok(Vec::new())
-        }
+        }}
       }
     },
     properties => skippable_props,

--- a/latexml_engine/src/tex_registers.rs
+++ b/latexml_engine/src/tex_registers.rs
@@ -121,15 +121,15 @@ LoadDefinitions!({
     if let ArgWrap::RegisterDefinition(dbox) = var {
       let (varname, inner) = *dbox;
       // Upgrade: Why are the arguments used twice here? Is there a way to avoid cloning them?
-      if let Some(defn) = state::lookup_register_definition(&varname) {
+      match state::lookup_register_definition(&varname) { Some(defn) => {
         let defn_args : Vec<ArgWrap> = inner.clone();
         let defn_value = defn.value_of(inner).unwrap_or_default();
         defn.set_value(defn_value.multiply(scale), None, defn_args);
-      } else {
+      } _ => {
         let message =
           s!("\\multiply expected a defined variable for {:?}, found no definition", varname);
         Error!("expected","definition", message);
-      }
+      }}
     } else {
       let message = s!("\\multiply expected a Variable argument, but got nothing.");
       Error!("expected","variable", message);
@@ -141,7 +141,7 @@ LoadDefinitions!({
       let (varname, inner) = *dbox;
       // Upgrade: Why are the arguments used twice here? Is there a way to avoid cloning them?
       let defn_args : Vec<ArgWrap> = inner.clone();
-      if let Some(defn) = state::lookup_register_definition(&varname) {
+      match state::lookup_register_definition(&varname) { Some(defn) => {
         let defn_value = defn.value_of(inner).unwrap_or_default();
         let mut denominator = scale.value_f64();
         if denominator == 0.0 {
@@ -149,11 +149,11 @@ LoadDefinitions!({
           denominator = 1.0;
         }
         defn.set_value(defn_value.divide(Float::new_f64(denominator)), None, defn_args);
-      } else {
+      } _ => {
         let message =
           s!("\\divide expected a defined variable for {:?}, found no definition", varname);
         Error!("expected","definition", message);
-      }
+      }}
     } else {
       let message = s!("\\divide expected a Variable argument, but got nothing.");
       Error!("expected","variable", message);

--- a/latexml_engine/src/tex_tables.rs
+++ b/latexml_engine/src/tex_tables.rs
@@ -25,7 +25,7 @@ LoadDefinitions!({
   // when \begin{aligned} is nested inside \begin{align}.
   DefConstructor!("\\lx@begin@alignment", "#alignment",
     reversion => sub[whatsit,_args] {
-      if let Some(Stored::Digested(alignment)) = whatsit.get_property("alignment").as_deref() {
+      match whatsit.get_property("alignment").as_deref() { Some(Stored::Digested(alignment)) => {
         if let DigestedData::Alignment(data) = alignment.data() {
           // Use try_borrow: nested array inside a delimited expression
           // (e.g. `\left( \begin{array}{ccc} ... \end{array} \right)`)
@@ -43,9 +43,9 @@ LoadDefinitions!({
         } else {
           Ok(Tokens!())
         }
-      } else {
+      } _ => {
         Ok(Tokens!())
-      }},
+      }}},
     sizer => "#alignment",
     after_digest => sub[whatsit] {
       bgroup();
@@ -263,12 +263,12 @@ LoadDefinitions!({
   bounded => true,
   leave_horizontal => true,
   sizer => sub[whatsit] {
-    if let Some(Stored::Digested(alignment_d)) = whatsit.get_property("alignment").as_deref() {
+    match whatsit.get_property("alignment").as_deref() { Some(Stored::Digested(alignment_d)) => {
       let (w, h, d, _, _, _) = alignment_d.clone().get_size(None)?;
       Ok((w, h, d))
-    } else {
+    } _ => {
       Ok((Dimension::default(), Dimension::default(), Dimension::default()))
-    }
+    }}
   },
   before_construct => sub[document, _whatsit] {
     document.maybe_close_element("ltx:p")?;
@@ -296,8 +296,8 @@ LoadDefinitions!({
     // variant; the inner Rc<Digested> + RefCell<Alignment> mutation
     // still works fine through the borrow.
     state::with_value("Alignment", |v| {
-      if let Some(Stored::Digested(ref d)) = v {
-        if let latexml_core::digested::DigestedData::Alignment(ref alignment) = d.data() {
+      if let Some(Stored::Digested(d)) = v {
+        if let latexml_core::digested::DigestedData::Alignment(alignment) = d.data() {
           alignment.borrow_mut().is_halign = true;
         }
       }
@@ -496,25 +496,25 @@ LoadDefinitions!({
   // Perl: DefRegisterI('\lx@alignment@ncolumns', undef, Dimension(0), getter => sub { ... })
   DefRegister!("\\lx@alignment@ncolumns", Number::new(0),
     getter => {
-      if let Some(alignment_stored) = lookup_alignment() {
+      match lookup_alignment() { Some(alignment_stored) => {
         let data = alignment_stored.alignment_cell().unwrap();
         let borrowed = data.borrow();
         Number::new(borrowed.get_template().get_columns().len() as i64)
-      } else {
+      } _ => {
         Number::new(0)
-      }
+      }}
     }
   );
   // Perl: DefRegisterI('\lx@alignment@column', undef, Dimension(0), getter => sub { ... })
   DefRegister!("\\lx@alignment@column", Number::new(0),
     getter => {
-      if let Some(alignment_stored) = lookup_alignment() {
+      match lookup_alignment() { Some(alignment_stored) => {
         let data = alignment_stored.alignment_cell().unwrap();
         let borrowed = data.borrow();
         Number::new(borrowed.current_column_number() as i64)
-      } else {
+      } _ => {
         Number::new(0)
-      }
+      }}
     }
   );
 
@@ -645,16 +645,16 @@ pub fn digest_alignment_body(whatsit: &mut Whatsit) -> Result<()> {
   // Note that the body MUST end with a \cr, and that we've made Special Arrangments
   // with \alignment@cr to recognize the end of the \halign
   local_align_group_count(0);
-  let alignment_stored = if let Some(alignment) = lookup_alignment() {
+  let alignment_stored = match lookup_alignment() { Some(alignment) => {
     alignment
-  } else {
+  } _ => {
     Error!(
       "missing",
       "alignment",
       "There is no open alignment structure here"
     );
     return Ok(());
-  };
+  }};
   local_reading_alignment(&alignment_stored);
   whatsit.set_property("alignment", Stored::Digested(alignment_stored.clone()));
 

--- a/latexml_math_parser/Cargo.toml
+++ b/latexml_math_parser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "latexml_math_parser"
 version = "0.3.0"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
-edition = "2021"
+edition = "2024"
 
 [lib]
 name = "latexml_math_parser"

--- a/latexml_math_parser/src/diag.rs
+++ b/latexml_math_parser/src/diag.rs
@@ -20,30 +20,30 @@
 
 #[macro_export]
 macro_rules! log_math_error {
-  ($category:expr, $object:expr, $msg:expr) => {
+  ($category:expr_2021, $object:expr_2021, $msg:expr_2021) => {
     log::error!(target: &format!("{}:{}", $category, $object), "{}", $msg)
   };
-  ($category:expr, $object:expr, $fmt:expr, $($arg:tt)+) => {
+  ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {
     log::error!(target: &format!("{}:{}", $category, $object), $fmt, $($arg)+)
   };
 }
 
 #[macro_export]
 macro_rules! log_math_warn {
-  ($category:expr, $object:expr, $msg:expr) => {
+  ($category:expr_2021, $object:expr_2021, $msg:expr_2021) => {
     log::warn!(target: &format!("{}:{}", $category, $object), "{}", $msg)
   };
-  ($category:expr, $object:expr, $fmt:expr, $($arg:tt)+) => {
+  ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {
     log::warn!(target: &format!("{}:{}", $category, $object), $fmt, $($arg)+)
   };
 }
 
 #[macro_export]
 macro_rules! log_math_info {
-  ($category:expr, $object:expr, $msg:expr) => {
+  ($category:expr_2021, $object:expr_2021, $msg:expr_2021) => {
     log::info!(target: &format!("{}:{}", $category, $object), "{}", $msg)
   };
-  ($category:expr, $object:expr, $fmt:expr, $($arg:tt)+) => {
+  ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {
     log::info!(target: &format!("{}:{}", $category, $object), $fmt, $($arg)+)
   };
 }

--- a/latexml_math_parser/src/parser.rs
+++ b/latexml_math_parser/src/parser.rs
@@ -997,7 +997,7 @@ impl MathParser {
     // $xnode)) {     my $id = $n->getAttribute('xml:id');
     //     $LaTeXML::MathParser::IDREFS{$id} = $n; }
     let mut p = xnode.get_parent().unwrap();
-    if let Some(result) = self.parse_rec(xnode, "Anything,", document)? {
+    match self.parse_rec(xnode, "Anything,", document)? { Some(result) => {
       // Add text representation to the containing Math element.
 
       // This is a VERY screwy situation? How can the parent be a document fragment??
@@ -1036,12 +1036,12 @@ impl MathParser {
       // ($document->findnodes("descendant-or-self::ltx:XMRef[\@idref='$id']", $p)) {
       // $document->setAttribute($n, idref => $repid); } } }
       p.set_attribute("text", &text_form(&result, document))?;
-    } else if let Some(text) = p
+    } _ => if let Some(text) = p
       .get_attribute("tex")
       .and_then(|tex| TEX_TEXT_FALLBACK.get(tex.as_str()))
     {
       p.set_attribute("text", text)?;
-    }
+    }}
     Ok(())
   }
 
@@ -1070,7 +1070,7 @@ impl MathParser {
     if rule == "kludge" {
       self.parse_kludge(&mut node, document);
       Ok(None)
-    } else if let Some(mut result) = self.parse_single(&mut node, document, &rule)? {
+    } else { match self.parse_single(&mut node, document, &rule)? { Some(mut result) => {
       *self.passed.entry_sym(tag).or_insert(0) += 1;
       if tag == pin!("ltx:XMath") {
         // Replace the content of XMath with parsed result
@@ -1150,7 +1150,7 @@ impl MathParser {
         }
       }
       Ok(Some(result))
-    } else {
+    } _ => {
       // Parse failed — run kludge to wrap OPEN/CLOSE delimiters
       *self.failed.entry_sym(tag).or_insert(0) += 1;
       if tag == pin!("ltx:XMath") {
@@ -1159,7 +1159,7 @@ impl MathParser {
         // using failed_xmath_ids to find the failed nodes.
       }
       Ok(None)
-    }
+    }}}
   }
 
   // Depth first parsing of XMArg nodes.
@@ -1179,14 +1179,14 @@ impl MathParser {
           if saved_role.is_some() {
             c.remove_attribute("role").ok();
           }
-          if let Some(mut result) = self.parse_rec(child, "Anything", document)? {
+          match self.parse_rec(child, "Anything", document)? { Some(mut result) => {
             if let Some(ref role) = saved_role {
               result.set_attribute("role", role).ok();
             }
-          } else if let Some(ref role) = saved_role {
+          } _ => if let Some(ref role) = saved_role {
             // Parse failed — XMWrap still in DOM, restore role
             c.set_attribute("role", role).ok();
-          }
+          }}
         } else {
           self.parse_rec(child, "Anything", document)?;
         }
@@ -1574,7 +1574,7 @@ impl MathParser {
           #[allow(clippy::drop_non_drop)]
           drop(traverser);
           record_ambiguity_metric(1, input);
-          let tree_outcome = if let Some(val) = tree_iter.next() {
+          let tree_outcome = match tree_iter.next() { Some(val) => {
             match self.actions.get_tree(
               self.builder.clone(),
               val,
@@ -1585,9 +1585,9 @@ impl MathParser {
               Ok(None) => ParseOutcome::Empty,
               Err(prune_err) => ParseOutcome::Rejected(prune_err.to_string()),
             }
-          } else {
+          } _ => {
             ParseOutcome::Empty
-          };
+          }};
           debug_assert!(
             tree_iter.next().is_none(),
             "hybrid unambiguous branch should expose exactly one raw tree"
@@ -2644,11 +2644,11 @@ fn textrec_array(node: &Node, document: &Document) -> String {
       let cells: Vec<String> = element_nodes(&row)
         .into_iter()
         .map(|cell| {
-          if let Some(first_child) = cell.get_first_child() {
+          match cell.get_first_child() { Some(first_child) => {
             textrec(&first_child, None, None, document)
-          } else {
+          } _ => {
             String::new()
-          }
+          }}
         })
         .collect();
       format!("[{}]", cells.join(", "))

--- a/latexml_math_parser/src/pragmatics.rs
+++ b/latexml_math_parser/src/pragmatics.rs
@@ -179,11 +179,11 @@ impl ValidationPragmatics {
           self.validate_recursive(arg_subtree)?;
         }
       },
-      XM::Dual(ref content, ref pres, ..) => {
+      XM::Dual(content, pres, ..) => {
         self.validate_recursive(content)?;
         self.validate_recursive(pres)?;
       },
-      XM::Wrap(ref items, ..) => {
+      XM::Wrap(items, ..) => {
         for item in items.iter() {
           self.validate_recursive(item)?;
         }
@@ -423,7 +423,7 @@ fn pragma_consistent_letter_case_flat_unstyled(tree: &XM) -> Result<(), Box<dyn 
 
 fn pragma_fenced_atoms_are_not_functions(tree: &XM) -> Result<(), Box<dyn Error>> {
   if let XM::Apply(Operator(op), ..) = tree {
-    if let XM::Lexeme(ref _lexeme, ref atom_meta) = &**op {
+    if let XM::Lexeme(_lexeme, atom_meta) = &**op {
       if let Some(ref fences) = atom_meta.fenced {
         if fences.as_str() == "parens" {
           return Err(
@@ -442,7 +442,7 @@ fn pragma_fenced_letters_are_function_arguments(tree: &XM) -> Result<(), Box<dyn
   // ambiguous forest; this pragma chooses the mathematically-consistent one
   // unconditionally. MATHPARSER_SPECULATE has no role here — the decision is
   // a pragmatic preference, not a grammar switch.
-  let XM::Apply(Operator(op), ref args, ..) = tree else {
+  let XM::Apply(Operator(op), args, ..) = tree else {
     return Ok(());
   };
   if !is_invisible_times_op(op) {
@@ -531,7 +531,7 @@ fn pragma_fenced_letters_are_function_arguments(tree: &XM) -> Result<(), Box<dyn
 /// `kind` is the fence-pair category for diagnostics:
 /// "parens" / "brackets" / "vertbars".
 fn is_dual_fenced_rhs(top_rhs: &XM, top_lhs: Option<&XM>) -> Option<&'static str> {
-  let XM::Dual(_, ref presentation, ..) = top_rhs else {
+  let XM::Dual(_, presentation, ..) = top_rhs else {
     return None;
   };
   let XM::Wrap(ref items, ..) = **presentation else {
@@ -695,10 +695,10 @@ fn pragma_opfunctions_are_rarely_arguments(tree: &XM) -> Result<(), Box<dyn Erro
 /// Mostly since we can't enforce IDs to strictly have "curry=1", rather
 /// we need them with "curry >= 1", to stay a little more lenient.
 fn pragma_higher_order_ids_are_exceptions(tree: &XM) -> Result<(), Box<dyn Error>> {
-  if let XM::Apply(ref op, ref args, ..) = tree {
+  if let XM::Apply(op, args, ..) = tree {
     if args.0.len() == 1 {
       match &*op.0 {
-        XM::Lexeme(ref op_name, _) if op_name.starts_with("ID:") => match args.0[0] {
+        XM::Lexeme(op_name, _) if op_name.starts_with("ID:") => match args.0[0] {
           Some(XM::Lexeme(ref rhs_name, ref rhs_meta)) => {
             if rhs_name.starts_with("FUNCTION") && rhs_meta.fenced.is_none() {
               return Err("ID of a higher order than a FUNCTION is not allowed.".into());
@@ -724,7 +724,7 @@ fn pragma_higher_order_ids_are_exceptions(tree: &XM) -> Result<(), Box<dyn Error
 /// A right-associative application h(f(x,y)) is instead.
 /// Prune it out if possible.
 fn pragma_higher_order_invisible_ops_are_exceptions(tree: &XM) -> Result<(), Box<dyn Error>> {
-  let XM::Apply(Operator(op), ref args, ..) = tree else {
+  let XM::Apply(Operator(op), args, ..) = tree else {
     return Ok(());
   };
   if !is_invisible_times_op(op) {
@@ -734,8 +734,8 @@ fn pragma_higher_order_invisible_ops_are_exceptions(tree: &XM) -> Result<(), Box
   if trees.len() == 2 {
     let lhs = trees[0];
     let rhs = trees[1];
-    if let XM::Lexeme(ref lhs_name, _) = lhs.get_baseline() {
-      if let XM::Lexeme(ref rhs_name, _) = rhs.get_baseline() {
+    if let XM::Lexeme(lhs_name, _) = lhs.get_baseline() {
+      if let XM::Lexeme(rhs_name, _) = rhs.get_baseline() {
         if name_is_functional_or_id(lhs_name) && name_is_functional(rhs_name) {
           return Err(
             "Pruning higher order 'FUNCTION x FUNCTION' parse to give precedence to \
@@ -753,7 +753,7 @@ fn pragma_higher_order_invisible_ops_are_exceptions(tree: &XM) -> Result<(), Box
 /// that they are to be multiplied Prune such parses. We have special rules for some notations, such
 /// as "dlmf_range".
 fn pragma_adjacent_numbers_dont_use_invisible_times(tree: &XM) -> Result<(), Box<dyn Error>> {
-  let XM::Apply(Operator(op), ref args, ..) = tree else {
+  let XM::Apply(Operator(op), args, ..) = tree else {
     return Ok(());
   };
   if !is_invisible_times_op(op) {
@@ -778,10 +778,10 @@ fn pragma_adjacent_numbers_dont_use_invisible_times(tree: &XM) -> Result<(), Box
 /// The only case (that I currently know) of a standalone "d" is in the Lebnitz derivative notation.
 /// For which we have a special rule. So the generic fraction parse should be pruned.
 fn pragma_standalone_diffops_are_not_numerators(tree: &XM) -> Result<(), Box<dyn Error>> {
-  if let XM::Apply(Operator(op), ref args, ..) = tree {
+  if let XM::Apply(Operator(op), args, ..) = tree {
     match **op {
       XM::Lexeme(ref oplexeme, _) if oplexeme.starts_with("MULOP") => {
-        if let Some(XM::Lexeme(ref numlexeme, _)) = args.trees().first() {
+        if let Some(XM::Lexeme(numlexeme, _)) = args.trees().first() {
           if numlexeme.starts_with("DIFFOP") {
             return Err("pruning standalone diffops are not numerators".into());
           }
@@ -797,7 +797,7 @@ fn pragma_standalone_diffops_are_not_numerators(tree: &XM) -> Result<(), Box<dyn
 /// function symbols say " f_i g_j ". This pragma prunes trees that applies two adjacent scripted
 /// constructs.
 fn pragma_adjacent_unfenced_scripts_dont_apply(tree: &XM) -> Result<(), Box<dyn Error>> {
-  if let XM::Apply(Operator(op), ref args, ..) = tree {
+  if let XM::Apply(Operator(op), args, ..) = tree {
     if args.trees().len() == 1 {
       if let XM::Apply(Operator(ref op_op), _, _, ref op_meta) = **op {
         let op_base_name = op_op.base_operator_name();
@@ -845,7 +845,7 @@ fn pragma_adjacent_functions_dont_unify_into_op(tree: &XM) -> Result<(), Box<dyn
 }
 /// Postfix
 fn pragma_postfix_terms_are_fenced_if_single_arg(tree: &XM) -> Result<(), Box<dyn Error>> {
-  if let XM::Apply(Operator(op), ref args, ..) = tree {
+  if let XM::Apply(Operator(op), args, ..) = tree {
     let arg_trees = args.trees();
     if arg_trees.len() == 1 {
       if let Some(XM::Apply(Operator(arg_op), _, _, arg_meta)) = arg_trees.first() {
@@ -876,7 +876,7 @@ fn pragma_postfix_terms_are_fenced_if_single_arg(tree: &XM) -> Result<(), Box<dy
 fn pragma_maximize_script_attachment(tree: &XM) -> Result<(), Box<dyn Error>> {
   // Detect any script-op Apply where the first arg (base) is "absent".
   // This pattern means a standalone floating script that should be a pre-script.
-  if let XM::Apply(Operator(ref op), ref args, ..) = tree {
+  if let XM::Apply(Operator(op), args, ..) = tree {
     if let XM::Token(ref props, _) = **op {
       if props
         .role
@@ -884,7 +884,7 @@ fn pragma_maximize_script_attachment(tree: &XM) -> Result<(), Box<dyn Error>> {
         .is_some_and(|r| r == "SUBSCRIPTOP" || r == "SUPERSCRIPTOP")
       {
         // Check if base (first arg) is "absent" — standalone script
-        if let Some(Some(XM::Token(ref base_props, _))) = args.0.first() {
+        if let Some(Some(XM::Token(base_props, _))) = args.0.first() {
           if base_props.meaning.as_deref() == Some("absent") {
             return Err(
               "Prune: standalone floating script (base=absent) should attach as pre-script.".into(),
@@ -903,13 +903,13 @@ fn pragma_maximize_script_attachment(tree: &XM) -> Result<(), Box<dyn Error>> {
 /// too tortured. This prunes `< a >` from being parsed as a bilateral relation chain,
 /// allowing QM expectation `<a>` to win instead.
 fn pragma_no_bilateral_absent(tree: &XM) -> Result<(), Box<dyn Error>> {
-  if let XM::Apply(_, ref args, ..) = tree {
+  if let XM::Apply(_, args, ..) = tree {
     let trees = args.trees();
     if trees.len() >= 2 {
       let first_absent = matches!(trees.first(),
-        Some(XM::Token(ref p, _)) if p.meaning.as_deref() == Some("absent"));
+        Some(XM::Token(p, _)) if p.meaning.as_deref() == Some("absent"));
       let last_absent = matches!(trees.last(),
-        Some(XM::Token(ref p, _)) if p.meaning.as_deref() == Some("absent"));
+        Some(XM::Token(p, _)) if p.meaning.as_deref() == Some("absent"));
       if first_absent && last_absent {
         return Err(
           "Prune: bilateral absent (absent on both sides) is never valid notation.".into(),
@@ -929,12 +929,12 @@ fn pragma_functions_prefer_wider_absorption(tree: &XM) -> Result<(), Box<dyn Err
   // This forces the wider parse: function_app(f, narrow_arg * rhs)
   // Only fires when RHS is a simple factor (Lexeme/Token/Wrap), NOT another
   // function application — chained functions like sin(πx)*cos(2πy) should stay separate.
-  if let XM::Apply(Operator(op), ref args, ..) = tree {
+  if let XM::Apply(Operator(op), args, ..) = tree {
     if is_invisible_times_op(op) {
       let trees = args.trees();
       if trees.len() == 2 {
         // LHS is a function application (Apply(function, arg))
-        if let XM::Apply(Operator(ref func_op), ref func_args, _, ref func_meta) = trees[0] {
+        if let XM::Apply(Operator(func_op), func_args, _, func_meta) = trees[0] {
           // Check if the function op is FUNCTION/OPFUNCTION/TRIGFUNCTION
           let func_name = func_op.base_operator_name();
           if (func_name.starts_with("OPFUNCTION") || func_name.starts_with("TRIGFUNCTION"))
@@ -946,11 +946,11 @@ fn pragma_functions_prefer_wider_absorption(tree: &XM) -> Result<(), Box<dyn Err
             let rhs = trees[1];
             let rhs_is_simple = match rhs {
               XM::Lexeme(..) | XM::Token(..) | XM::Wrap(..) => true,
-              XM::Apply(Operator(ref rhs_op), ..) => {
+              XM::Apply(Operator(rhs_op), ..) => {
                 // Scripted factors (SUPERSCRIPTOP/SUBSCRIPTOP) are simple
                 let rhs_role = match &**rhs_op {
-                  XM::Token(ref props, _) => props.role.as_deref().unwrap_or(""),
-                  XM::Lexeme(ref lex, _) => lex.split(':').next().unwrap_or(""),
+                  XM::Token(props, _) => props.role.as_deref().unwrap_or(""),
+                  XM::Lexeme(lex, _) => lex.split(':').next().unwrap_or(""),
                   _ => "",
                 };
                 rhs_role == "SUPERSCRIPTOP" || rhs_role == "SUBSCRIPTOP"
@@ -974,7 +974,7 @@ fn pragma_functions_prefer_wider_absorption(tree: &XM) -> Result<(), Box<dyn Err
   // positions. E.g. Apply(×, [f@(x), d, x]) where d is bare OPFUNCTION at index 1
   // (not the last). The competing parse Apply(×, [f@(x), d@(x)]) is preferred.
   // This covers the pattern: ∫ f(x) \diffd x → f@(x) * diffd@(x), not f@(x)*d*x.
-  if let XM::Apply(Operator(op), ref args, ..) = tree {
+  if let XM::Apply(Operator(op), args, ..) = tree {
     if is_invisible_times_op(op) {
       let trees = args.trees();
       // Check non-terminal positions for bare OPFUNCTION/TRIGFUNCTION tokens.
@@ -986,11 +986,11 @@ fn pragma_functions_prefer_wider_absorption(tree: &XM) -> Result<(), Box<dyn Err
       if trees.len() >= 3 {
         for tree in trees.iter().take(trees.len() - 1) {
           let is_bare_absorbing_func = match tree {
-            XM::Token(ref props, _) => matches!(
+            XM::Token(props, _) => matches!(
               props.role.as_deref(),
               Some("OPFUNCTION") | Some("TRIGFUNCTION")
             ),
-            XM::Lexeme(ref lex, _) => {
+            XM::Lexeme(lex, _) => {
               lex.starts_with("OPFUNCTION:") || lex.starts_with("TRIGFUNCTION:")
             },
             _ => false,
@@ -1014,7 +1014,7 @@ fn pragma_functions_prefer_wider_absorption(tree: &XM) -> Result<(), Box<dyn Err
 /// Perl's moreOpArgFactors absorbs MulOp chains into bigop arguments.
 fn pragma_bigop_prefer_wider_absorption(tree: &XM) -> Result<(), Box<dyn Error>> {
   // Pattern: mulop(bigop_app, simple_rhs) or invisible_times(bigop_app, simple_rhs)
-  if let XM::Apply(Operator(op), ref args, ..) = tree {
+  if let XM::Apply(Operator(op), args, ..) = tree {
     let is_mulop = match **op {
       XM::Token(ref props, _) => props.role.as_deref() == Some("MULOP"),
       XM::Lexeme(ref lex, _) => lex.starts_with("MULOP") || lex.contains("invisible_operator"),
@@ -1024,7 +1024,7 @@ fn pragma_bigop_prefer_wider_absorption(tree: &XM) -> Result<(), Box<dyn Error>>
       let trees = args.trees();
       if trees.len() == 2 {
         // LHS is a bigop application (Apply with BIGOP/SUMOP/INTOP/LIMITOP/DIFFOP op)
-        if let XM::Apply(Operator(ref bigop_op), ..) = trees[0] {
+        if let XM::Apply(Operator(bigop_op), ..) = trees[0] {
           let bigop_name = bigop_op.base_operator_name();
           let is_bigop = bigop_name.starts_with("BIGOP")
             || bigop_name.starts_with("SUMOP")
@@ -1036,10 +1036,10 @@ fn pragma_bigop_prefer_wider_absorption(tree: &XM) -> Result<(), Box<dyn Error>>
             let rhs = trees[1];
             let rhs_is_simple = match rhs {
               XM::Lexeme(..) | XM::Token(..) | XM::Wrap(..) => true,
-              XM::Apply(Operator(ref rhs_op), ..) => {
+              XM::Apply(Operator(rhs_op), ..) => {
                 let rhs_role = match &**rhs_op {
-                  XM::Token(ref props, _) => props.role.as_deref().unwrap_or(""),
-                  XM::Lexeme(ref lex, _) => lex.split(':').next().unwrap_or(""),
+                  XM::Token(props, _) => props.role.as_deref().unwrap_or(""),
+                  XM::Lexeme(lex, _) => lex.split(':').next().unwrap_or(""),
                   _ => "",
                 };
                 // Scripted factors and invisible_times products are simple
@@ -1071,7 +1071,7 @@ fn pragma_bigop_prefer_wider_absorption(tree: &XM) -> Result<(), Box<dyn Error>>
 /// For `a - b + c`, this rejects `a + (prefix(-,b+c))` in favor of `(a-b)+c`.
 fn pragma_prefer_binary_addop(tree: &XM) -> Result<(), Box<dyn Error>> {
   // Check: infix ADDOP application where one argument is itself a prefix ADDOP
-  if let XM::Apply(Operator(op), ref args, ..) = tree {
+  if let XM::Apply(Operator(op), args, ..) = tree {
     let is_addop = match **op {
       XM::Token(ref props, _) => props.role.as_deref() == Some("ADDOP"),
       XM::Lexeme(ref lex, _) => lex.starts_with("ADDOP"),
@@ -1096,7 +1096,7 @@ fn pragma_prefer_binary_addop(tree: &XM) -> Result<(), Box<dyn Error>> {
 
 /// Check if a tree is a unary ADDOP prefix application (like -x or +x).
 fn is_unary_addop_prefix(tree: &XM) -> bool {
-  if let XM::Apply(Operator(op), ref args, ..) = tree {
+  if let XM::Apply(Operator(op), args, ..) = tree {
     let is_addop = match **op {
       XM::Token(ref props, _) => props.role.as_deref() == Some("ADDOP"),
       XM::Lexeme(ref lex, _) => lex.starts_with("ADDOP"),
@@ -1110,7 +1110,7 @@ fn is_unary_addop_prefix(tree: &XM) -> bool {
 }
 
 fn pragma_restrict_numeral_fractions(tree: &XM) -> Result<(), Box<dyn Error>> {
-  if let XM::Apply(Operator(op), ref args, ..) = tree {
+  if let XM::Apply(Operator(op), args, ..) = tree {
     match **op {
       XM::Lexeme(ref oplexeme, _) if &**oplexeme == "arith1.divide" => {
         let arg_trees = args.trees();
@@ -1277,7 +1277,7 @@ fn pragma_flatten_simple_invisible_times(tree: &XM) -> Result<(), Box<dyn Error>
 
 /// Recursively check all subtrees for right-associative invisible-times chains.
 fn check_invisible_times_recursive(tree: &XM) -> Result<(), Box<dyn Error>> {
-  if let XM::Apply(Operator(op), ref args, ..) = tree {
+  if let XM::Apply(Operator(op), args, ..) = tree {
     if is_invisible_times_op(op) {
       let trees = args.trees();
       if trees.len() == 2 {
@@ -1317,7 +1317,7 @@ fn all_simple_identifiers(tree: &XM) -> bool {
       meta.fenced.is_none()
         && (name.starts_with("UNKNOWN") || name.starts_with("ID") || name.starts_with("NUMBER"))
     },
-    XM::Apply(Operator(op), ref args, ..) => {
+    XM::Apply(Operator(op), args, ..) => {
       // For invisible-times applications (either operator shape),
       // check operator and all args
       if is_invisible_times_op(op) {
@@ -1335,7 +1335,7 @@ fn all_simple_identifiers(tree: &XM) -> bool {
       }
       false
     },
-    XM::Token(ref props, _) => {
+    XM::Token(props, _) => {
       // Token with UNKNOWN/ID/NUMBER role
       props
         .role
@@ -1355,7 +1355,7 @@ fn pragma_relops_are_outermost(tree: &XM) -> Result<(), Box<dyn Error>> {
 }
 
 fn check_relops_recursive(tree: &XM, inside_addop_or_mulop: bool) -> Result<(), Box<dyn Error>> {
-  if let XM::Apply(Operator(op), ref args, ..) = tree {
+  if let XM::Apply(Operator(op), args, ..) = tree {
     if let XM::Lexeme(ref name, _) = **op {
       let is_addop = name.starts_with("ADDOP");
       let is_mulop = name.starts_with("MULOP") || &**name == "x.invisible_operator";
@@ -1384,8 +1384,8 @@ fn check_relops_recursive(tree: &XM, inside_addop_or_mulop: bool) -> Result<(), 
 /// Check if a tree represents a fenced (parenthesized) expression.
 fn is_fenced(tree: &XM) -> bool {
   match tree {
-    XM::Lexeme(_, ref meta) => meta.fenced.is_some(),
-    XM::Apply(_, _, _, ref meta) => meta.fenced.is_some(),
+    XM::Lexeme(_, meta) => meta.fenced.is_some(),
+    XM::Apply(_, _, _, meta) => meta.fenced.is_some(),
     _ => false,
   }
 }

--- a/latexml_math_parser/src/semantics.rs
+++ b/latexml_math_parser/src/semantics.rs
@@ -185,7 +185,7 @@ pub fn infix_apply(
 /// Check if an XM node is an applied function (curry level 1 / ground term).
 /// Applied functions are Apply(function, args...) — the function has been applied to arguments.
 fn is_applied_function(xm: &Option<XM>) -> bool {
-  if let Some(XM::Apply(ref op, ref args, ..)) = xm {
+  if let Some(XM::Apply(op, args, ..)) = xm {
     // An Apply with a function/trigfunction/opfunction operator that has arguments
     // is a ground-level application, not a function value.
     if !args.0.is_empty() {
@@ -236,7 +236,7 @@ pub fn list_apply(
   if left_rel || right_rel {
     // Allow extension of existing list/formulae Duals (flat accumulation)
     let left_is_list_dual = left.as_ref().is_some_and(|l| {
-      if let XM::Dual(ref content, ..) = l {
+      if let XM::Dual(content, ..) = l {
         if let XM::Apply(ref op, ..) = **content {
           if let XM::Token(ref props, _) = *op.0 {
             return props.meaning.as_deref() == Some("list")
@@ -410,7 +410,7 @@ pub fn formula_list_apply(
     return Err("formula_list_apply: items contain relations, use statement-level list".into());
   }
   // Also check if the left side is already a list Dual containing relational items
-  if let Some(Some(XM::Dual(ref content, ..))) = args.first() {
+  if let Some(Some(XM::Dual(content, ..))) = args.first() {
     if let XM::Apply(ref op, ref op_args, ..) = **content {
       if let XM::Token(ref props, _) = *op.0 {
         if props.meaning.as_deref() == Some("list") {
@@ -431,16 +431,16 @@ pub fn formula_list_apply(
 /// Absent operands are valid at the top level (equation fragments like `= f(x)`)
 /// but should be pruned when inside inner rules (lists, fenced expressions, function args).
 fn has_absent_relop_operand(xm: &XM) -> bool {
-  if let XM::Apply(ref op, ref args, ..) = xm {
+  if let XM::Apply(op, args, ..) = xm {
     let is_rel = match &*op.0 {
-      XM::Token(ref props, _) => {
+      XM::Token(props, _) => {
         props.meaning.as_deref() == Some("multirelation")
           || props
             .role
             .as_deref()
             .is_some_and(|r| r.contains("RELOP") || r.contains("ARROW"))
       },
-      XM::Lexeme(ref lex, _) => lex
+      XM::Lexeme(lex, _) => lex
         .split(':')
         .next()
         .is_some_and(|r| r.contains("RELOP") || r.contains("ARROW")),
@@ -448,7 +448,7 @@ fn has_absent_relop_operand(xm: &XM) -> bool {
     };
     if is_rel {
       for arg in &args.0 {
-        if let Some(XM::Token(ref props, _)) = arg {
+        if let Some(XM::Token(props, _)) = arg {
           if props.meaning.as_deref() == Some("absent") {
             return true;
           }
@@ -464,22 +464,22 @@ fn has_absent_relop_operand(xm: &XM) -> bool {
 /// from "list" (comma-separated plain expressions).
 fn is_relational_item(xm: &XM) -> bool {
   match xm {
-    XM::Apply(ref op, ..) => match &*op.0 {
-      XM::Token(ref props, _) => {
+    XM::Apply(op, ..) => match &*op.0 {
+      XM::Token(props, _) => {
         props.meaning.as_deref() == Some("multirelation")
           || props
             .role
             .as_deref()
             .is_some_and(|r| r.contains("RELOP") || r.contains("ARROW"))
       },
-      XM::Lexeme(ref lex, _) => lex
+      XM::Lexeme(lex, _) => lex
         .split(':')
         .next()
         .is_some_and(|r| r.contains("RELOP") || r.contains("ARROW")),
       _ => false,
     },
     // A formulae XMDual is inherently relational (it wraps relational items)
-    XM::Dual(ref content, ..) => {
+    XM::Dual(content, ..) => {
       if let XM::Apply(ref op, ..) = **content {
         if let XM::Token(ref props, _) = *op.0 {
           return props.meaning.as_deref() == Some("formulae");
@@ -549,8 +549,8 @@ pub fn formulae_apply(
   // list grouping. This forces `a=b, c` via `formula relop formula_list`
   // (producing `a = list(b,c)`) but allows `a=b. c` to produce `formulae(a=b, c)`.
   let sep_is_period = match &sep {
-    XM::Lexeme(ref lex, _) => lex.starts_with("PERIOD:"),
-    XM::Token(ref props, _) => props.role.as_deref() == Some("PERIOD"),
+    XM::Lexeme(lex, _) => lex.starts_with("PERIOD:"),
+    XM::Token(props, _) => props.role.as_deref() == Some("PERIOD"),
     _ => false,
   };
   if left_rel && !right_rel && !sep_is_period {
@@ -619,17 +619,17 @@ fn list_or_formulae_create(
 pub fn restructure_formulae_right(xm: &mut XM) -> Result<(), Box<dyn Error>> {
   // Recurse into children first (bottom-up)
   match xm {
-    XM::Apply(_, ref mut args, ..) => {
+    XM::Apply(_, args, ..) => {
       for arg in args.0.iter_mut().flatten() {
         restructure_formulae_right(arg)?;
       }
     },
-    XM::Wrap(ref mut items, ..) => {
+    XM::Wrap(items, ..) => {
       for item in items.iter_mut() {
         restructure_formulae_right(item)?;
       }
     },
-    XM::Dual(ref mut content, ref mut pres, ..) => {
+    XM::Dual(content, pres, ..) => {
       restructure_formulae_right(content)?;
       restructure_formulae_right(pres)?;
 
@@ -652,12 +652,12 @@ pub fn restructure_formulae_right(xm: &mut XM) -> Result<(), Box<dyn Error>> {
         }
       }
     },
-    XM::Choices(ref mut choices) => {
+    XM::Choices(choices) => {
       for choice in choices.iter_mut() {
         restructure_formulae_right(choice)?;
       }
     },
-    XM::Arg(ref mut items) => {
+    XM::Arg(items) => {
       for item in items.iter_mut() {
         restructure_formulae_right(item)?;
       }
@@ -670,8 +670,8 @@ pub fn restructure_formulae_right(xm: &mut XM) -> Result<(), Box<dyn Error>> {
 /// Check if an XM node is a \quad-type separator (XMHint PUNCT with name containing "uad").
 fn is_quad_separator(xm: &XM) -> bool {
   match xm {
-    XM::Token(ref props, _) => props.name.as_deref().is_some_and(|n| n.contains("uad")),
-    XM::Lexeme(ref lex, _) => lex.split(':').nth(1).is_some_and(|t| t.contains("uad")),
+    XM::Token(props, _) => props.name.as_deref().is_some_and(|n| n.contains("uad")),
+    XM::Lexeme(lex, _) => lex.split(':').nth(1).is_some_and(|t| t.contains("uad")),
     _ => false,
   }
 }
@@ -801,12 +801,12 @@ pub fn rename_fenced_lists(
   nodes: &[libxml::tree::Node],
 ) -> Result<(), Box<dyn Error>> {
   match xm {
-    XM::Apply(_, ref mut args, ..) => {
+    XM::Apply(_, args, ..) => {
       for arg in args.0.iter_mut().flatten() {
         rename_fenced_lists(arg, nodes)?;
       }
     },
-    XM::Wrap(ref mut items, ..) => {
+    XM::Wrap(items, ..) => {
       for item in items.iter_mut() {
         rename_fenced_lists(item, nodes)?;
       }
@@ -827,7 +827,7 @@ pub fn rename_fenced_lists(
           // Find and rename any list Dual among the inner items
           let len = items.len();
           for item in items[1..len - 1].iter_mut() {
-            if let XM::Dual(ref mut content, ..) = item {
+            if let XM::Dual(content, ..) = item {
               if let XM::Apply(ref mut op, ref args, ..) = **content {
                 if let XM::Token(ref mut props, _) = *op.0 {
                   if props.meaning.as_deref() == Some("list") {
@@ -852,11 +852,11 @@ pub fn rename_fenced_lists(
         }
       }
     },
-    XM::Dual(ref mut content, ref mut pres, ..) => {
+    XM::Dual(content, pres, ..) => {
       rename_fenced_lists(content, nodes)?;
       rename_fenced_lists(pres, nodes)?;
     },
-    XM::Choices(ref mut trees) => {
+    XM::Choices(trees) => {
       for tree in trees.iter_mut() {
         rename_fenced_lists(tree, nodes)?;
       }
@@ -873,17 +873,17 @@ pub fn rename_fenced_lists(
 /// and replaces them with combined `prime{N}` tokens.
 pub fn combine_supop_post(xm: &mut XM, nodes: &[libxml::tree::Node]) -> Result<(), Box<dyn Error>> {
   match xm {
-    XM::Apply(_, ref mut args, ..) => {
+    XM::Apply(_, args, ..) => {
       for arg in args.0.iter_mut().flatten() {
         combine_supop_post(arg, nodes)?;
       }
     },
-    XM::Wrap(ref mut items, ..) => {
+    XM::Wrap(items, ..) => {
       for item in items.iter_mut() {
         combine_supop_post(item, nodes)?;
       }
     },
-    XM::Dual(ref mut content, ref mut pres, ..) => {
+    XM::Dual(content, pres, ..) => {
       combine_supop_post(content, nodes)?;
       combine_supop_post(pres, nodes)?;
       // Check if content is Apply(list/times, args) where pres Wrap has all SUPOP items
@@ -932,7 +932,7 @@ pub fn combine_supop_post(xm: &mut XM, nodes: &[libxml::tree::Node]) -> Result<(
         }
       }
     },
-    XM::Choices(ref mut trees) => {
+    XM::Choices(trees) => {
       for tree in trees.iter_mut() {
         combine_supop_post(tree, nodes)?;
       }
@@ -997,7 +997,7 @@ pub fn infix_relation(
     // because list-Apply args are XMRefs after `create_xmrefs`; the
     // actual relation Applies live in the presentation branch.
     let (content_args, pres_items) = match xm {
-      XM::Apply(ref op, ref args, ..) => {
+      XM::Apply(op, args, ..) => {
         if let XM::Token(ref props, _) = *op.0 {
           if props.meaning.as_deref() == Some("list") {
             (Some(args), None)
@@ -1008,7 +1008,7 @@ pub fn infix_relation(
           (None, None)
         }
       },
-      XM::Dual(ref content, ref pres, ..) => {
+      XM::Dual(content, pres, ..) => {
         if let XM::Apply(ref op, ref args, ..) = **content {
           if let XM::Token(ref props, _) = *op.0 {
             if props.meaning.as_deref() == Some("list") {
@@ -1058,17 +1058,17 @@ pub fn infix_relation(
   if let Some(ref left_xm) = left {
     fn last_arg_is_list(xm: &XM) -> bool {
       match xm {
-        XM::Apply(ref op, ref args, ..) => {
+        XM::Apply(op, args, ..) => {
           // Check if this is a relational Apply (has RELOP/ARROW operator)
           let is_rel = match &*op.0 {
-            XM::Token(ref props, _) => {
+            XM::Token(props, _) => {
               props.meaning.as_deref() == Some("multirelation")
                 || props
                   .role
                   .as_deref()
                   .is_some_and(|r| r.contains("RELOP") || r.contains("ARROW"))
             },
-            XM::Lexeme(ref lex, _) => lex
+            XM::Lexeme(lex, _) => lex
               .split(':')
               .next()
               .is_some_and(|r| r.contains("RELOP") || r.contains("ARROW")),
@@ -1076,7 +1076,7 @@ pub fn infix_relation(
           };
           if is_rel {
             // Check last argument
-            if let Some(Some(XM::Dual(ref content, ..))) = args.0.last() {
+            if let Some(Some(XM::Dual(content, ..))) = args.0.last() {
               if let XM::Apply(ref inner_op, ..) = **content {
                 if let XM::Token(ref props, _) = *inner_op.0 {
                   return props.meaning.as_deref() == Some("list");
@@ -1204,7 +1204,7 @@ pub fn infix_apply_nary(
         let rhs_unfenced = right.as_ref().map(|r| r.get_meta().fenced.is_none()).unwrap_or(false);
         let rhs_is_simple = match right.as_ref() {
           Some(XM::Lexeme(..)) | Some(XM::Token(..)) | Some(XM::Wrap(..)) => true,
-          Some(XM::Apply(Operator(ref rhs_op), ..)) => {
+          Some(XM::Apply(Operator(rhs_op), ..)) => {
             let r = match &**rhs_op {
               XM::Token(p, _) => p.role.as_deref().unwrap_or(""),
               XM::Lexeme(lex, _) => lex.split(':').next().unwrap_or(""),
@@ -1277,7 +1277,7 @@ pub fn infix_apply_nary(
   };
   if is_explicit_mulop {
     let right_is_invisible_times = match &right {
-      Some(XM::Apply(ref op, ref args, ..)) => {
+      Some(XM::Apply(op, args, ..)) => {
         let op_is_times = match &*op.0 {
           XM::Lexeme(lex, _) => lex.split(':').nth(1) == Some("times"),
           XM::Token(props, _) => props.meaning.as_deref() == Some("times"),
@@ -1890,12 +1890,12 @@ pub fn postfix_apply(
     Meta::default(),
   );
   // Check if arg is an n-ary Apply with the same operator as op
-  if let (Some(XM::Apply(ref app_op, ref app_args, ref app_props, ref app_meta)), Some(ref op_xm)) =
+  if let (Some(XM::Apply(app_op, app_args, app_props, app_meta)), Some(op_xm)) =
     (&arg, &op)
   {
     let same_op = match (app_op.0.as_ref(), op_xm) {
       // Compare Lexemes: both are lexeme strings like "ADDOP:plus:+"
-      (XM::Lexeme(ref a_lex, _), XM::Lexeme(ref o_lex, _)) => {
+      (XM::Lexeme(a_lex, _), XM::Lexeme(o_lex, _)) => {
         // Compare role:meaning prefix (ignoring the actual symbol after last :)
         let a_parts: Vec<_> = a_lex.splitn(3, ':').collect();
         let o_parts: Vec<_> = o_lex.splitn(3, ':').collect();
@@ -1905,7 +1905,7 @@ pub fn postfix_apply(
           && a_parts[1] == o_parts[1]
       },
       // Compare realized Tokens
-      (XM::Token(ref a_props, _), XM::Token(ref o_props, _)) => {
+      (XM::Token(a_props, _), XM::Token(o_props, _)) => {
         a_props.meaning == o_props.meaning && a_props.meaning.is_some()
       },
       _ => false,
@@ -2025,14 +2025,14 @@ pub fn fenced(
     // Check if arg is a multi-item list (XM::Dual from list_apply/formulae_apply).
     // If so, use interpret_delimited for per-item XMRefs (matching Perl's NewFenced).
     let is_multi_item = match &arg {
-      XM::Dual(ref content, ..) => matches!(&**content, XM::Apply(ref op_box, ref args, ..)
+      XM::Dual(content, ..) => matches!(&**content, XM::Apply(op_box, args, ..)
         if args.0.len() >= 2 && matches!(&*op_box.0,
-          XM::Token(ref p, _) if matches!(p.meaning.as_deref(),
+          XM::Token(p, _) if matches!(p.meaning.as_deref(),
             Some("vector") | Some("list") | Some("formulae")))),
-      XM::Apply(ref op_box, ref args, ..) => {
+      XM::Apply(op_box, args, ..) => {
         args.0.len() >= 2
           && matches!(&*op_box.0,
-        XM::Token(ref p, _) if matches!(p.meaning.as_deref(),
+        XM::Token(p, _) if matches!(p.meaning.as_deref(),
           Some("vector") | Some("list") | Some("formulae")))
       },
       _ => false,
@@ -2334,10 +2334,10 @@ pub fn fence(
   let mut stuff = stuff;
   for i in (2..stuff.len().saturating_sub(1)).step_by(2) {
     match &mut stuff[i] {
-      XM::Token(ref mut props, _) if props.role.as_deref() == Some("VERTBAR") => {
+      XM::Token(props, _) if props.role.as_deref() == Some("VERTBAR") => {
         props.role = Some(Cow::Borrowed("MIDDLE"));
       },
-      XM::Lexeme(ref lex, ref meta) if lex.starts_with("VERTBAR:") => {
+      &mut XM::Lexeme(ref lex, ref meta) if lex.starts_with("VERTBAR:") => {
         // For lexemes, change the role on the underlying DOM node
         if let Some(ref cv) = meta.curry_level {
           let cv_str = cv.to_string();
@@ -2670,7 +2670,7 @@ fn extract_base_scriptpos(
   ctxt: &ActionContext,
 ) -> (&'static str, u32, bool, u32) {
   match base {
-    Some(XM::Apply(ref op, _, _props, ref meta)) => {
+    Some(XM::Apply(op, _, _props, meta)) => {
       // Check if the operator is a SCRIPTOP
       if let XM::Token(ref op_props, _) = *op.0 {
         let role = op_props.role.as_deref().unwrap_or("");
@@ -2686,7 +2686,7 @@ fn extract_base_scriptpos(
     },
     // For Lexeme bases (e.g., \sum with scriptpos="mid"),
     // look up the XML node to get scriptpos
-    Some(XM::Lexeme(ref lex, _)) => {
+    Some(XM::Lexeme(lex, _)) => {
       if let Ok(node) = lookup_lex_node(lex, ctxt.nodes) {
         let sp = node.get_attribute("scriptpos").unwrap_or_default();
         if !sp.is_empty() {
@@ -2696,7 +2696,7 @@ fn extract_base_scriptpos(
       }
       ("post", 0, false, 0)
     },
-    Some(XM::Token(ref props, _)) => {
+    Some(XM::Token(props, _)) => {
       let sp = props.scriptpos.as_deref().unwrap_or("post");
       let (bx, bl) = parse_scriptpos(sp);
       (bx, bl, false, 0)
@@ -2720,7 +2720,7 @@ pub fn obtain_arg(tree: XM, n: usize, ctxt: ActionContext) -> Result<Option<XM>,
       // if ($nth && !$node->isSameNode($onode)) {
       //   return LaTeXML::Package::createXMRefs($LaTeXML::MathParser::DOCUMENT, $nth); }
     },
-    XM::Apply(_, ref args, ..) => match args.0.get(n) {
+    XM::Apply(_, args, ..) => match args.0.get(n) {
       Some(t) => Ok(t.clone()),
       None => Ok(None),
     },
@@ -2830,9 +2830,9 @@ pub fn apply_invisible_times(
       // where log has role OPFUNCTION — should still prefer prefix_apply.
       // Also for compound operators: \nabla\log → Apply(nabla, [log])
       // where nabla is OPERATOR — the compound result should absorb args.
-      XM::Apply(ref op, ref args, ..) => {
+      XM::Apply(op, args, ..) => {
         let op_role = match &*op.0 {
-          XM::Token(ref p, _) => p.role.as_deref().map(String::from),
+          XM::Token(p, _) => p.role.as_deref().map(String::from),
           XM::Lexeme(lex, _) => {
             // Extract role from lexeme string prefix: "OPERATOR:nabla:1" → "OPERATOR"
             lex.split(':').next().map(String::from)
@@ -2968,7 +2968,7 @@ pub fn apply_invisible_times(
         .unwrap_or(true);
       let rhs_is_simple = match right.as_ref() {
         Some(XM::Lexeme(..)) | Some(XM::Token(..)) | Some(XM::Wrap(..)) => true,
-        Some(XM::Apply(Operator(ref rhs_op), ..)) => {
+        Some(XM::Apply(Operator(rhs_op), ..)) => {
           let rhs_role = match &**rhs_op {
             XM::Token(p, _) => p.role.as_deref().unwrap_or(""),
             XM::Lexeme(lex, _) => lex.split(':').next().unwrap_or(""),
@@ -3022,7 +3022,7 @@ pub fn apply_invisible_times(
   if let Some(ref l) = left {
     if let Some(ref r) = right {
       let is_scripted_function = is_scripted_function_head(l, ctxt.nodes);
-      let is_fenced_dual = matches!(r, XM::Dual(ref c, ref p, _, _)
+      let is_fenced_dual = matches!(r, XM::Dual(c, p, _, _)
         if matches!(**c, XM::Ref(_)) && matches!(**p, XM::Wrap(..)));
       if is_scripted_function && is_fenced_dual {
         // Lift the fenced XMDual: Apply(f^2, Dual(Ref, Wrap)) → Dual(Apply(Ref(f^2), Ref(arg)),
@@ -3067,8 +3067,8 @@ pub fn apply_invisible_times(
       if op_name.starts_with("TRIGFUNCTION") {
         if let Some(ref r) = right {
           let is_bare_factor = match r {
-            XM::Lexeme(_, ref rm) => rm.fenced.is_none(),
-            XM::Token(_, ref rm) => rm.fenced.is_none(),
+            XM::Lexeme(_, rm) => rm.fenced.is_none(),
+            XM::Token(_, rm) => rm.fenced.is_none(),
             _ => false,
           };
           if is_bare_factor {
@@ -3282,7 +3282,7 @@ fn morph_vertbar(xm: XM, role: &'static str, nodes: &[XMLNode]) -> XM {
   let is_delimiter = matches!(role, "OPEN" | "CLOSE" | "MIDDLE");
   match xm {
     XM::Lexeme(lex, meta) => {
-      if let Ok(node) = lookup_lex_node(&lex, nodes) {
+      match lookup_lex_node(&lex, nodes) { Ok(node) => {
         let mut props = XProps::from(node);
         props.role = Some(Cow::Borrowed(role));
         if !is_delimiter {
@@ -3293,9 +3293,9 @@ fn morph_vertbar(xm: XM, role: &'static str, nodes: &[XMLNode]) -> XM {
           }
         }
         XM::Token(props, meta)
-      } else {
+      } _ => {
         XM::Lexeme(lex, meta)
-      }
+      }}
     },
     XM::Token(mut props, meta) => {
       props.role = Some(Cow::Borrowed(role));
@@ -3336,10 +3336,10 @@ fn maybe_mark_possible_function(left: &mut Option<XM>, right: &Option<XM>, nodes
 
 fn mark_inner_possible_function(xm: &mut Option<XM>, nodes: &[XMLNode]) {
   match xm {
-    Some(XM::Token(ref mut props, _)) if props.role.as_deref() == Some("UNKNOWN") => {
+    Some(XM::Token(props, _)) if props.role.as_deref() == Some("UNKNOWN") => {
       props.possible_function = Some(Cow::Borrowed("yes"));
     },
-    Some(XM::Lexeme(ref lex, _)) if lex.starts_with("UNKNOWN:") => {
+    &mut Some(XM::Lexeme(ref lex, _)) if lex.starts_with("UNKNOWN:") => {
       // Lexemes are "ROLE:content:id" references to XML nodes.
       // Set the attribute directly on the underlying XML node.
       if let Some(id_str) = lex.split(':').next_back() {
@@ -3351,7 +3351,7 @@ fn mark_inner_possible_function(xm: &mut Option<XM>, nodes: &[XMLNode]) {
         }
       }
     },
-    Some(XM::Apply(_, ref mut args, ..)) => {
+    Some(XM::Apply(_, args, ..)) => {
       if let Some(first) = args.0.first_mut() {
         mark_inner_possible_function(first, nodes);
       }
@@ -3387,8 +3387,8 @@ fn find_fracop_node<'a>(
 ) -> Option<&'a libxml::tree::Node> {
   // Try via Lexeme curry_level (node index)
   let meta = match xm {
-    Some(XM::Lexeme(_, ref m)) => Some(m),
-    Some(XM::Apply(_, _, _, ref m)) => Some(m),
+    Some(XM::Lexeme(_, m)) => Some(m),
+    Some(XM::Apply(_, _, _, m)) => Some(m),
     _ => None,
   };
   if let Some(meta) = meta {
@@ -3404,7 +3404,7 @@ fn find_fracop_node<'a>(
       }
     }
     // Try via Lexeme content: "ROLE:meaning:N" → index N-1
-    if let Some(XM::Lexeme(ref lex, _)) = xm {
+    if let Some(XM::Lexeme(lex, _)) = xm {
       if let Some(idx_str) = lex.rsplit(':').next() {
         if let Ok(lex_idx) = idx_str.parse::<usize>() {
           let idx = if lex_idx > 0 { lex_idx - 1 } else { 0 };
@@ -3485,7 +3485,7 @@ fn is_bigop_or_scripted_bigop(xm: &XM, nodes: &[libxml::tree::Node]) -> bool {
         Some("INTOP") | Some("BIGOP") | Some("SUMOP") | Some("LIMITOP") | Some("DIFFOP")
       )
     },
-    XM::Apply(ref op, ref args, ..) => {
+    XM::Apply(op, args, ..) => {
       let op_role = get_operator_role(op, nodes);
       // Direct bigop application: Apply(INTOP, ...)
       if matches!(
@@ -3503,7 +3503,7 @@ fn is_bigop_or_scripted_bigop(xm: &XM, nodes: &[libxml::tree::Node]) -> bool {
           | Some("POSTSUBSCRIPT")
           | Some("POSTSUPERSCRIPT")
       ) {
-        if let Some(Some(ref base)) = args.0.first() {
+        if let Some(Some(base)) = args.0.first() {
           return is_bigop_or_scripted_bigop(base, nodes);
         }
       }
@@ -3519,7 +3519,7 @@ fn is_scripted_function_head(xm: &XM, nodes: &[libxml::tree::Node]) -> bool {
   match xm {
     // A bare function token is not "scripted" — handled by the earlier check
     XM::Token(..) | XM::Lexeme(..) => false,
-    XM::Apply(ref op, ref args, ..) => {
+    XM::Apply(op, args, ..) => {
       let op_role = get_operator_role(op, nodes);
       // Must be a script operator (SUBSCRIPTOP, SUPERSCRIPTOP, etc.)
       if matches!(
@@ -3530,7 +3530,7 @@ fn is_scripted_function_head(xm: &XM, nodes: &[libxml::tree::Node]) -> bool {
           | Some("POSTSUPERSCRIPT")
       ) {
         // Check the base (first arg) — is it a FUNCTION or another scripted function?
-        if let Some(Some(ref base)) = args.0.first() {
+        if let Some(Some(base)) = args.0.first() {
           return is_function_role_item(base, nodes) || is_scripted_function_head(base, nodes);
         }
       }
@@ -3634,8 +3634,8 @@ pub fn consecutive_relop_chain(
     }
     // If left is Apply(RELOP, a, b), convert to multirelation
     let is_relop = match &*op.0 {
-      XM::Lexeme(ref lex, _) => lex.split(':').next().unwrap().contains("RELOP"),
-      XM::Token(ref tok, _) => matches!(tok.role.as_deref(), Some("RELOP")),
+      XM::Lexeme(lex, _) => lex.split(':').next().unwrap().contains("RELOP"),
+      XM::Token(tok, _) => matches!(tok.role.as_deref(), Some("RELOP")),
       _ => false,
     };
     if is_relop {
@@ -3995,8 +3995,8 @@ pub fn eval_at(
     // faux_wrap returns Wrap([lexeme, content]) — extract the lexeme first.
     let s1_is_sub = s1.as_ref().is_none_or(|xm| {
       let lex = match xm {
-        XM::Lexeme(ref l, _) => Some(&**l),
-        XM::Wrap(ref items, ..) if !items.is_empty() => {
+        XM::Lexeme(l, _) => Some(&**l),
+        XM::Wrap(items, ..) if !items.is_empty() => {
           if let XM::Lexeme(ref l, _) = items[0] {
             Some(&**l)
           } else {
@@ -4103,13 +4103,13 @@ pub fn eval_at(
 fn get_script_child_xm(script_opt: &Option<XM>, nodes: &[XMLNode]) -> Option<XM> {
   let script = script_opt.as_ref()?;
   // New format: Wrap([lexeme, content]) — return the parsed content directly
-  if let XM::Wrap(ref items, ..) = script {
+  if let XM::Wrap(items, ..) = script {
     if items.len() == 2 {
       return Some(items[1].clone());
     }
   }
   // Old format: bare Lexeme — look up from DOM
-  if let XM::Lexeme(ref lex, _) = script {
+  if let XM::Lexeme(lex, _) = script {
     let node = lookup_lex_node(lex, nodes).ok()?;
     let children = node.get_child_elements();
     if let Some(first_child) = children.first() {
@@ -4296,11 +4296,11 @@ fn has_negative_rpadding(xm: &XM, nodes: &[XMLNode]) -> bool {
 fn merge_vertbar_triple(xm: XM, role: &'static str, nodes: &[XMLNode]) -> XM {
   let mut props = match xm {
     XM::Lexeme(ref lex, _) => {
-      if let Ok(node) = lookup_lex_node(lex, nodes) {
+      match lookup_lex_node(lex, nodes) { Ok(node) => {
         XProps::from(node)
-      } else {
+      } _ => {
         XProps::default()
-      }
+      }}
     },
     XM::Token(ref p, _) => p.clone(),
     _ => XProps::default(),
@@ -4390,11 +4390,11 @@ pub fn stretchy_triple_norm_fenced(
 fn merge_vertbar_pair(xm: XM, role: &'static str, nodes: &[XMLNode]) -> XM {
   let mut props = match xm {
     XM::Lexeme(ref lex, _) => {
-      if let Ok(node) = lookup_lex_node(lex, nodes) {
+      match lookup_lex_node(lex, nodes) { Ok(node) => {
         XProps::from(node)
-      } else {
+      } _ => {
         XProps::default()
-      }
+      }}
     },
     XM::Token(ref p, _) => p.clone(),
     _ => XProps::default(),

--- a/latexml_math_parser/src/semantics/curry.rs
+++ b/latexml_math_parser/src/semantics/curry.rs
@@ -183,7 +183,7 @@ impl CurryConstraint {
     let new_lhs;
     let mut new_cmp = *cmp;
     match rhs {
-      Literal(ref v) if *v > 0 => match lhs {
+      Literal(v) if *v > 0 => match lhs {
         Literal(lv) => {
           new_lhs = Literal(lv - v);
           new_rhs = Literal(0);

--- a/latexml_math_parser/src/semantics/tree.rs
+++ b/latexml_math_parser/src/semantics/tree.rs
@@ -310,22 +310,22 @@ impl From<Vec<XM>> for Args {
 impl XM {
   pub fn get_meta(&self) -> &Meta {
     match self {
-      XM::Lexeme(_, ref meta) => meta,
-      XM::Token(_, ref meta) => meta,
-      XM::Apply(_, _, _, ref meta) => meta,
-      XM::Dual(_, _, _, ref meta) => meta,
-      XM::Wrap(_, _, ref meta) => meta,
+      XM::Lexeme(_, meta) => meta,
+      XM::Token(_, meta) => meta,
+      XM::Apply(_, _, _, meta) => meta,
+      XM::Dual(_, _, _, meta) => meta,
+      XM::Wrap(_, _, meta) => meta,
       XM::Choices(cs) => cs[0].get_meta(), // Should we return a none type instead?
       XM::Ref(_) | XM::Arg(_) => todo!(),
     }
   }
   pub fn get_meta_mut(&mut self) -> &mut Meta {
     match self {
-      XM::Lexeme(_, ref mut meta) => meta,
-      XM::Token(_, ref mut meta) => meta,
-      XM::Apply(_, _, _, ref mut meta) => meta,
-      XM::Dual(_, _, _, ref mut meta) => meta,
-      XM::Wrap(_, _, ref mut meta) => meta,
+      XM::Lexeme(_, meta) => meta,
+      XM::Token(_, meta) => meta,
+      XM::Apply(_, _, _, meta) => meta,
+      XM::Dual(_, _, _, meta) => meta,
+      XM::Wrap(_, _, meta) => meta,
       XM::Choices(cs) => cs[0].get_meta_mut(), // Should we return a none type instead?
       XM::Ref(_) | XM::Arg(_) => todo!(),
     }
@@ -1291,7 +1291,7 @@ impl XM {
       }
     }
     fn arg_is_vertbar_fenced(arg: &XM) -> bool {
-      let XM::Dual(_, ref presentation, _, _) = arg else {
+      let XM::Dual(_, presentation, _, _) = arg else {
         return false;
       };
       let XM::Wrap(ref items, _, _) = **presentation else {
@@ -1638,7 +1638,7 @@ impl XM {
         let items_str: Vec<String> = items.iter().map(|i| i.text_summary()).collect();
         format!("Wrap({})", items_str.join(", "))
       },
-      XM::Choices(ref trees) => format!("Choices({})", trees.len()),
+      XM::Choices(trees) => format!("Choices({})", trees.len()),
       XM::Ref(idx) => format!("Ref({})", idx),
       XM::Arg(items) => {
         let items_str: Vec<String> = items.iter().map(|i| i.text_summary()).collect();
@@ -1649,14 +1649,14 @@ impl XM {
 
   pub fn base_operator_name(&self) -> String {
     match self {
-      XM::Lexeme(ref name, _) => name.to_string(),
-      XM::Apply(ref op, ref args, ..) => {
+      XM::Lexeme(name, _) => name.to_string(),
+      XM::Apply(op, args, ..) => {
         match &*op.0 {
-          XM::Lexeme(ref name, _) if &**name == "unknown.subscript" => {
+          XM::Lexeme(name, _) if &**name == "unknown.subscript" => {
             let arg_base = args.0.first().unwrap().as_ref().unwrap().clone();
             format!("sub__{}", arg_base.base_operator_name())
           },
-          XM::Lexeme(ref name, _) if &**name == "unknown.superscript" => {
+          XM::Lexeme(name, _) if &**name == "unknown.superscript" => {
             // TODO: Too much datastructure boilerplate with the unwrap incantation
             //       might be better to create some getter methods to explain the intent better
             //       this is meant to do "give me a clone of the first argument to this XM::Apply"
@@ -1678,7 +1678,7 @@ impl XM {
       XM::Lexeme(..) => self,
       XM::Token(..) => self,
       XM::Ref(_) => self,
-      XM::Apply(ref op, ref args, ..) => {
+      XM::Apply(op, args, ..) => {
         if let XM::Lexeme(name, _) = &*op.0 {
           if &**name == "unknown.subscript" || &**name == "unknown.superscript" {
             args.trees().first().unwrap().get_baseline()
@@ -1993,7 +1993,7 @@ impl XM {
           None => Ok(None),
         };
       },
-      XM::Apply(ref op, ..) => {
+      XM::Apply(op, ..) => {
         // Compound operator (e.g. composed_bigop): get meaning from the operator
         return op.0.get_token_meaning(nodes);
       },
@@ -2020,7 +2020,7 @@ impl XM {
         let lex_node = lookup_lex_node(lex, ctxt.nodes)?;
         Ok(Some(realize_xmnode(lex_node, ctxt.document).into_owned()))
       },
-      XM::Ref(ref refprops) => {
+      XM::Ref(refprops) => {
         if let Some(node) = ctxt.document.lookup_id(refprops.id.as_ref().unwrap()) {
           Ok(Some(node.clone()))
         } else {

--- a/latexml_math_parser/src/util.rs
+++ b/latexml_math_parser/src/util.rs
@@ -376,7 +376,7 @@ pub fn create_xmrefs(args: &mut [&mut XM], ctxt: ActionContext) -> Result<Vec<XM
   let mut refs = Vec::with_capacity(args.len());
   for arg in args {
     match arg {
-      XM::Token(ref mut props, _meta) => {
+      XM::Token(props, _meta) => {
         if let Some(id) = props.id.as_ref() {
           refs.push(XM::Ref(XProps {
             id: Some(id.clone()),
@@ -441,7 +441,7 @@ pub fn create_xmrefs(args: &mut [&mut XM], ctxt: ActionContext) -> Result<Vec<XM
           },
         }
       },
-      XM::Apply(_op, _args, ref mut props, _meta) => {
+      XM::Apply(_op, _args, props, _meta) => {
         if let Some(id) = props.id.as_ref() {
           refs.push(XM::Ref(XProps {
             id: Some(id.clone()),
@@ -474,7 +474,7 @@ pub fn create_xmrefs(args: &mut [&mut XM], ctxt: ActionContext) -> Result<Vec<XM
       XM::Ref(props) => {
         refs.push(XM::Ref(props.clone()));
       },
-      XM::Dual(_, _, ref mut props, _) | XM::Wrap(_, ref mut props, _) => {
+      XM::Dual(_, _, props, _) | XM::Wrap(_, props, _) => {
         if let Some(id) = props.id.as_ref() {
           refs.push(XM::Ref(XProps {
             id: Some(id.clone()),

--- a/latexml_oxide/Cargo.toml
+++ b/latexml_oxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "latexml"
 version = "0.6.2"
-edition = "2021"
+edition = "2024"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
 license = "CC0"
 homepage = "https://github.com/dginev/latexml-oxide"

--- a/latexml_oxide/bin/latexmlmath_oxide.rs
+++ b/latexml_oxide/bin/latexmlmath_oxide.rs
@@ -73,7 +73,7 @@ fn real_main() -> Result<()> {
 
   state::set_nomathparse_flag(false);
   let mut parser = MathParser::default();
-  if let Ok(Some(parse_tree)) = parser.parse_lexemes(lexemes, &lex_nodes, &mut doc) {
+  match parser.parse_lexemes(lexemes, &lex_nodes, &mut doc) { Ok(Some(parse_tree)) => {
     let mut xmath = xmath_opt.unwrap();
     for mut node in xmath.get_child_nodes() {
       node.unlink();
@@ -120,9 +120,9 @@ fn real_main() -> Result<()> {
         })
       );
     }
-  } else {
+  } _ => {
     Warn!("math", "parse", "Grammar did not recognize expression.");
     process::exit(1);
-  }
+  }}
   Ok(())
 }

--- a/latexml_oxide/src/post.rs
+++ b/latexml_oxide/src/post.rs
@@ -136,7 +136,7 @@ pub fn run_post_processing(xml: &str, opts: &PostOptions) -> String {
   // Phase 1: Split (only attributes time when --split is on)
   let mut docs: Vec<PostDocument> = if split {
     telemetry::phase_enter(Phase::Split);
-    let result = if let Some(ref xpath) = split_xpath {
+    let result = if let Some(xpath) = split_xpath {
       let naming = match split_naming {
         Some("id") | None => latexml_post::split::SplitNaming::Id,
         Some("idrelative") => latexml_post::split::SplitNaming::IdRelative,

--- a/latexml_oxide/src/util/test.rs
+++ b/latexml_oxide/src/util/test.rs
@@ -69,7 +69,7 @@ pub fn init_logger() {
 // stack dump is far more useful than the bare `signal: 11` line cargo
 // reports today.
 #[used]
-#[cfg_attr(target_os = "linux", link_section = ".init_array")]
+#[cfg_attr(target_os = "linux", unsafe(link_section = ".init_array"))]
 static SIGSEGV_INSTALLER: extern "C" fn() = sigsegv_installer;
 
 extern "C" fn sigsegv_installer() {
@@ -90,7 +90,7 @@ extern "C" fn sigsegv_installer() {
 /// stack print is more useful than the bare `signal: 11` line cargo
 /// reports today.
 fn install_sigsegv_handler() {
-  extern "C" {
+  unsafe extern "C" {
     fn signal(sig: i32, handler: extern "C" fn(i32)) -> usize;
     fn raise(sig: i32) -> i32;
   }
@@ -479,7 +479,7 @@ macro_rules! tex_tests {
   ($dir:literal) => {
     tex_tests!($dir, None, None);
   };
-  ($dir:literal, $requires:expr, $dispatch:expr) => {
+  ($dir:literal, $requires:expr_2021, $dispatch:expr_2021) => {
     macro_rules! this_test_requires {
       () => {
         $requires

--- a/latexml_package/Cargo.toml
+++ b/latexml_package/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "latexml_package"
 version = "0.5.0"
-edition = "2021"
+edition = "2024"
 license = "CC0"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
 description = "Bindings and related infrastructure for core processing"

--- a/latexml_package/src/package/accents_sty.rs
+++ b/latexml_package/src/package/accents_sty.rs
@@ -20,11 +20,11 @@ LoadDefinitions!({
     let toks = thing.unlist();
     // Must be a single token, with a definition that has exactly 1 parameter
     let is_accent = toks.len() == 1 && {
-      if let Some(defn) = state::lookup_definition(&toks[0])? {
+      match state::lookup_definition(&toks[0])? { Some(defn) => {
         defn.get_num_args() == 1
-      } else {
+      } _ => {
         false
-      }
+      }}
     };
     if is_accent {
       Ok(true_branch)

--- a/latexml_package/src/package/amsmath_sty.rs
+++ b/latexml_package/src/package/amsmath_sty.rs
@@ -2314,7 +2314,7 @@ fn sideset_wrap_impl(
   document.remove_node(inner);
   // Perl: $document->insertElement('ltx:XMWrap', $script->getArg(1))
   document.open_element("ltx:XMWrap", None, None)?;
-  if let DigestedData::Whatsit(ref w) = script.data() {
+  if let DigestedData::Whatsit(w) = script.data() {
     if let Some(arg) = w.borrow().get_arg(1) {
       document.absorb(arg, None)?;
     }

--- a/latexml_package/src/package/amsthm_sty.rs
+++ b/latexml_package/src/package/amsthm_sty.rs
@@ -129,11 +129,11 @@ LoadDefinitions!({
     Ok(Tokens!())
   });
   DefMacro!("\\popQED", sub[_args] {
-    if let Ok(Some(Stored::Tokens(t))) = pop_value("QED@stack") {
+    match pop_value("QED@stack") { Ok(Some(Stored::Tokens(t))) => {
       Ok(t)
-    } else {
+    } _ => {
       Ok(Tokens!())
-    }
+    }}
   });
 
   // QED symbol — Perl amsthm.sty.ltxml has `enterHorizontal => 1`.
@@ -181,7 +181,7 @@ LoadDefinitions!({
     },
     properties => sub[args] {
       let mut title_tokens = vec![T_BEGIN!(), T_CS!("\\the"), T_CS!("\\thm@headfont")];
-      if let Some(Some(ref arg)) = args.first() {
+      if let Some(Some(arg)) = args.first() {
         title_tokens.extend(arg.revert()?.unlist());
       } else {
         title_tokens.push(T_CS!("\\proofname"));

--- a/latexml_package/src/package/attachfile_sty.rs
+++ b/latexml_package/src/package/attachfile_sty.rs
@@ -24,7 +24,7 @@ fn attachfile_properties(
 ) -> latexml_core::common::arena::SymHashMap<Stored> {
   let icon_key = kv
     .and_then(|d| {
-      if let DigestedData::KeyVals(ref kvs) = d.data() {
+      if let DigestedData::KeyVals(kvs) = d.data() {
         kvs.get_value("icon")
       } else {
         None
@@ -34,7 +34,7 @@ fn attachfile_properties(
     .unwrap_or_else(|| "pushpin".to_string());
   let color = kv
     .and_then(|d| {
-      if let DigestedData::KeyVals(ref kvs) = d.data() {
+      if let DigestedData::KeyVals(kvs) = d.data() {
         kvs.get_value("color")
       } else {
         None

--- a/latexml_package/src/package/enumitem_sty.rs
+++ b/latexml_package/src/package/enumitem_sty.rs
@@ -359,7 +359,7 @@ fn newlist_impl(listname: &str, listtype: &str, maxdepth: i32) -> Result<()> {
 fn extract_keyvals(args: &[Option<Digested>]) -> Option<KeyVals> {
   args.first().and_then(|a| {
     a.as_ref().and_then(|d| {
-      if let DigestedData::KeyVals(ref kv) = d.data() {
+      if let DigestedData::KeyVals(kv) = d.data() {
         Some(kv.clone())
       } else {
         None

--- a/latexml_package/src/package/epsfig_sty.rs
+++ b/latexml_package/src/package/epsfig_sty.rs
@@ -37,7 +37,7 @@ LoadDefinitions!({
     properties => sub[args] {
       use DigestedData::*;
       let file = if let Some(kv_arg) = args[0].as_ref() {
-        if let KeyVals(ref kv) = kv_arg.data() {
+        if let KeyVals(kv) = kv_arg.data() {
           let raw = kv.get_value("file")
             .or_else(|| kv.get_value("figure"))
             .map(|v| v.to_string())
@@ -53,7 +53,7 @@ LoadDefinitions!({
         .unwrap_or(false);
       let mut opts = Vec::<String>::new();
       if let Some(kv_arg) = args[0].as_ref() {
-        if let KeyVals(ref kv) = kv_arg.data() {
+        if let KeyVals(kv) = kv_arg.data() {
           let mut saw_clip = false;
           for (k, v) in kv.get_pairs() {
             if k == "file" || k == "figure" { continue; }

--- a/latexml_package/src/package/float_sty.rs
+++ b/latexml_package/src/package/float_sty.rs
@@ -148,7 +148,7 @@ fn create_float_env(name: &str, class: &str, style: &str) -> Result<()> {
         }
       }
       // ?#1(placement='#1') — placement from optional arg
-      if let Some(Some(ref arg1)) = args.first() {
+      if let Some(Some(arg1)) = args.first() {
         let placement = arg1.to_string();
         if !placement.is_empty() {
           av.insert("placement".into(), placement);

--- a/latexml_package/src/package/floatfig_sty.rs
+++ b/latexml_package/src/package/floatfig_sty.rs
@@ -11,11 +11,11 @@ fn floatfig_float_direction(whatsit: &Whatsit) -> &'static str {
   let pos_arg = pos_arg.trim().to_string();
   let pos = if !pos_arg.is_empty() {
     pos_arg
-  } else if let Some(Stored::String(sym)) = state::lookup_value("floatfltpos") {
+  } else { match state::lookup_value("floatfltpos") { Some(Stored::String(sym)) => {
     arena::with(sym, |s| s.to_string())
-  } else {
+  } _ => {
     "v".to_string()
-  };
+  }}};
   if pos.starts_with('v') || pos.starts_with('r') {
     "right"
   } else {

--- a/latexml_package/src/package/floatflt_sty.rs
+++ b/latexml_package/src/package/floatflt_sty.rs
@@ -13,11 +13,11 @@ fn floatflt_float_direction(whatsit: &Whatsit) -> &'static str {
   let pos_arg = pos_arg.trim().to_string();
   let pos = if !pos_arg.is_empty() {
     pos_arg
-  } else if let Some(Stored::String(sym)) = state::lookup_value("floatfltpos") {
+  } else { match state::lookup_value("floatfltpos") { Some(Stored::String(sym)) => {
     arena::with(sym, |s| s.to_string())
-  } else {
+  } _ => {
     "v".to_string()
-  };
+  }}};
   if pos.starts_with('v') || pos.starts_with('r') {
     "right"
   } else {

--- a/latexml_package/src/package/graphicx_sty.rs
+++ b/latexml_package/src/package/graphicx_sty.rs
@@ -134,7 +134,7 @@ LoadDefinitions!({
       // a graphics option.
       let mut alt_value: Option<String> = None;
       if let Some(ref kv_digested) = args[1] {
-        if let DigestedData::KeyVals(ref kv) = kv_digested.data() {
+        if let DigestedData::KeyVals(kv) = kv_digested.data() {
           for (key, value) in kv.get_pairs() {
             if key == "alt" {
               alt_value = Some(value.to_string());

--- a/latexml_package/src/package/hyperref_sty.rs
+++ b/latexml_package/src/package/hyperref_sty.rs
@@ -1125,15 +1125,15 @@ fn localized_anchor(document: &mut Document, whatsit: &Whatsit) -> CoreResult<()
     }
   }
   if let Some(target) = found {
-    if let Some(mut anchor) = document.wrap_nodes("ltx:anchor", vec![target])? {
+    match document.wrap_nodes("ltx:anchor", vec![target])? { Some(mut anchor) => {
       document.set_attribute(&mut anchor, "xml:id", &id)?;
       if document.is_open(&anchor) {
         document.close_node(&anchor)?;
       }
-    } else {
+    } _ => {
       Warn!("malformed", "ltx:anchor",
         &s!("No available insertion point for ltx:anchor, failing \\hypertarget to {}", id));
-    }
+    }}
   } else {
     Warn!("malformed", "ltx:anchor",
       &s!("No available insertion point for ltx:anchor, failing \\hypertarget to {}", id));

--- a/latexml_package/src/package/ieeetran_cls.rs
+++ b/latexml_package/src/package/ieeetran_cls.rs
@@ -449,7 +449,7 @@ LoadDefinitions!({
   DefPrimitive!("\\IEEEnonumber OptionalMatch:*", sub[(star)] {
     let key = if star.is_some() { "EQUATION_NUMBERING" } else { "EQUATIONROW_TAGS" };
     with_value_mut(key, |v| {
-      if let Some(Stored::HashStored(ref mut m)) = v {
+      if let Some(Stored::HashStored(m)) = v {
         m.insert("retract", Stored::Bool(true));
         m.remove("counter");
       }
@@ -459,7 +459,7 @@ LoadDefinitions!({
   DefPrimitive!("\\IEEEyesnumber OptionalMatch:*", sub[(star)] {
     // Perl: if EQUATION_NUMBERING.counter == 'subequation', step the equation counter
     let subeq = with_value("EQUATION_NUMBERING", |v| {
-      if let Some(Stored::HashStored(ref m)) = v {
+      if let Some(Stored::HashStored(m)) = v {
         matches!(m.get("counter"),
           Some(Stored::String(s)) if arena::to_string(*s) == "subequation")
       } else { false }
@@ -469,14 +469,14 @@ LoadDefinitions!({
     }
     if star.is_some() {
       with_value_mut("EQUATION_NUMBERING", |v| {
-        if let Some(Stored::HashStored(ref mut m)) = v {
+        if let Some(Stored::HashStored(m)) = v {
           m.insert("retract", Stored::Bool(false));
           m.remove("counter");
         }
       });
     } else {
       with_value_mut("EQUATIONROW_TAGS", |v| {
-        if let Some(Stored::HashStored(ref mut m)) = v {
+        if let Some(Stored::HashStored(m)) = v {
           m.insert("noretract", Stored::Bool(true));
           m.remove("counter");
         }
@@ -487,7 +487,7 @@ LoadDefinitions!({
   DefPrimitive!("\\IEEEyessubnumber OptionalMatch:*", sub[(star)] {
     let key = if star.is_some() { "EQUATION_NUMBERING" } else { "EQUATIONROW_TAGS" };
     with_value_mut(key, |v| {
-      if let Some(Stored::HashStored(ref mut m)) = v {
+      if let Some(Stored::HashStored(m)) = v {
         m.insert("counter", Stored::String(pin!("subequation")));
       }
     });
@@ -504,7 +504,7 @@ LoadDefinitions!({
   DefPrimitive!("\\IEEEnosubnumber OptionalMatch:*", sub[(star)] {
     let key = if star.is_some() { "EQUATION_NUMBERING" } else { "EQUATIONROW_TAGS" };
     with_value_mut(key, |v| {
-      if let Some(Stored::HashStored(ref mut m)) = v {
+      if let Some(Stored::HashStored(m)) = v {
         m.insert("counter", Stored::String(pin!("equation")));
       }
     });

--- a/latexml_package/src/package/latexml_sty.rs
+++ b/latexml_package/src/package/latexml_sty.rs
@@ -603,7 +603,7 @@ LoadDefinitions!({
     let mut tag_text = String::new();
     let mut description_text = String::new();
     if let Some(kv_arg) = whatsit.get_arg(2) {
-      if let DigestedData::KeyVals(ref kv) = kv_arg.data() {
+      if let DigestedData::KeyVals(kv) = kv_arg.data() {
         let hash = kv.get_hash_digested();
         if let Some(v) = hash.get("role") { role = v.clone(); }
         if let Some(v) = hash.get("name") { name_val = v.clone(); }
@@ -673,7 +673,7 @@ LoadDefinitions!({
               // holds a State borrow while its closure runs (see
               // mathchar.rs fix for 0711.4787 RefCell panic pattern).
               let mut encoding_opt: Option<String> = state::with_font_info(ftok, |fontinfo| {
-                if let Some(Stored::Font(ref info)) = fontinfo.unwrap_or(None) {
+                if let Some(Stored::Font(info)) = fontinfo.unwrap_or(None) {
                   info.encoding.as_ref().map(|s| s.to_string())
                 } else {
                   None

--- a/latexml_package/src/package/listings_sty.rs
+++ b/latexml_package/src/package/listings_sty.rs
@@ -1415,7 +1415,7 @@ fn lst_process_internal(
             };
             let content_tokens = tokenize_balanced(&content);
             ctx.lsttokens.extend(content_tokens);
-          } else if let Ok(close_re) = Regex::new(&close_re_str) {
+          } else { match Regex::new(&close_re_str) { Ok(close_re) => {
             if let Some(cm) = close_re.find(&ctx.listing) {
               let content = ctx.listing[..cm.start()].to_string();
               ctx.listing = ctx.listing[cm.end()..].to_string();
@@ -1424,7 +1424,7 @@ fn lst_process_internal(
               ctx.lsttokens.extend(content_tokens);
               // Note: close delimiter is NOT pushed — lstClassEnd handles it
             }
-          }
+          } _ => {}}}
         } else {
           // For non-eval classes (strings, comments): recurse with limited delimiters
           let recursive_key = s!("LST_DELIM@{open}@recursive");
@@ -2188,8 +2188,8 @@ LoadDefinitions!({
         let sub_args: Vec<Option<Cow<Tokens>>> = args.iter()
           .map(|a| match a {
             ArgWrap::None => None,
-            ArgWrap::Tokens(ref t) => Some(Cow::Borrowed(t)),
-            ArgWrap::Token(ref t) => Some(Cow::Owned(Tokens::new(vec![*t]))),
+            ArgWrap::Tokens(t) => Some(Cow::Borrowed(t)),
+            ArgWrap::Token(t) => Some(Cow::Owned(Tokens::new(vec![*t]))),
             other => Some(Cow::Owned(Tokens::new(ExplodeText!(other.to_string())))),
           })
           .collect();

--- a/latexml_package/src/package/lxrdfa_sty.rs
+++ b/latexml_package/src/package/lxrdfa_sty.rs
@@ -65,11 +65,11 @@ fn rdf_attributes_from_argwrap(arg: &ArgWrap) -> HashMap<String, String> {
     },
     _ => {
       // Try converting to Digested
-      if let Some(d) = arg.clone().undigested() {
+      match arg.clone().undigested() { Some(d) => {
         rdf_attributes_from_digested(&d)
-      } else {
+      } _ => {
         HashMap::default()
-      }
+      }}
     },
   }
 }

--- a/latexml_package/src/package/makecell_sty.rs
+++ b/latexml_package/src/package/makecell_sty.rs
@@ -108,11 +108,11 @@ LoadDefinitions!({
           let _ = line_node.set_attribute("stroke-width", "0.4");
           // Insert as first child of picture
           let pic_children = picture.get_child_nodes();
-          if let Some(mut first_g) = pic_children.into_iter().find(|c| c.get_name() == "g") {
+          match pic_children.into_iter().find(|c| c.get_name() == "g") { Some(mut first_g) => {
             first_g.add_prev_sibling(&mut line_node)?;
-          } else {
+          } _ => {
             picture.add_child(&mut line_node)?;
-          }
+          }}
           // Set tex= attribute on <picture> from constructor reversion
           let tex_str = whatsit.revert()
             .map(|toks| toks.untex())
@@ -162,13 +162,13 @@ LoadDefinitions!({
       // Get width from space arg (#3)
       // Perl: $space->getWidth->pxValue
       let w = if let Some(sp) = whatsit.get_arg(3) {
-        if let Ok(Some(wd)) = sp.clone().get_width(None) {
+        match sp.clone().get_width(None) { Ok(Some(wd)) => {
           let dim: Dimension = wd.into();
           px(dim)
-        } else {
+        } _ => {
           let (wd,_,_,_,_,_) = sp.clone().get_size(None)?;
           px(wd)
-        }
+        }}
       } else { 0.0 };
       // Perl: $h = $w * abs($diagV / $diagH); — raw pxValue, no rounding
       let h = w * (dv / dh).abs();

--- a/latexml_package/src/package/omnibus_cls.rs
+++ b/latexml_package/src/package/omnibus_cls.rs
@@ -26,7 +26,7 @@ fn push_keyword_body_to_frontmatter(
       content: vec![latexml_core::document::tag::TagContent::Box(body)],
     };
     latexml_core::state::with_value_mut("frontmatter", |val_opt| {
-      if let Some(Stored::HashTagData(ref mut frnt)) = val_opt {
+      if let Some(Stored::HashTagData(frnt)) = val_opt {
         frnt
           .entry("ltx:classification".to_string())
           .or_insert_with(Vec::new)

--- a/latexml_package/src/package/pdfpages_sty.rs
+++ b/latexml_package/src/package/pdfpages_sty.rs
@@ -18,7 +18,7 @@ LoadDefinitions!({
     "<ltx:resource src='#src' type='application/pdf'/>See #pages<ltx:ref href='#src'>#src</ltx:ref>",
     properties => sub[args] {
       let pages = args[0].as_ref().and_then(|d| {
-        if let DigestedData::KeyVals(ref kvs) = d.data() {
+        if let DigestedData::KeyVals(kvs) = d.data() {
           kvs.get_value("pages").map(|v| v.to_string())
         } else { None }
       });

--- a/latexml_package/src/package/pgfmath_code_tex.rs
+++ b/latexml_package/src/package/pgfmath_code_tex.rs
@@ -139,16 +139,16 @@ fn parse_pgf_number(arg: &Tokens) -> f64 {
     return v;
   }
   // If direct parse fails (e.g. unexpanded macro), expand and retry
-  if let Ok(expanded) = gullet::do_expand(arg.clone()) {
+  match gullet::do_expand(arg.clone()) { Ok(expanded) => {
     let s = expanded.to_string();
     let s = strip_leading_double_negation(s.trim());
     if s == "." {
       return 0.0;
     }
     s.parse::<f64>().unwrap_or(0.0)
-  } else {
+  } _ => {
     0.0
-  }
+  }}
 }
 
 // Perl #2711 uses `s/^\-\-//g`, which strips every leading `--` pair
@@ -245,16 +245,16 @@ fn pgfmath_convert(number: f64, unit: &str) -> f64 {
 /// Look up a TeX register value, return as points
 /// Perl: sub pgfmath_register (L487-493)
 fn pgfmath_register_lookup(cs: &str) -> f64 {
-  if let Ok(Some(reg)) = state::lookup_register(cs, vec![]) {
+  match state::lookup_register(cs, vec![]) { Ok(Some(reg)) => {
     match reg {
       RegisterValue::Number(n) => n.value_of() as f64,
       RegisterValue::Dimension(d) => d.value_of() as f64 / 65536.0,
       RegisterValue::Glue(g) => g.value_of() as f64 / 65536.0,
       _ => 0.0,
     }
-  } else {
+  } _ => {
     0.0
-  }
+  }}
 }
 
 // ==================== Built-in Function Application ====================
@@ -932,11 +932,11 @@ mod pgfmath_grammar {
       loop {
         sb(i);
         if eat(i, b',') {
-          if let Ok(arg) = formula(i) {
+          match formula(i) { Ok(arg) => {
             args.push(arg);
-          } else {
+          } _ => {
             break;
-          }
+          }}
         } else {
           break;
         }

--- a/latexml_package/src/package/pgfsys_latexml_def.rs
+++ b/latexml_package/src/package/pgfsys_latexml_def.rs
@@ -325,12 +325,12 @@ LoadDefinitions!({
     "#alignment",
     bounded => true, leave_horizontal => true,
     sizer => sub[whatsit] {
-      if let Some(Stored::Digested(alignment_d)) = whatsit.get_property("alignment").as_deref() {
+      match whatsit.get_property("alignment").as_deref() { Some(Stored::Digested(alignment_d)) => {
         let (w, h, d, _, _, _) = alignment_d.clone().get_size(None)?;
         Ok((w, h, d))
-      } else {
+      } _ => {
         Ok((Dimension::default(), Dimension::default(), Dimension::default()))
-      }
+      }}
     },
     after_digest => sub[whatsit] {
       use crate::engine::tex_tables::{
@@ -518,11 +518,11 @@ LoadDefinitions!({
       let shift_str = shift_tokens.to_string();
       let shift_str = shift_str.trim();
       let base = if !shift_str.is_empty() && shift_str != "0pt" {
-        if let Ok(shift_dim) = Dimension::from_str(shift_str) {
+        match Dimension::from_str(shift_str) { Ok(shift_dim) => {
           // Perl: $base = ($shift ? $miny->subtract(Dimension($shift))->pxValue : 0)
           let base_dim = Dimension::new(miny.value_of() - shift_dim.value_of());
           dim_to_px(base_dim)
-        } else { 0.0 }
+        } _ => { 0.0 }}
       } else { 0.0 };
 
       whatsit.set_property("minx", Stored::Float(Float::new_f64(0.0)));
@@ -875,7 +875,7 @@ LoadDefinitions!({
       let mut attrs = string_map!("_autoclose" => "1".to_string());
       if let Some(Some(kv_arg)) = args.first() {
         // Perl: $doc->openElement('svg:g', $kv->getHash, _autoclose => 1);
-        if let DigestedData::KeyVals(ref kv) = kv_arg.data() {
+        if let DigestedData::KeyVals(kv) = kv_arg.data() {
           let hash = kv.get_hash();
           for (k, v) in hash {
             attrs.insert(k, v);
@@ -1576,9 +1576,9 @@ LoadDefinitions!({
     let name = args.first().map(|a| a.to_string()).unwrap_or_default();
     let flag: i64 = args.get(1).map(|a| a.value_of()).unwrap_or(0);
     // Collect digested stops from state
-    let stops: Vec<Digested> = if let Some(Stored::VecDequeStored(vd)) = state::lookup_value("pgf_sh_stops") {
+    let stops: Vec<Digested> = match state::lookup_value("pgf_sh_stops") { Some(Stored::VecDequeStored(vd)) => {
       vd.into_iter().filter_map(|s| if let Stored::Digested(d) = s { Some(d) } else { None }).collect()
-    } else { vec![] };
+    } _ => { vec![] }};
     state::assign_value("pgf_sh_stops", Stored::VecDequeStored(VecDeque::new()), Scope::Global);
     let x = dim_to_px(read_dim_register("\\pgf@x"));
     let y = dim_to_px(read_dim_register("\\pgf@y"));
@@ -1641,9 +1641,9 @@ LoadDefinitions!({
   DefPrimitive!("\\lxSVG@sh@defcircles{}", sub[args] {
     let name = args.first().map(|a| a.to_string().trim().to_string()).unwrap_or_default();
     // Collect digested stops from state
-    let stops: Vec<Digested> = if let Some(Stored::VecDequeStored(vd)) = state::lookup_value("pgf_sh_stops") {
+    let stops: Vec<Digested> = match state::lookup_value("pgf_sh_stops") { Some(Stored::VecDequeStored(vd)) => {
       vd.into_iter().filter_map(|s| if let Stored::Digested(d) = s { Some(d) } else { None }).collect()
-    } else { vec![] };
+    } _ => { vec![] }};
     state::assign_value("pgf_sh_stops", Stored::VecDequeStored(VecDeque::new()), Scope::Global);
     // Perl: Dimension(ToString(Expand(T_CS('\pgf@sys@shading@end@pos'))))->pxValue
     let endpos_tokens = gullet::do_expand(T_CS!("\\pgf@sys@shading@end@pos"))?;

--- a/latexml_package/src/package/physics_sty.rs
+++ b/latexml_package/src/package/physics_sty.rs
@@ -43,7 +43,7 @@ fn phys_read_size() -> Result<(bool, Option<Token>)> {
 
 /// Perl: phys_revSize — reversion tokens for size
 fn phys_rev_size(no_stretch: bool, size_tok: &Option<Token>) -> Vec<Token> {
-  if let Some(ref sz) = size_tok {
+  if let Some(sz) = size_tok {
     vec![*sz]
   } else if no_stretch {
     vec![T_OTHER!("*")]

--- a/latexml_package/src/package/siunitx_sty.rs
+++ b/latexml_package/src/package/siunitx_sty.rs
@@ -36,10 +36,10 @@ fn read_si_declare_cs() -> Result<Token> {
 /// The thin emit-only macro keeps the harness `Error:<class>:<object>`
 /// format contract while staying type-compatible.
 macro_rules! six_log_error {
-  ($category:expr, $object:expr, $msg:expr) => {
+  ($category:expr_2021, $object:expr_2021, $msg:expr_2021) => {
     log::error!(target: &format!("{}:{}", $category, $object), "{}", $msg)
   };
-  ($category:expr, $object:expr, $fmt:expr, $($arg:tt)+) => {
+  ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {
     log::error!(target: &format!("{}:{}", $category, $object), $fmt, $($arg)+)
   };
 }

--- a/latexml_package/src/package/xcolor_sty.rs
+++ b/latexml_package/src/package/xcolor_sty.rs
@@ -207,7 +207,7 @@ fn decode_color(expression: &str) -> Color {
   };
 
   // Apply blend from state
-  let full_mix = if let Some(Stored::String(blend_sym)) = state::lookup_value("color_blend") {
+  let full_mix = match state::lookup_value("color_blend") { Some(Stored::String(blend_sym)) => {
     arena::with(blend_sym, |blend| {
       if !blend.is_empty() {
         format!("{}{}", mix_part, blend)
@@ -215,9 +215,9 @@ fn decode_color(expression: &str) -> Color {
         mix_part.clone()
       }
     })
-  } else {
+  } _ => {
     mix_part
-  };
+  }};
 
   // Apply mix expressions: !pct!name...
   if !full_mix.is_empty() {
@@ -449,10 +449,10 @@ fn step_color_series(name: &str, n: usize) {
 fn index_color_series(name: &str, p: usize) -> Color {
   let base_key = s!("color_series_{name}_base");
   let step_key = s!("color_series_{name}_step");
-  if let (Some(Stored::String(b_sym)), Some(Stored::String(s_sym))) = (
+  match (
     state::lookup_value(&base_key),
     state::lookup_value(&step_key),
-  ) {
+  ) { (Some(Stored::String(b_sym)), Some(Stored::String(s_sym))) => {
     let base = Color::from_stored(&arena::to_string(b_sym)).unwrap_or(BLACK);
     let step = Color::from_stored(&arena::to_string(s_sym)).unwrap_or(BLACK);
     let comps = base.components();
@@ -463,9 +463,9 @@ fn index_color_series(name: &str, p: usize) -> Color {
       .map(|(c, s)| range_reduction(c + p as f64 * s))
       .collect();
     from_model_components(base.model(), &new_comps)
-  } else {
+  } _ => {
     BLACK
-  }
+  }}
 }
 
 /// Perl xcolor.sty.ltxml L403-409: if the optional `[type]` argument
@@ -925,11 +925,11 @@ LoadDefinitions!({
     let scope = if state::lookup_bool_sym(pin!("xglobal@")) { Some(Scope::Global) } else { None };
     let new_blend = if star.is_some() {
       // Starred: append to existing blend
-      if let Some(Stored::String(old_sym)) = state::lookup_value("color_blend") {
+      match state::lookup_value("color_blend") { Some(Stored::String(old_sym)) => {
         arena::with(old_sym, |old| format!("{old}{mix_str}"))
-      } else {
+      } _ => {
         mix_str
-      }
+      }}
     } else {
       mix_str
     };
@@ -1014,18 +1014,18 @@ LoadDefinitions!({
       let step = match method.as_str() {
         "step" => {
           // delta is the step itself
-          if let Some(Stored::String(d_sym)) = state::lookup_value(&delta_key) {
+          match state::lookup_value(&delta_key) { Some(Stored::String(d_sym)) => {
             arena::with(d_sym, Color::from_stored).unwrap_or(BLACK)
-          } else { BLACK }
+          } _ => { BLACK }}
         },
         "grad" => {
-          if let Some(Stored::String(d_sym)) = state::lookup_value(&delta_key) {
+          match state::lookup_value(&delta_key) { Some(Stored::String(d_sym)) => {
             arena::with(d_sym, Color::from_stored).unwrap_or(BLACK).scale(1.0 / div)
-          } else { BLACK }
+          } _ => { BLACK }}
         },
         "last" => {
           // For "last": step = (last - base) / div
-          if let Some(Stored::String(d_sym)) = state::lookup_value(&delta_key) {
+          match state::lookup_value(&delta_key) { Some(Stored::String(d_sym)) => {
             let last = arena::with(d_sym, Color::from_stored).unwrap_or(BLACK);
             let base_comps = base.components();
             let last_comps = last.components();
@@ -1033,7 +1033,7 @@ LoadDefinitions!({
               .map(|(b, l)| (l - b) / div)
               .collect();
             from_model_components(base.model(), &step_comps)
-          } else { BLACK }
+          } _ => { BLACK }}
         },
         other => {
           Warn!("unknown","xcolor_step",format!("the step '{other}' was not step/grad/last"));
@@ -1364,7 +1364,7 @@ LoadDefinitions!({
     T_CS!("\\rownum"),
     None,
     Some(ExpansionBody::Closure(Rc::new(|_args: Vec<ArgWrap>| {
-      if let Some(alignment) = state::lookup_alignment() {
+      match state::lookup_alignment() { Some(alignment) => {
         if let DigestedData::Alignment(cell) = alignment.data() {
           let row_num = cell.borrow().current_row_number();
           let num_str = row_num.to_string();
@@ -1377,9 +1377,9 @@ LoadDefinitions!({
         } else {
           Ok(Tokens!(T_OTHER!("0")))
         }
-      } else {
+      } _ => {
         Ok(Tokens!(T_OTHER!("0")))
-      }
+      }}
     }))),
     None,
   )?;

--- a/latexml_package/src/package/xy_sty.rs
+++ b/latexml_package/src/package/xy_sty.rs
@@ -198,7 +198,7 @@ LoadDefinitions!({
   DefPrimitive!("\\lx@xy@capturerange", {
     let mut dims = String::new();
     for reg in ["\\X@min", "\\Y@min", "\\X@max", "\\Y@max"] {
-      if let Ok(Some(val)) = state::lookup_register(reg, Vec::new()) {
+      match state::lookup_register(reg, Vec::new()) { Ok(Some(val)) => {
         let sp = match val {
           RegisterValue::Dimension(d) => d.value_of(),
           RegisterValue::Number(n) => n.value_of(),
@@ -206,10 +206,10 @@ LoadDefinitions!({
         };
         if !dims.is_empty() { dims.push(','); }
         dims.push_str(&sp.to_string());
-      } else {
+      } _ => {
         if !dims.is_empty() { dims.push(','); }
         dims.push('0');
-      }
+      }}
     }
     state::assign_value("saved_xy_range", Stored::String(arena::pin(&dims)), Some(Scope::Global));
   });

--- a/latexml_post/Cargo.toml
+++ b/latexml_post/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "latexml_post"
 version = "0.3.0"
-edition = "2021"
+edition = "2024"
 license = "CC0"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
 description = "Post-processing pipeline for latexml_oxide (Rust port of LaTeXML::Post)"

--- a/latexml_post/src/diag.rs
+++ b/latexml_post/src/diag.rs
@@ -38,7 +38,7 @@
 
 #[macro_export]
 macro_rules! Note {
-  ($input:expr) => {{
+  ($input:expr_2021) => {{
     if log::max_level() >= log::LevelFilter::Info {
       eprintln!("{}", $input);
     }
@@ -47,43 +47,43 @@ macro_rules! Note {
 
 #[macro_export]
 macro_rules! Info {
-  ($category:expr, $object:expr, $msg:expr) => {
+  ($category:expr_2021, $object:expr_2021, $msg:expr_2021) => {
     log::info!(target: &format!("{}:{}", $category, $object), "{}", $msg)
   };
-  ($category:expr, $object:expr, $fmt:expr, $($arg:tt)+) => {
+  ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {
     log::info!(target: &format!("{}:{}", $category, $object), $fmt, $($arg)+)
   };
 }
 
 #[macro_export]
 macro_rules! Warn {
-  ($category:expr, $object:expr, $msg:expr) => {
+  ($category:expr_2021, $object:expr_2021, $msg:expr_2021) => {
     log::warn!(target: &format!("{}:{}", $category, $object), "{}", $msg)
   };
-  ($category:expr, $object:expr, $fmt:expr, $($arg:tt)+) => {
+  ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {
     log::warn!(target: &format!("{}:{}", $category, $object), $fmt, $($arg)+)
   };
 }
 
 #[macro_export]
 macro_rules! Error {
-  ($category:expr, $object:expr, $msg:expr) => {
+  ($category:expr_2021, $object:expr_2021, $msg:expr_2021) => {
     log::error!(target: &format!("{}:{}", $category, $object), "{}", $msg)
   };
-  ($category:expr, $object:expr, $fmt:expr, $($arg:tt)+) => {
+  ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {
     log::error!(target: &format!("{}:{}", $category, $object), $fmt, $($arg)+)
   };
 }
 
 #[macro_export]
 macro_rules! Fatal {
-  ($category:expr, $object:expr, $msg:expr) => {{
+  ($category:expr_2021, $object:expr_2021, $msg:expr_2021) => {{
     log::error!(target: &format!("Fatal:{}:{}", $category, $object), "{}", $msg);
     return Err($crate::processor::PostError::Processing(
       format!("{}:{}: {}", $category, $object, $msg)
     ));
   }};
-  ($category:expr, $object:expr, $fmt:expr, $($arg:tt)+) => {{
+  ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {{
     let __m = format!($fmt, $($arg)+);
     log::error!(target: &format!("Fatal:{}:{}", $category, $object), "{}", __m);
     return Err($crate::processor::PostError::Processing(

--- a/latexml_post/src/document.rs
+++ b/latexml_post/src/document.rs
@@ -1409,16 +1409,16 @@ impl PostDocument {
       children:   vec![],
     };
 
-    if let Some(mut nav) = self.findnode("//ltx:navigation") {
+    match self.findnode("//ltx:navigation") { Some(mut nav) => {
       self.add_nodes(&mut nav, &[ref_node]);
-    } else if let Some(mut root) = self.get_document_element() {
+    } _ => { match self.get_document_element() { Some(mut root) => {
       let nav_node = NodeData::Element {
         tag:        "ltx:navigation".to_string(),
         attributes: None,
         children:   vec![ref_node],
       };
       self.add_nodes(&mut root, &[nav_node]);
-    }
+    } _ => {}}}}
   }
 
   // ======================================================================
@@ -1566,7 +1566,7 @@ pub fn element_children(node: &Node) -> Vec<Node> {
 /// Prefer this in hot paths that only need to read or filter children
 /// without materializing a Vec. Callers that need len() or random access
 /// still want the Vec version.
-pub fn element_children_iter(node: &Node) -> impl Iterator<Item = Node> {
+pub fn element_children_iter(node: &Node) -> impl Iterator<Item = Node> + use<> {
   let first = node.get_first_child();
   std::iter::successors(first, |c| c.get_next_sibling())
     .filter(|c| c.get_type() == Some(NodeType::ElementNode))

--- a/latexml_post/src/graphics.rs
+++ b/latexml_post/src/graphics.rs
@@ -2310,7 +2310,8 @@ mod tests {
   impl EnvGuard {
     fn set(key: &str, value: &str) -> Self {
       let old = std::env::var(key).ok();
-      std::env::set_var(key, value);
+      // FIXME: Audit that the environment access only happens in single-threaded code.
+      unsafe { std::env::set_var(key, value) };
       Self { key: key.to_string(), old }
     }
   }
@@ -2318,9 +2319,11 @@ mod tests {
   impl Drop for EnvGuard {
     fn drop(&mut self) {
       if let Some(old) = &self.old {
-        std::env::set_var(&self.key, old);
+        // FIXME: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var(&self.key, old) };
       } else {
-        std::env::remove_var(&self.key);
+        // FIXME: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var(&self.key) };
       }
     }
   }

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -397,7 +397,7 @@ impl MakeBibliography {
       seen.insert(bibkey.clone());
       let lc_key = bibkey.to_lowercase();
 
-      if let Some(mut entry) = entries.remove(&lc_key) {
+      match entries.remove(&lc_key) { Some(mut entry) => {
         // Extract metadata from bibentry XML node (if available)
         if let Some(ref bibentry) = entry.bibentry {
           let (sort_names, short_names, _full_names) = extract_names(doc, bibentry);
@@ -406,20 +406,19 @@ impl MakeBibliography {
 
           let names_for_sort = if sort_names.is_empty() {
             // Try bib-key or bib-title as fallback
-            if let Some(key_node) = PostDocument::findnodes_foreign("ltx:bib-key", bibentry)
+            match PostDocument::findnodes_foreign("ltx:bib-key", bibentry)
               .into_iter()
               .next()
-            {
+            { Some(key_node) => {
               key_node.get_content()
-            } else if let Some(title_node) =
-              PostDocument::findnodes_foreign("ltx:bib-title", bibentry)
+            } _ => { match PostDocument::findnodes_foreign("ltx:bib-title", bibentry)
                 .into_iter()
                 .next()
-            {
+            { Some(title_node) => {
               title_node.get_content()
-            } else {
+            } _ => {
               bibkey.clone()
-            }
+            }}}}
           } else {
             sort_names
           };
@@ -518,10 +517,10 @@ impl MakeBibliography {
             missing_keys.push(bibkey);
           }
         }
-      } else {
+      } _ => {
         // Not found in entries map
         missing_keys.push(bibkey);
-      }
+      }}
     }
 
     if !missing_keys.is_empty() {

--- a/latexml_post/src/make_index.rs
+++ b/latexml_post/src/make_index.rs
@@ -304,9 +304,9 @@ impl MakeIndex {
           xml: vec![NodeData::Text(see.text.clone())],
         }],
       };
-      if let Some(see_links) = seealso_search_rec(&parts, all_phrases, &see_context) {
+      match seealso_search_rec(&parts, all_phrases, &see_context) { Some(see_links) => {
         links.extend(see_links);
-      } else {
+      } _ => {
         // Perl warns unless the see phrase already contains refs of
         // its own, then falls back to the phrase's own markup.
         let already_linked = see
@@ -331,7 +331,7 @@ impl MakeIndex {
           attributes: None,
           children:   content,
         });
-      }
+      }}
     }
 
     if !links.is_empty() {

--- a/latexml_post/src/math_processor.rs
+++ b/latexml_post/src/math_processor.rs
@@ -231,9 +231,9 @@ fn process_math_node(
     });
 
   // Apply outer wrapper if we got XML
-  if let Some(xml) = conversion.xml.take() {
+  match conversion.xml.take() { Some(xml) => {
     conversion.xml = Some(processor.outer_wrapper(doc, &xmath, xml));
-  } else if let Some(ref string) = conversion.string {
+  } _ => if let Some(ref string) = conversion.string {
     // Wrap string in ltx:text
     let mimetype = conversion.mimetype.as_deref().unwrap_or("unknown");
     conversion.xml = Some(NodeData::Element {
@@ -244,7 +244,7 @@ fn process_math_node(
       )])),
       children:   vec![NodeData::Text(string.clone())],
     });
-  }
+  }}
 
   if !keep_xmath {
     // Mark XMath IDs as reusable (it will be removed)

--- a/latexml_post/src/mathml/mod.rs
+++ b/latexml_post/src/mathml/mod.rs
@@ -736,7 +736,7 @@ pub fn get_xm_hint_spacing(width: &str) -> f64 {
 pub fn needs_mathstyle(node: &NodeData) -> bool {
   match node {
     NodeData::Element { attributes, children, .. } => {
-      if let Some(ref attrs) = attributes {
+      if let Some(attrs) = attributes {
         if attrs.contains_key("_largeop") {
           return true;
         }
@@ -1048,7 +1048,7 @@ pub fn pmml_row(items: Vec<NodeData>) -> NodeData {
     .into_iter()
     .filter(|item| match item {
       NodeData::Element { attributes, .. } => {
-        if let Some(ref attrs) = attributes {
+        if let Some(attrs) = attributes {
           !attrs.contains_key("_ignorable")
         } else {
           true
@@ -1186,11 +1186,11 @@ pub fn pmml_text_aux(doc: &PostDocument, node: &Node) -> Vec<NodeData> {
       match tag.as_str() {
         "ltx:Math" => {
           // Nested math: convert XMath if present
-          if let Some(xmath) = doc.findnode_at("ltx:XMath", node) {
+          match doc.findnode_at("ltx:XMath", node) { Some(xmath) => {
             vec![presentation::convert_to_pmml(doc, &xmath)]
-          } else {
+          } _ => {
             vec![]
-          }
+          }}
         },
         "ltx:text" => {
           // Recurse on children

--- a/latexml_post/src/object_db.rs
+++ b/latexml_post/src/object_db.rs
@@ -195,7 +195,7 @@ impl Entry {
       .values
       .entry(attr.to_string())
       .or_insert_with(|| Value::List(Vec::new()));
-    if let Value::List(ref mut items) = list {
+    if let Value::List(items) = list {
       for v in values {
         items.push(v);
       }
@@ -210,7 +210,7 @@ impl Entry {
       .values
       .entry(attr.to_string())
       .or_insert_with(|| Value::List(Vec::new()));
-    if let Value::List(ref mut items) = list {
+    if let Value::List(items) = list {
       for v in values {
         let s = v.to_string();
         if !items.iter().any(|existing| existing.to_string() == s) {
@@ -242,7 +242,7 @@ impl Entry {
       .entry(first.to_string())
       .or_insert_with(|| Value::Hash(HashMap::default()));
 
-    if let Value::Hash(ref mut h) = hash {
+    if let Value::Hash(h) = hash {
       let mut current = h;
       for (i, &key) in rest.iter().enumerate() {
         if i == rest.len() - 1 {
@@ -253,7 +253,7 @@ impl Entry {
           let entry = current
             .entry(key.to_string())
             .or_insert_with(|| Value::Hash(HashMap::default()));
-          if let Value::Hash(ref mut inner) = entry {
+          if let Value::Hash(inner) = entry {
             current = inner;
           } else {
             break;

--- a/latexml_post/src/unicode_math.rs
+++ b/latexml_post/src/unicode_math.rs
@@ -287,11 +287,11 @@ fn unimath_internal(doc: &PostDocument, node: &Node) -> (String, i32) {
     },
     "ltx:XMText" => unimath_text(node),
     "ltx:XMRef" => {
-      if let Some(target) = realize(doc, node) {
+      match realize(doc, node) { Some(target) => {
         unimath_internal(doc, &target)
-      } else {
+      } _ => {
         unimath_error("Unresolved XMRef")
-      }
+      }}
     },
     "ltx:ERROR" => unimath_error(&node.get_content()),
     _ => unimath_text(node),

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -12,5 +12,5 @@ condense_wildcard_suffixes = true
 overflow_delimited_expr = true
 struct_field_align_threshold = 30
 struct_lit_width = 30
-edition = "2021"
+edition = "2024"
 style_edition = "2024"


### PR DESCRIPTION
Bumps the whole workspace (all 8 crates + `rustfmt.toml`) from edition **2021 → 2024**.

## How it was done

- `cargo fix --edition --workspace --all-targets` applied the automated migration (101 files). The vast majority is the behavior-preserving **`expr` → `expr_2021`** macro-fragment rename (2024 widened `expr` to also match `const {}` / `_`; the rename keeps exact 2021 matching). The rest: a few `unsafe`-wrapped `env::set_var`/`remove_var` (now unsafe in 2024), one `unsafe extern` block, one RPIT `+ use<>` capture, and `if let` temporary-scope adjustments.
- Two **macro-generated** patterns `cargo fix` can't reach were fixed at source for the 2024 match-ergonomics rule (no explicit `ref` within an implicitly-borrowing pattern):
  - `latexml_codegen` `CompileReplacement` (`constructable.rs`) — dropped the redundant `ref` on the four `&args[i]` reference-scrutinee patterns; match ergonomics already yields `&T`, so it's type-preserving.
  - `latexml_core` `prop_digested!` macro_rules — same, on the `props.get(..)` (`Option<&Stored>`) scrutinee.

## Verification

- `cargo check --workspace --all-targets`: **0 errors / 0 warnings**.
- `cargo check --workspace --all-targets --all-features` (covers `cortex`, `script-bindings`, `token-locators`, `runtime-bindings`): **0 / 0**.
- Full suite: **1452 / 0 / 0** — behavior unchanged.

## Notes

- `expr_2021` kept deliberately (it's a stable, supported specifier; switching to `expr` is cosmetic-only here and buys nothing, since these macros never receive `const {}`/`_`).
- Independent of #250 (the `--css` resource-copy fix) — different files, separate branch off master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)