### PR TITLE
Post-processing signal-fidelity: silence ~200.7k spurious Rust-only warnings (faithful to Perl)

### DIFF
--- a/docs/EXPECTED_ID_XMREF_DESIGN_2026-06-08.md
+++ b/docs/EXPECTED_ID_XMREF_DESIGN_2026-06-08.md
@@ -1,5 +1,24 @@
 # `expected:id` dangling-XMRef — Design Scope
 
+> **UPDATE 2026-06-25 — parse-time warning SUPPRESSED (signal-fidelity), Class B
+> structural fix still deferred.** The dominant emitter of this cluster was the
+> math-parser's *parse-time* `realize_xmnode` (`parser.rs:2840`, ~128.9k of the
+> ~130.8k `warning:expected:id` messages in the 10k sandbox). It is a **benign
+> transient false-positive**: it consults the LIVE `document.lookup_id` mid-parse
+> while XMath elements reinstall (a Rust/ASF artifact Perl lacks), but the FINAL
+> tree is clean — empirically verified on the heaviest witness `0704.2400`: of 98
+> transient misses, 85 ids are present in the output and the other 13 leave **0
+> dangling `<XMRef idref>`** (the output has 0 dangling idrefs of 2597). The whole
+> 10k run has **0 `error:expected:id`**, i.e. the authoritative post-processing
+> check (`latexml_post` `realize_xm_node` / `mark_xm_node_visibility_aux`, faithful
+> Perl `Post.pm:1444/1456` Error) flags no genuine output danglers. So the
+> parse-time Warn was made SILENT (`parser.rs`), output byte-identical, genuine
+> danglers still caught downstream. The Rust-only `base_xmath.rs` createXMRefs
+> "Unresolved _xmkey" Warn (Perl `Base_XMath.pool.ltxml:306-308` is silent) was
+> also removed. **The Class B structural divergence below (equation→equationgroup
+> refnum-id loss) is NOT fixed** — it simply no longer floods the cortex signal;
+> when a genuine dangler reaches output, the faithful post-Error reports it.
+>
 > **Status:** DESIGN + PHASE-0 GROUNDED (no fix code yet). Scopes the fix for
 > the residual `expected:id Cannot find a node with xml:id='…'` cluster — the
 > non-VERTBAR XMDual-dangling remainder after the bra-ket VERTBAR work

--- a/docs/EXPECTED_ID_XMREF_DESIGN_2026-06-08.md
+++ b/docs/EXPECTED_ID_XMREF_DESIGN_2026-06-08.md
@@ -19,6 +19,41 @@
 > refnum-id loss) is NOT fixed** — it simply no longer floods the cortex signal;
 > when a genuine dangler reaches output, the faithful post-Error reports it.
 >
