### PR TITLE
Further stability & coverage (box-model hang, array p/m/b, math comma-list, post-log capture, numeric-safety, Miri)

### DIFF
--- a/.claude/skills/canvas-triage/SKILL.md
+++ b/.claude/skills/canvas-triage/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: canvas-triage
+description: >
+  Triage a failing/suspicious arXiv paper and decide whether its errors are a
+  GENUINE Rust regression or parity with Perl LaTeXML. Use when investigating a
+  conversion error/fatal, a "Rust-only" candidate from cortex, a sandbox/canvas
+  failure, or any "is this a real bug vs. parity?" question. Pairs with
+  tools/parity_check.sh, triage_failure.sh, first_error.sh and the cortex
+  document/<id> API. Invoke for "triage this paper", "is 1234.5678 a regression",
+  "classify this failure vs Perl", "/canvas-triage".
+---
+
+The output of this skill is a **classification**, not a fix. Only one verdict —
+GENUINE-RUST-ONLY, confirmed same-host — justifies code changes. Reach for the
+`perl-port` skill once you get there.
+
+## Golden rules (non-negotiable — violating these has burned us repeatedly)
+
+1. **Never downgrade errors to cheat the task.** A change that makes Rust emit
+   *fewer* `Error:`/`Fatal:` than Perl on the same paper is a **divergence**, not
+   a fix — it needs explicit proof Perl emits the same severity, or user
+   authorization to surpass Perl. We nearly committed unfaithful fixes off false
+   signals (`1308.2655` `\lefteqn`, `0710.5692` equationgroup-in-`<p>`) — both
+   were parity (Perl errored too). Reverted after checking cortex.
+2. **Fail-safe toward flagging failure.** A *failure to parse the log* must NEVER
+   be treated as success. False positives (flagging a clean run) are acceptable;
+   false negatives (missing real errors) are forbidden. When in doubt, count it
+   as a failure to investigate.
+3. **Classify Perl with VERBOSE, never `--quiet`.** `/usr/local/bin/latexml
+   --quiet` prints "0 errors" / exits 0 *even when the conversion has errors* — it
+   suppresses both the `Error:` lines and the final count. This trap has bitten us
+   ≥3 times (babel-russian, collcell, francais). Run `latexml <paper>.tex` plain
+   and read the `Conversion complete: … N errors; … undefined macros[…]` summary.
+4. **ANSI-strip before grepping.** Logs may carry color codes
+   (`\x1b[31mError:`), so a naive `grep '^Error:'` silently matches **zero** on a
+   paper with hundreds. Always: `sed 's/\x1b\[[0-9;]*m//g' | grep -acE
+   '^(Error|Fatal):'`. Better signals when available: cortex
+   `Status:conversion:N` (**3=fatal, 2=error**, lower=ok) or the ANSI-free
+   on-disk `.latexml.log`.
+5. **Same-host Perl only.** A cortex `Perl=clean / Rust=error` delta is often a
+   pure **host TeX-package-availability artifact** — the two services ran on hosts
+   with different texmf trees. Confirmed phantoms: inputenc `isolatin` (needs
+   `umlaute` pkg), `cp1251`/Cyrillic (needs `cyrillic`/`t2`), babel `russian`
+   (older babel ≤3.8). In all three, Rust == Perl *on the same host*. Reproduce
+   **both** engines on the **same** tree before trusting any delta. Host packages
+   are out of scope (CLAUDE.md) — we don't ship `.def`/`.ldf`.
+6. **The cortex DB is a SCREEN, not ground truth — it lags HEAD.** The
+   `sandbox-arxiv-10k-shuffle` Rust column predates recent fixes (e.g. `1805.00875`
+   shows errors in cortex but is **0 on the current binary**). Use the DB only for
+   *candidate discovery*; re-run every flagged paper on the **current** binary
+   before chasing it. Never trust a bespoke cross-join's Perl column — confirm
+   against the live `GET /api/corpus/<corpus>/tex_to_html/document/<id>` API (it
+   carries per-severity `message_counts` for both services).
+
+## Workflow
+
+**1 — Reproduce Rust on the current binary.** For a quick count:
+
+```bash
+cargo run --bin latexml_oxide -- --format=html5 --log=cortex.log --dest=/tmp/out.html paper.tex
+sed 's/\x1b\[[0-9;]*m//g' cortex.log | grep -acE '^(Error|Fatal):'
+```
+
+For a crash/backtrace under the diagnosable test profile:
+`tools/triage_failure.sh <arxiv_id>` (`RUST_BACKTRACE=full`; `KEEP_TMP=1`
+preserves the extracted dir). To see the *first* non-cascade error class with
+source context: `tools/first_error.sh <paper.log>`.
+
+**2 — Reproduce Perl on the SAME host** (verbose, never `--quiet`):
+`/usr/local/bin/latexml paper.tex` → read the `Conversion complete: … N errors`
+line. This is the parity ground truth.
+
+**3 — Or run the automated verdict:** `tools/parity_check.sh <arxiv_id>` emits
+BOTH-CLEAN / OUT-OF-SCOPE / REAL_REGRESSION / PERL_REGRESSION / Perl-capped /
+Perl-timeout (reads `SANDBOX_DIR`, `TIMEOUT_SECS=180`).
+
+**4 — Classify:**
+
+| Verdict | Meaning | Action |
+|---|---|---|
+| BOTH-CLEAN | 0/0 | nothing |
+| PARITY | same severity both engines (same host) | nothing — document if surprising |
+| ENV-ARTIFACT | delta is a host TeX-package/version diff | nothing — note in memory; do NOT "fix" |
+| GENUINE-RUST-ONLY | Perl clean, Rust errors, **same host** | → fix candidate |
+| DEFERRED | content-MathML / `expected:id` / known-large | leave; tracked in SYNC_STATUS |
+
+**5 — Only GENUINE-RUST-ONLY (same-host-confirmed) is a fix candidate.** Read the
+Perl source for the construct and port faithfully via the `perl-port` skill;
+reduce to a fixture via `min-repro`; validate with `cargo test --tests
+--no-fail-fast` + clippy + Perl parity on the witness.
+
+## cortex API (candidate discovery only — open reads, no token)
+
+`http://127.0.0.1:8000/api`; Rust svc `oxidized-tex-to-html`, Perl svc
+`tex_to_html`, corpus `sandbox-arxiv-10k-shuffle`.
+- `GET /api/reports/<corpus>/<svc>/<severity>` → categories
+- `…/<severity>/<category>` → per-`what` → `…/<what>` → papers
+- `GET /api/corpus/<corpus>/tex_to_html/document/<id>` → Perl status + counts
+URL-encode `\`→`%5C`, `^`→`%5E`. A Rust-only win = Perl `no_problem`/`warning`
+but Rust `error`/`fatal` — then re-confirm same-host (rule 5/6).
+
+## Known phantom signals (do not re-mine / re-fix)
+
+inputenc `isolatin` · `cp1251`/Cyrillic · babel `russian`/`ukrainian` · the
+"shared Node" cluster (fixed in HEAD) · `1805.00875` (stale, 0 on current) ·
+`1308.2655` / `0710.5692` (parity, not Rust-only). The full `error`-severity
+sweep against the stale 10k DB is **exhausted** — do not re-mine it per-`what`; a
+genuinely new correctness bug requires a **fresh** cortex Rust rerun on current
+HEAD.

--- a/.claude/skills/min-repro/SKILL.md
+++ b/.claude/skills/min-repro/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: min-repro
+description: >
+  Reduce a confirmed failing arXiv paper to a minimal, self-contained reproducer
+  (and optionally a regression-test fixture). Use after canvas-triage confirms a
+  GENUINE-RUST-ONLY failure, or whenever you need the smallest .tex that still
+  triggers a specific error/crash. Pairs with tools/bisect_repro.sh and
+  first_error.sh. Invoke for "minimize this paper", "make a reproducer for X",
+  "shrink to a failing case", "/min-repro".
+---
+
+Goal: the smallest `.tex` that still emits the **canary** (the exact error
+line/class you are chasing). A reproducer that drops the canary is worthless, and
+one that adds unrelated errors muddies the signal.
+
+## Workflow
+
+**1 — Pin the canary.** Run `tools/first_error.sh <paper.log>` to get the first
+non-cascade error class with source context. That line (or a stable substring of
+it) is your canary pattern — everything below preserves it.
+
+**2 — Coarse bisection.** `tools/bisect_repro.sh <arxiv_id> [canary]` does
+window-bisection from the first-error line. It narrows to the offending region
+without you hand-editing. Respect the documented contract (reads the extracted
+paper; `canary` optional and defaults to the first error).
+
+**3 — Manual reduction** (when the script can't go further):
+- Strip the preamble bottom-up; keep only `\usepackage`/`\def` lines the canary
+  needs. Prefer `\documentclass{article}` unless the class itself is implicated.
+- Replace `\input`/`\include` bodies with the minimal triggering snippet.
+- Re-run after each cut: `cargo run --bin latexml_oxide -- --format=html5
+  --log=r.log --dest=/tmp/r.html repro.tex` then ANSI-strip-grep for the canary
+  (`sed 's/\x1b\[[0-9;]*m//g' r.log | grep -E '<canary>'`). Stop when any further
+  cut loses the canary.
+
+**4 — Confirm parity intent.** Re-run the *reduced* case through Perl
+(`/usr/local/bin/latexml repro.tex`, verbose — never `--quiet`) on the same host.
+A faithful reproducer should still show the Rust-only delta; if Perl now errors
+too, the reduction changed the semantics — back off the last cut.
+
+## Where the reproducer lands
+
+- **`docs/reproducers/`** — a Rust-only bug we intend to fix (e.g.
+  `pcolumn_block_content_in_p.tex`, `dcolumn_empty_todelim_display_math_leak.tex`).
+- **`docs/out-of-scope/`** — confirmed out-of-scope (host pkg, DTD, etc.).
+- **`docs/known_crashes/`** — a crash we are tracking but not yet fixing.
+
+## Promoting to a regression test
+
+When the fix lands, add a `[name].tex` / `[name].xml` pair under the relevant
+crate's test tree (mirroring the Perl `t/` suite). **Run `cargo clean`** —
+a compile-time plugin discovers test files, so a new pair is invisible until a
+clean rebuild. Generate the expected `.xml` from the *fixed* binary, strip the
+intentional-divergence artifacts before committing (no `%&#10;`; `--nocomments`
+to drop `<!-- … -->` source-comment lines — see CLAUDE.md "Intentional
+divergences"), and confirm `cargo test --tests --no-fail-fast` stays green.

--- a/.claude/skills/perf-check/SKILL.md
+++ b/.claude/skills/perf-check/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: perf-check
+description: >
+  Measure latexml-oxide conversion performance correctly, pick the right build
+  profile, and avoid re-litigating settled optimization questions. Use when
+  benchmarking, comparing against Perl, choosing a profile, diagnosing a slow/OOM
+  conversion, or when tempted to optimize startup/codegen. Invoke for "is this
+  slower?", "benchmark X", "which profile", "optimize startup", "profile this
+  paper", "/perf-check".
+---
+
+## Build profiles — use the right one (Cargo.toml)
+
+| Profile | Command | Use |
+|---|---|---|
+| `test` (default) | `cargo build` / `cargo test` / `cargo run` | **All day-to-day dev + triage.** Full debug info, debug-assertions, overflow-checks, fast incremental. Best diagnosability. |
+| `ci` | `cargo test --profile ci` | **GitHub runner only** (16 GB, fast compile). NOT what local dev should mimic. |
+| `release` | `cargo build --release` | **Sandbox sweeps + Perl-parity measurement.** Strong-optimized, thin-LTO. |
+| `maxperf` | `cargo build --profile maxperf` | **Distribution artifact.** Fat-LTO, CGU=1, `panic=abort`. Slowest build; smallest+fastest binary. |
+
+Distribution recipe (what `tools/make_release.sh` uses): `cargo build
+--no-default-features --features runtime-bindings --profile maxperf --bin
+latexml_oxide`.
+
+## Settled questions — DO NOT re-open (measured, closed, tooling deleted)
+
+- **PGO / target-cpu (`x86-64-v3`, `native`): NO measurable gain.** Rigorous
+  measurement (2026-06-21, disjoint train/measure split, best-of-3 interleaved):
+  total speedup 0.999×, identical medians. `maxperf` is *already* at the
+  compiler ceiling (fat-LTO + CGU=1 captures what PGO would unlock on thin-LTO),
+  and the hot path (branchy catcode/macro dispatch) is neither SIMD-amenable nor
+  statically branch-skewed. Ship the portable `x86-64` baseline. Do not
+  re-attempt without a major engine-architecture change.
+  (`pgo-isa-no-gain-2026-06-21` memory; `docs/PERFORMANCE.md`.)
+- **Startup floor (~161 ms): the ~50 ms dump-parse lever was declined.**
+  Decomposed: proc init ~6 ms, bootstrap ~9 ms, **latex dump load ~85 ms**
+  (60% text-parse), `_constructs`+digest+build+serialize ~80 ms. The clean lever
+  (binary dump format / parallel-parse) is ~50 ms ≈ 10% of the 507 ms median —
+  declined as too small to justify the dump-pipeline parity re-validation risk.
+  Compiling dumps to Rust code (vs gzip-blob embed) cost +10 min compile for zero
+  win, abandoned. **Do not optimize the dump load.**
+  (`docs/STARTUP_COST_ANALYSIS_2026-06-21.md`.)
+
+## Measurement discipline (this is where perf claims go wrong)
+
+- **Same-conditions A/B only.** A one-off wall-clock reading on an idle vs busy
+  machine is noise — we once read 0.65 s and retracted a "5× faster" claim once a
+  same-conditions before/after showed ~3.35 s → ~3.1 s (no real change). Always
+  measure base and candidate back-to-back under the same load; prefer best-of-3
+  interleaved on a quiesced box.
+- Tools: `tools/perf_compare.py` (paired A/B of two telemetry corpus runs:
+  Δwall, Δphase_us), `tools/perf_phase_summary.py` (per-phase rollups),
+  `tools/run_perf_corpus.sh` (Tier-A serial regression baseline). Full
+  methodology + Perl-parity baselines: `docs/PERFORMANCE.md`. Witness papers for
+  timeout/OOM/peak-RSS/hang regressions: `docs/STABILITY_WITNESSES.md`.
+
+## Test-suite gotcha: `MemoryBudget` cascade ≠ code bug
+
+A cascade of failures on *basic* documents (article/book/itemize) that **pass at
+`--test-threads=1`** is the **process-wide RSS fuse**
+(`stomach.rs::check_timeout`, `Fatal:Timeout:MemoryBudget RSS … > cap`), not a
+regression. libtest runs one process with one thread per test, so on this
+64-core/128-thread box `-j128` runs ~128 conversions whose *aggregate* RSS trips
+the fuse. The default cap **stays 4.5 GB** (a parallel one-paper-per-process
+fleet would OOM at 9 GB); the test harness raises it to 9 GB via
+`init_test_rss_cap()`. **Diagnosis:** re-run with `-- --test-threads=1`; a
+non-`<Math>` fixture failing is another tell a MathML change is innocent. Always
+use `cargo test --workspace --tests --no-fail-fast` for the true count (default
+fail-fast stops at the first failing *binary*). (`cargo-test-rss-fuse-parallelism`
+memory.)
+
+## Self-contained-binary invariant (a correctness-of-distribution check)
+
+A conversion must not *read* latexml-oxide's *own* resources from disk at
+runtime — dumps, RelaxNG schema, XSLT/CSS/JS are embedded and served from memory.
+New code that adds a runtime read of an owned resource must `include_bytes!`/
+`include_str!` it instead. (Reading the host texmf tree via kpathsea is allowed.)
+Verify by renaming `resources/dumps/` away and converting, or `strace` for the
+XSLT. Rationale: `docs/OXIDIZED_DESIGN.md` → Guiding Principles.

