### PR TITLE
release: auto-append the merged-PR list to release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,6 +198,11 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
           body_path: target/release-artifacts/RELEASE_BODY.md
+          # Append GitHub's auto-generated "What's Changed" — every merged PR
+          # since the previous tag — below our curated RELEASE_BODY summary
+          # (softprops pre-pends `body` to the generated notes). Brief, high-level
+          # highlights up top + the full per-PR list underneath.
+          generate_release_notes: true
           files: |
             target/release-artifacts/latexml-oxide-${{ github.ref_name }}-x86_64-unknown-linux-gnu.tar.gz
             target/release-artifacts/latexml-oxide-${{ github.ref_name }}-x86_64-unknown-linux-gnu.tar.gz.sha256


### PR DESCRIPTION
Small release-workflow tweak so the **0.7.0** notes (and every future release) carry GitHub's standard **"What's Changed"** PR list.

Sets `generate_release_notes: true` on the `softprops/action-gh-release` publish step. softprops **pre-pends** our curated `RELEASE_BODY.md` (install recipes + the high-level 0.7.0 CHANGELOG slice) **above** GitHub's auto-generated per-PR list (every merged PR since the previous tag) + a Full Changelog link.

Result: brief, high-level highlights up top; the complete per-PR enumeration underneath; no manual upkeep.

Must land before the `0.7.0` tag, since `release.yml` runs from the *tagged* commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)