+> **CLASS B RE-CONFIRMED + GUARANTEE CLARIFIED 2026-06-25.** Re-ran the
+> fully-traced witness `2311.01600` on current HEAD. Class B is **still live** but
+> the picture has moved on from the 2026-06-08 trace:
+> * The **container-id half IS fixed** — the group is `A1.E66` (NOT the old
+>   `A1.p10.1`), with per-row presentation equations `A1.E66X`/`A1.E66Xa`/`A1.E66Xb`
+>   and math under `A1.E66Xa.m1.*` (the X-equation scheme).
+> * **6 residual danglers**: `A1.E66.m1.1a/1b/4a/4b`, `A1.E68.m1.1a/1b` — the `\Pr`
+>   XMDual **content** refs, minted against the *group* Math scheme `A1.E66.m1.*`
+>   (pre-rearrange) while the parsed content lands under the *per-row* X scheme
+>   `A1.E66Xa.m1.*`. So `A1.E66.m1.*` never materializes → dangling.
+> * **Current root** (`rearrange_lone_ams_aligned`, `amsmath_sty.rs:1703`): Rust
+>   builds *per-row* equations each with their **own** MathFork main, id'd off the
+>   inner X equation (`A1.E66Xa.m1.*`). **Perl builds ONE group-level content Math
+>   `A1.E66.m1` + per-row presentation equations.** Closing it = restructure
+>   rearrange to Perl's single-content-Math shape (main Math id derived from the
+>   GROUP, one content Math, parse-reinstall id preservation). Multi-part,
+>   high-fixture-churn — the "3 prior reverts" area. **Deferred to a dedicated,
+>   carefully-validated effort.**
+>
+> **GUARANTEE (important correction).** These danglers are **NOT** unflagged: core
+> `markXMNodeVisibility` (`latexml_core/document.rs:3250`) fires **`Warning:expected:node`
+> "No node found with id='…' (referred to from ltx:XMRef)"** — one per dangling ref,
+> reaching the XMDual **content** branch — faithful to Perl `Document.pm:1553` (a
+> Warning). The 2026-06-25 parse-time `realize_xmnode` suppression did **not**
+> create a false negative; the earlier "0 errors / 6 danglers" reading was a grep
+> artifact (only `expected:id` was counted, not the `expected:node` Warning that
+> actually fires). So the id-message guarantee for digestion-created danglers is
+> already met by the faithful `expected:node` signal. (A genuinely-final-tree
+> fresh-scan check was prototyped and **reverted** — it merely duplicated the
+> `expected:node` Warning as an `expected:id` Error, double-fired, and escalated
+> severity, which Perl does not.) The remaining hardening target is *post-created*
+> danglers (a target renamed during a post phase), where the post
+> `markXMNodeVisibility` uses the possibly-stale `idcache` — verify before adding
+> any new signal.
+>
 > **Status:** DESIGN + PHASE-0 GROUNDED (no fix code yet). Scopes the fix for
 > the residual `expected:id Cannot find a node with xml:id='…'` cluster — the
 > non-VERTBAR XMDual-dangling remainder after the bra-ket VERTBAR work

--- a/docs/EXPECTED_ID_XMREF_DESIGN_2026-06-08.md
+++ b/docs/EXPECTED_ID_XMREF_DESIGN_2026-06-08.md
@@ -37,6 +37,23 @@
 >   GROUP, one content Math, parse-reinstall id preservation). Multi-part,
 >   high-fixture-churn — the "3 prior reverts" area. **Deferred to a dedicated,
 >   carefully-validated effort.**
+>   * **MOVE-only approach EMPIRICALLY EXHAUSTED 2026-06-25.** Changed the
+>     main-fork content append from `append_clone` (re-ids) to a true MOVE
+>     (`add_child`, keeping the originals' `A1.E66.m1.*` ids). Built clean, but the
+>     witness STILL danglers 6 (set shifted to `A1.E66.m1.{1,1a,4,4a}` /
+>     `A1.E68.m1.{1,1a}`). Dumped ids: the moved content's defs are re-assigned to
+>     `A1.E66X/Xa/Xb.m1.*` (ZERO `A1.E66.m1.*` defs). So a re-id pass keyed off the
+>     **main Math's id** — `open_math_fork` (`base_xmath.rs:1397`) ids the main
+>     `<ltx:Math>` off the enclosing **inner X equation** (`A1.E66Xa` → `A1.E66Xa.m1`),
+>     and `finalize_rec`/`generate_id` (`document.rs:377/4565`) + the parse reinstall
+>     overwrite the moved ids — confirming §3e is LIVE on current code, not stale.
+>     **Reverted (witness gate failed).** The actionable next step: make
+>     `open_math_fork` (or rearrange) derive the MathFork main content Math id from
+>     the **GROUP** (`{group}.m1`), build it **ONCE per group** (per-row mains
+>     collide on `{group}.m1`), MOVE all rows' originals into it, and ensure the
+>     parse reinstall **preserves** pre-existing ids. Core-builder + math-parser
+>     change — validate every `MathFork`/`equation`/`equationgroup` fixture vs Perl
+>     incrementally.
 >
 > **GUARANTEE (important correction).** These danglers are **NOT** unflagged: core
 > `markXMNodeVisibility` (`latexml_core/document.rs:3250`) fires **`Warning:expected:node`

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -74,6 +74,24 @@ snapshot, true per-task transition matrix from `historical_tasks`):
   74,790 → 3,865 (only the parity pgfmath/counter ones remain). error 1175→1174,
   fatal 65→66 (within run-to-run variance).
 