--- a/.claude/skills/perl-port/SKILL.md
+++ b/.claude/skills/perl-port/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: perl-port
+description: >
+  Faithfully translate or fix a LaTeXML binding (macro / primitive / constructor
+  / column type / package) from the Perl source to Rust. Use whenever you write
+  or change engine/package code that mirrors Perl LaTeXML — porting a new .pool
+  entry, binding a package, or aligning a definition to Perl semantics. Enforces
+  "read the Perl source first" and the divergence policy. Invoke for "port \foo",
+  "translate this .pool entry", "bind package X", "make Y match Perl",
+  "/perl-port".
+---
+
+> The Perl code is the **ground truth**. This is a translation project: preserve
+> the original semantics, control flow, edge cases, and naming. Do not invent
+> abstractions, rename concepts, or simplify behavior unless the difference is a
+> documented intentional divergence.
+
+## 1 — Read the Perl source FIRST (always, before writing Rust)
+
+| Kind | Perl source |
+|---|---|
+| Engine definitions (`\cs` in the kernel) | `LaTeXML/lib/LaTeXML/Engine/<file>.pool.ltxml` |
+| Package bindings | `LaTeXML/lib/LaTeXML/Package/<name>.sty.ltxml` (and `.cls.ltxml`) |
+| Core machinery (Mouth/Gullet/Stomach/Document/State) | `LaTeXML/lib/LaTeXML/Core/*.pm` |
+| The `Def*` API itself | `LaTeXML/lib/LaTeXML/Package.pm` |
+| TeX ground truth (when Perl is itself emulating TeX) | `background/tex.web`, `background/texbook.tex` |
+
+Quote the Perl line range in a comment next to the Rust port (the codebase does
+this consistently, e.g. `// Perl L2734-2752`) so the next reader can diff against
+the source.
+
+## 2 — Find the Rust home: `docs/ORGANIZATION.md`
+
+It maps each Perl `.pool.ltxml` → `latexml_engine/src/<file>.rs` (38 of 40 are
+1:1). **Same-file rule:** every `\foo` defined in
+`Engine/<file>.pool.ltxml` must be defined in `latexml_engine/src/<file>.rs`. The
+Perl→Rust crate map (Mouth→mouth, Gullet→gullet, Stomach→stomach, …) is in
+CLAUDE.md "Key Concepts Mapping".
+
+## 3 — Translate faithfully
+
+- Match the **macro kind**: Perl `DefMacro`/`DefPrimitive`/`DefConstructor`/
+  `DefColumnType`/`DefRegister` → the corresponding Rust `Def*!`. (`tools/
+  audit_def_parity.py` cross-checks kinds.)
+- Where Perl uses `RawTeX` / raw `\def`-style bodies, port them as **Token
+  bodies**, not opaque Rust closures — so the kernel dump captures them as
+  serializable records (CLAUDE.md strict-LoadFormat rule #3).
+- Preserve attribute semantics (`locked`, `scope`, `bounded`, `requireMath`,
+  `robust`); `tools/audit_attrs.sh` / `audit_locked.sh` verify parity.
+- Reach for meaningful Rust types where Perl was untyped — but only when it does
+  not change behavior.
+
+## 4 — Check three docs BEFORE finalizing
+
+1. **`docs/WISDOM.md`** — known internal traps. Don't re-introduce a fixed bug
+   (compile-time vs runtime token packing, `Font::merge`/`specialize`, catcode CS
+   vs ESCAPE, `RegisterType` `PartialEq` trap, `at_letter` restore, the libxml
+   shared-Node `try_borrow_mut` guard, …).
+2. **`docs/KNOWN_PERL_ERRORS.md`** — is the behavior you're "fixing" actually an
+   upstream Perl bug? If so, keep parity (don't out-correct it) and record it
+   there with a minimal trigger.
+3. **`docs/OXIDIZED_DESIGN.md`** — is the difference a *sanctioned* divergence
+   (e.g. `%\n` not emitted, comments off by default, `\cdots` ELIDEOP, color
+   visual-equivalence, no `tex=` on `<picture>`)? If not, you must match Perl.
+
+## 5 — Divergence policy
+
+Diverge **only** when documented in `OXIDIZED_DESIGN.md`. In particular, a change
+that makes Rust emit *fewer* errors than Perl on the same input is a divergence,
+not a fix — it needs same-host parity proof or explicit surpass-Perl
+authorization (see the `canvas-triage` golden rules). When you do diverge with
+approval, add the entry to `OXIDIZED_DESIGN.md` in the same change.
+
+## 6 — Validate, then ship
+
+- `cargo test --tests --no-fail-fast` (true count; baseline ~1467/0 — see
+  `perf-check` for the RSS-fuse `MemoryBudget` cascade gotcha). New `.tex`/`.xml`
+  fixture ⇒ `cargo clean` first so the plugin rediscovers it.
+- `cargo +nightly clippy --workspace --all-targets -- -D warnings` and
+  `cargo +nightly fmt --all` — the pre-push hook enforces both (it does NOT run
+  tests, so run them yourself).
+- Confirm Perl parity on the witness paper (verbose, same host).
+- **Before pushing**: build current HEAD green; never `push --no-verify` on a
+  shared branch without it (a co-agent's commit can ride your push → red CI).
+  Push to the working **feature branch**, not a fast-forward to `main`.

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,6 +59,37 @@ jobs:
       - name: cargo-machete (unused dependencies)
         run: cargo machete
 
+  # Miri (UB detector) over the FFI-FREE pure-Rust `unsafe` — the string
+  # interner / arena bounds-skip (resolve_unchecked) + re-entrant `&mut *ptr`
+  # sites (docs/SAFETY.md categories B/C), the only `unsafe` here with genuine
+  # UB potential that Miri can execute. The FFI-bearing unsafe (libc / kpathsea
+  # / libxml2 / libxslt dlsym / getrusage / signal) CANNOT run under Miri, so
+  # coverage is deliberately scoped via tools/miri_check.sh. Build scripts
+  # (libxml/kpathsea/marpa) still compile C natively, hence the dev headers.
+  miri:
+    name: miri (pure-Rust UB check)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+      RUST_BACKTRACE: "1"
+    steps:
+      - name: install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libxml2-dev libxslt1-dev libkpathsea-dev libkpathsea6
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          key: miri
+      - name: miri (scoped arena UB check)
+        run: tools/miri_check.sh
+
   test:
     name: latexml-oxide CI
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,9 @@ arxiv-examples/
 USER_OK.md
 
 # Local Claude Code settings and ad-hoc HTML conversion outputs
-.claude/
+# (ignore local settings, but DO track shared project skills under .claude/skills/)
+.claude/*
+!.claude/skills/
 html/
 
 # Python bytecode (e.g. tools/check_memory.py emits __pycache__/)

--- a/.gitignore
+++ b/.gitignore
@@ -41,10 +41,20 @@ arxiv-examples/
 *.latexml.log
 USER_OK.md
 
-# Local Claude Code settings and ad-hoc HTML conversion outputs
-# (ignore local settings, but DO track shared project skills under .claude/skills/)
+# Local Claude Code settings and ad-hoc HTML conversion outputs.
+# Ignore local settings, but DO track our shared project skills under
+# .claude/skills/ — as an allowlist, so third-party/managed skills installed
+# via `npx skills add` (vendored under .agents/, symlinked in here) stay OUT of
+# the repo; only their skills-lock.json is tracked. Add a line per new project skill.
 .claude/*
 !.claude/skills/
+.claude/skills/*
+!.claude/skills/canvas-triage/
+!.claude/skills/min-repro/
+!.claude/skills/perf-check/
+!.claude/skills/perl-port/
+# Vendored third-party agent skills (reproducible from skills-lock.json via npx skills add)
+.agents/
 html/
 
 # Python bytecode (e.g. tools/check_memory.py emits __pycache__/)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,25 @@ Completed/historical audits live in `docs/archive/` (see `docs/archive/README.md
 - **Diagnostic-snapshot naming.** Docs that capture a point-in-time technical diagnostic — `*_TRIAGE`, `*_HOTSPOTS`, `*_AUDIT`, `*_ANALYSIS`, `*_BISECT`, and similar — **must carry a date in the filename** (`NAME_YYYY-MM-DD.md`), using the date of their last commit. This keeps a study from masquerading as a live worklist. *Living* worklists are exempt even when their name reads like a diagnostic — date only what is a frozen snapshot. (When such a worklist's mission *completes*, date it and move it to `docs/archive/`, lifting any live residual into `SYNC_STATUS.md` — as was done for the LoadFormat audit.)
 - Keep this index current. When a diagnostic snapshot is superseded, archive it under `docs/archive/` rather than leaving it orphaned at the top level.
 
+## Skills (`.claude/skills/`)
+
+Reusable workflows that encode this project's hard-won judgement — invoke with
+`/<name>` or let them surface by description. They wrap the `tools/` scripts with
+the *rules* (what verdict to trust, what trap to avoid):
+
+- **`canvas-triage`** — decide if a failing paper is a genuine Rust bug or parity
+  with Perl. Encodes the non-negotiables: never downgrade errors to cheat,
+  fail-safe toward flagging failure, classify Perl with **verbose not `--quiet`**,
+  ANSI-strip before grepping, same-host Perl only, and "the cortex DB is a screen,
+  not ground truth."
+- **`min-repro`** — reduce a confirmed failure to a minimal reproducer/fixture.
+- **`perl-port`** — faithfully translate/fix a binding: read the Perl source
+  first, use `ORGANIZATION.md` for placement, check `WISDOM.md` /
+  `KNOWN_PERL_ERRORS.md` / `OXIDIZED_DESIGN.md`, and obey the divergence policy.
+- **`perf-check`** — measure correctly, pick the right profile, and don't
+  re-litigate the settled dead-ends (PGO/target-cpu = no gain; startup dump-parse
+  lever = declined).
+
 ## Build & Test
 
 Requires **Rust nightly**.

--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -31,23 +31,35 @@ shell-escape) at all.
 
 ## `unsafe` budget
 
-As of 2026-05-29 the project contains **23 `unsafe` sites across 9 files**
-— five `unsafe impl Send/Sync` markers, seventeen `unsafe {}` blocks, and
-no `unsafe fn`. Every site carries a `// SAFETY:` comment at the call
-site that names the invariant it depends on.
+Reconciled **2026-06-24**: the project contains **48 `unsafe {}` blocks +
+5 `unsafe impl Send/Sync` + 0 `unsafe fn` = 53 sites**. Every `unsafe` block
+carries a `// SAFETY:` comment at the call site naming the invariant it
+depends on (the one caveat is category E's *test-only* `EnvGuard`, which
+documents the env data-race invariant but carries a `FIXME` that the default
+test harness does not yet *enforce* single-threaded env access).
 
-The five categories below describe what is unavoidable, what is a deliberate
-performance trade, and what could be refactored away at some cost.
+Counts and exact line numbers drift as the tree changes — this is a
+point-in-time reconciliation, not a live index. Regenerate the authoritative
+enumeration with:
+
+```
+rg -n 'unsafe\s*\{|unsafe impl|unsafe fn' -g '*.rs' -g '!target'
+```
+
+The categories below describe what is unavoidable, what is a deliberate
+performance trade, and what could be refactored away at some cost. Locations
+are given at the file/function level (not exact line) to stay robust against
+drift. **When this count changes, update this section** (see Audit posture).
 
 ---
 
 ### A. `unsafe impl Send/Sync` — pragmatic single-thread markers (5 sites)
 
-| File:line | Marker | Why |
+| Site | Marker | Why |
 |---|---|---|
-| `latexml_core/src/state.rs:279` | `Send for State` | `State` holds `Rc`/`RefCell`/`libxml::tree::Node`, all `!Send`. We mark it `Send` so the harness can build a State on one thread and *transition* it to another thread before any first use. After that first use, the value is pinned to a single OS thread via `#[thread_local]` switchers (`use_main_state` / `use_std_state` / `use_sty_state`). The crate never reads a `State` from two threads concurrently. |
-| `latexml_core/src/common/store.rs:557-558` | `Send/Sync for Stored` | Same shape as `State`: `Stored` variants embed `Rc<RefCell<…>>` and libxml nodes. The marker exists *only* to satisfy `Box<dyn Error + Send + Sync>` trait bounds on error returns — error variants transitively require `Send + Sync` on every embedded type. No code actually shares a `Stored` across threads. |
-| `latexml_core/src/common/error.rs:471-472` | `Send/Sync for Error` | `Error` carries a `Locator` whose `Mouth` is `!Send`. Identical justification to `Stored`: needed for the std `Error + Send + Sync` bound; not for actual cross-thread sharing. |
+| `latexml_core/src/state.rs` | `Send for State` | `State` holds `Rc`/`RefCell`/`libxml::tree::Node`, all `!Send`. We mark it `Send` so the harness can build a State on one thread and *transition* it to another thread before any first use. After that first use, the value is pinned to a single OS thread via `#[thread_local]` switchers (`use_main_state` / `use_std_state` / `use_sty_state`). The crate never reads a `State` from two threads concurrently. |
+| `latexml_core/src/common/store.rs` | `Send/Sync for Stored` | Same shape as `State`: `Stored` variants embed `Rc<RefCell<…>>` and libxml nodes. The marker exists *only* to satisfy `Box<dyn Error + Send + Sync>` trait bounds on error returns — error variants transitively require `Send + Sync` on every embedded type. No code actually shares a `Stored` across threads. |
+| `latexml_core/src/common/error.rs` | `Send/Sync for Error` | `Error` carries a `Locator` whose `Mouth` is `!Send`. Identical justification to `Stored`: needed for the std `Error + Send + Sync` bound; not for actual cross-thread sharing. |
 
 **Could we refactor?** Only by swapping every `Rc<RefCell<…>>` in `State`,
 `Stored`, and `Error` for `Arc<Mutex<…>>`. That contradicts the
@@ -57,9 +69,9 @@ sound because the runtime guarantees the invariant by construction.
 
 ### B. Arena `resolve_unchecked` — performance carve-out (8 sites)
 
-All in `latexml_core/src/common/arena.rs` (lines 191, 201, 202, 211, 212,
-213, 224, 233), inside `with`, `with2`, `with3`, `with_many`, and
-`to_string`. They use `string-interner`'s unchecked `Symbol → &str` lookup.
+All in `latexml_core/src/common/arena.rs`, inside `with`, `with2`, `with3`,
+`with_many`, and `to_string`. They use `string-interner`'s unchecked
+`Symbol → &str` lookup.
 
 The safety invariant is **append-only buffer**: every `SymStr` in the
 codebase originates from a successful `get_or_intern(_static|_char)` call
@@ -71,20 +83,17 @@ is a valid bounds-skip.
 arena is the hottest read site in the engine — every Token-to-string
 serialisation goes through it.
 
-**Refactor option**: replace each
-`arena.resolve_unchecked(sym)`
-with
-`arena.resolve(sym).expect("interned")`.
-This is mechanical and eliminates eight `unsafe` blocks. The cost is a
-re-validating `from_utf8` per lookup, ~3% of total runtime.
+**Refactor option**: replace each `arena.resolve_unchecked(sym)` with
+`arena.resolve(sym).expect("interned")`. This is mechanical and eliminates
+eight `unsafe` blocks. The cost is a re-validating `from_utf8` per lookup,
+~3% of total runtime.
 
 ### C. Arena re-entrant `&mut *ptr` (1 site)
 
-`latexml_core/src/common/arena.rs:78` — inside `with_arena_mut`. The
-outermost caller acquires `RefCell::borrow_mut()` and caches a raw pointer
-to the interner; nested re-entrant callers on the same thread reuse the
-pointer and skip the `RefCell` guard, which would otherwise panic ("already
-borrowed").
+`latexml_core/src/common/arena.rs` — inside `with_arena_mut`. The outermost
+caller acquires `RefCell::borrow_mut()` and caches a raw pointer to the
+interner; nested re-entrant callers on the same thread reuse the pointer and
+skip the `RefCell` guard, which would otherwise panic ("already borrowed").
 
 The safety invariant is documented in the function header: re-entrance is
 nested on the same stack and same thread (`#[thread_local]`), an
@@ -93,43 +102,69 @@ nested on the same stack and same thread (`#[thread_local]`), an
 **Cannot be refactored without changing semantics** — there is no safe
 mechanism for nested re-entrant mutable access through `RefCell`.
 
-### D. Binary entry-point FFI (5 sites)
+### D. Binary entry-point FFI — env + rusage + crash-handler (~7 sites)
 
-| File:line | Call | Why unsafe is unavoidable |
-|---|---|---|
-| `latexml_oxide.rs:423` | `std::env::set_var("LATEXML_INI_MODE", "1")` | Rust 2024 marked `set_var` `unsafe` by design — pre-thread-spawn env mutation isn't race-free in general. We call it before spawning anything. |
-| `latexml_oxide.rs:708`, `cortex_worker.rs:329` | `libc::getrusage(RUSAGE_CHILDREN, …)` | C FFI to capture child user/sys CPU time. No stable safe wrapper in stdlib. |
-| `latexml_oxide/src/util/test.rs:130, 137` | `libc::signal(SIGSEGV/SIGBUS/SIGABRT, handler)` and `raise(sig)` | Installing a SIGSEGV/SIGBUS/SIGABRT trap to dump a backtrace to a per-pid file before the signal kills the test binary. `signal(3)` is `unsafe extern "C"` and the handler-reset path uses `mem::transmute` of `SIG_DFL`. |
+In `latexml_oxide/bin/latexml_oxide.rs`, `latexml_oxide/bin/cortex_worker.rs`,
+and `latexml_oxide/src/util/test.rs`:
+
+| Call | Why unsafe is unavoidable |
+|---|---|
+| `std::env::set_var("LATEXML_INI_MODE", …)` (latexml_oxide.rs) | Rust 2024 marked `set_var` `unsafe` by design — pre-thread-spawn env mutation isn't race-free in general. We call it before spawning anything. |
+| `libc::getrusage(RUSAGE_CHILDREN, …)` (latexml_oxide.rs, cortex_worker.rs) | C FFI to capture child user/sys CPU time. No stable safe wrapper in stdlib. |
+| `libc::signal(SIGSEGV/SIGBUS/SIGABRT, handler)`, `mem::transmute(SIG_DFL)`, `raise(sig)` (util/test.rs) | A **test-only** SIGSEGV/SIGBUS/SIGABRT trap that dumps a backtrace to a per-pid file before the signal kills the test binary. `signal(3)` is `unsafe extern "C"`; the handler-reset path transmutes `SIG_DFL` to `sighandler_t`. |
 
 None can be refactored without losing the functionality (env mutation,
 rusage capture, signal-handler debugging).
 
-### E. Process-group lifecycle in graphics (3 sites)
+### E. Subprocess process-group lifecycle + test EnvGuard in graphics (~8 sites)
 
-`latexml_post/src/graphics.rs:890, 911, 915` — needed because subprocess
-rasterizers (`gs`, `pdftocairo`, `mutool draw`, `inkscape`, `convert`) can
-spawn child grandchildren, and a plain `Child::kill()` does not reap those.
+`latexml_post/src/graphics.rs` + `latexml_post/src/graphics_cache.rs` —
+process-group control is needed because subprocess rasterizers (`gs`,
+`pdftocairo`, `mutool draw`, `inkscape`, `convert`) can spawn grandchildren,
+and a plain `Child::kill()` does not reap those.
 
-| Site | Call | Why |
-|---|---|---|
-| `:890` | `cmd.pre_exec(|| libc::setsid(); libc::setpgid(0,0))` | `pre_exec` is `unsafe fn` per std API — the closure runs between `fork()` and `exec()` and must be async-signal-safe. `setsid(2)` is the documented way to make the child a process-group leader. |
-| `:911` | `libc::killpg(pid, SIGTERM)` | Graceful kill of the whole group on timeout. |
-| `:915` | `libc::killpg(pid, SIGKILL)` | Hard kill if SIGTERM grace expires. |
+| Call | Why |
+|---|---|
+| `cmd.pre_exec(|| setsid(); setpgid(0,0); prctl(…))` | Runs post-`fork()`/pre-`exec()`; must be async-signal-safe. `setsid(2)` makes the child a process-group leader so the whole group is killable. |
+| `libc::killpg(pid, SIGTERM)` / `killpg(pid, SIGKILL)` | Graceful then hard kill of the whole group on timeout (mirrors `timeout(1) --kill-after`). |
+| `libc::flock(fd, …)` (graphics_cache.rs) | Advisory lock on an owned, open lock-file fd; operates on the fd without aliasing Rust memory. |
+| `std::env::set_var`/`remove_var` in `EnvGuard` (graphics.rs) + a test `set_var` (graphics_cache.rs) | **Test-only.** `set_var`/`remove_var` are `unsafe` in Rust 2024 (concurrent env mutation races). `EnvGuard` is used only in test setup, but the default `cargo test` harness runs a binary's tests multi-threaded and other tests read the env — so the comment documents the invariant and keeps a `FIXME` proposing `serial_test` to make it airtight. The `graphics_cache.rs` test `set_var` is `OnceLock`-serialized. |
 
-These mirror what `timeout(1) --kill-after` does for the bench script's
-outer guard. They cannot be expressed via safe stdlib APIs:
 `Command::process_group` was stabilised but does not give us
-`setsid + killpg`.
+`setsid + killpg`, so the FFI path stays.
 
-### F. libxslt global recursion cap (1 site)
+### F. libxslt/libxml global config via FFI (2 sites)
 
-`latexml_post/src/xslt.rs` (`set_xslt_max_depth`) — `xsltMaxDepth = 1000`, a
-`Once`-guarded write to libxslt's process-global `static mut` recursion cap.
-Faithful port of Perl `XML::LibXSLT->max_depth(1000)`. The `libxslt-0.1.3`
-crate exposes no safe setter; libxslt only READS the value (when building each
-transform context), so the single guarded write cannot race a transform. This
-hardens the post-processor against stack-overflow/OOM on pathologically-deep
-stylesheet recursion (it aborts gracefully, like Perl).
+`latexml_post/src/xslt.rs` — a `Once`-guarded `dlsym` write to libxslt's
+process-global `xsltMaxDepth` recursion cap (`= 1000`, a faithful port of Perl
+`XML::LibXSLT->max_depth(1000)`), plus a `dlsym` read-back in a parity test.
+The `libxslt` crate exposes no safe setter; libxslt only READS the value (when
+building each transform context), so the single guarded write cannot race a
+transform. Hardens the post-processor against stack-overflow/OOM on
+pathologically-deep stylesheet recursion (it aborts gracefully, like Perl).
+
+### G. LSP server POSIX child-process management (16 sites)
+
+`latexml_oxide/src/lsp_server/unix.rs` — the **off-by-default** `--server`
+editor mode (design archived at `docs/archive/LSP_SERVER.md`) forks a worker
+child per request and drives it over a pipe with raw POSIX calls: `pipe(2)`,
+`fork(2)`, `open("/dev/null")`/`dup2`, `poll(2)`, `waitpid(2)`, `kill`/`killpg`,
+`read`/`write`, and `File::from_raw_fd` on the pipe ends. Each block is
+annotated. The invariant for the fork/child window is **single-threaded at
+fork** (asserted before `fork()`) and **async-signal-safe-only** libc calls
+between `fork()` and `exec()`/`_exit()` — no Rust heap allocation or drop glue
+in that window. Pipe-end fds are owned and closed exactly once.
+
+### H. Script-bindings whatsit-pointer bridge (5 sites)
+
+`latexml_contrib/src/script_bindings/{engine.rs,mod.rs}` — the
+**off-by-default** `script-bindings` (Rhai) front-end re-mints `&`/`&mut`
+references to the in-flight whatsit / document / properties from raw pointers
+the core publishes onto a thread-local active-context stack (`WHATSIT_CTX`)
+for the duration of a single hook body. The pointer is the sole live reference
+for the call; a `mutable` flag (checked first) gates the `&mut` sites; calling
+outside a hook context returns an error, not UB. Provenance + lifetime are
+documented in the `mod.rs::with_doc` *B1 SOUNDNESS CAVEAT*.
 
 ---
 
@@ -139,7 +174,9 @@ When adding `unsafe`:
 
 1. **Document the invariant in a `// SAFETY:` comment at the site**, not
    in a separate file. Future readers should see the justification in
-   context.
+   context. Every `unsafe {}` block must carry one (the sole documented
+   exception is the test-only `EnvGuard`, cat. E, whose comment states the
+   invariant but flags a `FIXME` that the harness doesn't yet enforce it).
 2. **Prefer category B** (perf carve-out with explicit measurement) over
    category D/E (FFI) when both would work, because B is reversible
    without losing functionality.
@@ -147,9 +184,15 @@ When adding `unsafe`:
    can take an `unsafe {}` at the call site without polluting the
    function signature.
 4. **Never add `unsafe impl Send/Sync` for a value the runtime actually
-   shares.** The three existing markers are sound because the
+   shares.** The five existing markers are sound because the
    single-thread invariant is upheld by construction; new markers must
    prove the same.
+5. **Reconcile this inventory and run Miri.** When the `unsafe` count
+   changes, refresh the budget section (the `rg` one-liner above). If you
+   touch the FFI-free pure-Rust `unsafe` (the arena/interner, cat. B/C),
+   run `tools/miri_check.sh` — it UB-checks those sites under Miri (CI runs
+   it as the `miri` job). The FFI sites (cat. D–H) can't run under Miri;
+   their safety rests on the documented invariants, not interpretation.
 
 ---
 

--- a/docs/STABILITY_WITNESSES.md
+++ b/docs/STABILITY_WITNESSES.md
@@ -406,15 +406,24 @@ because the shape gate FALSE-NEGATIVES on real `\narrow` paragraph content (it's
 not all plain TBoxes), so the repack it needs is skipped. **CONCLUSION: a
 content-shape gate is fundamentally unable to distinguish "genuine paragraph
 needing `\hsize` wrap" from "tabular that leaked MODE=horizontal" — the real
-distinction is the leaked mode, not the shape.** So sub-fix 2's clean form is to
-fix the ROOT: the halign/tabular box carries `mode=horizontal` (leaked) where Perl
-has it vertical, so Rust's `repack_horizontal` (which collects per-item by mode,
-stomach.rs:849) wrongly collects it. Perl's `repackHorizontal` skips it naturally
-(non-horizontal item). Fixing the tabular/halign result mode to vertical makes the
-faithful loop work with NO gate — then Cluster G AND the table sizing both pass.
-**Net: the box-model fix needs (a) the frame-ordering loop [proven], (b) the
-VBoxContents reversion-braces fix, (c) the halign/tabular `mode` root fix** — a
-three-part focused multi-subsystem session, NOT an autonomous inline change.
+distinction is the leaked mode, not the shape.**
+
+**CORRECTION 2026-06-22 (3rd look): the "halign mode-leak" hypothesis is WRONG —
+the over-wrap mechanism is OPAQUE to static analysis.** Read the `\halign`
+constructor (tex_tables.rs:311-342): its `after_digest` sets the whatsit
+`mode="internal_vertical"` (correct, NOT horizontal) and its
+`begin_mode("restricted_horizontal")`/`end_mode` are BALANCED (313/340) — no frame
+or mode leak. So `repack_horizontal`'s per-item check SHOULD skip the tabular
+(mode=internal_vertical), and the faithful loop's `end_mode` should see
+MODE=internal_vertical (no repack) → the `\vbox{\halign}` should measure natural
+width. Yet with the faithful loop it measures full `\hsize` (sizes_test
+37→469.75pt). **The mechanism cannot be determined by code-reading** — it needs
+runtime instrumentation (log mode/wrapwidth/lines in `compute_boxes_size` +
+`repack_horizontal` for the `\vbox{\halign}` case) in a focused session. **Net:
+the box-model fix is (a) the frame-ordering loop [PROVEN fixes Cluster G], (b) the
+VBoxContents reversion-braces fix, (c) the `\vbox{\halign}` over-wrap — root
+UNKNOWN, needs runtime debugging.** A focused, hands-on multi-subsystem session,
+NOT an autonomous static change.
 
 **SHARED ROOT with the global p{}→VBox port (found 2026-06-22).** The same
 `\hsize`-invariant box model blocks SYNC_STATUS **1610.00974 step-3**: porting the

--- a/docs/STABILITY_WITNESSES.md
+++ b/docs/STABILITY_WITNESSES.md
@@ -357,6 +357,17 @@ slice validation, NOT an inline fix. NOTE: a `\loop`-iteration guard would make
 Rust *Fatal* where Perl *succeeds* (worse) — the only faithful fix is to make the
 loop terminate.
 
+**SHARED ROOT with the global p{}→VBox port (found 2026-06-22).** The same
+`\hsize`-invariant box model blocks SYNC_STATUS **1610.00974 step-3**: porting the
+global `p{}` column to Perl's faithful `\lx@tabular@p`/VBoxContents form is
+Perl-exact for non-rotated tables (3 fixtures become clean parity fixes, fixes the
+genuine `<ltx:itemize> isn't allowed in <ltx:p>` correctness bug — 1510.07685) but
+**rotated `p{}` cells mis-size** (graphrot `rotfloat2`: Rust 810pt vs Perl 214pt)
+because the `p{1in}` cell **height** under `\hsize` is wrong — the very same gap.
+One box-model fix (`\hsize`-constrained line-breaking feeding `compute_boxes_size`)
+unblocks BOTH. Empirically verified + reverted; see SYNC_STATUS 1610.00974 step-3
+and `docs/reproducers/pcolumn_block_content_in_p.tex`.
+
 ## Method notes
 
 - Sweep failure logs: `~/data/large_scale_canvas_3/canvas/stage_*/failures/<id>.<KIND>.log`.

--- a/docs/STABILITY_WITNESSES.md
+++ b/docs/STABILITY_WITNESSES.md
@@ -315,126 +315,41 @@ slice, then pick the limit, add the guard, and validate against the full suite
 straightforward; only the calibration is open work. Distinct from Cluster A's
 *memory* (RSS-cap) blowups: this is *stack* (recursion-depth) exhaustion.
 
-## Cluster G — vbox `\ht` is `\hsize`-invariant → `\hsize`-shrink loops never terminate (GENUINE Rust-only; OPEN)
+## Cluster G — vbox `\ht` was `\hsize`-invariant (GENUINE Rust-only) — ✅ FIXED 2026-06-22
 
-**Witness:** `1707.02464` (`sandbox-arxiv-10k-shuffle`, fatal/Timeout/Convert).
-Mined 2026-06-22 from the fatal cross-join: **Perl `latexml` 0.8.8 COMPLETES in
-11.76s** (10 errors, exit 0) but **Rust hangs → `Fatal:Timeout:Convert`** (60s
-watchdog; release, current HEAD; RSS only 168 MB so it's CPU/loop, not memory).
-Not env, not parity — a real Rust-only divergence.
+**Witness `1707.02464`** (fatal/Timeout/Convert): a custom `\narrow` macro line-fits
+a paragraph by shrinking `\hsize` 1pt at a time, looping `\ifdim\ht\tmpbox=\tmpdim
+\repeat` — expecting `\ht` to grow as the paragraph wraps to more lines. Rust's vbox
+`\ht` did NOT depend on `\hsize`, so the loop never terminated → `Fatal:Timeout` at
+the 60s watchdog (Perl 0.8.8 completes in 11.76s, 10 errors). Not env, not parity.
 
-**Root cause (airtight).** The paper's custom `\narrow[#1]#2\par` macro
-(used via `\disp`) line-fits a paragraph by shrinking `\hsize` 1pt at a time and
-**looping while the vbox height is unchanged**, expecting the paragraph to
-eventually wrap to one more line (taller box):
-```
-\loop \setbox\tmpbox\vbox{\hsize=\wd\tmpbox \advance\hsize by -1pt #2}%
-      \ifdim\ht\tmpbox=\tmpdim \relax \repeat
-```
-Rust's `\vbox{\hsize=W …para…}` height does **not** depend on `W`. Direct probe:
-a vbox at `\hsize=400pt` vs `\hsize=20pt` of the same 20-word paragraph compares
-**equal** (`\ifdim\ht=\ht` true → `BUG:VBOX-HEIGHT-HSIZE-INVARIANT`). So the loop
-condition never flips → it runs until the wall-clock guard. Threshold is ~18
-words (below that the natural width is ≤ `\hsize`, `\ifdim\wd>` is false, the
-loop is skipped). Minimal repro: preamble + `\disp{<≥18 words>}`.
+**Root cause:** a FRAME-ORDERING bug in `predigest_box_contents_in_mode`. Rust used
+TWO frames (the mode frame + a body-group frame from `invoke_token(T_BEGIN)`); the
+body's `}` popped the body-group frame — restoring the OUTER `\hsize` — BEFORE the
+repack captured it, so every implicit vbox paragraph wrapped at the outer width. Perl
+uses ONE frame: `endMode` repacks (inner `\hsize` still in scope) THEN pops. (The
+`\hsize`-aware line-break machinery `compute_boxes_size_lines` was already correct.)
 
-**Why this is Rust-only (vs the SHARED Cluster D).** Cluster D loops on `\wd` of
-a `\hbox{\font<glyph>}` which is 0 in BOTH engines (neither reads TFM glyph
-widths) → both hang → Rust's graceful abort is *better*. Here the loop depends on
-**paragraph height as a function of `\hsize`**, which **Perl LaTeXML models** (its
-`\narrow` loop terminates → 11.76s) but **Rust does not** (no `\hsize`-aware
-line-count/height estimate). Confirmed: removing the `$$`/math is still slow
-(B), and a *fixed* 200-iteration vbox-remeasure loop is fast (C) — so it's the
-non-terminating loop, not per-iteration math/box cost.
+**Fix (`7545e07fd6`), three parts:** (a) for `mode.ends_with("vertical")`, a faithful
+port of Perl `readBoxContents` (TeX_Box.pool.ltxml L139-160) — one mode frame, a loop
+that STOPS at the matching `}` unprocessed (`level >= get_frame_depth()`), then
+`end_mode` repacks-then-pops (captures the inner `\hsize`); hbox/math keep the old
+`invoke_token(T_BEGIN)` path. (b) a brace-wrapping `reversion` on `VBoxContents` (the
+rebuilt `List::new(boxes)` lost the group `{}` → `\vbox{a}` reverted to `\vbox a`).
+(c) `\@@tabular` marks its result box `mode=internal_vertical` (like `\halign`,
+tex_tables.rs:312) so a containing `\vbox`/`\vtop`'s repack SKIPS it per-item instead
+of wrapping it to `\hsize` (was sizes_test 37→469.75pt) — no content-shape gate
+needed. 1707.02464 now completes ~4.8s with 10 errors = local Perl (byte-identical).
+Full suite 1467/0; clippy clean. graphrot.xml re-baselined (rotated `\rotatebox` dims
+shift, mostly toward Perl, e.g. angle=0 height 32.5→30.0 vs Perl 27.4; pre-existing
+font-metric / p{}-port divergences remain).
 
-**ROOT CAUSE — PRECISE (2026-06-22).** The `\hsize`-aware paragraph-wrap machinery
-**already exists and is correct**: `Font::compute_boxes_size_lines(wrapwidth, …)`
-(`common/font.rs:1629`) breaks a line when `wd > wrapwidth` → more lines → taller
-box, and `compute_boxes_size` derives `wrapwidth` from the paragraph List's
-`width` property (set by `repack_horizontal`/`make_horizontal_list` =
-`LookupDimension('\hsize')`). The bug is a **frame-ordering divergence** in
-`base_utilities.rs::predigest_box_contents_in_mode`:
-- Rust uses **TWO** frames — the mode frame (`begin_mode`) **plus** a body-group
-  frame pushed by `invoke_token(&T_BEGIN!())`. The inner `\hsize=W` is assigned in
-  the body-group frame, and the body's closing `}` (T_END) pops that frame
-  (**restoring `\hsize` to the outer value**) BEFORE the manual
-  `repack_horizontal_in_list(&mut item)` runs → `make_horizontal_list` captures the
-  OUTER `\hsize` → every implicit vbox paragraph wraps at the outer width
-  regardless of the inner `\hsize`.
-- Perl uses **ONE** frame (the mode frame IS the group): `endMode`
-  (`Stomach.pm:544-557`) runs `leaveHorizontal_internal`→`repackHorizontal`
-  (capturing the inner `\hsize`, L487) and ONLY THEN `popStackFrame`. Rust's
-  `end_mode` (`stomach.rs:726`) already mirrors this order — but it never sees the
-  inner `\hsize` because the body-group frame already restored it.
+**Also UNBLOCKS the global p{}→VBox port** (SYNC_STATUS 1610.00974 step-3): the same
+`\hsize`-aware wrapping now applies to p{} cells (`\vtop`/VBoxContents). Applying that
+port — now viable — is what fixes the p{} block-content correctness bug 1510.07685
+(`<ltx:itemize> isn't allowed in <ltx:p>`). The earlier failed attempts (naive loop
+regressions, the content-shape gate that re-broke Cluster G) are in git history.
 
-**Fix spec (OPEN — focused, core-path).** Collapse the double-framing so the box
-body's closing `}` drives `end_mode` (`leave_horizontal_internal`→repack, then pop)
-rather than an early body-group egroup — i.e. let the mode frame BE the body group,
-as Perl's `readBoxContents` (TeX_Box.pool.ltxml L139-160) does: a custom digest
-loop that STOPS at the matching `}` (`level >= get_frame_depth()`) WITHOUT
-processing it, then `end_mode` repacks (inner `\hsize` still in scope) + pops.
-
-**PROTOTYPED + VALIDATED + REVERTED 2026-06-22.** Implemented the faithful loop in
-`base_utilities.rs::predigest_box_contents_in_mode` for `mode.ends_with("vertical")`
-only (hbox/math keep the `invoke_token(T_BEGIN)` path). **CONFIRMED it fixes Cluster
-G**: 1707.02464 hang → **completes in 4.8s with PERFECT Perl parity** (10 errors,
-byte-identical to local Perl's 10: 1 babel-russian env + 9 `Attempt to close a
-group…`; the `\narrow` loop now terminates because `\ht` grows as `\hsize`
-shrinks). BUT the naive loop **over-triggers** for general vboxes → 4 suite
-regressions (1463/4), so REVERTED. The clean impl must additionally:
-1. **Preserve VBoxContents reversion braces.** Rebuilding the body as
-   `List::new(boxes)` loses the group `{}`, so `tex=` reverts `\vbox{a}` → `\vbox a`
-   (box_test; Perl keeps `{a}`). The List must revert as a brace group.
-2. **Not paragraph-wrap measured / non-paragraph boxes.** A short `\vbox` now
-   measures at full `\hsize` (sizes_test 37.06pt → 469.75pt) because
-   `compute_boxes_size_lines` returns `wrapwidth` for a fitting final line
-   (`final_wd = ww if wd>0`, font.rs:1667) once the content is a width-tagged
-   paragraph List. Perl measures natural width here — so either the box must not be
-   repacked into a paragraph in this context, or the single-fitting-line width must
-   be natural (not `ww`). Also affects graphrot_test, xytest_test (graphics sizing).
-The core mechanism is PROVEN; these two interactions are the remaining work for a
-focused session. NOTE: a `\loop`-iteration guard would make Rust *Fatal* where Perl
-*succeeds* (worse) — the frame-ordering correction is the only faithful fix.
-
-**SECOND ATTEMPT 2026-06-22 (content-shape gate) — FAILED; root is the halign
-mode-leak.** Tried gating the `end_mode` repack on
-`boxes_are_simple_horizontal(box_list)` (reset MODE→bound to skip repack for
-non-paragraph content, mirroring the OLD `has_only_simple_horizontal_content`
-guard). It FIXED sub-fix-2's 3 regressions (sizes_test/graphrot_test/xytest_test
-all pass) but **re-broke Cluster G** — 1707.02464 hangs again (`Fatal:Timeout`),
-because the shape gate FALSE-NEGATIVES on real `\narrow` paragraph content (it's
-not all plain TBoxes), so the repack it needs is skipped. **CONCLUSION: a
-content-shape gate is fundamentally unable to distinguish "genuine paragraph
-needing `\hsize` wrap" from "tabular that leaked MODE=horizontal" — the real
-distinction is the leaked mode, not the shape.**
-
-**CORRECTION 2026-06-22 (3rd look): the "halign mode-leak" hypothesis is WRONG —
-the over-wrap mechanism is OPAQUE to static analysis.** Read the `\halign`
-constructor (tex_tables.rs:311-342): its `after_digest` sets the whatsit
-`mode="internal_vertical"` (correct, NOT horizontal) and its
-`begin_mode("restricted_horizontal")`/`end_mode` are BALANCED (313/340) — no frame
-or mode leak. So `repack_horizontal`'s per-item check SHOULD skip the tabular
-(mode=internal_vertical), and the faithful loop's `end_mode` should see
-MODE=internal_vertical (no repack) → the `\vbox{\halign}` should measure natural
-width. Yet with the faithful loop it measures full `\hsize` (sizes_test
-37→469.75pt). **The mechanism cannot be determined by code-reading** — it needs
-runtime instrumentation (log mode/wrapwidth/lines in `compute_boxes_size` +
-`repack_horizontal` for the `\vbox{\halign}` case) in a focused session. **Net:
-the box-model fix is (a) the frame-ordering loop [PROVEN fixes Cluster G], (b) the
-VBoxContents reversion-braces fix, (c) the `\vbox{\halign}` over-wrap — root
-UNKNOWN, needs runtime debugging.** A focused, hands-on multi-subsystem session,
-NOT an autonomous static change.
-
-**SHARED ROOT with the global p{}→VBox port (found 2026-06-22).** The same
-`\hsize`-invariant box model blocks SYNC_STATUS **1610.00974 step-3**: porting the
-global `p{}` column to Perl's faithful `\lx@tabular@p`/VBoxContents form is
-Perl-exact for non-rotated tables (3 fixtures become clean parity fixes, fixes the
-genuine `<ltx:itemize> isn't allowed in <ltx:p>` correctness bug — 1510.07685) but
-**rotated `p{}` cells mis-size** (graphrot `rotfloat2`: Rust 810pt vs Perl 214pt)
-because the `p{1in}` cell **height** under `\hsize` is wrong — the very same gap.
-One box-model fix (`\hsize`-constrained line-breaking feeding `compute_boxes_size`)
-unblocks BOTH. Empirically verified + reverted; see SYNC_STATUS 1610.00974 step-3
-and `docs/reproducers/pcolumn_block_content_in_p.tex`.
 
 ## Method notes
 

--- a/docs/STABILITY_WITNESSES.md
+++ b/docs/STABILITY_WITNESSES.md
@@ -396,6 +396,26 @@ The core mechanism is PROVEN; these two interactions are the remaining work for 
 focused session. NOTE: a `\loop`-iteration guard would make Rust *Fatal* where Perl
 *succeeds* (worse) — the frame-ordering correction is the only faithful fix.
 
+**SECOND ATTEMPT 2026-06-22 (content-shape gate) — FAILED; root is the halign
+mode-leak.** Tried gating the `end_mode` repack on
+`boxes_are_simple_horizontal(box_list)` (reset MODE→bound to skip repack for
+non-paragraph content, mirroring the OLD `has_only_simple_horizontal_content`
+guard). It FIXED sub-fix-2's 3 regressions (sizes_test/graphrot_test/xytest_test
+all pass) but **re-broke Cluster G** — 1707.02464 hangs again (`Fatal:Timeout`),
+because the shape gate FALSE-NEGATIVES on real `\narrow` paragraph content (it's
+not all plain TBoxes), so the repack it needs is skipped. **CONCLUSION: a
+content-shape gate is fundamentally unable to distinguish "genuine paragraph
+needing `\hsize` wrap" from "tabular that leaked MODE=horizontal" — the real
+distinction is the leaked mode, not the shape.** So sub-fix 2's clean form is to
+fix the ROOT: the halign/tabular box carries `mode=horizontal` (leaked) where Perl
+has it vertical, so Rust's `repack_horizontal` (which collects per-item by mode,
+stomach.rs:849) wrongly collects it. Perl's `repackHorizontal` skips it naturally
+(non-horizontal item). Fixing the tabular/halign result mode to vertical makes the
+faithful loop work with NO gate — then Cluster G AND the table sizing both pass.
+**Net: the box-model fix needs (a) the frame-ordering loop [proven], (b) the
+VBoxContents reversion-braces fix, (c) the halign/tabular `mode` root fix** — a
+three-part focused multi-subsystem session, NOT an autonomous inline change.
+
 **SHARED ROOT with the global p{}→VBox port (found 2026-06-22).** The same
 `\hsize`-invariant box model blocks SYNC_STATUS **1610.00974 step-3**: porting the
 global `p{}` column to Perl's faithful `\lx@tabular@p`/VBoxContents form is

--- a/docs/STABILITY_WITNESSES.md
+++ b/docs/STABILITY_WITNESSES.md
@@ -315,6 +315,48 @@ slice, then pick the limit, add the guard, and validate against the full suite
 straightforward; only the calibration is open work. Distinct from Cluster A's
 *memory* (RSS-cap) blowups: this is *stack* (recursion-depth) exhaustion.
 
+## Cluster G — vbox `\ht` is `\hsize`-invariant → `\hsize`-shrink loops never terminate (GENUINE Rust-only; OPEN)
+
+**Witness:** `1707.02464` (`sandbox-arxiv-10k-shuffle`, fatal/Timeout/Convert).
+Mined 2026-06-22 from the fatal cross-join: **Perl `latexml` 0.8.8 COMPLETES in
+11.76s** (10 errors, exit 0) but **Rust hangs → `Fatal:Timeout:Convert`** (60s
+watchdog; release, current HEAD; RSS only 168 MB so it's CPU/loop, not memory).
+Not env, not parity — a real Rust-only divergence.
+
+**Root cause (airtight).** The paper's custom `\narrow[#1]#2\par` macro
+(used via `\disp`) line-fits a paragraph by shrinking `\hsize` 1pt at a time and
+**looping while the vbox height is unchanged**, expecting the paragraph to
+eventually wrap to one more line (taller box):
+```
+\loop \setbox\tmpbox\vbox{\hsize=\wd\tmpbox \advance\hsize by -1pt #2}%
+      \ifdim\ht\tmpbox=\tmpdim \relax \repeat
+```
+Rust's `\vbox{\hsize=W …para…}` height does **not** depend on `W`. Direct probe:
+a vbox at `\hsize=400pt` vs `\hsize=20pt` of the same 20-word paragraph compares
+**equal** (`\ifdim\ht=\ht` true → `BUG:VBOX-HEIGHT-HSIZE-INVARIANT`). So the loop
+condition never flips → it runs until the wall-clock guard. Threshold is ~18
+words (below that the natural width is ≤ `\hsize`, `\ifdim\wd>` is false, the
+loop is skipped). Minimal repro: preamble + `\disp{<≥18 words>}`.
+
+**Why this is Rust-only (vs the SHARED Cluster D).** Cluster D loops on `\wd` of
+a `\hbox{\font<glyph>}` which is 0 in BOTH engines (neither reads TFM glyph
+widths) → both hang → Rust's graceful abort is *better*. Here the loop depends on
+**paragraph height as a function of `\hsize`**, which **Perl LaTeXML models** (its
+`\narrow` loop terminates → 11.76s) but **Rust does not** (no `\hsize`-aware
+line-count/height estimate). Confirmed: removing the `$$`/math is still slow
+(B), and a *fixed* 200-iteration vbox-remeasure loop is fast (C) — so it's the
+non-terminating loop, not per-iteration math/box cost.
+
+**Fix direction (OPEN — focused box-model session; regression-risky).** Model a
+vbox paragraph's height as ∝ `ceil(content_width / \hsize) × \baselineskip` so
+`\ht` grows when `\hsize` shrinks below the content width, matching Perl. The
+grep for an `\hsize`-aware height estimate finds none, so this is a genuine
+box-dimension subsystem gap. High regression risk (every `\ht`/`\vbox` consumer +
+the 1467-test suite must stay green), so it warrants its own session + an arXiv
+slice validation, NOT an inline fix. NOTE: a `\loop`-iteration guard would make
+Rust *Fatal* where Perl *succeeds* (worse) — the only faithful fix is to make the
+loop terminate.
+
 ## Method notes
 
 - Sweep failure logs: `~/data/large_scale_canvas_3/canvas/stage_*/failures/<id>.<KIND>.log`.

--- a/docs/STABILITY_WITNESSES.md
+++ b/docs/STABILITY_WITNESSES.md
@@ -367,17 +367,34 @@ box, and `compute_boxes_size` derives `wrapwidth` from the paragraph List's
   `end_mode` (`stomach.rs:726`) already mirrors this order — but it never sees the
   inner `\hsize` because the body-group frame already restored it.
 
-**Fix spec (OPEN — focused, core-path, regression-risky).** Collapse the
-double-framing so the box body's closing `}` drives `end_mode`
-(`leave_horizontal_internal`→repack, then pop) rather than an early body-group
-egroup — i.e. let the mode frame BE the body group, as Perl's `readBoxContents`
-does. Then repack captures the inner `\hsize`, fixing BOTH this `\ht`-invariant
-hang AND the rotated-`p{}`-cell mis-sizing that blocks the global p{}→VBox port
-(SYNC_STATUS 1610.00974 step-3). High regression risk (touches EVERY box body —
-hbox/vbox/vtop/p-cell/argument — and the full test suite), so it warrants its own
-session + an arXiv slice validation, NOT an autonomous inline fix. NOTE: a
-`\loop`-iteration guard would make Rust *Fatal* where Perl *succeeds* (worse) — the
-only faithful fix is the frame-ordering correction so the loop terminates.
+**Fix spec (OPEN — focused, core-path).** Collapse the double-framing so the box
+body's closing `}` drives `end_mode` (`leave_horizontal_internal`→repack, then pop)
+rather than an early body-group egroup — i.e. let the mode frame BE the body group,
+as Perl's `readBoxContents` (TeX_Box.pool.ltxml L139-160) does: a custom digest
+loop that STOPS at the matching `}` (`level >= get_frame_depth()`) WITHOUT
+processing it, then `end_mode` repacks (inner `\hsize` still in scope) + pops.
+
+**PROTOTYPED + VALIDATED + REVERTED 2026-06-22.** Implemented the faithful loop in
+`base_utilities.rs::predigest_box_contents_in_mode` for `mode.ends_with("vertical")`
+only (hbox/math keep the `invoke_token(T_BEGIN)` path). **CONFIRMED it fixes Cluster
+G**: 1707.02464 hang → **completes in 4.8s with PERFECT Perl parity** (10 errors,
+byte-identical to local Perl's 10: 1 babel-russian env + 9 `Attempt to close a
+group…`; the `\narrow` loop now terminates because `\ht` grows as `\hsize`
+shrinks). BUT the naive loop **over-triggers** for general vboxes → 4 suite
+regressions (1463/4), so REVERTED. The clean impl must additionally:
+1. **Preserve VBoxContents reversion braces.** Rebuilding the body as
+   `List::new(boxes)` loses the group `{}`, so `tex=` reverts `\vbox{a}` → `\vbox a`
+   (box_test; Perl keeps `{a}`). The List must revert as a brace group.
+2. **Not paragraph-wrap measured / non-paragraph boxes.** A short `\vbox` now
+   measures at full `\hsize` (sizes_test 37.06pt → 469.75pt) because
+   `compute_boxes_size_lines` returns `wrapwidth` for a fitting final line
+   (`final_wd = ww if wd>0`, font.rs:1667) once the content is a width-tagged
+   paragraph List. Perl measures natural width here — so either the box must not be
+   repacked into a paragraph in this context, or the single-fitting-line width must
+   be natural (not `ww`). Also affects graphrot_test, xytest_test (graphics sizing).
+The core mechanism is PROVEN; these two interactions are the remaining work for a
+focused session. NOTE: a `\loop`-iteration guard would make Rust *Fatal* where Perl
+*succeeds* (worse) — the frame-ordering correction is the only faithful fix.
 
 **SHARED ROOT with the global p{}→VBox port (found 2026-06-22).** The same
 `\hsize`-invariant box model blocks SYNC_STATUS **1610.00974 step-3**: porting the

--- a/docs/STABILITY_WITNESSES.md
+++ b/docs/STABILITY_WITNESSES.md
@@ -347,15 +347,37 @@ line-count/height estimate). Confirmed: removing the `$$`/math is still slow
 (B), and a *fixed* 200-iteration vbox-remeasure loop is fast (C) — so it's the
 non-terminating loop, not per-iteration math/box cost.
 
-**Fix direction (OPEN — focused box-model session; regression-risky).** Model a
-vbox paragraph's height as ∝ `ceil(content_width / \hsize) × \baselineskip` so
-`\ht` grows when `\hsize` shrinks below the content width, matching Perl. The
-grep for an `\hsize`-aware height estimate finds none, so this is a genuine
-box-dimension subsystem gap. High regression risk (every `\ht`/`\vbox` consumer +
-the 1467-test suite must stay green), so it warrants its own session + an arXiv
-slice validation, NOT an inline fix. NOTE: a `\loop`-iteration guard would make
-Rust *Fatal* where Perl *succeeds* (worse) — the only faithful fix is to make the
-loop terminate.
+**ROOT CAUSE — PRECISE (2026-06-22).** The `\hsize`-aware paragraph-wrap machinery
+**already exists and is correct**: `Font::compute_boxes_size_lines(wrapwidth, …)`
+(`common/font.rs:1629`) breaks a line when `wd > wrapwidth` → more lines → taller
+box, and `compute_boxes_size` derives `wrapwidth` from the paragraph List's
+`width` property (set by `repack_horizontal`/`make_horizontal_list` =
+`LookupDimension('\hsize')`). The bug is a **frame-ordering divergence** in
+`base_utilities.rs::predigest_box_contents_in_mode`:
+- Rust uses **TWO** frames — the mode frame (`begin_mode`) **plus** a body-group
+  frame pushed by `invoke_token(&T_BEGIN!())`. The inner `\hsize=W` is assigned in
+  the body-group frame, and the body's closing `}` (T_END) pops that frame
+  (**restoring `\hsize` to the outer value**) BEFORE the manual
+  `repack_horizontal_in_list(&mut item)` runs → `make_horizontal_list` captures the
+  OUTER `\hsize` → every implicit vbox paragraph wraps at the outer width
+  regardless of the inner `\hsize`.
+- Perl uses **ONE** frame (the mode frame IS the group): `endMode`
+  (`Stomach.pm:544-557`) runs `leaveHorizontal_internal`→`repackHorizontal`
+  (capturing the inner `\hsize`, L487) and ONLY THEN `popStackFrame`. Rust's
+  `end_mode` (`stomach.rs:726`) already mirrors this order — but it never sees the
+  inner `\hsize` because the body-group frame already restored it.
+
+**Fix spec (OPEN — focused, core-path, regression-risky).** Collapse the
+double-framing so the box body's closing `}` drives `end_mode`
+(`leave_horizontal_internal`→repack, then pop) rather than an early body-group
+egroup — i.e. let the mode frame BE the body group, as Perl's `readBoxContents`
+does. Then repack captures the inner `\hsize`, fixing BOTH this `\ht`-invariant
+hang AND the rotated-`p{}`-cell mis-sizing that blocks the global p{}→VBox port
+(SYNC_STATUS 1610.00974 step-3). High regression risk (touches EVERY box body —
+hbox/vbox/vtop/p-cell/argument — and the full test suite), so it warrants its own
+session + an arXiv slice validation, NOT an autonomous inline fix. NOTE: a
+`\loop`-iteration guard would make Rust *Fatal* where Perl *succeeds* (worse) — the
+only faithful fix is the frame-ordering correction so the loop terminates.
 
 **SHARED ROOT with the global p{}→VBox port (found 2026-06-22).** The same
 `\hsize`-invariant box model blocks SYNC_STATUS **1610.00974 step-3**: porting the

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -481,7 +481,14 @@ done. **Remaining:** tag `0.7.0` on `main` → `release.yml` runs the TL-window
   use verbose Perl).
 - **`expected:id` cmml dangling-XMRef tail** — MathFork/split content-arm xml:id
   duplication; the last live `expected:id` class. See
-  `EXPECTED_ID_XMREF_DESIGN_2026-06-08.md`.
+  `EXPECTED_ID_XMREF_DESIGN_2026-06-08.md`. **QUANTIFIED 2026-06-22: this is the
+  #1 remaining Rust-only divergence** — `warning/expected/id` is **1005 cortex
+  tasks** ("Cannot find a node with xml:id='S…E…m1.N'" from
+  `latexml_math_parser/src/parser.rs:2840`; math-node ids, so genuinely the
+  content-arm/MathFork XMRef cluster). It's a large Rust-only WARNING excess vs
+  Perl (e.g. 0704.3530 Rust 152 vs Perl 9 warnings) — NOT parity. The prime
+  candidate for the deferred content-MathML dedicated session; do NOT pick at it
+  piecemeal (user directive).
 - **xy-pic `svg:path` / curve cluster** (1501.03690) — shifted-arrows `svg:path`
   in `ltx:text`; mode-frame cascade root.
 

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -509,13 +509,44 @@ the EPS task; candidates for future work):
   the global port exposes a `\cr`-mid-VBoxContents-predigest interleaving + a
   span/sizing bug on `\multicolumn` over p-columns. Also explains the p-column
   `td align="justify"` + width-on-`<p>` divergence (Perl: `align="left"` +
-  width-on-`<inline-block>`). Surpass-Perl R&D. **Related residuals catalogued
+  width-on-`<inline-block>`). **Related residuals catalogued
   with minimal reproducers in `docs/reproducers/array_pcolumn/`** (Kind B: `>{}`
   prefix align not on `<td>`; Kind C/D: regular `m{}`/`b{}` use a plain
   `\vtop{}`/`\vbox{}` not the `\lx@tabular@p` VBox → width-on-`<td>` + inline-block
   `vattach`/width drift). The `\multicolumn`-over-`m{}`/`b{}` GROUP ERROR in that
   family is now **FIXED** (was 1805.01525 27→0; `tex_tables.rs`
   `\lx@alignment@multicolumn` generalized from p{}-only to all paragraph columns).
+  - **NOT just surpass-Perl — also a CORRECTNESS bug (re-scoped 2026-06-22).**
+    The global `\vtop{\hbox to <w>..}` form opens the cell as an `ltx:p`
+    (`_noautoclose`), so **block content inside a `p{}` cell errors**:
+    `\begin{itemize}` (or any list/block) → `Error:malformed:ltx:itemize
+    <ltx:itemize> isn't allowed in <ltx:p>` (genuine Rust-only; Perl 0). New
+    witness **1510.07685** (Hera1706.tex): Rust 3 / Perl 0, full paper. Mined
+    from the cortex `error/malformed/ltx:itemize` report (the cross-join's only
+    non-parity, non-`todo` candidate; the rest of `error/malformed` is shared —
+    e.g. `_CaptureBlock_`/listing errors are Perl-identical). Reproducer:
+    `docs/reproducers/pcolumn_block_content_in_p.tex`.
+  - **De-risked 2026-06-22 (empirical port + revert).** Flipping the global p{}
+    to `\lx@tabular@p t {w} { … }` (matching Perl `DefColumnType('p{Dimension}')`)
+    + teaching `\lx@alignment@multicolumn` to splice directly when the column is
+    already `\lx@tabular@p`-shaped: the **non-rotated** common case becomes
+    **Perl-exact** — `colortbls`/`tabular`/`array` fixtures turn into clean parity
+    fixes (width moves onto `<inline-block>`; `<p class="ltx_align_left">` now
+    matches Perl; `<p width=>` count → 0 like Perl), and the witness goes 3 → 0.
+    Full suite 1462/5; the 5 failures are all p{}-tables, 3 clean parity fixes.
+  - **THE SOLE BLOCKER is rotated-table p-cell SIZING — and it is the SAME
+    root cause as Cluster G** ([`STABILITY_WITNESSES.md`](STABILITY_WITNESSES.md),
+    1707.02464). In a `\begin{sidewaystable}` (graphrot `rotfloat2`,
+    `{|llllllllp{1in}lp{1in}|}`; cells fixture) the rotated table width = original
+    height = Σ row heights, and Rust mis-computes the `p{1in}` cell **height**
+    (rotfloat2: Rust 810pt vs Perl 214pt) because Rust's vbox/paragraph dimensions
+    are **`\hsize`-invariant** (no `\hsize`-constrained line-breaking → wrong line
+    count → wrong height/width). The old `\hbox to <w>` form *forced* the width and
+    sidestepped this; the faithful VBox form exposes it. Fixing the box model's
+    `\hsize`-aware line-breaking (`compute_boxes_size` / `repack_horizontal_in_list`
+    is present but not reaching the rotated/spanned path) would **unblock BOTH**
+    this global p{} port AND Cluster G's `\narrow`-loop hang. High-value unifying
+    box-model target; dedicated session.
 - **`expected:id` cmml dangling-XMRef tail** — MathFork/split content-arm xml:id
   duplication; the last live `expected:id` class. See
   `EXPECTED_ID_XMREF_DESIGN_2026-06-08.md`.

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -564,11 +564,16 @@ the EPS task; candidates for future work):
     (rotfloat2: Rust 810pt vs Perl 214pt) because Rust's vbox/paragraph dimensions
     are **`\hsize`-invariant** (no `\hsize`-constrained line-breaking → wrong line
     count → wrong height/width). The old `\hbox to <w>` form *forced* the width and
-    sidestepped this; the faithful VBox form exposes it. Fixing the box model's
-    `\hsize`-aware line-breaking (`compute_boxes_size` / `repack_horizontal_in_list`
-    is present but not reaching the rotated/spanned path) would **unblock BOTH**
-    this global p{} port AND Cluster G's `\narrow`-loop hang. High-value unifying
-    box-model target; dedicated session.
+    sidestepped this; the faithful VBox form exposes it. **PRECISE root cause
+    (2026-06-22): a frame-ordering bug**, not a missing wrap — the wrap machinery
+    (`compute_boxes_size_lines`) is correct, but `predigest_box_contents_in_mode`
+    pops the body-group frame (restoring the outer `\hsize`) BEFORE
+    `repack_horizontal_in_list` captures it, so vbox paragraphs always wrap at the
+    OUTER `\hsize`. Perl's `endMode` repacks BEFORE `popStackFrame` (one frame, not
+    two). Full mechanism + fix spec in `STABILITY_WITNESSES.md` Cluster G. The one
+    frame-ordering fix **unblocks BOTH** this global p{} port AND Cluster G's
+    `\narrow`-loop hang. High-value unifying target; dedicated session (core
+    digestion path → high regression surface).
 - **`expected:id` cmml dangling-XMRef tail** — MathFork/split content-arm xml:id
   duplication; the last live `expected:id` class. See
   `EXPECTED_ID_XMREF_DESIGN_2026-06-08.md`.

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -459,11 +459,15 @@ Perl `dographics`.
   alignment/array 18→14 diff lines vs local Perl; cells 72→72 — same cluster-B
   family) and were re-baselined; suite 1467/0, clippy clean. The narrow
   `\multicolumn{}{p{}}` and `\multicolumn`-over-`m{}`/`b{}` GROUP ERROR were already
