### PR TITLE
feat(cortex): self-supervising harness with controlled over-commit + memory governor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,7 @@ current when adding, renaming, merging, or archiving a doc. Grouped by role:
 
 **Release & operations:**
 - **[`docs/RELEASING.md`](docs/RELEASING.md)** — Tag-driven release procedure; what ships in a release; the self-contained-binary requirement.
+- **[`docs/CORTEX_WORKER_HARNESS.md`](docs/CORTEX_WORKER_HARNESS.md)** — `cortex_worker --harness` fleet orchestration: the self-supervising one-conversion-per-process model (drives `pericortex::harness`) with **deliberate over-commit**, the five-layer memory guards (stomach byte budget → polled RSS → alloc hook → per-child `RLIMIT_AS` → fleet memory-pressure governor that sheds the largest worker under aggregate pressure), crash-loop backoff / SIGCHLD respawn / `PR_SET_PDEATHSIG`, the address-space-vs-RSS caveat with mimalloc, and the production deployment recommendation. Companion to pericortex's `docs/HARNESS.md` (mechanism) and CorTeX `MANUAL.md` §7 (operator how-to).
 - **[`docs/SAFETY.md`](docs/SAFETY.md)** — Threat model and `unsafe` inventory (local-CLI posture; distribution posture is tracked in `RELEASE_CRITERIA.md` §6).
 - **[`docs/PERFORMANCE.md`](docs/PERFORMANCE.md)** — Average-wall performance bands and Perl-parity baselines.
 - **[`docs/STABILITY_WITNESSES.md`](docs/STABILITY_WITNESSES.md)** — Living worklist of reliability/performance witness papers (timeout/OOM/peak-RSS/hang), with current-binary + Perl baselines and root-cause notes. Distinct from `SYNC_STATUS.md` (correctness errors).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,23 @@ unused_qualifications = "warn"
 # [patch."https://github.com/dginev/marpa"]
 # marpa = { path = "/home/deyan/git/marpa/marpa" }
 
+# `pericortex` (the CorTeX worker runtime, used only by the optional
+# `cortex_worker` binary under `--features cortex`) tracks its default branch
+# via the git dep in `latexml_oxide/Cargo.toml`. Same local-development
+# shortcut as marpa above: clone `cortex-peripherals` to
+# `~/git/cortex-peripherals` and *uncomment* the [patch] block below to build
+# `cortex_worker` against in-flight local worker-runtime edits without a
+# push/cargo-update round trip. Re-comment (and `cargo update -p pericortex`
+# to the published commit) before committing a workspace change, so the repo
+# state always references upstream — a path patch would break the
+# `--features cortex` docker build (which only `COPY`s this repo).
+#
+# INACTIVE (committed state references upstream master). To resume local
+# co-development of the worker runtime, uncomment the two lines below, then
+# re-comment + `cargo update -p pericortex` before committing a workspace change.
+# [patch."https://github.com/dginev/cortex-peripherals.git"]
+# pericortex = { path = "/home/deyan/git/cortex-peripherals" }
+
 [profile.release]
 # Local benchmark/sandbox/canvas profile. Tuned for the 32 GB / 20-thread
 # laptop used to rebuild the sandbox corpus: keep strong optimized binaries

