### PR TITLE
refactor: drop kpathsea from the latexml_codegen proc-macro build

### DIFF
--- a/latexml_codegen/Cargo.toml
+++ b/latexml_codegen/Cargo.toml
@@ -30,4 +30,10 @@ glob = "0.3"
 # splice runtime values into generated code). Audit DEP-14 (2026-05-18):
 # resolver v2 keeps proc-macro features isolated, so the runtime
 # `latexml_core` does NOT inherit this feature.
-latexml_core = { path = "../latexml_core", features = ["codegen"] }
+#
+# `default-features = false` drops the runtime kpathsea backend (and its
+# static-link / PIC constraints) from this host-side proc-macro cdylib — the
+# codegen path uses only the binding AST and never resolves TeX files. The
+# runtime `latexml_core` (linked into the binary) keeps kpathsea via its
+# default feature; resolver v2 keeps the two builds separate.
+latexml_core = { path = "../latexml_core", default-features = false, features = ["codegen"] }

--- a/latexml_core/Cargo.toml
+++ b/latexml_core/Cargo.toml
@@ -14,6 +14,17 @@ name = "latexml_core"
 crate-type = ["lib"]
 
 [features]
+# The kpathsea file-resolution backend (libkpathsea / subprocess kpsewhich) is a
+# RUNTIME concern — default-on for every normal build. It is optional so the
+# host-side proc-macro build (`latexml_codegen`, which uses only the binding AST
+# and never resolves TeX files) can drop it via `default-features = false`,
+# keeping kpathsea — and its static-link / PIC constraints — out of the
+# proc-macro cdylib. Resolver v2 isolates proc-macro features from the runtime,
+# so the runtime `latexml_core` still gets kpathsea. See util/pathname.rs for the
+# gated code + no-op fallbacks.
+default = ["kpathsea"]
+kpathsea = ["dep:kpathsea"]
+
 # Activated by `latexml_codegen` (host-side proc-macro) to enable the
 # `impl ToTokens for Tokens / Catcode / Token / Parameters / Parameter`
 # blocks. Resolver v2 isolates proc-macro feature unification, so the
@@ -45,7 +56,7 @@ libxml = "0.3.12"
 # 0.3: backend-dispatched — in-process libkpathsea when linked at build
 # time, subprocess-kpsewhich fallback otherwise (MacTeX ships no
 # libkpathsea at all; see docs/PORTABILITY_MACOS_PROBE_2026-06-07.md).
-kpathsea = "0.3"
+kpathsea = { version = "0.3", optional = true }
 unidecode = "0.3.0"
 rustc-hash = "2.0.0"
 string-interner = { version = "0.20.0", default-features = false, features = ["std", "backends", "inline-more"] }

--- a/latexml_core/src/util/pathname.rs
+++ b/latexml_core/src/util/pathname.rs
@@ -1,9 +1,11 @@
+#[cfg(feature = "kpathsea")]
+use std::sync::Mutex;
 use std::{
   env,
   path::{Path, PathBuf},
-  sync::Mutex,
 };
 
+#[cfg(feature = "kpathsea")]
 use kpathsea::Kpaths;
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -68,6 +70,7 @@ static URL_PREFIX_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(?:https|http|ftp
 /// `latexml_core::watchdog::PRE_EXIT_HOOK`. See
 /// `feedback_no_mutex_use_thread_local` in user memory for the
 /// general rule.
+#[cfg(feature = "kpathsea")]
 static KPSE: Lazy<Mutex<Option<Kpaths>>> = Lazy::new(|| Mutex::new(Kpaths::new().ok()));
 
 /// Force-initialize the kpathsea global state and warm up the per-
@@ -94,6 +97,7 @@ static KPSE: Lazy<Mutex<Option<Kpaths>>> = Lazy::new(|| Mutex::new(Kpaths::new()
 /// digest reaches its first package resolution, by which point the
 /// prewarm is usually finished. Idempotent: re-entry while in flight
 /// is a no-op (lock contention only).
+#[cfg(feature = "kpathsea")]
 pub fn prewarm_kpathsea() {
   let kpse_guard = KPSE.lock().unwrap();
   let Some(ref kpse) = *kpse_guard else {
@@ -125,6 +129,12 @@ pub fn prewarm_kpathsea() {
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| kpse.find_file(sentinel)));
   }
 }
+
+/// No-op when built without the `kpathsea` feature (e.g. the host-side
+/// proc-macro build, which never resolves TeX files).
+#[cfg(not(feature = "kpathsea"))]
+pub fn prewarm_kpathsea() {}
+
 // Perl: $pathname =~ s|^($PROTOCOL_RE//[^/]*)/|/|
 static CANONICAL_URL_RE: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"^((?:https|http|ftp)://[^/]*)").unwrap());
@@ -584,6 +594,7 @@ pub fn findall(pathname: &str, options: PathnameFindOptions) -> Vec<String> {
 
 /// search for a list of candidate names via the external `kpsewhich` utility
 /// returning the first path that is found
+#[cfg(feature = "kpathsea")]
 pub fn kpsewhich(candidates: &[&str]) -> Option<String> {
   if let Some(ref kpse) = *KPSE.lock().unwrap() {
     for candidate in candidates {
@@ -609,6 +620,12 @@ pub fn kpsewhich(candidates: &[&str]) -> Option<String> {
   }
   None
 }
+
+/// Without the `kpathsea` feature, file resolution is unavailable — every lookup
+/// returns `None` (graceful degradation). The host-side proc-macro codegen build
+/// takes this path; it never resolves TeX files at compile time.
+#[cfg(not(feature = "kpathsea"))]
+pub fn kpsewhich(_candidates: &[&str]) -> Option<String> { None }
 
 /// check if pathname contains dangerous pieces
 pub fn is_nasty(file: &str) -> bool { PATHNAME_IS_NASTY_RE.is_match(file) }


### PR DESCRIPTION
`latexml_codegen` is a **host-side proc-macro** (a cdylib rustc loads at compile time). It uses only `latexml_core`'s binding AST and **never resolves TeX files** — but it depended on `latexml_core` with *default* features, dragging the kpathsea runtime backend into the proc-macro cdylib. That's exactly what made a non-PIC static `libkpathsea` fail to link there (the `R_X86_64_PC32 … recompile with -fPIC` error from the static-linking work).

## Change

- Make `kpathsea` an **optional, default-on** feature of `latexml_core`, gating its 4 call sites in `util/pathname.rs` behind it with no-op / `None`-returning fallbacks.
- `latexml_codegen` depends on `latexml_core` with **`default-features = false`** (codegen only).
- Resolver v2 keeps the proc-macro's feature set separate from the runtime's, so the runtime `latexml_core` (linked into the binary) still gets kpathsea.

## Result

- **kpathsea is gone from `latexml_codegen`'s dependency tree** — the proc-macro links faster and carries none of kpathsea's static-link / PIC constraints.
- The kpathsea-off path doubles as **graceful degradation** (lookups return `None` when the backend is absent).
- No change to the shipped binary or runtime behavior — the runtime keeps kpathsea via the default feature.

## Validation

- `cargo build -p latexml_core --no-default-features --features codegen` — clean.
- `cargo tree -p latexml_codegen` — no kpathsea; `cargo tree -p latexml_core` — still `kpathsea v0.3.0`.
- Default build + `hello.tex` smoke: 0 errors. clippy + fmt clean on both feature configs.

Independent of the static-linking release work (#257); this is a build-speed + dependency-hygiene cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)