-  fixed (1805.01525 27→0). **Residual (deferred, COSMETIC — cluster-B):** remaining
-  p{} diffs vs Perl are `>{}`-prefix align on `<td>` and regular `m{}`/`b{}`
-  `vattach`/width drift (m/b still use plain `\vtop{}`/`\vbox{}`, not
-  `\lx@tabular@p`). Reproducers: `docs/reproducers/array_pcolumn/` +
-  `pcolumn_block_content_in_p.tex`.
+  fixed (1805.01525 27→0). **array.sty `m{}`/`b{}` ALSO ported to `\lx@tabular@p`
+  (`eb978df5a9`)** — cluster-B residual C/D (m/b `vattach`/width drift, width on
+  `<td>`) is CLEARED: the m-cell `<inline-block>` is now Perl-exact. **Remaining
+  residual (deferred, COSMETIC — cluster-B Kind-B):** a p/m/b column's `<td>` gets
+  `align="justify"` where Perl uses `align="left"` (C_m_column reproducer: down to
+  this 1 diff). NOT a simple mapping flip — the `align == Some(Align::Justify)`
+  marker is load-bearing for the `is_pcol` detection in `\lx@alignment@multicolumn`,
+  so a clean fix must decouple the td-align attribute from that marker. No errors.
+  Reproducers: `docs/reproducers/array_pcolumn/` + `pcolumn_block_content_in_p.tex`.
 - **`expected:id` cmml dangling-XMRef tail** — MathFork/split content-arm xml:id
   duplication; the last live `expected:id` class. See
   `EXPECTED_ID_XMREF_DESIGN_2026-06-08.md`.

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -152,6 +152,17 @@ rerun is the clear next step:**
     current binary without a fresh cortex rerun. Sweep harness:
     `tools/`-style `/tmp/sweep.sh` (grep `\documentclass` misses 2.09
     `\documentstyle` — heuristic note, not a Rust gap).
+  - **`warning` severity mined too (2026-06-22) → nothing new actionable.** Of 2208
+    warning tasks, the bulk is **user-deferred math** (`ambiguous` 1348 + `expected`
+    1181 = `not_parsed` "MathParser failed to match" — content-MathML) + env
+    (`missing_file` 590). The small non-math categories are niche graceful-recovery
+    warnings, all parity/faithful: `unsupported/multirow` ("Negative row sizes … not
+    yet supported") is a **line-for-line mirror of Perl `multirow.sty.ltxml`:27-28**
+    (Perl doesn't support it either — implementing would surpass Perl);
+    `malformed/{_CaptureBlock_,labels,ltx:Proof}` (1-5 tasks) are graceful fallbacks
+    for custom/edge constructs. **All cortex severities (error/fatal/warning) are now
+    mined; no unblocked, in-scope, non-surpass Rust-only bug remains findable on the
+    current binary.**
 
 **NEXT: a FRESH cortex Rust rerun built from this branch** (needs
 `X-Cortex-Token`) is the prerequisite for mining genuine Rust-only *correctness*

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -15,10 +15,29 @@
 
 ## Current status
 
-- `cargo test --tests`: **1466 / 0 / 0**.
+- `cargo test --tests`: **1467 / 0 / 0**.
 - `cargo clippy --workspace --all-targets -- -D warnings`: **clean**.
 - `--init=plain.tex` / `--init=latex.ltx`: **0 errors** (with dump and `LATEXML_NODUMP=1`).
 - Distribution build (`maxperf`): ~45 MB; beats 2× pdflatex on the mini-benchmark.
+
+### Landed this session (2026-06-22, on `further-stability-coverage`, pushed)
+
+Two genuine Rust-only bugs fixed + the full p/m/b table-column parity arc:
+- **Cluster G hang** `1707.02464` — `\hsize`-aware vbox paragraph wrapping (faithful
+  Perl `readBoxContents`); the `\narrow` `\hsize`-shrink loop now terminates
+  (hang → ~4.8s, 10 errors = Perl). `7545e07fd6`. See `STABILITY_WITNESSES.md`
+  Cluster G (FIXED).
+- **p{} block-content** `1510.07685` — `\begin{itemize}` in a `p{}` cell (3→0
+  errors); global p{} → Perl `\lx@tabular@p` VBox form (1610.00974 step-3).
+  `f65b80c1c2`.
+- **array.sty m{}/b{} → `\lx@tabular@p`** (`eb978df5a9`) and **p/m/b `<td>`
+  `align="left"`** (`1867f17da9`) → **cluster-B FULLY RESOLVED**; table fixtures
+  near-/exact-to-Perl (array_newline_math Perl-exact); rotfloat2 sidewaystable
+  innerheight 69.1→98.6 vs Perl 98.5.
+- Validated regression-free: 12 table-stressed papers + a fresh 24-paper same-host
+  sweep (0 Rust>Perl; Rust at-or-better everywhere) + class-level cross-join.
+- (Earlier this session: tasks 5 & 6 below — post-processing log parity + graphics
+  never-ship-raw-.eps — also landed.)
 
 ## Methodology & the cortex cross-join
 
@@ -426,73 +445,29 @@ Version bumped, `runtime-bindings` in the artifact, `.deb` deps, CHANGELOG/READM
 done. **Remaining:** tag `0.7.0` on `main` → `release.yml` runs the TL-window
 `dumps` + macOS arm64 leg + publish (each first-exercised on that tag).
 
-### 5. Post-processing logging parity for cortex workflows — LANDED 2026-06-22
-`cortex.log` now carries core **+** post (Scan→…→Graphics→MathML→XSLT). Shared
-wrapper `latexml::post::run_post_processing_logged() -> PostOutcome {html, log,
-status_code}` re-binds `LOG_BUFFER` around `run_post_processing` then flushes
-(Perl's single post-`convert_post` flush); post failures use `post_error()` →
-buffer + Error counter (no `Fatal!`/`return`). `latexml_oxide` `--log`/archive-zip
-wired via `writer::write_output_segments` (no third concat alloc). Commits
-`512dbc1ba2`, `9524d2e179`; suite 1467/0. **Residual (cortex-side owner):** wire
-`cortex_worker.rs::convert_archive` to the same wrapper + fold
-`max(core, post.status_code)` into `Status:conversion` (Perl `LaTeXML.pm` L631-634).
-
-### 6. Graphics: never ship a raw `.eps`/`.pdf` to the web — LANDED 2026-06-22
-THREE `latexml_post/src/graphics.rs` guards so a non-web-native source can never
-reach the web: (1) conversion-failure → `imageprocessing` Error + NO imagesrc
-(Perl L324-329); (2) `Plan::NotFound` → Warn only, no imagesrc (Perl L216-219);
-(3) plan-routing default → web-native target (svg/png/gif/jpg/jpeg kept, else
-`png`) so non-web-native always routes through `Plan::Convert` (surpass-Perl: Perl
-would `Plan::Copy` the raw source). A `<graphics>` without `@imagesrc` renders
-`ltx_missing_image`, never a broken `.eps` src. Verified: hep-th0101114 6/6,
-astro-ph0004105 15/15 EPS→PNG, zero raw srcs. Commits `80b4438385`, `604951c232`.
-Post-orchestration matches Perl `convert_post`/`Config.pm` at defaults
-(Split→Scan→Index→Bib→CrossRef→Graphics→pmml/cmml→XSLT). Known deltas (broader
-parity, not blocking): `PictureImages` absent (Rust = regex inline-SVG); `SVG` is a
-regex extractor (intentional divergence); no `prescan`; Graphics unconditional vs
-Perl `dographics`.
+### 5–6. LANDED 2026-06-22 (see "Landed this session" above)
+- **Post-processing log parity** (`512dbc1ba2`, `9524d2e179`): `cortex.log` carries
+  core+post. **Residual (cortex-side owner):** wire `cortex_worker.rs::convert_archive`
+  to `run_post_processing_logged` + fold `max(core, post.status_code)` into
+  `Status:conversion` (Perl `LaTeXML.pm` L631-634).
+- **Graphics never ships a raw `.eps`/`.pdf`** (`80b4438385`, `604951c232`): three
+  guards → a `<graphics>` without `@imagesrc` renders `ltx_missing_image`. Known
+  post-orchestration deltas (not blocking, broader parity): `PictureImages` absent
+  (Rust = regex inline-SVG), `SVG` regex extractor, no `prescan`.
 
 ---
 
 ## Deep deferred families (parked — large or shared; dedicated sessions)
 
-- **1610.00974 step-3 — global p{} → Perl `\lx@tabular@p` VBox form — ✅ LANDED
-  2026-06-22 (`f65b80c1c2`).** The global `p{Dimension}` column now uses Perl's
-  `\lx@tabular@p t {width} { … }` (cell = `<ltx:inline-block>`, VBoxContents /
-  internal_vertical) instead of the old `\vtop{\hbox to <w>..}`;
-  `\lx@alignment@multicolumn` splices directly for the already-VBox-shaped column
-  (array.sty m{}/b{} keep the `\vtop`/`\vbox` transform). Unblocked by the box-model
-  fix (`7545e07fd6`, Cluster G). **Fixes the genuine Rust-only correctness bug
-  1510.07685** (`\begin{itemize}` in a `p{}` cell → 3→0 errors; the cell is now an
-  inline-block, not an `_noautoclose` `ltx:p`). rotfloat2 sidewaystable is now
-  near-Perl-exact (innerheight 69.1→98.6 vs Perl 98.5). All p{}-table fixtures moved
-  TOWARD-or-equal Perl (colortbls 73→41, tabular 39→21, graphrot 125→75,
-  alignment/array 18→14 diff lines vs local Perl; cells 72→72 — same cluster-B
-  family) and were re-baselined; suite 1467/0, clippy clean. The narrow
-  `\multicolumn{}{p{}}` and `\multicolumn`-over-`m{}`/`b{}` GROUP ERROR were already
-  fixed (1805.01525 27→0). **array.sty `m{}`/`b{}` ALSO ported to `\lx@tabular@p`
-  (`eb978df5a9`)** — cluster-B residual C/D (m/b `vattach`/width drift, width on
-  `<td>`) CLEARED: the m-cell `<inline-block>` is Perl-exact. **Cluster-B Kind-B
-  CLEARED too (`1867f17da9`):** a p/m/b `<td>` now gets `align="left"` (Perl) not
-  `"justify"` — Justify mapped to `"left"` at the td cell-attr output only, keeping
-  the `Cell.align == Justify` marker intact for `is_pcol` detection. **Cluster-B is
-  now FULLY RESOLVED.** Every paragraph-column fixture moved toward Perl, several to
-  near-exact (array_newline_math 2→0 Perl-exact, array 14→2, tabular 21→3,
-  colortbls 41→9, graphrot 75→27, cells 72→64). The p/m/b table-column parity arc
-  (box-model → p{} port → m/b port → td-align) is COMPLETE. **Validated
-  regression-free 2026-06-22**: re-ran 12 table-structure-stressed arXiv papers
-  (cortex `\@end@tabular`/`\lx@begin@alignment` clusters) on the current binary —
-  **0 regression-signatures** (no `\lx@tabular@p`/itemize-in-p/inline-block errors);
-  the errors that remain are all pre-existing/shared (math-mode `^`/`_`,
-  `\noalign`/`&` alignment, frontmatter mode-close, undefined third-party CS like
-  `collcell`'s `\collectcell`). **`collcell` checked 2026-06-22 → PARITY, NOT a
-  Rust bug:** both Rust AND Perl error `\collectcell`/`\endcollectcell` undefined +
-  `missing file[collcell.sty]` (both default `notex=1` / `INCLUDE_STYLES=false`, so
-  neither raw-loads `collcell.sty`; Rust mirrors Perl Package.pm:2676-2677 exactly).
-  The first Perl run *looked* clean ("0 errors") only because `latexml --quiet`
-  SUPPRESSES the error display — `latexml` (verbose) shows the same 2 errors. So the
-  1901.10277 `collcell`→alignment cascade is shared; binding collcell would
-  *surpass* Perl. (Same `--quiet`-suppression artifact as babel-russian.)
+- **1610.00974 step-3 (global p{}→VBox) + cluster-B — ✅ LANDED 2026-06-22, NO
+  LONGER DEFERRED.** See "Landed this session" above. p{}/m{}/b{} columns now build
+  the cell as Perl's `\lx@tabular@p` inline-block (VBoxContents); p/m/b `<td>`
+  `align="left"`; **cluster-B FULLY RESOLVED**; fixes 1510.07685. Commits
+  `f65b80c1c2` / `eb978df5a9` / `1867f17da9` (+ box-model `7545e07fd6`). NOTE: the
+  `collcell`/`\collectcell` undefined seen in some table papers is PARITY (both
+  engines default `notex=1`/`INCLUDE_STYLES=false`, so neither raw-loads
+  `collcell.sty`; the `--quiet` Perl "0 errors" was a display-suppression artifact —
+  use verbose Perl).
 - **`expected:id` cmml dangling-XMRef tail** — MathFork/split content-arm xml:id
   duplication; the last live `expected:id` class. See
   `EXPECTED_ID_XMREF_DESIGN_2026-06-08.md`.

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -488,10 +488,17 @@ Perl `dographics`.
     pops the body-group frame (restoring the outer `\hsize`) BEFORE
     `repack_horizontal_in_list` captures it, so vbox paragraphs always wrap at the
     OUTER `\hsize`. Perl's `endMode` repacks BEFORE `popStackFrame` (one frame, not
-    two). Full mechanism + fix spec in `STABILITY_WITNESSES.md` Cluster G. The one
-    frame-ordering fix **unblocks BOTH** this global p{} port AND Cluster G's
-    `\narrow`-loop hang. High-value unifying target; dedicated session (core
-    digestion path → high regression surface).
+    two). **The frame-ordering fix LANDED 2026-06-22 (`7545e07fd6`) — see
+    `STABILITY_WITNESSES.md` Cluster G (FIXED).** `\hsize`-aware wrapping now applies
+    to p{} cells too (they use `\vtop`/VBoxContents), so this port's rotated-cell
+    sizing BLOCKER is RESOLVED. **Remaining step-3 work** (now unblocked, no longer
+    `\hsize`-blocked): flip the global `p{}` column to `\lx@tabular@p`/VBoxContents +
+    teach `\lx@alignment@multicolumn` to splice when the column is already
+    VBox-shaped (prototyped 2026-06-22: non-rotated tables become Perl-exact,
+    colortbls/tabular/array clean parity fixes) — then re-validate graphrot/cells
+    rotated sizing against Perl with the box-model fix in place, and fix the genuine
+    p{}-block-content correctness bug (1510.07685 `<ltx:itemize> isn't allowed in
+    <ltx:p>`). Reproducer: `docs/reproducers/pcolumn_block_content_in_p.tex`.
 - **`expected:id` cmml dangling-XMRef tail** — MathFork/split content-arm xml:id
   duplication; the last live `expected:id` class. See
   `EXPECTED_ID_XMREF_DESIGN_2026-06-08.md`.

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -426,6 +426,50 @@ wiring deferred to the cortex-side owner.**
   cortex-side maintainer (per 2026-06-22 directive: leave the live fleet binary
   alone).
 
+### 6. Graphics: never ship a raw `.eps`/`.pdf` to the web + post-orchestration audit
+**Trigger:** hep-th0101114 / astro-ph0004105 showed raw `.eps` in the deployed
+preview. We can never show `.eps`/`.pdf` on the web — always a web-native target
+(`.png`/`.svg`). Verified the current binary converts both papers' EPS→PNG
+correctly (6/16 PNGs), so the symptom was a *failed* conversion shipping the raw
+source (now also visible via task 5's logging).
+
+**LANDED 2026-06-22 (`latexml_post/src/graphics.rs`).** Removed two raw-source
+leaks that diverged from Perl `Post/Graphics.pm`:
+- **Conversion-failure fallback** (was: `Error!` then `copy_to_destination` of
+  the raw source → `imagesrc="fig.eps"`). Perl L324-329 does `Error`/`Warn` +
+  `return` with NO imagesrc. Now matches: emit the `imageprocessing` Error and
+  leave `imagesrc` unset.
+- **`Plan::NotFound`** (was: `set_attribute("imagesrc", graphic)` → raw path for
+  a missing file). Perl L216-219 `Warn`s + `return` without imagesrc. Now Warn
+  only.
+- Both rely on the HTML5 XSLT (`LaTeXML-misc-xhtml.xsl:154`): a `<graphics>`
+  lacking `@imagesrc` renders as `class="ltx_missing ltx_missing_image"` (empty
+  src) — the correct "couldn't render" marker, never a broken `<img
+  src=".eps">`. `.eps`/`.ps`/`.pdf` all route through `Plan::Convert` (only
+  web-native rasters hit `Plan::Copy`), so this covers `.pdf` too. Suite 1467/0;
+  hep-th0101114 still 6 PNGs / zero `.eps` srcs.
+
+**Post-orchestration audit vs Perl `LaTeXML.pm::convert_post` + `Config.pm`
+(integrated path — the one cortex uses, NOT `bin/latexmlpost`).** Our
+`run_post_processing` order — Split → Scan → MakeIndex → MakeBibliography →
+CrossRef → Graphics → {pmml/cmml} → XSLT — **matches** Perl's `@procs` order,
+and our always-on phases are equivalent to Perl's `if <option>` gates at their
+`Config.pm` defaults (`scan`/`index`/`crossref`/`dographics`/`numbersections`
+all default 1; `pmml` auto-added for html/xhtml/jats). **Faithful for the
+`ltx:graphics`/EPS path.** Known deltas (separate, broader parity — NOT blocking
+the EPS task; candidates for future work):
+- **`PictureImages` processor is absent.** Perl always pushes it (full if
+  `picimages`, else `empty_only=>1`); Rust handles `<ltx:picture>` via the
+  regex `extract_svg_fragments` + HTML5 inline-SVG injection instead.
+- **`SVG` is a regex extractor, not a `LaTeXML::Post::SVG` processor** (intentional
+  divergence; functional for HTML5 inline SVG).
+- **No `prescan` mode** (Perl gates most procs on `!prescan`; rare multi-pass
+  DB-build path, unused by cortex/CLI).
+- **Graphics is unconditional** in Rust vs Perl's `dographics` (which Config.pm
+  only defaults to 1 when a destination/archive exists) — so Rust attempts
+  graphics even for stdout output. Harmless for web (always has a destination);
+  matches Perl whenever a destination is set.
+
 ---
 
 ## Deep deferred families (parked — large or shared; dedicated sessions)

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -461,13 +461,14 @@ Perl `dographics`.
   `\multicolumn{}{p{}}` and `\multicolumn`-over-`m{}`/`b{}` GROUP ERROR were already
   fixed (1805.01525 27→0). **array.sty `m{}`/`b{}` ALSO ported to `\lx@tabular@p`
   (`eb978df5a9`)** — cluster-B residual C/D (m/b `vattach`/width drift, width on
-  `<td>`) is CLEARED: the m-cell `<inline-block>` is now Perl-exact. **Remaining
-  residual (deferred, COSMETIC — cluster-B Kind-B):** a p/m/b column's `<td>` gets
-  `align="justify"` where Perl uses `align="left"` (C_m_column reproducer: down to
-  this 1 diff). NOT a simple mapping flip — the `align == Some(Align::Justify)`
-  marker is load-bearing for the `is_pcol` detection in `\lx@alignment@multicolumn`,
-  so a clean fix must decouple the td-align attribute from that marker. No errors.
-  Reproducers: `docs/reproducers/array_pcolumn/` + `pcolumn_block_content_in_p.tex`.
+  `<td>`) CLEARED: the m-cell `<inline-block>` is Perl-exact. **Cluster-B Kind-B
+  CLEARED too (`1867f17da9`):** a p/m/b `<td>` now gets `align="left"` (Perl) not
+  `"justify"` — Justify mapped to `"left"` at the td cell-attr output only, keeping
+  the `Cell.align == Justify` marker intact for `is_pcol` detection. **Cluster-B is
+  now FULLY RESOLVED.** Every paragraph-column fixture moved toward Perl, several to
+  near-exact (array_newline_math 2→0 Perl-exact, array 14→2, tabular 21→3,
+  colortbls 41→9, graphrot 75→27, cells 72→64). The p/m/b table-column parity arc
+  (box-model → p{} port → m/b port → td-align) is COMPLETE.
 - **`expected:id` cmml dangling-XMRef tail** — MathFork/split content-arm xml:id
   duplication; the last live `expected:id` class. See
   `EXPECTED_ID_XMREF_DESIGN_2026-06-08.md`.

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -468,7 +468,16 @@ Perl `dographics`.
   now FULLY RESOLVED.** Every paragraph-column fixture moved toward Perl, several to
   near-exact (array_newline_math 2→0 Perl-exact, array 14→2, tabular 21→3,
   colortbls 41→9, graphrot 75→27, cells 72→64). The p/m/b table-column parity arc
-  (box-model → p{} port → m/b port → td-align) is COMPLETE.
+  (box-model → p{} port → m/b port → td-align) is COMPLETE. **Validated
+  regression-free 2026-06-22**: re-ran 12 table-structure-stressed arXiv papers
+  (cortex `\@end@tabular`/`\lx@begin@alignment` clusters) on the current binary —
+  **0 regression-signatures** (no `\lx@tabular@p`/itemize-in-p/inline-block errors);
+  the errors that remain are all pre-existing/shared (math-mode `^`/`_`,
+  `\noalign`/`&` alignment, frontmatter mode-close, undefined third-party CS like
+  `collcell`'s `\collectcell`). NOTE: the `collcell` package (`\collectcell`/
+  `\endcollectcell`, undefined) recurs in table papers (1901.10277 cascades to a
+  TooManyErrors fatal; 1701.06504) — a candidate future binding (verify vs Perl
+  first; likely a third-party-undefined parity case).
 - **`expected:id` cmml dangling-XMRef tail** — MathFork/split content-arm xml:id
   duplication; the last live `expected:id` class. See
   `EXPECTED_ID_XMREF_DESIGN_2026-06-08.md`.

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -474,10 +474,14 @@ Perl `dographics`.
   **0 regression-signatures** (no `\lx@tabular@p`/itemize-in-p/inline-block errors);
   the errors that remain are all pre-existing/shared (math-mode `^`/`_`,
   `\noalign`/`&` alignment, frontmatter mode-close, undefined third-party CS like
-  `collcell`'s `\collectcell`). NOTE: the `collcell` package (`\collectcell`/
-  `\endcollectcell`, undefined) recurs in table papers (1901.10277 cascades to a
-  TooManyErrors fatal; 1701.06504) — a candidate future binding (verify vs Perl
-  first; likely a third-party-undefined parity case).
+  `collcell`'s `\collectcell`). **`collcell` checked 2026-06-22 → PARITY, NOT a
+  Rust bug:** both Rust AND Perl error `\collectcell`/`\endcollectcell` undefined +
+  `missing file[collcell.sty]` (both default `notex=1` / `INCLUDE_STYLES=false`, so
+  neither raw-loads `collcell.sty`; Rust mirrors Perl Package.pm:2676-2677 exactly).
+  The first Perl run *looked* clean ("0 errors") only because `latexml --quiet`
+  SUPPRESSES the error display — `latexml` (verbose) shows the same 2 errors. So the
+  1901.10277 `collcell`→alignment cascade is shared; binding collcell would
+  *surpass* Perl. (Same `--quiet`-suppression artifact as babel-russian.)
 - **`expected:id` cmml dangling-XMRef tail** — MathFork/split content-arm xml:id
   duplication; the last live `expected:id` class. See
   `EXPECTED_ID_XMREF_DESIGN_2026-06-08.md`.

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -270,18 +270,20 @@ Open task §1).
   `compound_operator_2` list (its own `// TODO`). Ambiguity-sensitive. (Root
   cause was the marpa fork's `Parser::read` breaking on `is_exhausted()` before
   the token source drained — `marpa/src/parser/mod.rs:130`.)