+**Error-category triage (2026-06-25, same fresh rerun).** After the warning
+de-noising, re-mined the ERROR/FATAL cross-join (Rust error/fatal vs Perl
+no_problem/warning) for genuine Rust-only regressions. **Mined out** — the strict
+filter (Rust error/fatal AND Perl `no_problem`, excluding cyrillic phantoms)
+returns a single missing-macro singleton (`\textcjheb`). Specifics:
+- `unexpected:<char>` inputenc (20 papers) + babel (13) = **re-confirmed env-artifact
+  phantoms** (host lacks the `cyrillic` collection; same-host Perl fails identically).
+- `Attempt to end mode` box-recovery (73 papers) = **71/73 Perl-parity**.
+- `malformed:ltx:XMTok` (3 papers) = parity/Rust-better (Perl error/fatal).
+- The only GENUINE Rust-only finding is the **`{\input file}` box cascade**
+  (math0701308: same-host Perl 0, Rust 90; `TeXFileName` consumes the `}` —
+  shared Perl parity — then Rust's stricter box recovery cascades into text-mode
+  `_`/`^` errors). **Low-breadth (3 papers); deferred** — the faithful fix is a
+  deep stomach-recovery change, the easy fix (`TeXFileName` stop-at-`}`) diverges
+  from Perl-LaTeXML and has broad blast radius. Characterized for a dedicated
+  effort. Reconfirms: the cortex `Perl=clean` baseline is unreliable (env
+  artifacts) — verify every cross-service delta with same-host Perl.
+
 ### Landed earlier (2026-06-22, on `further-stability-coverage`, pushed)
 
 Two genuine Rust-only bugs fixed + the full p/m/b table-column parity arc:

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -60,6 +60,20 @@ reads the macro body; 354 msgs / 2 tasks) — deferred, needs a `LookupDimension
 
 Suite 1468/0, clippy clean, fmt clean.
 
+**10k-sandbox rerun validation** (maxperf-cortex, 72-worker fleet, vs the PR#269
+snapshot, true per-task transition matrix from `historical_tasks`):
+- **no_problem 6219 → 6982 (+763)**, warning 2446 → 1683 (−763) — the +763 are
+  papers that were `warning` SOLELY from the removed spurious diagnostics, now
+  correctly clean (matching Perl's clean output).
+- **ZERO clean→hard regressions**: 0 no_problem→{warning,error,fatal}, 0
+  warning→error. Only transitions: `warning→no_problem` 763, plus `error↔fatal`
+  ±1 boundary noise (2 papers `never_completed_with_retries` = cortex
+  timeout/retry infra, unrelated to the warning-suppression code).
+- **Total warning messages 262,986 → 62,106 (−200,880, −76%)**; `expected:id`
+  130,814 → 1,011 (only the faithful "Missing idref" Warn remains); `expected:register`
+  74,790 → 3,865 (only the parity pgfmath/counter ones remain). error 1175→1174,
+  fatal 65→66 (within run-to-run variance).
+
 ### Landed earlier (2026-06-22, on `further-stability-coverage`, pushed)
 
 Two genuine Rust-only bugs fixed + the full p/m/b table-column parity arc:

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -15,12 +15,52 @@
 
 ## Current status
 
-- `cargo test --tests`: **1467 / 0 / 0**.
+- `cargo test --tests`: **1468 / 0 / 0**.
 - `cargo clippy --workspace --all-targets -- -D warnings`: **clean**.
 - `--init=plain.tex` / `--init=latex.ltx`: **0 errors** (with dump and `LATEXML_NODUMP=1`).
 - Distribution build (`maxperf`): ~45 MB; beats 2× pdflatex on the mini-benchmark.
 
-### Landed this session (2026-06-22, on `further-stability-coverage`, pushed)
+### Landed this session (2026-06-25, on `post-processing-signal-fidelity`)
+
+**Signal-fidelity pass — ~200.7k spurious `warning` messages eliminated from the
+10k sandbox, all faithful to Perl, ZERO output change.** Triaged the dominant
+post-processing/digestion warning clusters in the cortex 10k run; each was a
+Rust-only divergence where Perl is silent (verified against the Perl source per
+fix):
+
+- **`expected:id` parse-time transient (128.9k msgs / 1142 tasks)** — the
+  math-parser `realize_xmnode` (`parser.rs`) warned "Cannot find a node with
+  xml:id" on a LIVE-`lookup_id` miss mid-reinstall (a Rust/ASF artifact Perl's
+  `MathParser::realizeXMNode` lacks). Empirically benign: on the heaviest witness
+  `0704.2400`, 85/98 warned ids are present in the output and the other 13 leave
+  **0 dangling `<XMRef>`** (0 dangling of 2597 idrefs); the whole 10k has **0
+  `error:expected:id`**. Made silent; genuine danglers still caught by the
+  faithful post-Error (`latexml_post`, Perl `Post.pm:1444/1456`). Output
+  byte-identical. See `EXPECTED_ID_XMREF_DESIGN_2026-06-08.md` (2026-06-25 banner).
+- **`expected:register \tabcolsep`/`\arraycolsep` (43.8k msgs)** — `\lx@text@intercol`
+  / `\lx@math@intercol` used the warning `lookup_register`; Perl
+  (`TeX_Tables.pool.ltxml:639/646`) uses a silent `isRegister ? valueOf :
+  Dimension(0)` inline guard (a document may `\renewcommand` the length register
+  into a macro). Added `state::lookup_register_quiet` (no warn) and used it.
+- **`expected:register \fam` (27.1k msgs)** — `decode_math_char` (`mathchar.rs`)
+  read `\fam` via warning `lookup_register`; Perl `decodeMathChar`
+  (`Package.pm:2928`) reads `lookupValue('fontfamily')` DIRECTLY. Switched to a
+  direct `fontfamily` read (the `\fam` register's own getter already does this) —
+  no warn, and correct even when `\fam` is shadowed (matches Perl). Normal
+  (non-shadowed) `\fam` is unaffected (suite unchanged).
+- **`expected:id` createXMRefs (900 msgs)** — `base_xmath.rs` XMDual
+  `after_close_late` warned "Unresolved _xmkey"; Perl (`Base_XMath.pool.ltxml:306-308`)
+  silently does `setAttribute(idref => undef)`. Removed the Rust-only warning.
+
+NON-fixes (confirmed PARITY — Perl warns too via `LookupRegister`, left as-is):
+`\tikz@dashphase`/`\cmdGR@*` (pgfmath `pgfmath_register`→`LookupRegister`), `\c@*`
+counters (`CounterValue`→`LookupRegister`). `eqnarray` `\arraycolsep` at
+`latex_constructs.rs:971` is a minor remaining divergence (Perl `LookupDimension`
+reads the macro body; 354 msgs / 2 tasks) — deferred, needs a `LookupDimension` port.
+
+Suite 1468/0, clippy clean, fmt clean.
+
+### Landed earlier (2026-06-22, on `further-stability-coverage`, pushed)
 
 Two genuine Rust-only bugs fixed + the full p/m/b table-column parity arc:
 - **Cluster G hang** `1707.02464` — `\hsize`-aware vbox paragraph wrapping (faithful

--- a/latexml_core/src/common/mathchar.rs
+++ b/latexml_core/src/common/mathchar.rs
@@ -721,10 +721,18 @@ pub fn decode_math_char(
   n %= 16 * 256;
   let mut fam: u16 = n / 256;
 
-  let curfam_val: i32 = match state::lookup_register("\\fam", Vec::new()) {
-    Ok(Some(crate::definition::register::RegisterValue::Number(curfam))) => curfam.0 as i32,
+  // Perl Package.pm:2928 reads the internal `fontfamily` value DIRECTLY
+  // (`$STATE->lookupValue('fontfamily') // -1`), NOT the `\fam` register CS.
+  // The `\fam` register is merely backed by `fontfamily` (its getter, tex_math.rs;
+  // Perl TeX_Math.pool.ltxml:639-641). Reading the value directly mirrors Perl,
+  // stays correct when a document shadows `\fam` (e.g. `\let`/`\renewcommand`),
+  // and avoids the spurious `expected:register` warning that `lookup_register`
+  // emits per math char when `\fam` is no longer a register.
+  let curfam_val: i32 = state::with_value("fontfamily", |v| match v {
+    Some(Stored::Int(i)) => *i as i32,
+    Some(Stored::Number(n)) => n.0 as i32,
     _ => -1,
-  };
+  });
 
   if class == 7 && (0..=15).contains(&curfam_val) {
     fam = curfam_val as u16;

--- a/latexml_core/src/state.rs
+++ b/latexml_core/src/state.rs
@@ -1744,6 +1744,24 @@ pub fn lookup_register_token(
   })
 }
 
