### PR TITLE
build(release): deterministic, minimal static libxml2/libxslt config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,6 +241,21 @@ jobs:
             echo "::error::release binary dynamically links a library that must be static"; exit 1
           fi
           echo "OK: glibc-only (no dynamic libxml2/libxslt/kpathsea)"
+          # Functional gate (complements the structural ldd above): our static
+          # libxml2/libxslt are built with a deliberately minimal feature set, so a
+          # mis-trimmed config could drop something LaTeXML needs — that would LINK
+          # fine but fail at conversion. Convert a real document (exercises the
+          # RelaxNG / XPath / XSLT paths) and assert zero Error/Fatal. TeX Live is
+          # installed on this leg.
+          out="$(mktemp -d)"
+          "$bin" --destination="$out/hello.html" latexml_oxide/tests/hello/hello.tex 2>"$out/log" \
+            || { echo "::error::release binary failed to run a conversion"; cat "$out/log"; exit 1; }
+          errs=$(sed 's/\x1b\[[0-9;]*m//g' "$out/log" | grep -acE '^(Error|Fatal):' || true)
+          if [ "$errs" != "0" ] || [ ! -s "$out/hello.html" ]; then
+            echo "::error::conversion smoke: $errs Error/Fatal, $(wc -c <"$out/hello.html" 2>/dev/null || echo 0) bytes out"
+            sed 's/\x1b\[[0-9;]*m//g' "$out/log" | grep -E '^(Error|Fatal):' | head; exit 1
+          fi
+          echo "OK: hello.tex converts clean ($(wc -c <"$out/hello.html") bytes, 0 errors)"
 
       # Pull the macOS tarball (+ sidecar) built by the build-macos job into
       # the staging dir so they publish alongside the Linux artifacts.

--- a/tools/build_static_libxml.sh
+++ b/tools/build_static_libxml.sh
@@ -20,8 +20,29 @@
 #     default, so `--with-pic` is a harmless no-op there.
 #   * Into a NON-system prefix so pkg-config's static guard permits a static link
 #     (it refuses `static=` for libs under /usr/lib); the crates then probe with
-#     `.statik(true)` and pick up transitive deps (-lz, -lm, -lgcrypt) from the
-#     installed .pc Libs.private — those stay DYNAMIC (stable SONAMEs, no churn).
+#     `.statik(true)`.
+#
+# Build-configuration policy — a DETERMINISTIC, MINIMAL dependency closure:
+#   The purpose of static linking is host-independence. `configure` undermines that
+#   by AUTO-DETECTING optional external libraries from whatever dev headers happen
+#   to sit on the build host — so the same script yields a DIFFERENT dependency
+#   surface per runner. (That is exactly how the macOS leg pulled libgcrypt/
+#   libgpg-error via Homebrew while Linux did not, breaking the link with
+#   unresolved __gpg_* symbols.) A point-patch for crypto would leave the next
+#   environment-specific lib to bite. So the rule is: every OPTIONAL,
+#   EXTERNAL-DEPENDENCY feature is disabled EXPLICITLY here; nothing is inherited
+#   from the host. We keep exactly two things:
+#     1. the core API LaTeXML exercises (XPath, RelaxNG/schemas, c14n, output,
+#        XInclude, reader/writer, …) — these carry no external deps; and
+#     2. iconv — the lone external dep that is a guaranteed, stable system library
+#        on every target (glibc on Linux, libiconv on macOS), so it may stay
+#        dynamic under the same rule that lets libc/libm/libgcc_s/CoreFoundation
+#        stay dynamic. (Disabling it would only trade a stable dep for an encoding-
+#        coverage risk.)
+#   Everything else optional+external is OFF: python, zlib, lzma, icu (libxml2;
+#   icu's SONAME churns), crypto (libxslt). Net closure: -lm (+ -liconv on macOS),
+#   reproducibly, regardless of build host. Any NEW optional dep must be opted into
+#   here CONSCIOUSLY, never auto-detected.
 #
 # Build parallelism is capped (JOBS, default 4): the dev box hard-freezes under a
 # full -j load. CI runners can raise it (JOBS=$(nproc)).