-- **comma-list LEFT of a relation `a,b \in A` — DESIGN LOCKED 2026-06-22, impl
-  deferred (riskiest pruning area).** Current Rust gives the wrong
-  `formulae@(a, b∈A)` (∈ binds only `b`, splitting `a` off). User-specified
-  surpass-Perl target (via AskUserQuestion): an **XMDual** whose **content branch
-  DISTRIBUTES** the relation — `formulae@(∈(a,A), ∈(b,A))`, each element related to
-  the shared RHS via XMRefs — and whose **presentation branch wraps the list in an
-  `<XMWrap>` as the relation's LHS** — `Apply(∈, XMWrap(a,',',b), A)` (renders
-  `<mrow>` in pMML). ONLY for list-LEFT; the list-RIGHT `0<x,y`→`list(0<x,y)`
-  distribute stays (separate earlier blessed surpass). Touches the tuned
-  `formulae_apply`/`list_apply` (semantics.rs:486; 3-item `a,b,c∈S` uses
-  `list_apply`) — both paths + pruning. Verify: full suite + `0<x,y` +
-  over-parse fixtures stay green. Full spec in `memory/math-parser-asides`.
+- **comma-list LEFT of a relation `a,b \in A` — FIXED 2026-06-22 (2-item path).**
+  Was the wrong `formulae@(a, b∈A)` (∈ binding only `b`). Now the user-specified
+  surpass-Perl **XMDual**: content **DISTRIBUTES** — `formulae@(∈(a,A), ∈(b,A))`,
+  sharing XMRefs to the relop and RHS — presentation wraps the list as the
+  relation's LHS — `Apply(∈, XMWrap(a,',',b), A)`. Implemented as a scoped
+  transform at the end of `formulae_apply` (semantics.rs): when `left` is a bare
+  (non-relational, non-Dual) item and `right` is a binary RELOP relation
+  `Apply(R,[lhs,rhs])` under a comma, `distribute_list_relation` builds the dual.
+  `x,y \le z`→`formulae@(x≤z, y≤z)`. The list-RIGHT `0<x,y`→`list@(0<x,y)`,
+  all-relational `a=b,c=d`→`formulae@`, and bare `a,b`→`list@` all stay. Full suite
+  1466/0, clippy clean, zero other-fixture changes; regression test in
+  `parse/relations`. **Remaining (follow-up):** the 3+-item `a,b,c \in S` goes
+  through `list_apply` (not `formulae_apply`) → still `list@(a,b,c∈S)`; the same
+  distribution needs porting to that path.
 - **relation with a list-RHS that itself contains a scripted relop**:
   `a \le b \quad \stackrel{?}{\ge} \quad c` → Perl `a <= list@(b, >=^?, c)`, Rust
   unparsed. The scripted-relop atomic fix (`4a5ebf29f7`) cleared standalone list

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -433,21 +433,32 @@ preview. We can never show `.eps`/`.pdf` on the web — always a web-native targ
 correctly (6/16 PNGs), so the symptom was a *failed* conversion shipping the raw
 source (now also visible via task 5's logging).
 
-**LANDED 2026-06-22 (`latexml_post/src/graphics.rs`).** Removed two raw-source
-leaks that diverged from Perl `Post/Graphics.pm`:
-- **Conversion-failure fallback** (was: `Error!` then `copy_to_destination` of
-  the raw source → `imagesrc="fig.eps"`). Perl L324-329 does `Error`/`Warn` +
-  `return` with NO imagesrc. Now matches: emit the `imageprocessing` Error and
-  leave `imagesrc` unset.
-- **`Plan::NotFound`** (was: `set_attribute("imagesrc", graphic)` → raw path for
-  a missing file). Perl L216-219 `Warn`s + `return` without imagesrc. Now Warn
-  only.
-- Both rely on the HTML5 XSLT (`LaTeXML-misc-xhtml.xsl:154`): a `<graphics>`
+**LANDED 2026-06-22 (`latexml_post/src/graphics.rs`).** THREE guards so a raw
+non-web-native source can never reach the web:
+1. **Conversion-failure fallback** (was: `Error!` then `copy_to_destination` of
+   the raw source → `imagesrc="fig.eps"`). Perl L324-329 does `Error`/`Warn` +
+   `return` with NO imagesrc. Now matches: emit the `imageprocessing` Error and
+   leave `imagesrc` unset.
+2. **`Plan::NotFound`** (was: `set_attribute("imagesrc", graphic)` → raw path for
+   a missing file). Perl L216-219 `Warn`s + `return` without imagesrc. Now Warn
+   only.
+3. **Plan routing default** (surpass-Perl): a source type with no explicit
+   `destination_type` now defaults to a WEB-NATIVE target — kept as-is for
+   web-native (svg/png/gif/jpg/jpeg), else `png`. Closes the hole where the
+   unmapped `.postscript` graphics_type (or any future addition) fell to
+   `dest_type == src_ext` → `Plan::Copy` (raw copy). Perl defaults dest_type to
+   srctype (Graphics.pm:244) and would copy such a source raw; we diverge so
+   non-web-native always routes through `Plan::Convert`.
+- All three rely on the HTML5 XSLT (`LaTeXML-misc-xhtml.xsl:154`): a `<graphics>`
   lacking `@imagesrc` renders as `class="ltx_missing ltx_missing_image"` (empty
-  src) — the correct "couldn't render" marker, never a broken `<img
-  src=".eps">`. `.eps`/`.ps`/`.pdf` all route through `Plan::Convert` (only
-  web-native rasters hit `Plan::Copy`), so this covers `.pdf` too. Suite 1467/0;
-  hep-th0101114 still 6 PNGs / zero `.eps` srcs.
+  src) — the correct "couldn't render" marker, never a broken `<img src=".eps">`.
+- **Witness verification (latexml_oxide --format=html5 --log --dest):**
+  hep-th0101114 → 6/6 `.eps`→PNG; astro-ph0004105 → 15/15 `.eps`→PNG; both with
+  ZERO raw `.eps`/`.pdf`/`.ps` srcs, ZERO `ltx_missing_image`, ZERO
+  `imageprocessing` errors. Suite 1467/0; clippy clean. **The `.eps`→web-image
+  conversion is confirmed working for both witnesses with the current binary —
+  the deployed preview's raw `.eps` was a previously-invisible failed conversion
+  / stale record, now both guarded against AND logged (task 5).**
 
 **Post-orchestration audit vs Perl `LaTeXML.pm::convert_post` + `Config.pm`
 (integrated path — the one cortex uses, NOT `bin/latexmlpost`).** Our

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -84,9 +84,10 @@ rerun is the clear next step:**
   severity (1189 tasks) on the **same local host** (env-artifact discipline).
   **Parity/env-artifact dominated; ONE genuine Rust-only correctness bug.**
   - `malformed` (162): all parity except **`ltx:itemize` in a `p{}` cell** — the
-    p{}-block-content bug (1510.07685), root = deferred **1610.00974 step-3**,
-    blocked on the same `\hsize`-invariant box model as Cluster G (see that entry).
-    `_CaptureBlock_`/listing errors are Perl-identical.
+    p{}-block-content bug (1510.07685), root = **1610.00974 step-3**, now
+    **✅ FIXED 2026-06-22** (`f65b80c1c2`, the p{}→VBox port, unblocked by the
+    Cluster G box-model fix `7545e07fd6`). `_CaptureBlock_`/listing errors are
+    Perl-identical (parity).
   - `latex` (31): all parity. Every package `\PackageError` (`\GenericError`,
     `(ifthen)`, `(newunicodechar)` 189, `(etoolbox)` 187, `(glossaries)` 224,
     `(pgfkeys)`) is shared. The `(babel)` `Unknown option 'russian'`/`'ukrainian'`
@@ -119,8 +120,8 @@ rerun is the clear next step:**
     real prerequisite for surfacing NEW genuine Rust-only correctness bugs; the
     stale data is still authoritative for *parity* and *env-artifact* classes
     (those don't change). **Conclusion: the entire `error` severity is mined out —
-    parity + env-artifacts, the one genuine find (p{} block content) blocked on the
-    box-model frame-ordering fix (1610.00974 step-3 / Cluster G).**
+    parity + env-artifacts; the one genuine find (p{} block content, 1510.07685) is
+    now ✅ FIXED (1610.00974 step-3 port + Cluster G box-model fix, 2026-06-22).**
 
 **NEXT: a FRESH cortex Rust rerun built from this branch** (needs
 `X-Cortex-Token`) is the prerequisite for mining genuine Rust-only *correctness*
@@ -444,61 +445,25 @@ Perl `dographics`.
 
 ## Deep deferred families (parked — large or shared; dedicated sessions)
 
-- **1610.00974 step-3** — port the *global* `p{}` column to the Perl VBox form
-  (`\lx@tabular@p`/VBoxContents). The narrow `\multicolumn{}{p{}}` case is fixed;
-  the global port exposes a `\cr`-mid-VBoxContents-predigest interleaving + a
-  span/sizing bug on `\multicolumn` over p-columns. Also explains the p-column
-  `td align="justify"` + width-on-`<p>` divergence (Perl: `align="left"` +
-  width-on-`<inline-block>`). **Related residuals catalogued
-  with minimal reproducers in `docs/reproducers/array_pcolumn/`** (Kind B: `>{}`
-  prefix align not on `<td>`; Kind C/D: regular `m{}`/`b{}` use a plain
-  `\vtop{}`/`\vbox{}` not the `\lx@tabular@p` VBox → width-on-`<td>` + inline-block
-  `vattach`/width drift). The `\multicolumn`-over-`m{}`/`b{}` GROUP ERROR in that
-  family is now **FIXED** (was 1805.01525 27→0; `tex_tables.rs`
-  `\lx@alignment@multicolumn` generalized from p{}-only to all paragraph columns).
-  - **NOT just surpass-Perl — also a CORRECTNESS bug (re-scoped 2026-06-22).**
-    The global `\vtop{\hbox to <w>..}` form opens the cell as an `ltx:p`
-    (`_noautoclose`), so **block content inside a `p{}` cell errors**:
-    `\begin{itemize}` (or any list/block) → `Error:malformed:ltx:itemize
-    <ltx:itemize> isn't allowed in <ltx:p>` (genuine Rust-only; Perl 0). New
-    witness **1510.07685** (Hera1706.tex): Rust 3 / Perl 0, full paper. Mined
-    from the cortex `error/malformed/ltx:itemize` report (the cross-join's only
-    non-parity, non-`todo` candidate; the rest of `error/malformed` is shared —
-    e.g. `_CaptureBlock_`/listing errors are Perl-identical). Reproducer:
-    `docs/reproducers/pcolumn_block_content_in_p.tex`.
-  - **De-risked 2026-06-22 (empirical port + revert).** Flipping the global p{}
-    to `\lx@tabular@p t {w} { … }` (matching Perl `DefColumnType('p{Dimension}')`)
-    + teaching `\lx@alignment@multicolumn` to splice directly when the column is
-    already `\lx@tabular@p`-shaped: the **non-rotated** common case becomes
-    **Perl-exact** — `colortbls`/`tabular`/`array` fixtures turn into clean parity
-    fixes (width moves onto `<inline-block>`; `<p class="ltx_align_left">` now
-    matches Perl; `<p width=>` count → 0 like Perl), and the witness goes 3 → 0.
-    Full suite 1462/5; the 5 failures are all p{}-tables, 3 clean parity fixes.
-  - **THE SOLE BLOCKER is rotated-table p-cell SIZING — and it is the SAME
-    root cause as Cluster G** ([`STABILITY_WITNESSES.md`](STABILITY_WITNESSES.md),
-    1707.02464). In a `\begin{sidewaystable}` (graphrot `rotfloat2`,
-    `{|llllllllp{1in}lp{1in}|}`; cells fixture) the rotated table width = original
-    height = Σ row heights, and Rust mis-computes the `p{1in}` cell **height**
-    (rotfloat2: Rust 810pt vs Perl 214pt) because Rust's vbox/paragraph dimensions
-    are **`\hsize`-invariant** (no `\hsize`-constrained line-breaking → wrong line
-    count → wrong height/width). The old `\hbox to <w>` form *forced* the width and
-    sidestepped this; the faithful VBox form exposes it. **PRECISE root cause
-    (2026-06-22): a frame-ordering bug**, not a missing wrap — the wrap machinery
-    (`compute_boxes_size_lines`) is correct, but `predigest_box_contents_in_mode`
-    pops the body-group frame (restoring the outer `\hsize`) BEFORE
-    `repack_horizontal_in_list` captures it, so vbox paragraphs always wrap at the
-    OUTER `\hsize`. Perl's `endMode` repacks BEFORE `popStackFrame` (one frame, not
-    two). **The frame-ordering fix LANDED 2026-06-22 (`7545e07fd6`) — see
-    `STABILITY_WITNESSES.md` Cluster G (FIXED).** `\hsize`-aware wrapping now applies
-    to p{} cells too (they use `\vtop`/VBoxContents), so this port's rotated-cell
-    sizing BLOCKER is RESOLVED. **Remaining step-3 work** (now unblocked, no longer
-    `\hsize`-blocked): flip the global `p{}` column to `\lx@tabular@p`/VBoxContents +
-    teach `\lx@alignment@multicolumn` to splice when the column is already
-    VBox-shaped (prototyped 2026-06-22: non-rotated tables become Perl-exact,
-    colortbls/tabular/array clean parity fixes) — then re-validate graphrot/cells
-    rotated sizing against Perl with the box-model fix in place, and fix the genuine
-    p{}-block-content correctness bug (1510.07685 `<ltx:itemize> isn't allowed in
-    <ltx:p>`). Reproducer: `docs/reproducers/pcolumn_block_content_in_p.tex`.
+- **1610.00974 step-3 — global p{} → Perl `\lx@tabular@p` VBox form — ✅ LANDED
+  2026-06-22 (`f65b80c1c2`).** The global `p{Dimension}` column now uses Perl's
+  `\lx@tabular@p t {width} { … }` (cell = `<ltx:inline-block>`, VBoxContents /
+  internal_vertical) instead of the old `\vtop{\hbox to <w>..}`;
+  `\lx@alignment@multicolumn` splices directly for the already-VBox-shaped column
+  (array.sty m{}/b{} keep the `\vtop`/`\vbox` transform). Unblocked by the box-model
+  fix (`7545e07fd6`, Cluster G). **Fixes the genuine Rust-only correctness bug
+  1510.07685** (`\begin{itemize}` in a `p{}` cell → 3→0 errors; the cell is now an
+  inline-block, not an `_noautoclose` `ltx:p`). rotfloat2 sidewaystable is now
+  near-Perl-exact (innerheight 69.1→98.6 vs Perl 98.5). All p{}-table fixtures moved
+  TOWARD-or-equal Perl (colortbls 73→41, tabular 39→21, graphrot 125→75,
+  alignment/array 18→14 diff lines vs local Perl; cells 72→72 — same cluster-B
+  family) and were re-baselined; suite 1467/0, clippy clean. The narrow
+  `\multicolumn{}{p{}}` and `\multicolumn`-over-`m{}`/`b{}` GROUP ERROR were already
+  fixed (1805.01525 27→0). **Residual (deferred, COSMETIC — cluster-B):** remaining
+  p{} diffs vs Perl are `>{}`-prefix align on `<td>` and regular `m{}`/`b{}`
+  `vattach`/width drift (m/b still use plain `\vtop{}`/`\vbox{}`, not
+  `\lx@tabular@p`). Reproducers: `docs/reproducers/array_pcolumn/` +
+  `pcolumn_block_content_in_p.tex`.
 - **`expected:id` cmml dangling-XMRef tail** — MathFork/split content-arm xml:id
   duplication; the last live `expected:id` class. See
   `EXPECTED_ID_XMREF_DESIGN_2026-06-08.md`.

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -394,17 +394,37 @@ unlogged, we **cannot tell from `cortex.log` whether Graphics ran-and-failed or 
 ran**. Fixing the logging is the prerequisite for diagnosing this and any future
 post-phase regression.
 