+/// Quiet sibling of [`lookup_register`] for call sites that mirror Perl's
+/// explicit `lookupDefinition(cs) && $defn->isRegister ? $defn->valueOf : <default>`
+/// guard — e.g. TeX_Tables `\lx@text@intercol`/`\lx@math@intercol`
+/// (`TeX_Tables.pool.ltxml` L639/L646), where a document may legitimately
+/// `\renewcommand` a length register (`\tabcolsep`/`\arraycolsep`) into a plain
+/// macro. In that case the register-ness is genuinely gone in Perl too, and Perl
+/// silently falls back to its default (`Dimension(0)`) with **no warning**.
+/// Returns `None` (no warning) when the CS is undefined or is not a register,
+/// so the caller can apply its own faithful default.
+pub fn lookup_register_quiet(cs: &str) -> Option<RegisterValue> {
+  let defn = lookup_definition(&T_CS!(cs)).ok().flatten()?;
+  if defn.is_register() {
+    defn.value_of(Vec::new())
+  } else {
+    None
+  }
+}
+
 pub fn lookup_expandable(
   token: &Token,
   toplevel_opt: Option<bool>,

--- a/latexml_engine/src/base_xmath.rs
+++ b/latexml_engine/src/base_xmath.rs
@@ -503,10 +503,13 @@ LoadDefinitions!({
       let Some(r_xmkey) = r.get_attribute("_xmkey") else { continue };
       if let Some(idref) = ids.get(&r_xmkey) {
         document.set_attribute(&mut r, "idref", idref)?;
-      } else {
-        // xmkey not resolved — may happen with parser-generated nested structures
-        Warn!("expected", "id", s!("Unresolved _xmkey '{}' in createXMRefs", r_xmkey));
       }
+      // else: Perl (Base_XMath.pool.ltxml L306-308) silently does
+      // `setAttribute($r, idref => $ids{key})` with an undef value — a no-op
+      // that leaves the ref with no idref — and emits NO warning. A genuinely
+      // dangling XMRef is flagged faithfully downstream by markXMNodeVisibility
+      // ("Missing idref on ltx:XMRef", Document.pm:1548). Do not emit a
+      // Rust-only warning that Perl never produces.
       r.remove_attribute("_xmkey")?;
     }
   });