@@ -54,13 +75,16 @@ tar xf "libxslt-${LIBXSLT_VER}.tar.xz"
 # --- libxml2 (built first; libxslt links against it) ----------------------------
 echo "[build_static_libxml] configure libxml2 ${LIBXML2_VER} (static, PIC)"
 cd "${WORK}/libxml2-${LIBXML2_VER}"
+# --without-{python,zlib,lzma,icu}: disable every optional external-dependency
+# feature per the configuration policy above (icu in particular — libicu's SONAME
+# churns hard). The core API LaTeXML uses carries no external deps and stays on.
 # Explicit CFLAGS=-fPIC: libtool's --with-pic alone does NOT force PIC objects for
 # a --disable-shared (static-only) build here — it yields absolute R_X86_64_32
 # relocations that a shared object (our proc-macro cdylib) rejects. -fPIC on every
 # compile guarantees a PIC archive that links into both the cdylib and the binary.
 ./configure --prefix="$PREFIX" \
   --enable-static --disable-shared --with-pic \
-  --without-python \
+  --without-python --without-zlib --without-lzma --without-icu \
   --disable-dependency-tracking \
   CFLAGS="-fPIC -O2" >/dev/null
 echo "[build_static_libxml] make libxml2 -j${JOBS}"
@@ -70,9 +94,15 @@ make install >/dev/null
 # --- libxslt + libexslt (against our static libxml2) ----------------------------
 echo "[build_static_libxml] configure libxslt ${LIBXSLT_VER} (static, PIC)"
 cd "${WORK}/libxslt-${LIBXSLT_VER}"
+# --without-crypto: the libxslt arm of the same policy. The EXSLT crypto module
+# (md5/sha1/...) pulls in libgcrypt + libgpg-error, which configure auto-detected
+# on the macOS runner (Homebrew) but not on Linux, leaving libexslt.a with
+# unresolved __gpg_* symbols at the final link. LaTeXML never uses crypto:*, so the
+# module is off on every platform.
 PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="$PREFIX" \
   --enable-static --disable-shared --with-pic \
   --without-python \
+  --without-crypto \
   --with-libxml-prefix="$PREFIX" \
   --disable-dependency-tracking \
   CFLAGS="-fPIC -O2" >/dev/null


### PR DESCRIPTION
**Not a hotfix — a configuration policy.** The macOS link failure was a *symptom*; the fix is the *principle* behind how we configure the source-built static libraries.

## The failure
```
Undefined symbols for architecture arm64:
   __gpg_err_init / __gpg_strerror  in libxslt (libgpg_error_la-*.o)
```
libxslt's `configure` **auto-detected** the runner's Homebrew libgcrypt/libgpg-error and built the EXSLT crypto module. Linux (no such libs) built crypto-free. The *same script* produced a *different dependency surface per host*.

## The principle
Static linking exists to make the artifact **host-independent**. `configure`'s auto-detection defeats that by inheriting the build host's optional libraries — relocating host-dependence from runtime to build-time. So:

> **Every optional, external-dependency feature is disabled explicitly; nothing is inherited from the host.** The dependency closure must be a function of *our configuration*, not of *whoever built it*.

Two principled exceptions:
1. **Keep the core API LaTeXML uses** (XPath, RelaxNG/schemas, c14n, output, XInclude, …) — no external deps. (Don't *over*-trim.)
2. **Keep iconv** — the one external dep that's a *guaranteed, stable system lib* on every target (glibc / libiconv), so it rides the same rule that lets libc/libm/libgcc_s stay dynamic.

## The change
- `tools/build_static_libxml.sh`: libxml2 `--without-{python,zlib,lzma,icu}` (icu's SONAME churns); libxslt `--without-{python,crypto}`. Net closure: **`-lm`** (+ `-liconv` on macOS), reproducibly.
- **Functional release gate**: structural `ldd`/`otool` cannot catch an *over*-trimmed config (a dropped feature LaTeXML needs links fine but fails to convert), so the Linux leg now converts `hello.tex` and asserts zero Error/Fatal.

## Verified locally
Closure exactly `-lm`; no zlib/lzma/icu/gcrypt symbols in the archives; binary glibc-only; hello.tex 0 errors.

After merge, re-tag `0.7.1` to re-trigger the release.