--- a/docs/CORTEX_WORKER_HARNESS.md
+++ b/docs/CORTEX_WORKER_HARNESS.md
@@ -1,0 +1,154 @@
+# `cortex_worker` harness mode — fleet orchestration & memory caps
+
+How latexml-oxide's `cortex_worker` binary orchestrates a robust, self-contained
+fleet of conversion workers, and the layered memory guards that bound each one.
+
+* **Mechanism** (the reusable supervision/respawn/`RLIMIT_AS` library):
+  pericortex, `docs/HARNESS.md`.
+* **Operator deployment** (bring the fleet up against a running dispatcher):
+  CorTeX `MANUAL.md` §7.
+* **In-process runaway guards** (the byte budget / cycle guards *inside* one
+  conversion): `docs/MEMORY_GUARD_HARDENING_2026-06-09.md`.
+
+## The two modes of `cortex_worker`
+
+`cortex_worker` implements `pericortex::worker::Worker` and can run as either:
+
+1. **A single worker** (default): connects to the dispatcher and converts.
+   `--pool-size 1` is one conversion per process; `--pool-size N` runs N
+   conversion threads in **one** process sharing **one** RAM ceiling — avoid it
+   for production (the shared ceiling false-positives the memory guards on every
+   in-flight paper; see pericortex `docs/HARNESS.md`).
+2. **A self-supervising harness** (`--harness`): becomes a process supervisor.
+   It does no conversion itself; it spawns and keeps alive a fleet of
+   single-conversion (`--pool-size 1`) **child processes** — copies of its own
+   `current_exe()` with the dispatcher/profile flags forwarded and `--harness`
+   **omitted** (so there is no fork bomb) — respawning any that die, until
+   SIGTERM/SIGINT tears the fleet down cleanly.
+
+`--harness` does not reimplement supervision: it calls
+`pericortex::harness::supervise()`. The harness *logic* lives in pericortex
+(reusable across CorTeX workers); `cortex_worker` is the worker that *drives*
+it. "Self-supervising" and "the pericortex harness" are the same design viewed
+from two layers — not competing options.
+
+## Harness CLI
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--harness` | off | Run as the supervising harness instead of converting. |
+| `--workers N` | CPU-derived¹ | Number of single-conversion child processes to keep alive. A **deliberate over-commit** (see below) — explicit override. |
+| `--child-mem-limit-mb MB` | `8192` | Per-child **address-space** ceiling, enforced via `setrlimit(RLIMIT_AS)` before each child execs (`0` disables). Contains a *single* runaway job. |
+| `--mem-pressure-floor-mb MB` | auto³ | Fleet **memory-pressure governor** floor. Contains the *aggregate* (a heavy cluster). Omit = auto; `0` = disable. |
+| `--max-rss-mb MB` | auto² | Per-child polled **RSS** soft guard (forwarded to children). |
+
+¹ `pericortex::harness::default_worker_count()`: CPU count minus a reservation
+for the OS + dispatcher (−4 above 16 cores, −2 above 4, −1 above 2). This is a
+**deliberate over-commit** — most jobs use a fraction of the per-child cap, so
+sizing the fleet to the cap would idle most of the box; the governor (below)
+makes the over-commit safe against the rare heavy cluster.
+² In harness mode the child's `--max-rss-mb` is auto-set to
+`--child-mem-limit-mb − 256` so the soft guard fires just before the hard cap.
+With the 8192 default the soft guard sits at 7936 MiB RSS (1.75 GiB above 6 GB)
+and the VSZ cap clears a 6 GB job's ~7–7.5 GiB address space, so the effective
+resident ceiling is ~6.5–7 GB RSS — a legitimate ~6 GB paper completes with
+headroom.
+³ Auto = `max(one per-child cap, 10% of physical RAM)`: shed when free RAM
+drops below that, resume past 1.5×. Set explicitly to tune; `0` disables the
+governor (then rely on the per-child cap + an external cgroup).
+
+Example (one command brings up the whole fleet):
+
+```bash
+cortex_worker --harness \
+  --child-mem-limit-mb 8192 \
+  --service oxidized-tex-to-html \
+  --source-address tcp://dispatcher:51695 \
+  --sink-address   tcp://dispatcher:51696 \
+  --profile ar5iv
+# --workers defaults to the CPU-derived over-commit; --mem-pressure-floor-mb
+# defaults to max(8192, 10% of RAM). Add either flag only to override.
+```
+
+The dispatcher/profile flags (`--source-address`, `--sink-address`, `--service`,
+`--profile`, `--timeout`, `--message-size`, `--preload`, `--path`, `--no-pmml`,
+`--no-mathtex`, `--limit`, verbosity) are forwarded to every child. Forwarding
+`--limit N` recycles each child after N tasks (the harness respawns it),
+bounding any slow per-process memory creep.
+
+## Layered memory guards (defense in depth)
+
+Guards 1–4 bound a **single conversion** (per-process); guard 5 bounds the
+**fleet aggregate**. Innermost to outermost:
+
+1. **Gullet/stomach cycle guards + stomach byte budget** (`STOMACH_BOX_BYTES_BUDGET`,
+   ~3.2 GB of estimate) — detect a runaway *during* digestion and `Fatal` with a
+   structured `Stomach:MemoryBudget`/`Stomach:Recursion`. Portable, fires before
+   any RSS ceiling. See `docs/MEMORY_GUARD_HARDENING_2026-06-09.md`.
+2. **Polled RSS soft guard** (`--max-rss-mb`, the shared `Watchdog`) — samples
+   `/proc/self/status` `VmRSS` and exits `137` with a `Fatal:oom:rss` log line
+   and a `Status:conversion:3` artifact. Linux-only (reads `/proc`).
+3. **Alloc-error hook** (`custom_alloc_error_hook`) — when *any* allocation
+   returns null (e.g. an `ENOMEM` from the hard cap below), emits
+   `Fatal:oom:alloc_failed` and exits `137`. Portable.
+4. **Hard `RLIMIT_AS` cap** (`--child-mem-limit-mb`, applied by the harness) —
+   the kernel refuses allocations past the address-space ceiling, which surfaces
+   as `ENOMEM` → guard #3 → clean attributable exit → respawn. Contains a
+   **single** runaway job.
+5. **Fleet memory-pressure governor** (`--mem-pressure-floor-mb`, in the harness
+   process) — samples system `MemAvailable`; below the floor it SIGTERMs the
+   **largest-RSS** child (its task re-leased) and pauses respawns until memory
+   recovers past 1.5× the floor. Contains the **aggregate** — a cluster of
+   concurrently-heavy jobs that each stay under guard #4 but together threaten
+   the host. This is what makes the deliberate worker over-commit safe.
+
+Guards 1–4 are deliberately staggered so the **inner, attributable** ones fire
+first: a paper is reported as a logged `Status:conversion:3` (and its task
+re-leased) rather than vanishing in a silent kill. Guard 5 likewise *chooses* a
+victim and re-leases it, in place of an indiscriminate kernel OOM-kill.
+
+For a hard host-level backstop beneath all five, run the harness inside a cgroup
+`memory.max` (a memory-limited container, or `systemd-run --scope -p
+MemoryMax=…`); they compose — the cgroup caps the host, the governor sheds
+proactively before it, and `RLIMIT_AS` caps each child.
+
+### `RLIMIT_AS` caps address space, not RSS
+
+The worker uses **mimalloc** (`#[global_allocator]`) to avoid glibc arena-mutex
+contention under the multi-process fleet. mimalloc reserves virtual address
+space above its resident set, so a `--child-mem-limit-mb 4096` cap (which bounds
+**VSZ**) trips at a *true RSS* somewhat **below** 4 GiB. This is the right
+trade: it errs toward killing a runaway early, and it is the only privilege-free,
+portable `setrlimit` knob (`RLIMIT_RSS` is a Linux no-op). For a *precise* 4 GiB
+*RAM* cap, run the harness inside a cgroup `memory.max` (a memory-limited
+container, or `systemd-run --scope -p MemoryMax=4G`); the cgroup caps the
+aggregate while each child's `RLIMIT_AS` caps the individual — they compose.
+Full mechanism + rationale: pericortex `docs/HARNESS.md`.
+
+## Production recommendation
+
+* **Default: `cortex_worker --harness`.** Self-contained, single binary, single
+  command, portable to any host or bare container, shipping per-child
+  `RLIMIT_AS` + the fleet memory-pressure governor + crash-loop backoff +
+  SIGCHLD-prompt respawn + `PR_SET_PDEATHSIG` (no orphans) + graceful shutdown,
+  with no external dependency — consistent with the project's
+  self-contained-binary design principle.
+* **Under systemd/k8s:** either run `--harness` inside a memory-limited
+  container/pod (per-child `RLIMIT_AS` + an aggregate cgroup cap — defense in
+  depth), or let the platform supervise `--pool-size 1` workers directly and use
+  cgroup `MemoryMax`/`resources.limits.memory` for a true-RSS cap. Use whichever
+  the platform makes ergonomic; `--harness` is the portable fallback.
+* **Never `--pool-size N` for production** — it shares one RAM ceiling across N
+  conversions.
+
+## Exit-code reference (per child)
+
+| Code | Meaning | Source |
+| --- | --- | --- |
+| `0` | success / warnings | normal |
+| `124` | wall-clock timeout | `Watchdog` |
+| `137` | memory ceiling / alloc failure | `Watchdog` RSS guard or `custom_alloc_error_hook` (incl. `RLIMIT_AS` `ENOMEM`) |
+| `70` | 5 consecutive caught panics → clean restart | `cortex_worker` `MAX_CONSECUTIVE_PANICS` |
+
+All map to a `Status:conversion:3` failure the dispatcher records; the lease
+reaper recovers the in-flight task and the harness respawns the worker.

--- a/latexml_oxide/Cargo.toml
+++ b/latexml_oxide/Cargo.toml
@@ -43,6 +43,11 @@ default = ["test-utils", "runtime-bindings"]
 # rand, chrono, tempdir, walkdir — ~15 minutes of CI compile time we don't pay
 # for the core latexml_oxide / latexmlmath_oxide / latexmlpost_oxide binaries.
 cortex = ["dep:pericortex", "dep:hostname"]