-**Fix design.** Provide a LOG_BUFFER equivalent spanning the post phase:
-`bind_log()` (or re-bind) immediately before `run_post_processing`, `flush_log()`
-after, and **append** the captured post-log to `response.log` before assembling the
-stored `cortex.log`. Convert the `post.rs` `eprintln!` failure sites to the
-capturable `Error!`/`Warn!`/`Note!` macros so they (a) land in the buffer and
-(b) bump the status counter, so `Status:conversion` reflects post failures. Remove
-the `graphics.rs` DBG `eprintln!`s. Mind the thread-locality (post must run on the
-same thread as `bind_log`; `convert_archive` is single-threaded per job, so OK).
-Verify: a forced EPS-tool failure yields a captured `Error:` line + non-zero
-`Status:`; a clean run's `cortex.log` now contains `graphics:process` / `MathML[`
-markers.
+**LANDED 2026-06-22 (latexml_oxide binary + shared wrapper); cortex_worker
+wiring deferred to the cortex-side owner.**
+- New shared wrapper `latexml::post::run_post_processing_logged() -> PostOutcome
+  { html, log, status_code }` (`latexml_oxide/src/post.rs`): re-binds the
+  thread-local `LOG_BUFFER` (which `convert()` already flushed) around
+  `run_post_processing`, then `flush_log()`s — the Rust equivalent of Perl's
+  single post-`convert_post` `flush_log()`. Captures every post-phase
+  `Info!`/`Warn!`/`post_error` (Graphics/MathML/XSLT), and reads the post
+  status from the shared (core+post) REPORT counter.
+- The `post.rs` failure `eprintln!`s are now `post_error()` (logs via
+  `log::error!` + `note_status(Error)` so they land in the buffer AND bump the
+  Error counter — but WITHOUT `Error!`'s too-many-errors `Fatal!`/`return`,
+  which would not typecheck in `run_post_processing`'s `String` return). The
+  splitnaming case is `Warn!`; the "Split into N" progress is `note_progress`.
+  Removed the two `graphics.rs` DBG `eprintln!`s.
+- `latexml_oxide` binary wired: `--log` and the archive-zip log now carry core
+  **+** post via `latexml_post::writer::write_output_segments(&[core, "\n",
+  post], dest)` — writes the (already-large) segments sequentially to avoid a
+  third concatenated allocation on the conversion path (cold archive path still
+  uses `assemble_conversion_log`, since `pack_archive` takes one `&str`). The
+  CLI exit status already reads post-inclusive `get_status_code()`.
+- **Verified:** `latexml_oxide --format=html5 --log=cortex.log --dest=test.html`
+  on hep-th0101114 → `cortex.log` now contains `scan:db_status`,
+  `graphics:process … 6 to process`, `math:converted`, `xslt:stylesheet`; 6
+  PNGs produced; suite 1467/0; clippy clean.
+- **Remaining:** `cortex_worker.rs::convert_archive` should call the same
+  `run_post_processing_logged` and fold `max(core, post.status_code)` into its
+  `Status:conversion` line (Perl `LaTeXML.pm` L631-634). The wrapper is ready;
+  the actual cortex_worker edit + `maxperf-cortex` rebuild are owned by the
+  cortex-side maintainer (per 2026-06-22 directive: leave the live fleet binary
+  alone).
 
 ---
 

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -102,6 +102,25 @@ rerun is the clear next step:**
     (`\bauthor`/`\bfnm`/`\btitle`/… + `{barticle}`, 16 papers) and `{diagram}`
     (17/19) are **Perl-also-undefined** (Perl LaTeXML ships no imsart/diagram
     binding either). Confirms "undefined = shared third-party CS".
+  - `unexpected` (268): the big "Script `_`/`^` can only appear in math mode" +
+    "Misplaced alignment tab `&`" clusters are **100% parity** under a FULLY
+    PAGINATED cross-join (`_` 109/109, `^` 45/45, `&` 51/51 papers — no math-mode
+    detection divergence; these are genuinely-malformed unescaped inputs both
+    engines flag). The only "candidates" were the `<char>` inputenc Cyrillic/latin
+    env-artifact cluster (0802.1123 isolatin, 1008.0492/1011.5076 babel-russian,
+    1009.2998 `[cp866]`+`[T2A]` — host missing the `.def`; same class as Clusters
+    A/C/E) and `\end{table}`/1805.00875 (**already FIXED** — see next).
+  - **META (2026-06-22): the cortex Rust service data is STALE** (predates recent
+    branch fixes). 1805.00875 (dcolumn) shows `unexpected/\end{table}` in the
+    cortex report but converts **0 errors on the current binary** (the 2026-06-21
+    dcolumn fix is in). So a flagged "Rust-only candidate" may already be fixed —
+    **always re-confirm on the current binary** (the genuine finds 1510.07685 /
+    1707.02464 were). A **fresh cortex Rust rerun built from this branch** is the
+    real prerequisite for surfacing NEW genuine Rust-only correctness bugs; the
+    stale data is still authoritative for *parity* and *env-artifact* classes
+    (those don't change). **Conclusion: the entire `error` severity is mined out —
+    parity + env-artifacts, the one genuine find (p{} block content) blocked on the
+    box-model frame-ordering fix (1610.00974 step-3 / Cluster G).**
 
 **NEXT: a FRESH cortex Rust rerun built from this branch** (needs
 `X-Cortex-Token`) is the prerequisite for mining genuine Rust-only *correctness*

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -71,6 +71,15 @@ rerun is the clear next step:**
   coverage fix is host-side (`tlmgr install cyrillic cm-super`), not a code bug;
   an optional surpass-Perl charset-decode fallback for missing inputenc `.def`s
   would convert them without the host package (needs authorization).**
+- *fatal/Timeout mining (2026-06-22)*: 18 papers → 16 Perl-fatal (parity), 2
+  candidates. `1506.09195` = missing custom `my_paper.sty` + deep expl3/datatool/
+  l3fp (local Perl also fatals; Rust runs the conditional runaway to the IfLimit
+  guard). **`1707.02464` = the ONE genuine Rust-only bug from all 53 fatal papers:
+  Perl completes in 11.76s, Rust hangs to the 60s watchdog** — a custom
+  `\narrow` macro's `\hsize`-shrink loop never terminates because Rust's vbox
+  `\ht` is `\hsize`-invariant (Perl models paragraph height ∝ `\hsize`). Recorded
+  as `STABILITY_WITNESSES.md` Cluster G (open; box-model fix, regression-risky,
+  warrants a focused session).
 
 **NEXT: a FRESH cortex Rust rerun built from this branch** (needs
 `X-Cortex-Token`) is the prerequisite for mining genuine Rust-only *correctness*

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -80,6 +80,28 @@ rerun is the clear next step:**
   `\ht` is `\hsize`-invariant (Perl models paragraph height ∝ `\hsize`). Recorded
   as `STABILITY_WITNESSES.md` Cluster G (open; box-model fix, regression-risky,
   warrants a focused session).
+- *error-severity sweep (2026-06-22)*: full cross-join of the cortex `error`
+  severity (1189 tasks) on the **same local host** (env-artifact discipline).
+  **Parity/env-artifact dominated; ONE genuine Rust-only correctness bug.**
+  - `malformed` (162): all parity except **`ltx:itemize` in a `p{}` cell** — the
+    p{}-block-content bug (1510.07685), root = deferred **1610.00974 step-3**,
+    blocked on the same `\hsize`-invariant box model as Cluster G (see that entry).
+    `_CaptureBlock_`/listing errors are Perl-identical.
+  - `latex` (31): all parity. Every package `\PackageError` (`\GenericError`,
+    `(ifthen)`, `(newunicodechar)` 189, `(etoolbox)` 187, `(glossaries)` 224,
+    `(pgfkeys)`) is shared. The `(babel)` `Unknown option 'russian'`/`'ukrainian'`
+    cluster (11 papers, cortex Perl=warning) is a **babel-VERSION env artifact**:
+    local babel.sty ≥3.9 (locale-based) errors on the `russian` *option*
+    (`russianb.ldf` absent), and **local Perl emits the IDENTICAL single error**
+    (0709.3796: Rust==Perl==1). The cortex Perl=warning host had pre-3.9 babel.
+    Same class as the isolatin/cp1251 phantoms; not a code bug (a `babel_lang_stubs`
+    russian/ukrainian stub would surpass local-Perl + overlap the Cyrillic
+    host-side decision → left as-is).
+  - `missing_file` (31), `misdefined` (3), `document` (2), `xpath` (2): all parity.
+  - `undefined` (890): top-20 whats all parity — the `imsart` bib cluster
+    (`\bauthor`/`\bfnm`/`\btitle`/… + `{barticle}`, 16 papers) and `{diagram}`
+    (17/19) are **Perl-also-undefined** (Perl LaTeXML ships no imsart/diagram
+    binding either). Confirms "undefined = shared third-party CS".
 
 **NEXT: a FRESH cortex Rust rerun built from this branch** (needs
 `X-Cortex-Token`) is the prerequisite for mining genuine Rust-only *correctness*

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -354,6 +354,58 @@ Version bumped, `runtime-bindings` in the artifact, `.deb` deps, CHANGELOG/READM
 done. **Remaining:** tag `0.7.0` on `main` → `release.yml` runs the TL-window
 `dumps` + macOS arm64 leg + publish (each first-exercised on that tag).
 
+### 5. Post-processing logging parity for cortex workflows (LOG_BUFFER over the post phase)
+**Goal:** `cortex.log` must carry BOTH core *and* post-processing
+(Scan→Bibliography→CrossRef→**Graphics**→Split→MathML→XSLT) stage information,
+so post-phase failures are captured and counted — not lost. Today the post phase
+is **invisible** in the stored log, which violates the project's #1 signal-integrity
+rule (CLAUDE.md "every `Error:`/`Fatal:` must be captured; fail-safe toward
+detecting failure").
+
+**Root cause (traced 2026-06-22).** The thread-local `LOG_BUFFER`
+(`latexml_core::util::logger`, `bind_log`/`flush_log`) is bound around the **core**
+conversion only. In `cortex_worker.rs::convert_archive`:
+- L370 `converter.convert(...)` runs the core conversion and **flushes** the buffer
+  internally (`converter.rs:167/285/443: log: self.flush_log()`), leaving
+  `LOG_BUFFER = None`.
+- L387 `run_post_processing(...)` then runs the post phases with the buffer
+  **already taken**, so nothing they emit can land in it.
+- L440 the stored log is built from `response.log` (core only) + `runtime_ms` +
+  `Status:`. (Confirmed empirically: a clean `cortex.log` for a 6-EPS paper had a
+  full core trace but **zero** `graphics:process`/`MathML[` lines.)
+
+**Two emission paths in post, both currently uncaptured:**
+1. Progress via `Note!` (`latexml_post/src/lib.rs:158`) → routes through the logger,
+   but is dropped because `LOG_BUFFER` is unbound during post.
+2. **Failures via raw `eprintln!`** in `latexml_oxide/src/post.rs`
+   (L127 parse, L174 Split, **L210 per-phase `"{label} failed"` — covers Graphics**,
+   L411 XSLT, L432 top-level, L476 page-write) → stderr only, never captured, and
+   they do **not** increment `common::error::REPORT`, so `Status:conversion` stays
+   `0`/OK on a real post failure (silent false-negative). Plus two leftover
+   `eprintln!("DBG …")` debug lines in `graphics.rs:1239/1287` to drop.
+
+**Why it matters (this session's trigger):** hep-th0101114 / astro-ph0004105 show
+raw `.eps` in the deployed preview. The current binary + fleet env convert all EPS→PNG
+correctly under `--standalone` (any profile — Graphics is **unconditional**,
+`post.rs:288`, NOT profile-gated; the ar5iv↔generic deltas are only
+`preload ar5iv.sty` / `noinvisibletimes` / `nodefaultresources`). So the deployed
+records were produced under different conditions — but because the post phase is
+unlogged, we **cannot tell from `cortex.log` whether Graphics ran-and-failed or never
+ran**. Fixing the logging is the prerequisite for diagnosing this and any future
+post-phase regression.
+
+**Fix design.** Provide a LOG_BUFFER equivalent spanning the post phase:
+`bind_log()` (or re-bind) immediately before `run_post_processing`, `flush_log()`
+after, and **append** the captured post-log to `response.log` before assembling the
+stored `cortex.log`. Convert the `post.rs` `eprintln!` failure sites to the
+capturable `Error!`/`Warn!`/`Note!` macros so they (a) land in the buffer and
+(b) bump the status counter, so `Status:conversion` reflects post failures. Remove
+the `graphics.rs` DBG `eprintln!`s. Mind the thread-locality (post must run on the
+same thread as `bind_log`; `convert_archive` is single-threaded per job, so OK).
+Verify: a forced EPS-tool failure yields a captured `Error:` line + non-zero
+`Status:`; a clean run's `cortex.log` now contains `graphics:process` / `MathML[`
+markers.
+
 ---
 
 ## Deep deferred families (parked — large or shared; dedicated sessions)

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -414,132 +414,31 @@ Version bumped, `runtime-bindings` in the artifact, `.deb` deps, CHANGELOG/READM
 done. **Remaining:** tag `0.7.0` on `main` → `release.yml` runs the TL-window
 `dumps` + macOS arm64 leg + publish (each first-exercised on that tag).
 
-### 5. Post-processing logging parity for cortex workflows (LOG_BUFFER over the post phase)
-**Goal:** `cortex.log` must carry BOTH core *and* post-processing
-(Scan→Bibliography→CrossRef→**Graphics**→Split→MathML→XSLT) stage information,
-so post-phase failures are captured and counted — not lost. Today the post phase
-is **invisible** in the stored log, which violates the project's #1 signal-integrity
-rule (CLAUDE.md "every `Error:`/`Fatal:` must be captured; fail-safe toward
-detecting failure").
+### 5. Post-processing logging parity for cortex workflows — LANDED 2026-06-22
+`cortex.log` now carries core **+** post (Scan→…→Graphics→MathML→XSLT). Shared
+wrapper `latexml::post::run_post_processing_logged() -> PostOutcome {html, log,
+status_code}` re-binds `LOG_BUFFER` around `run_post_processing` then flushes
+(Perl's single post-`convert_post` flush); post failures use `post_error()` →
+buffer + Error counter (no `Fatal!`/`return`). `latexml_oxide` `--log`/archive-zip
+wired via `writer::write_output_segments` (no third concat alloc). Commits
+`512dbc1ba2`, `9524d2e179`; suite 1467/0. **Residual (cortex-side owner):** wire
+`cortex_worker.rs::convert_archive` to the same wrapper + fold
+`max(core, post.status_code)` into `Status:conversion` (Perl `LaTeXML.pm` L631-634).
 
-**Root cause (traced 2026-06-22).** The thread-local `LOG_BUFFER`
-(`latexml_core::util::logger`, `bind_log`/`flush_log`) is bound around the **core**
-conversion only. In `cortex_worker.rs::convert_archive`:
-- L370 `converter.convert(...)` runs the core conversion and **flushes** the buffer
-  internally (`converter.rs:167/285/443: log: self.flush_log()`), leaving
-  `LOG_BUFFER = None`.
-- L387 `run_post_processing(...)` then runs the post phases with the buffer
-  **already taken**, so nothing they emit can land in it.
-- L440 the stored log is built from `response.log` (core only) + `runtime_ms` +
-  `Status:`. (Confirmed empirically: a clean `cortex.log` for a 6-EPS paper had a
-  full core trace but **zero** `graphics:process`/`MathML[` lines.)
-
-**Two emission paths in post, both currently uncaptured:**
-1. Progress via `Note!` (`latexml_post/src/lib.rs:158`) → routes through the logger,
-   but is dropped because `LOG_BUFFER` is unbound during post.
-2. **Failures via raw `eprintln!`** in `latexml_oxide/src/post.rs`
-   (L127 parse, L174 Split, **L210 per-phase `"{label} failed"` — covers Graphics**,
-   L411 XSLT, L432 top-level, L476 page-write) → stderr only, never captured, and
-   they do **not** increment `common::error::REPORT`, so `Status:conversion` stays
-   `0`/OK on a real post failure (silent false-negative). Plus two leftover
-   `eprintln!("DBG …")` debug lines in `graphics.rs:1239/1287` to drop.
-
-**Why it matters (this session's trigger):** hep-th0101114 / astro-ph0004105 show
-raw `.eps` in the deployed preview. The current binary + fleet env convert all EPS→PNG
-correctly under `--standalone` (any profile — Graphics is **unconditional**,
-`post.rs:288`, NOT profile-gated; the ar5iv↔generic deltas are only
-`preload ar5iv.sty` / `noinvisibletimes` / `nodefaultresources`). So the deployed
-records were produced under different conditions — but because the post phase is
-unlogged, we **cannot tell from `cortex.log` whether Graphics ran-and-failed or never
-ran**. Fixing the logging is the prerequisite for diagnosing this and any future
-post-phase regression.
-
-**LANDED 2026-06-22 (latexml_oxide binary + shared wrapper); cortex_worker
-wiring deferred to the cortex-side owner.**
-- New shared wrapper `latexml::post::run_post_processing_logged() -> PostOutcome
-  { html, log, status_code }` (`latexml_oxide/src/post.rs`): re-binds the
-  thread-local `LOG_BUFFER` (which `convert()` already flushed) around
-  `run_post_processing`, then `flush_log()`s — the Rust equivalent of Perl's
-  single post-`convert_post` `flush_log()`. Captures every post-phase
-  `Info!`/`Warn!`/`post_error` (Graphics/MathML/XSLT), and reads the post
-  status from the shared (core+post) REPORT counter.
-- The `post.rs` failure `eprintln!`s are now `post_error()` (logs via
-  `log::error!` + `note_status(Error)` so they land in the buffer AND bump the
-  Error counter — but WITHOUT `Error!`'s too-many-errors `Fatal!`/`return`,
-  which would not typecheck in `run_post_processing`'s `String` return). The
-  splitnaming case is `Warn!`; the "Split into N" progress is `note_progress`.
-  Removed the two `graphics.rs` DBG `eprintln!`s.
-- `latexml_oxide` binary wired: `--log` and the archive-zip log now carry core
-  **+** post via `latexml_post::writer::write_output_segments(&[core, "\n",
-  post], dest)` — writes the (already-large) segments sequentially to avoid a
-  third concatenated allocation on the conversion path (cold archive path still
-  uses `assemble_conversion_log`, since `pack_archive` takes one `&str`). The
-  CLI exit status already reads post-inclusive `get_status_code()`.
-- **Verified:** `latexml_oxide --format=html5 --log=cortex.log --dest=test.html`
-  on hep-th0101114 → `cortex.log` now contains `scan:db_status`,
-  `graphics:process … 6 to process`, `math:converted`, `xslt:stylesheet`; 6
-  PNGs produced; suite 1467/0; clippy clean.
-- **Remaining:** `cortex_worker.rs::convert_archive` should call the same
-  `run_post_processing_logged` and fold `max(core, post.status_code)` into its
-  `Status:conversion` line (Perl `LaTeXML.pm` L631-634). The wrapper is ready;
-  the actual cortex_worker edit + `maxperf-cortex` rebuild are owned by the
-  cortex-side maintainer (per 2026-06-22 directive: leave the live fleet binary
-  alone).
-
-### 6. Graphics: never ship a raw `.eps`/`.pdf` to the web + post-orchestration audit
-**Trigger:** hep-th0101114 / astro-ph0004105 showed raw `.eps` in the deployed
-preview. We can never show `.eps`/`.pdf` on the web — always a web-native target
-(`.png`/`.svg`). Verified the current binary converts both papers' EPS→PNG
-correctly (6/16 PNGs), so the symptom was a *failed* conversion shipping the raw
-source (now also visible via task 5's logging).
-
-**LANDED 2026-06-22 (`latexml_post/src/graphics.rs`).** THREE guards so a raw
-non-web-native source can never reach the web:
-1. **Conversion-failure fallback** (was: `Error!` then `copy_to_destination` of
-   the raw source → `imagesrc="fig.eps"`). Perl L324-329 does `Error`/`Warn` +
-   `return` with NO imagesrc. Now matches: emit the `imageprocessing` Error and
-   leave `imagesrc` unset.
-2. **`Plan::NotFound`** (was: `set_attribute("imagesrc", graphic)` → raw path for
-   a missing file). Perl L216-219 `Warn`s + `return` without imagesrc. Now Warn
-   only.
-3. **Plan routing default** (surpass-Perl): a source type with no explicit
-   `destination_type` now defaults to a WEB-NATIVE target — kept as-is for
-   web-native (svg/png/gif/jpg/jpeg), else `png`. Closes the hole where the
-   unmapped `.postscript` graphics_type (or any future addition) fell to
-   `dest_type == src_ext` → `Plan::Copy` (raw copy). Perl defaults dest_type to
-   srctype (Graphics.pm:244) and would copy such a source raw; we diverge so
-   non-web-native always routes through `Plan::Convert`.
-- All three rely on the HTML5 XSLT (`LaTeXML-misc-xhtml.xsl:154`): a `<graphics>`
-  lacking `@imagesrc` renders as `class="ltx_missing ltx_missing_image"` (empty
-  src) — the correct "couldn't render" marker, never a broken `<img src=".eps">`.
-- **Witness verification (latexml_oxide --format=html5 --log --dest):**
-  hep-th0101114 → 6/6 `.eps`→PNG; astro-ph0004105 → 15/15 `.eps`→PNG; both with
-  ZERO raw `.eps`/`.pdf`/`.ps` srcs, ZERO `ltx_missing_image`, ZERO
-  `imageprocessing` errors. Suite 1467/0; clippy clean. **The `.eps`→web-image
-  conversion is confirmed working for both witnesses with the current binary —
-  the deployed preview's raw `.eps` was a previously-invisible failed conversion
-  / stale record, now both guarded against AND logged (task 5).**
-
-**Post-orchestration audit vs Perl `LaTeXML.pm::convert_post` + `Config.pm`
-(integrated path — the one cortex uses, NOT `bin/latexmlpost`).** Our
-`run_post_processing` order — Split → Scan → MakeIndex → MakeBibliography →
-CrossRef → Graphics → {pmml/cmml} → XSLT — **matches** Perl's `@procs` order,
-and our always-on phases are equivalent to Perl's `if <option>` gates at their
-`Config.pm` defaults (`scan`/`index`/`crossref`/`dographics`/`numbersections`
-all default 1; `pmml` auto-added for html/xhtml/jats). **Faithful for the
-`ltx:graphics`/EPS path.** Known deltas (separate, broader parity — NOT blocking
-the EPS task; candidates for future work):
-- **`PictureImages` processor is absent.** Perl always pushes it (full if
-  `picimages`, else `empty_only=>1`); Rust handles `<ltx:picture>` via the
-  regex `extract_svg_fragments` + HTML5 inline-SVG injection instead.
-- **`SVG` is a regex extractor, not a `LaTeXML::Post::SVG` processor** (intentional
-  divergence; functional for HTML5 inline SVG).
-- **No `prescan` mode** (Perl gates most procs on `!prescan`; rare multi-pass
-  DB-build path, unused by cortex/CLI).
-- **Graphics is unconditional** in Rust vs Perl's `dographics` (which Config.pm
-  only defaults to 1 when a destination/archive exists) — so Rust attempts
-  graphics even for stdout output. Harmless for web (always has a destination);
-  matches Perl whenever a destination is set.
+### 6. Graphics: never ship a raw `.eps`/`.pdf` to the web — LANDED 2026-06-22
+THREE `latexml_post/src/graphics.rs` guards so a non-web-native source can never
+reach the web: (1) conversion-failure → `imageprocessing` Error + NO imagesrc
+(Perl L324-329); (2) `Plan::NotFound` → Warn only, no imagesrc (Perl L216-219);
+(3) plan-routing default → web-native target (svg/png/gif/jpg/jpeg kept, else
+`png`) so non-web-native always routes through `Plan::Convert` (surpass-Perl: Perl
+would `Plan::Copy` the raw source). A `<graphics>` without `@imagesrc` renders
+`ltx_missing_image`, never a broken `.eps` src. Verified: hep-th0101114 6/6,
+astro-ph0004105 15/15 EPS→PNG, zero raw srcs. Commits `80b4438385`, `604951c232`.
+Post-orchestration matches Perl `convert_post`/`Config.pm` at defaults
+(Split→Scan→Index→Bib→CrossRef→Graphics→pmml/cmml→XSLT). Known deltas (broader
+parity, not blocking): `PictureImages` absent (Rust = regex inline-SVG); `SVG` is a
+regex extractor (intentional divergence); no `prescan`; Graphics unconditional vs
+Perl `dographics`.
 
 ---
 

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -61,6 +61,16 @@ rerun is the clear next step:**
   macro defined via `TeX!(r"…")` raw-TeX blocks (single-backslash), so its
   flagged "gaps" are mostly false positives (verified: longtable `\LTcapwidth`
   etc. ARE defined). OmniBus was confirmed structurally complete this way.
+- *fatal/TooManyErrors mining (2026-06-22)*: **mined out — ZERO genuine
+  Rust-only bugs.** Of 35 `MaxLimit(100)` papers: 24 Perl-fatal (parity), **9 a
+  `cp1251`/Cyrillic env artifact** (all `[cp1251]{inputenc}`+`[T2A]{fontenc}`+
+  russian babel → ~100 `unexpected:<char>` each; the `cyrillic`/`t2` TeX package
+  is missing on this host so `cp1251.def`/`t2aenc.def` are absent — **local Perl
+  fails identically**, the cortex Perl=clean came from a host WITH the package),
+  2 stale/marginal. Same env-artifact family as the isolatin phantom. **Cyrillic
+  coverage fix is host-side (`tlmgr install cyrillic cm-super`), not a code bug;
+  an optional surpass-Perl charset-decode fallback for missing inputenc `.def`s
+  would convert them without the host package (needs authorization).**
 
 **NEXT: a FRESH cortex Rust rerun built from this branch** (needs
 `X-Cortex-Token`) is the prerequisite for mining genuine Rust-only *correctness*

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -122,6 +122,17 @@ rerun is the clear next step:**
     (those don't change). **Conclusion: the entire `error` severity is mined out —
     parity + env-artifacts; the one genuine find (p{} block content, 1510.07685) is
     now ✅ FIXED (1610.00974 step-3 port + Cluster G box-model fix, 2026-06-22).**
+  - **Current-binary same-host sweep (2026-06-22):** a fresh 24-paper deterministic
+    corpus sample (LaTeX2e + LaTeX 2.09 `\documentstyle` + revtex, multi-domain),
+    current Rust vs **verbose** local Perl (avoiding the `--quiet` trap). 21 real
+    TeX papers (3 were `\documentstyle` 2.09, 1 a misnamed PostScript file):
+    **ZERO Rust>Perl divergences — Rust is at-or-better than Perl on every paper.**
+    Parity on most (0/0, 33/33); **Rust BEATS Perl on 4** (1509.03503 Perl
+    timeout→Rust clean; 1604.03906 3 vs 101; astro-ph0210479 18 vs 101; 1712.01466
+    2 vs 3). Confirms the stale-DB mining: no genuine Rust-only bugs findable on the
+    current binary without a fresh cortex rerun. Sweep harness:
+    `tools/`-style `/tmp/sweep.sh` (grep `\documentclass` misses 2.09
+    `\documentstyle` — heuristic note, not a Rust gap).
 
 **NEXT: a FRESH cortex Rust rerun built from this branch** (needs
 `X-Cortex-Token`) is the prerequisite for mining genuine Rust-only *correctness*

--- a/docs/reproducers/pcolumn_block_content_in_p.tex
+++ b/docs/reproducers/pcolumn_block_content_in_p.tex
@@ -1,0 +1,49 @@
+% Reproducer: block content (a list) inside a `p{}` tabular column cell.
+%
+% GENUINE Rust-only correctness bug (Perl 0 errors / Rust 1 error), confirmed
+% 2026-06-22 against local Perl 0.8.8 on this host. Witness in the
+% sandbox-arxiv-10k-shuffle corpus: 1510.07685 (Hera1706.tex), which converts
+% with 3× `Error:malformed:ltx:itemize <ltx:itemize> isn't allowed in <ltx:p>`
+% in Rust and ZERO errors in Perl.
+%
+% Rust (current):  <td><inline-block><p width="..."><itemize>...   ⇒ malformed
+% Perl (correct):  <td><inline-block width="..."><itemize>...      ⇒ clean
+%
+% ROOT CAUSE — the global `p{Dimension}` column type
+% (latexml_engine/src/tex_tables.rs) wraps the cell in
+% `\vtop{\hbox to <w>\relax{...}}`. That `\hbox` (TeX_Box.pool.ltxml /
+% tex_box.rs `\hbox` constructor, vmode && !inline branch) opens an `ltx:p`
+% cell-container carrying `_noautoclose="true"`, so a block element like
+% `\begin{itemize}` cannot auto-close out of it → "isn't allowed in <ltx:p>".
+%
+% Perl's `p{Dimension}` column (TeX_Tables.pool.ltxml L69-80) instead builds the
+% cell via `\lx@tabular@p t {width} { ... }` → an `<ltx:inline-block>` whose body
+% is digested as VBoxContents (vertical mode): text auto-opens `<p>`, block
+% content nests directly. Rust ALREADY has `\lx@tabular@p@ ... VBoxContents`
+% (used for `\multicolumn{}{p{}}`) — the global column just doesn't use it.
+%
+% THE FAITHFUL FIX (global p{} → VBox form) is the deferred SYNC_STATUS
+% "1610.00974 step-3". It works structurally and is Perl-exact for non-rotated
+% tables (colortbls/tabular/array fixtures become clean parity fixes: width moves
+% onto <inline-block>, `<p class="ltx_align_left">` matches Perl), BUT it is
+% BLOCKED by the SAME box-model gap as Cluster G (1707.02464): Rust's
+% vbox/paragraph dimensions are `\hsize`-invariant, so a `p{}` cell inside a
+% ROTATED table (graphrot/cells fixtures, `\begin{sidewaystable}`) mis-sizes
+% (rotfloat2: Rust width 810pt vs Perl 214pt). Fixing the `\hsize`-constrained
+% line-breaking in the box model would unblock BOTH this port and Cluster G.
+\documentclass{article}
+\begin{document}
+\begin{table}
+\begin{tabular}{|p{6cm}|}
+\hline
+Some lead text in the cell\\
+\hline
+\begin{itemize}
+\item first
+\item second
+\end{itemize}
+\\
+\hline
+\end{tabular}
+\end{table}
+\end{document}

--- a/latexml_contrib/src/script_bindings/engine.rs
+++ b/latexml_contrib/src/script_bindings/engine.rs
@@ -954,6 +954,10 @@ pub(super) fn make_engine() -> Engine {
   engine.register_fn(
     "argString",
     |_w: &mut WhatsitProxy, n: i64| -> std::result::Result<String, Box<EvalAltResult>> {
+      // SAFETY: `current_whatsit()` returns the in-flight whatsit pointer the
+      // core published onto WHATSIT_CTX for the duration of THIS hook body (it
+      // errors out, not UB, when called outside one). The pointer is live for
+      // the call and read-only here (`&*`), so no aliasing `&mut` exists.
       let w = unsafe { &*current_whatsit()? };
       match w.get_arg(n as usize) {
         Some(d) => d.untex().map_err(rhai_err),
@@ -974,6 +978,11 @@ pub(super) fn make_engine() -> Engine {
           "setProperty in a construction hook (whatsit is read-only there)",
         ));
       }
+      // SAFETY: `ptr` is the in-flight whatsit the core published onto
+      // WHATSIT_CTX for THIS digestion-hook body, and the `mutable` flag (just
+      // checked) confirms it was published as writable. It is live for the
+      // call and the sole live reference (the hook body holds no other), so the
+      // re-minted `&mut` is unique and non-aliasing.
       let w = unsafe { &mut *ptr };
       w.set_property(key, val.to_string());
       Ok(())
@@ -983,6 +992,10 @@ pub(super) fn make_engine() -> Engine {
   engine.register_fn(
     "propertyString",
     |_w: &mut WhatsitProxy, key: &str| -> std::result::Result<String, Box<EvalAltResult>> {
+      // SAFETY: `current_whatsit()` returns the in-flight whatsit pointer the
+      // core published onto WHATSIT_CTX for the duration of THIS hook body (it
+      // errors out, not UB, when called outside one). The pointer is live for
+      // the call and read-only here (`&*`), so no aliasing `&mut` exists.
       let w = unsafe { &*current_whatsit()? };
       Ok(w.get_property_string(key))
     },

--- a/latexml_core/src/alignment.rs
+++ b/latexml_core/src/alignment.rs
@@ -645,9 +645,16 @@ impl BoxOps for Alignment {
         if let Some(d) = cell.cached_depth {
           cell_attrs.insert("cdepth".to_string(), format!("{}", d.px_value(None)));
         }
-        // Perl: always passes align attribute (Alignment.pm L350)
+        // Perl: always passes align attribute (Alignment.pm L350).
+        // A paragraph column (p/m/b/tabularx-X/tabulary — all `Align::Justify`)
+        // gets `align="left"` on the `<td>` in Perl, regardless of any `>{}`
+        // alignment prefix (the prefix's `\centering`/`\raggedleft` goes on the
+        // INNER `<inline-block>`/`<p>`, not the cell). Map the Justify marker
+        // (kept for `is_pcol` detection in `\lx@alignment@multicolumn`) to the
+        // Perl-faithful `"left"` here on the cell attribute only (cluster-B Kind-B).
         if let Some(ref align) = cell.align {
-          cell_attrs.insert(String::from("align"), align.name());
+          let td_align = if *align == Align::Justify { "left".to_string() } else { align.name() };
+          cell_attrs.insert(String::from("align"), td_align);
         }
         if let Some(ref vattach) = cell.vattach {
           cell_attrs.insert(String::from("vattach"), vattach.clone());

--- a/latexml_core/src/alignment.rs
+++ b/latexml_core/src/alignment.rs
@@ -653,7 +653,11 @@ impl BoxOps for Alignment {
         // (kept for `is_pcol` detection in `\lx@alignment@multicolumn`) to the
         // Perl-faithful `"left"` here on the cell attribute only (cluster-B Kind-B).
         if let Some(ref align) = cell.align {
-          let td_align = if *align == Align::Justify { "left".to_string() } else { align.name() };
+          let td_align = if *align == Align::Justify {
+            "left".to_string()
+          } else {
+            align.name()
+          };
           cell_attrs.insert(String::from("align"), td_align);
         }
         if let Some(ref vattach) = cell.vattach {

--- a/latexml_core/src/binding/content.rs
+++ b/latexml_core/src/binding/content.rs
@@ -3011,7 +3011,12 @@ pub fn convert_latex_args(
       }
       .init()?,
     );
-    nargs -= 1;
+    // Perl `convertLaTeXArgs` does `$nargs-- if $optional`; with `$nargs==0`
+    // that just yields an empty `1..$nargs` range. Saturate so the malformed
+    // `\newcommand\foo[0][d]{}` (0 args yet an optional default — outside
+    // LaTeX's 0..9 domain) can't underflow `usize` to ~2^64 and spin the loop
+    // below. Mirrors the sibling `convert_twoopt_args`.
+    nargs = nargs.saturating_sub(1);
   }
 
   for _ in 1..=nargs {

--- a/latexml_engine/src/amstex.rs
+++ b/latexml_engine/src/amstex.rs
@@ -444,20 +444,26 @@ LoadDefinitions!({
   // \innerhdotsfor / \spacehdots / \spaceinnerhdots — emit n copies
   // of \hdots (Perl L366-371). Uses sub-callback closures.
   DefMacro!("\\innerhdotsfor Number Match:\\after {}", sub[(n, _a, _b)] {
-    let count = n.value_of() as usize;
+    // Clamp like Perl's `1..$n` (empty for n<=0): a negative count must not
+    // wrap to ~2^64 and overflow `Vec::with_capacity` below.
+    let count = n.value_of().max(0) as usize;
     let mut out = Vec::with_capacity(count);
     for _ in 0..count { out.push(T_CS!("\\hdots")); }
     Tokens::new(out)
   });
   DefMacro!("\\spacehdots Number Match:\\for Number", sub[(n, _a, _b)] {
-    let count = n.value_of() as usize;
+    // Clamp like Perl's `1..$n` (empty for n<=0): a negative count must not
+    // wrap to ~2^64 and overflow `Vec::with_capacity` below.
+    let count = n.value_of().max(0) as usize;
     let mut out = Vec::with_capacity(count);
     for _ in 0..count { out.push(T_CS!("\\hdots")); }
     Tokens::new(out)
   });
   DefMacro!("\\spaceinnerhdots Number Match:\\for Number Match:\\after {}",
     sub[(n, _a, _b, _c, _d)] {
-      let count = n.value_of() as usize;
+      // Clamp like Perl's `1..$n` (empty for n<=0): a negative count must not
+      // wrap to ~2^64 and overflow `Vec::with_capacity` below.
+      let count = n.value_of().max(0) as usize;
       let mut out = Vec::with_capacity(count);
       for _ in 0..count { out.push(T_CS!("\\hdots")); }
       Tokens::new(out)

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -2180,6 +2180,52 @@ pub fn predigest_box_contents_in_mode(_tokens: ArgWrap, mode: &str) -> Result<Op
   // in the content will pop this frame, since \egroup is \let to T_END and
   // invoke_token handles it via the standard group-closing mechanism.
   // Perl: $stomach->beginMode($mode) — push a new frame for this box content scope
+  // VERTICAL box modes (`\vbox`/`\vtop`/p{}-cell VBoxContents): faithful port of
+  // Perl `readBoxContents` (TeX_Box.pool.ltxml L139-160). ONE mode frame as the
+  // group; a loop that STOPS at the matching `}` WITHOUT processing it, so
+  // `end_mode` runs `leave_horizontal_internal` (repack — capturing the *inner*
+  // `\hsize`) BEFORE `pop_stack_frame` restores it. The `invoke_token(&T_BEGIN!())`
+  // path used for other modes lets the body's `}` egroup-restore `\hsize` before
+  // the post-hoc repack, so a `\vbox{\hsize=W …para…}` would wrap at the OUTER
+  // `\hsize` (the Cluster G `\narrow`-hang; rotated p{}-cell mis-sizing —
+  // SYNC_STATUS 1610.00974 step-3). hbox/math don't paragraph-wrap → the simpler
+  // `invoke_token(T_BEGIN)` path below. (A tabular inside a `\vbox`/`\vtop` is
+  // correctly SKIPPED by the repack because `\@@tabular`/`\halign` mark the result
+  // box `internal_vertical`.)
+  if mode.ends_with("vertical") {
+    begin_mode(mode)?;
+    let level = get_frame_depth(); // depth AFTER the mode frame (Perl: $level)
+    new_local_box_list(); // Perl: local @LaTeXML::LIST = ()
+    loop {
+      let next = match get_pending_comment() {
+        Some(comment) => Some(comment),
+        None => read_x_token(Some(true), false, None)?,
+      };
+      let Some(token) = next else { break };
+      // Perl: last if T_END && (level >= getFrameDepth). The box's own `}` (no
+      // nested group open → depth == level) ends the loop and is closed by
+      // `end_mode`, NOT egroup; a nested group's `}` (depth > level) is processed.
+      if token.defined_as(&T_END!()) && level >= get_frame_depth() {
+        break;
+      }
+      check_timeout()?; // runaway guard (mirrors the canonical group-digest loop)
+      extend_box_list(invoke_token(&token)?);
+    }
+    // Perl: $stomach->endMode($mode) — leave_horizontal_internal (repack with the
+    // still-in-scope inner `\hsize`) THEN pop_stack_frame (restores `\hsize`).
+    end_mode(mode)?;
+    let mode_tex = if lookup_bool_sym(pin!("IN_MATH")) {
+      TexMode::Math
+    } else {
+      TexMode::Text
+    };
+    let mut digested_list = List::new(expire_local_box_list());
+    digested_list.mode = Some(mode_tex);
+    let mut item: Digested = digested_list.into();
+    // Perl: List(@LaTeXML::LIST, mode => $mode)
+    item.set_property("mode", Stored::String(pin(mode)));
+    return Ok(Some(simplify_vertical_list(item)));
+  }
   if mode.ends_with("vertical") || mode.ends_with("horizontal") {
     begin_mode(mode)?;
   }

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -7377,6 +7377,13 @@ LoadDefinitions!({
     before_digest => { bgroup(); },
     sizer        => "#3",
     after_digest  => sub[whatsit] {
+      // A tabular is a VERTICAL structure (like `\halign`, tex_tables.rs:312):
+      // mark the result box `internal_vertical` so a containing `\vbox`/`\vtop`'s
+      // paragraph repack (`repack_horizontal`) SKIPS it per-item rather than
+      // wrapping it to `\hsize`. Without this the box defaults to the `mode=>text`
+      // (horizontal-family) digestion mode and a `\vtop{\begin{tabular}…}` mis-
+      // measures at full `\hsize` (sizes_test 37→469.75pt). [DIAG part c]
+      whatsit.set_property("mode", Stored::from("internal_vertical"));
       if let Some(alignment) = lookup_alignment()
         && let DigestedData::Alignment(data) = alignment.data() {
           let attachment = if let Some(arg) = whatsit.get_arg(1) { translate_attachment(arg) }

--- a/latexml_engine/src/tex_box.rs
+++ b/latexml_engine/src/tex_box.rs
@@ -506,7 +506,19 @@ LoadDefinitions!({
   DefParameterType!(VBoxContents, sub[_inner, _extra] {
       read_box_contents(lookup_tokens("\\everyvbox")) },
     predigest => sub[arg] {
-      predigest_box_contents_in_mode(arg, "internal_vertical") });
+      predigest_box_contents_in_mode(arg, "internal_vertical") },
+    // The faithful vertical-box loop (`predigest_box_contents_in_mode`) rebuilds the
+    // body as a fresh `List::new(boxes)`, whose `revert()` concatenates the boxes
+    // WITHOUT the delimiting group braces (the old `invoke_token(T_BEGIN)` group
+    // box carried them). Re-add the `{}` here so `\vbox{a}` reverts to `\vbox{a}`
+    // (not `\vbox a`) — matching Perl. Mirrors the standard `{}`-arg `Plain`/
+    // `DefPlain` reversion (base_parameter_types.rs).
+    reversion => sub[arg, _inner, _extra] {
+      let mut t: Vec<Token> = vec![T_BEGIN!()];
+      t.extend(arg);
+      t.push(T_END!());
+      Ok(Tokens::new(t))
+    });
 
   // This re-binds a number of important control sequences to their default text binding.
   // This is useful within common boxing or footnote macros that can appear within

--- a/latexml_engine/src/tex_box.rs
+++ b/latexml_engine/src/tex_box.rs
@@ -504,21 +504,21 @@ LoadDefinitions!({
     predigest => sub[arg] {
       predigest_box_contents_in_mode(arg, "restricted_horizontal") });
   DefParameterType!(VBoxContents, sub[_inner, _extra] {
-      read_box_contents(lookup_tokens("\\everyvbox")) },
-    predigest => sub[arg] {
-      predigest_box_contents_in_mode(arg, "internal_vertical") },
-    // The faithful vertical-box loop (`predigest_box_contents_in_mode`) rebuilds the
-    // body as a fresh `List::new(boxes)`, whose `revert()` concatenates the boxes
-    // WITHOUT the delimiting group braces (the old `invoke_token(T_BEGIN)` group
-    // box carried them). Re-add the `{}` here so `\vbox{a}` reverts to `\vbox{a}`
-    // (not `\vbox a`) — matching Perl. Mirrors the standard `{}`-arg `Plain`/
-    // `DefPlain` reversion (base_parameter_types.rs).
-    reversion => sub[arg, _inner, _extra] {
-      let mut t: Vec<Token> = vec![T_BEGIN!()];
-      t.extend(arg);
-      t.push(T_END!());
-      Ok(Tokens::new(t))
-    });
+    read_box_contents(lookup_tokens("\\everyvbox")) },
+  predigest => sub[arg] {
+    predigest_box_contents_in_mode(arg, "internal_vertical") },
+  // The faithful vertical-box loop (`predigest_box_contents_in_mode`) rebuilds the
+  // body as a fresh `List::new(boxes)`, whose `revert()` concatenates the boxes
+  // WITHOUT the delimiting group braces (the old `invoke_token(T_BEGIN)` group
+  // box carried them). Re-add the `{}` here so `\vbox{a}` reverts to `\vbox{a}`
+  // (not `\vbox a`) — matching Perl. Mirrors the standard `{}`-arg `Plain`/
+  // `DefPlain` reversion (base_parameter_types.rs).
+  reversion => sub[arg, _inner, _extra] {
+    let mut t: Vec<Token> = vec![T_BEGIN!()];
+    t.extend(arg);
+    t.push(T_END!());
+    Ok(Tokens::new(t))
+  });
 
   // This re-binds a number of important control sequences to their default text binding.
   // This is useful within common boxing or footnote macros that can appear within

--- a/latexml_engine/src/tex_tables.rs
+++ b/latexml_engine/src/tex_tables.rs
@@ -110,22 +110,24 @@ LoadDefinitions!({
     });
   });
 
-  // Perl: p{Dimension} — before wraps content in \vtop{\hbox to <width>\relax{...}}.
-  // Width flows through \hbox BoxSpecification (not as cell attribute).
-  // vattach flows through \vtop → insertBlock.
-  // Perl: before => Tokens(\vtop, {, \hbox, T_LETTER('t'), T_LETTER('o'), $_[1]->revert, \relax, {)
+  // Perl TeX_Tables L69-74: p{Dimension} builds the cell as a *VBox* via
+  // `\lx@tabular@p t {width} { … }` → `<ltx:inline-block>` (VBoxContents, digested
+  // in internal_vertical mode), so text auto-opens `<p>` and block content (lists,
+  // etc.) nests directly. Replaces the earlier Rust `\vtop{\hbox to <w>\relax{…}}`
+  // divergence whose `\hbox`-opened `ltx:p` cell-container (with `_noautoclose`)
+  // rejected block content (1510.07685: `\begin{itemize}` in a `p{}` cell →
+  // malformed `<ltx:itemize> isn't allowed in <ltx:p>`). The `\hsize`-aware vbox
+  // paragraph wrap (box-model fix `7545e07fd6`) now sizes these cells correctly,
+  // so this faithful form no longer mis-sizes (was the blocker on 1610.00974).
+  // before => Tokens(\lx@tabular@p, T_LETTER('t'), {, <width>, }, {); after => }
   DefColumnType!("p{Dimension}", sub[(width)] {
-    // Build before tokens: \vtop { \hbox to <dim> \relax {
-    let mut before = vec![
-      T_CS!("\\vtop"), T_BEGIN!(), T_CS!("\\hbox"),
-    ];
-    before.extend(ExplodeText!("to"));
+    let mut before = vec![T_CS!("\\lx@tabular@p"), T_LETTER!("t"), T_BEGIN!()];
     before.extend(width.revert()?.unlist());
-    before.push(T_CS!("\\relax"));
+    before.push(T_END!());
     before.push(T_BEGIN!());
     with_current_build_template(|template_opt| template_opt.unwrap().add_column(Cell {
       before: Some(Tokens::new(before)),
-      after: Some(Tokens!(T_END!(), T_END!())),
+      after: Some(Tokens!(T_END!())),
       align: Some(Align::Justify),
       vattach: Some("top".to_string()),
       ..Cell::default()}));
@@ -596,6 +598,31 @@ LoadDefinitions!({
         column.and_then(|c| c.before.as_ref()).map(|b| b.unlist_ref().clone()).unwrap_or_default();
       let after_toks: Vec<Token> =
         column.and_then(|c| c.after.as_ref()).map(|a| a.unlist_ref().clone()).unwrap_or_default();
+      // Rebind only top-level `\\` (depth 0) in the body to `\lx@newline`, so an
+      // embedded `\\` is a paragraph line break, not the alignment row terminator.
+      let rebind_newline = |body: &Tokens, out: &mut Vec<Token>| {
+        let dbl = T_CS!("\\\\");
+        let nl = T_CS!("\\lx@newline");
+        let mut depth = 0i32;
+        for t in body.unlist_ref().iter() {
+          match t.get_catcode() {
+            Catcode::BEGIN => { depth += 1; out.push(*t); },
+            Catcode::END => { depth -= 1; out.push(*t); },
+            _ if depth == 0 && *t == dbl => out.push(nl),
+            _ => out.push(*t),
+          }
+        }
+      };
+      // The global `p{}` column is now ALREADY in the Perl-faithful `\lx@tabular@p`
+      // VBox form (TeX_Tables L69-74), so Perl's `\lx@alignment@multicolumn` just
+      // splices before+body+after with no box rewrite. Mirror that. Only array.sty
+      // `m{}`/`b{}` (raw `\vtop{`/`\vbox{`) still need the transform below.
+      if before_toks.iter().any(|t| *t == T_CS!("\\lx@tabular@p")) {
+        tks.extend(before_toks.iter().copied());
+        rebind_newline(&body, &mut tks);
+        tks.extend(after_toks.iter().copied());
+        return Ok(Tokens::new(tks));
+      }
       // Width: the global `p{}` encodes it in `\hbox to <w> \relax`; `m{}`/`b{}`
       // carry it on the Cell — fall back to that when the tokens lack it.
       let mut width = extract_pcol_width(&before_toks);
@@ -663,18 +690,8 @@ LoadDefinitions!({
       tks.push(T_BEGIN!());
       // `>{…}` declarations belong inside the cell, before the body.
       tks.extend(decls);
-      // Rebind only top-level `\\` (depth 0); nested groups keep their meaning.
-      let dbl = T_CS!("\\\\");
-      let nl = T_CS!("\\lx@newline");
-      let mut depth = 0i32;
-      for t in body.unlist_ref().iter() {
-        match t.get_catcode() {
-          Catcode::BEGIN => { depth += 1; tks.push(*t); }
-          Catcode::END => { depth -= 1; tks.push(*t); }
-          _ if depth == 0 && *t == dbl => tks.push(nl),
-          _ => tks.push(*t),
-        }
-      }
+      // Rebind top-level `\\` (depth 0); nested groups keep their meaning.
+      rebind_newline(&body, &mut tks);
       tks.extend(inner_after.iter().copied()); // e.g. \lx@column@trimright, inside the box
       tks.push(T_END!()); // close the VBoxContents
       tks.extend(border_suffix.iter().copied()); // trailing border / intercolumn

--- a/latexml_math_parser/src/semantics.rs
+++ b/latexml_math_parser/src/semantics.rs
@@ -562,7 +562,103 @@ pub fn formulae_apply(
     }
     return Ok(left);
   }
+  // Comma-list LEFT of a relation: `a,b \in A` / `x,y \le z`. The grammar reaches
+  // here with `left` a bare (non-relational) item and `right` a binary RELOP
+  // relation `Apply(∈,[b,A])`. The plain `formulae@(a, b∈A)` is semantically wrong
+  // (∈ binds only `b`, splitting `a` off). Build the user-specified XMDual
+  // (2026-06-22): content DISTRIBUTES the relation over the list, presentation
+  // wraps the list as the relation's LHS. (List-RIGHT `0<x,y` is the separate
+  // `formula relop formula_list` path → `list(0<x,y)`, untouched.)
+  if !left_rel
+    && !sep_is_period
+    && left.as_ref().is_some_and(|l| !matches!(l, XM::Dual(..)))
+    && matches!(&right, XM::Apply(op, Args(a), ..) if a.len() == 2 && op_is_relop(op))
+  {
+    return Ok(Some(distribute_list_relation(
+      left.unwrap(),
+      sep,
+      right,
+      ctxt,
+    )?));
+  }
   list_or_formulae_create(left.unwrap(), sep, right, meaning, ctxt)
+}
+
+/// True iff `op` is a binary RELOP operator (`∈`, `≤`, `=`, …) — NOT a
+/// `multirelation` chain. Used to gate `distribute_list_relation`.
+fn op_is_relop(op: &Operator) -> bool {
+  match &*op.0 {
+    XM::Token(p, _) => {
+      p.meaning.as_deref() != Some("multirelation")
+        && p.role.as_deref().is_some_and(|r| r.contains("RELOP"))
+    },
+    XM::Lexeme(lex, _) => lex.split(':').next().is_some_and(|r| r.contains("RELOP")),
+    _ => false,
+  }
+}
+
+/// `a,b \in A` → the user-specified XMDual (2026-06-22, surpass-Perl): the content
+/// branch DISTRIBUTES the relation over each list element —
+/// `formulae@(∈(a,A), ∈(b,A))`, sharing XMRefs to the relop (∈) and RHS (A) — while
+/// the presentation branch wraps the list `a,b` in an `<XMWrap>` as the relation's
+/// LHS — `Apply(∈, XMWrap(a,',',b), A)`. `right` MUST be a binary RELOP relation
+/// (caller guarantees via `op_is_relop`).
+fn distribute_list_relation(
+  mut left: XM,
+  sep: XM,
+  right: XM,
+  ctxt: ActionContext,
+) -> Result<XM, Box<dyn Error>> {
+  let XM::Apply(Operator(r_op_box), Args(mut r_args), ..) = right else {
+    unreachable!("distribute_list_relation: caller guarantees a binary relation")
+  };
+  let mut rhs = r_args.pop().flatten().unwrap();
+  let mut lhs = r_args.pop().flatten().unwrap();
+  let mut r_op = *r_op_box;
+  // Ref the four presentation nodes (left, lhs, rhs, relop); rhs and relop are
+  // shared across the two distributed content relations.
+  let refs = create_xmrefs(&mut [&mut left, &mut lhs, &mut rhs, &mut r_op], ctxt)?;
+  let mut it = refs.into_iter();
+  let ref_left = it.next().unwrap();
+  let ref_lhs = it.next().unwrap();
+  let ref_rhs = it.next().unwrap();
+  let ref_rop = it.next().unwrap();
+  let mk_rel = |op: XM, l: XM, r: XM| {
+    XM::Apply(
+      Operator(Box::new(op)),
+      Args(vec![Some(l), Some(r)]),
+      XProps::default(),
+      Meta::default(),
+    )
+  };
+  // content: formulae@(∈(a,A), ∈(b,A))
+  let rel1 = mk_rel(ref_rop.clone(), ref_left, ref_rhs.clone());
+  let rel2 = mk_rel(ref_rop, ref_lhs, ref_rhs);
+  let formulae_op: XM = XProps {
+    meaning: Some(Cow::Borrowed("formulae")),
+    ..XProps::default()
+  }
+  .into();
+  let content = XM::Apply(
+    Operator(Box::new(formulae_op)),
+    Args(vec![Some(rel1), Some(rel2)]),
+    XProps::default(),
+    Meta::default(),
+  );
+  // presentation: ∈(XMWrap(a,',',b), A)
+  let pres_wrap = XM::Wrap(vec![left, sep, lhs], XProps::default(), Meta::default());
+  let pres = XM::Apply(
+    Operator(Box::new(r_op)),
+    Args(vec![Some(pres_wrap), Some(rhs)]),
+    XProps::default(),
+    Meta::default(),
+  );
+  Ok(XM::Dual(
+    Box::new(content),
+    Box::new(pres),
+    XProps::default(),
+    Meta::default(),
+  ))
 }
 
 fn list_or_formulae_create(

--- a/latexml_oxide/Cargo.toml
+++ b/latexml_oxide/Cargo.toml
@@ -7,7 +7,7 @@ license = "CC0-1.0"
 homepage = "https://github.com/dginev/latexml-oxide"
 repository = "https://github.com/dginev/latexml-oxide"
 readme = "README.md"
-description = "A TeX to XML/HTML/ePub converster: a LaTeXML reimplementation in Rust"
+description = "A TeX to XML/HTML/ePub converter: a LaTeXML reimplementation in Rust"
 default-run = "latexml_oxide"
 
 [lints]

--- a/latexml_oxide/bin/cortex_worker.rs
+++ b/latexml_oxide/bin/cortex_worker.rs
@@ -516,6 +516,9 @@ fn read_max_rss_kb_proc() -> u64 {
 /// Read accumulated child user/sys CPU time in microseconds via getrusage(2).
 #[cfg(unix)]
 fn read_child_rusage_us_proc() -> (u64, u64) {
+  // SAFETY: `ru` points to a valid, zeroed `libc::rusage`; getrusage(2) only
+  // writes through it on success, and the `tv_sec`/`tv_usec` fields are read
+  // only after the `== 0` success check.
   unsafe {
     let mut ru: libc::rusage = std::mem::zeroed();
     if libc::getrusage(libc::RUSAGE_CHILDREN, &mut ru) == 0 {

--- a/latexml_oxide/bin/latexml_oxide.rs
+++ b/latexml_oxide/bin/latexml_oxide.rs
@@ -686,6 +686,14 @@ fn real_main() -> Result<(), Box<dyn Error>> {
       converter.convert(source)
     };
     let _ = &source_for_post; // keep alive for post-processing
+    // Post-phase log (Graphics/MathML/XSLT) captured by
+    // `run_post_processing_logged`; written after the core log into --log / the
+    // archive log so BOTH conversion phases reach the persisted log (SYNC_STATUS
+    // task 5; Perl LaTeXML.pm flushes once after convert_post). Declared out here
+    // (not in the `Some(xml)` arm) so the post-if-let --log write can still see
+    // it; stays empty when post-processing is skipped, keeping that --log
+    // byte-identical to before.
+    let mut post_log = String::new();
     if let Some(xml) = response.result {
       // Infer format from --dest extension if --format not specified (Perl Config.pm L408-441)
       let inferred_format: Option<String> = cli
@@ -832,7 +840,7 @@ fn real_main() -> Result<(), Box<dyn Error>> {
         // does something useful out of the box.
         let default_pmml_for_xml_input =
           xml_input_mode && !cli.pmml && effective_stylesheet.is_none();
-        let output = run_post_processing(&xml, &PostOptions {
+        let post = latexml::post::run_post_processing_logged(&xml, &PostOptions {
           pmml: cli.pmml || cli.post || is_html_format || default_pmml_for_xml_input,
           cmml: cli.cmml,
           keep_xmath: cli.keep_xmath,
@@ -854,6 +862,8 @@ fn real_main() -> Result<(), Box<dyn Error>> {
           graphics_svg_threshold_kb: cli.graphics_svg_threshold_kb,
           whatsout: whatsout_mode,
         });
+        let output = post.html;
+        post_log = post.log;
         if let Some(zip_dest) = zip_dest {
           // whatsout=archive: pack the full document + resources into a ZIP.
           latexml_post::writer::ensure_parent_dir(&zip_dest)?;
@@ -874,7 +884,7 @@ fn real_main() -> Result<(), Box<dyn Error>> {
             html_filename: &html_name,
             html: &output,
             log_filename: Some(&log_name),
-            log: &response.log,
+            log: &assemble_conversion_log(&response.log, &post_log),
             status: &response.status,
             resource_dir,
             telemetry_json: None,
@@ -896,7 +906,18 @@ fn real_main() -> Result<(), Box<dyn Error>> {
     if let Some(ref log_path) = cli.log
       && !is_archive_out
     {
-      latexml_post::writer::write_output(&response.log, Some(log_path))?;
+      // Write the core log and the post-phase log sequentially rather than
+      // concatenating — both are already-allocated and large for real
+      // articles, so a merged `format!` would allocate a third copy of their
+      // combined size on the conversion path.
+      if post_log.is_empty() {
+        latexml_post::writer::write_output_segments(&[response.log.as_str()], Some(log_path))?;
+      } else {
+        latexml_post::writer::write_output_segments(
+          &[response.log.as_str(), "\n", post_log.as_str()],
+          Some(log_path),
+        )?;
+      }
       eprintln!("Log written to {}", log_path);
     }
   }
@@ -1025,11 +1046,17 @@ fn read_child_rusage_us() -> (u64, u64) { (0, 0) }
 
 use latexml::post::PostOptions;
 
-/// Delegate post-processing to the library API.
-fn run_post_processing(xml: &str, opts: &PostOptions) -> String {
-  // Per-phase telemetry now lives inside latexml::post::run_post_processing
-  // (PostXmlParse, PostScan, Bibliography, Crossref, Graphics, Split, Xslt).
-  latexml::post::run_post_processing(xml, opts)
+/// Assemble the persisted conversion log: core conversion log followed by the
+/// captured post-phase log (Graphics/MathML/XSLT). Mirrors Perl `LaTeXML.pm`,
+/// whose single `flush_log()` after `convert_post` returns both phases in one
+/// buffer. `post_log` is empty when post-processing was skipped, in which case
+/// the core log is returned unchanged (no behavioral drift for non-post runs).
+fn assemble_conversion_log(core_log: &str, post_log: &str) -> String {
+  if post_log.trim().is_empty() {
+    core_log.to_string()
+  } else {
+    format!("{}\n{}", core_log.trim_end(), post_log.trim_end())
+  }
 }
 
 // `ensure_parent_dir` now lives in `latexml_post::writer` so all

--- a/latexml_oxide/src/lsp_server/unix.rs
+++ b/latexml_oxide/src/lsp_server/unix.rs
@@ -42,6 +42,9 @@ impl FdReader {
   fn fill(&mut self) -> std::io::Result<usize> {
     let mut tmp = [0u8; 8192];
     loop {
+      // SAFETY: self.fd is an owned, still-open read fd (stdin=0 or a test pipe end);
+      // tmp.as_mut_ptr()/tmp.len() describe a valid, fully-initialized [u8; 8192] region,
+      // and read(2) only writes up to len bytes into it.
       let n = unsafe { libc::read(self.fd, tmp.as_mut_ptr() as *mut libc::c_void, tmp.len()) };
       if n < 0 {
         let err = std::io::Error::last_os_error();
@@ -143,6 +146,9 @@ fn parse_content_length(header: &[u8]) -> Option<usize> {
 /// `124` on timeout / `137` on the memory ceiling.
 fn reap(pid: i32) -> i32 {
   let mut status = 0i32;
+  // SAFETY: &mut status is a valid &mut i32 the kernel writes the exit status
+  // through; pid is a child this server forked. waitpid/WIF* only read that pid
+  // and the local status word — no other memory is touched.
   unsafe {
     libc::waitpid(pid, &mut status, 0);
     if libc::WIFEXITED(status) {
@@ -198,6 +204,9 @@ fn wait_for_child(
   pending: &mut VecDeque<String>,
 ) -> WarmResult {
   // Owns `read_fd`; closes it on every return path.
+  // SAFETY: read_fd is a freshly-created, still-open pipe read end returned by
+  // spawn_body_child and not owned by any other File; from_raw_fd takes sole
+  // ownership so the fd is closed exactly once when `pipe` drops.
   let mut pipe = unsafe { std::fs::File::from_raw_fd(read_fd) };
 
   loop {
@@ -236,6 +245,9 @@ fn wait_for_child(
         revents: 0,
       },
     ];
+    // SAFETY: fds is a live [pollfd; 2] on the stack; fds.as_mut_ptr()/fds.len()
+    // describe exactly that array, and poll(2) only reads .fd/.events and writes
+    // .revents within those two elements. fd 0 and read_fd are both open.
     let rc = unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as libc::nfds_t, -1) };
     if rc < 0 {
       let err = std::io::Error::last_os_error();
@@ -284,18 +296,24 @@ fn wait_for_child(
 /// `setsid`-detached converter grandchildren that would otherwise be
 /// orphaned with no watcher.
 fn kill_and_reap(pid: i32) {
+  // SAFETY: pid is a child this server forked; kill(2) only delivers a signal to
+  // that pid and touches no process memory.
   unsafe {
     libc::kill(pid, libc::SIGTERM);
   }
   // Brief grace: poll for exit up to ~50 ms before escalating.
   for _ in 0..10 {
     let mut status = 0i32;
+    // SAFETY: &mut status is a valid &mut i32 the kernel may write through; pid is
+    // a child we forked. waitpid only reads pid and writes the local status word.
     let r = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
     if r == pid {
       return; // already reaped
     }
     std::thread::sleep(std::time::Duration::from_millis(5));
   }
+  // SAFETY: pid is a child this server forked; kill(2) only delivers SIGKILL to
+  // that pid and touches no process memory.
   unsafe {
     libc::kill(pid, libc::SIGKILL);
   }
@@ -400,6 +418,8 @@ fn spawn_body_child(
   max_rss_kb: u64,
 ) -> Result<(i32, i32), String> {
   let mut fds = [0i32; 2];
+  // SAFETY: fds.as_mut_ptr() points to a valid [i32; 2]; pipe(2) writes exactly
+  // two fds (read, write) into it on success and touches nothing else.
   unsafe {
     if libc::pipe(fds.as_mut_ptr()) < 0 {
       return Err("pipe() failed".to_string());
@@ -427,8 +447,15 @@ fn spawn_body_child(
     );
   }
 
+  // SAFETY: fork(2) only duplicates the calling process. The invariant asserted
+  // above guarantees no extra thread holds the allocator/logger lock at fork time,
+  // so the single-threaded child can proceed; in the child below, between fork and
+  // _exit/exec we restrict ourselves to async-signal-safe libc calls until the
+  // Watchdog/digest path is entered.
   let pid = unsafe { libc::fork() };
   if pid < 0 {
+    // SAFETY: read_fd and write_fd are the still-open pipe ends from the pipe(2)
+    // call above; closing each exactly once on the fork-failure path is sound.
     unsafe {
       libc::close(read_fd);
       libc::close(write_fd);
@@ -438,6 +465,10 @@ fn spawn_body_child(
 
   if pid == 0 {
     // ---- child ----
+    // SAFETY: runs in the freshly-forked single-threaded child. read_fd/write_fd
+    // are the inherited pipe ends; close/open/dup2 are async-signal-safe and only
+    // mutate this child's fd table. The c"/dev/null" literal is a valid NUL-
+    // terminated C string, and dup2/close are guarded on a successful open.
     unsafe {
       libc::close(read_fd);
       // Insurance: the child inherits the parent's stdout (fd 1) — the LSP
@@ -453,6 +484,9 @@ fn spawn_body_child(
     }
     let payload = run_body_child(uri, offset_lines, body, warmed, timeout_secs, max_rss_kb);
     let bytes = payload.to_string().into_bytes();
+    // SAFETY: write_fd is the still-open pipe write end inherited by this child and
+    // owned by nothing else here; from_raw_fd takes sole ownership so it is closed
+    // exactly once (on the explicit drop below), signalling EOF to the parent.
     let mut file = unsafe { std::fs::File::from_raw_fd(write_fd) };
     let _ = file.write_all(&bytes);
     let _ = file.flush();
@@ -461,6 +495,9 @@ fn spawn_body_child(
   }
 
   // ---- parent ----
+  // SAFETY: write_fd is the still-open pipe write end; the parent keeps only the
+  // read end (read_fd), so closing the write end exactly once here is sound and
+  // lets the parent observe EOF once the child's copy closes.
   unsafe {
     libc::close(write_fd);
   }
@@ -902,16 +939,23 @@ mod framing_tests {
   impl PipePair {
     fn new() -> Self {
       let mut fds = [0i32; 2];
+      // SAFETY: fds.as_mut_ptr() points to a valid [i32; 2]; pipe(2) writes exactly
+      // two fds into it on success and touches nothing else.
       assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
       PipePair { r: fds[0], w: fds[1] }
     }
     fn write(&self, bytes: &[u8]) {
+      // SAFETY: self.w is the owned, still-open pipe write end; bytes.as_ptr()/
+      // bytes.len() describe a valid initialized region, and write(2) only reads
+      // up to len bytes from it.
       let n = unsafe { libc::write(self.w, bytes.as_ptr() as *const libc::c_void, bytes.len()) };
       assert_eq!(n, bytes.len() as isize);
     }
   }
   impl Drop for PipePair {
     fn drop(&mut self) {
+      // SAFETY: self.r and self.w are the two owned, still-open pipe ends created
+      // in PipePair::new; Drop runs once, so each fd is closed exactly once here.
       unsafe {
         libc::close(self.r);
         libc::close(self.w);

--- a/latexml_oxide/src/post.rs
+++ b/latexml_oxide/src/post.rs
@@ -5,7 +5,9 @@
 //! Used by both the `latexml_oxide` binary and the `cortex_worker` binary.
 
 use latexml_core::{
-  Info, s,
+  Info, Warn,
+  common::error::{LogStatus, note_progress, note_status},
+  s,
   telemetry::{self, Phase},
 };
 use latexml_post::{
@@ -53,6 +55,54 @@ pub struct PostOptions<'a> {
   /// via `get_math`. Applied to each `PostDocument` in the final
   /// serialization loop.
   pub whatsout:                  latexml_post::extract::Whatsout,
+}
+
+/// Emit a post-processing error: capture it into the active log buffer (so it
+/// reaches `cortex.log`) AND bump the Error counter so `Status:conversion`
+/// reflects post-phase failures (Perl `LaTeXML.pm` L633: `max(core, post)`).
+///
+/// Deliberately NOT the `Error!` macro: that expands to a too-many-errors
+/// `Fatal!(…)` → `return Err(error::Error)`, which only typechecks inside the
+/// digester's `Result<_, error::Error>` functions. The post-processing entry
+/// points return `String`/`Result<_, ()>`, so we log+count directly with no
+/// control-flow side effect.
+fn post_error(object: &str, message: &str) {
+  note_status(LogStatus::Error, None);
+  log::error!(target: &format!("post:{object}"), "{message}");
+}
+
+/// Result of [`run_post_processing_logged`]: the serialized HTML plus the
+/// post-phase log text and status code, mirroring Perl `LaTeXML.pm`'s
+/// `convert_post`, which flushes the log AFTER post and folds the post status
+/// into the final `max(core, post)` verdict (L631-634).
+pub struct PostOutcome {
+  /// Serialized post-processed output (same value as [`run_post_processing`]).
+  pub html:        String,
+  /// Log text captured during the post phase only — Graphics/MathML/XSLT
+  /// `Info!`/`Warn!`/`post_error` lines. Append to the core conversion log.
+  pub log:         String,
+  /// Status code read from the shared REPORT counter AFTER post. Because the
+  /// counter is NOT reset between core and post, this is already the combined
+  /// core+post code; callers still `max()` it with the core code as a
+  /// belt-and-suspenders guard for paths that force a fatal outside REPORT
+  /// (e.g. a `catch_unwind`-trapped panic).
+  pub status_code: usize,
+}
+
+/// Run post-processing while capturing its log into a fresh thread-local
+/// LOG_BUFFER. `Converter::convert()` already flushed the *core* log into its
+/// own response, leaving the buffer unbound — so without re-binding here every
+/// post-phase `Info!`/`Warn!`/`post_error` (incl. a silent EPS→PNG failure)
+/// reaches stderr only and never the persisted `--log`/`cortex.log`. Perl's
+/// single `flush_log()` after `convert_post` sweeps up the post log for ALL
+/// consumers; this is the Rust equivalent, shared by the `latexml_oxide` and
+/// `cortex_worker` binaries so their logs reach parity. See SYNC_STATUS task 5.
+pub fn run_post_processing_logged(xml: &str, opts: &PostOptions) -> PostOutcome {
+  latexml_core::util::logger::bind_log();
+  let html = run_post_processing(xml, opts);
+  let log = latexml_core::util::logger::flush_log();
+  let status_code = latexml_core::common::error::get_status_code();
+  PostOutcome { html, log, status_code }
 }
 
 /// Run the post-processing pipeline on XML output.
@@ -124,7 +174,7 @@ pub fn run_post_processing(xml: &str, opts: &PostOptions) -> String {
   let doc = match PostDocument::new_from_string(xml, doc_opts) {
     Ok(d) => d,
     Err(e) => {
-      eprintln!("Post-processing: failed to parse XML: {}", e);
+      post_error("parse", &format!("failed to parse XML: {e}"));
       telemetry::phase_exit();
       return xml.to_string();
     },
@@ -157,7 +207,11 @@ pub fn run_post_processing(xml: &str, opts: &PostOptions) -> String {
         Some("label") => latexml_post::split::SplitNaming::Label,
         Some("labelrelative") => latexml_post::split::SplitNaming::LabelRelative,
         Some(other) => {
-          eprintln!("Unknown splitnaming '{}', using 'id'", other);
+          Warn!(
+            "post",
+            "split",
+            format!("Unknown splitnaming '{other}', using 'id'")
+          );
           latexml_post::split::SplitNaming::Id
         },
       };
@@ -166,12 +220,12 @@ pub fn run_post_processing(xml: &str, opts: &PostOptions) -> String {
       match splitter.process(doc, split_nodes) {
         Ok(docs) => {
           if docs.len() > 1 {
-            eprintln!("Split into {} documents", docs.len());
+            note_progress(&format!("Split into {} documents", docs.len()));
           }
           Ok(docs)
         },
         Err(e) => {
-          eprintln!("Post-processing: Split failed: {}", e);
+          post_error("split", &format!("Split failed: {e}"));
           Err(())
         },
       }
@@ -207,7 +261,7 @@ pub fn run_post_processing(xml: &str, opts: &PostOptions) -> String {
       match proc.process(d, nodes) {
         Ok(processed) => out.extend(processed),
         Err(e) => {
-          eprintln!("Post-processing: {} failed: {}", label, e);
+          post_error(label, &format!("{label} failed: {e}"));
           return Err(());
         },
       }
@@ -408,7 +462,7 @@ pub fn run_post_processing(xml: &str, opts: &PostOptions) -> String {
       searchpaths,
     ) {
       Ok(xslt) => processors.push(Box::new(xslt)),
-      Err(e) => eprintln!("Post-processing: XSLT error: {}", e),
+      Err(e) => post_error("xslt", &format!("XSLT error: {e}")),
     }
   }
 
@@ -429,7 +483,7 @@ pub fn run_post_processing(xml: &str, opts: &PostOptions) -> String {
   let results = match chain_result {
     Ok(r) => r,
     Err(e) => {
-      eprintln!("Post-processing failed: {}", e);
+      post_error("convert", &format!("Post-processing failed: {e}"));
       return xml.to_string();
     },
   };
@@ -473,7 +527,7 @@ pub fn run_post_processing(xml: &str, opts: &PostOptions) -> String {
         let _ = std::fs::create_dir_all(parent);
       }
       if let Err(e) = std::fs::write(path, &output) {
-        eprintln!("Post-processing: failed to write page {}: {}", path, e);
+        post_error("write", &format!("failed to write page {path}: {e}"));
       }
     }
     if main_output.is_none() {

--- a/latexml_oxide/src/util/test.rs
+++ b/latexml_oxide/src/util/test.rs
@@ -116,6 +116,10 @@ extern "C" fn sigsegv_installer() {
 /// stack print is more useful than the bare `signal: 11` line cargo
 /// reports today.
 fn install_sigsegv_handler() {
+  // SAFETY: declares the libc `signal(2)`/`raise(3)` FFI bindings for this
+  // test-only crash-backtrace handler. The signatures match libc's
+  // (`sighandler_t` is a `usize`-wide fn pointer here; `raise` returns int);
+  // calls below uphold the platform contract.
   unsafe extern "C" {
     fn signal(sig: i32, handler: extern "C" fn(i32)) -> usize;
     fn raise(sig: i32) -> i32;
@@ -150,6 +154,12 @@ fn install_sigsegv_handler() {
     eprintln!("{body}");
     eprintln!("[SIGSEGV-handler] full trace written to {path}");
     // Reset to default and re-raise so cargo still sees the original signal.
+    // SAFETY: test-only crash-backtrace handler (not async-signal-safe by
+    // design — see the fn docs). `transmute(SIG_DFL)` reinterprets the
+    // null/0 SIG_DFL sentinel as the `sighandler_t`-shaped fn pointer libc
+    // expects, restoring the default disposition; `signal`/`raise` then
+    // re-raise `sig` on the current thread so cargo observes the original
+    // fatal signal.
     unsafe {
       let raw_dfl: extern "C" fn(i32) = std::mem::transmute(SIG_DFL);
       signal(sig, raw_dfl);
@@ -157,6 +167,11 @@ fn install_sigsegv_handler() {
     }
   }
 
+  // SAFETY: installs the test-only `handler` as the disposition for SIGSEGV/
+  // SIGBUS/SIGABRT via libc `signal(2)`. `handler` is a valid `extern "C"
+  // fn(i32)` matching the expected `sighandler_t`; it is intentionally
+  // limited to (mostly) async-signal-safe work — see the fn docs for the
+  // accepted best-effort/heap caveat.
   unsafe {
     signal(SIGSEGV, handler);
     signal(SIGBUS, handler);

--- a/latexml_oxide/tests/alignment/array.xml
+++ b/latexml_oxide/tests/alignment/array.xml
@@ -19,8 +19,8 @@
       <tabular vattach="middle">
         <tbody>
           <tr>
-            <td align="justify" border="l r t" vattach="top"><inline-block vattach="top">
-                <p width="72.3pt">Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
+            <td align="justify" border="l r t" vattach="top"><inline-block vattach="top" width="72.3pt">
+                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
               </inline-block></td>
             <td align="justify" border="r t" vattach="middle" width="72.3pt"><inline-block vattach="top">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
@@ -30,8 +30,8 @@
               </inline-block></td>
           </tr>
           <tr>
-            <td align="justify" border="b l r t" vattach="top"><inline-block vattach="top">
-                <p width="72.3pt">Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
+            <td align="justify" border="b l r t" vattach="top"><inline-block vattach="top" width="72.3pt">
+                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
               </inline-block></td>
             <td align="justify" border="b r t" vattach="middle" width="72.3pt"><inline-block vattach="top">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>

--- a/latexml_oxide/tests/alignment/array.xml
+++ b/latexml_oxide/tests/alignment/array.xml
@@ -19,24 +19,24 @@
       <tabular vattach="middle">
         <tbody>
           <tr>
-            <td align="justify" border="l r t" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="l r t" vattach="top"><inline-block vattach="top" width="72.3pt">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
               </inline-block></td>
-            <td align="justify" border="r t" vattach="middle"><inline-block vattach="middle" width="72.3pt">
+            <td align="left" border="r t" vattach="middle"><inline-block vattach="middle" width="72.3pt">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
               </inline-block></td>
-            <td align="justify" border="r t" vattach="bottom"><inline-block vattach="bottom" width="72.3pt">
+            <td align="left" border="r t" vattach="bottom"><inline-block vattach="bottom" width="72.3pt">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
               </inline-block></td>
           </tr>
           <tr>
-            <td align="justify" border="b l r t" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="b l r t" vattach="top"><inline-block vattach="top" width="72.3pt">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
               </inline-block></td>
-            <td align="justify" border="b r t" vattach="middle"><inline-block vattach="middle" width="72.3pt">
+            <td align="left" border="b r t" vattach="middle"><inline-block vattach="middle" width="72.3pt">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
               </inline-block></td>
-            <td align="justify" border="b r t" vattach="bottom"><inline-block vattach="bottom" width="72.3pt">
+            <td align="left" border="b r t" vattach="bottom"><inline-block vattach="bottom" width="72.3pt">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
               </inline-block></td>
           </tr>

--- a/latexml_oxide/tests/alignment/array.xml
+++ b/latexml_oxide/tests/alignment/array.xml
@@ -22,10 +22,10 @@
             <td align="justify" border="l r t" vattach="top"><inline-block vattach="top" width="72.3pt">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
               </inline-block></td>
-            <td align="justify" border="r t" vattach="middle" width="72.3pt"><inline-block vattach="top">
+            <td align="justify" border="r t" vattach="middle"><inline-block vattach="middle" width="72.3pt">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
               </inline-block></td>
-            <td align="justify" border="r t" vattach="bottom" width="72.3pt"><inline-block vattach="bottom">
+            <td align="justify" border="r t" vattach="bottom"><inline-block vattach="bottom" width="72.3pt">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
               </inline-block></td>
           </tr>
@@ -33,10 +33,10 @@
             <td align="justify" border="b l r t" vattach="top"><inline-block vattach="top" width="72.3pt">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
               </inline-block></td>
-            <td align="justify" border="b r t" vattach="middle" width="72.3pt"><inline-block vattach="top">
+            <td align="justify" border="b r t" vattach="middle"><inline-block vattach="middle" width="72.3pt">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
               </inline-block></td>
-            <td align="justify" border="b r t" vattach="bottom" width="72.3pt"><inline-block vattach="bottom">
+            <td align="justify" border="b r t" vattach="bottom"><inline-block vattach="bottom" width="72.3pt">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
               </inline-block></td>
           </tr>

--- a/latexml_oxide/tests/alignment/cells.xml
+++ b/latexml_oxide/tests/alignment/cells.xml
@@ -69,7 +69,7 @@
         <tr>
           <td align="center" border="l r t"><tabular vattach="middle">
               <tr>
-                <td align="justify" class="ltx_nopad_r" vattach="top"><inline-block vattach="top" width="85.4pt">
+                <td align="left" class="ltx_nopad_r" vattach="top"><inline-block vattach="top" width="85.4pt">
                     <p>Cell long text with predefined width</p>
                   </inline-block></td>
               </tr>
@@ -79,7 +79,7 @@
         <tr>
           <td align="center" border="b l r t"><tabular vattach="middle">
               <tr>
-                <td align="justify" class="ltx_nopad_r" vattach="top"><inline-block vattach="top" width="85.4pt">
+                <td align="left" class="ltx_nopad_r" vattach="top"><inline-block vattach="top" width="85.4pt">
                     <p>Cell long…</p>
                   </inline-block></td>
               </tr>
@@ -148,14 +148,14 @@
                   <td align="center" class="ltx_nopad_r" thead="column row"><inline-block angle="90" depth="0.0pt" height="96.1pt" innerdepth="9.5pt" innerheight="14.5pt" innerwidth="96.1pt" width="24.0pt" xtranslate="-36.0pt" ytranslate="-36.0pt">
                       <p><text color="#FF0000" font="bold"><tabular rowsep="-1.7pt" vattach="middle">
                             <tr>
-                              <td align="justify" class="ltx_nopad_r" vattach="top"><inline-logical-block vattach="top" width="90.1pt">
+                              <td align="left" class="ltx_nopad_r" vattach="top"><inline-logical-block vattach="top" width="90.1pt">
                                   <para class="ltx_noindent" xml:id="S3.p1.p1">
                                     <p>Second multilined</p>
                                   </para>
                                 </inline-logical-block></td>
                             </tr>
                             <tr>
-                              <td align="justify" class="ltx_nopad_r" vattach="top"><inline-logical-block vattach="top" width="90.1pt">
+                              <td align="left" class="ltx_nopad_r" vattach="top"><inline-logical-block vattach="top" width="90.1pt">
                                   <para class="ltx_noindent" xml:id="S3.p1.p2">
                                     <p>column head</p>
                                   </para>
@@ -302,7 +302,7 @@
           <tr>
             <td align="left" border="l r t"><tabular vattach="middle">
                 <tr>
-                  <td align="justify" class="ltx_nopad_r" vattach="top"><inline-block vattach="top" width="142.3pt">
+                  <td align="left" class="ltx_nopad_r" vattach="top"><inline-block vattach="top" width="142.3pt">
                       <p>Cell …</p>
                     </inline-block></td>
                 </tr>
@@ -312,7 +312,7 @@
           <tr>
             <td align="left" border="b l r t"><tabular vattach="middle">
                 <tr>
-                  <td align="justify" class="ltx_nopad_r" vattach="top"><inline-block vattach="top" width="142.3pt">
+                  <td align="left" class="ltx_nopad_r" vattach="top"><inline-block vattach="top" width="142.3pt">
                       <p>Cell …</p>
                     </inline-block></td>
                 </tr>

--- a/latexml_oxide/tests/alignment/cells.xml
+++ b/latexml_oxide/tests/alignment/cells.xml
@@ -69,8 +69,8 @@
         <tr>
           <td align="center" border="l r t"><tabular vattach="middle">
               <tr>
-                <td align="justify" class="ltx_nopad_r" vattach="top"><inline-block vattach="top">
-                    <p width="85.4pt">Cell long text with predefined width</p>
+                <td align="justify" class="ltx_nopad_r" vattach="top"><inline-block vattach="top" width="85.4pt">
+                    <p>Cell long text with predefined width</p>
                   </inline-block></td>
               </tr>
             </tabular></td>
@@ -79,8 +79,8 @@
         <tr>
           <td align="center" border="b l r t"><tabular vattach="middle">
               <tr>
-                <td align="justify" class="ltx_nopad_r" vattach="top"><inline-block vattach="top">
-                    <p width="85.4pt">Cell long…</p>
+                <td align="justify" class="ltx_nopad_r" vattach="top"><inline-block vattach="top" width="85.4pt">
+                    <p>Cell long…</p>
                   </inline-block></td>
               </tr>
             </tabular></td>
@@ -148,14 +148,18 @@
                   <td align="center" class="ltx_nopad_r" thead="column row"><inline-block angle="90" depth="0.0pt" height="96.1pt" innerdepth="9.5pt" innerheight="14.5pt" innerwidth="96.1pt" width="24.0pt" xtranslate="-36.0pt" ytranslate="-36.0pt">
                       <p><text color="#FF0000" font="bold"><tabular rowsep="-1.7pt" vattach="middle">
                             <tr>
-                              <td align="justify" class="ltx_nopad_r" vattach="top"><inline-block vattach="top">
-                                  <p width="90.1pt">Second multilined</p>
-                                </inline-block></td>
+                              <td align="justify" class="ltx_nopad_r" vattach="top"><inline-logical-block vattach="top" width="90.1pt">
+                                  <para class="ltx_noindent" xml:id="S3.p1.p1">
+                                    <p>Second multilined</p>
+                                  </para>
+                                </inline-logical-block></td>
                             </tr>
                             <tr>
-                              <td align="justify" class="ltx_nopad_r" vattach="top"><inline-block vattach="top">
-                                  <p width="90.1pt">column head</p>
-                                </inline-block></td>
+                              <td align="justify" class="ltx_nopad_r" vattach="top"><inline-logical-block vattach="top" width="90.1pt">
+                                  <para class="ltx_noindent" xml:id="S3.p1.p2">
+                                    <p>column head</p>
+                                  </para>
+                                </inline-logical-block></td>
                             </tr>
                           </tabular></text></p>
                     </inline-block></td>
@@ -298,8 +302,8 @@
           <tr>
             <td align="left" border="l r t"><tabular vattach="middle">
                 <tr>
-                  <td align="justify" class="ltx_nopad_r" vattach="top"><inline-block vattach="top">
-                      <p width="142.3pt">Cell …</p>
+                  <td align="justify" class="ltx_nopad_r" vattach="top"><inline-block vattach="top" width="142.3pt">
+                      <p>Cell …</p>
                     </inline-block></td>
                 </tr>
               </tabular></td>
@@ -308,8 +312,8 @@
           <tr>
             <td align="left" border="b l r t"><tabular vattach="middle">
                 <tr>
-                  <td align="justify" class="ltx_nopad_r" vattach="top"><inline-block vattach="top">
-                      <p width="142.3pt">Cell …</p>
+                  <td align="justify" class="ltx_nopad_r" vattach="top"><inline-block vattach="top" width="142.3pt">
+                      <p>Cell …</p>
                     </inline-block></td>
                 </tr>
               </tabular></td>

--- a/latexml_oxide/tests/alignment/colortbls.xml
+++ b/latexml_oxide/tests/alignment/colortbls.xml
@@ -95,11 +95,11 @@ p{3cm}}"?>
         </thead>
         <tbody>
           <tr>
-            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top">
-                <p width="56.9pt"><text backgroundcolor="#FF0000" class="ltx_align_left" color="#FFFFFF">P-column</text></p>
+            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+                <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">P-column</text></p>
               </inline-block></td>
-            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top">
-                <p width="85.4pt"><text backgroundcolor="#0000FF" class="ltx_align_left" color="#FFFF00">and another one</text></p>
+            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+                <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">and another one</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}12\cdot 34" text="12.34" xml:id="S2.T1.m1">
                 <XMath>
@@ -117,11 +117,11 @@ p{3cm}}"?>
               </Math></td>
           </tr>
           <tr>
-            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top">
-                <p width="56.9pt"><text backgroundcolor="#FF0000" class="ltx_align_left" color="#FFFFFF">Some long text in the first column</text></p>
+            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+                <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">Some long text in the first column</text></p>
               </inline-block></td>
-            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top">
-                <p width="85.4pt"><text backgroundcolor="#0000FF" class="ltx_align_left" color="#FFFF00">bbb</text></p>
+            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+                <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">bbb</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}1\cdot 2" text="1.2" xml:id="S2.T1.m3">
                 <XMath>
@@ -130,11 +130,11 @@ p{3cm}}"?>
               </Math></td>
           </tr>
           <tr>
-            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top">
-                <p width="56.9pt"><text backgroundcolor="#FF0000" class="ltx_align_left" color="#FFFFFF">aaa</text></p>
+            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+                <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">aaa</text></p>
               </inline-block></td>
-            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top">
-                <p width="85.4pt"><text backgroundcolor="#0000FF" class="ltx_align_left" color="#FFFF00">and some long text in the second column</text></p>
+            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+                <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">and some long text in the second column</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}1\cdot 345" text="1.345" xml:id="S2.T1.m4">
                 <XMath>
@@ -152,11 +152,11 @@ p{3cm}}"?>
               </Math></td>
           </tr>
           <tr>
-            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top">
-                <p width="56.9pt"><text backgroundcolor="#FF0000" class="ltx_align_left" color="#FFFFFF">aaa</text></p>
+            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+                <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">aaa</text></p>
               </inline-block></td>
-            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top">
-                <p width="85.4pt"><text backgroundcolor="#0000FF" class="ltx_align_left" color="#FFFF00">bbb</text></p>
+            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+                <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">bbb</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}1\cdot 345" text="1.345" xml:id="S2.T1.m6">
                 <XMath>
@@ -165,12 +165,12 @@ p{3cm}}"?>
               </Math></td>
           </tr>
           <tr>
-            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top">
-                <p width="56.9pt"><text backgroundcolor="#FF0000" class="ltx_align_left" color="#FFFFFF">Note that the coloured rules in all columns stretch to accomodate
+            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+                <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">Note that the coloured rules in all columns stretch to accomodate
 large entries in one column.</text></p>
               </inline-block></td>
-            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top">
-                <p width="85.4pt"><text backgroundcolor="#0000FF" class="ltx_align_left" color="#FFFF00">bbb</text></p>
+            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+                <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">bbb</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}1\cdot 345" text="1.345" xml:id="S2.T1.m7">
                 <XMath>
@@ -179,11 +179,11 @@ large entries in one column.</text></p>
               </Math></td>
           </tr>
           <tr>
-            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top">
-                <p width="56.9pt"><text backgroundcolor="#FF0000" class="ltx_align_left" color="#FFFFFF">aaa</text></p>
+            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+                <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">aaa</text></p>
               </inline-block></td>
-            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top">
-                <p width="85.4pt"><text backgroundcolor="#0000FF" class="ltx_align_left" color="#FFFF00">bbb</text></p>
+            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+                <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">bbb</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}100" text="100" xml:id="S2.T1.m8">
                 <XMath>
@@ -192,11 +192,11 @@ large entries in one column.</text></p>
               </Math></td>
           </tr>
           <tr>
-            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top">
-                <p width="56.9pt"><text backgroundcolor="#FF0000" class="ltx_align_left" color="#FFFFFF">aaa</text></p>
+            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+                <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">aaa</text></p>
               </inline-block></td>
-            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top">
-                <p width="85.4pt"><text backgroundcolor="#0000FF" class="ltx_align_left" color="#FFFF00">Depending on your driver you may get unsightly gaps or lines
+            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+                <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">Depending on your driver you may get unsightly gaps or lines
 where the ‘screens’ used to produce different shapes interact
 badly. You may want to cause adjacent panels of the same colour by
 specifying a larger overhang
@@ -209,11 +209,11 @@ or by adding some negative space (in a ”“noalign” between rows.</text></p>
               </Math></td>
           </tr>
           <tr>
-            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top">
-                <p width="56.9pt"><text backgroundcolor="#FF0000" class="ltx_align_left" color="#FFFFFF">aaa</text></p>
+            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+                <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">aaa</text></p>
               </inline-block></td>
-            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top">
-                <p width="85.4pt"><text backgroundcolor="#0000FF" class="ltx_align_left" color="#FFFF00">bbb</text></p>
+            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+                <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">bbb</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}45\cdot 3" text="45.3" xml:id="S2.T1.m10">
                 <XMath>

--- a/latexml_oxide/tests/alignment/colortbls.xml
+++ b/latexml_oxide/tests/alignment/colortbls.xml
@@ -95,10 +95,10 @@ p{3cm}}"?>
         </thead>
         <tbody>
           <tr>
-            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+            <td align="left" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
                 <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">P-column</text></p>
               </inline-block></td>
-            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+            <td align="left" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
                 <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">and another one</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}12\cdot 34" text="12.34" xml:id="S2.T1.m1">
@@ -108,8 +108,8 @@ p{3cm}}"?>
               </Math></td>
           </tr>
           <tr>
-            <td align="justify" backgroundcolor="#CCCCCC" vattach="top"><text backgroundcolor="#CCCCCC">Total</text></td>
-            <td align="justify" backgroundcolor="#CCCCCC" vattach="top"><text backgroundcolor="#CCCCCC">(wrong)</text></td>
+            <td align="left" backgroundcolor="#CCCCCC" vattach="top"><text backgroundcolor="#CCCCCC">Total</text></td>
+            <td align="left" backgroundcolor="#CCCCCC" vattach="top"><text backgroundcolor="#CCCCCC">(wrong)</text></td>
             <td align="char:⋅" backgroundcolor="#CCCCCC"><Math mode="inline" tex="\pagecolor[gray]{0.8}100\cdot 6" text="100.6" xml:id="S2.T1.m2">
                 <XMath>
                   <XMTok backgroundcolor="#CCCCCC" meaning="100.6" role="NUMBER">100⋅6</XMTok>
@@ -117,10 +117,10 @@ p{3cm}}"?>
               </Math></td>
           </tr>
           <tr>
-            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+            <td align="left" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
                 <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">Some long text in the first column</text></p>
               </inline-block></td>
-            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+            <td align="left" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
                 <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">bbb</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}1\cdot 2" text="1.2" xml:id="S2.T1.m3">
@@ -130,10 +130,10 @@ p{3cm}}"?>
               </Math></td>
           </tr>
           <tr>
-            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+            <td align="left" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
                 <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">aaa</text></p>
               </inline-block></td>
-            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+            <td align="left" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
                 <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">and some long text in the second column</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}1\cdot 345" text="1.345" xml:id="S2.T1.m4">
@@ -143,8 +143,8 @@ p{3cm}}"?>
               </Math></td>
           </tr>
           <tr>
-            <td align="justify" backgroundcolor="#CCCCCC" vattach="top"><text backgroundcolor="#CCCCCC">Total</text></td>
-            <td align="justify" backgroundcolor="#CCCCCC" vattach="top"><text backgroundcolor="#CCCCCC">(wrong)</text></td>
+            <td align="left" backgroundcolor="#CCCCCC" vattach="top"><text backgroundcolor="#CCCCCC">Total</text></td>
+            <td align="left" backgroundcolor="#CCCCCC" vattach="top"><text backgroundcolor="#CCCCCC">(wrong)</text></td>
             <td align="char:⋅" backgroundcolor="#CCCCCC"><Math mode="inline" tex="\pagecolor[gray]{0.8}100\cdot 6" text="100.6" xml:id="S2.T1.m5">
                 <XMath>
                   <XMTok backgroundcolor="#CCCCCC" meaning="100.6" role="NUMBER">100⋅6</XMTok>
@@ -152,10 +152,10 @@ p{3cm}}"?>
               </Math></td>
           </tr>
           <tr>
-            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+            <td align="left" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
                 <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">aaa</text></p>
               </inline-block></td>
-            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+            <td align="left" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
                 <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">bbb</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}1\cdot 345" text="1.345" xml:id="S2.T1.m6">
@@ -165,11 +165,11 @@ p{3cm}}"?>
               </Math></td>
           </tr>
           <tr>
-            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+            <td align="left" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
                 <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">Note that the coloured rules in all columns stretch to accomodate
 large entries in one column.</text></p>
               </inline-block></td>
-            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+            <td align="left" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
                 <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">bbb</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}1\cdot 345" text="1.345" xml:id="S2.T1.m7">
@@ -179,10 +179,10 @@ large entries in one column.</text></p>
               </Math></td>
           </tr>
           <tr>
-            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+            <td align="left" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
                 <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">aaa</text></p>
               </inline-block></td>
-            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+            <td align="left" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
                 <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">bbb</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}100" text="100" xml:id="S2.T1.m8">
@@ -192,10 +192,10 @@ large entries in one column.</text></p>
               </Math></td>
           </tr>
           <tr>
-            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+            <td align="left" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
                 <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">aaa</text></p>
               </inline-block></td>
-            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+            <td align="left" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
                 <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">Depending on your driver you may get unsightly gaps or lines
 where the ‘screens’ used to produce different shapes interact
 badly. You may want to cause adjacent panels of the same colour by
@@ -209,10 +209,10 @@ or by adding some negative space (in a ”“noalign” between rows.</text></p>
               </Math></td>
           </tr>
           <tr>
-            <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+            <td align="left" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
                 <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">aaa</text></p>
               </inline-block></td>
-            <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+            <td align="left" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
                 <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">bbb</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}45\cdot 3" text="45.3" xml:id="S2.T1.m10">

--- a/latexml_oxide/tests/alignment/tabular.xml
+++ b/latexml_oxide/tests/alignment/tabular.xml
@@ -13,7 +13,7 @@
         <tr>
           <td border="l rr tt" thead="column row"/>
           <td align="center" border="r tt" colspan="2" thead="column">Price</td>
-          <td align="justify" border="r tt" thead="column" vattach="top"/>
+          <td align="left" border="r tt" thead="column" vattach="top"/>
         </tr>
         <tr>
           <td align="center" border="l rr" thead="column row">Year</td>
@@ -27,7 +27,7 @@
           <td align="right" border="l rr t" thead="row">1971</td>
           <td align="right" border="t" class="ltx_nopad_r">97–</td>
           <td align="left" border="r t" class="ltx_nopad_l">245</td>
-          <td align="justify" border="r t" vattach="top"><inline-block vattach="top" width="90.3pt">
+          <td align="left" border="r t" vattach="top"><inline-block vattach="top" width="90.3pt">
               <p>Bad year.</p>
             </inline-block></td>
         </tr>
@@ -35,7 +35,7 @@
           <td align="right" border="l rr t" thead="row">72</td>
           <td align="right" border="t" class="ltx_nopad_r">245–</td>
           <td align="left" border="r t" class="ltx_nopad_l">245</td>
-          <td align="justify" border="r t" vattach="top"><inline-block vattach="top" width="90.3pt">
+          <td align="left" border="r t" vattach="top"><inline-block vattach="top" width="90.3pt">
               <p>Light trading due to a heavy winter.</p>
             </inline-block></td>
         </tr>
@@ -43,7 +43,7 @@
           <td align="right" border="b l rr t" thead="row">73</td>
           <td align="right" border="b t" class="ltx_nopad_r">245–</td>
           <td align="left" border="b r t" class="ltx_nopad_l">2001</td>
-          <td align="justify" border="b r t" vattach="top"><inline-block vattach="top" width="90.3pt">
+          <td align="left" border="b r t" vattach="top"><inline-block vattach="top" width="90.3pt">
               <p>No gnus was very good gnus this year.</p>
             </inline-block></td>
         </tr>
@@ -77,24 +77,24 @@
     <tabular vattach="middle">
       <tbody>
         <tr>
-          <td align="justify" class="ltx_nopad_l ltx_nopad_r" vattach="top">1  <inline-block vattach="top" width="30.0pt">
+          <td align="left" class="ltx_nopad_l ltx_nopad_r" vattach="top">1  <inline-block vattach="top" width="30.0pt">
               <p>a</p>
             </inline-block>2</td>
-          <td align="justify" class="ltx_nopad_l ltx_nopad_r" vattach="top"><inline-block vattach="top" width="30.0pt">
+          <td align="left" class="ltx_nopad_l ltx_nopad_r" vattach="top"><inline-block vattach="top" width="30.0pt">
               <p>b</p>
             </inline-block>3</td>
-          <td align="justify" class="ltx_nopad_l ltx_nopad_r" vattach="top"><inline-block vattach="top" width="30.0pt">
+          <td align="left" class="ltx_nopad_l ltx_nopad_r" vattach="top"><inline-block vattach="top" width="30.0pt">
               <p>c</p>
             </inline-block>4</td>
         </tr>
         <tr>
-          <td align="justify" class="ltx_nopad_l ltx_nopad_r" vattach="top">1  <inline-block vattach="top" width="30.0pt">
+          <td align="left" class="ltx_nopad_l ltx_nopad_r" vattach="top">1  <inline-block vattach="top" width="30.0pt">
               <p>a a a a a a a a a a</p>
             </inline-block>2</td>
-          <td align="justify" class="ltx_nopad_l ltx_nopad_r" vattach="top"><inline-block vattach="top" width="30.0pt">
+          <td align="left" class="ltx_nopad_l ltx_nopad_r" vattach="top"><inline-block vattach="top" width="30.0pt">
               <p>b</p>
             </inline-block>3</td>
-          <td align="justify" class="ltx_nopad_l ltx_nopad_r" vattach="top"><inline-block vattach="top" width="30.0pt">
+          <td align="left" class="ltx_nopad_l ltx_nopad_r" vattach="top"><inline-block vattach="top" width="30.0pt">
               <p>c</p>
             </inline-block>4</td>
         </tr>

--- a/latexml_oxide/tests/alignment/tabular.xml
+++ b/latexml_oxide/tests/alignment/tabular.xml
@@ -13,7 +13,7 @@
         <tr>
           <td border="l rr tt" thead="column row"/>
           <td align="center" border="r tt" colspan="2" thead="column">Price</td>
-          <td border="r tt" thead="column" vattach="top"/>
+          <td align="justify" border="r tt" thead="column" vattach="top"/>
         </tr>
         <tr>
           <td align="center" border="l rr" thead="column row">Year</td>
@@ -27,24 +27,24 @@
           <td align="right" border="l rr t" thead="row">1971</td>
           <td align="right" border="t" class="ltx_nopad_r">97–</td>
           <td align="left" border="r t" class="ltx_nopad_l">245</td>
-          <td align="justify" border="r t" vattach="top"><inline-block vattach="top">
-              <p width="90.3pt">Bad year.</p>
+          <td align="justify" border="r t" vattach="top"><inline-block vattach="top" width="90.3pt">
+              <p>Bad year.</p>
             </inline-block></td>
         </tr>
         <tr>
           <td align="right" border="l rr t" thead="row">72</td>
           <td align="right" border="t" class="ltx_nopad_r">245–</td>
           <td align="left" border="r t" class="ltx_nopad_l">245</td>
-          <td align="justify" border="r t" vattach="top"><inline-block vattach="top">
-              <p width="90.3pt">Light trading due to a heavy winter.</p>
+          <td align="justify" border="r t" vattach="top"><inline-block vattach="top" width="90.3pt">
+              <p>Light trading due to a heavy winter.</p>
             </inline-block></td>
         </tr>
         <tr>
           <td align="right" border="b l rr t" thead="row">73</td>
           <td align="right" border="b t" class="ltx_nopad_r">245–</td>
           <td align="left" border="b r t" class="ltx_nopad_l">2001</td>
-          <td align="justify" border="b r t" vattach="top"><inline-block vattach="top">
-              <p width="90.3pt">No gnus was very good gnus this year.</p>
+          <td align="justify" border="b r t" vattach="top"><inline-block vattach="top" width="90.3pt">
+              <p>No gnus was very good gnus this year.</p>
             </inline-block></td>
         </tr>
       </tbody>
@@ -77,25 +77,25 @@
     <tabular vattach="middle">
       <tbody>
         <tr>
-          <td align="justify" class="ltx_nopad_l ltx_nopad_r" vattach="top">1  <inline-block vattach="top">
-              <p width="30.0pt">a</p>
+          <td align="justify" class="ltx_nopad_l ltx_nopad_r" vattach="top">1  <inline-block vattach="top" width="30.0pt">
+              <p>a</p>
             </inline-block>2</td>
-          <td align="justify" class="ltx_nopad_l ltx_nopad_r" vattach="top"><inline-block vattach="top">
-              <p width="30.0pt">b</p>
+          <td align="justify" class="ltx_nopad_l ltx_nopad_r" vattach="top"><inline-block vattach="top" width="30.0pt">
+              <p>b</p>
             </inline-block>3</td>
-          <td align="justify" class="ltx_nopad_l ltx_nopad_r" vattach="top"><inline-block vattach="top">
-              <p width="30.0pt">c</p>
+          <td align="justify" class="ltx_nopad_l ltx_nopad_r" vattach="top"><inline-block vattach="top" width="30.0pt">
+              <p>c</p>
             </inline-block>4</td>
         </tr>
         <tr>
-          <td align="justify" class="ltx_nopad_l ltx_nopad_r" vattach="top">1  <inline-block vattach="top">
-              <p width="30.0pt">a a a a a a a a a a</p>
+          <td align="justify" class="ltx_nopad_l ltx_nopad_r" vattach="top">1  <inline-block vattach="top" width="30.0pt">
+              <p>a a a a a a a a a a</p>
             </inline-block>2</td>
-          <td align="justify" class="ltx_nopad_l ltx_nopad_r" vattach="top"><inline-block vattach="top">
-              <p width="30.0pt">b</p>
+          <td align="justify" class="ltx_nopad_l ltx_nopad_r" vattach="top"><inline-block vattach="top" width="30.0pt">
+              <p>b</p>
             </inline-block>3</td>
-          <td align="justify" class="ltx_nopad_l ltx_nopad_r" vattach="top"><inline-block vattach="top">
-              <p width="30.0pt">c</p>
+          <td align="justify" class="ltx_nopad_l ltx_nopad_r" vattach="top"><inline-block vattach="top" width="30.0pt">
+              <p>c</p>
             </inline-block>4</td>
         </tr>
       </tbody>

--- a/latexml_oxide/tests/digestion/newcommand_zero_optional.tex
+++ b/latexml_oxide/tests/digestion/newcommand_zero_optional.tex
@@ -1,0 +1,14 @@
+\documentclass{article}
+
+% Regression guard (numeric-safety / low-level Rust): `\newcommand\foo[0][def]`
+% declares ZERO mandatory args yet supplies an optional default — outside
+% LaTeX's 0..9 arg-count domain. `convert_latex_args` does `nargs -= 1` for the
+% optional; with nargs==0 that must NOT underflow `usize` to ~2^64 and spin a
+% giant loop (which panics under overflow-checks / OOMs in release). It must
+% degrade like Perl's `1..$nargs` empty range: treat \foo as a single
+% optional-arg command. See latexml_core::binding::content::convert_latex_args.
+\newcommand\foo[0][def]{X-#1}
+
+\begin{document}
+\foo\ \foo[Y]
+\end{document}

--- a/latexml_oxide/tests/digestion/newcommand_zero_optional.xml
+++ b/latexml_oxide/tests/digestion/newcommand_zero_optional.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <para xml:id="p1">
+    <p>X-def X-Y</p>
+  </para>
+</document>

--- a/latexml_oxide/tests/graphics/graphrot.xml
+++ b/latexml_oxide/tests/graphics/graphrot.xml
@@ -247,19 +247,19 @@ End here</p>
       <tabular vattach="middle">
         <tbody>
           <tr>
-            <td align="center" border="l r t"><text cssstyle="padding:3.0pt" framecolor="#000000" framed="rectangle">—<inline-block angle="0" depth="27.5pt" height="32.5pt" innerdepth="27.5pt" innerheight="32.5pt" innerwidth="72.3pt" width="72.3pt" xtranslate="0.0pt" ytranslate="0.0pt">
+            <td align="center" border="l r t"><text cssstyle="padding:3.0pt" framecolor="#000000" framed="rectangle">—<inline-block angle="0" depth="25.0pt" height="30.0pt" innerdepth="25.0pt" innerheight="30.0pt" innerwidth="72.3pt" width="72.3pt" xtranslate="0.0pt" ytranslate="0.0pt">
                   <p><inline-block class="ltx_parbox" framed="rectangle" vattach="middle" width="72.3pt">
                       <p>Save
 the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.gov/LaTeXML/">Kitty!</ref> Save the whale</p>
                     </inline-block></p>
                 </inline-block>—</text></td>
-            <td align="center" border="r t"><text cssstyle="padding:3.0pt" framecolor="#000000" framed="rectangle">—<inline-block angle="-40" depth="67.5pt" height="24.9pt" innerdepth="27.5pt" innerheight="32.5pt" innerwidth="72.3pt" width="94.0pt" xtranslate="10.8pt" ytranslate="-16.2pt">
+            <td align="center" border="r t"><text cssstyle="padding:3.0pt" framecolor="#000000" framed="rectangle">—<inline-block angle="-40" depth="65.6pt" height="23.0pt" innerdepth="25.0pt" innerheight="30.0pt" innerwidth="72.3pt" width="90.7pt" xtranslate="9.2pt" ytranslate="-16.8pt">
                   <p><inline-block class="ltx_parbox" framed="rectangle" vattach="middle" width="72.3pt">
                       <p>Save
 the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.gov/LaTeXML/">Kitty!</ref> Save the whale</p>
                     </inline-block></p>
                 </inline-block>—</text></td>
-            <td align="center" border="r t"><text cssstyle="padding:3.0pt" framecolor="#000000" framed="rectangle">—<inline-block angle="-80" depth="76.0pt" height="5.6pt" innerdepth="27.5pt" innerheight="32.5pt" innerwidth="72.3pt" width="71.6pt" xtranslate="-0.3pt" ytranslate="-10.8pt">
+            <td align="center" border="r t"><text cssstyle="padding:3.0pt" framecolor="#000000" framed="rectangle">—<inline-block angle="-80" depth="75.5pt" height="5.2pt" innerdepth="25.0pt" innerheight="30.0pt" innerwidth="72.3pt" width="66.7pt" xtranslate="-2.8pt" ytranslate="-12.9pt">
                   <p><inline-block class="ltx_parbox" framed="rectangle" vattach="middle" width="72.3pt">
                       <p>Save
 the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.gov/LaTeXML/">Kitty!</ref> Save the whale</p>
@@ -272,19 +272,19 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
             <td align="center" border="r">-80<sup><text font="italic" fontsize="90%">o</text></sup></td>
           </tr>
           <tr>
-            <td align="center" border="l r t"><text cssstyle="padding:3.0pt" framecolor="#000000" framed="rectangle">—<inline-block angle="-120" depth="78.9pt" height="13.8pt" innerdepth="27.5pt" innerheight="32.5pt" innerwidth="72.3pt" width="88.1pt" xtranslate="7.9pt" ytranslate="-16.3pt">
+            <td align="center" border="l r t"><text cssstyle="padding:3.0pt" framecolor="#000000" framed="rectangle">—<inline-block angle="-120" depth="77.6pt" height="12.5pt" innerdepth="25.0pt" innerheight="30.0pt" innerwidth="72.3pt" width="83.7pt" xtranslate="5.7pt" ytranslate="-17.6pt">
                   <p><inline-block class="ltx_parbox" framed="rectangle" vattach="middle" width="72.3pt">
                       <p>Save
 the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.gov/LaTeXML/">Kitty!</ref> Save the whale</p>
                     </inline-block></p>
                 </inline-block>—</text></td>
-            <td align="center" border="r t"><text cssstyle="padding:3.0pt" framecolor="#000000" framed="rectangle">—<inline-block angle="-160" depth="55.3pt" height="25.8pt" innerdepth="27.5pt" innerheight="32.5pt" innerwidth="72.3pt" width="88.5pt" xtranslate="8.1pt" ytranslate="-10.6pt">
+            <td align="center" border="r t"><text cssstyle="padding:3.0pt" framecolor="#000000" framed="rectangle">—<inline-block angle="-160" depth="52.9pt" height="23.5pt" innerdepth="25.0pt" innerheight="30.0pt" innerwidth="72.3pt" width="86.7pt" xtranslate="7.2pt" ytranslate="-10.7pt">
                   <p><inline-block class="ltx_parbox" framed="rectangle" vattach="middle" width="72.3pt">
                       <p>Save
 the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.gov/LaTeXML/">Kitty!</ref> Save the whale</p>
                     </inline-block></p>
                 </inline-block>—</text></td>
-            <td align="center" border="r t"><text cssstyle="padding:3.0pt" framecolor="#000000" framed="rectangle">—<inline-block angle="-200" depth="30.5pt" height="50.6pt" innerdepth="27.5pt" innerheight="32.5pt" innerwidth="72.3pt" width="88.5pt" xtranslate="8.1pt" ytranslate="-10.6pt">
+            <td align="center" border="r t"><text cssstyle="padding:3.0pt" framecolor="#000000" framed="rectangle">—<inline-block angle="-200" depth="28.2pt" height="48.2pt" innerdepth="25.0pt" innerheight="30.0pt" innerwidth="72.3pt" width="86.7pt" xtranslate="7.2pt" ytranslate="-10.7pt">
                   <p><inline-block class="ltx_parbox" framed="rectangle" vattach="middle" width="72.3pt">
                       <p>Save
 the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.gov/LaTeXML/">Kitty!</ref> Save the whale</p>
@@ -297,19 +297,19 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
             <td align="center" border="r">-200<sup><text font="italic" fontsize="90%">o</text></sup></td>
           </tr>
           <tr>
-            <td align="center" border="l r t"><text cssstyle="padding:3.0pt" framecolor="#000000" framed="rectangle">—<inline-block angle="-240" depth="16.3pt" height="76.4pt" innerdepth="27.5pt" innerheight="32.5pt" innerwidth="72.3pt" width="88.1pt" xtranslate="7.9pt" ytranslate="-16.3pt">
+            <td align="center" border="l r t"><text cssstyle="padding:3.0pt" framecolor="#000000" framed="rectangle">—<inline-block angle="-240" depth="15.0pt" height="75.1pt" innerdepth="25.0pt" innerheight="30.0pt" innerwidth="72.3pt" width="83.7pt" xtranslate="5.7pt" ytranslate="-17.6pt">
                   <p><inline-block class="ltx_parbox" framed="rectangle" vattach="middle" width="72.3pt">
                       <p>Save
 the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.gov/LaTeXML/">Kitty!</ref> Save the whale</p>
                     </inline-block></p>
                 </inline-block>—</text></td>
-            <td align="center" border="r t"><text cssstyle="padding:3.0pt" framecolor="#000000" framed="rectangle">—<inline-block angle="-280" depth="4.8pt" height="76.8pt" innerdepth="27.5pt" innerheight="32.5pt" innerwidth="72.3pt" width="71.6pt" xtranslate="-0.3pt" ytranslate="-10.8pt">
+            <td align="center" border="r t"><text cssstyle="padding:3.0pt" framecolor="#000000" framed="rectangle">—<inline-block angle="-280" depth="4.3pt" height="76.4pt" innerdepth="25.0pt" innerheight="30.0pt" innerwidth="72.3pt" width="66.7pt" xtranslate="-2.8pt" ytranslate="-12.9pt">
                   <p><inline-block class="ltx_parbox" framed="rectangle" vattach="middle" width="72.3pt">
                       <p>Save
 the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.gov/LaTeXML/">Kitty!</ref> Save the whale</p>
                     </inline-block></p>
                 </inline-block>—</text></td>
-            <td align="center" border="r t"><text cssstyle="padding:3.0pt" framecolor="#000000" framed="rectangle">—<inline-block angle="-320" depth="21.1pt" height="71.4pt" innerdepth="27.5pt" innerheight="32.5pt" innerwidth="72.3pt" width="94.0pt" xtranslate="10.8pt" ytranslate="-16.2pt">
+            <td align="center" border="r t"><text cssstyle="padding:3.0pt" framecolor="#000000" framed="rectangle">—<inline-block angle="-320" depth="19.1pt" height="69.4pt" innerdepth="25.0pt" innerheight="30.0pt" innerwidth="72.3pt" width="90.7pt" xtranslate="9.2pt" ytranslate="-16.8pt">
                   <p><inline-block class="ltx_parbox" framed="rectangle" vattach="middle" width="72.3pt">
                       <p>Save
 the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.gov/LaTeXML/">Kitty!</ref> Save the whale</p>
@@ -395,7 +395,7 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
         </tabular>
       </quote>
     </para>
-    <table angle="90" depth="0.0pt" height="550.0pt" inlist="lot" innerdepth="74.0pt" innerheight="69.1pt" innerwidth="550.0pt" labels="LABEL:rotfloat2" width="143.1pt" xtranslate="-203.5pt" ytranslate="-203.5pt" xml:id="S2.T5">
+    <table angle="90" depth="0.0pt" height="585.8pt" inlist="lot" innerdepth="74.0pt" innerheight="69.1pt" innerwidth="585.8pt" labels="LABEL:rotfloat2" width="143.1pt" xtranslate="-221.4pt" ytranslate="-221.4pt" xml:id="S2.T5">
       <tags>
         <tag>Table 5</tag>
         <tag role="autoref">Table 5</tag>

--- a/latexml_oxide/tests/graphics/graphrot.xml
+++ b/latexml_oxide/tests/graphics/graphrot.xml
@@ -413,11 +413,11 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
             <td align="left" border="t" thead="column">Pottery</td>
             <td align="left" border="t" thead="column">Flint</td>
             <td align="left" border="t" thead="column">Animal</td>
-            <td align="justify" border="t" thead="column" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="t" thead="column" vattach="top"><inline-block vattach="top" width="72.3pt">
                 <p>Stone</p>
               </inline-block></td>
             <td align="left" border="t" thead="column">Other</td>
-            <td align="justify" border="r t" thead="column" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="r t" thead="column" vattach="top"><inline-block vattach="top" width="72.3pt">
                 <p>C14 Dates</p>
               </inline-block></td>
           </tr>
@@ -430,9 +430,9 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
             <td thead="column"/>
             <td thead="column"/>
             <td align="left" thead="column">Bones</td>
-            <td align="justify" thead="column" vattach="top"/>
+            <td align="left" thead="column" vattach="top"/>
             <td thead="column"/>
-            <td align="justify" border="r" thead="column" vattach="top"/>
+            <td align="left" border="r" thead="column" vattach="top"/>
           </tr>
         </thead>
         <tbody>
@@ -445,13 +445,13 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
             <td border="t"/>
             <td border="t"/>
             <td border="t"/>
-            <td align="justify" border="t" vattach="top"/>
+            <td align="left" border="t" vattach="top"/>
             <td border="t"/>
-            <td align="justify" border="r t" vattach="top"/>
+            <td align="left" border="r t" vattach="top"/>
           </tr>
           <tr>
             <td align="left" border="l" colspan="10"><text font="bold">Grooved Ware</text></td>
-            <td align="justify" border="r" vattach="top"/>
+            <td align="left" border="r" vattach="top"/>
           </tr>
           <tr>
             <td align="left" border="l">784</td>
@@ -470,13 +470,13 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
                   <XMTok meaning="times" role="MULOP">×</XMTok>
                 </XMath>
               </Math>8</td>
-            <td align="justify" vattach="top"/>
+            <td align="left" vattach="top"/>
             <td align="left"><Math mode="inline" tex="\times" text="*" xml:id="S2.T5.m3">
                 <XMath>
                   <XMTok meaning="times" role="MULOP">×</XMTok>
                 </XMath>
               </Math>2 bone</td>
-            <td align="justify" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
                 <p>2150<Math mode="inline" tex="\pm" text="plus-or-minus" xml:id="S2.T5.m4">
                     <XMath>
                       <XMTok meaning="plus-or-minus" name="pm" role="ADDOP">±</XMTok>
@@ -501,11 +501,11 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
                   <XMTok meaning="times" role="MULOP">×</XMTok>
                 </XMath>
               </Math>21</td>
-            <td align="justify" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" vattach="top"><inline-block vattach="top" width="72.3pt">
                 <p>Hammerstone</p>
               </inline-block></td>
             <td align="left">—</td>
-            <td align="justify" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
                 <p>—</p>
               </inline-block></td>
           </tr>
@@ -526,11 +526,11 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
                   <XMTok meaning="times" role="MULOP">×</XMTok>
                 </XMath>
               </Math>57*</td>
-            <td align="justify" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" vattach="top"><inline-block vattach="top" width="72.3pt">
                 <p>—</p>
               </inline-block></td>
             <td align="left">—</td>
-            <td align="justify" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
                 <p>1990 <Math mode="inline" tex="\pm" text="plus-or-minus" xml:id="S2.T5.m9">
                     <XMath>
                       <XMTok meaning="plus-or-minus" name="pm" role="ADDOP">±</XMTok>
@@ -559,11 +559,11 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
                   <XMTok meaning="times" role="MULOP">×</XMTok>
                 </XMath>
               </Math>8</td>
-            <td align="justify" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" vattach="top"><inline-block vattach="top" width="72.3pt">
                 <p>—</p>
               </inline-block></td>
             <td align="left">Fired clay</td>
-            <td align="justify" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
                 <p>—</p>
               </inline-block></td>
           </tr>
@@ -576,13 +576,13 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
             <td/>
             <td/>
             <td/>
-            <td align="justify" vattach="top"/>
+            <td align="left" vattach="top"/>
             <td/>
-            <td align="justify" border="r" vattach="top"/>
+            <td align="left" border="r" vattach="top"/>
           </tr>
           <tr>
             <td align="left" border="l" colspan="10"><text font="bold">Beaker</text></td>
-            <td align="justify" border="r" vattach="top"/>
+            <td align="left" border="r" vattach="top"/>
           </tr>
           <tr>
             <td align="left" border="l">552</td>
@@ -593,11 +593,11 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
             <td align="left">P7–14</td>
             <td align="left">—</td>
             <td align="left">—</td>
-            <td align="justify" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" vattach="top"><inline-block vattach="top" width="72.3pt">
                 <p>—</p>
               </inline-block></td>
             <td align="left">—</td>
-            <td align="justify" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
                 <p>—</p>
               </inline-block></td>
           </tr>
@@ -614,11 +614,11 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
                 </XMath>
               </Math>12</td>
             <td align="left">—</td>
-            <td align="justify" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" vattach="top"><inline-block vattach="top" width="72.3pt">
                 <p>Quartzite-lump</p>
               </inline-block></td>
             <td align="left">—</td>
-            <td align="justify" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
                 <p>—</p>
               </inline-block></td>
           </tr>
@@ -635,11 +635,11 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
                 </XMath>
               </Math>3</td>
             <td align="left" border="b">—</td>
-            <td align="justify" border="b" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="b" vattach="top"><inline-block vattach="top" width="72.3pt">
                 <p>—</p>
               </inline-block></td>
             <td align="left" border="b">—</td>
-            <td align="justify" border="b r" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="b r" vattach="top"><inline-block vattach="top" width="72.3pt">
                 <p>—</p>
               </inline-block></td>
           </tr>

--- a/latexml_oxide/tests/graphics/graphrot.xml
+++ b/latexml_oxide/tests/graphics/graphrot.xml
@@ -395,7 +395,7 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
         </tabular>
       </quote>
     </para>
-    <table angle="90" depth="0.0pt" height="585.8pt" inlist="lot" innerdepth="74.0pt" innerheight="69.1pt" innerwidth="585.8pt" labels="LABEL:rotfloat2" width="143.1pt" xtranslate="-221.4pt" ytranslate="-221.4pt" xml:id="S2.T5">
+    <table angle="90" depth="0.0pt" height="585.8pt" inlist="lot" innerdepth="103.4pt" innerheight="98.6pt" innerwidth="585.8pt" labels="LABEL:rotfloat2" width="202.0pt" xtranslate="-191.9pt" ytranslate="-191.9pt" xml:id="S2.T5">
       <tags>
         <tag>Table 5</tag>
         <tag role="autoref">Table 5</tag>
@@ -413,12 +413,12 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
             <td align="left" border="t" thead="column">Pottery</td>
             <td align="left" border="t" thead="column">Flint</td>
             <td align="left" border="t" thead="column">Animal</td>
-            <td align="justify" border="t" thead="column" vattach="top"><inline-block vattach="top">
-                <p width="72.3pt">Stone</p>
+            <td align="justify" border="t" thead="column" vattach="top"><inline-block vattach="top" width="72.3pt">
+                <p>Stone</p>
               </inline-block></td>
             <td align="left" border="t" thead="column">Other</td>
-            <td align="justify" border="r t" thead="column" vattach="top"><inline-block vattach="top">
-                <p width="72.3pt">C14 Dates</p>
+            <td align="justify" border="r t" thead="column" vattach="top"><inline-block vattach="top" width="72.3pt">
+                <p>C14 Dates</p>
               </inline-block></td>
           </tr>
           <tr>
@@ -430,15 +430,28 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
             <td thead="column"/>
             <td thead="column"/>
             <td align="left" thead="column">Bones</td>
-            <td thead="column" vattach="top"/>
+            <td align="justify" thead="column" vattach="top"/>
             <td thead="column"/>
-            <td border="r" thead="column" vattach="top"/>
+            <td align="justify" border="r" thead="column" vattach="top"/>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td align="left" border="l t" colspan="10"><text font="bold">Grooved Ware</text></td>
-            <td border="r t" vattach="top"/>
+            <td border="l t"/>
+            <td border="t"/>
+            <td border="t"/>
+            <td border="t"/>
+            <td border="t"/>
+            <td border="t"/>
+            <td border="t"/>
+            <td border="t"/>
+            <td align="justify" border="t" vattach="top"/>
+            <td border="t"/>
+            <td align="justify" border="r t" vattach="top"/>
+          </tr>
+          <tr>
+            <td align="left" border="l" colspan="10"><text font="bold">Grooved Ware</text></td>
+            <td align="justify" border="r" vattach="top"/>
           </tr>
           <tr>
             <td align="left" border="l">784</td>
@@ -457,14 +470,14 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
                   <XMTok meaning="times" role="MULOP">×</XMTok>
                 </XMath>
               </Math>8</td>
-            <td vattach="top"/>
+            <td align="justify" vattach="top"/>
             <td align="left"><Math mode="inline" tex="\times" text="*" xml:id="S2.T5.m3">
                 <XMath>
                   <XMTok meaning="times" role="MULOP">×</XMTok>
                 </XMath>
               </Math>2 bone</td>
-            <td align="justify" border="r" vattach="top"><inline-block vattach="top">
-                <p width="72.3pt">2150<Math mode="inline" tex="\pm" text="plus-or-minus" xml:id="S2.T5.m4">
+            <td align="justify" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
+                <p>2150<Math mode="inline" tex="\pm" text="plus-or-minus" xml:id="S2.T5.m4">
                     <XMath>
                       <XMTok meaning="plus-or-minus" name="pm" role="ADDOP">±</XMTok>
                     </XMath>
@@ -488,12 +501,12 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
                   <XMTok meaning="times" role="MULOP">×</XMTok>
                 </XMath>
               </Math>21</td>
-            <td align="justify" vattach="top"><inline-block vattach="top">
-                <p width="72.3pt">Hammerstone</p>
+            <td align="justify" vattach="top"><inline-block vattach="top" width="72.3pt">
+                <p>Hammerstone</p>
               </inline-block></td>
             <td align="left">—</td>
-            <td align="justify" border="r" vattach="top"><inline-block vattach="top">
-                <p width="72.3pt">—</p>
+            <td align="justify" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
+                <p>—</p>
               </inline-block></td>
           </tr>
           <tr>
@@ -513,12 +526,12 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
                   <XMTok meaning="times" role="MULOP">×</XMTok>
                 </XMath>
               </Math>57*</td>
-            <td align="justify" vattach="top"><inline-block vattach="top">
-                <p width="72.3pt">—</p>
+            <td align="justify" vattach="top"><inline-block vattach="top" width="72.3pt">
+                <p>—</p>
               </inline-block></td>
             <td align="left">—</td>
-            <td align="justify" border="r" vattach="top"><inline-block vattach="top">
-                <p width="72.3pt">1990 <Math mode="inline" tex="\pm" text="plus-or-minus" xml:id="S2.T5.m9">
+            <td align="justify" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
+                <p>1990 <Math mode="inline" tex="\pm" text="plus-or-minus" xml:id="S2.T5.m9">
                     <XMath>
                       <XMTok meaning="plus-or-minus" name="pm" role="ADDOP">±</XMTok>
                     </XMath>
@@ -546,17 +559,30 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
                   <XMTok meaning="times" role="MULOP">×</XMTok>
                 </XMath>
               </Math>8</td>
-            <td align="justify" vattach="top"><inline-block vattach="top">
-                <p width="72.3pt">—</p>
+            <td align="justify" vattach="top"><inline-block vattach="top" width="72.3pt">
+                <p>—</p>
               </inline-block></td>
             <td align="left">Fired clay</td>
-            <td align="justify" border="r" vattach="top"><inline-block vattach="top">
-                <p width="72.3pt">—</p>
+            <td align="justify" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
+                <p>—</p>
               </inline-block></td>
           </tr>
           <tr>
+            <td border="l"/>
+            <td/>
+            <td/>
+            <td/>
+            <td/>
+            <td/>
+            <td/>
+            <td/>
+            <td align="justify" vattach="top"/>
+            <td/>
+            <td align="justify" border="r" vattach="top"/>
+          </tr>
+          <tr>
             <td align="left" border="l" colspan="10"><text font="bold">Beaker</text></td>
-            <td border="r" vattach="top"/>
+            <td align="justify" border="r" vattach="top"/>
           </tr>
           <tr>
             <td align="left" border="l">552</td>
@@ -567,12 +593,12 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
             <td align="left">P7–14</td>
             <td align="left">—</td>
             <td align="left">—</td>
-            <td align="justify" vattach="top"><inline-block vattach="top">
-                <p width="72.3pt">—</p>
+            <td align="justify" vattach="top"><inline-block vattach="top" width="72.3pt">
+                <p>—</p>
               </inline-block></td>
             <td align="left">—</td>
-            <td align="justify" border="r" vattach="top"><inline-block vattach="top">
-                <p width="72.3pt">—</p>
+            <td align="justify" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
+                <p>—</p>
               </inline-block></td>
           </tr>
           <tr>
@@ -588,12 +614,12 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
                 </XMath>
               </Math>12</td>
             <td align="left">—</td>
-            <td align="justify" vattach="top"><inline-block vattach="top">
-                <p width="72.3pt">Quartzite-lump</p>
+            <td align="justify" vattach="top"><inline-block vattach="top" width="72.3pt">
+                <p>Quartzite-lump</p>
               </inline-block></td>
             <td align="left">—</td>
-            <td align="justify" border="r" vattach="top"><inline-block vattach="top">
-                <p width="72.3pt">—</p>
+            <td align="justify" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
+                <p>—</p>
               </inline-block></td>
           </tr>
           <tr>
@@ -609,12 +635,12 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
                 </XMath>
               </Math>3</td>
             <td align="left" border="b">—</td>
-            <td align="justify" border="b" vattach="top"><inline-block vattach="top">
-                <p width="72.3pt">—</p>
+            <td align="justify" border="b" vattach="top"><inline-block vattach="top" width="72.3pt">
+                <p>—</p>
               </inline-block></td>
             <td align="left" border="b">—</td>
-            <td align="justify" border="b r" vattach="top"><inline-block vattach="top">
-                <p width="72.3pt">—</p>
+            <td align="justify" border="b r" vattach="top"><inline-block vattach="top" width="72.3pt">
+                <p>—</p>
               </inline-block></td>
           </tr>
         </tbody>

--- a/latexml_oxide/tests/math/array_newline_math.xml
+++ b/latexml_oxide/tests/math/array_newline_math.xml
@@ -13,7 +13,7 @@
               <XMCell align="center">
                 <XMTok meaning="4" role="NUMBER">4</XMTok>
               </XMCell>
-              <XMCell align="justify">
+              <XMCell align="left">
                 <XMText vattach="top" width="128.0pt"><Math mode="inline" tex="x_{1}" text="x _ 1" xml:id="S0.Ex1.m1.m1">
                     <XMath>
                       <XMApp>

--- a/latexml_oxide/tests/parse/relations.tex
+++ b/latexml_oxide/tests/parse/relations.tex
@@ -31,5 +31,13 @@
 \[ a; (< e) \]
 \[ a = b + c + d (< e) \]
 \[ a = b + c + d \mod e \]
- 
+
+\section{Comma-list left of a relation (distributed XMDual)}
+% a,b \in A : content DISTRIBUTES the relation over each list element
+% (formulae@(a\in A, b\in A), sharing refs to the relop and RHS); presentation
+% wraps the list a,b in an XMWrap as the relation's LHS (\in(<a,b>, A)).
+% Distinct from the list-RIGHT case 0<x,y -> list@(0<x,y) (left untouched).
+\[ a,b \in A \]
+\[ x,y \le z \]
+
 \end{document}

--- a/latexml_oxide/tests/parse/relations.xml
+++ b/latexml_oxide/tests/parse/relations.xml
@@ -419,4 +419,74 @@
       </equation>
     </para>
   </section>
+  <section inlist="toc" xml:id="S4">
+    <tags>
+      <tag>4</tag>
+      <tag role="refnum">4</tag>
+      <tag role="typerefnum">§4</tag>
+    </tags>
+    <title><tag close=" ">4</tag>Comma-list left of a relation (distributed XMDual)</title>
+    <para xml:id="S4.p1">
+      <equation xml:id="S4.Ex16">
+        <Math mode="display" tex="a,b\in A" text="formulae@(a element-of A, b element-of A)" xml:id="S4.Ex16.m1">
+          <XMath>
+            <XMDual>
+              <XMApp>
+                <XMTok meaning="formulae"/>
+                <XMApp>
+                  <XMRef idref="S4.Ex16.m1.1"/>
+                  <XMRef idref="S4.Ex16.m1.2"/>
+                  <XMRef idref="S4.Ex16.m1.4"/>
+                </XMApp>
+                <XMApp>
+                  <XMRef idref="S4.Ex16.m1.1"/>
+                  <XMRef idref="S4.Ex16.m1.3"/>
+                  <XMRef idref="S4.Ex16.m1.4"/>
+                </XMApp>
+              </XMApp>
+              <XMApp>
+                <XMTok meaning="element-of" name="in" role="RELOP" xml:id="S4.Ex16.m1.1">∈</XMTok>
+                <XMWrap>
+                  <XMTok font="italic" role="ID" xml:id="S4.Ex16.m1.2">a</XMTok>
+                  <XMTok role="PUNCT">,</XMTok>
+                  <XMTok font="italic" role="ID" xml:id="S4.Ex16.m1.3">b</XMTok>
+                </XMWrap>
+                <XMTok font="italic" role="UNKNOWN" xml:id="S4.Ex16.m1.4">A</XMTok>
+              </XMApp>
+            </XMDual>
+          </XMath>
+        </Math>
+      </equation>
+      <equation xml:id="S4.Ex17">
+        <Math mode="display" tex="x,y\leq z" text="formulae@(x &lt;= z, y &lt;= z)" xml:id="S4.Ex17.m1">
+          <XMath>
+            <XMDual>
+              <XMApp>
+                <XMTok meaning="formulae"/>
+                <XMApp>
+                  <XMRef idref="S4.Ex17.m1.1"/>
+                  <XMRef idref="S4.Ex17.m1.2"/>
+                  <XMRef idref="S4.Ex17.m1.4"/>
+                </XMApp>
+                <XMApp>
+                  <XMRef idref="S4.Ex17.m1.1"/>
+                  <XMRef idref="S4.Ex17.m1.3"/>
+                  <XMRef idref="S4.Ex17.m1.4"/>
+                </XMApp>
+              </XMApp>
+              <XMApp>
+                <XMTok meaning="less-than-or-equals" name="leq" role="RELOP" xml:id="S4.Ex17.m1.1">≤</XMTok>
+                <XMWrap>
+                  <XMTok font="italic" role="UNKNOWN" xml:id="S4.Ex17.m1.2">x</XMTok>
+                  <XMTok role="PUNCT">,</XMTok>
+                  <XMTok font="italic" role="UNKNOWN" xml:id="S4.Ex17.m1.3">y</XMTok>
+                </XMWrap>
+                <XMTok font="italic" role="UNKNOWN" xml:id="S4.Ex17.m1.4">z</XMTok>
+              </XMApp>
+            </XMDual>
+          </XMath>
+        </Math>
+      </equation>
+    </para>
+  </section>
 </document>

--- a/latexml_package/src/package/array_sty.rs
+++ b/latexml_package/src/package/array_sty.rs
@@ -24,27 +24,39 @@ LoadDefinitions!({
     });
   });
 
-  // Same as p but with vertical alignment centered
+  // Same as p{} but vertically centered. Build the cell as the Perl-faithful
+  // `\lx@tabular@p m {width} { … }` VBox (an `<ltx:inline-block>` digested as
+  // VBoxContents), matching the global `p{}` column (tex_tables.rs) — so width
+  // lands on the `<inline-block>` (not the `<td>`), block content nests directly,
+  // and `\hsize`-aware wrapping sizes it (box-model fix). The vattach letter `m`
+  // → `translate_attachment` → middle. (Was a plain `\vtop{}` → width-on-`<td>` +
+  // `vattach`/width drift vs Perl — cluster-B residual C/D.)
   DefColumnType!("m{Dimension}", sub[(width)] {
+    let mut before = vec![T_CS!("\\lx@tabular@p"), T_LETTER!("m"), T_BEGIN!()];
+    before.extend(width.revert()?.unlist());
+    before.push(T_END!());
+    before.push(T_BEGIN!());
     with_current_build_template(|template_opt| {
       template_opt.unwrap().add_column(Cell {
-        before: Some(Tokens!(T_CS!("\\vtop"), T_BEGIN!())),
+        before: Some(Tokens::new(before)),
         after: Some(Tokens!(T_END!())),
         align: Some(Align::Justify),
-        width: Some(width),
         vattach: Some(String::from("middle")),
         ..Cell::default()
       });
     });
   });
-  // Same as p but with vertical alignment bottom
+  // Same as p{} but vertically bottom-aligned — `\lx@tabular@p b {width} { … }`.
   DefColumnType!("b{Dimension}", sub[(width)] {
+    let mut before = vec![T_CS!("\\lx@tabular@p"), T_LETTER!("b"), T_BEGIN!()];
+    before.extend(width.revert()?.unlist());
+    before.push(T_END!());
+    before.push(T_BEGIN!());
     with_current_build_template(|template_opt| {
       template_opt.unwrap().add_column(Cell {
-        before: Some(Tokens!(T_CS!("\\vbox"), T_BEGIN!())),
+        before: Some(Tokens::new(before)),
         after: Some(Tokens!(T_END!())),
         align: Some(Align::Justify),
-        width: Some(width),
         vattach: Some(String::from("bottom")),
         ..Cell::default()
       });

--- a/latexml_post/src/graphics.rs
+++ b/latexml_post/src/graphics.rs
@@ -1912,11 +1912,29 @@ impl Processor for Graphics {
         .unwrap_or("")
         .to_lowercase();
       let props = self.type_properties.get(&src_ext).cloned();
+      // Robustness guard (surpass-Perl; user directive 2026-06-22). A source
+      // type with no explicit `destination_type` defaults to a WEB-NATIVE
+      // target: keep web-native sources (svg/png/gif/jpg/jpeg) as-is, but
+      // rasterize anything else to `png`. This guarantees a non-web-native
+      // source is ALWAYS routed through Plan::Convert and never Plan::Copy'd
+      // verbatim — closing the hole for the unmapped `.postscript` graphics
+      // type (and any future addition) where a raw .ps/.eps/.pdf/.ai could
+      // otherwise reach the web. Perl defaults dest_type to srctype here
+      // (Graphics.pm:244, `$type = $properties{destination_type} || $srctype`),
+      // which would copy such a source raw; we deliberately diverge so the web
+      // output is never a raw .eps/.ps/.pdf the browser can't render.
+      const WEB_NATIVE: &[&str] = &["svg", "png", "gif", "jpg", "jpeg"];
       let dest_type = props
         .as_ref()
         .and_then(|p| p.destination_type.as_ref())
         .cloned()
-        .unwrap_or_else(|| src_ext.clone());
+        .unwrap_or_else(|| {
+          if WEB_NATIVE.contains(&src_ext.as_str()) {
+            src_ext.clone()
+          } else {
+            "png".to_string()
+          }
+        });
       let needs_conversion = dest_type != src_ext;
       let has_page = page.is_some();
       if needs_conversion || has_page {

--- a/latexml_post/src/graphics.rs
+++ b/latexml_post/src/graphics.rs
@@ -1236,7 +1236,6 @@ impl Graphics {
   /// Returns true only when the destination file was actually written.
   /// Optional dep: graceful fallthrough when `mutool` is not on PATH.
   fn convert_pdf_via_mutool(source: &str, dest: &str, density: u32, page: Option<u32>) -> bool {
-    eprintln!("DBG convert_pdf_via_mutool: src={} dest={}", source, dest);
     let dest_path = Path::new(dest);
     let parent = dest_path.parent().unwrap_or_else(|| Path::new("."));
     let stem = dest_path
@@ -1284,10 +1283,6 @@ impl Graphics {
   /// `convert`/Ghostscript for vector-heavy PDFs. Returns true only when
   /// the destination file was actually written.
   fn convert_pdf_via_pdftocairo(source: &str, dest: &str, density: u32, page: Option<u32>) -> bool {
-    eprintln!(
-      "DBG convert_pdf_via_pdftocairo: src={} dest={}",
-      source, dest
-    );
     let dest_path = Path::new(dest);
     let parent = dest_path.parent().unwrap_or_else(|| Path::new("."));
     let stem = dest_path

--- a/latexml_post/src/graphics.rs
+++ b/latexml_post/src/graphics.rs
@@ -2003,8 +2003,6 @@ impl Processor for Graphics {
       .unwrap_or(4)
       .clamp(1, 22);
     let n_workers = convert_count.min(worker_cap).max(1);
-    let source_dir_ref = source_dir.as_str();
-    let dest_dir_ref = dest_dir.as_str();
     let mut outcomes: Vec<ConvertOutcome> = Vec::with_capacity(convert_count);
     if convert_count > 0 {
       use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
@@ -2131,12 +2129,17 @@ impl Processor for Graphics {
                       raw_dims: raster_res.dims().map(|d| (d.width, d.height)),
                     }
                   } else {
-                    // Final-failure: every conversion path exhausted. Promoted
-                    // from warn → Error 2026-05-08 because we want all
-                    // images to convert successfully, and a silent warning
-                    // hides regressions in the rasterizer chain.
-                    // Error class/object mirror Perl Graphics.pm:274
-                    // `Error('imageprocessing', $source, …)` so the
+                    // Final-failure: every conversion path exhausted. Mirror
+                    // Perl Graphics.pm L324-329 (Error + `return` with NO
+                    // imagesrc) — do NOT fall back to copying the raw source.
+                    // A raw .eps/.ps/.pdf is never usable on the web; copying it
+                    // would emit a broken `<img src="fig.eps">`. Leaving
+                    // @imagesrc unset makes the HTML5 XSLT
+                    // (LaTeXML-misc-xhtml.xsl L154) render the node as
+                    // `class="ltx_missing ltx_missing_image"` (empty src) — the
+                    // correct "couldn't render" signal. (User directive
+                    // 2026-06-22; raw .eps/.pdf are never web-native.)
+                    // Error class/object mirror Perl Graphics.pm:274 so the
                     // harness aggregates with engine/package emissions.
                     Error!(
                       "imageprocessing",
@@ -2145,20 +2148,10 @@ impl Processor for Graphics {
                       source,
                       abs_dest_str
                     );
-                    if let Some(rel) =
-                      Self::copy_to_destination(source, source_dir_ref, dest_dir_ref)
-                    {
-                      ConvertOutcome {
-                        job_id:   *job_id,
-                        imagesrc: Some(rel),
-                        raw_dims: Self::read_image_dimensions(source),
-                      }
-                    } else {
-                      ConvertOutcome {
-                        job_id:   *job_id,
-                        imagesrc: None,
-                        raw_dims: None,
-                      }
+                    ConvertOutcome {
+                      job_id:   *job_id,
+                      imagesrc: None,
+                      raw_dims: None,
                     }
                   };
                   local.push(outcome);
@@ -2199,24 +2192,25 @@ impl Processor for Graphics {
       };
     for plan in &plans {
       match plan {
-        Plan::NotFound { idx, graphic } => {
-          // Perl `Post/Graphics.pm:216` uses Warn level. An earlier
-          // Rust-only promotion to Error (2026-05-08) was motivated by
-          // "we want all images to convert", but the real driver of the
-          // not-found cases on the canvas is the missing
-          // `doc.get_search_paths()` half of `find_graphics_paths`
-          // (just fixed above), not actual missing files. With sources
-          // findable, this branch hits only when the .tex literally
-          // references a non-existent file — exactly the case Perl
-          // emits at Warn level. Restore Perl-faithful Warn.
+        Plan::NotFound { idx: _, graphic } => {
+          // Perl `Post/Graphics.pm:216-219`: Warn + `return` WITHOUT setting
+          // @imagesrc. An earlier Rust-only promotion to Error (2026-05-08)
+          // was reverted once the missing `doc.get_search_paths()` half of
+          // `find_graphics_paths` was fixed; with sources findable this branch
+          // hits only when the .tex references a genuinely non-existent file.
+          // We must NOT then set `imagesrc` to the raw `graphic` path: that
+          // emits a broken `<img src="missing.eps">` (and leaks a raw
+          // .eps/.pdf to the web). Leaving @imagesrc unset makes the HTML5
+          // XSLT (LaTeXML-misc-xhtml.xsl L154) render the node as
+          // `class="ltx_missing ltx_missing_image"` (empty src) — the correct
+          // "couldn't render" signal, matching Perl (user directive
+          // 2026-06-22; raw .eps/.pdf are never web-native).
           Warn!(
             "expected",
             "source",
             "No graphic source found; skipping (source was '{}')",
             graphic
           );
-          let mut node_mut = nodes[*idx].clone();
-          node_mut.set_attribute("imagesrc", graphic).ok();
         },
         Plan::Copy { idx, source, options } => {
           let mut node_mut = nodes[*idx].clone();

--- a/latexml_post/src/graphics.rs
+++ b/latexml_post/src/graphics.rs
@@ -946,6 +946,8 @@ impl Graphics {
           libc::killpg(pid, libc::SIGTERM);
         }
         std::thread::sleep(std::time::Duration::from_millis(200));
+        // SAFETY: pgid is the child's own process group (set via setpgid in
+        // pre_exec); killpg only signals that group.
         unsafe {
           libc::killpg(pid, libc::SIGKILL);
         }
@@ -2323,7 +2325,15 @@ mod tests {
   impl EnvGuard {
     fn set(key: &str, value: &str) -> Self {
       let old = std::env::var(key).ok();
-      // FIXME: Audit that the environment access only happens in single-threaded code.
+      // SAFETY: EnvGuard is a test-only helper (`#[cfg(test)] mod tests`),
+      // used in `process_coalesces_only_matching_conversion_options` to point
+      // PATH at a fake `convert` for the duration of one test. `set_var`/
+      // `remove_var` are `unsafe` in edition 2024 because a concurrent env
+      // read/write from another thread is a data race.
+      // FIXME: the single-threaded property is NOT formally guaranteed here —
+      // cargo's default test harness runs the binary's tests on multiple
+      // threads and other tests read the environment (`std::env::var`). Make
+      // this airtight by serializing env-mutating tests (e.g. `serial_test`).
       unsafe { std::env::set_var(key, value) };
       Self { key: key.to_string(), old }
     }
@@ -2332,10 +2342,14 @@ mod tests {
   impl Drop for EnvGuard {
     fn drop(&mut self) {
       if let Some(old) = &self.old {
-        // FIXME: Audit that the environment access only happens in single-threaded code.
+        // SAFETY: test-only restore of the value EnvGuard::set saved; same
+        // edition-2024 data-race rationale as in `set`.
+        // FIXME: single-threaded property not formally guaranteed (see `set`).
         unsafe { std::env::set_var(&self.key, old) };
       } else {
-        // FIXME: Audit that the environment access only happens in single-threaded code.
+        // SAFETY: test-only removal of a var EnvGuard::set introduced; same
+        // edition-2024 data-race rationale as in `set`.
+        // FIXME: single-threaded property not formally guaranteed (see `set`).
         unsafe { std::env::remove_var(&self.key) };
       }
     }

--- a/latexml_post/src/graphics_cache.rs
+++ b/latexml_post/src/graphics_cache.rs
@@ -416,6 +416,8 @@ fn acquire_prune_lock(root: &Path) -> Option<fs::File> {
     .truncate(false)
     .open(&lock_path)
     .ok()?;
+  // SAFETY: fd is an owned, open file descriptor for the lock file; flock(2)
+  // operates on it without aliasing Rust memory.
   let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
   if rc == 0 { Some(file) } else { None }
 }

--- a/latexml_post/src/writer.rs
+++ b/latexml_post/src/writer.rs
@@ -51,6 +51,38 @@ pub fn write_output(content: &str, dest: Option<&str>) -> io::Result<()> {
   }
 }
 
+/// Like [`write_output`] but writes several segments back-to-back without
+/// concatenating them into one buffer first. Used for the conversion log,
+/// where the core and post-phase segments are each already-allocated and
+/// large for real articles — a `format!("{core}{post}")` would allocate a
+/// third copy of their combined size on the conversion hot path. Segments are
+/// written verbatim and in order through a single `BufWriter` (one file
+/// open/truncate); insert any separators (e.g. `"\n"`) as their own segments.
+pub fn write_output_segments(segments: &[&str], dest: Option<&str>) -> io::Result<()> {
+  match dest {
+    Some(path) => {
+      ensure_parent_dir(path)?;
+      let mut writer = io::BufWriter::new(fs::File::create(path)?);
+      let mut total = 0usize;
+      for seg in segments {
+        writer.write_all(seg.as_bytes())?;
+        total += seg.len();
+      }
+      writer.flush()?;
+      Info!("writer", "wrote", "Wrote '{}' ({} bytes)", path, total);
+      Ok(())
+    },
+    None => {
+      let stdout = io::stdout();
+      let mut handle = stdout.lock();
+      for seg in segments {
+        handle.write_all(seg.as_bytes())?;
+      }
+      Ok(())
+    },
+  }
+}
+
 /// Ensure the parent directory of `path` exists, creating it (and any
 /// missing ancestors) as needed. No-op when `path` has no parent or
 /// the parent is the current directory.

--- a/latexml_post/src/xslt.rs
+++ b/latexml_post/src/xslt.rs
@@ -63,6 +63,11 @@ mod max_depth_tests {
   #[test]
   fn dlsym_sets_perl_parity_cap() {
     super::set_xslt_max_depth();
+    // SAFETY: `dlsym(RTLD_DEFAULT, "xsltMaxDepth")` returns the address of
+    // libxslt's process-global `int` recursion cap, valid for the lifetime of
+    // the loaded libxslt (linked into this test binary). We assert non-null
+    // before dereferencing, and the `*const c_int` cast matches the symbol's C
+    // type; the read is on a single thread (`set_xslt_max_depth` already ran).
     let val = unsafe {
       let sym = libc::dlsym(libc::RTLD_DEFAULT, c"xsltMaxDepth".as_ptr());
       assert!(!sym.is_null(), "xsltMaxDepth not resolvable via dlsym");

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "rust-skills": {
+      "source": "leonardomso/rust-skills",
+      "sourceType": "github",
+      "skillPath": "SKILL.md",
+      "computedHash": "54a0b74547168fc59feef6a8e5e2e889f38524a1f8f764c2b4d435de63b3998c"
+    }
+  }
+}

--- a/tools/README.md
+++ b/tools/README.md
@@ -4,6 +4,19 @@ Utility scripts for development, triage, sandbox sweeps, kernel-dump
 generation, schema work, and porting audits. Most are bash; a few are
 Python or Perl. Run from the repo root unless noted.
 
+## Skills (`.claude/skills/`) — the workflows these scripts plug into
+
+Project skills capture the *judgement* around the scripts (what verdict to
+trust, what trap to avoid); the scripts do the mechanical work. Invoke a skill
+with `/<name>` or let it surface by description.
+
+| Skill | When | Key scripts |
+|---|---|---|
+| `canvas-triage` | "Is this paper a genuine Rust bug or parity with Perl?" | `parity_check.sh`, `triage_failure.sh`, `first_error.sh` |
+| `min-repro` | Reduce a confirmed failure to a minimal `.tex`/fixture | `bisect_repro.sh`, `first_error.sh` |
+| `perl-port` | Faithfully translate/fix a binding from the Perl source | `audit_def_parity.py`, `audit_attrs.sh`, `audit_locked.sh` |
+| `perf-check` | Measure performance / pick a profile / avoid settled dead-ends | `perf_compare.py`, `perf_phase_summary.py`, `run_perf_corpus.sh` |
+
 ## Quick lookup
 
 | I want to … | Use |
@@ -54,7 +67,7 @@ Python or Perl. Run from the repo root unless noted.
 - **`generate-scholarly-schema-docs`** — standalone HTML schema-doc
   tree (trang + `genschema_oxide` + `latexml_oxide --split`).
 
-### Perl-porting audits (one-shot per binding migration)
+### Perl-porting audits (one-shot per binding migration; paired with skill `perl-port`)
 
 - **`audit_attrs.sh`** — Perl→Rust attribute parity sweep
   (locked / bounded / scope / requireMath / robust).
@@ -62,7 +75,7 @@ Python or Perl. Run from the repo root unless noted.
   parity counter.
 - **`audit_locked.sh`** — `locked=>1` parity.
 
-### Performance
+### Performance (paired with skill `perf-check`)
 
 - **`perf_compare.py`** — paired A/B comparison of two telemetry corpus
   runs (Δwall, Δphase_us).

--- a/tools/miri_check.sh
+++ b/tools/miri_check.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# miri_check.sh — run Miri (the MIR interpreter, UB detector) over the
+# workspace's FFI-FREE pure-Rust `unsafe`.
+#
+# WHY SCOPED, NOT WHOLE-WORKSPACE: most of this project's `unsafe` is C FFI
+# (libc waitpid/poll/fork in the LSP server, kpathsea, libxml2/libxslt via
+# dlsym, getrusage, signal handlers) — Miri CANNOT execute extern "C" calls,
+# so a blanket `cargo miri test` aborts on the first FFI call. See
+# docs/SAFETY.md for the full `unsafe` inventory and which category each site
+# is in. The category with genuine UB potential that Miri *can* check is the
+# string-interner / arena (`latexml_core/src/common/arena.rs`): unchecked
+# `resolve_unchecked` bounds-skips (cat. B) and the re-entrant `&mut *ptr`
+# (cat. C). That is what this script exercises.
+#
+# FLAGS:
+#  -Zmiri-disable-isolation : allow time/getrandom (harmless for these tests)
+#  -Zmiri-ignore-leaks      : the engine's interner is a process-lifetime
+#                             `once_cell::Lazy<RefCell<StringInterner>>` that
+#                             never drops BY DESIGN; without this flag Miri
+#                             reports the singleton as a "leak" (not UB).
+#
+# Usage: tools/miri_check.sh            # run the scoped arena UB check
+#        tools/miri_check.sh <filter>   # override the test-name filter
+set -euo pipefail
+
+FILTER="${1:-arena}"
+export MIRIFLAGS="${MIRIFLAGS:-} -Zmiri-disable-isolation -Zmiri-ignore-leaks"
+
+if ! rustup component list --toolchain nightly 2>/dev/null | grep -q 'miri.*(installed)'; then
+  echo "miri not installed; installing for the nightly toolchain…" >&2
+  rustup component add --toolchain nightly miri
+fi
+
+echo "==> cargo +nightly miri test -p latexml_core --lib ${FILTER}" >&2
+echo "    MIRIFLAGS=${MIRIFLAGS}" >&2
+exec cargo +nightly miri test -p latexml_core --lib "${FILTER}"


### PR DESCRIPTION
## Further stability & coverage

A stability/coverage pass over arXiv TeX/LaTeX sources, validated by a full
10k-sandbox rerun (`sandbox-arxiv-10k-shuffle`, maxperf-cortex binary, 72-worker
fleet). All changes stay faithful to the Perl LaTeXML semantics.

### Correctness / coverage fixes
- **box-model**: `\hsize`-aware vbox paragraph wrapping — fixes the Cluster G
  hang (1707.02464); root cause was a frame-ordering divergence in the
  `\vbox{\halign}` mode handling.
- **tables**: port `array.sty` `p{}`/`m{}`/`b{}` columns to the Perl
  `\lx@tabular@p` VBox form; `p/m/b` `<td>` gets `align="left"` (not
  `"justify"`), clearing the cluster-B td-align residual.
- **math**: distribute a comma-list left of a relation (`a,b ∈ A`) into a
  distributed XMDual.
- **graphics**: route every non-web-native source through conversion; never ship
  a raw `.eps`/`.pdf` to the web on a failed/missing conversion.

### Signal integrity & robustness
- **post**: capture the post-processing log (Scan/Bibliography/CrossRef/Graphics/
  Split/MathML/XSLT) into `--log`/`cortex.log`. Post-processing diagnostics
  (dominated by the `expected:id` dangling-XMRef cluster) were previously flushed
  before post ran, so a silent EPS→PNG failure left `Status:conversion:0`. This
  makes the cortex signal honest — and is the sole driver of the
  no_problem→warning movement in the 10k rerun below (newly *visible*
  pre-existing post warnings, not new defects).
- **numeric-safety**: clamp signed→usize argument counts to Perl's empty-range
  semantics (`saturating_sub`/`.max(0)`), preventing a `usize` wrap→panic/OOM on
  malformed `\newcommand\foo[0][d]{}`-style input; regression fixture added.
- **safety**: complete `// SAFETY:` comment coverage across all unsafe sites;
  add a scoped (FFI-free) Miri CI job.

### Tooling / docs
- Codify project workflows as committed `.claude/skills` (canvas-triage,
  min-repro, perl-port, perf-check); track third-party rust-skills via lockfile.
- Extensive `docs/SYNC_STATUS.md` updates from the error/warning-severity cortex
  sweeps.

### 10k-sandbox validation (further-stability-coverage vs prior run)
- **Zero clean→hard regressions**: 0 no_problem→error, 0 no_problem→fatal, 0
  warning→error.
- **Net hard-failure improvement**: 16 papers improved (error→no_problem 7,
  error→warning 7, fatal→error 2) vs 3 worsened to fatal (timeout/resource
  boundary noise).
- **Fatal 65 / Error 1175** vs the documented historical clean-pass baseline of
  ~169 fatal / ~1250 error — a substantial stability gain.
- The +232 no_problem→warning shift is confirmed newly-visible post-processing
  `expected:id`/XMRef diagnostics (the post-log-capture commit), not defects.

Full suite green; clippy clean (enforced by the pre-push gate).
