### PR TITLE
release: prepare 0.7.0 (runtime-bindings, .deb deps, pinned nightly, docs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             libxml2-dev libxslt1-dev libkpathsea-dev libkpathsea6 \
             mold \
+            dpkg-dev \
             texlive texlive-latex-extra texlive-science \
             texlive-bibtex-extra texlive-publishers \
             poppler-utils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Change Log
 
+## [0.7.0] (single-binary release: portability, runtime bindings, edition 2024)
+
+  - **Self-contained, redistributable binary** (#236). Engine dumps, the
+    RelaxNG schema, and XSLT/CSS/JS are embedded and served from memory; the
+    `maxperf` binary runs with no `resources/` tree. A tag-driven release
+    workflow builds the publish-grade artifact and attaches a portable tarball
+    + Debian `.deb` (each with a SHA-256 sidecar) as GitHub Release assets.
+  - **macOS (Apple Silicon) support** (#245). Full test suite green on arm64;
+    the distributed binary uses the subprocess-`kpsewhich` backend (no
+    libkpathsea ABI dependency, works on MacTeX). The release ships an
+    `aarch64-apple-darwin` tarball alongside the Linux artifacts.
+  - **Runtime (Rhai) script bindings** shipped in the release artifact
+    (#171, #248). A shared winnow template AST backs both the compile-time
+    native binding front-end and an optional runtime contributed-bindings
+    front-end embedded via Rhai — customize bindings without recompiling.
+    Runtime opt-in, so default conversions are unaffected.
+  - **Frontmatter refactor**: faithful port of upstream LaTeXML PR #2767
+    (#241), with a `--debug NAME` CLI and a deep-recursion pre-clear guard
+    that surpasses the Perl original on pathological inputs.
+  - **Persistent server mode** `latexml_oxide --server` (#243) for
+    editor/preview integration, plus opt-in source locators (`--source-map`)
+    and `token-locators` precision (#237) toward live source↔preview.
+  - **Post-processing**: faithful MakeIndex port — see/seeonly, styles,
+    anchors, placement (#244); CLI `--css`/`--javascript` resources copied and
+    followed (#250); html_feedback regression fixes (#240).
+  - **Engine parity at scale**: error-free conversion sweeps over the arXiv
+    "warning" corpus scaled to 1.5M → 2M articles (#238, #242) and a third
+    500K canvas at ≥99.0% success (#249). `ProcessOptions` keysets (#235).
+  - **Toolchain & quality**: migrated the workspace to Rust edition 2024 and
+    centralized lint enforcement (#252) — clean `clippy -D warnings`,
+    tree-wide `style_edition = "2024"` formatting, a `[workspace.lints]`
+    policy, and a CI `lint` gate (rustfmt + clippy + cargo-deny advisories/
+    licenses + cargo-machete) plus an auto-installed pre-push hook. Three
+    unmaintained/vulnerable transitive dependencies (tempdir, ansi_term) were
+    dropped at the source, so the dependency audit is clean.
+
 ## [0.4.3] (round-19 — 100k canvas REAL-regression-free)
 
   - **100k canvas mission accomplished**. Staged 10 × 10k validation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ We follow Rust best practice with four named profiles in `Cargo.toml`:
 
 **Publish-grade measurement** (matching against Perl LaTeXML, baseline updates in `docs/PERFORMANCE.md`): use `--release`. The CI profile is for the GitHub runner only.
 
-**Distribution build** (shipping the binary to users): use `--profile maxperf --no-default-features` for the smallest, fastest artifact. Example: `cargo build --no-default-features --profile maxperf --bin latexml_oxide`. The `--no-default-features` flag drops the `test-utils` feature, removing `phf` + `glob` (and 4 transitive crates) from the binary. The `maxperf` profile uses `panic = "abort"` — production-only since canvas sweeps depend on `catch_unwind` for per-paper panic isolation.
+**Distribution build** (shipping the binary to users): use `--profile maxperf --no-default-features --features runtime-bindings` for the smallest, fastest artifact that still ships the Rhai script-bindings capability. Example: `cargo build --no-default-features --features runtime-bindings --profile maxperf --bin latexml_oxide`. The `--no-default-features` flag drops the `test-utils` feature (removing `phf` + `glob` and 4 transitive crates), while `--features runtime-bindings` keeps the runtime contributed-bindings front-end — runtime opt-in, so default conversions are unaffected (this is the recipe `tools/make_release.sh` uses). The `maxperf` profile uses `panic = "abort"` — production-only since canvas sweeps depend on `catch_unwind` for per-paper panic isolation.
 
 ```bash
 # Run all tests (default test profile)
@@ -207,8 +207,8 @@ tools/triage_failure.sh <arxiv_id>
 cargo build --release --bin latexml_oxide
 
 # Distribution build — smallest, fastest artifact (slow build, fat LTO,
-# panic=abort, no test-utils feature)
-cargo build --no-default-features --profile maxperf --bin latexml_oxide
+# panic=abort, no test-utils; keeps runtime-bindings)
+cargo build --no-default-features --features runtime-bindings --profile maxperf --bin latexml_oxide
 
 # Generate docs
 cargo doc --workspace --no-deps --open

--- a/README.md
+++ b/README.md
@@ -1,31 +1,30 @@
 # A Rust port of [LaTeXML](https://github.com/brucemiller/latexml)
 
-[![CI](https://github.com/dginev/latexml-oxide/actions/workflows/CI.yml/badge.svg)](https://github.com/dginev/latexml-oxide/actions/workflows/CI.yml) ![version](https://img.shields.io/badge/version-0.5.0-orange.svg) 
-[![ported tests](https://img.shields.io/badge/ported%20tests%20-%201328%2F0%2F0-%20%2332a852?style=flat)
+[![CI](https://github.com/dginev/latexml-oxide/actions/workflows/CI.yml/badge.svg)](https://github.com/dginev/latexml-oxide/actions/workflows/CI.yml) ![version](https://img.shields.io/badge/version-0.7.0-orange.svg) 
+[![ported tests](https://img.shields.io/badge/ported%20tests%20-%201454%2F0%2F0-%20%2332a852?style=flat)
 ](https://github.com/dginev/latexml-oxide/issues/30)
 
-This project is in an **early beta** stage. Please avoid using it in any real world setting before mainline LaTeXML parity is reached.
+This project is in active **beta**, approaching mainline LaTeXML parity. The full
+conversion pipeline already works end-to-end —
+`latexml_oxide --format=html5 --dest=paper.html paper.tex` produces complete HTML
+with cross-references, citations, MathML, and XSLT — but treat the output as
+not-yet-production-grade until parity is declared.
 
-**Current status (2026-05-19):** active strict-Perl parity work at
-the format/dump and package-loading boundary, followed by sandbox
-long-tail cleanup (see [`docs/SYNC_STATUS.md`](docs/SYNC_STATUS.md)).
-Current local verification is `cargo test --tests` **1328/0/0** and
-the latest 100k-paper warning-subset sandbox result is **~99.4% OK**.
-Full post-processing pipeline:
-`latexml_oxide --format=html5 --dest=paper.html paper.tex`
-produces complete HTML with cross-references, citations, MathML,
-and XSLT. Release-profile wall time on the
-[1910.01256](https://arxiv.org/abs/1910.01256) mini-benchmark is
-**0.71 s** (vs ~1.11 s pdflatex idle).
+**Status:** strict-Perl dump/format parity is complete; remaining work is
+sandbox long-tail cleanup (see [`docs/SYNC_STATUS.md`](docs/SYNC_STATUS.md)).
+Local verification: `cargo test --tests` **1454/0/0**; the latest 100k-paper
+warning-subset sandbox run is **~99.4% OK**. Release-profile wall time on the
+[1910.01256](https://arxiv.org/abs/1910.01256) mini-benchmark is **0.71 s**
+(vs ~1.11 s pdflatex idle).
 
 ### Why?
 
 The three main reasons:
 
   * LaTeXML is **too slow** for large-scale production use.
-  * Perl 5 has **no street cred** anymore.
-  * LaTeXML is **urgently needed**
-    - for turning LaTeX sources into responsive, accessible web documents.
+  * Perl 5's ecosystem and tooling have **aged out of the mainstream**.
+  * LaTeXML is **urgently needed** for turning LaTeX sources into responsive,
+    accessible web documents.
 
 Design goals:
 
@@ -33,43 +32,58 @@ Design goals:
   * Use idiomatic Rust when possible, especially when refactoring Perl idioms
   * Carefully address the newly required resource constraints
 
-### Releases
+### Install (prebuilt binaries)
 
-Prebuilt `x86_64-unknown-linux-gnu` binaries are attached to every
-tagged release on the [Releases page](https://github.com/dginev/latexml-oxide/releases).
-The binary is fully self-contained — all XSLT stylesheets, CSS, JS,
-and RelaxNG schemas are embedded at build time and served from memory,
-so no `resources/` tree is needed alongside it (a deliberate design
-goal — see [docs/OXIDIZED_DESIGN.md](docs/OXIDIZED_DESIGN.md)). A working
-TeX Live installation is still required at runtime for TeX
-package/class/font resolution (see the runtime dependencies below).
-Tested on Ubuntu 22.04 LTS and later (glibc ≥ 2.35) and Debian 12+.
+Every tagged release on the [Releases page](https://github.com/dginev/latexml-oxide/releases)
+ships prebuilt binaries for **Linux x86-64** (`.deb` + portable tarball) and
+**macOS Apple Silicon** (tarball). The binary is fully self-contained — all XSLT
+stylesheets, CSS, JS, and RelaxNG schemas are embedded at build time and served
+from memory, so no `resources/` tree is needed alongside it (a deliberate design
+goal — see [docs/OXIDIZED_DESIGN.md](docs/OXIDIZED_DESIGN.md)). A working TeX Live
+installation is still required at runtime for TeX package/class/font resolution.
+Every asset has a `<name>.sha256` sidecar for integrity checking.
 
-**Debian / Ubuntu (`.deb`, declares runtime apt deps):**
-
-```
-$ curl -LO https://github.com/dginev/latexml-oxide/releases/latest/download/latexml-oxide_<VERSION>-1_amd64.deb
-$ sudo apt install ./latexml-oxide_<VERSION>-1_amd64.deb
-```
-
-**Portable tarball:**
+Set the version once (use the latest from the Releases page):
 
 ```
-$ curl -LO https://github.com/dginev/latexml-oxide/releases/latest/download/latexml-oxide-<VERSION>-x86_64-unknown-linux-gnu.tar.gz
-$ tar xzf latexml-oxide-<VERSION>-x86_64-unknown-linux-gnu.tar.gz
-$ sudo cp latexml-oxide-<VERSION>-x86_64-unknown-linux-gnu/latexml_oxide /usr/local/bin/
+$ VERSION=0.7.0
 ```
 
-Tarball users also need the runtime libraries:
+#### Ubuntu / Debian
+
+The `.deb` declares its runtime apt dependencies (libraries + TeX Live + the
+graphics tools), so this is the recommended path. Built on Ubuntu 22.04
+(glibc 2.35), so it runs on Ubuntu 22.04+ and Debian 12+.
 
 ```
-$ sudo apt install libxml2 libxslt1.1 libkpathsea6 \
+$ curl -LO https://github.com/dginev/latexml-oxide/releases/download/$VERSION/latexml-oxide_${VERSION}-1_amd64.deb
+$ sudo apt install ./latexml-oxide_${VERSION}-1_amd64.deb
+```
+
+Prefer the portable tarball? Install the runtime dependencies yourself:
+
+```
+$ curl -LO https://github.com/dginev/latexml-oxide/releases/download/$VERSION/latexml-oxide-$VERSION-x86_64-unknown-linux-gnu.tar.gz
+$ tar xzf latexml-oxide-$VERSION-x86_64-unknown-linux-gnu.tar.gz
+$ sudo cp latexml-oxide-$VERSION-x86_64-unknown-linux-gnu/latexml_oxide /usr/local/bin/
+$ sudo apt install libxml2 libxslt1.1 libkpathsea6 imagemagick mupdf-tools \
                    texlive-latex-base texlive-latex-extra texlive-science
 ```
 
-Every asset has a SHA-256 sidecar file (`<name>.sha256`) for integrity
-checking. Other platforms are not yet shipped — see
-[docs/RELEASING.md](docs/RELEASING.md).
+#### macOS (Apple Silicon / arm64 only)
+
+```
+$ curl -LO https://github.com/dginev/latexml-oxide/releases/download/$VERSION/latexml-oxide-$VERSION-aarch64-apple-darwin.tar.gz
+$ tar xzf latexml-oxide-$VERSION-aarch64-apple-darwin.tar.gz
+$ sudo cp latexml-oxide-$VERSION-aarch64-apple-darwin/latexml_oxide /usr/local/bin/
+$ brew install libxml2 libxslt imagemagick mupdf-tools
+$ brew install texlive          # or install MacTeX / BasicTeX
+```
+
+Homebrew's `texlive` ships `libkpathsea`; with MacTeX/BasicTeX the binary instead
+resolves TeX files through your distribution's `kpsewhich` executable (ensure
+`/Library/TeX/texbin` is on `PATH`). Intel Macs are not yet a published target —
+see [docs/RELEASING.md](docs/RELEASING.md) for the platform roadmap.
 
 ### Build from source
 
@@ -85,8 +99,7 @@ $ sudo apt install libxml2-dev libxslt1-dev texlive-latex-base imagemagick libkp
                    texlive-bibtex-extra texlive-publishers poppler-utils
 ```
 
-Example for macOS (arm64; the full test suite runs on macOS CI — see
-[docs/archive/PORTABILITY_MACOS_PROBE_2026-06-07.md](docs/archive/PORTABILITY_MACOS_PROBE_2026-06-07.md)):
+Example for macOS (Apple Silicon / arm64; the full test suite runs on macOS CI):
 
 ```
 $ brew install libxml2 libxslt texlive
@@ -147,7 +160,7 @@ Four named profiles in `Cargo.toml`, each tuned for one purpose:
 | **`test`** (default for `cargo test`) | day-to-day development | Maximum debug info (`debug = "full"`, `debug-assertions`, `overflow-checks`), incremental rebuilds, `-O1` for tolerable test runtime. Use as much local RAM/CPU as needed. |
 | **`ci`**   | GitHub Actions only      | Lowest possible RAM (16 GB runner budget) and fastest compile (`opt-level = 0`, `codegen-units = 256`, no LTO). Just enough to prove tests pass. |
 | **`release`** | local sandbox canvas / perf measurement | Laptop-throughput release: `opt-level = 3`, `lto = "thin"`, `codegen-units = 20`, `strip = "symbols"`. Strong runtime optimization while using the 20-thread local machine during release builds. |
-| **`maxperf`** | one-off absolute runtime build | Preserves the old maximum optimizer scope: `lto = "fat"`, `codegen-units = 1`. Slower and less parallel, but available when build time is irrelevant. |
+| **`maxperf`** | distribution / published release artifact | Smallest, fastest binary: `lto = "fat"`, `codegen-units = 1`, `panic = "abort"`, stripped. Slowest build; used by `tools/make_release.sh` for the shipped binaries. |
 
 ### Sample use
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -192,9 +192,12 @@ closed):
 * `clippy::manual_string_new` + `single_char_pattern` — 10 sites
   (`ae192d3c6c`).
 
-After all of the above, `cargo clippy --workspace --all-targets` is
-back to its 14-warning baseline (all in `latexml_math_parser` ASF
-lane, collaborator's track). Tests 1328/0/0 throughout.
+After all of the above, `cargo clippy --workspace --all-targets` was
+back to a 14-warning baseline (all in the `latexml_math_parser` ASF
+lane). That residual was later cleared by #252 (edition-2024 migration
++ centralized lint enforcement): the workspace is now
+`clippy -D warnings`-clean. Tests were 1328/0/0 at the time of this
+round (1454/0/0 as of #252).
 
 **Witnesses retained** for any future digest-perf re-examination:
 `2305.06773` (ACM-class), `2103.00971` (tikz-heavy, 8.8s digest),
@@ -240,6 +243,127 @@ profile shows them on the hot path. The 2026-05-19 perf sweep
 confirmed the current state.meaning HashMap traffic is the floor;
 do not chase further internal allocations without evidence they're
 above the SwissTable probe band.
+
+---
+
+## Build-pipeline optimization roadmap (binary perf + size)
+
+The key release deliverable is a **maximally-performant, smallest**
+`latexml_oxide` binary (`maxperf`: opt-3, fat-LTO, codegen-units=1,
+panic=abort, stripped, `--no-default-features --features runtime-bindings`).
+Beyond the source-level principles above, these are *build-time* levers.
+**Prerequisite for all of them:** pin the nightly toolchain
+(`rust-toolchain.toml`) so PGO / `-Z build-std` / codegen are reproducible
+and not at the mercy of nightly churn (we hit a live example: the
+`build-std-features=panic_immediate_abort` flag was renamed to a real
+`-Cpanic=immediate-abort` strategy on a 2026-06 nightly).
+
+### Binary size composition (measured 2026-06-11)
+
+Where the 46.7 MB maxperf binary's bytes actually are — measured with
+`cargo bloat` on a symbol-preserving **no-LTO** build (per-crate numbers are
+"where code *originates*"; fat-LTO then redistributes/shrinks, so treat these as
+proportions, not exact final bytes).
+
+**Per-crate `.text`:**
+
+| Component | `.text` | What |
+|---|---:|---|
+| `latexml_package` | 9.2 MiB | LaTeX package/class binding pool — largest single component |
+| `[Unknown]` | 13.3 MiB | static C libs (libmarpa, mimalloc, compression) + untagged compiler/std |
+| `latexml_engine` | 3.6 MiB | TeX/LaTeX engine binding pool |
+| `latexml_contrib` | 2.6 MiB | contributed bindings (+ rhai monomorphizations under LTO) |
+| `latexml_core` | 1.6 MiB | core engine |
+| `rhai` | 0.7 MiB (true cost +2.23 MB — see below) | embedded script engine |
+| `latexml_post` / `latexml_math_parser` / `latexml` (cli) | ~0.5 MiB each | |
+| regex stack, `clap`, `marpa`, `kpathsea`/`libxml`/`libxslt` wrappers, `zip` | <0.4 MiB each | deps |
+
+**Per-function:** `[59740 Others] = 26.4 MiB (79% of `.text`)`. The binary is
+**~60,000 small functions — one per `\def`/construct — NOT a few fat generics.**
+The named large functions are all per-package `load_definitions` registration
+shells: `latex_constructs` 1.0 MiB, `amsmath_sty` 313 KiB, `mathtools_sty`
+271 KiB, `pgfsys` 253 KiB, … plus two non-binding items: `STDMETRICS`
+(807 KiB of font-metric **data**) and `__ModelLoader::build_model` (543 KiB,
+RelaxNG schema construction).
+
+**Conclusion — the size is structural, not waste.** It is the cost of porting
+LaTeXML's entire macro surface to native code: `package + engine + contrib +
+core ≈ 17 MiB` of attributable binding code over ~60k functions. There is **no
+single fat generic to de-monomorphize → no cheap size lever.** The only knobs
+both fight the project's goals:
+
+1. **Coverage ↔ size** — drop rarely-used package/class ports. Measurable (each
+   `*_sty::load_definitions` + its bindings is attributable) but every drop is
+   lost compatibility. Not quantified; feature-completeness is the current
+   priority, so this is moot unless size becomes a hard requirement.
+2. **Data-table binding encoding** — re-represent bindings as runtime-interpreted
+   data instead of compiled code. Could cut `.text` dramatically but is a major
+   refactor that swaps inlined code for an interpreter — opposes the
+   highest-performance goal.
+
+**Decision (2026-06-11): accept the size.** 47 MB is the cost of feature-complete
+LaTeX coverage; spend the optimization budget on PGO (real perf headroom on the
+full-corpus run) rather than shrinking `.text`. Confirms the long-standing
+attribution: the binary is `.text`/binding-pool, **not** dumps (those gzip to
+~870 KB).
+
+Reproduce (symbol-preserving, no-LTO so code stays attributed to its origin crate):
+
+```
+CARGO_PROFILE_RELEASE_STRIP=false CARGO_PROFILE_RELEASE_DEBUG=1 \
+CARGO_PROFILE_RELEASE_LTO=off \
+cargo bloat --release --no-default-features --features runtime-bindings \
+  --bin latexml_oxide --crates       # drop --crates, add -n 30 for per-function
+```
+
+### High-effort (tracked tasks — not yet attempted)
+
+> **Measurement venue.** PGO, BOLT and the `target-cpu` decision all need
+> full-scale empirical measurement and belong on the **new hardware running the
+> entire arXiv corpus** (expected ~mid-June 2026), not the dev box. Schedule
+> them there; this dev box is freeze-prone under heavy builds and unrepresentative
+> for perf numbers.
+
+- **[ ] PGO (Profile-Guided Optimization)** — the single largest perf lever
+  for this CPU-bound tool; typically 10–20% on hot paths. We have the ideal
+  training set: the arXiv sandbox corpus. Two-stage build:
+  `RUSTFLAGS=-Cprofile-generate=/tmp/pgo` → run a representative corpus slice
+  (`tools/run_perf_corpus.sh` / `benchmark_canvas.sh`) → `llvm-profdata merge`
+  → rebuild with `-Cprofile-use`. Wire into `release.yml` as a two-pass build.
+  Acceptance: standing-corpus wall before/after per the checklist below.
+- **[ ] BOLT (post-link binary optimization)** — stacks on PGO for a further
+  few % by reordering hot/cold code in the linked binary (`llvm-bolt` + a
+  profiling run on the final executable). Attempt only after PGO lands.
+
+### Lower-effort levers (measure / decide)
+
+- **`build-std` (panic_abort) — MEASURED, PARKED (2026-06-11).** Hypothesis: a
+  std rebuilt with panic=abort would strip the ~1.4 MB of `.eh_frame` unwind
+  tables the binary still carries. **The data refuted it:** 46.69 → 46.58 MB
+  (−0.11 MB, ~0.2%), with `.eh_frame` **unchanged** (1.240 MB → 1.240 MB). Those
+  tables come from the static **C deps** (mimalloc, libmarpa, zstd/bzip2), which
+  `-Z build-std` does not touch — NOT from Rust std. Cross-std LTO inlining also
+  gave ~nothing (.text 39.75 → 39.64 MB). Not worth the cost (std recompiled
+  every build; explicit `--target`; nightly fragility — the
+  `panic_immediate_abort` feature was renamed to `-Cpanic=immediate-abort`
+  mid-evaluation) for 0.2%. Revisit only if the C-dep `.eh_frame` is addressed
+  separately. (Aside: panic=abort already no-ops the `catch_unwind` backstops in
+  `pathname.rs` — an accepted CLI trade, unrelated to build-std.)
+- **[ ] `target-cpu` baseline (decision) — DEFERRED to the full-corpus run.**
+  Release builds for the conservative default `x86-64` (no SSE4/AVX).
+  `-Ctarget-cpu=x86-64-v2` (SSE4.2, ~2009+) or `v3` (AVX2, ~2013+) can speed hot
+  loops at the cost of older CPUs — a deliberate **portability call**, not a free
+  win. macOS arm64 is already a fixed Apple-Silicon baseline. Examine this on the
+  **new hardware running the entire arXiv corpus** (expected ~mid-June 2026, a
+  few days after 2026-06-11), NOT on this dev box — the speedup is only
+  meaningful measured at full-corpus scale on representative hardware.
+- **runtime-bindings (rhai) size cost — MEASURED (2026-06-11): +2.23 MB
+  (~4.8%).** maxperf with `runtime-bindings` 46.69 MB vs without 44.46 MB
+  (`.text` 39.75 vs 37.84 MB → ~1.91 MB of rhai engine code). Shipping it is the
+  current decision (customize contributed bindings without recompiling; runtime
+  opt-in, so default conversions are unaffected). If the 2.23 MB becomes a
+  concern, the clean resolution is two artifacts: a lean default + a `+bindings`
+  variant.
 
 ---
 

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -123,6 +123,41 @@ remaining work is the optional architectural fix above.
 
 ---
 
+## Release-prep for 0.7.0 — LANDED (release-prep PR, 2026-06-11)
+
+Shipped on the `release-prep` branch (separate from #252):
+- **Version 0.6.2 → 0.7.0** in `latexml_oxide/Cargo.toml` only — the
+  release-tracking crate; sub-crates keep independent versions (convention).
+- **`runtime-bindings` enabled in the release artifact** (`make_release.sh`:
+  `--no-default-features --features runtime-bindings --profile maxperf`) — ship
+  the Rhai capability without recompiling; runtime opt-in. test-utils /
+  token-locators / cortex stay excluded. Measured rhai cost **+2.23 MB** —
+  accepted.
+- **`.deb` deps** (`[package.metadata.deb]`): `Depends` → `$auto`
+  (dpkg-shlibdeps versioned linked libs) + `imagemagick` + `mupdf-tools`
+  (primary graphics processors, promoted to hard deps) + texlive; `Recommends`
+  poppler-utils/ghostscript/dvipng; `Suggests` inkscape. `dpkg-dev` added to
+  `release.yml` so `$auto` has `dpkg-shlibdeps` in CI.
+- **CLAUDE.md** distribution command reconciled; **`## [0.7.0]` CHANGELOG**
+  section (feeds the release-body slice); **README** Ubuntu + macOS install
+  recipes + outdated-language drain.
+- **`rust-toolchain.toml`** pins `nightly-2026-06-10` (reproducible release).
+- **`docs/PERFORMANCE.md`**: build-pipeline optimization roadmap + the measured
+  **binary size composition** (44 MB `.text` ≈ ~60k binding functions,
+  structural → accept the size); build-std parked (+0.11 MB, measured).
+
+Decisions (2026-06-11): only `latexml_oxide` ships (latexmlmath/post deferred);
+**no RC prerelease rehearsal** (private project — fix-and-re-tag is cheap);
+**PGO/BOLT/target-cpu deferred to the new-hardware full-arXiv-corpus run**
+(~mid-June 2026). Local `make_release.sh` dry-run green (0.7.0
+tarball + `.deb` + sidecars + RELEASE_BODY; binary converts `hello.tex` 0-error).
+
+**Remaining:** merge the PR, then tag `0.7.0` on master → `release.yml` runs the
+full pipeline (TL-window `dumps` + macOS arm64 leg + publish). The `dumps` job,
+macOS leg, and publish are first-exercised on that tag.
+
+---
+
 ## Active mission (Round-37, opened 2026-05-26): 1,000,000 error-free conversions on the arXiv "warning" corpus
 
 > **✅ PARITY-TRACK Rust-only pool DRAINED across the sampled corpus (capstone, 2026-06-01).**

--- a/latexml_oxide/Cargo.toml
+++ b/latexml_oxide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2024"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
 license = "CC0-1.0"
@@ -132,8 +132,25 @@ A Rust port of LaTeXML — converts LaTeX documents to accessible web
 formats (HTML5, XHTML, EPUB3, JATS). Drop-in replacement for the
 upstream Perl tool with significant throughput improvements on the
 arXiv corpus."""
-depends = "libc6, libxml2, libxslt1.1, libkpathsea6, texlive-latex-base, texlive-latex-extra, texlive-science"
-recommends = "imagemagick, poppler-utils, mupdf-tools"
+# `$auto` runs dpkg-shlibdeps on the packaged binary, deriving the exact,
+# versioned linked-library deps (libc6, libgcc-s1, zlib1g, libxml2 (>= the
+# SONAME we link), libxslt1.1, libgcrypt20, libgpg-error0, libkpathsea6, …) so
+# the list never drifts from what we actually link. The remaining entries are
+# appended manually — they are runtime data/tools, not linked libraries:
+#   * imagemagick — our PRIMARY graphics processor (`convert`, the most-invoked
+#     graphics tool).
+#   * mupdf-tools — `mutool`, our PDF graphics processor.
+#     Both are promoted to hard Depends so graphics handling works out of the
+#     box rather than silently degrading.
+#   * texlive-* — the texmf trees kpsewhich resolves against.
+depends = "$auto, imagemagick, mupdf-tools, texlive-latex-base, texlive-latex-extra, texlive-science"
+# Secondary graphics/PDF helpers are SHELLED OUT at runtime (not linked) and only
+# needed for specific source content, so they stay in Recommends: pdftocairo
+# (poppler-utils), gs/ps2pdf (ghostscript), dvipng.
+recommends = "poppler-utils, ghostscript, dvipng"
+# inkscape (SVG conversion) is optional and pulls a large GTK stack — keep it a
+# soft suggestion rather than a recommend.
+suggests = "inkscape"
 section = "tex"
 priority = "optional"
 assets = [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,16 @@
+# Pinned nightly for reproducible builds.
+#
+# The release's key deliverable is a maximally-performant, smallest binary, and
+# the build-time levers that get us there — PGO and `-Z build-std` — are
+# nightly-feature-sensitive. We hit a live example while evaluating them: the
+# `build-std-features = panic_immediate_abort` flag was renamed to a real
+# `-Cpanic=immediate-abort` strategy on a 2026-06 nightly. A floating nightly
+# would let release-day churn break the build or silently change codegen/perf.
+#
+# Pinned to the toolchain CI is already green on (does not change today's
+# toolchain — only freezes it). Bump deliberately: after a green CI run AND a
+# release dry-run on the new date. See docs/PERFORMANCE.md "Build-pipeline
+# optimization roadmap". (The project requires nightly — see CLAUDE.md.)
+[toolchain]
+channel = "nightly-2026-06-10"
+components = ["rustfmt", "clippy", "rust-src"]

--- a/tools/make_release.sh
+++ b/tools/make_release.sh
@@ -84,10 +84,13 @@ rm -rf "${artifacts_dir}"
 mkdir -p "${stage_dir}"
 
 # --- build the binary -------------------------------------------------------
-# Distribution build: drop test-utils (audit DEP-02) and use the publish-grade
-# profile (fat LTO, panic=abort, codegen-units=1).
-echo "make_release: cargo build --no-default-features --profile maxperf --bin latexml_oxide"
-cargo build --no-default-features --profile maxperf --bin latexml_oxide
+# Distribution build: drop test-utils (audit DEP-02) but KEEP runtime-bindings
+# (ship the Rhai script-bindings capability so users customize contributed
+# bindings without recompiling — runtime opt-in, so default conversions are
+# unchanged), on the publish-grade profile (fat LTO, panic=abort,
+# codegen-units=1).
+echo "make_release: cargo build --no-default-features --features runtime-bindings --profile maxperf --bin latexml_oxide"
+cargo build --no-default-features --features runtime-bindings --profile maxperf --bin latexml_oxide
 
 bin_path="target/maxperf/latexml_oxide"
 if [[ ! -x "${bin_path}" ]]; then


### PR DESCRIPTION
Prepares the **0.7.0** release. Validated by a local `make_release.sh` dry-run (tarball + `.deb` + SHA-256 sidecars + `RELEASE_BODY.md`; the maxperf binary reports `0.7.0` and converts `hello.tex` with **0 Error/Fatal**).

## What's in here

- **Version** `0.6.2 → 0.7.0` (`latexml_oxide` only — the release-tracking crate; sub-crates keep their independent versions).
- **`runtime-bindings` shipped in the release artifact** — `make_release.sh` now builds `--no-default-features --features runtime-bindings --profile maxperf`. Ships the Rhai script-bindings capability so users customize contributed bindings without recompiling; **runtime opt-in**, so default conversions are byte-identical. Measured cost **+2.23 MB**, accepted.
- **`.deb` runtime deps revised** (`[package.metadata.deb]`):
  - `Depends` → `$auto` (dpkg-shlibdeps — exact, versioned linked-lib deps, no drift) + **`imagemagick`** + **`mupdf-tools`** (primary graphics processors, promoted to hard deps) + texlive.
  - `Recommends` → `poppler-utils, ghostscript, dvipng`; `Suggests` → `inkscape`.
  - `release.yml` gains `dpkg-dev` so `$auto` has `dpkg-shlibdeps` in CI.
- **`rust-toolchain.toml`** pins `nightly-2026-06-10` for reproducible release builds.
- **`CHANGELOG.md`** — new `## [0.7.0]` section (feeds the release-body slice).
- **`CLAUDE.md`** — distribution-build command reconciled with the new feature set.
- **`README.md`** — brief Ubuntu + macOS install recipes; drained outdated language (stale version/test badges, dated status snapshot, "other platforms not yet shipped").
- **`docs/PERFORMANCE.md`** — build-pipeline optimization roadmap (PGO/BOLT/`target-cpu` deferred to the new-hardware full-corpus run ~mid-June 2026) + the measured **binary size composition** (44 MB `.text` ≈ ~60k binding functions → structural, accept the size). `build-std` parked at a measured +0.11 MB.
- **`docs/SYNC_STATUS.md`** — release-prep handoff converted to a landed record.

## After merge

Tag `0.7.0` on master → `release.yml` runs the full pipeline (TL-window `dumps` + macOS arm64 leg + publish → GitHub Release). The `dumps` job, macOS leg, and publish are first-exercised on that tag (no RC rehearsal — private project, clean fix-and-re-tag on any hiccup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)