+# Use jemalloc instead of mimalloc as the global allocator in `cortex_worker`.
+# jemalloc returns freed memory to the OS via background decay, keeping a
+# long-lived worker's RSS bounded to the current paper (see the `tikv-jemallocator`
+# dep note). Intended to pair with `cortex`: `--features cortex,jemalloc`.
+jemalloc = ["dep:tikv-jemallocator"]
 # Compile the integration-test harness in `src/util/test.rs`. On by default
 # so `cargo test` and `cargo build` (no flags) work as expected. Distribution
 # builds should pass `--no-default-features` (or `--no-default-features
@@ -115,6 +120,13 @@ hostname = { version = "0.4", optional = true }
 # for multi-process workloads like cortex_worker (arena contention via futex).
 # mimalloc gives each thread a private heap with lock-free fast paths.
 mimalloc = { version = "0.1", default-features = false }
+# Alternative allocator for the persistent `cortex_worker` fleet (enable with
+# `--features jemalloc`). jemalloc's decay-based purging returns freed pages to
+# the OS automatically (a background thread, tunable via `*_decay_ms`), so a
+# long-lived worker's RSS tracks the CURRENT paper instead of mimalloc's
+# retain-the-high-water default — the property a persistent conversion worker
+# needs. Used for the mimalloc-vs-jemalloc A/B and the recommended harness build.
+tikv-jemallocator = { version = "0.6", optional = true }
 
 # Metadata for `cargo deb` (https://github.com/kornelski/cargo-deb).
 # Drives `tools/make_release.sh` step 6: `cargo deb --no-build --profile maxperf -p latexml`.

