### PR TITLE
release: statically link libkpathsea (in-process, self-contained) on both legs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,9 +55,11 @@ jobs:
 
       # libxml2 + libxslt are keg-only on Homebrew; install them and surface
       # their pkgconfig dirs so the libxml/libxslt build scripts find them.
-      # kpathsea is NOT linked here: the distributed binary uses the
-      # subprocess-`kpsewhich` backend (decoupled from libkpathsea ABI;
-      # mandatory on MacTeX, which ships no libkpathsea).
+      # libkpathsea is built from source and STATICALLY linked (see the
+      # build-static-kpathsea step below): Homebrew ships no static `.a`, and a
+      # static link makes the binary self-contained — in-process lookups with NO
+      # runtime libkpathsea dependency, so it launches on MacTeX (which ships no
+      # libkpathsea) and degrades to empty lookups where no TeX is present.
       - name: install dependencies
         run: |
           command -v pkg-config >/dev/null || brew install pkgconf
@@ -90,6 +92,11 @@ jobs:
               fi
             done
           done
+
+      # Static, self-contained libkpathsea (in-process lookups, no runtime dep).
+      # Sets KPATHSEA_LIB_DIR + KPATHSEA_STATIC for the build below.
+      - name: build static libkpathsea from source
+        run: bash tools/build_static_kpathsea.sh
 
       - name: build macOS release tarball
         run: bash tools/make_release.sh
@@ -171,6 +178,14 @@ jobs:
               fi
             done
           done
+
+      # Static, self-contained libkpathsea (in-process lookups, no runtime
+      # libkpathsea6 dependency — dropping it from the .deb's $auto deps).
+      # Built from source with --with-pic: the system libkpathsea-dev .a is
+      # non-PIC and is rejected when our proc-macro cdylib links kpathsea.
+      # Sets KPATHSEA_LIB_DIR + KPATHSEA_STATIC for the build below.
+      - name: build static libkpathsea from source
+        run: bash tools/build_static_kpathsea.sh
 
       - name: build release artifacts
         run: bash tools/make_release.sh

--- a/tools/build_static_kpathsea.sh
+++ b/tools/build_static_kpathsea.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Build a self-contained, PIC static libkpathsea.a from the TeX Live source and
+# point the kpathsea_sys build at it (KPATHSEA_LIB_DIR + KPATHSEA_STATIC, emitted
+# to $GITHUB_ENV when running under Actions). Used by the Linux and macOS release
+# legs in .github/workflows/release.yml.
+#
+# Why static, from source:
+#   * Static link => the release binary does IN-PROCESS kpathsea lookups (fast)
+#     with NO runtime libkpathsea dependency, so it launches on MacTeX / no-TeX
+#     and degrades to empty lookups instead of failing to load.
+#   * From source (not the system libkpathsea-dev .a) because that archive is
+#     NON-PIC, and our proc-macro crate (latexml_codegen) is a cdylib that links
+#     kpathsea transitively — a non-PIC archive is rejected there ("R_X86_64_PC32
+#     relocation ... recompile with -fPIC"). `--with-pic` produces a PIC archive
+#     that links into BOTH the cdylib and the final binary. macOS Mach-O is PIC
+#     by default, so `--with-pic` is a harmless no-op there; Homebrew also ships
+#     no static .a at all, so source-building is the only macOS option.
+#
+# Pinned to a commit whose kpathsea matches the kpathsea_sys bindgen bindings
+# (6.4.1 / TL2025): the `format_info` struct walk in the `kpathsea` crate depends
+# on the layout. Bump KPSE_REF in lockstep with a bindings regeneration.
+set -euo pipefail
+
+KPSE_REF="${KPSE_REF:-def12ffd4d6e46bae03b3e5c7ff6f5f14dced3ab}"
+SRC_DIR="${KPSE_SRC_DIR:-/tmp/tlsrc}"
+
+echo "[build_static_kpathsea] fetching kpathsea source @ ${KPSE_REF} (sparse, shallow)"
+rm -rf "$SRC_DIR"
+mkdir -p "$SRC_DIR"
+cd "$SRC_DIR"
+git init -q
+git remote add origin https://github.com/TeX-Live/texlive-source.git
+git sparse-checkout init --cone
+git sparse-checkout set texk/kpathsea build-aux m4
+git fetch --depth 1 --filter=blob:none origin "$KPSE_REF"
+git checkout -q FETCH_HEAD
+
+cd texk/kpathsea
+echo "[build_static_kpathsea] configure --enable-static --with-pic"
+./configure --enable-static --disable-shared --disable-dependency-tracking --with-pic >/dev/null
+echo "[build_static_kpathsea] make libkpathsea.la"
+make libkpathsea.la >/dev/null
+
+libdir="${SRC_DIR}/texk/kpathsea/.libs"
+if [[ ! -f "${libdir}/libkpathsea.a" ]]; then
+  echo "[build_static_kpathsea] ERROR: libkpathsea.a not produced" >&2
+  exit 1
+fi
+echo "[build_static_kpathsea] built ${libdir}/libkpathsea.a"
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  {
+    echo "KPATHSEA_LIB_DIR=${libdir}"
+    echo "KPATHSEA_STATIC=1"
+  } >> "$GITHUB_ENV"
+  echo "[build_static_kpathsea] exported KPATHSEA_LIB_DIR / KPATHSEA_STATIC=1"
+fi


### PR DESCRIPTION
Fixes the 0.7.0 macOS build failure **and** gives both platforms the in-process performance path, by statically linking a PIC `libkpathsea.a` built from source.

## What

- **`tools/build_static_kpathsea.sh`** — sparse+shallow fetch of `texk/kpathsea` from the TeX Live source (pinned to a commit matching the `kpathsea_sys` 6.4.1 bindings), then `./configure --enable-static --with-pic && make libkpathsea.la`. Emits `KPATHSEA_LIB_DIR` + `KPATHSEA_STATIC`.
- **`release.yml`** — runs it on both the Linux and macOS build legs before the maxperf build.

## Why source + `--with-pic` (not the system `libkpathsea-dev` `.a`)

The system static archive is **non-PIC**, and our proc-macro crate (`latexml_codegen`) is a cdylib that links kpathsea transitively — mold rejects non-PIC code in a shared object (`R_X86_64_PC32 relocation … recompile with -fPIC`). A PIC archive links into **both** the cdylib and the final binary. macOS Mach-O is PIC by default, and Homebrew ships no static `.a` anyway, so source-building is the only macOS option.

## Result

In-process kpathsea lookups with **no runtime libkpathsea dependency** → launches on MacTeX / no-TeX, degrades to empty lookups, and drops `libkpathsea6` from the `.deb`'s `$auto` deps. Needs `kpathsea_sys 0.2.1` (published; picked up via `^0.2`).

Validated on Linux end-to-end: ldd-clean of libkpathsea, in-process lookups work (`hello.tex` converts 0-error). The macOS leg is first exercised on the re-tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)