--- a/latexml_engine/src/tex_tables.rs
+++ b/latexml_engine/src/tex_tables.rs
@@ -446,7 +446,11 @@ LoadDefinitions!({
   },
   reversion => Tokens!(T_CS!("\\lx@intercol")),
   properties => {
-    let w = match lookup_register("\\tabcolsep", Vec::new())? {
+    // Perl TeX_Tables.pool.ltxml L639: silently falls back to Dimension(0)
+    // when \tabcolsep is not a register (e.g. a document \renewcommand'd it
+    // into a plain macro — a common author slip for \setlength). Use the quiet
+    // lookup so we don't emit a spurious `expected:register` warning per cell.
+    let w = match lookup_register_quiet("\\tabcolsep") {
       Some(RegisterValue::Dimension(d)) => d,
       Some(RegisterValue::Glue(g)) => Dimension::new(g.value_of()),
       _ => Dimension::default(),
@@ -456,7 +460,8 @@ LoadDefinitions!({
   DefConstructor!("\\lx@math@intercol", "",
   reversion => Tokens!(T_CS!("\\lx@intercol")),
   properties => {
-    let w = match lookup_register("\\arraycolsep", Vec::new())? {
+    // Perl TeX_Tables.pool.ltxml L646: same silent isRegister guard for \arraycolsep.
+    let w = match lookup_register_quiet("\\arraycolsep") {
       Some(RegisterValue::Dimension(d)) => d,
       Some(RegisterValue::Glue(g)) => Dimension::new(g.value_of()),
       _ => Dimension::default(),

--- a/latexml_math_parser/src/parser.rs
+++ b/latexml_math_parser/src/parser.rs
@@ -2829,20 +2829,25 @@ pub fn realize_xmnode<'a>(node: &'a Node, document: &'a Document) -> Cow<'a, Nod
     // Can it happen that the target is itself an XMRef? Then recurse.
     if let Some(realnode) = document.lookup_id(&idref) {
       return Cow::Borrowed(realnode);
-    } else {
-      let message = s!("Cannot find a node with xml:id='{}'", idref);
-      // TODO:
-      // LaTeXML::MathParser::IDREFS{$idref}
-      // ? "Previously bound to " .
-      // ToString($LaTeXML::MathParser::IDREFS{$idref})           : ()));
-      // Perl Document.pm L1553: Warn, not Error (missing XMRef targets are common)
-      let warn_fn = || -> Result<()> {
-        Warn!("expected", "id", message);
-        Ok(())
-      };
-      warn_fn().ok();
-      //       return ['ltx:ERROR', {}, "Missing XMRef idref=$idref"]; } }
     }
+    // An unresolved ref HERE is a BENIGN parse-time transient, not a defect, so
+    // we stay SILENT. This resolver consults the LIVE `document.lookup_id`, which
+    // is mutated as each XMath element reinstalls during the parse — a Rust/ASF
+    // architectural artifact that Perl's `MathParser::realizeXMNode`
+    // (MathParser.pm:135) does NOT have, so Perl emits ~0 of these mid-parse.
+    // The target reliably exists in the FINAL tree (empirically on the heaviest
+    // witness 0704.2400: of 98 transient misses, 85 ids are present in the output
+    // and the other 13 leave ZERO dangling `<XMRef idref=…>` — the refs were
+    // re-pointed or absorbed; the output has 0 dangling idrefs of 2597).
+    // Callers rely on an unresolved ref returning the XMRef itself; do NOT "fix"
+    // by swapping in `resolve_xmref` — that DUPLICATES content (\choose →
+    // "a + ba + b binomial c + dc + d"; regresses choose/declare/sampler). See
+    // docs/EXPECTED_ID_XMREF_DESIGN_2026-06-08.md §3b.
+    // The AUTHORITATIVE dangling-ref check is the faithful post-processing pass
+    // (Perl Post.pm:1444/1456 → latexml_post `realize_xm_node` /
+    // `mark_xm_node_visibility_aux`, Error severity) plus core
+    // `markXMNodeVisibility` (Document.pm:1548/1553). Warning here floods ~128k
+    // false positives that bury that genuine signal.
   }
   Cow::Borrowed(node)
 }


### PR DESCRIPTION
## Post-processing signal-fidelity + id-message guarantee

A faithful-to-Perl signal-integrity pass over the cortex 10k sandbox: silence
spurious Rust-only diagnostics that were burying the genuine signal, validated by
a full 10k rerun. Plus error-category triage and a precise Class B (dangling
`expected:id`) diagnosis.

### Signal-fidelity fixes (~200.7k spurious warnings removed, ZERO output change)
Each was a Rust-only divergence where the Perl source is silent — verified against
the Perl source per fix, byte-identical output (witness 0704.2400):

- **`parser.rs::realize_xmnode`** — silence the parse-time `expected:id`
  "Cannot find a node" transient (128.9k msgs / 1142 tasks). It consults the LIVE
  `document.lookup_id` mid-reinstall (a Rust/ASF artifact Perl's
  `MathParser::realizeXMNode` lacks → Perl emits ~0). The final tree is clean
  (0704.2400: 0 dangling of 2597 idrefs); genuine danglers are still flagged
  downstream by the faithful core `markXMNodeVisibility` `expected:node` Warning.
- **`tex_tables.rs` `\tabcolsep`/`\arraycolsep`** (43.8k) — `\lx@text@intercol` /
  `\lx@math@intercol` used the warning `lookup_register`; Perl
  `TeX_Tables.pool.ltxml:639/646` uses a silent `isRegister ? valueOf :
  Dimension(0)` inline guard (a doc may `\renewcommand` the length register into a
  macro). New `state::lookup_register_quiet`.
- **`mathchar.rs` `\fam`** (27.1k) — `decode_math_char` read `\fam` via warning
  `lookup_register`; Perl `decodeMathChar` (`Package.pm:2928`) reads
  `lookupValue('fontfamily')` directly. Switched to the direct read (the `\fam`
  register's own getter already does this) — correct even when `\fam` is shadowed.
- **`base_xmath.rs` createXMRefs** (0.9k) — removed a Rust-only "Unresolved
  _xmkey" warning; Perl `Base_XMath.pool.ltxml:306-308` is silent.

Confirmed PARITY (Perl warns too via `LookupRegister`), left untouched:
`\tikz@dashphase`/`\cmdGR@*` (pgfmath), `\c@*` counters.

### 10k-sandbox validation (vs PR#269 snapshot, true per-task transition matrix)
- **no_problem 6219 → 6982 (+763)**, warning 2446 → 1683 (−763)
- **ZERO clean→hard regressions** (only `warning→no_problem` 763 + ±1 `error↔fatal`
  timeout boundary noise)
- **Total warning messages 262,986 → 62,106 (−200,880, −76%)**; `expected:id`
  130,814 → 1,011; `expected:register` 74,790 → 3,865

### Triage / diagnosis docs
- **Error category mined out**: the top Rust-only error clusters are env-artifact
  phantoms (inputenc `<char>`, babel — host lacks the cyrillic collection;
  same-host Perl fails identically) or parity; the only genuine Rust-only finding
  is the low-breadth (3-paper) `{\input file}` box cascade (characterized,
  deferred).
- **Class B `expected:id` diagnosis** (`EXPECTED_ID_XMREF_DESIGN`): re-confirmed
  live on current HEAD (container-id half fixed; group=`A1.E66`); the guarantee is
  met (faithful `expected:node` Warning fires for the danglers). The MOVE-only
  faithful approach is **empirically exhausted** (a re-id pass off the inner
  X-equation main Math id overwrites moved ids); the next step (group-derived main
  Math id + single group content Math + parse-reinstall id preservation) is pinned
  as a dedicated effort. 0 sandbox breadth.

Suite 1468/0, clippy clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