--- a/latexml_oxide/bin/cortex_worker.rs
+++ b/latexml_oxide/bin/cortex_worker.rs
@@ -12,7 +12,7 @@
 use std::{
   alloc::{Layout, set_alloc_error_hook},
   borrow::Cow,
-  cell::Cell,
+  cell::{Cell, RefCell},
   error::Error,
   ffi::OsString,
   fs::{self, File},
@@ -22,10 +22,19 @@ use std::{
   sync::atomic::{AtomicU64, Ordering},
 };
 
-/// Per-process allocator: mimalloc avoids glibc's arena-mutex contention
-/// which dominates multi-process workloads (seen as 3.4x slowdown at 16 workers).
+/// Per-process allocator. Default is **mimalloc** (lock-free per-thread heaps,
+/// avoids glibc's arena-mutex contention). Building with `--features jemalloc`
+/// swaps in **jemalloc**, whose decay-based background purging returns freed
+/// pages to the OS so a long-lived worker's RSS tracks the *current* paper
+/// rather than retaining the high-water of the heaviest paper it has processed —
+/// the disposition a persistent one-conversion-per-process worker needs (tune
+/// the decay via `_RJEM_MALLOC_CONF`, set on children by `run_harness`).
+#[cfg(not(feature = "jemalloc"))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 use std::{process, rc::Rc};
 
 use clap::Parser;
@@ -470,6 +479,43 @@ thread_local! {
   /// Consecutive caught-panic counter for *this* worker thread (each pool
   /// thread keeps its own engine state, hence its own streak).
   static PANIC_STREAK: Cell<u32> = const { Cell::new(0) };
+
+  /// Detail of the most recent panic on this thread — the panic **location**
+  /// (`file:line:col`) plus message — stashed by the panic hook
+  /// ([`install_panic_hook`]) at unwind time, then consumed by [`Worker::convert`]
+  /// for the failure artifact. `catch_unwind` only hands back the payload (the
+  /// bare message, e.g. "called `Option::unwrap()` on a `None` value"), which has
+  /// no location; capturing it in the hook is the only way to record *where* a
+  /// conversion panicked. The full backtrace is emitted to stderr by the hook.
+  static LAST_PANIC_DETAIL: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+/// Install a process-wide panic hook that records, for every panic, the panic
+/// **location** + message (into [`LAST_PANIC_DETAIL`] for the failing task's
+/// artifact) and prints the **full backtrace** to stderr (captured in the
+/// worker/harness log) so a caught conversion panic is debuggable. Uses
+/// `Backtrace::force_capture`, so a backtrace is taken regardless of
+/// `RUST_BACKTRACE`; the panic location is present even in a stripped release
+/// build (panic-location strings survive `strip`), while symbolicated frames
+/// need a build with debug info.
+fn install_panic_hook() {
+  std::panic::set_hook(Box::new(|info| {
+    let loc = info
+      .location()
+      .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+      .unwrap_or_else(|| "<unknown location>".to_string());
+    let payload = info.payload();
+    let msg = payload
+      .downcast_ref::<&str>()
+      .map(|s| (*s).to_string())
+      .or_else(|| payload.downcast_ref::<String>().cloned())
+      .unwrap_or_else(|| "<non-string panic payload>".to_string());
+    let bt = std::backtrace::Backtrace::force_capture();
+    // Full backtrace → stderr (captured in the worker/harness log) for debugging.
+    eprintln!("Fatal:panic:backtrace panicked at {loc}: {msg}\n{bt}");
+    // Bounded location+message → the per-task failure artifact (parser-safe).
+    LAST_PANIC_DETAIL.with(|p| *p.borrow_mut() = Some(format!("panicked at {loc}: {msg}")));
+  }));
 }
 
 impl Worker for LatexmlWorker {
@@ -515,7 +561,11 @@ impl Worker for LatexmlWorker {
         write_failure_zip(&arxiv_id, "conversion", &e.to_string())?
       },
       Err(panic) => {
-        let msg = panic_message(&*panic);
+        // Prefer the panic hook's captured detail (location + message); fall back
+        // to the bare payload if the hook didn't run for some reason.
+        let msg = LAST_PANIC_DETAIL
+          .with(|p| p.borrow_mut().take())
+          .unwrap_or_else(|| panic_message(&*panic));
         let streak = PANIC_STREAK.with(|s| {
           let n = s.get() + 1;
           s.set(n);
@@ -541,6 +591,14 @@ impl Worker for LatexmlWorker {
     let file = File::open(&output_path)?;
     // Clean up temp file after opening (the open fd keeps the bytes readable).
     let _ = fs::remove_file(&output_path);
+    // NB: do NOT reset the thread engine here. The persistent worker relies on
+    // the dump definitions (loaded once) PERSISTING across papers — `prepare_session`
+    // re-initialises only the ephemeral per-conversion state. Returning memory to
+    // the OS between papers is the **allocator's** job (jemalloc decay under
+    // `--features jemalloc`), not an explicit engine reset: an earlier attempt to
+    // call `reset_thread_engine()` here wiped the persisted definitions and made
+    // every subsequent conversion panic (`unwrap() on None`). See the harness
+    // validation, 2026-06-17.
     Ok(file)
   }
 
@@ -1193,6 +1251,10 @@ fn custom_alloc_error_hook(layout: Layout) {
 
 fn main() -> Result<(), Box<dyn Error>> {
   set_alloc_error_hook(custom_alloc_error_hook);
+  // Capture panic location + full backtrace for every panic (the conversion
+  // catch_unwind only sees the bare payload otherwise). Process-wide, so it also
+  // covers the harness supervisor.
+  install_panic_hook();
 
   // R35.A: install a default gullet pushback limit so runaway
   // macro expansion (witnessed on plain-TeX `\displaylines{ …
@@ -1305,6 +1367,35 @@ fn run_harness(cli: &Cli) -> Result<(), Box<dyn Error>> {
 
   supervise(&config, move |_index| {
     let mut cmd = process::Command::new(&exe);
+    // jemalloc tuning for children (read at allocator init, so it must be set by
+    // us before exec — too late from inside the child). Enable the background
+    // purge thread and a short dirty-page decay so a worker returns freed memory
+    // to the OS promptly between papers, keeping per-process RSS tracking the
+    // current paper. Harmless for a mimalloc-built binary (ignores these). Both
+    // the jemalloc-prefixed and unprefixed names are set for build-config safety.
+    cmd
+      .env(
+        "_RJEM_MALLOC_CONF",
+        "background_thread:true,dirty_decay_ms:500,muzzy_decay_ms:0",
+      )
+      .env(
+        "MALLOC_CONF",
+        "background_thread:true,dirty_decay_ms:500,muzzy_decay_ms:0",
+      );
+    // Align the engine's in-process RSS fuse (`stomach::check_timeout`, default
+    // 4.5 GB) with this fleet's actual per-child ceiling. That default is a
+    // one-conversion-per-process leftover: in a long-lived worker the working set
+    // creeps across papers and trips the 4.5 GB fuse on otherwise-fine papers,
+    // producing a false `Fatal:Timeout:MemoryBudget RSS … > cap` cascade (observed
+    // 2026-06-17). Raise it to the polled `--max-rss-mb` watchdog value so the
+    // cooperative fuse fires only for a genuine single-paper runaway (just before
+    // the watchdog), and the fleet governor handles aggregate pressure.
+    if child_max_rss_mb > 0 {
+      cmd.env(
+        "LATEXML_RSS_CAP_BYTES",
+        child_max_rss_mb.saturating_mul(1024 * 1024).to_string(),
+      );
+    }
     cmd
       .arg("--pool-size")
       .arg("1")

--- a/latexml_oxide/bin/cortex_worker.rs
+++ b/latexml_oxide/bin/cortex_worker.rs
@@ -12,11 +12,14 @@
 use std::{
   alloc::{Layout, set_alloc_error_hook},
   borrow::Cow,
+  cell::Cell,
   error::Error,
   ffi::OsString,
   fs::{self, File},
   io::{Read, Write},
+  panic::AssertUnwindSafe,
   path::{Path, PathBuf},
+  sync::atomic::{AtomicU64, Ordering},
 };
 
 /// Per-process allocator: mimalloc avoids glibc's arena-mutex contention
@@ -43,8 +46,13 @@ struct Cli {
   #[arg(long, default_value = "tcp://localhost:51696")]
   sink_address: String,
 
-  /// Service name as registered in CorTeX
-  #[arg(long, default_value = "oxidized_tex_to_html")]
+  /// Service name as registered in CorTeX. Must match the service's `name`
+  /// **exactly**: the dispatcher's ventilator leases tasks for this name, and
+  /// the sink re-validates each returned result's service name against the
+  /// task's service id (`src/dispatcher/sink.rs`) — a mismatch silently
+  /// discards the result. The CorTeX preview registers this service as
+  /// `oxidized-tex-to-html` (hyphenated), so that is the default.
+  #[arg(long, default_value = "oxidized-tex-to-html")]
   service: String,
 
   /// Number of parallel worker threads
@@ -125,6 +133,50 @@ struct Cli {
   /// Quiet output
   #[arg(short, long)]
   quiet: bool,
+
+  /// Run as a process-supervising **harness**: spawn and keep alive a fleet of
+  /// single-conversion (`--pool-size 1`) worker child processes — respawning
+  /// any that exit — instead of converting in this process. This is the robust
+  /// deployment model: one conversion per process gives each paper its own RAM
+  /// ceiling and wall-clock timeout, so a timeout / OOM / panic / segfault
+  /// kills only that one worker (the dispatcher's lease reaper recovers its
+  /// task) and the harness respawns a fresh process. A single `--pool-size N`
+  /// process would instead share one RAM ceiling across N concurrent
+  /// conversions, false-positiving the memory guards on every paper.
+  #[arg(long)]
+  harness: bool,
+
+  /// Harness mode: number of worker child processes to keep alive. Default:
+  /// CPU-derived, reserving 1–4 logical cores for the OS + dispatcher.
+  #[arg(long)]
+  workers: Option<usize>,
+
+  /// Harness mode: per-child **address-space** ceiling in MiB, enforced via
+  /// `setrlimit(RLIMIT_AS)` before each child execs (0 disables). Default 8192
+  /// (8 GiB) — sized so a *legitimate* heavy paper (≈6 GB RSS observed) reliably
+  /// completes with headroom. NB: this bounds address space (VSZ), and with
+  /// mimalloc VSZ runs ~1–1.5 GiB above true RSS; at 8 GiB the soft `--max-rss-mb`
+  /// guard sits at 7936 MiB RSS (1.75 GiB above 6 GB) and the VSZ cap clears a
+  /// 6 GB job's ~7–7.5 GiB address space, so the effective resident ceiling is
+  /// ~6.5–7 GB RSS. This cap contains a **single** runaway job; the fleet-wide
+  /// `--mem-pressure-floor-mb` governor contains the **aggregate** (a cluster of
+  /// concurrently-heavy jobs). A breach makes the child's next allocation fail
+  /// with `ENOMEM`, which `custom_alloc_error_hook` turns into a clean
+  /// `Fatal:oom` + exit 137, and the harness respawns it.
+  #[arg(long, default_value = "8192")]
+  child_mem_limit_mb: u64,
+
+  /// Harness mode: fleet **memory-pressure governor** floor in MiB. Omit for
+  /// auto (`max(one per-child cap, 10% of RAM)`); `0` disables the governor;
+  /// a positive value sets an explicit floor. While system `MemAvailable` is
+  /// below the floor, the harness sheds its **largest-RSS** worker (its task is
+  /// re-leased) and pauses respawns until memory recovers past 1.5× the floor —
+  /// so the fleet may safely over-commit (the common case runs the full worker
+  /// count) yet survives a rare cluster of heavy jobs with a deliberate,
+  /// attributable shed instead of an uncontrolled kernel OOM-kill. Pair with an
+  /// outer cgroup `memory.max` for a hard backstop.
+  #[arg(long)]
+  mem_pressure_floor_mb: Option<u64>,
 }
 
 /// Conversion profile presets
@@ -349,9 +401,13 @@ impl LatexmlWorker {
       telemetry::take().to_json_line()
     };
 
-    // 8. Pack output ZIP: HTML (named after source) + images + log + status + telemetry
-    let output_path =
-      std::env::temp_dir().join(format!("cortex_output_{}.zip", std::process::id()));
+    // 8. Pack output ZIP: HTML (named after source) + images + log + status + telemetry.
+    //    The path must be UNIQUE per task, not just per process: with `--pool-size N`
+    //    (N worker threads sharing one PID) a PID-only name would have every thread
+    //    write the same `/tmp/cortex_output_<pid>.zip` concurrently — interleaved
+    //    writes corrupt the archive and threads stream each other's bytes back. A
+    //    process-wide atomic sequence makes it collision-free across threads + papers.
+    let output_path = unique_output_path();
     latexml_post::pack::pack_archive(&latexml_post::pack::PackOptions {
       zip_path:          &output_path.to_string_lossy(),
       html_filename:     &html_filename,
@@ -372,7 +428,7 @@ impl LatexmlWorker {
 
 /// Read peak RSS in KB from /proc/self/status's VmHWM. 0 on failure.
 fn read_max_rss_kb_proc() -> u64 {
-  std::fs::read_to_string("/proc/self/status")
+  fs::read_to_string("/proc/self/status")
     .ok()
     .and_then(|content| {
       content
@@ -402,11 +458,88 @@ fn read_child_rusage_us_proc() -> (u64, u64) {
 #[cfg(not(unix))]
 fn read_child_rusage_us_proc() -> (u64, u64) { (0, 0) }
 
+/// Maximum number of *consecutive* caught panics before the worker process
+/// exits for a clean supervisor restart. A single poison paper among healthy
+/// ones never trips this (the streak resets on the next success); a sustained
+/// run of panics means the thread-local engine state is likely corrupted
+/// (an unwind left a lock/`RefCell` mid-mutation), so a fresh process is safer
+/// than risking silently-wrong output on subsequent papers.
+const MAX_CONSECUTIVE_PANICS: u32 = 5;
+
+thread_local! {
+  /// Consecutive caught-panic counter for *this* worker thread (each pool
+  /// thread keeps its own engine state, hence its own streak).
+  static PANIC_STREAK: Cell<u32> = const { Cell::new(0) };
+}
+
 impl Worker for LatexmlWorker {
+  /// Convert one task archive, **isolating every failure mode of the
+  /// latexml-oxide conversion call** so a single paper can never take the
+  /// worker down (the "anything that can go wrong will go wrong" contract):
+  ///
+  /// * A returned `Err` (unpack failure, disk-write failure, …) → a structured
+  ///   `Status:conversion:3` archive carrying a `Fatal:conversion:*` log line.
+  /// * A **panic** inside digestion/post-processing (the most dangerous case:
+  ///   it would otherwise unwind through `pericortex`'s loop and kill the
+  ///   process) → caught here (release builds use `panic = "unwind"`), turned
+  ///   into a `Fatal:panic:*` archive, and counted toward [`MAX_CONSECUTIVE_PANICS`].
+  ///
+  /// Either way the dispatcher receives an attributable result for the paper
+  /// instead of losing the task (and the worker), and the next paper proceeds.
+  /// Timeouts / OOM are handled out-of-band by the `Watchdog` + alloc hook
+  /// (they exit the process; the dispatcher's lease reaper recovers the task).
   fn convert(&self, path: &Path) -> Result<File, Box<dyn Error>> {
-    let output_path = self.convert_archive(path)?;
+    let arxiv_id = path
+      .file_stem()
+      .and_then(|s| s.to_str())
+      .unwrap_or("document")
+      .to_string();
+
+    // `AssertUnwindSafe`: the engine state is a thread-local singleton rebuilt
+    // per paper (`prepare_session`), so a caught unwind does not hand a logically
+    // half-updated value across the boundary — the next paper re-initialises it.
+    let outcome = std::panic::catch_unwind(AssertUnwindSafe(|| self.convert_archive(path)));
+
+    let output_path = match outcome {
+      Ok(Ok(path)) => {
+        PANIC_STREAK.with(|s| s.set(0));
+        path
+      },
+      Ok(Err(e)) => {
+        // The conversion failed cleanly (returned `Err`). Not a panic, so don't
+        // touch the streak — produce an attributable Fatal result and continue.
+        log::warn!(
+          target: "cortex_worker",
+          "conversion of {arxiv_id} failed: {e}; returning a Fatal result archive"
+        );
+        write_failure_zip(&arxiv_id, "conversion", &e.to_string())?
+      },
+      Err(panic) => {
+        let msg = panic_message(&*panic);
+        let streak = PANIC_STREAK.with(|s| {
+          let n = s.get() + 1;
+          s.set(n);
+          n
+        });
+        log::error!(
+          target: "cortex_worker",
+          "PANIC caught converting {arxiv_id} (consecutive: {streak}/{MAX_CONSECUTIVE_PANICS}): {msg}"
+        );
+        if streak >= MAX_CONSECUTIVE_PANICS {
+          log::error!(
+            target: "cortex_worker",
+            "{MAX_CONSECUTIVE_PANICS} consecutive panics — engine state is likely corrupted; \
+             exiting (code 70) for a clean supervisor restart. The dispatcher's lease reaper \
+             re-leases the in-flight task to another worker."
+          );
+          process::exit(70);
+        }
+        write_failure_zip(&arxiv_id, "panic", &msg)?
+      },
+    };
+
     let file = File::open(&output_path)?;
-    // Clean up temp file after opening
+    // Clean up temp file after opening (the open fd keeps the bytes readable).
     let _ = fs::remove_file(&output_path);
     Ok(file)
   }
@@ -470,15 +603,15 @@ fn find_main_tex(dir: &Path) -> Result<String, Box<dyn Error>> {
 
   // Phase I.1.2: Check 00README.XXX (legacy arXiv format)
   let readme_xxx = dir.join("00README.XXX");
-  if readme_xxx.exists() {
-    if let Ok(content) = fs::read_to_string(&readme_xxx) {
-      for line in content.lines() {
-        let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.len() >= 2 && parts[1] == "toplevelfile" {
-          let main_path = dir.join(parts[0]);
-          if main_path.exists() {
-            return Ok(main_path.to_string_lossy().to_string());
-          }
+  if readme_xxx.exists()
+    && let Ok(content) = fs::read_to_string(&readme_xxx)
+  {
+    for line in content.lines() {
+      let parts: Vec<&str> = line.split_whitespace().collect();
+      if parts.len() >= 2 && parts[1] == "toplevelfile" {
+        let main_path = dir.join(parts[0]);
+        if main_path.exists() {
+          return Ok(main_path.to_string_lossy().to_string());
         }
       }
     }
@@ -524,7 +657,7 @@ fn find_main_tex(dir: &Path) -> Result<String, Box<dyn Error>> {
   // `Fatal:invalid:not_tex_source` (status 3) and bail.
   fn is_pdf_magic(path: &Path) -> bool {
     let mut buf = [0u8; 5];
-    if let Ok(mut f) = fs::File::open(path) {
+    if let Ok(mut f) = File::open(path) {
       use std::io::Read;
       if f.read(&mut buf).is_ok_and(|n| n == 5) {
         return &buf == b"%PDF-";
@@ -626,22 +759,22 @@ fn find_main_tex(dir: &Path) -> Result<String, Box<dyn Error>> {
         determined = true;
         break;
       }
-      if lineno1 <= 12 {
-        if let Some(cap) = RE_FORMAT_HINT.captures(raw_line) {
-          let fmt = &cap[1];
-          if fmt == "latex209" || fmt == "biglatex" || fmt == "latex" || fmt == "LaTeX" {
-            likelihood.insert(tex_file.clone(), 3.0);
-          } else {
-            likelihood.insert(tex_file.clone(), 1.0);
-          }
-          determined = true;
-          break;
+      if lineno1 <= 12
+        && let Some(cap) = RE_FORMAT_HINT.captures(raw_line)
+      {
+        let fmt = &cap[1];
+        if fmt == "latex209" || fmt == "biglatex" || fmt == "latex" || fmt == "LaTeX" {
+          likelihood.insert(tex_file.clone(), 3.0);
+        } else {
+          likelihood.insert(tex_file.clone(), 1.0);
         }
+        determined = true;
+        break;
       }
       // Perl L128: strip ONE `%`-comment up to the next `\r`. `\r`-aware
       // so bare-`\r` line-ended files (read as one big "line" in Perl
       // because `$/=\n`) preserve subsequent `\r\documentclass` chunks.
-      let stripped: std::borrow::Cow<str> = RE_STRIP_COMMENT.replacen(raw_line, 1, "");
+      let stripped: Cow<str> = RE_STRIP_COMMENT.replacen(raw_line, 1, "");
       let line: &str = &stripped;
 
       if RE_DOCCLASS.is_match(line) {
@@ -907,6 +1040,76 @@ fn parse_readme_json(dir: &Path) -> Option<String> {
   None
 }
 
+/// A process-unique temp path for a packed result archive. Combines the PID
+/// (distinguishes concurrent worker *processes* on a shared `/tmp`) with a
+/// monotonic per-process counter (distinguishes pool *threads* and successive
+/// papers within one process), so no two in-flight conversions ever target the
+/// same file. Replaces the former PID-only name that pooled threads raced on.
+fn unique_output_path() -> PathBuf {
+  static OUTPUT_SEQ: AtomicU64 = AtomicU64::new(0);
+  let seq = OUTPUT_SEQ.fetch_add(1, Ordering::Relaxed);
+  std::env::temp_dir().join(format!("cortex_output_{}_{}.zip", process::id(), seq))
+}
+
+/// Extract a human-readable message from a caught-panic payload — the usual
+/// `&str` / `String` cases, else a generic label.
+fn panic_message(panic: &(dyn std::any::Any + Send)) -> String {
+  if let Some(s) = panic.downcast_ref::<&str>() {
+    (*s).to_string()
+  } else if let Some(s) = panic.downcast_ref::<String>() {
+    s.clone()
+  } else {
+    "<non-string panic payload>".to_string()
+  }
+}
+
+/// Build a minimal, **attributable** failure archive at a unique temp path and
+/// return that path. Carries exactly what the dispatcher needs to record a hard
+/// failure for a paper whose conversion `Err`'d or panicked: a `status` member
+/// (`Status:conversion:3`), a `cortex.log` with one `Fatal:<category>:caught …`
+/// line (so the dispatcher's log parse + telemetry count it as a fatal, never a
+/// silent "0 errors"), and a minimal `telemetry.json`. Mirrors the member shape
+/// of [`write_timeout_placeholder_zip`] so the same parser handles both.
+fn write_failure_zip(
+  arxiv_id: &str,
+  category: &str,
+  message: &str,
+) -> Result<PathBuf, Box<dyn Error>> {
+  let output_path = unique_output_path();
+  // Single-line + length-bounded so a giant or newline-laden panic payload can
+  // neither bloat the archive nor smuggle a fake `Status:`/`Fatal:` line into
+  // the log parser.
+  let sanitized: String = message
+    .replace(['\n', '\r'], " ")
+    .chars()
+    .take(2000)
+    .collect();
+  let log = format!(
+    "Fatal:{category}:caught latexml-oxide failed to convert {arxiv_id}: {sanitized}\n\
+     Status:conversion:3\n"
+  );
+  // `serde_json` so a hostile filename can't break the JSON (robustness).
+  let telemetry = serde_json::json!({
+    "paper_id": arxiv_id,
+    "category": "conversion_fatal",
+    "exit_code": 3,
+  })
+  .to_string();
+
+  let file = File::create(&output_path)?;
+  let mut zip = zip::ZipWriter::new(file);
+  let options =
+    zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+  zip.start_file("status", options)?;
+  zip.write_all(b"Status:conversion:3")?;
+  zip.start_file("cortex.log", options)?;
+  zip.write_all(log.as_bytes())?;
+  zip.start_file("telemetry.json", options)?;
+  zip.write_all(telemetry.as_bytes())?;
+  zip.finish()?;
+  Ok(output_path)
+}
+
 /// Minimal "we timed out" placeholder zip. Written only from the
 /// watchdog's pre-exit hook (`set_pre_exit_hook` in `latexml_core::
 /// watchdog`), so the happy-path overhead is zero. Contains just
@@ -985,7 +1188,7 @@ fn custom_alloc_error_hook(layout: Layout) {
     let bt = std::backtrace::Backtrace::force_capture();
     eprintln!("{bt}");
   }
-  std::process::exit(137);
+  process::exit(137);
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -1024,13 +1227,138 @@ fn main() -> Result<(), Box<dyn Error>> {
     .map_err(|s| s.into())
 }
 
+/// Run the process-supervising harness (`--harness`): keep a fleet of
+/// single-conversion (`--pool-size 1`) worker child processes alive, each
+/// capped at `--child-mem-limit-mb` of address space via `setrlimit(RLIMIT_AS)`
+/// (applied by `pericortex::harness` in the forked child before `exec`), and
+/// respawn any that die — until SIGTERM/SIGINT tears the fleet down cleanly.
+///
+/// Children are this same binary re-invoked with the dispatcher/profile flags
+/// forwarded, `--pool-size 1`, and **without** `--harness` (so no fork bomb).
+/// Each child's polled `--max-rss-mb` soft guard is set ~256 MiB under the hard
+/// `RLIMIT_AS` cap so the watchdog emits an attributable `Status:conversion:3`
+/// just before the hard `ENOMEM` kill.
+fn run_harness(cli: &Cli) -> Result<(), Box<dyn Error>> {
+  use pericortex::harness::{HarnessConfig, default_worker_count, supervise, total_ram_bytes};
+
+  const MIB: u64 = 1024 * 1024;
+
+  let mem_limit_bytes =
+    (cli.child_mem_limit_mb > 0).then(|| cli.child_mem_limit_mb.saturating_mul(MIB));
+
+  // Worker count: CPU-derived by default — a deliberate over-commit. Most jobs
+  // use a small fraction of the per-child cap (observed: median a few hundred
+  // MB), so sizing the fleet to the worst-case cap would idle most of the box.
+  // The fleet memory-pressure governor below is what makes the over-commit safe
+  // against the rare cluster of concurrently-heavy jobs. An explicit `--workers`
+  // overrides.
+  let workers = cli.workers.unwrap_or_else(default_worker_count);
+
+  // Memory-pressure governor floor. Omitted → auto = max(one per-child cap, 10%
+  // of RAM): enough free headroom for one heavy job to keep growing before the
+  // governor steps in. `--mem-pressure-floor-mb 0` disables it (rely on the
+  // per-child cap + any outer cgroup); an explicit value sets the MiB floor.
+  let mem_pressure_floor_bytes = match cli.mem_pressure_floor_mb {
+    Some(0) => None,
+    Some(mb) => Some(mb.saturating_mul(MIB)),
+    None => total_ram_bytes().map(|total| mem_limit_bytes.unwrap_or(0).max(total / 10)),
+  };
+
+  // Soft RSS guard ~256 MiB under the hard cap (or the user's value if no hard
+  // cap), so the in-process watchdog fires an attributable Fatal before ENOMEM.
+  let child_max_rss_mb = if cli.child_mem_limit_mb > 0 {
+    cli.child_mem_limit_mb.saturating_sub(256)
+  } else {
+    cli.max_rss_mb
+  };
+
+  let exe = std::env::current_exe()?;
+  let governor = match mem_pressure_floor_bytes {
+    Some(b) => format!("shed below {} MiB MemAvailable", b / MIB),
+    None => "off".to_string(),
+  };
+  eprintln!(
+    "Starting CorTeX harness: {workers} single-conversion worker process(es), \
+     service '{}', RLIMIT_AS {} MiB/child (soft RSS guard {} MiB), mem-governor: {governor}",
+    cli.service, cli.child_mem_limit_mb, child_max_rss_mb
+  );
+
+  // Owned clones for the build closure: `supervise` calls it once per spawn
+  // (including every respawn), so it must outlive `cli`'s borrow and be `Fn`.
+  let source_address = cli.source_address.clone();
+  let sink_address = cli.sink_address.clone();
+  let service = cli.service.clone();
+  let profile = cli.profile.clone();
+  let timeout = cli.timeout;
+  let message_size = cli.message_size;
+  let limit = cli.limit;
+  let preload = cli.preload.clone();
+  let search_paths = cli.search_paths.clone();
+  let (no_pmml, no_mathtex, verbose, quiet) = (cli.no_pmml, cli.no_mathtex, cli.verbose, cli.quiet);
+
+  let config = HarnessConfig {
+    workers,
+    mem_limit_bytes,
+    mem_pressure_floor_bytes,
+    ..Default::default()
+  };
+
+  supervise(&config, move |_index| {
+    let mut cmd = process::Command::new(&exe);
+    cmd
+      .arg("--pool-size")
+      .arg("1")
+      .arg("--source-address")
+      .arg(&source_address)
+      .arg("--sink-address")
+      .arg(&sink_address)
+      .arg("--service")
+      .arg(&service)
+      .arg("--profile")
+      .arg(&profile)
+      .arg("--timeout")
+      .arg(timeout.to_string())
+      .arg("--max-rss-mb")
+      .arg(child_max_rss_mb.to_string())
+      .arg("--message-size")
+      .arg(message_size.to_string());
+    // Forwarding `--limit` recycles each child after N tasks (the harness
+    // respawns it), bounding any slow per-process memory creep.
+    if let Some(l) = limit {
+      cmd.arg("--limit").arg(l.to_string());
+    }
+    for p in &preload {
+      cmd.arg("--preload").arg(p);
+    }
+    for p in &search_paths {
+      cmd.arg("--path").arg(p);
+    }
+    if no_pmml {
+      cmd.arg("--no-pmml");
+    }
+    if no_mathtex {
+      cmd.arg("--no-mathtex");
+    }
+    if verbose {
+      cmd.arg("--verbose");
+    }
+    if quiet {
+      cmd.arg("--quiet");
+    }
+    cmd
+  })
+}
+
 fn real_main() -> Result<(), Box<dyn Error>> {
   let cli = Cli::parse();
 
   // Spawn kpathsea pre-init in a background thread (overlaps the
   // ~30-40 ms `kpathsea_init_db` cost with arg parse + dump load).
-  // See `latexml_core::util::pathname::prewarm_kpathsea`.
-  let _kpse_warmup_handle = if std::env::var("LATEXML_NO_KPATHSEA_PREWARM").is_err() {
+  // See `latexml_core::util::pathname::prewarm_kpathsea`. Skipped in harness
+  // mode — the supervisor never converts, so it would only waste a thread; each
+  // spawned child prewarms its own.
+  let _kpse_warmup_handle = if std::env::var("LATEXML_NO_KPATHSEA_PREWARM").is_err() && !cli.harness
+  {
     Some(std::thread::spawn(
       latexml_core::util::pathname::prewarm_kpathsea,
     ))
@@ -1051,6 +1379,13 @@ fn real_main() -> Result<(), Box<dyn Error>> {
     _ => log::LevelFilter::Debug,
   };
   latexml_core::util::logger::init(log_level).ok();
+
+  // Harness mode: become a process supervisor for a fleet of single-conversion
+  // child workers, each `RLIMIT_AS`-capped. The supervisor itself does no
+  // conversion, so we branch out before building any engine state.
+  if cli.harness {
+    return run_harness(&cli);
+  }
 
   let profile = match cli.profile.as_str() {
     "ar5iv" => ConversionProfile::ar5iv(

--- a/latexml_oxide/bin/cortex_worker.rs
+++ b/latexml_oxide/bin/cortex_worker.rs
@@ -186,6 +186,19 @@ struct Cli {
   /// outer cgroup `memory.max` for a hard backstop.
   #[arg(long)]
   mem_pressure_floor_mb: Option<u64>,
+
+  /// Per-worker memory-based **recycle** threshold in MiB (0 disables). After each
+  /// conversion — with the result already returned to the dispatcher, so nothing is
+  /// lost — if the worker's RSS exceeds this, it exits cleanly and the harness forks
+  /// a fresh one. This reclaims the engine's accumulated interner/arena (a
+  /// thread-local that is never reset mid-process — it assumes a short-lived,
+  /// one-conversion-per-process model) by process replacement, without failing a
+  /// paper, while keeping startup amortized for the common case of light papers. In
+  /// harness mode it auto-sets to **50% of `--child-mem-limit-mb`** (the rule: a
+  /// fresh worker keeps the *full* ceiling for any single — even aberrant — paper,
+  /// then retires once it has consumed half of it). A standalone worker leaves it 0.
+  #[arg(long, default_value = "0")]
+  allocation_limit_mb: u64,
 }
 
 /// Conversion profile presets
@@ -260,6 +273,9 @@ struct LatexmlWorker {
   verbosity:      i32,
   /// Extra --path search dirs from CLI, prepended to per-job source_dir.
   search_paths:   Vec<String>,
+  /// Recycle the worker after a conversion once RSS exceeds this many MiB (0 =
+  /// never). See `--allocation-limit-mb` and `Worker::recycle_after_task`.
+  alloc_limit_mb: u64,
 }
 
 impl LatexmlWorker {
@@ -615,6 +631,17 @@ impl Worker for LatexmlWorker {
   fn set_identity(&mut self, identity: String) { self.identity = identity; }
 
   fn get_identity(&self) -> &str { &self.identity }
+
+  /// Recycle this worker (clean exit → fresh respawn) once its resident memory has
+  /// grown past `--allocation-limit-mb`. Called by `start_single` AFTER the result is
+  /// returned, so no paper is lost. Reads current `VmRSS` (one cheap `/proc` read);
+  /// `0` disables. Bounds the engine's never-reset thread-local interner/arena by
+  /// process replacement rather than a fragile mid-life reset.
+  fn recycle_after_task(&self) -> bool {
+    self.alloc_limit_mb > 0
+      && latexml_core::watchdog::process_rss_kb()
+        .is_some_and(|rss_kb| rss_kb / 1024 > self.alloc_limit_mb)
+  }
 }
 
 // --- Helper functions (shared with latexml_oxide.rs) ---
@@ -1334,6 +1361,20 @@ fn run_harness(cli: &Cli) -> Result<(), Box<dyn Error>> {
     cli.max_rss_mb
   };
 
+  // Memory-based recycle threshold: 50% of the per-child ceiling. After a clean
+  // conversion, a worker whose RSS has passed this exits and is re-forked fresh,
+  // reclaiming the engine's never-reset interner/arena by process replacement
+  // (the common case of light papers never trips it). A fresh worker keeps the
+  // full ceiling for any single (even aberrant) paper, then retires once it has
+  // consumed half of it. `--allocation-limit-mb` overrides; 0 disables.
+  let child_alloc_limit_mb = if cli.allocation_limit_mb > 0 {
+    cli.allocation_limit_mb
+  } else if cli.child_mem_limit_mb > 0 {
+    cli.child_mem_limit_mb / 2
+  } else {
+    cli.max_rss_mb / 2
+  };
+
   let exe = std::env::current_exe()?;
   let governor = match mem_pressure_floor_bytes {
     Some(b) => format!("shed below {} MiB MemAvailable", b / MIB),
@@ -1341,8 +1382,9 @@ fn run_harness(cli: &Cli) -> Result<(), Box<dyn Error>> {
   };
   eprintln!(
     "Starting CorTeX harness: {workers} single-conversion worker process(es), \
-     service '{}', RLIMIT_AS {} MiB/child (soft RSS guard {} MiB), mem-governor: {governor}",
-    cli.service, cli.child_mem_limit_mb, child_max_rss_mb
+     service '{}', RLIMIT_AS {} MiB/child (soft RSS guard {} MiB, recycle @ {} MiB RSS), \
+     mem-governor: {governor}",
+    cli.service, cli.child_mem_limit_mb, child_max_rss_mb, child_alloc_limit_mb
   );
 
   // Owned clones for the build closure: `supervise` calls it once per spawn
@@ -1411,6 +1453,8 @@ fn run_harness(cli: &Cli) -> Result<(), Box<dyn Error>> {
       .arg(timeout.to_string())
       .arg("--max-rss-mb")
       .arg(child_max_rss_mb.to_string())
+      .arg("--allocation-limit-mb")
+      .arg(child_alloc_limit_mb.to_string())
       .arg("--message-size")
       .arg(message_size.to_string());
     // Forwarding `--limit` recycles each child after N tasks (the harness
@@ -1520,6 +1564,7 @@ fn real_main() -> Result<(), Box<dyn Error>> {
     profile,
     verbosity,
     search_paths: cli.search_paths.clone(),
+    alloc_limit_mb: cli.allocation_limit_mb,
   };
 
   if cli.standalone {


### PR DESCRIPTION
Makes `cortex_worker --harness` a production-grade fleet supervisor for large-scale conversion runs, driving `pericortex::harness`.

## Memory model — controlled over-commit + two limits
Workload reality: most papers use a few hundred MB, the occasional *legitimate* one ~6 GB. Sizing the fleet to the worst case idles the box, so the fleet **over-commits deliberately** (CPU-derived worker count) and is bounded by two complementary limits:

- **Per-child `RLIMIT_AS`** (`--child-mem-limit-mb`, default **8192**) — contains a *single* runaway job. Sized so a legitimate ~6 GB paper reliably completes (soft RSS guard at 7936 MiB; effective resident ceiling ~6.5–7 GB, accounting for mimalloc VSZ > RSS).
- **Fleet memory-pressure governor** (`--mem-pressure-floor-mb`, auto = `max(cap, 10% RAM)`) — contains the *aggregate*: under `MemAvailable` pressure it SIGTERMs the largest-RSS worker (task re-leased) and pauses respawns with hysteresis, surviving a heavy cluster instead of a random kernel OOM-kill.

## Robustness
Crash-loop exponential backoff (fast unclean deaths only), SIGCHLD-prompt respawn, `PR_SET_PDEATHSIG` (no orphaned workers if the harness dies), graceful SIGTERM/SIGINT shutdown.

## Notes
- New `docs/CORTEX_WORKER_HARNESS.md` (+ CLAUDE.md index); companion to pericortex `docs/HARNESS.md` and CorTeX `MANUAL.md` §7.
- Depends on pericortex master (`a8c6f73`); `[patch]` block re-commented to reference upstream.
- Verified: `cargo clippy --features cortex` clean, end-to-end harness smoke test (banner, spawn, governor shed path, graceful shutdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)