### PR TITLE
Parity follow-ups: xint/ar5iv surpass, post-processing failure reporting, panics & frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,15 @@ but adapted for Rust bindings.
 
 Example for Ubuntu:
 ```
-$ sudo apt install libxml2-dev libxslt1-dev texlive-latex-base imagemagick libkpathsea-dev libkpathsea6 mold \
+$ sudo apt install libxml2-dev libxslt1-dev texlive-latex-base imagemagick ghostscript libkpathsea-dev libkpathsea6 mold \
                    texlive texlive-latex-extra texlive-science \
                    texlive-bibtex-extra texlive-publishers poppler-utils
 ```
+
+`ghostscript` (`gs`) is listed explicitly: it is the EPS/PS rasterizer and
+ImageMagick's PS/EPS/PDF delegate, so every EPS/PS figure needs it. It is only a
+*Recommends* of `imagemagick`, so a host configured with `APT::Install-Recommends
+"false"` would silently omit it and fail every EPS/PS conversion.
 
 Example for macOS (Apple Silicon / arm64; the full test suite runs on macOS CI):
 
@@ -136,26 +141,29 @@ PDF, mutool runs in 0.48 s vs pdftocairo's 0.86 s, and its SVG
 output is ~4× more gzip-compressible. Falls through to `pdftocairo`
 if `mutool` is not on PATH — install is optional.
 
-The opt-in vector-SVG path (`--graphics-svg-threshold-kb N`; see
-[docs/SYNC_STATUS.md](docs/SYNC_STATUS.md) and upstream
-[brucemiller/LaTeXML#902](https://github.com/brucemiller/LaTeXML/issues/902))
-uses **only** `mutool` then `pdftocairo`. If both fail (or are absent)
-the pipeline falls back to the raster `convert`/`gs` → PNG path, so a PDF
-is never lost — just rasterized. A heavyweight third resort (inkscape)
-was evaluated and **deliberately dropped**: it pulls a large GTK/X11
-stack, runs 20–40× slower, and is timeout-prone, while adding no real
-coverage over the raster fallback.
+#### Graphics delegate chain
+
+`\includegraphics` figures are converted by external delegates, tried
+fastest-first with fallback:
+
+- **EPS / PS → PNG** — `gs` (Ghostscript), the primary rasterizer, then `convert` (ImageMagick). Landscape PS routes via `ps2pdf` → `pdftocairo` to keep page rotation.
+- **PDF → PNG** — `mutool draw` (MuPDF, fastest) → `pdftocairo` (poppler, ships with TeX Live) → `convert` (ImageMagick).
+- **PDF → SVG** — opt-in vector path for small PDFs (`--graphics-svg-threshold-kb N`): `mutool convert` → `pdftocairo -svg`, falling back to PDF→PNG so a figure is never lost.
+
+`gs` is the most load-bearing delegate (the whole EPS/PS branch plus ImageMagick's
+PS/EPS/PDF delegate), hence the explicit `ghostscript` above.
 
 ### Build profiles (Rust best practice)
 
-Four named profiles in `Cargo.toml`, each tuned for one purpose:
+Five named profiles in `Cargo.toml` (plus a profiling-only `bench`), each tuned for one purpose:
 
 | Profile | When | Goal |
 |---------|------|------|
 | **`test`** (default for `cargo test`) | day-to-day development | Maximum debug info (`debug = "full"`, `debug-assertions`, `overflow-checks`), incremental rebuilds, `-O1` for tolerable test runtime. Use as much local RAM/CPU as needed. |
 | **`ci`**   | GitHub Actions only      | Lowest possible RAM (16 GB runner budget) and fastest compile (`opt-level = 0`, `codegen-units = 256`, no LTO). Just enough to prove tests pass. |
 | **`release`** | local sandbox canvas / perf measurement | Laptop-throughput release: `opt-level = 3`, `lto = "thin"`, `codegen-units = 20`, `strip = "symbols"`. Strong runtime optimization while using the 20-thread local machine during release builds. |
-| **`maxperf`** | distribution / published release artifact | Smallest, fastest binary: `lto = "fat"`, `codegen-units = 1`, `panic = "abort"`, stripped. Slowest build; used by `tools/make_release.sh` for the shipped binaries. |
+| **`maxperf`** | distribution / published release artifact (the standalone `latexml_oxide` / `latexmlmath_oxide` CLIs) | Smallest, fastest binary: `lto = "fat"`, `codegen-units = 1`, `panic = "abort"`, stripped. Slowest build; used by `tools/make_release.sh` for the shipped binaries. |
+| **`maxperf-cortex`** | distribution build of the `cortex_worker` fleet binary (the `docker/cortex-worker.dockerfile` image) | The same fat-LTO / `codegen-units = 1` levers as `maxperf`, but keeps `panic = "unwind"`: the worker relies on `std::panic::catch_unwind` to isolate per-paper panics across a long-lived fleet, which `panic = "abort"` would silently turn into a no-op. |
 
 ### Sample use
 

--- a/README.md
+++ b/README.md
@@ -136,20 +136,15 @@ PDF, mutool runs in 0.48 s vs pdftocairo's 0.86 s, and its SVG
 output is ~4× more gzip-compressible. Falls through to `pdftocairo`
 if `mutool` is not on PATH — install is optional.
 
-#### Optional: inkscape fallback for vector-preserving PDF → SVG
-
-For the opt-in `--graphics-svg-threshold-kb N` flag (see
+The opt-in vector-SVG path (`--graphics-svg-threshold-kb N`; see
 [docs/SYNC_STATUS.md](docs/SYNC_STATUS.md) and upstream
-[brucemiller/LaTeXML#902](https://github.com/brucemiller/LaTeXML/issues/902)):
-
-```
-$ sudo apt install inkscape
-```
-
-`inkscape` is used as the **last-resort** SVG converter when both
-`mutool` and `pdftocairo` fail. The path is disabled by default; if
-the flag is enabled but inkscape is missing at runtime, the pipeline
-silently falls back to raster `convert`.
+[brucemiller/LaTeXML#902](https://github.com/brucemiller/LaTeXML/issues/902))
+uses **only** `mutool` then `pdftocairo`. If both fail (or are absent)
+the pipeline falls back to the raster `convert`/`gs` → PNG path, so a PDF
+is never lost — just rasterized. A heavyweight third resort (inkscape)
+was evaluated and **deliberately dropped**: it pulls a large GTK/X11
+stack, runs 20–40× slower, and is timeout-prone, while adding no real
+coverage over the raster fallback.
 
 ### Build profiles (Rust best practice)
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,7 +13,7 @@ the [pericortex](https://github.com/dginev/cortex-peripherals) `Worker` trait fo
 [CorTeX](https://github.com/dginev/cortex) distributed pipeline, and is the **Rust counterpart of the
 legacy Perl fleet image** ([`LaTeXML-Plugin-CorTeX/Dockerfile`](https://github.com/dginev/LaTeXML-Plugin-CorTeX/blob/master/Dockerfile)):
 same dispatcher, ZMQ ports (`51695`/`51696`), and result-archive contract — different engine and a
-different service name (`oxidized-tex-to-html` vs the Perl `tex_to_html`). One dispatcher can run
+different service name (`oxidized_tex_to_html` vs the Perl `tex_to_html`). One dispatcher can run
 both fleets at once; it leases by `service_id`.
 
 **Build:**
@@ -30,7 +30,7 @@ docker run --network host -v /opt/cortex-scratch:/opt/cortex-scratch --hostname=
 # remote dispatcher:
 docker run -v /opt/cortex-scratch:/opt/cortex-scratch --hostname=$(hostname) cortex-worker DISPATCHER_IP
 
-# positional args:  <dispatcher-host> [ventilator-port=51695] [sink-port=51696] [service=oxidized-tex-to-html]
+# positional args:  <dispatcher-host> [ventilator-port=51695] [sink-port=51696] [service=oxidized_tex_to_html]
 ```
 
 **Tuning (env vars):**

--- a/docker/cortex-worker-entrypoint.sh
+++ b/docker/cortex-worker-entrypoint.sh
@@ -3,7 +3,7 @@
 # Perl `latexml_harness`. Brings up the self-supervising `--harness` fleet pointed at a dispatcher.
 #
 #   cortex-worker <dispatcher-host> [ventilator-port] [sink-port] [service]
-#   defaults:                        51695            51696       oxidized-tex-to-html
+#   defaults:                        51695            51696       oxidized_tex_to_html
 #
 #   env:  PROFILE=ar5iv (default) | generic
 #         WORKERS=<n>  pin the fleet size (battle-hardened sweet spot = physical cores + 1/8;
@@ -24,7 +24,7 @@ esac
 HOST="${1:-127.0.0.1}"
 VENT="${2:-51695}"
 SINK="${3:-51696}"
-SERVICE="${4:-oxidized-tex-to-html}"
+SERVICE="${4:-oxidized_tex_to_html}"
 
 # Optional explicit worker count (else the harness sizes itself); keep memory/timeout guards at the
 # binary's validated defaults — see docs/CORTEX_WORKER_HARNESS.md.

--- a/docker/cortex-worker.dockerfile
+++ b/docker/cortex-worker.dockerfile
@@ -71,12 +71,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       texlive-bibtex-extra texlive-science texlive-pictures texlive-pstricks \
       texlive-publishers \
       libxml2 libxslt1.1 libkpathsea6 libzmq5 \
-      imagemagick poppler-utils mupdf-tools \
+      ghostscript imagemagick poppler-utils mupdf-tools \
       ca-certificates \
     && rm -rf /var/lib/apt/lists/*
-# poppler-utils → pdftocairo; mupdf-tools → `mutool draw`, the first-choice PDF rasterizer
-# (faster + more gzip-compressible than pdftocairo on the canvas slow-tail PDFs; graceful
-# fallback to pdftocairo if absent).
+# ghostscript → `gs`, the EPS/PS rasterizer (convert_eps_via_gs) AND ImageMagick's
+# delegate for PS/EPS/PDF. MANDATORY and EXPLICIT: on Ubuntu `ghostscript` is only a
+# *Recommends* of `imagemagick`, so `--no-install-recommends` would drop it — leaving
+# both `convert file.eps` and direct `gs` unable to run, so EVERY EPS/PS figure fails
+# `imageprocessing:failed_to_convert` (PDFs survive via mutool/pdftocairo, which need no
+# gs). Installing `ghostscript` also pulls `libpng16-16` (a Depends of `libgs`), which
+# gs's `pngalpha`/`png16m` devices need to emit PNG output. poppler-utils → pdftocairo;
+# mupdf-tools → `mutool draw`, the first-choice PDF rasterizer (faster + more
+# gzip-compressible than pdftocairo on the canvas slow-tail PDFs; graceful fallback to
+# pdftocairo if absent).
 
 # Let ImageMagick read/write PDF/EPS and raise its resource ceilings — arXiv figures need it
 # (the same patch the legacy Perl image applies; Debian's default policy.xml blocks PDF/EPS).

--- a/docker/cortex-worker.dockerfile
+++ b/docker/cortex-worker.dockerfile
@@ -52,7 +52,18 @@ COPY . .
 # `cargo build --bin cortex_worker` refuses to build it. The worker uses compiled-in bindings, so
 # `runtime-bindings` is NOT enabled (unused). Also build latexml_oxide: its `--init` generates the
 # kernel dumps baked into the runtime stage below (cortex_worker has no --init of its own).
-RUN cargo build --release --no-default-features --features cortex \
+#
+# Profile = `maxperf-cortex`, NOT `release`: this is a DISTRIBUTION artifact (a long-lived fleet
+# binary built once and run over millions of conversions), and `release` is the dev/sandbox/
+# Perl-parity-measurement profile. `maxperf-cortex` inherits maxperf's real levers (opt-level=3,
+# fat LTO, codegen-units=1) for the smallest+fastest binary, but overrides `panic = "abort"` back
+# to `panic = "unwind"` — MANDATORY here, because the worker relies on `std::panic::catch_unwind`
+# to isolate per-paper panics (cortex_worker.rs); maxperf's abort would turn that into a no-op and
+# crash the whole fleet child on one bad paper. Trade-off: fat LTO + CGU=1 makes THIS layer much
+# slower to build than release — acceptable for a once-per-release image. latexml_oxide rides the
+# same profile (one cargo invocation, one target dir, shared dep graph); it only runs at image-build
+# time for dump-gen, so its extra LTO cost is a single link.
+RUN cargo build --profile maxperf-cortex --no-default-features --features cortex \
       --bin cortex_worker --bin latexml_oxide
 
 # --- Stage 2: runtime — same ubuntu:24.04, full arXiv-capable TeX Live ---
@@ -98,8 +109,9 @@ RUN set -e; P=/etc/ImageMagick-6/policy.xml; if [ -f "$P" ]; then \
     fi
 
 # The worker binary + its resources (XSLT/CSS/RelaxNG), plus latexml_oxide (only to generate dumps).
-COPY --from=builder /build/target/release/cortex_worker /usr/local/bin/
-COPY --from=builder /build/target/release/latexml_oxide /usr/local/bin/
+# Built under the `maxperf-cortex` profile (see the build stage), so they live in target/maxperf-cortex/.
+COPY --from=builder /build/target/maxperf-cortex/cortex_worker /usr/local/bin/
+COPY --from=builder /build/target/maxperf-cortex/latexml_oxide /usr/local/bin/
 COPY --from=builder /build/resources/ /usr/local/share/latexml-oxide/resources/
 
 # Bake the ambient-year TeX kernel dumps into the image — the Rust analog of the legacy Perl image's

--- a/docs/ARXIV_PERFORMANCE.md
+++ b/docs/ARXIV_PERFORMANCE.md
@@ -327,6 +327,35 @@ See the testbed table above (category + dominant phase per paper). Status legend
 > One entry per investigated hotspot: root cause, change, before→after delta,
 > output-neutrality (byte-identical XML) + test evidence. Newest first.
 
+### #3 — XSLT `head-keywords` index dedup O(n²) (batch #201–300 index cluster) — 2026-06-28
+- **Root cause:** `resources/XSLT/LaTeXML-webpage-xhtml.xsl`'s `head-keywords`
+  (builds `<meta name="keywords">`) deduplicated index phrases with
+  `//ltx:indexphrase[not(.=preceding::ltx:indexphrase)]` — the XSLT-1.0
+  distinct-by-value antipattern: each indexphrase walks the `preceding::` axis ⇒
+  **O(indexphrases² × tree-size)**. `xsltproc --profile` pinned it: `head-keywords`
+  = **145 s of a ~150 s** transform on 2208.07515 (1 call), matching the gdb stack
+  `xsltElement(meta)→xsltAttribute(content)→xsltForEach→xmlXPathCompiledEval`.
+- **Change:** the Muenchian method — a hashed
+  `<xsl:key name="f:indexphrase-by-value" match="ltx:indexphrase" use="."/>` +
+  `//ltx:indexphrase[generate-id()=generate-id(key('f:indexphrase-by-value',.)[1])]`.
+  O(n), identical first-occurrence-in-document-order + `<xsl:sort>` semantics.
+  File: `resources/XSLT/LaTeXML-webpage-xhtml.xsl` (embedded at build time).
+- **Before→after** (HEAD pre-fix → post-fix wall; all were ~173–175 s in cortex):
+  2208.07515 (560 \index) 95.5 s → **33.4 s** (xslt 71.5 → 11.8 s); 0807.4838 (1032)
+  78.1 → **13.2 s**; 1802.06435 (515) 77.6 → **17.3 s**; 2403.19732 (334) 68.1 →
+  **29.1 s**; math0206203 (189) 50.0 → **30.0 s**; 1807.02129 (310) 49.6 → **26.9 s**.
+- **Output-neutral:** `xsltproc` full-HTML byte-identical (3.2 MB, 2208.07515 `diff`
+  IDENTICAL); independently, the keywords-meta is byte-identical between the
+  historical pre-fix bundle and the fixed binary on 2208.07515 (5991 ch) and
+  1802.06435 (14394 ch). Suite **1488/0** + new guard `08_xslt_head_keywords.rs`.
+- **Supersedes** the prior campaign's *deferred* "Third XSLT O(n²) — large-index"
+  (1802.06435): the real root was `head-keywords`, NOT the index-render templates
+  (which are locally linear); the prior deferral couldn't pin it without
+  `xsltproc --profile`. 1802.06435 is now 77.6 → 17.3 s.
+- **Note:** local-only XSLT divergence from upstream LaTeXML; the O(n²) exists
+  verbatim upstream — candidate to upstream (like the seclev memoization).
+  See OXIDIZED_DESIGN.md #40.
+
 ### #2 — XSLT `f:seclev-aux` O(n²) heading-level computation (Cluster B; 14 papers) — 2026-06-27
 - **Root cause:** `LaTeXML-structure-xhtml.xsl`'s `f:seclev-aux` recomputes
   whole-tree `boolean(//ltx:X/ltx:title)` descendant scans on every heading

--- a/docs/CORTEX_WORKER_HARNESS.md
+++ b/docs/CORTEX_WORKER_HARNESS.md
@@ -61,7 +61,7 @@ Example (one command brings up the whole fleet):
 
 ```bash
 cortex_worker --harness \
-  --service oxidized-tex-to-html \
+  --service oxidized_tex_to_html \
   --source-address tcp://dispatcher:51695 \
   --sink-address   tcp://dispatcher:51696 \
   --profile ar5iv

--- a/docs/KNOWN_PERL_ERRORS.md
+++ b/docs/KNOWN_PERL_ERRORS.md
@@ -1548,3 +1548,30 @@ margin note — e.g. the mhchem package manual's `\marginpar{\Large !}` rendered
 **Rust status — DELIBERATE DIVERGENCE (Rust supersedes).** `\marginpar` now carries
 `bounded => true` (mirrors `\mbox`), scoping the note's font/catcode changes. Output-
 neutral across the suite (1487/0). See `OXIDIZED_DESIGN.md` #39. Candidate to upstream.
+
+## 39. booktabs `\cmidrule` defined via `\cline` → infinite loop under `\let\cline\cmidrule`
+
+`booktabs.sty.ltxml` defines `\cmidrule` to draw its partial rule by expanding to
+`\cline{<cols>}` (`\ltx@cmidrule` / `\ltx@@cmidrule` → `\cline{#2}`/`\cline{#3}`).
+This is a simplification — real booktabs `\cmidrule` draws the rule directly and
+does **not** touch `\cline`.
+
+**Trigger:** a document that does `\let\cline\cmidrule` (a common idiom to make
+`\cline` render as a nicer booktabs-style partial rule). In real LaTeX this is
+harmless because `\cmidrule` is self-contained. In LaTeXML it creates a cycle:
+`\cline` → `\cmidrule` → `\ltx@cmidrule` → `\cline` → `\cmidrule` → … — an infinite
+macro expansion.
+
+**Perl behavior:** Perl LaTeXML **hangs** (confirmed: `latexml --quiet` on
+arXiv 2506.23179 runs to a 90 s+ timeout with no output) — the identical
+`\cmidrule`→`\cline` binding loops with no conditional/expansion guard.
+
+**Rust status — DELIBERATE DIVERGENCE (Rust supersedes).** Rust's gullet has an
+8M-conditional `IfLimit` guard, so it fatals at ~12 s rather than hanging; and the
+booktabs binding now routes `\cmidrule` through a **private saved copy** of `\cline`
+(`\ltx@saved@cline`, captured at package-load before any document `\let`), so the
+cycle never forms — the witnesses convert cleanly (2506.23179 172.9 s→fatal ⇒ **3 s,
+0 errors**; 2511.17056 171.4 s→fatal ⇒ **1 s, 0 errors**). Output-neutral for ordinary
+`\cmidrule` (the saved CS equals `\cline` at load). Guard:
+`06_cluster_regressions.rs::cluster_cmidrule_cline_let`. Candidate to upstream.
+File: `latexml_package/src/package/booktabs_sty.rs`.

--- a/docs/KNOWN_PERL_ERRORS.md
+++ b/docs/KNOWN_PERL_ERRORS.md
@@ -1527,3 +1527,24 @@ All multi-item containers are kept **flat** (the `moreRHS`-analog
 reading, this **eliminates a large grammar-ambiguity over-parse**: on
 `1510.03361` the worst equation fell from the 5000-tree cap (578 ms) to 256
 trees (31 ms, ~19×) and the `math_parse` phase dropped ~12%. Suite 1466/0/0.
+
+## 38. `\marginpar` does not scope font/catcode changes (leaks into body)
+
+**Trigger:**
+```latex
+\marginpar{\Large !} BODYWORD
+```
+**Perl behavior:** `BODYWORD` (and everything after) renders at `\Large` (144%) —
+the `\Large` inside the margin note leaks into the main galley. Verified on Perl
+LaTeXML 0.8.8 (`<text fontsize="144%">BODYWORD`). Real pdflatex typesets the note
+in a separate margin box, so the switch is scoped; the LaTeXML `\marginpar`
+`DefConstructor` (`latex_constructs.pool.ltxml` L3487) is not `bounded`, so its
+argument digests in the enclosing group and the font assignment persists.
+
+**Severity:** can be catastrophic for documents that put a size/style switch in a
+margin note — e.g. the mhchem package manual's `\marginpar{\Large !}` rendered the
+*entire* manual at 144%.
+
+**Rust status — DELIBERATE DIVERGENCE (Rust supersedes).** `\marginpar` now carries
+`bounded => true` (mirrors `\mbox`), scoping the note's font/catcode changes. Output-
+neutral across the suite (1487/0). See `OXIDIZED_DESIGN.md` #39. Candidate to upstream.

--- a/docs/OXIDIZED_DESIGN.md
+++ b/docs/OXIDIZED_DESIGN.md
@@ -1505,6 +1505,26 @@ cannot invalidate any document that validated before, so no existing test can br
 is now empty. Surpass-Perl; candidate to upstream. (mdframed-style framed blocks
 typically lower to `float`/`theorem` too, so they benefit as well.)
 
+### 39. `\marginpar` font/catcode changes are scoped (`bounded`)
+
+**Decision:** `\marginpar[]{}` (`latex_constructs.rs`) now carries `bounded => true`,
+so font/catcode switches inside the margin note are local to the note. Mirrors
+`\mbox`'s `bounded => true`.
+
+**Perl behavior:** upstream Perl LaTeXML's `\marginpar` is NOT bounded, so a
+`\marginpar{\Large …}` **leaks** the `\Large` (or any switch) into the body text that
+follows. Verified parity bug — Perl LaTeXML 0.8.8 reproduces it identically
+(`\marginpar{\Large !} X` renders `X` at 144%); real pdflatex scopes the note to its
+margin box, so the leak is a LaTeXML-engine bug shared by both ports, NOT a Rust
+regression.
+
+**Rationale:** the margin note's content is conceptually a separate box; its size/font
+changes must not affect the main galley. **Witness:** the mhchem manual's
+`\marginpar{\Large !}` (line 120) leaked `\Large` document-wide, rendering the ENTIRE
+manual at 144% (1388 `fontsize="144%"` nodes → 4 after the fix). Output-neutral across
+the suite (1487/0): no golden test relies on the leak. Surpass-Perl; candidate to
+upstream. See `KNOWN_PERL_ERRORS.md`.
+
 ---
 
 ## Future Work (Beyond Perl Parity)

--- a/docs/OXIDIZED_DESIGN.md
+++ b/docs/OXIDIZED_DESIGN.md
@@ -1525,6 +1525,36 @@ manual at 144% (1388 `fontsize="144%"` nodes → 4 after the fix). Output-neutra
 the suite (1487/0): no golden test relies on the leak. Surpass-Perl; candidate to
 upstream. See `KNOWN_PERL_ERRORS.md`.
 
+### 40. XSLT `head-keywords` index dedup via Muenchian key (O(n²)→O(n), output-neutral)
+
+**Decision:** In the embedded `resources/XSLT/LaTeXML-webpage-xhtml.xsl`, the
+`head-keywords` template (which builds `<meta name="keywords">` from the distinct
+index phrases) selects its distinct set with a hashed `xsl:key`
+(`f:indexphrase-by-value`, the **Muenchian method**:
+`//ltx:indexphrase[generate-id() = generate-id(key('f:indexphrase-by-value',.)[1])]`)
+instead of upstream's `//ltx:indexphrase[not(.=preceding::ltx:indexphrase)]`.
+
+**Perl behavior:** upstream LaTeXML deduplicates by testing each indexphrase
+against the entire `preceding::ltx:indexphrase` axis — O(P²) string comparisons in
+the indexphrase count P, and each `preceding::` traversal is itself O(tree-size).
+On index-bearing math documents (large trees) this is the dominant XSLT cost. Perl
+keeps the O(n²).
+
+**Rationale & neutrality:** the Muenchian key returns, for each distinct
+string-value, the first indexphrase in document order — exactly the set
+`not(.=preceding::)` keeps. The `<xsl:sort>` is unchanged, so the keywords string is
+**identical**. Verified byte-identical via `xsltproc` (full HTML `diff` IDENTICAL on
+arXiv 2208.07515) and a full-pipeline regression guard
+(`08_xslt_head_keywords.rs`); suite unchanged.
+
+**Impact:** the `head-keywords` template went 145 s → 0.04 s on 2208.07515 (560
+indexphrases); cluster-wide the index-bearing arXiv perf survivors dropped 2–5×
+(2208.07515 95 s→33 s, 1802.06435 78 s→17 s, 0807.4838 78 s→13 s). This **supersedes**
+the prior campaign's deferral of the "third XSLT O(n²)" (`docs/ARXIV_PERFORMANCE.md`)
+— head-keywords, not the index-render templates, was the real root. Surpass-Perl;
+candidate to upstream. Local divergence from upstream XSLT only. Full analysis:
+`docs/ARXIV_PERFORMANCE.md` (Hotspot #3).
+
 ---
 
 ## Future Work (Beyond Perl Parity)

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -66,7 +66,7 @@ Three tools, in order of preference:
 
 ## 5. External-process discipline (fork-exec is not free)
 
-Every `gs`/`convert`/`inkscape`/`kpsewhich`/`pdfcrop` costs 10–50 ms
+Every `gs`/`convert`/`mutool`/`pdftocairo`/`kpsewhich`/`pdfcrop` costs 10–50 ms
 ambient plus dynamic-linker and font-cache init for `gs`/`convert`.
 **Coalesce, dedup, and cache before spawning — not after.**
 
@@ -785,7 +785,7 @@ messages. Keep here as breadcrumbs for regression triage.
   `--graphics-svg-threshold-kb N` bypasses ImageMagick for vector PDFs.
   Witness: `fig8.pdf` (41 KB) 32.4s → 0.3s (~130× / ~111×). Test:
   `latexml_post/tests/integration.rs::test_vector_svg_pathological_convert_case`
-  (<5s assertion, skipped without inkscape).
+  (<5s assertion, skipped without a vector converter — mutool/pdftocairo).
 - **Vector-PDF auto-detection** (2026-05-16) — `cortex_worker` `ar5iv`
   profile passes `graphics_svg_threshold_kb: 0`; auto-detect scans PDF
   header (≤256 KB) for `/Subtype /Image` markers and routes to SVG
@@ -796,7 +796,7 @@ messages. Keep here as breadcrumbs for regression triage.
   `latexml_post::graphics::tests::should_try_svg_path_auto_detect`.
 - **Sandbox worker default 20 → 8** (2026-05-16,
   `tools/benchmark_canvas.sh`) — graphics-bound papers ran 5–10×
-  slower at 20 workers vs single-threaded due to gs/convert/inkscape
+  slower at 20 workers vs single-threaded due to gs/convert
   fork-exec contention; at 8 workers per-paper overhead is ≤30% and
   corpus throughput is higher. Override `--workers N` only when the
   canvas is known compute-bound (math/digest-heavy) rather than

--- a/docs/RELEASE_CRITERIA.md
+++ b/docs/RELEASE_CRITERIA.md
@@ -159,7 +159,7 @@ gate (§2); embedded-resource smoke — *promote/extend* existing
 `tests/001_single_binary_smoke.rs` + the "rename `resources/` away" check;
 `strace` no-own-disk-read assertion; license-inventory check (§4); corpus
 smoke + telemetry upload; graphics-tool matrix (pdftocairo / mutool /
-inkscape present-or-not); `cargo clippy --all-targets`.
+gs present-or-not); `cargo clippy --all-targets`.
 
 ## 8. Surpass-Perl policy
 

--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -120,7 +120,7 @@ rusage capture, signal-handler debugging).
 
 `latexml_post/src/graphics.rs` + `latexml_post/src/graphics_cache.rs` —
 process-group control is needed because subprocess rasterizers (`gs`,
-`pdftocairo`, `mutool draw`, `inkscape`, `convert`) can spawn grandchildren,
+`pdftocairo`, `mutool draw`, `ps2pdf`, `convert`) can spawn grandchildren,
 and a plain `Child::kill()` does not reap those.
 
 | Call | Why |

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -1470,13 +1470,22 @@ done. **Remaining:** tag `0.7.0` on `main` → `release.yml` runs the TL-window
   1409.4048, 2011.08422) fail in BOTH. Only **1804.01117 (svjour3) is genuine Rust-only**
   (Perl completes in 32 s; Rust hits the token-stack guard). Crucially the limit
   **matches Perl exactly** (`Stomach.pm:159 $MAXSTACK=200`, identical guard at L175) —
-  so it is NOT a mis-set cap; Rust's `invoke_token` token_stack simply grows DEEPER than
-  Perl for the same input (the deep `\usepackage`→`\RequirePackage`→`\@iinput`→`{`…
-  stack), most likely because Rust digests package/`\@iinput` content inline on the
-  token_stack where Perl re-feeds it through the mouth/outer loop. Aligning that is a
-  deep, risky core-digestion change for a ~1-paper Rust-only subset ⇒ **deferred**; do
-  NOT raise `MAXSTACK` (diverges from Perl and lets genuine infinite recursion run). The
-  guard is doing its job — this category is a Rust **stability win**, not a bug cluster.
+  so it is NOT a mis-set cap; do NOT raise `MAXSTACK` (diverges from Perl and lets genuine
+  infinite recursion run). The guard is doing its job — this category is a Rust **stability
+  win**, not a bug cluster.
+  **DEEP-DIVE of the lone Rust-only case 1804.01117 (2026-06-28): it is NOT a
+  stomach-accounting bug — it is a tikz/pgf cascade.** Full stack capture: the top ~170
+  frames are `{ \bgroup { \bgroup …` piled up by **`\pgffor@expand@list`** (pgffor's
+  `\foreach`), immediately after `Error:pushback_limit:Timeout … loading binding for
+  'tikz.sty'`. Rust fails to load the `tikz.sty` binding (pushback-limit), leaving
+  `\foreach` in a broken state that floods the digestion stack → `Stomach:Recursion`;
+  Perl loads tikz fine and never gets there. (The earlier "Rust digests packages deeper"
+  hypothesis was WRONG.) Minimal `\usepackage{tikz}`, the full preamble package set, and
+  `tikz`+`\foreach` in the body all load CLEANLY — the binding-load pushback only triggers
+  under the paper's specific complex state (late in-body `\usepackage`/`\@iinput` mixed
+  with nested tables/cases), so it is not minimally reducible. ⇒ The real root is the
+  **known deep tikz/pgf binding-load lever**, not the stomach; the Stomach:Recursion
+  category has **zero genuine stomach bugs**.
 
 - **1610.00974 step-3 (global p{}→VBox) + cluster-B — ✅ LANDED 2026-06-22, NO
   LONGER DEFERRED.** See "Landed this session" above. p{}/m{}/b{} columns now build

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -1739,8 +1739,11 @@ drops stretch/shrink to bare pt.
 
 ### Graphics renderer chain (subprocess-only; LANDED)
 PDF→PNG `mutool draw`→`pdftocairo`→`convert+gs`; PDF→SVG `mutool convert`→
-`pdftocairo`→`inkscape`. Subprocess `exec` (no GPL linking). Apt: `poppler-utils`
-(req), `mupdf-tools` (rec), `imagemagick+ghostscript`, `inkscape`.
+`pdftocairo`→(raster PNG fallback). EPS/PS→`gs` direct→`convert+gs`. Subprocess
+`exec` (no GPL linking). Apt: `poppler-utils` (req), `mupdf-tools` (rec),
+`imagemagick+ghostscript`. A heavyweight inkscape third resort for PDF→SVG was
+removed 2026-06-29 (GTK stack, 20–40× slower, timeout-prone, no coverage over the
+raster fallback).
 
 ### Other tracks (separate docs)
 - Performance: `PERFORMANCE.md` (P1 math/large-doc open; P2 allocation partial).

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -38,6 +38,17 @@
   — Perl keeps the O(n²)). Byte-identical output, suite 1480/0. Shared upstream XSLT
   issue (candidate to upstream); see `docs/OXIDIZED_DESIGN.md` #37 +
   `docs/ARXIV_PERFORMANCE.md` Hotspot #2.
+- **PERF (2026-06-28): XSLT `head-keywords` index-dedup O(n²) — FIXED (output-neutral).**
+  The slowest-100 follow-up batch (#201–300) re-run on HEAD was 81/100 already <5 s
+  (natbib fix) but left an XSLT survivor tier; root-caused via `xsltproc --profile`
+  to `head-keywords` in `resources/XSLT/LaTeXML-webpage-xhtml.xsl` building
+  `<meta name="keywords">` with `//ltx:indexphrase[not(.=preceding::ltx:indexphrase)]`
+  — O(indexphrases² × tree). Replaced with a Muenchian `xsl:key` (O(n)).
+  2208.07515 95→**33 s** (xslt 71.5→11.8); 1802.06435 (the prior campaign's *deferred*
+  large-index witness) 78→**17 s**; 0807.4838 78→**13 s**. Byte-identical output
+  (xsltproc full-HTML diff + historical-bundle keywords-meta diff), suite **1488/0**
+  + guard `08_xslt_head_keywords.rs`. See the #201–300 4-cluster triage below,
+  `OXIDIZED_DESIGN.md` #40, `ARXIV_PERFORMANCE.md` Hotspot #3.
 - **Broad regression + health sweep (2026-06-27):** ~140 diverse random corpus
   papers (two samples of 40 + 100, NOT the perf testbed) on the current binary →
   **0 crashes, 0 fatals, 0 hangs** across all conversions; unbound-class (OmniBus
@@ -275,6 +286,104 @@ Two genuine Rust-only bugs fixed + the full p/m/b table-column parity arc:
   sweep (0 Rust>Perl; Rust at-or-better everywhere) + class-level cross-join.
 - (Earlier this session: tasks 5 & 6 below — post-processing log parity + graphics
   never-ship-raw-.eps — also landed.)
+
+## arXiv slowest-100 batch #201–300 — 4-cluster triage (2026-06-28, on `followups-2026-06-27`)
+
+The follow-up perf batch (ranks #201–300; historically **173.2–175.5 s**, all pinned
+near the 180 s cortex watchdog). Re-run on HEAD (current binary, *after* the 2026-06-27
+natbib + seclev fixes): **81/100 already <5 s**, **1 still timing out**, ~18 XSLT/math
+survivors at 13–95 s. Triaged into 4 clusters (the last 4 investigated in parallel);
+**one new shared O(n²) fix landed, one genuine Rust-only timeout root-caused.**
+Methodology: in-zip `telemetry.json` phase split (`scratchpad/triage_slow.py`) → re-run
+on HEAD (`rerun.sh`, `--preload=ar5iv.sty`) → for survivors, `xsltproc --profile` +
+gdb worker-thread sampling + (Cluster D) Perl-parity check. Full analysis in
+`docs/ARXIV_PERFORMANCE.md` (Hotspot #3).
+
+### Cluster A — OmniBus/natbib digest (≈77 papers) — ✅ CLEARED
+Unbound journal classes → OmniBus → natbib (sn-jnl ×52, Wiley/sagej/ws-procs/lmcs/oup/
+ecai/…). Already fixed by the loop-safe `def_autoload` (2026-06-27). Verified on HEAD:
+every class now **0.3–0.9 s**, natbib loads exactly once, citations render (196–321
+ltx_cite/ref), zero undefined-`\citep`. **No action.** Only OmniBus paper still slow is
+2209.11799 → Cluster D (a *different* loop). Guard `omnibus_natbib_autoload_no_reload_loop`.
+
+### Cluster B — index `head-keywords` XSLT O(n²) — ✅ FIXED this session
+`resources/XSLT/LaTeXML-webpage-xhtml.xsl` `head-keywords` built `<meta name="keywords">`
+via `//ltx:indexphrase[not(.=preceding::ltx:indexphrase)]` — distinct-by-value over the
+`preceding::` axis = **O(indexphrases² × tree)**. `xsltproc --profile` pinned it (145 s of
+a ~150 s transform on 2208.07515, 1 call). Replaced with a Muenchian hashed `xsl:key`
+(O(n), identical first-occurrence + `xsl:sort` ⇒ byte-identical output). Cluster-wide:
+2208.07515 95→**33 s** (xslt 71.5→11.8); 1802.06435 78→**17 s**; 0807.4838 78→**13 s**;
+2403.19732 68→29 s; math0206203 50→30 s; 1807.02129 50→27 s. Output-neutral (xsltproc
+full-HTML diff + historical-bundle keywords-meta diff, byte-identical), suite **1488/0** +
+guard `08_xslt_head_keywords.rs`. **Supersedes** the prior campaign's *deferred* large-index
+witness (1802.06435 — the real root was head-keywords, not the index-render templates).
+Surpass-Perl; candidate to upstream. See `OXIDIZED_DESIGN.md` #40.
+
+### Cluster C — math-heavy large-doc residual (6 papers) — ⏸ DEFERRED (P1 large-doc lever)
+0707.3572 (20894 formulae), 2310.07949, 2106.02143, 2406.00467, 1708.01795, 1912.06823 —
+~33–50 s, **no significant index** (head-keywords didn't help). Cost is **distributed**
+across build + math_parse + xslt + mathml_pres, scaling with formula volume; **O(n²) ruled
+out** by element-scaling on 0707.3572 (xslt ms/formula 0.43→0.83 across 25→100 % ⇒ ~**n^1.45
+mild superlinear**, not the ~4× of O(n²)). gdb localizes the mild superlinearity to diffuse
+per-element descendant-axis `xsl:if`/`xsl:choose` in the math/structural templates
+(`xsltCallTemplate→xsltIf→xmlXPathNextDescendant`), worse on libxml2 2.16. No single hoistable
+template (unlike seclev/head-keywords). All complete under the 180 s budget (max ~50 s).
+**Second-XSLT-win hunt (deep dive, 2026-06-28): NEGATIVE.** Static enumeration of the
+per-element high-frequency templates (`add_id` common.xsl:469, `add_classes`:511, `add_style`:572,
+`base-classes`/`base-styling`/`add_RDFa`) found **no `//`/`descendant::`/`generate-id`/`count()`/
+`key()`** — genuinely O(1)/element. The only per-element descendant-axis predicates are in
+equation handling (`LaTeXML-block-xhtml.xsl:279/287/549`, `not(descendant::ltx:equation[ltx:tags])`
+etc.), which scan an **equationgroup's own subtree, not the whole tree** — group-size-bounded, the
+source of the n^1.45, NOT whole-tree O(n²). Memoizing them saves <~15 % of the ~16–22 s xslt only on
+align-heavy docs, for real output-divergence risk ⇒ not worth it. (The `xsltproc --profile`
+`maketitle` 66 s #1 is an inclusive-time + core.xml-XMath artifact — core.xml carries the giant
+XMath trees the real compact-MathML input lacks — not a real leaf hotspot.)
+**Digest/math-parse half (deep dive, 2026-06-28): also inherent O(formulae), no fixable hotspot.**
+On the math-heavy papers build (~11 s) + math_parse (~12 s) are large but **not** a re-parse blowup:
+`math_parse_count/formulae` ≈ **1.2** (0707.3572: 20894 formulae → 25086 parses; buckets
+[13954,4004,1768,710,132,21,0,0,0] decay cleanly — Marpa healthy, no ambiguity blowup), and
+build+math_parse µs/formula is **FLAT** across a 0707.3572 truncation (916.8 → 923.2 → 1085.5 at
+25/50/100 %, +18 % at 4× = cache/working-set, not quadratic) ⇒ **O(n), ~1 ms/formula**. The only
+lever is shrinking that per-formula constant (math-recognizer / document-builder micro-opt) = the
+deep **P1 large-doc track**. **Action:** defer to P1; keep 0707.3572 as a STABILITY_WITNESS.
+
+**Isolated outlier (not Cluster C): 2112.14457 — DIGEST-bound (7.1 s of 16.5 s), not math/xslt.**
+`lipics-v2021` + `tikz`/`pgfplots`/`pgfplotstable`/`algorithm2e` (206 package-load lines); the
+digest cost points to **pgfplots picture digestion** (known-heavy). Not pinned to a frame (stripped
+release binary; needs a symbols build). **Low priority** — 16.5 s, well under the 180 s budget; no
+shared breadth. Noted, not actioned.
+
+### Cluster D — 2209.11799 token-limit recursion — 🐞 GENUINE RUST-ONLY (fix queued)
+The lone HEAD timeout (sn-jnl, 200 s, `Fatal:Timeout:TokenLimit`). NOT the natbib reload —
+a **follow-on regression of the `def_autoload` fix**. When natbib is side-loaded via a
+non-autoload path (OmniBus's redefined `\bibitem` sees `[\protect\citeauthoryear` in the
+`.bbl` → `\lx@late@usepackage{natbib}`, `omnibus_cls.rs:80`), the `\citep`/`\citet`
+`def_autoload` triggers are **never cleared**; the "already-loaded → re-emit `cs_for_closure`
+without clearing" branch (`latexml_engine/src/tex.rs:60-62`, added for the `\let`-alias case
+2310.13684) re-fires the same closure → infinite token recursion (gdb: tight `__memcpy` +
+repeating return-address cycle). **Perl completes** (repro 1.0 s, full paper 11.7 s) ⇒
+genuine Rust-only. Minimal repro: `\documentclass{sn-jnl}` + `\begin{thebibliography}` with one
+`\bibitem[\protect\citeauthoryear{Foo et~al.}{2020}]{a}` + a top-level `\citep{a}`
+(saved at `scratchpad/cluster_D/repro.tex`). gdb on a debug build confirms a gullet
+token-expansion spin (`read_x_token`/`read_internal_token` under `digest_next_body`) —
+the `\citep` re-emit re-firing the autoload closure.
+**Likely deeper mechanism (refined 2026-06-28):** natbib's real `\citep` is installed at
+the `\bibitem`/bbl group frame during the side-load and **popped on group exit**, reverting
+`\citep` to the global autoload trigger; the body `\citep{a}` then re-fires it. The
+non-early-return path already guards this via `hoist_top_frame_meaning_delta`, but the
+side-load (`\lx@late@usepackage{natbib}`) bypasses that hoist. NB: `require_package` is
+**idempotent** (skips when `<pkg>.sty_loaded`), so a naive "clear + re-`require_package`"
+in the early-return branch would NOT reinstall `\citep` — a correct fix must hoist the
+already-installed defs to global (or detect the self-loop and clear→graceful-undefined,
+which still diverges from Perl's rendered cite).
+**Implementation DEFERRED (task #7), per the established policy** (`ARXIV_PERFORMANCE.md`
+L420): *do not fix speculatively in the shared `def_autoload` path* — regression traps
+2310.13684 (`\varmathbb`) + 1403.6801 (wlpeerj) are live, and the mechanism needs a full
+meaning-resolution state-trace to fix correctly. This entry SUPERSEDES the prior vaguer
+2602.15365 (informs4) deferral with a precise root cause + minimal repro, so the future
+focused session starts from a strong position. Breadth: 1 paper of 100; completes-as-fatal
+under the 180 s budget (not a hang that consumes the slot). Guards for the eventual fix:
+2310.13684, 1403.6801, 2207.14344, + the new repro.
 
 ## Upstream sync — translate brucemiller/LaTeXML PRs since #2767 (NEW MISSION, opened 2026-06-25)
 

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -49,6 +49,18 @@
   (xsltproc full-HTML diff + historical-bundle keywords-meta diff), suite **1488/0**
   + guard `08_xslt_head_keywords.rs`. See the #201–300 4-cluster triage below,
   `OXIDIZED_DESIGN.md` #40, `ARXIV_PERFORMANCE.md` Hotspot #3.
+- **PERF/parity (2026-06-28): booktabs `\cmidrule` infinite loop under
+  `\let\cline\cmidrule` — FIXED (surpass-Perl).** Triaging the slowest-100 batch
+  **#301-400** (parallel 50-worker re-run: 74/100 <5 s, ~24 known Cluster-C
+  math-heavy theses, **0 timeouts**) surfaced 2 `Fatal:Timeout:IfLimit` papers
+  (2506.23179, 2511.17056, both sn-jnl). Root cause: LaTeXML's booktabs binding
+  defines `\cmidrule`→`\cline`, so a document `\let\cline\cmidrule` makes
+  `\cmidrule`→`\cline`→`\cmidrule` loop forever. **Shared with Perl** (Perl *hangs*
+  90 s+; Rust's 8M-`IfLimit` guard fatals at ~12 s — already better). Fixed by
+  routing `\cmidrule` through a private `\ltx@saved@cline` captured at booktabs-load
+  (`booktabs_sty.rs`): 2506.23179 →**3 s/0 err**, 2511.17056 →**1 s/0 err**.
+  Output-neutral for ordinary `\cmidrule`; guard
+  `06_cluster_regressions.rs::cluster_cmidrule_cline_let`; `KNOWN_PERL_ERRORS.md` #39.
 - **Broad regression + health sweep (2026-06-27):** ~140 diverse random corpus
   papers (two samples of 40 + 100, NOT the perf testbed) on the current binary →
   **0 crashes, 0 fatals, 0 hangs** across all conversions; unbound-class (OmniBus

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -1248,7 +1248,13 @@ runs it (stacked + tree) in CI. The checked-guard "fix" was correctly rejected:
 there is no UB to guard, and it would deadlock `Document::absorb`'s loop (which
 needs the nested construction to SUCCEED). No architectural change needed; the
 single audited `with_doc` `unsafe` stays, now documented as verified-sound.
-`runtime-bindings` stays on by default.
+`runtime-bindings` stays on by default. **Sibling site audited too (2026-06-27):**
+the `WHATSIT_CTX` re-mint (`engine.rs` `setProperty` `&mut *ptr`; `argString`/
+`propertyString` are read-only `&*`) is sound — after-digest hooks run one-pass/
+sequentially on a fresh-local whatsit (`definition.rs::execute_after_digest`) and
+never re-enter on the SAME whatsit, so it's always the single-body re-mint pattern
+the Miri model already covers. The runtime-bindings unsafe re-mint sites are now
+fully audited.
 
 ### 4. 0.7.0 release — release-prep LANDED; tag pending
 Version bumped, `runtime-bindings` in the artifact, `.deb` deps, CHANGELOG/README

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -1482,10 +1482,29 @@ done. **Remaining:** tag `0.7.0` on `main` → `release.yml` runs the TL-window
   Perl loads tikz fine and never gets there. (The earlier "Rust digests packages deeper"
   hypothesis was WRONG.) Minimal `\usepackage{tikz}`, the full preamble package set, and
   `tikz`+`\foreach` in the body all load CLEANLY — the binding-load pushback only triggers
-  under the paper's specific complex state (late in-body `\usepackage`/`\@iinput` mixed
-  with nested tables/cases), so it is not minimally reducible. ⇒ The real root is the
-  **known deep tikz/pgf binding-load lever**, not the stomach; the Stomach:Recursion
-  category has **zero genuine stomach bugs**.
+  under the paper's specific complex state. **FULLY ROOT-CAUSED 2026-06-28 (a 2nd deep
+  dive) — it is NOT tikz/pgf either; it is a Rust `read_balanced` bug in xint.** The
+  trigger is **`--preload=ar5iv.sty` + `xintexpr` (loaded before pgfmath/tikz)**. ar5iv
+  (INCLUDE_STYLES) RAW-loads xint; `xintexpr`'s load of its built-in float functions
+  (`\xintdeffloatfunc`, e.g. xinttrig's `@sind`) runs `\xintexprSafeCatcodes` (a
+  `\begingroup`) then `\XINT_NewFloatFunc`/`\XINT_NewExpr` (xintexpr.sty:3871/4672) whose
+  body-compilation does a balanced read that goes **UNBALANCED in Rust** ("readBalanced
+  ran out of input in an unbalanced state" + "Attempt to close boxing group") — so the
+  SafeCatcodes `\begingroup` never closes. **`\currentgrouplevel` is 1 after
+  `\usepackage{xintexpr}` (baseline 0)** — exactly one leaked group. That open group then
+  corrupts the later pgfmath raw-load (its `\pgfkeys{/pgf/declare function/…}` reader hits
+  a stray `\fi`, conditional.rs:429, loops to the 650000 pushback limit), which breaks
+  `\foreach`, which floods the digest stack → `Stomach:Recursion`. Perl processes the SAME
+  xint TeX with no leak (the paper converts in Perl, 32 s) and 1804.01117 converts CLEANLY
+  in Rust WITHOUT ar5iv (0 err, 394 KB HTML). **Minimal bug repro:
+  `\usepackage{xintexpr}\xintdeffloatfunc @f(x):=x+1;` + ar5iv** (SafeCatcodes keeps {=1
+  }=2, so NOT a brace-catcode issue — it is the expansion `read_balanced` itself). Full
+  bisection in `docs/reproducers/xintexpr_pgfmath_ar5iv_pushback.tex`. **FIX = a deep
+  gullet `read_balanced`/expansion divergence in xint's expr-function compiler under
+  SafeCatcodes** — a focused engine task (multi-hour expansion trace through
+  `\XINT_NewExpr`/`\subs`/`\xintFor*`); deferred. The Stomach:Recursion category itself
+  still has **zero genuine stomach bugs** (this is an upstream `read_balanced` divergence
+  surfacing through it).
 
 - **1610.00974 step-3 (global p{}→VBox) + cluster-B — ✅ LANDED 2026-06-22, NO
   LONGER DEFERRED.** See "Landed this session" above. p{}/m{}/b{} columns now build

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -1459,6 +1459,25 @@ done. **Remaining:** tag `0.7.0` on `main` → `release.yml` runs the TL-window
 
 ## Deep deferred families (parked — large or shared; dedicated sessions)
 
+- **`Fatal:Stomach:Recursion` (43 cortex Rust-service fatals) — TRIAGED 2026-06-28,
+  mostly SHARED / Rust-better; ~1 Rust-only over-fatal DEFERRED (deep core).** Two
+  guards in `stomach.rs`: the box-cycle "Infinite digestion loop" (9 papers,
+  stomach.rs:1040) and the token-stack-depth "Excessive recursion(?)" (28 pkg-loading
+  + 6 box/thm, stomach.rs:1343, `MAXSTACK=200`). **Same-host Perl parity on an 11-paper
+  sample: ~10/11 SHARED** — the box-cycle/digloop papers (1906.06902, 1810.02304,
+  1911.00254, 1911.11563, 2605.27339) **HANG in Perl 50–94 s** while Rust fail-fasts in
+  <1 s via the guard (**Rust strictly better**); others (1809.00641, 2103.12717,
+  1409.4048, 2011.08422) fail in BOTH. Only **1804.01117 (svjour3) is genuine Rust-only**
+  (Perl completes in 32 s; Rust hits the token-stack guard). Crucially the limit
+  **matches Perl exactly** (`Stomach.pm:159 $MAXSTACK=200`, identical guard at L175) —
+  so it is NOT a mis-set cap; Rust's `invoke_token` token_stack simply grows DEEPER than
+  Perl for the same input (the deep `\usepackage`→`\RequirePackage`→`\@iinput`→`{`…
+  stack), most likely because Rust digests package/`\@iinput` content inline on the
+  token_stack where Perl re-feeds it through the mouth/outer loop. Aligning that is a
+  deep, risky core-digestion change for a ~1-paper Rust-only subset ⇒ **deferred**; do
+  NOT raise `MAXSTACK` (diverges from Perl and lets genuine infinite recursion run). The
+  guard is doing its job — this category is a Rust **stability win**, not a bug cluster.
+
 - **1610.00974 step-3 (global p{}→VBox) + cluster-B — ✅ LANDED 2026-06-22, NO
   LONGER DEFERRED.** See "Landed this session" above. p{}/m{}/b{} columns now build
   the cell as Perl's `\lx@tabular@p` inline-block (VBoxContents); p/m/b `<td>`

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -1467,8 +1467,9 @@ done. **Remaining:** tag `0.7.0` on `main` → `release.yml` runs the TL-window
   sample: ~10/11 SHARED** — the box-cycle/digloop papers (1906.06902, 1810.02304,
   1911.00254, 1911.11563, 2605.27339) **HANG in Perl 50–94 s** while Rust fail-fasts in
   <1 s via the guard (**Rust strictly better**); others (1809.00641, 2103.12717,
-  1409.4048, 2011.08422) fail in BOTH. Only **1804.01117 (svjour3) is genuine Rust-only**
-  (Perl completes in 32 s; Rust hits the token-stack guard). Crucially the limit
+  1409.4048, 2011.08422) fail in BOTH. **1804.01117 (svjour3) was thought Rust-only but
+  is actually SHARED — see the corrected deep-dive below (Perl `--includestyles` hits the
+  identical readBalanced failure).** Crucially the limit
   **matches Perl exactly** (`Stomach.pm:159 $MAXSTACK=200`, identical guard at L175) —
   so it is NOT a mis-set cap; do NOT raise `MAXSTACK` (diverges from Perl and lets genuine
   infinite recursion run). The guard is doing its job — this category is a Rust **stability
@@ -1487,24 +1488,35 @@ done. **Remaining:** tag `0.7.0` on `main` → `release.yml` runs the TL-window
   trigger is **`--preload=ar5iv.sty` + `xintexpr` (loaded before pgfmath/tikz)**. ar5iv
   (INCLUDE_STYLES) RAW-loads xint; `xintexpr`'s load of its built-in float functions
   (`\xintdeffloatfunc`, e.g. xinttrig's `@sind`) runs `\xintexprSafeCatcodes` (a
-  `\begingroup`) then `\XINT_NewFloatFunc`/`\XINT_NewExpr` (xintexpr.sty:3871/4672) whose
-  body-compilation does a balanced read that goes **UNBALANCED in Rust** ("readBalanced
-  ran out of input in an unbalanced state" + "Attempt to close boxing group") — so the
-  SafeCatcodes `\begingroup` never closes. **`\currentgrouplevel` is 1 after
-  `\usepackage{xintexpr}` (baseline 0)** — exactly one leaked group. That open group then
-  corrupts the later pgfmath raw-load (its `\pgfkeys{/pgf/declare function/…}` reader hits
-  a stray `\fi`, conditional.rs:429, loops to the 650000 pushback limit), which breaks
-  `\foreach`, which floods the digest stack → `Stomach:Recursion`. Perl processes the SAME
-  xint TeX with no leak (the paper converts in Perl, 32 s) and 1804.01117 converts CLEANLY
-  in Rust WITHOUT ar5iv (0 err, 394 KB HTML). **Minimal bug repro:
-  `\usepackage{xintexpr}\xintdeffloatfunc @f(x):=x+1;` + ar5iv** (SafeCatcodes keeps {=1
-  }=2, so NOT a brace-catcode issue — it is the expansion `read_balanced` itself). Full
-  bisection in `docs/reproducers/xintexpr_pgfmath_ar5iv_pushback.tex`. **FIX = a deep
-  gullet `read_balanced`/expansion divergence in xint's expr-function compiler under
-  SafeCatcodes** — a focused engine task (multi-hour expansion trace through
-  `\XINT_NewExpr`/`\subs`/`\xintFor*`); deferred. The Stomach:Recursion category itself
-  still has **zero genuine stomach bugs** (this is an upstream `read_balanced` divergence
-  surfacing through it).
+  `\begingroup`) then `\XINT_NewFloatFunc`/`\XINT_NewExpr` (xintexpr.sty:4721) whose
+  body-compilation does a balanced read that goes UNBALANCED ("readBalanced ran out of
+  input in an unbalanced state" + "Attempt to close boxing group").
+  **CORRECTED CONCLUSION (3rd deep dive, 2026-06-28): this is a SHARED LaTeXML limitation,
+  NOT a Rust-unique bug.** The earlier "Perl processes the SAME xint TeX with no leak /
+  converts in 32 s" was an **invalid comparison** — the reference Perl on this host has no
+  `ar5iv.sty`, so `--preload=ar5iv.sty` silently emitted `missing_file:xintexpr` and
+  SKIPPED xint (never raw-loaded it). Forcing the raw-load with **`latexml --includestyles`
+  reproduces the IDENTICAL `readBalanced ran out` at xinttrig.sty:350** (26 errors,
+  degraded 459-byte XML, exit 0). Mechanism: xint does `\edef\X{\scantokens{...}}` where
+  `\scantokens` opens an autoclose "Anonymous String" mouth MID-`\edef`-body and the
+  `\edef`'s closing `}` is in the PARENT file; `readBalanced` reads the raw mouth and
+  breaks at the boundary WITHOUT crossing (gullet.rs `None => break`; **Perl Gullet.pm:466,
+  470-472 is line-for-line identical, same `level>0` TODO**). Real pdflatex succeeds only
+  because TeX `get_x_token`/`scan_toks` (tex.web §362-365) pops exhausted input levels
+  transparently. **The Rust-specific gap is RECOVERY, not the failure itself:** Rust leaks
+  the `\xintexprSafeCatcodes` `\begingroup` → "Attempt to close boxing group" → Missing-
+  number cascade through xinttrig → `Fatal:Timeout:TokenLimit`, where Perl degrades
+  gracefully (`\XINT_zapsp_b Match:` errors) and completes. **So 1804.01117 cannot convert
+  cleanly even in Perl — out of scope for the "clean ar5iv conversion" goal.** Fix options
+  (both deferred): (1) **parity** = harden Rust's post-readBalanced recovery so the leaked
+  `\begingroup` doesn't cascade to a TokenLimit fatal → match Perl's degraded-but-completing
+  output (delicate stomach/group code); (2) **surpass-Perl** = make `read_balanced` cross
+  autoclose mouths like `get_x_token` (prototyped this session: eliminates the readBalanced
+  failure + GD leak, passes all 1491 tests, dumps stay semantically identical — but
+  DIVERGES from Perl and exposes a deeper xint `\number` "Missing number" loop = a
+  multi-layer surpass-Perl chain). Full bisection +corrected diagnosis in
+  `docs/reproducers/xintexpr_pgfmath_ar5iv_pushback.tex`. The Stomach:Recursion category
+  itself still has **zero genuine stomach bugs**.
 
 - **1610.00974 step-3 (global p{}→VBox) + cluster-B — ✅ LANDED 2026-06-22, NO
   LONGER DEFERRED.** See "Landed this session" above. p{}/m{}/b{} columns now build

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -61,6 +61,15 @@
   (`booktabs_sty.rs`): 2506.23179 →**3 s/0 err**, 2511.17056 →**1 s/0 err**.
   Output-neutral for ordinary `\cmidrule`; guard
   `06_cluster_regressions.rs::cluster_cmidrule_cline_let`; `KNOWN_PERL_ERRORS.md` #39.
+- **PERF/parity (2026-06-28): OmniBus bbl-side-load natbib loop (2209.11799) — FIXED.**
+  The lone HEAD timeout from the #201-300 batch (sn-jnl, 200 s `Fatal:Timeout:TokenLimit`):
+  an unbound class's `.bbl` `\bibitem[\protect\citeauthoryear…]` side-loads natbib INSIDE
+  the `thebibliography` group, so natbib's `\citep` is popped on group exit and reverts to
+  its `def_autoload` trigger, whose already-loaded re-emit then loops. Fixed by hoisting the
+  side-loaded defs to global in `\lx@late@usepackage` (`omnibus_cls.rs`) — localized to
+  OmniBus, NOT the regression-trap-heavy shared `def_autoload` path. 2209.11799 →**1 s/0 err**;
+  brings Rust to parity with Perl. Witnesses clean (2310.13684/1403.6801/2207.14344); guard
+  `cluster_omnibus_natbib_bbl_sideload`. See the #201-300 Cluster D triage below.
 - **Broad regression + health sweep (2026-06-27):** ~140 diverse random corpus
   papers (two samples of 40 + 100, NOT the perf testbed) on the current binary →
   **0 crashes, 0 fatals, 0 hangs** across all conversions; unbound-class (OmniBus
@@ -365,9 +374,9 @@ digest cost points to **pgfplots picture digestion** (known-heavy). Not pinned t
 release binary; needs a symbols build). **Low priority** — 16.5 s, well under the 180 s budget; no
 shared breadth. Noted, not actioned.
 
-### Cluster D — 2209.11799 token-limit recursion — 🐞 GENUINE RUST-ONLY (fix queued)
+### Cluster D — 2209.11799 token-limit recursion — ✅ FIXED 2026-06-28 (Rust-only, parity)
 The lone HEAD timeout (sn-jnl, 200 s, `Fatal:Timeout:TokenLimit`). NOT the natbib reload —
-a **follow-on regression of the `def_autoload` fix**. When natbib is side-loaded via a
+a **follow-on of the `def_autoload` fix**. When natbib is side-loaded via a
 non-autoload path (OmniBus's redefined `\bibitem` sees `[\protect\citeauthoryear` in the
 `.bbl` → `\lx@late@usepackage{natbib}`, `omnibus_cls.rs:80`), the `\citep`/`\citet`
 `def_autoload` triggers are **never cleared**; the "already-loaded → re-emit `cs_for_closure`
@@ -383,19 +392,21 @@ the `\citep` re-emit re-firing the autoload closure.
 the `\bibitem`/bbl group frame during the side-load and **popped on group exit**, reverting
 `\citep` to the global autoload trigger; the body `\citep{a}` then re-fires it. The
 non-early-return path already guards this via `hoist_top_frame_meaning_delta`, but the
-side-load (`\lx@late@usepackage{natbib}`) bypasses that hoist. NB: `require_package` is
-**idempotent** (skips when `<pkg>.sty_loaded`), so a naive "clear + re-`require_package`"
-in the early-return branch would NOT reinstall `\citep` — a correct fix must hoist the
-already-installed defs to global (or detect the self-loop and clear→graceful-undefined,
-which still diverges from Perl's rendered cite).
-**Implementation DEFERRED (task #7), per the established policy** (`ARXIV_PERFORMANCE.md`
-L420): *do not fix speculatively in the shared `def_autoload` path* — regression traps
-2310.13684 (`\varmathbb`) + 1403.6801 (wlpeerj) are live, and the mechanism needs a full
-meaning-resolution state-trace to fix correctly. This entry SUPERSEDES the prior vaguer
-2602.15365 (informs4) deferral with a precise root cause + minimal repro, so the future
-focused session starts from a strong position. Breadth: 1 paper of 100; completes-as-fatal
-under the 180 s budget (not a hang that consumes the slot). Guards for the eventual fix:
-2310.13684, 1403.6801, 2207.14344, + the new repro.
+side-load (`\lx@late@usepackage{natbib}`) bypasses that hoist. (`require_package` is
+**idempotent** — skips when `<pkg>.sty_loaded` — so a naive "clear + re-`require_package`"
+in the shared early-return branch would NOT reinstall `\citep`; the correct fix hoists the
+already-installed defs to global.)
+**Fix (landed 2026-06-28):** `\lx@late@usepackage` (`omnibus_cls.rs`) now snapshots the
+calling frame's meanings, loads, then `hoist_top_frame_meaning_delta` — exactly mirroring
+`def_autoload` — so the side-loaded natbib's `\citep`/`\citet` are hoisted to GLOBAL and
+survive `\end{thebibliography}` (matching a top-level `\usepackage{natbib}`). The fix is
+**localized to OmniBus**, NOT the regression-trap-heavy shared `def_autoload` closure (so it
+sidesteps the `ARXIV_PERFORMANCE.md` L420 "don't fix speculatively in the shared path"
+hazard). 2209.11799: 200 s TokenLimit fatal ⇒ **1 s, 0 errors** (cite renders). Brings Rust
+to **parity with Perl** (Perl already handled this — repro 1.0 s, full 11.7 s). Regression
+witnesses all clean: 2310.13684 (`\varmathbb`) 0.3 s/0, 1403.6801 (wlpeerj) 0.6 s/0,
+2207.14344 0.4 s/0. Guard: `06_cluster_regressions.rs::cluster_omnibus_natbib_bbl_sideload`.
+Also resolves the analogous earlier-deferred 2602.15365 (informs4) class of secondary loop.
 
 ## Upstream sync — translate brucemiller/LaTeXML PRs since #2767 (NEW MISSION, opened 2026-06-25)
 

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -1459,6 +1459,28 @@ done. **Remaining:** tag `0.7.0` on `main` → `release.yml` runs the TL-window
 
 ## Deep deferred families (parked — large or shared; dedicated sessions)
 
+- **Native `.bst` interpretation — DEFERRED (pending plan, ~a few months out; do NOT
+  start work that requires reading `.bst`).** arXiv's bibliography convention is codified
+  in `ar5iv.sty`: LaTeXML prefers a ready-made `.bbl` and, only if none is present,
+  interprets the `.bib` itself into XML internally (its own `MakeBibliography` conventions).
+  In production this is a non-issue — arXiv's AutoTeX runs `bibtex`, so a `.bbl` is present
+  and the conversion reproduces the PDF. The gap only appears when a conversion sees
+  `.bib` + `.bst` but **no** `.bbl` (e.g. a standalone/manual run that skips `bibtex`):
+  the `.bib`-direct fallback cannot reproduce the document's `.bst` output, because we do
+  not read `.bst` yet. **Witness: arXiv:2605.16562** (LNCS, `splncs04.bst`). With a
+  `bibtex`-generated `main.bbl` present, the bibliography matches the PDF exactly — PDF sort
+  order, inline `\url`/`\doi` links, no "External Links:" label, corporate author rendered
+  "W3C Math Working Group". Without the `.bbl`, the `.bib`-direct path diverges: LaTeXML's
+  own alphabetical sort (different order), "External Links:" prefixes, DOI shown as bare
+  text (`10.48550/...`) rather than a `https://doi.org/...` link, the corporate author
+  mis-parsed as a personal name ("W. M. W. Group"), and a "See ," empty-crossref artifact.
+  None of these are formatting bugs in `MakeBibliography` (the duplicate-bibblock bug that
+  *was* there is fixed, commit `8ffca54713`); they are all consequences of synthesising a
+  bibliography from `.bib` without the `.bst`. **Resolution:** until native `.bst`
+  interpretation lands, rely on `bibtex`/AutoTeX producing the `.bbl` (production already
+  does); no latexml-oxide change. To reproduce: `latex main && bibtex main`, add `main.bbl`
+  to the source, re-convert → matches PDF; remove it → diverges as above.
+
 - **`Fatal:Stomach:Recursion` (43 cortex Rust-service fatals) — TRIAGED 2026-06-28,
   mostly SHARED / Rust-better; ~1 Rust-only over-fatal DEFERRED (deep core).** Two
   guards in `stomach.rs`: the box-cycle "Infinite digestion loop" (9 papers,

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -1521,30 +1521,36 @@ done. **Remaining:** tag `0.7.0` on `main` → `release.yml` runs the TL-window
   `\begingroup`) then `\XINT_NewFloatFunc`/`\XINT_NewExpr` (xintexpr.sty:4721) whose
   body-compilation does a balanced read that goes UNBALANCED ("readBalanced ran out of
   input in an unbalanced state" + "Attempt to close boxing group").
-  **CORRECTED CONCLUSION (3rd deep dive, 2026-06-28): this is a SHARED LaTeXML limitation,
-  NOT a Rust-unique bug.** The earlier "Perl processes the SAME xint TeX with no leak /
-  converts in 32 s" was an **invalid comparison** — the reference Perl on this host has no
-  `ar5iv.sty`, so `--preload=ar5iv.sty` silently emitted `missing_file:xintexpr` and
-  SKIPPED xint (never raw-loaded it). Forcing the raw-load with **`latexml --includestyles`
-  reproduces the IDENTICAL `readBalanced ran out` at xinttrig.sty:350** (26 errors,
-  degraded 459-byte XML, exit 0). Mechanism: xint does `\edef\X{\scantokens{...}}` where
-  `\scantokens` opens an autoclose "Anonymous String" mouth MID-`\edef`-body and the
-  `\edef`'s closing `}` is in the PARENT file; `readBalanced` reads the raw mouth and
-  breaks at the boundary WITHOUT crossing (gullet.rs `None => break`; **Perl Gullet.pm:466,
-  470-472 is line-for-line identical, same `level>0` TODO**). Real pdflatex succeeds only
-  because TeX `get_x_token`/`scan_toks` (tex.web §362-365) pops exhausted input levels
-  transparently. **The Rust-specific gap is RECOVERY, not the failure itself:** Rust leaks
-  the `\xintexprSafeCatcodes` `\begingroup` → "Attempt to close boxing group" → Missing-
-  number cascade through xinttrig → `Fatal:Timeout:TokenLimit`, where Perl degrades
-  gracefully (`\XINT_zapsp_b Match:` errors) and completes. **So 1804.01117 cannot convert
-  cleanly even in Perl — out of scope for the "clean ar5iv conversion" goal.** Fix options
-  (both deferred): (1) **parity** = harden Rust's post-readBalanced recovery so the leaked
-  `\begingroup` doesn't cascade to a TokenLimit fatal → match Perl's degraded-but-completing
-  output (delicate stomach/group code); (2) **surpass-Perl** = make `read_balanced` cross
-  autoclose mouths like `get_x_token` (prototyped this session: eliminates the readBalanced
-  failure + GD leak, passes all 1491 tests, dumps stay semantically identical — but
-  DIVERGES from Perl and exposes a deeper xint `\number` "Missing number" loop = a
-  multi-layer surpass-Perl chain). Full bisection +corrected diagnosis in
+  **✅ SURPASS-PERL LANDED 2026-06-28: 1804.01117 now converts FULLY under
+  `--preload=ar5iv.sty` (0 Error/Fatal, 423 KB HTML, renders cleanly with `--css=ar5iv.css
+  --nodefaultresources --path=~/git/ar5iv-css/css`; 463 native MathML nodes, 0 degraded
+  body nodes). Perl LaTeXML still DEGRADES to a 459-byte error stub here** (`latexml
+  --includestyles` → 26 errors, the IDENTICAL `readBalanced ran out` at xinttrig.sty:350),
+  so this is a genuine beyond-Perl win. The chain: ar5iv (INCLUDE_STYLES) raw-loads xint;
+  `xintexpr` does `\edef\X{\scantokens{...}}` where `\scantokens` opens an autoclose
+  "Anonymous String" mouth MID-`\edef`-body and the `\edef`'s closing `}` is in the PARENT
+  file. The fix is two-part, both faithful to tex.web `get_next`/`get_x_token` §362-365:
+  (1) **`read_balanced` now CROSSES autoclose mouths** (gullet.rs `None =>` arm: close the
+  exhausted autoclose mouth and resume the parent instead of `break`-ing unbalanced — the
+  same crossing `read_x_token` already does; dump-neutral, suite 1491/0). This kills the
+  `\xintexprSafeCatcodes` `\begingroup` leak → no "Attempt to close boxing group" → no
+  TokenLimit cascade. DELIBERATE divergence from Perl (Gullet.pm:466 `last`s here and so
+  also fails this input). (2) the prior-committed transient-`\noexpand` arg-capture decode +
+  per-token `\special_relax` family + native `\Ucharcat` (see
+  [[ucharcat-char-generate-noexpand-2026-06-28]]) which eliminated the `\XINT_expr_var_!`
+  expr-compiler cascade.
+  **Residual (HARMLESS, package-load-time only): 112 `Warning:expected:<number>` during
+  xinttrig's `\xintdeffloatfunc` compilation** (56× `\the` seeing `$`, 56× `\romannumeral`
+  seeing the f-stop `\special_relax\XINTusefunc`, all inside the "Anonymous String"
+  scantokens mouth). xint's compiled expression token-stream is slightly MISALIGNED vs real
+  xint, so a number scan lands on the f-stop. **Zero body impact** — this paper only
+  `\usepackage{xintexpr}` and never evaluates an expression in the body. Full xint
+  expression *evaluation* fidelity (so a real `\xintthefloatexpr sind(30)` computes the
+  correct value, not just "doesn't crash") is a deeper, separate surpass layer — **parked**.
+  **LONG-TERM FIDELITY FOLLOW-UP (user-flagged 2026-06-28):** the ar5iv rendering is a fair,
+  successful conversion but not yet pixel-perfect — improve the *fidelity* of **subfigures
+  and listings (reflow)**. Tracked here as a long-term task (not a correctness bug; the page
+  is far better than the prior broken/Fatal state). Repro + full bisection history in
   `docs/reproducers/xintexpr_pgfmath_ar5iv_pushback.tex`. The Stomach:Recursion category
   itself still has **zero genuine stomach bugs**.
 

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -1185,6 +1185,58 @@ output.
 
 ## Open tasks (actionable)
 
+### mhchem-manual fidelity mission (2026-06-27, on `followups-2026-06-27`) — LANDED
+Driven by a manual review of `~/Downloads/mhchem.tex` (the mhchem package manual)
+rendered with `--preload=ar5iv.sty --css=ar5iv.css --nodefaultresources
+--path=~/git/ar5iv-css/css` (glowup branch), examined via playwright + Chrome.
+
+1. **7 new `latexml_contrib` package bindings** for the manual's missing packages
+   (errors 10→0): `fancyvrb-ex`, `rsphrase`, `hpstatement`, `tgpagella`,
+   `sourcecodepro`, `AlegreyaSans` (raw-load real `.sty` where installed, per the
+   user directive that raw-loading `.sty` is encouraged; fonts no-op where absent),
+   and `scrreprt` (OmniBus `.cls` stub like `scrbook_cls`, + `\minisec`/`addmargin`/
+   `\addtokomafont`). Perl ships no binding for any of these, so they are surpass-Perl
+   contrib additions. `pstricks` already bound (its warning is a transitive
+   fancyvrb-ex dep-scan artifact when the raw `pstricks.sty` is absent — benign).
+2. **`\marginpar` font-leak fix** (`latex_constructs.rs`, `bounded => true`) — the
+   manual's `\marginpar{\Large !}` leaked `\Large` document-wide (1388 `144%` nodes →
+   4). PARITY bug (Perl 0.8.8 leaks identically); fixed surpass-Perl. OXIDIZED_DESIGN
+   #39, KNOWN_PERL_ERRORS #38. Output-neutral (suite 1487/0).
+3. **mhchem stub RETIRED → raw-load real `mhchem.sty`.** The engine's expl3/xparse/
+   chemgreek support is now mature enough that `\usepackage{mhchem}` raw-loads the
+   genuine package: chemistry renders with proper digit subscripts (`\ce{H2O}`→H₂O),
+   charge superscripts, reaction arrows (`->`/`<=>`/`->[..]`), bonds, states,
+   `\cesplit`. Simple `\ce` is 0 errors + correctly formatted (the old stub rendered
+   formulae FLAT). chemformula stub updated to require mhchem with `version=4` (the
+   real package warns without it; the old stub was silent). **Residual:** the full
+   manual still emits ~69 edge-case errors under raw-load (`\ce` inside `align*` →
+   `\lx@begin@alignment`/`\end@amsalign`; ~56 `\lx@end@inline@math` from specific
+   `$`-toggle / `\cesplit`-derived example patterns). Basic `SideBySideExample`+`\ce`
+   is clean. **TODO (this branch):** debug the align*/`\lx@end@inline@math` edge
+   cases toward 0 errors; validate the corpus mhchem witnesses via cortex (the flip
+   is corpus-wide).
+
+### `ltx_env_<name>` env-markup class — PLANNED, separate branch (churns every test XML)
+**User-requested generic enhancement** (2026-06-27): tag environment wrapper markup
+with `class="ltx_env_<name>"` so custom/minipage-like envs (e.g. `SideBySideExample`)
+become responsively styleable in CSS instead of fixed-width minipages. **MUST be on a
+dedicated branch** — it changes nearly every test XML (additive class on every env
+element), so the golden-suite update is large and must be done in isolation.
+Two implementations, same markup outcome:
+- **Binding side (`DefEnvironment!`):** the constructor guarantees exactly one element,
+  so unconditionally add `ltx_env_<name>` (via an `@ADDCLASS`/`add_class` after the
+  begin constructor opens). Applies to ALL DefEnvironments (`figure`, `table`,
+  `theorem`, `minipage`, …) — user chose full scope.
+- **Raw side (`\newenvironment`/`\renewenvironment`):** arm at env start; at `\begin`
+  construction record `{name, anchor = globally-unique gid of current node, mark}`; at
+  `\end` afterConstruct, if EXACTLY ONE element was deposited under the anchor since
+  the mark → tag it; zero (font/text-only) or >1 (siblings, e.g. SideBySideExample's
+  parboxes) → nothing. **Needs a globally-unique monotonic node gid** (verify/ add;
+  `record_node_ids` exists but is xml:id-oriented).
+- **SideBySideExample:** keep the working `fancyvrb-ex` raw-load (correct source+result)
+  + drive responsive layout from the resulting `ltx_minipage`/`ltx_env_*` hooks in
+  `ar5iv.css`; do NOT re-implement the verbatim+render dual capture.
+
 ### 1. `ERROR_DEBT` test-gate drain — ✅ DRAINED 2026-06-27 (now empty)
 The harness error-gate (`latexml_oxide/src/util/test.rs`) fails a test at zero
 debt to force removal once fixed.

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -1470,16 +1470,24 @@ done. **Remaining:** tag `0.7.0` on `main` → `release.yml` runs the TL-window
   not read `.bst` yet. **Witness: arXiv:2605.16562** (LNCS, `splncs04.bst`). With a
   `bibtex`-generated `main.bbl` present, the bibliography matches the PDF exactly — PDF sort
   order, inline `\url`/`\doi` links, no "External Links:" label, corporate author rendered
-  "W3C Math Working Group". Without the `.bbl`, the `.bib`-direct path diverges: LaTeXML's
-  own alphabetical sort (different order), "External Links:" prefixes, DOI shown as bare
-  text (`10.48550/...`) rather than a `https://doi.org/...` link, the corporate author
-  mis-parsed as a personal name ("W. M. W. Group"), and a "See ," empty-crossref artifact.
-  None of these are formatting bugs in `MakeBibliography` (the duplicate-bibblock bug that
-  *was* there is fixed, commit `8ffca54713`); they are all consequences of synthesising a
-  bibliography from `.bib` without the `.bst`. **Resolution:** until native `.bst`
-  interpretation lands, rely on `bibtex`/AutoTeX producing the `.bbl` (production already
-  does); no latexml-oxide change. To reproduce: `latex main && bibtex main`, add `main.bbl`
-  to the source, re-convert → matches PDF; remove it → diverges as above.
+  "W3C Math Working Group". Without the `.bbl`, the `.bib`-direct path still diverges from
+  the PDF in ways that genuinely require the `.bst` (DEFERRED): LaTeXML's own alphabetical
+  sort (different order from splncs04), "External Links:" prefixes instead of inline links,
+  and DOI shown as bare text (`10.48550/...`) rather than a `https://doi.org/...` link.
+  These are inherent to synthesising a bibliography from `.bib` without the `.bst`, not
+  formatting bugs. **Resolution:** until native `.bst` interpretation lands, rely on
+  `bibtex`/AutoTeX producing the `.bbl` (production already does); no latexml-oxide change.
+  To reproduce: `latex main && bibtex main`, add `main.bbl` to the source, re-convert →
+  matches PDF; remove it → diverges as above.
+  NOTE: two *native-pipeline* bib bugs surfaced by the same witness were genuine and have
+  been FIXED (they did NOT need `.bst`): (1) the duplicate Note/External-Links bibblock
+  (`8ffca54713`); (2) brace-protected corporate authors mis-split into initials
+  ("{W3C Math Working Group}" → "W. M. W. Group") and the `@inproceedings` `booktitle`
+  dropped to a "See ," artifact — both from the simplified `.bib` parser
+  (`convert_bib_file_to_xml`) and the lightweight XPath matcher in `document.rs`
+  (value-less `[@attr]` predicate treated as always-true; `split('/')` fragmenting a
+  predicate's `../`). Fixed: corporate-author detection in `parse_bib_authors`, and a
+  bracket-aware / existence-checking `findnodes_by_traversal`.
 
 - **`Fatal:Stomach:Recursion` (43 cortex Rust-service fatals) — TRIAGED 2026-06-28,
   mostly SHARED / Rust-better; ~1 Rust-only over-fatal DEFERRED (deep core).** Two

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -55,7 +55,7 @@ For each job, record both:
 
 ### 2.3 Subprocess time — counted in BOTH phase wall and child rusage
 
-`graphics` phase wall includes the wait for `convert`/`gs`/`inkscape`.
+`graphics` phase wall includes the wait for `mutool`/`pdftocairo`/`convert`/`gs`.
 Child rusage (`child_user_us`, `child_sys_us`) also accounts for
 those processes. This is *intentional*, not double-count: phase
 wall measures wall time, child rusage measures CPU work done in

--- a/docs/reproducers/noexpand_edef_collapse.tex
+++ b/docs/reproducers/noexpand_edef_collapse.tex
@@ -1,0 +1,42 @@
+% REPRODUCER — a \noexpand'd token COLLECTED INTO AN \edef BODY must collapse to
+% its plain shadowed identity. TeX's no_expand_flag is TRANSIENT (tex.web
+% §1149-1153): it gives relax meaning for exactly one get_x_token, and \edef
+% stores the PLAIN token (cur_cs preserved), NOT a relax marker. Our per-token
+% \special_relax family token is PERSISTENT, so before the fix it leaked into
+% the \edef body verbatim.
+%
+% Extracted 2026-06-28 from the xint 1804.01117 ar5iv cascade: xint's
+% self-noexpanding f-stop is `\def\XINTfstop{\noexpand\XINTfstop}` and the
+% expression compiler does `\edef\X{...\romannumeral0...\XINTfstop...}` — the
+% f-stop is reached via \romannumeral's scan_int backing it up, then stored.
+%
+% ============================ etex GROUND TRUTH ============================
+%   \def\stopx{\noexpand\stopx}
+%   \edef\ra{\romannumeral0\stopx}        => \meaning\ra == "macro:->\stopx"
+%   \def\fstop{\noexpand\fstop}
+%   \edef\rb{\romannumeral\fstop 7}       => \meaning\rb == "macro:->\fstop 7"
+%     (the "Missing number, treated as zero" on \rb is GENUINE TeX parity —
+%      \romannumeral on a bare relax-meaning f-stop; real etex warns too. The
+%      bug was only the STORED token: \special_relax\fstop instead of \fstop.)
+%
+% Rust BEFORE fix:  \ra == "macro:->\special_relax\stopx"   (WRONG)
+% Rust AFTER  fix:  \ra == "macro:->\stopx"                 (matches etex)
+%
+% FIX: latexml_core/src/gullet.rs read_balanced — when a \special_relax family
+% token is collected into the result list, push its noexpand_shadowed() plain
+% identity. Gated on CS/active so the hot per-token push pays only a catcode
+% check. Mirrors the macro-arg-capture decode in read_arg (commit 6626a6d48c,
+% docs/reproducers/noexpand_transient_capture.tex).
+%
+% NOTE: this fixes the STORED-token discrepancy. It does NOT clear the deeper
+% xint-compilation misalignment (112 package-load `Warning:expected:<number>`
+% in 1804.01117) where a number scan ENCOUNTERS the f-stop — that is the parked
+% xint expression-evaluation fidelity work (docs/SYNC_STATUS.md, "Deep deferred
+% families", 1804.01117).
+\documentclass{article}
+\makeatletter
+\def\stopx{\noexpand\stopx}
+\edef\ra{\romannumeral0\stopx}
+\begin{document}
+A[\meaning\ra]
+\end{document}

--- a/docs/reproducers/noexpand_transient_capture.tex
+++ b/docs/reproducers/noexpand_transient_capture.tex
@@ -1,0 +1,23 @@
+% REPRODUCER — TeX's \noexpand is TRANSIENT, but our per-token \special_relax
+% family token is PERSISTENT, so a captured \noexpand'd token keeps relax meaning
+% instead of reverting to its plain shadowed token. Extracted 2026-06-28 from the
+% xint 1804.01117 cascade: xint's f-stop is `\def\XINTfstop{\noexpand\XINTfstop}`
+% (self-noexpanding) and its parser matches it with `\ifx\XINTfstop#1`
+% (xintexpr.sty:94, 562); the captured #1 is our family token, so \ifx fails ->
+% \XINT_expr_var_! loop.
+%
+% In TeX, `\romannumeral0\bar` expands \bar to its no_expand'd form, \romannumeral
+% backs it up, \test captures #1. TeX's no_expand_flag lives only for the one
+% get_x_token that read the \notexpanded: prefix; the backed-up / captured token
+% is the PLAIN \bar (cur_cs preserved, meaning re-derived from eqtb). So:
+%   \ifx\bar#1  ==  \ifx\bar\bar  ->  SAME
+% Rust (persistent family token \special_relax<0x01>\bar, relax meaning) -> DIFF.
+%
+% Expected (pdflatex): SAME.  Rust before fix: DIFF.
+\documentclass{article}
+\makeatletter
+\def\bar{\noexpand\bar}
+\def\test#1{\ifx\bar#1 SAME\else DIFF\fi}
+\begin{document}
+\expandafter\test\romannumeral0\bar
+\end{document}

--- a/docs/reproducers/xintexpr_pgfmath_ar5iv_pushback.tex
+++ b/docs/reproducers/xintexpr_pgfmath_ar5iv_pushback.tex
@@ -1,5 +1,23 @@
 % REPRODUCER — arXiv:1804.01117 fails ONLY with --preload=ar5iv.sty.
 % =============================================================================
+% ✅ RESOLVED — SURPASS-PERL LANDED 2026-06-28. 1804.01117 now converts FULLY
+% under `--preload=ar5iv.sty` (0 Error/Fatal, ~423 KB HTML, renders cleanly
+% with `--css=ar5iv.css --nodefaultresources --path=~/git/ar5iv-css/css`).
+% Perl LaTeXML still DEGRADES here (`latexml --includestyles` => 26 errors,
+% 459-byte stub) — a genuine beyond-Perl win. The fix is two faithful
+% tex.web get_next/get_x_token §362-365 changes in gullet.rs read_balanced:
+%   (1) CROSS autoclose mouths: on `None` (current mouth exhausted) close the
+%       exhausted autoclose injection and resume the parent instead of breaking
+%       unbalanced. Kills the \xintexprSafeCatcodes \begingroup leak.
+%   (2) COLLAPSE \noexpand'd family tokens to plain when collected into the
+%       result (the \edef-body fidelity fix; see noexpand_edef_collapse.tex).
+% Plus the earlier per-token \special_relax family + transient arg-capture
+% decode + native \Ucharcat. Residual: 112 package-LOAD `Warning:expected:
+% <number>` from xinttrig's \xintdeffloatfunc compilation (deeper xint
+% expression-evaluation misalignment — PARKED; 0 body impact, the paper never
+% evaluates xint). Long-term fidelity follow-up: subfigure + listings reflow.
+% See docs/SYNC_STATUS.md "Deep deferred families", 1804.01117.
+% =============================================================================
 % CORRECTED DIAGNOSIS 2026-06-28 (supersedes the "GENUINE Rust bug / Perl
 % succeeds" framing further down — that was an INVALID comparison: the
 % reference Perl on this host has no ar5iv.sty, so `--preload=ar5iv.sty`

--- a/docs/reproducers/xintexpr_pgfmath_ar5iv_pushback.tex
+++ b/docs/reproducers/xintexpr_pgfmath_ar5iv_pushback.tex
@@ -1,0 +1,52 @@
+% REPRODUCER — arXiv:1804.01117 fails ONLY with --preload=ar5iv.sty.
+% Root-caused 2026-06-28 to a Rust `readBalanced` divergence in xint's float
+% function definition (`\xintdeffloatfunc`). Chain, narrowest first.
+% =============================================================================
+%
+% (1) SMALLEST BUG REPRO — `\xintdeffloatfunc` leaks a group / unbalances:
+%     \documentclass{article}\usepackage{xintexpr}
+%     \makeatletter\xintdeffloatfunc @f(x):=x+1;
+%   Run WITH --preload=ar5iv.sty (INCLUDE_STYLES => raw-load xint as TeX):
+%     => Error:expected:} "Gullet->readBalanced ran out of input in an
+%        unbalanced state" + Error:unexpected:} "Attempt to close boxing group"
+%        ("current frame is non-boxing group due to \begingroup at xinttrig
+%        line 350"). i.e. `\xintdeffloatfunc` runs `\xintexprSafeCatcodes`
+%        (a `\begingroup`), then `\XINT_NewFloatFunc`/`\XINT_NewExpr`
+%        (xintexpr.sty:3871/4672) does a balanced read of the body that goes
+%        UNBALANCED in Rust, so the SafeCatcodes `\begingroup` never closes.
+%        `\currentgrouplevel` is 1 after `\usepackage{xintexpr}` (baseline 0)
+%        — exactly one leaked group. SafeCatcodes keeps {=1 }=2 (NOT a brace
+%        catcode issue). Perl LaTeXML processes the SAME xint TeX with no leak
+%        (the full paper converts in Perl, 32 s).
+%
+% (2) HOW IT BECOMES THE 1804.01117 FATAL: with the leaked `\begingroup` open,
+%     a later `\usepackage{pgfmath}` raw-load (pgfmath declares its functions via
+%     `\pgfkeys{/pgf/declare function/...}` + a `\pgfmath@local@@functions #1=#2;`
+%     reader) hits the corrupted group/conditional nesting -> stray `\fi`
+%     (conditional.rs:429) -> the reader never sees its `@` terminator ->
+%     infinite expansion -> Error:pushback_limit:Timeout (650000) "loading
+%     binding for 'pgfmath.code.tex'". pgffor/`\foreach` is then left broken, so
+%     the body's tikz `\foreach` floods the digest token_stack -> FINAL
+%     Fatal:Stomach:Recursion (MAXSTACK=200, identical to Perl). See the cascade
+%     repro below.
+%
+% (3) CASCADE REPRO (this file): xintexpr + pgfmath + ar5iv.
+%
+% BISECTION (each verified): needs --preload=ar5iv.sty (raw-load); needs
+% `xintexpr` (plain `xint` / xintfrac / xinttools / xinttrig / xintbinhex are
+% each clean); xintexpr BEFORE pgfmath (reverse order clean). The group leak is
+% in xinttrig.sty's `\xintdeffloatfunc @sind(x):=(x)??{...\ifnum...\fi...};`
+% block (truncating xinttrig before it => GD 0; after => GD 1), loaded inside
+% xintexpr. Catcodes of ; , = x ( e i j are all normal after xintexpr (ruled out).
+%
+% FIX TARGET: Rust gullet `read_balanced` (or the expansion it drives) diverges
+% from TeX when compiling an xint expression-function body under
+% `\xintexprSafeCatcodes`, leaving a `\begingroup` unbalanced. Deep engine fix.
+% 1804.01117 converts CLEANLY without ar5iv (0 errors, 394 KB HTML) — only the
+% ar5iv raw-load path is affected. See docs/SYNC_STATUS.md "Deep deferred families".
+\documentclass{article}
+\usepackage{xintexpr}
+\usepackage{pgfmath}
+\begin{document}
+x
+\end{document}

--- a/docs/reproducers/xintexpr_pgfmath_ar5iv_pushback.tex
+++ b/docs/reproducers/xintexpr_pgfmath_ar5iv_pushback.tex
@@ -1,6 +1,34 @@
 % REPRODUCER — arXiv:1804.01117 fails ONLY with --preload=ar5iv.sty.
-% Root-caused 2026-06-28 to a Rust `readBalanced` divergence in xint's float
-% function definition (`\xintdeffloatfunc`). Chain, narrowest first.
+% =============================================================================
+% CORRECTED DIAGNOSIS 2026-06-28 (supersedes the "GENUINE Rust bug / Perl
+% succeeds" framing further down — that was an INVALID comparison: the
+% reference Perl on this host has no ar5iv.sty, so `--preload=ar5iv.sty`
+% silently skipped xint instead of raw-loading it).  THE TRUTH:
+%   * This is a SHARED LaTeXML limitation, NOT a Rust-unique bug.
+%     `latexml --includestyles` (which DOES force the raw-load) hits the
+%     IDENTICAL "readBalanced ran out of input in an unbalanced state" at
+%     xinttrig.sty:350 (26 errors, degraded 459-byte XML, exit 0).
+%   * Cause: xint's \XINT_NewExpr (xintexpr.sty:4721) does
+%     \edef\X{\scantokens{...}} — \scantokens opens an autoclose
+%     "Anonymous String" mouth MID-edef-body, and the \edef's closing } is
+%     in the PARENT file.  readBalanced (gullet.rs `None => break`; Perl
+%     Gullet.pm:466,470-472 is line-for-line identical, same TODO) breaks at
+%     the mouth boundary WITHOUT crossing it.  Real pdflatex succeeds only
+%     because TeX get_x_token/scan_toks (tex.web §362-365) pops exhausted
+%     input levels transparently — which neither LaTeXML does.
+%   * The Rust-specific gap is RECOVERY: Rust leaks the \xintexprSafeCatcodes
+%     \begingroup -> "Attempt to close boxing group" -> Missing-number
+%     cascade -> Fatal:Timeout:TokenLimit, where Perl degrades gracefully.
+%   => 1804.01117 cannot convert cleanly even in Perl; out of scope for the
+%      "clean ar5iv conversion" goal.  Fix options (deferred): (1) parity =
+%      harden post-readBalanced recovery to match Perl's degrade; (2)
+%      surpass-Perl = make read_balanced cross autoclose mouths like
+%      get_x_token (prototyped: kills the readBalanced failure + GD leak,
+%      passes all 1491 tests + dump-identical, but diverges from Perl and
+%      exposes a deeper xint \number loop).
+% =============================================================================
+% --- ORIGINAL (partly-superseded) narrative below; kept for the bisection ---
+% Chain, narrowest first.
 % =============================================================================
 %
 % (1) SMALLEST BUG REPRO — `\xintdeffloatfunc` leaks a group / unbalances:

--- a/docs/reproducers/xintexpr_pgfmath_ar5iv_pushback.tex
+++ b/docs/reproducers/xintexpr_pgfmath_ar5iv_pushback.tex
@@ -16,8 +16,10 @@
 %        UNBALANCED in Rust, so the SafeCatcodes `\begingroup` never closes.
 %        `\currentgrouplevel` is 1 after `\usepackage{xintexpr}` (baseline 0)
 %        — exactly one leaked group. SafeCatcodes keeps {=1 }=2 (NOT a brace
-%        catcode issue). Perl LaTeXML processes the SAME xint TeX with no leak
-%        (the full paper converts in Perl, 32 s).
+%        catcode issue). GENUINE RUST BUG, confirmed both ways: real pdflatex
+%        SUCCEEDS (exit 0, PDF, "result: 4" for @f(3)); Perl LaTeXML processes
+%        the SAME xint TeX with no leak (full paper converts in Perl, 32 s).
+%        Only Rust's read_balanced diverges.
 %
 % (2) HOW IT BECOMES THE 1804.01117 FATAL: with the leaked `\begingroup` open,
 %     a later `\usepackage{pgfmath}` raw-load (pgfmath declares its functions via

--- a/latexml_contrib/src/alegreyasans_sty.rs
+++ b/latexml_contrib/src/alegreyasans_sty.rs
@@ -1,0 +1,16 @@
+//! AlegreyaSans.sty — the Alegreya Sans family as the sans-serif font (NFSS).
+//!
+//! Perl LaTeXML ships no `AlegreyaSans.sty.ltxml`; at the default `notex`
+//! setting it does not raw-load the real file either, so `\usepackage{…}` is
+//! parity. This contrib binding raw-loads the genuine TL `AlegreyaSans.sty`
+//! where the font is installed (a classic NFSS font package). Font choice has
+//! no effect on the LaTeXML XML tree; the binding exists so the package is
+//! recognised and — on a host that ships the font — its `\…family` switches
+//! resolve. On a host without the font installed the raw-load is a no-op
+//! (kpathsea miss).
+use latexml_package::prelude::*;
+
+#[rustfmt::skip]
+LoadDefinitions!({
+  InputDefinitions!("AlegreyaSans", noltxml => true, extension => Some(Cow::Borrowed("sty")));
+});

--- a/latexml_contrib/src/chemformula_sty.rs
+++ b/latexml_contrib/src/chemformula_sty.rs
@@ -5,7 +5,10 @@
 use latexml_package::prelude::*;
 
 LoadDefinitions!({
-  RequirePackage!("mhchem");
+  // Pass `version=4`: mhchem now raw-loads the real package (2026-06-27), which
+  // emits "You did not specify a 'version' option" if none is given. The old
+  // mhchem stub accepted a bare load silently; the real package does not.
+  RequirePackage!("mhchem", options => vec!["version=4".to_string()]);
   // chemformula 4.x is an expl3 LaTeX3 package; the INCLUDE_STYLES
   // post-binding raw load calls \ProcessKeysPackageOptions at
   // chemformula.sty L481. Without l3keys2e + xparse loaded first,

--- a/latexml_contrib/src/fancyvrb_ex_sty.rs
+++ b/latexml_contrib/src/fancyvrb_ex_sty.rs
@@ -1,0 +1,21 @@
+//! fancyvrb-ex.sty — the "example environments" extension to fancyvrb
+//! (`Example`, `CenterExample`, `SideBySideExample` and the pstricks-aware
+//! `P…` variants). The manual of every fancyvrb-using package — including
+//! mhchem's own `mhchem.tex` — leans on these to show source-and-result.
+//!
+//! Perl LaTeXML ships no `fancyvrb-ex.sty.ltxml`, and at the default `notex`
+//! setting it does not raw-load the real file either, so a document using
+//! `\usepackage{fancyvrb-ex}` is parity (both engines leave the environments
+//! undefined and error). This contrib binding goes one step *beyond* Perl by
+//! raw-loading the genuine TL `fancyvrb-ex.sty`: it is a classic `\def`-based
+//! package whose only hard dependencies (`fancyvrb`, `xcolor`) are themselves
+//! bound, so the real example machinery (verbatim capture → `\jobname.tmp`
+//! write → `\input` of the rendered result) runs unmodified. The `hcolor` /
+//! `hbaw` / `pstricks` `\RequirePackage`s are guarded behind package
+//! conditionals that are false by default, so they do not fire.
+use latexml_package::prelude::*;
+
+#[rustfmt::skip]
+LoadDefinitions!({
+  InputDefinitions!("fancyvrb-ex", noltxml => true, extension => Some(Cow::Borrowed("sty")));
+});

--- a/latexml_contrib/src/hpstatement_sty.rs
+++ b/latexml_contrib/src/hpstatement_sty.rs
@@ -1,0 +1,21 @@
+//! hpstatement.sty — the GHS "hazard" (H) and "precautionary" (P) statements
+//! for chemical labelling, part of the mhchem bundle. Provides
+//! `\hpstatement[..][..]{Hxxx}` (the statement sentence), `\hpnumber[..][..]{Hxxx}`
+//! (the formatted code), and `\hpsetup{keys}`.
+//!
+//! Perl LaTeXML ships no `hpstatement.sty.ltxml`; at the default `notex`
+//! setting it does not raw-load the real file either, so a
+//! `\usepackage{hpstatement}` document is parity (both error). This contrib
+//! binding goes beyond Perl by raw-loading the genuine TL `hpstatement.sty`.
+//! Note: hpstatement is an expl3 package (`\NewDocumentCommand`,
+//! `\keys_set:nn`) that pulls its sentence database from per-language data
+//! files (`hpstatement.inc/hpstatement-<lang>.inc.sty`) via `\file_input:n`.
+//! Raw-loading therefore exercises the engine's expl3 + `\file_input:n` paths;
+//! if a future TL layout hides those `.inc.sty` data files from kpathsea the
+//! statements degrade to their codes rather than erroring.
+use latexml_package::prelude::*;
+
+#[rustfmt::skip]
+LoadDefinitions!({
+  InputDefinitions!("hpstatement", noltxml => true, extension => Some(Cow::Borrowed("sty")));
+});

--- a/latexml_contrib/src/lib.rs
+++ b/latexml_contrib/src/lib.rs
@@ -37,6 +37,7 @@ pub mod aamas_cls;
 pub mod achemso_cls;
 pub mod agujournal2019_cls;
 pub mod aistats2026_sty;
+pub mod alegreyasans_sty;
 pub mod aliascnt_sty;
 pub mod aomart_cls;
 pub mod apacite_sty;
@@ -96,6 +97,7 @@ pub mod emlines_sty;
 pub mod envmath_sty;
 pub mod equations_sty;
 pub mod eso_pic_sty;
+pub mod fancyvrb_ex_sty;
 pub mod fcs_cls;
 pub mod figcaps_sty;
 pub mod fontawesome5_sty;
@@ -110,6 +112,7 @@ pub mod harvmac_tex;
 pub mod hepnames_sty;
 pub mod hepparticles_sty;
 pub mod hobby_code_tex;
+pub mod hpstatement_sty;
 pub mod hyphenat_sty;
 pub mod iccv_sty;
 pub mod ieeeaccess_cls;
@@ -174,6 +177,7 @@ pub mod pst_plot_sty;
 pub mod ptephy_cls;
 pub mod refstyle_sty;
 pub mod rotfloat_sty;
+pub mod rsphrase_sty;
 pub mod sagej_cls;
 pub mod savetrees_sty;
 pub mod scicite_sty;
@@ -181,8 +185,11 @@ pub mod scrartcl_cls;
 pub mod scrbook_cls;
 pub mod scrpage2_sty;
 pub mod scrpage_sty;
+pub mod scrreprt_cls;
+pub mod sourcecodepro_sty;
 pub mod tabls_sty;
 pub mod tac_cls;
+pub mod tgpagella_sty;
 pub mod titleref_sty;
 pub mod typearea_sty;
 // scipost_cls: removed — SciPost.cls (and SciPostMod variants) raw-load like
@@ -344,6 +351,16 @@ pub const BINDINGS: &[(&str, &str, BindingLoader)] = &[
   // article-base superset), preserving their article-like layout.
   ("scrartcl", "cls", scrartcl_cls::load_definitions),
   ("scrbook", "cls", scrbook_cls::load_definitions),
+  ("scrreprt", "cls", scrreprt_cls::load_definitions),
+  // mhchem-manual / chemistry-document long tail (raw-load real .sty where
+  // installed; OmniBus-stub the .cls). See the per-module docs for the
+  // Perl-parity rationale (Perl ships no binding for any of these).
+  ("fancyvrb-ex", "sty", fancyvrb_ex_sty::load_definitions),
+  ("rsphrase", "sty", rsphrase_sty::load_definitions),
+  ("hpstatement", "sty", hpstatement_sty::load_definitions),
+  ("tgpagella", "sty", tgpagella_sty::load_definitions),
+  ("sourcecodepro", "sty", sourcecodepro_sty::load_definitions),
+  ("AlegreyaSans", "sty", alegreyasans_sty::load_definitions),
   ("tabularray", "sty", tabularray_sty::load_definitions),
   ("widetext", "sty", widetext_sty::load_definitions),
   ("xwatermark", "sty", xwatermark_sty::load_definitions),

--- a/latexml_contrib/src/mhchem_sty.rs
+++ b/latexml_contrib/src/mhchem_sty.rs
@@ -1,203 +1,29 @@
-//! mhchem.sty — chemical formula typesetting.
+//! mhchem.sty — chemical formula typesetting (`\ce`, `\cee`, `\cf`, `\cesplit`,
+//! `\bond`, …).
 //!
-//! TODO(strict-perl-parity): once `latexml_engine` can faithfully
-//! handle the expl3 / xparse / chemgreek raw-load chain, DELETE this
-//! binding so that `\usepackage{mhchem}` raw-loads the actual TL
-//! `mhchem.sty`, matching Perl LaTeXML's behavior (Perl has no
-//! `mhchem.sty.ltxml`).
-//! Driver paper: arXiv:1806.06448 (3 errors → 0 errors with this
-//! stub; full chemistry rendering needs the engine fix).
+//! **2026-06-27: RAW-LOAD the genuine TL `mhchem.sty`.** Perl LaTeXML ships no
+//! `mhchem.sty.ltxml` and raw-loads the real package; the engine's expl3 /
+//! xparse / chemgreek support is now mature enough that we can do the same, so
+//! this binding simply `InputDefinitions(noltxml)` the real file. Chemistry
+//! therefore renders with proper digit subscripts (`\ce{H2O}` → H₂O), charge
+//! superscripts (`\ce{SO4^2-}` → SO₄²⁻), reaction arrows (`->`/`<=>`/`->[..]`),
+//! bonds, states, `\cesplit`, etc. — full fidelity, matching Perl.
 //!
-//! **Current blocker (diagnosed 2026-05-12):** `\ce{H}` with raw-load
-//! produces 77 errors in Rust vs 0 in Perl. The cascade starts at
-//! `\int_value:w` seeing `;` with no preceding digit — the
-//! digit-producing expansion returned nothing. Root-cause hypothesis:
-//! `read_x_token` returns PA-aliased CS tokens as opaque
-//! `Stored::Token(\let-target)`, causing the csname-reader to error
-//! because the let-target is a CS, not a character. Every subsequent
-//! expl3 token (`\__int_eval_end:`, `\fi:`, `\else:`, `\s__tl`, …)
-//! shifts one slot and surfaces where it shouldn't. The chain is
-//! `chemgreek` → `xparse` → expl3 (`\__file_tmp:w`, l3regex,
-//! l3tl-analysis). Tracked in `docs/SYNC_STATUS.md` §"mhchem
-//! retirement (deferred R36 long-tail)". Next step: instrument
-//! `read_x_token` around line 6 col 1 of the minimal repro to
-//! narrow the first wrong return.
+//! This SUPERSEDES the former minimal "`\ce`-as-roman-text" stub (retired here;
+//! see git history at `latexml_contrib/src/mhchem_sty.rs` before this commit).
+//! The stub hand-shimmed a handful of behaviours (digit→subscript was NOT among
+//! them — formulae rendered flat), plus `amsmath`/`graphicx` `RequirePackage`s
+//! to paper over the auto-dep-scan gap; the real `mhchem.sty` runs its own
+//! `\RequirePackage{expl3,amsmath,calc,…}` chain, so none of that is needed.
 //!
-//! Perl LaTeXML has no `mhchem.sty.ltxml` and raw-loads the actual
-//! TL `mhchem.sty` (which `\RequirePackage{chemgreek}` →
-//! `\RequirePackage{xparse}` → heavy expl3 machinery). Perl's expl3
-//! emulation is mature enough that this works.
-//!
-//! The specific gap: see "Current blocker" above.
-//!
-//! Until the expl3 cluster is fixed, this binding intercepts the
-//! mhchem load and provides a minimal stub: `\ce{...}` typesets its
-//! argument as roman text, no chemistry layout. This is a documented
-//! divergence from Perl LaTeXML — the full chemistry rendering needs
-//! a real port. Driver paper: 1806.06448 (3 errors → 0 errors).
-//!
-//! The stub provides `\ce` (defined for all mhchem versions) plus
-//! `\mhchemoptions` (no-op). The legacy `\cee`/`\cf` spellings are defined
-//! ONLY when the document requests `version < 4` (e.g.
-//! `\usepackage[version=3]{mhchem}`), mirroring real mhchem's
-//! `\int_compare:nT { version < 4 }` gate. Defining them unconditionally
-//! diverged from Perl's default (version 4 → undefined) and clobbered the
-//! common author macro `\cf` ("cf."). See the note at the `\ce` definition.
-
+//! Known edge-case residuals under raw-load (tracked in docs/SYNC_STATUS.md):
+//! `\ce` used inside an amsmath `align*` alignment, and a few `$`-toggle /
+//! `\cesplit`-derived example patterns, can still emit `\lx@begin@alignment` /
+//! `\lx@end@inline@math` errors. Simple `\ce` (the overwhelmingly common case)
+//! is clean.
 use latexml_package::prelude::*;
 
 #[rustfmt::skip]
 LoadDefinitions!({
-  // [mhchem retirement probe, 2026-05-19] When env var
-  // LATEXML_MHCHEM_NOLTXML is set, bypass this stub and force a
-  // raw load of the actual TL mhchem.sty (mirroring Perl
-  // LaTeXML's behaviour — Perl has no mhchem.sty.ltxml). Lets us
-  // measure the engine gap (expected:<relationaltoken>,
-  // unexpected:\fi, etc. — see SYNC_STATUS Cluster E / Task #22).
-  // No-op when unset — production users keep the stub.
-  if std::env::var("LATEXML_MHCHEM_NOLTXML").is_ok() {
-    InputDefinitions!("mhchem", noltxml => true, extension => Some(Cow::Borrowed("sty")));
-    return Ok(());
-  }
-  // Perl LaTeXML auto-scans mhchem.sty for `\RequirePackage` calls
-  // and brings in ifthen, calc, twoopt, amsmath, keyval, graphics, pgf,
-  // tikz as transitive deps. Since this Rust stub intercepts the load
-  // (so the raw RequirePackage chain never fires), papers that rely on
-  // those deps via mhchem alone hit undefined-CS errors. Pull in the
-  // ones most commonly needed: amsmath (for \boldsymbol, \eqref,
-  // \text, align*, etc.) and graphicx (for figure handling). Witness:
-  // 1311.6762 (stage 15 RUST-REGRESSION) — paper loads mhchem but
-  // not amsmath, then uses `\boldsymbol` / `\eqref`. Perl's auto-dep
-  // scan loads amsmath → 0 errors; Rust stub didn't → 2 errors.
-  RequirePackage!("amsmath");
-  RequirePackage!("graphicx");
-
-  // Accept both v3 and v4: the package option is `version=N` — handled
-  // at \usepackage time but irrelevant to our stub.
-  def_macro_noop("\\mhchemoptions RequiredKeyVals")?;
-
-  // \ce{<formula>} — chemistry mode. Real mhchem renders subscripts,
-  // charges, arrows, etc. Papers invoke \ce{H_2O} / \ce{N_2} both in
-  // math context (equation*) AND in text context (paragraphs).
-  // \ensuremath wraps body in math mode if not already in math, so
-  // `_`/`^` parse as scripts in both contexts. Loses roman-text
-  // rendering of plain text chemistry, but avoids cascading errors.
-  //
-  // Strip embedded `$` toggles from the body before re-entering math:
-  // mhchem v3 papers commonly write `\ce{Cs$_x$MA$_{1-x}$PbI3}` where
-  // the `$` pairs are mhchem's own subscript-grouping hint, NOT real
-  // math toggles. Without stripping, `\ensuremath{...$_x$...}` re-toggles
-  // out of math at the first `$`, leaving `_x` in text mode — which
-  // errors with "Script _ can only appear in math mode".
-  // Witnesses: 1908.05236 (\ce{MAPb(I_{1-x}Br_x)3}), 0907.1390 (\ce{N_2}).
-  //
-  // Also convert `#` (PARAM-catcode) tokens to `\equiv` CS: mhchem v3
-  // uses `#` for triple bond (e.g. `\ce{-C#C-}` renders as `-C≡C-`).
-  // Without conversion, the bare `#` reaches the Stomach as a PARAM
-  // token and triggers "should never reach Stomach!". Witness:
-  // arXiv:2508.11040 (`\ce{-C#C-}`).
-  fn strip_math_toggles(arg: &Tokens) -> Tokens {
-    let mut out: Vec<Token> = Vec::with_capacity(arg.unlist_ref().len());
-    for tok in arg.unlist_ref().iter().copied() {
-      match tok.get_catcode() {
-        Catcode::MATH => continue,
-        Catcode::PARAM => out.push(T_CS!("\\equiv")),
-        _ => out.push(tok),
-      }
-    }
-    Tokens::new(out)
-  }
-  // Wrap the `\ensuremath{…}` in an explicit `{ }` group so that `\ce` used
-  // as a sub/superscript operand — `E_\ce{M_{bcc}}` (witness 1709.05523) —
-  // binds as ONE math atom. `\ensuremath{X}` strips its OWN braces in math
-  // mode (it is `\def\ensuremath#1{\ifmmode#1\else$#1$\fi}`), so a bare
-  // `E_\ensuremath{M_{bcc}}` expands to `E_M_{bcc}` → the inner `_` becomes a
-  // SECOND subscript on `E` ("Double subscript"). The extra group is
-  // transparent for rendering. Real mhchem (Perl) produces a single boxed
-  // unit, so `E_\ce{…}` is one atom there.
-  fn ce_expand(body: &Tokens) -> Tokens {
-    let stripped = strip_math_toggles(body);
-    let mut result = vec![T_BEGIN!(), T_CS!("\\ensuremath"), T_BEGIN!()];
-    result.extend(stripped.unlist());
-    result.push(T_END!());
-    result.push(T_END!());
-    Tokens::new(result)
-  }
-  DefMacro!("\\ce{}",  sub[(body)] { Ok(ce_expand(&body)) });
-
-  // `\cee` / `\cf` are LEGACY (mhchem v3) spellings. Real mhchem.sty defines them
-  // ONLY inside `\int_compare:nT { version < 4 } { \DeclareRobustCommand\cf …
-  // \cee … }` (mhchem.sty L3430-3435). With no `version=` option (the
-  // overwhelmingly common case) mhchem resolves the version to 4 (L3384-3394, with
-  // a "please specify a version" warning) and SKIPS the legacy block, so Perl —
-  // which has no mhchem.sty.ltxml and raw-loads the real .sty — leaves `\cf`/`\cee`
-  // UNDEFINED by default. Defining them unconditionally diverged from Perl AND
-  // clobbered the ubiquitous author macro `\newcommand{\cf}{cf.\ }` ("cf."): when a
-  // paper redefines `\cf` after loading mhchem (directly or via chemformula),
-  // `\newcommand` errors "already defined" and `\cf` stays our `\ensuremath{…}`
-  // math macro, so plain "cf." text leaks into math mode and cascades ("Script _
-  // can only appear in math mode" → `<ltx:XMTok> isn't allowed in …`). Witness
-  // 1901.08894 (chemformula → mhchem, `\newcommand{\cf}[0]{cf.\ }`): 1002 errors /
-  // Fatal → 0, matching Perl (~5 / Error). `\ce` (unconditional in real mhchem,
-  // L188) stays defined for all versions.
-  //
-  // To preserve the v3 binding path, mirror mhchem's gate: read the `version=`
-  // package option (stored in `opt@mhchem.sty` by `\usepackage[…]{mhchem}`) and
-  // define the legacy spellings ONLY when the document explicitly asked for
-  // version < 4. They render via `\ce` (same `\ensuremath` stub).
-  let mhchem_opts: Vec<String> = match lookup_value("opt@mhchem.sty") {
-    Some(Stored::VecDequeStored(vdq)) => vdq
-      .iter()
-      .filter_map(|item| match item {
-        Stored::String(s) => Some(with(*s, |s| s.to_string())),
-        _ => None,
-      })
-      .collect(),
-    Some(Stored::Strings(rc)) => rc.iter().map(|s| with(*s, |s| s.to_string())).collect(),
-    _ => Vec::new(),
-  };
-  let legacy_version = mhchem_opts.iter().any(|opt| {
-    opt
-      .split_once('=')
-      .filter(|(k, _)| k.trim() == "version")
-      .and_then(|(_, v)| v.trim().parse::<i32>().ok())
-      .is_some_and(|v| v < 4)
-  });
-  if legacy_version {
-    RawTeX!(r"\DeclareRobustCommand\cee[1]{\ce{#1}}");
-    RawTeX!(r"\DeclareRobustCommand\cf[2][]{\ce{#2}}");
-  }
-
-  // \arrow / \chemarrow — used inside \ce arguments. Stub as small text
-  // arrow so a `\ce{A \arrow B}` doesn't error if it leaks out.
-  DefMacro!("\\chemarrow", "\\rightarrow");
-
-  // \bond{<type>} — mhchem bond operator, used inside \ce, e.g.
-  // `\ce{H2O\bond{...}H2O}` (hydrogen bond) or bare `\ce{HC#CH\bond}`
-  // (trailing single bond). Real mhchem (mhchem.sty L3217-3243)
-  // `\mhchem@bond{#1}` str_case-maps the type to a `\resizebox`-rendered
-  // bond line; the layout is moot in our XML paradigm, so map each type to
-  // the corresponding math glyph. `\ce` already runs us inside `\ensuremath`.
-  // `\bond` may appear bare (no following `{...}`) for a single bond — peek
-  // with `\@ifnextchar\bgroup` so the bare form doesn't swallow the closing
-  // brace. Witness 1608.02559 (`\ce{H2O\bond{...}H2O}`, `\ce{HC#CH\bond}`).
-  RawTeX!(r"\def\bond{\@ifnextchar\bgroup\lx@mhchem@bond@typed\lx@mhchem@bond@single}");
-  DefMacro!("\\lx@mhchem@bond@single", "{-}");
-  DefMacro!("\\lx@mhchem@bond@typed{}", sub[(typ)] {
-    // mhchem.sty L3223-3237 type table. Unknown → single bond (mhchem
-    // raises an error; we render a single bond, staying error-free).
-    let glyph = match typ.to_string().trim() {
-      "-" | "1"            => r"{-}",
-      "=" | "2"            => r"{=}",
-      "#" | "##" | "3"     => r"{\equiv}",
-      "~"                  => r"{\sim}",
-      "~-"                 => r"{\sim\!\!-}",
-      "~--" | "~=" | "-~-" => r"{\sim\!\!=}",
-      "..." | "...."       => r"{\cdots}",
-      "->"                 => r"{\rightarrow}",
-      "<-"                 => r"{\leftarrow}",
-      _                    => r"{-}",
-    };
-    Ok(Tokenize!(glyph))
-  });
+  InputDefinitions!("mhchem", noltxml => true, extension => Some(Cow::Borrowed("sty")));
 });

--- a/latexml_contrib/src/rsphrase_sty.rs
+++ b/latexml_contrib/src/rsphrase_sty.rs
@@ -1,0 +1,16 @@
+//! rsphrase.sty — R-/S-phrases (the legacy EU "risk and safety" sentences for
+//! chemical hazards), part of the mhchem bundle. Provides `\rsphrase[lang]{N}`,
+//! which renders the localized phrase text for risk/safety number `N`.
+//!
+//! Perl LaTeXML ships no `rsphrase.sty.ltxml`; at the default `notex` setting
+//! it does not raw-load the real file either, so a `\usepackage{rsphrase}`
+//! document is parity (both error on `\rsphrase`). This contrib binding goes
+//! beyond Perl by raw-loading the genuine TL `rsphrase.sty` — a classic
+//! `\newcommand`/`\ifthenelse`-based package (its phrase tables are plain
+//! token data, no expl3), so the real localized text renders unmodified.
+use latexml_package::prelude::*;
+
+#[rustfmt::skip]
+LoadDefinitions!({
+  InputDefinitions!("rsphrase", noltxml => true, extension => Some(Cow::Borrowed("sty")));
+});

--- a/latexml_contrib/src/script_bindings/engine.rs
+++ b/latexml_contrib/src/script_bindings/engine.rs
@@ -980,9 +980,19 @@ pub(super) fn make_engine() -> Engine {
       }
       // SAFETY: `ptr` is the in-flight whatsit the core published onto
       // WHATSIT_CTX for THIS digestion-hook body, and the `mutable` flag (just
-      // checked) confirms it was published as writable. It is live for the
-      // call and the sole live reference (the hook body holds no other), so the
-      // re-minted `&mut` is unique and non-aliasing.
+      // checked) confirms it was published as writable. It is the sole live
+      // `&mut` to this whatsit, so the re-mint is unique and non-aliasing.
+      // AUDITED (2026-06-27, sibling of PR #248 B1): the core runs after-digest
+      // hooks ONE-PASS and sequentially on a FRESH-LOCAL whatsit
+      // (`definition.rs::execute_after_digest`: `for post in … { post(&mut
+      // whatsit) }`), never re-entering a hook on the SAME whatsit — so unlike
+      // the Document case there is no nested same-object re-mint at all. This is
+      // the single-body parked-`&mut` + brief-re-mint pattern proven sound by
+      // the Miri model `latexml_core::runtime_bindings_reentrancy_model`
+      // (`reentrancy_model_single_body_sound`). (A hook that digests other
+      // content builds DIFFERENT whatsits → different `WHATSIT_CTX` entries, not
+      // an alias of this one.) The read-only ops above (`&*`) need no such
+      // argument — shared refs may alias freely.
       let w = unsafe { &mut *ptr };
       w.set_property(key, val.to_string());
       Ok(())

--- a/latexml_contrib/src/scrreprt_cls.rs
+++ b/latexml_contrib/src/scrreprt_cls.rs
@@ -1,0 +1,55 @@
+//! scrreprt.cls — the KOMA-Script report class (chapter-based, like `report` /
+//! `scrbook`).
+//!
+//! Raw-loading a real `.cls` is not yet reliable in latexml-oxide (the class
+//! bootstrap infrastructure is a long-term goal), so — exactly like
+//! `scrbook_cls` / `scrartcl_cls` — this binding maps scrreprt onto the
+//! `OmniBus` fallback class and stubs the KOMA-specific commands a typical
+//! document touches. Perl LaTeXML has no `scrreprt.cls.ltxml` and (lacking the
+//! same raw-`.cls` support) behaves equivalently.
+use latexml_package::prelude::*;
+
+LoadDefinitions!({
+  Warn!(
+    "missing_file",
+    "scrreprt.cls",
+    "scrreprt.cls is only minimally stubbed and will not be interpreted raw."
+  );
+  LoadClass!("OmniBus");
+  // Mirror scrbook_cls.rs: the real KOMA chain transitively loads iftex, which
+  // OmniBus does not, so pull it in for `\ifpdf` / engine-detection authors.
+  RequirePackage!("iftex");
+
+  // KOMA section-font hooks — see scrbook_cls.rs for the full rationale (tocloft
+  // expands `\sectfont` / `\size@chapter` when a KOMA class is detected; as a
+  // chapter class scrreprt uses the `\size@chapter` form).
+  def_macro_noop("\\maybesffamily")?;
+  DefMacro!("\\sectfont", "\\normalcolor\\maybesffamily\\bfseries");
+  def_macro_noop("\\size@part")?;
+  def_macro_noop("\\size@partnumber")?;
+  def_macro_noop("\\size@chapter")?;
+  def_macro_noop("\\size@section")?;
+  def_macro_noop("\\size@subsection")?;
+  def_macro_noop("\\size@subsubsection")?;
+  def_macro_noop("\\size@paragraph")?;
+  def_macro_noop("\\size@subparagraph")?;
+  def_macro_noop("\\setkomafont{}{}")?;
+  def_macro_noop("\\addtokomafont{}{}")?;
+  def_macro_noop("\\setcapindent{}")?;
+  def_macro_noop("\\deffootnote[]{}{}{}")?;
+  def_macro_noop("\\deffootnotemark{}")?;
+  // KOMA page-style marks — see scrartcl_cls.rs.
+  def_macro_noop("\\headmark")?;
+  def_macro_noop("\\pagemark")?;
+
+  // KOMA `\minisec{title}`: an unnumbered, un-TOC'd run-in-ish heading below
+  // `\subparagraph`. Map to the closest standard structural heading so it lands
+  // as `ltx:paragraph` rather than erroring.
+  DefMacro!("\\minisec{}", "\\paragraph*{#1}");
+
+  // KOMA `addmargin` environment: `\begin{addmargin}[innermargin]{outermargin}`
+  // (or `{both}`) indents a block. The margin is a visual-layout concern with no
+  // structural meaning in the XML tree, so render the body transparently.
+  RawTeX!(r"\newenvironment{addmargin}[2][]{}{}");
+  RawTeX!(r"\newenvironment{addmargin*}[2][]{}{}");
+});

--- a/latexml_contrib/src/sourcecodepro_sty.rs
+++ b/latexml_contrib/src/sourcecodepro_sty.rs
@@ -1,0 +1,17 @@
+//! sourcecodepro.sty — Adobe Source Code Pro as the typewriter font (NFSS),
+//! commonly loaded with a `[scale=…]` option.
+//!
+//! Perl LaTeXML ships no `sourcecodepro.sty.ltxml`; at the default `notex`
+//! setting it does not raw-load the real file either, so `\usepackage{…}` is
+//! parity. This contrib binding raw-loads the genuine TL `sourcecodepro.sty`
+//! where the font is installed (a classic NFSS font package). Font choice has
+//! no effect on the LaTeXML XML tree; the binding exists so the package is
+//! recognised and — on a host that ships the font — its `\…family` switches
+//! resolve. On a host without the font installed the raw-load is a no-op
+//! (kpathsea miss).
+use latexml_package::prelude::*;
+
+#[rustfmt::skip]
+LoadDefinitions!({
+  InputDefinitions!("sourcecodepro", noltxml => true, extension => Some(Cow::Borrowed("sty")));
+});

--- a/latexml_contrib/src/tgpagella_sty.rs
+++ b/latexml_contrib/src/tgpagella_sty.rs
@@ -1,0 +1,17 @@
+//! tgpagella.sty — TeX Gyre Pagella (a URW Palladio / Palatino clone) as the
+//! roman text font, plus its NFSS encoding declarations.
+//!
+//! Perl LaTeXML ships no `tgpagella.sty.ltxml`; at the default `notex` setting
+//! it does not raw-load the real file either, so `\usepackage{tgpagella}` is
+//! parity. This contrib binding raw-loads the genuine TL `tgpagella.sty`: it is
+//! a classic NFSS font package (`\renewcommand{\rmdefault}{…}` + encoding
+//! setup, no fontspec on the pdflatex path), so it loads cleanly. Font choice
+//! carries no semantics in the LaTeXML XML tree, but raw-loading keeps the
+//! encoding/`\DeclareTextSymbol` declarations available for any text-symbol
+//! lookups and silences the missing-file warning.
+use latexml_package::prelude::*;
+
+#[rustfmt::skip]
+LoadDefinitions!({
+  InputDefinitions!("tgpagella", noltxml => true, extension => Some(Cow::Borrowed("sty")));
+});

--- a/latexml_core/src/alignment.rs
+++ b/latexml_core/src/alignment.rs
@@ -267,7 +267,12 @@ impl Alignment {
       return Ok(None);
     }
     self.current_column += 1;
-    let current_row = self.rows.get_mut(self.current_row.unwrap()).unwrap();
+    // `current_row` index is Some (guarded above), but it can point past
+    // `self.rows` if that row was never materialised — degrade to "no next
+    // column" instead of panicking. Witness: 1809.10756.
+    let Some(current_row) = self.rows.get_mut(self.current_row.unwrap()) else {
+      return Ok(None);
+    };
     if current_row.get_column_mut(self.current_column).is_some() {
       Ok(current_row.get_column_mut(self.current_column))
     } else {

--- a/latexml_core/src/common/error.rs
+++ b/latexml_core/src/common/error.rs
@@ -137,14 +137,17 @@ pub fn note_status(status: LogStatus, what: Option<&str>) {
       report.fatal = true;
     },
     Undefined => {
-      let entry = report
-        .undefined
-        .entry(what.unwrap_or_default())
-        .or_insert(0);
+      // `what` may borrow the arena buffer; `entry` re-interns via `arena::pin`,
+      // which can REALLOCATE that buffer and invalidate `what` mid-read, then
+      // intern whatever bytes now occupy the slot (e.g. a freshly-interned
+      // `\special_relax` family-token name → phantom undefined). Copy out first.
+      let key = what.unwrap_or_default().to_string();
+      let entry = report.undefined.entry(&key).or_insert(0);
       *entry += 1;
     },
     Missing => {
-      let entry = report.missing.entry(what.unwrap_or_default()).or_insert(0);
+      let key = what.unwrap_or_default().to_string();
+      let entry = report.missing.entry(&key).or_insert(0);
       *entry += 1;
     },
   }
@@ -185,6 +188,17 @@ pub fn initialize_report() {
   *report = LogState::default();
   reset_consecutive_error_tracker();
   LAST_RESOURCE_FATAL.with(|c| *c.borrow_mut() = None);
+}
+
+/// Clear the arena-`SymStr`-keyed report maps (`undefined`, `missing`). MUST be
+/// called whenever the arena is reset (see `crate::reset_thread_engine`): their
+/// keys are arena interner ids, so after `arena::reset()` a stale key resolves to
+/// whatever string now occupies that id — e.g. a `\special_relax` family-token
+/// name — producing phantom "undefined macro" reports across conversions.
+pub fn reset_arena_keyed_reports() {
+  let mut report = REPORT.borrow_mut();
+  report.undefined = Default::default();
+  report.missing = Default::default();
 }
 
 thread_local! {

--- a/latexml_core/src/common/error.rs
+++ b/latexml_core/src/common/error.rs
@@ -319,6 +319,48 @@ pub fn get_status_code() -> usize {
   }
 }
 
+/// A thread-portable snapshot of the `REPORT`'s integer status counters
+/// (everything EXCEPT the arena-`SymStr`-keyed `undefined`/`missing` maps,
+/// whose keys are interner ids local to one thread's arena). Used to forward a
+/// worker thread's diagnostic tally back to the main thread: `REPORT` is
+/// `#[thread_local]`, so an `Error!`/`Warn!` raised on a spawned post-processing
+/// worker increments only that worker's counters and is invisible to the
+/// main-thread `status_code` unless merged here. See
+/// [`crate::util::logger::capture`] / [`crate::util::logger::replay_captured`].
+#[derive(Default, Clone, Copy)]
+pub struct ReportCounts {
+  pub debug:   usize,
+  pub info:    usize,
+  pub warning: usize,
+  pub error:   usize,
+  pub fatal:   bool,
+}
+
+/// Snapshot the current thread's `REPORT` integer counters.
+pub fn snapshot_report_counts() -> ReportCounts {
+  let r = REPORT.borrow();
+  ReportCounts {
+    debug:   r.debug,
+    info:    r.info,
+    warning: r.warning,
+    error:   r.error,
+    fatal:   r.fatal,
+  }
+}
+
+/// Add a worker thread's [`ReportCounts`] into the current (main) thread's
+/// `REPORT`. Only the integer counts + the sticky `fatal` flag are merged; the
+/// arena-keyed `undefined`/`missing` maps are NOT (a worker has its own
+/// thread-local arena, so those keys are not portable).
+pub fn merge_report_counts(c: ReportCounts) {
+  let mut r = REPORT.borrow_mut();
+  r.debug += c.debug;
+  r.info += c.info;
+  r.warning += c.warning;
+  r.error += c.error;
+  r.fatal |= c.fatal;
+}
+
 //======================================================================
 // Debuggable features (Perl: `DebuggableFeature($name)` registration +
 // `$LaTeXML::DEBUG{$name}` gating, enabled by the CLI's `--debug NAME`).

--- a/latexml_core/src/digested.rs
+++ b/latexml_core/src/digested.rs
@@ -439,15 +439,32 @@ impl BoxOps for Digested {
   /// but when called on the concrete types it will always compute sizes fresh.
   fn compute_size(&self, options: HashMap<Stored>) -> Result<(Dimension, Dimension, Dimension)> {
     use DigestedData::*;
+    // A self-referential box (its size computation recurses into the SAME
+    // RefCell — e.g. a box that transitively contains itself) would re-enter
+    // `borrow_mut` and panic ("already borrowed"). The other traversals on
+    // `Digested` (fingerprint, serialization) already guard with `try_borrow`;
+    // do the same here and treat a re-entrant cycle as zero-size to break it.
+    // Witness: astro-ph0310145 (panicked at digested.rs Alignment arm).
+    let zero = (Dimension::new(0), Dimension::new(0), Dimension::new(0));
     match *self.0 {
-      TBox(ref b) => b.borrow_mut().compute_size_and_cache(options),
-      List(ref l) => l.borrow_mut().compute_size_and_cache(options),
-      KeyVals(ref kvs) => kvs.compute_size(options),
-      Whatsit(ref w) => w.borrow_mut().compute_size_and_cache(options),
-      Alignment(ref w) => w.borrow_mut().compute_size_and_cache(options),
-      Postponed(_) | RegisterValue(_) | Comment(_) => {
-        Ok((Dimension::new(0), Dimension::new(0), Dimension::new(0)))
+      TBox(ref b) => match b.try_borrow_mut() {
+        Ok(mut x) => x.compute_size_and_cache(options),
+        Err(_) => Ok(zero),
       },
+      List(ref l) => match l.try_borrow_mut() {
+        Ok(mut x) => x.compute_size_and_cache(options),
+        Err(_) => Ok(zero),
+      },
+      KeyVals(ref kvs) => kvs.compute_size(options),
+      Whatsit(ref w) => match w.try_borrow_mut() {
+        Ok(mut x) => x.compute_size_and_cache(options),
+        Err(_) => Ok(zero),
+      },
+      Alignment(ref w) => match w.try_borrow_mut() {
+        Ok(mut x) => x.compute_size_and_cache(options),
+        Err(_) => Ok(zero),
+      },
+      Postponed(_) | RegisterValue(_) | Comment(_) => Ok(zero),
     }
   }
 }

--- a/latexml_core/src/document.rs
+++ b/latexml_core/src/document.rs
@@ -667,7 +667,13 @@ impl Document {
         Alignment(alignment) => {
           self.set_box_to_absorb(Some((*front_box).clone()));
           self.init_constructed_nodes();
-          alignment.borrow_mut().be_absorbed_mut(self)?;
+          // A self-referential alignment (transitively contains itself) would
+          // re-enter `borrow_mut` here and panic ("already borrowed"). Guard like
+          // the size-computation traversal (digested.rs) and skip the re-entrant
+          // absorption to break the cycle. Witness: astro-ph0310145 et al.
+          if let Ok(mut a) = alignment.try_borrow_mut() {
+            a.be_absorbed_mut(self)?;
+          }
           self.close_constructed_nodes();
           self.expire_box_to_absorb();
         },
@@ -844,17 +850,22 @@ impl Document {
       self.absorb(digested, None)?;
     }
 
-    let self_node = self.node.get_parent().unwrap();
-    let mut c = Some(self_node);
+    // Walk up from the current insertion point to learn whether `node` is still
+    // an open ancestor (so it can be closed below). `self.node` may be the
+    // parentless document root, and an intermediate node may be detached — a
+    // `None` parent there simply means `node` is NOT an ancestor (stop the walk),
+    // so don't `.unwrap()`-panic on it. Witnesses: hep-th0201062, 1009.0637.
+    let mut c = self.node.get_parent();
     while c.is_some()
       && c.as_ref() != Some(&node)
       && c.as_ref().unwrap().get_type() != Some(NodeType::DocumentNode)
     {
-      let parent = c.unwrap().get_parent().unwrap();
-      c = match parent.get_type() {
-        Some(NodeType::DocumentNode) => None,
+      c = match c.as_ref().unwrap().get_parent() {
         None => None,
-        Some(_) => Some(parent),
+        Some(parent) => match parent.get_type() {
+          Some(NodeType::DocumentNode) | None => None,
+          Some(_) => Some(parent),
+        },
       };
     }
 

--- a/latexml_core/src/document.rs
+++ b/latexml_core/src/document.rs
@@ -4192,7 +4192,11 @@ impl Document {
       return Ok(None);
     }
     let first_node = &nodes[0];
-    let mut parent = first_node.get_parent().unwrap();
+    // Can't wrap a node that has no parent (already detached / is the root) —
+    // return None like the other "can't wrap here" paths. Witness: 1804.09736.
+    let Some(mut parent) = first_node.get_parent() else {
+      return Ok(None);
+    };
     let (ns, tag) = model::decode_qname(qname)?;
     let mut new = self.open_element_internal(&mut parent, ns, &tag)?;
     self.after_open(&mut new)?;

--- a/latexml_core/src/gullet.rs
+++ b/latexml_core/src/gullet.rs
@@ -668,6 +668,26 @@ fn cycle_guard_checkpoint(active: bool, nextt: &Token) -> Result<()> {
   Ok(())
 }
 
+/// Read a token that the calling macro/primitive REQUIRES, holding the
+/// "argument expected but input ended" diagnostic in one place.
+///
+/// `read_token()` returning `None` (input exhausted) is a normal, expected
+/// control-flow signal in most contexts (end of file/group/optional-arg scan) —
+/// so the primitive deliberately keeps the `Option`. But for a caller that
+/// genuinely requires a token here, `None` is TeX's *"File ended while scanning
+/// use of \cs"* error state (real `pdftex` raises an `! Emergency stop`). This
+/// helper emits that parity `Error!` once, centrally, instead of every call site
+/// `.unwrap()`-panicking on the `None`. It STILL returns the `Option` (it does
+/// NOT fabricate a token), so the type system keeps each caller honest about how
+/// it degrades — close its group, substitute a default, etc.
+pub fn read_token_required(what: &str) -> Result<Option<Token>> {
+  let tok = read_token()?;
+  if tok.is_none() {
+    Error!("expected", what, format!("input ended while scanning use of {what}"));
+  }
+  Ok(tok)
+}
+
 pub fn read_token() -> Result<Option<Token>> {
   let mut next_token: Option<Token>;
   loop {
@@ -1539,7 +1559,9 @@ fn read_cs_name_inner(quiet: bool) -> Result<Token> {
         "csname",
         format!(
           "CS-name read exceeded {MAX_CS_NAME_BYTES} bytes; aborting at partial cs: {:?}",
-          &cs[..cs.len().min(200)]
+          // Truncate by CHARS, not bytes — a byte slice at 200 can split a
+          // multi-byte UTF-8 char (e.g. 'ä') and panic. Witness 2601.03403.
+          cs.chars().take(200).collect::<String>()
         )
       );
       break;

--- a/latexml_core/src/gullet.rs
+++ b/latexml_core/src/gullet.rs
@@ -52,25 +52,21 @@ static HEX_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"[0-9A-F]").unwrap());
 pub static TRACE_GROUP_END: Lazy<bool> =
   Lazy::new(|| std::env::var("LXML_TRACE_GROUP_END").is_ok());
 
-// Perl smuggles the unexpanded token inside \special_relax's slot [2].
-// Rust Token is Copy+Clone with no extra slot, so we use a thread-local Cell.
+// `\noexpand`'d tokens are represented per-token by the `\special_relax` family
+// (`Token::is_noexpand_family` / `token::noexpand_family`): the shadowed token's
+// identity is encoded in the CS name, so it survives storage and dumps without a
+// global smuggle slot. The family resolves to `\relax` meaning via the
+// `state::lookup_meaning` fallback. Faithful to TeX's `no_expand_flag`, which
+// preserves the shadowed `cur_cs` while giving it relax meaning for one access.
 use std::cell::Cell;
 
 use crate::pin;
-#[thread_local]
-static SPECIAL_RELAX_SMUGGLED: Cell<Option<Token>> = Cell::new(None);
 
-/// Store the unexpanded token smuggled inside \special_relax (Perl: $$special_relax[2])
-fn set_special_relax_smuggled(token: Token) { SPECIAL_RELAX_SMUGGLED.set(Some(token)); }
-/// Retrieve (and clear) the smuggled token from the last \special_relax
-pub fn take_special_relax_smuggled() -> Option<Token> { SPECIAL_RELAX_SMUGGLED.take() }
-/// Peek at the smuggled token without consuming it
-fn peek_special_relax_smuggled() -> Option<Token> { SPECIAL_RELAX_SMUGGLED.get() }
-/// Check if a token is \special_relax and its smuggled unexpanded token matches `target`
+/// True when `token` is a `\noexpand`'d form (`\special_relax` family) shadowing
+/// `target` — used by delimited-parameter / keyword matching so that, faithful to
+/// TeX, a `\noexpand`'d token still matches its underlying identity.
 fn special_relax_matches(token: &Token, target: &Token) -> bool {
-  token.code == Catcode::CS
-    && token.text == pin!("\\special_relax")
-    && peek_special_relax_smuggled().as_ref() == Some(target)
+  token.noexpand_shadowed().as_ref() == Some(target)
 }
 #[thread_local]
 static DEFERRED_COMMANDS: Lazy<HashSet<SymStr>> = Lazy::new(|| {
@@ -278,8 +274,6 @@ pub fn initialize_gullet() {
   gullet.ctx_serial = 0;
   gullet.ctx_next = 0;
   gullet.ctx_stack.clear();
-  // Reset smuggled token from previous conversion
-  SPECIAL_RELAX_SMUGGLED.set(None);
 }
 
 /// Get the current location of input getting read
@@ -723,12 +717,14 @@ pub fn read_token() -> Result<Option<Token>> {
         continue; // Perl: handleTemplate then continue while(1) loop
       }
       if nextt.code == Catcode::CS && nextt.text == pin!("\\dont_expand") {
-        let unexpanded = read_token()?;
-        // Perl: smuggle the unexpanded token in the "meaning" slot of \special_relax
-        if let Some(tok) = unexpanded {
-          set_special_relax_smuggled(tok);
-        }
-        next_token = Some(T_CS!("\\special_relax"));
+        // `\noexpand <tok>`: collapse to the per-token `\special_relax` family,
+        // encoding <tok>'s identity in the name (faithful to TeX's
+        // `no_expand_flag`, which keeps `cur_cs`). End-of-input ⇒ bare
+        // `\special_relax` (nothing to shadow).
+        next_token = Some(match read_token()? {
+          Some(tok) => crate::token::noexpand_family(&tok),
+          None => T_CS!("\\special_relax"),
+        });
       }
       break;
     } else {
@@ -895,12 +891,14 @@ pub fn read_x_token(
       if for_conditional && unexpanded.code == Catcode::ACTIVE {
         return Ok(Some(unexpanded));
       } else {
-        // Perl Gullet.pm L395-397 (readXToken): does NOT smuggle the
-        // unexpanded token here. Only Perl's readToken (Gullet.pm
-        // L313-317) smuggles. We follow Perl exactly: drop the
-        // unexpanded token in this path. (Earlier Rust always
-        // smuggled; that diverged from Perl on this branch.)
-        return Ok(Some(T_CS!("\\special_relax")));
+        // `\noexpand <tok>`: per-token `\special_relax` family encoding <tok>'s
+        // identity in the name — faithful to TeX's `no_expand_flag`, which keeps
+        // `cur_cs` while giving relax meaning for this one access. (Perl
+        // readXToken returns a bare `\special_relax`, dropping the identity;
+        // recovering it is a deliberate, SURPASS-PERL fidelity fix so a
+        // `\noexpand`'d delimiter — e.g. xint's `\XINTfstop`, witness
+        // 1804.01117 — survives a number/macro scan for the surrounding parser.)
+        return Ok(Some(crate::token::noexpand_family(&unexpanded)));
       }
     }
     // Wow!!!!! See TeX the Program \S 309

--- a/latexml_core/src/gullet.rs
+++ b/latexml_core/src/gullet.rs
@@ -1225,8 +1225,31 @@ pub fn read_balanced(
       cycle_guard_checkpoint(guard_active, t)?;
     }
     match next_token {
-      // What's the right error handling now?
-      None => break,
+      // Current mouth exhausted mid-balanced-read. Mirror read_x_token /
+      // tex.web get_next §362-365: a *transparent autoclose injection*
+      // (\scantokens, raw_tex) is part of the current logical input stream,
+      // so drain it and resume the enclosing mouth rather than reporting an
+      // unbalanced read. xint's `\edef\X{\scantokens{...}}` (xintexpr.sty
+      // \XINT_NewExpr) opens an autoclose "Anonymous String" mouth
+      // mid-edef-body whose matching `}` lives in the PARENT file; without
+      // crossing, the balanced read breaks at the mouth boundary and leaks the
+      // `\xintexprSafeCatcodes` `\begingroup`, corrupting everything after.
+      // DELIBERATE SURPASS-PERL divergence: Perl readBalanced (Gullet.pm:466)
+      // `last`s here and so also fails this xint input. We only cross autoclose
+      // injections (a real file/stream boundary is still left to its owner),
+      // matching the established read_x_token crossing.
+      None => {
+        let cross = {
+          let gullet = gullet!();
+          gullet.runtime.as_ref().map(|r| r.autoclose).unwrap_or(false)
+            && !gullet.mouthstack.is_empty()
+        };
+        if cross {
+          close_mouth(false)?;
+          continue;
+        }
+        break;
+      },
       Some(token) => match token.get_catcode() {
         Catcode::CS if token.text == pin!("\\dont_expand") => {
           if let Some(next_t) = read_token()? {

--- a/latexml_core/src/gullet.rs
+++ b/latexml_core/src/gullet.rs
@@ -677,7 +677,11 @@ fn cycle_guard_checkpoint(active: bool, nextt: &Token) -> Result<()> {
 pub fn read_token_required(what: &str) -> Result<Option<Token>> {
   let tok = read_token()?;
   if tok.is_none() {
-    Error!("expected", what, format!("input ended while scanning use of {what}"));
+    Error!(
+      "expected",
+      what,
+      format!("input ended while scanning use of {what}")
+    );
   }
   Ok(tok)
 }
@@ -1241,7 +1245,11 @@ pub fn read_balanced(
       None => {
         let cross = {
           let gullet = gullet!();
-          gullet.runtime.as_ref().map(|r| r.autoclose).unwrap_or(false)
+          gullet
+            .runtime
+            .as_ref()
+            .map(|r| r.autoclose)
+            .unwrap_or(false)
             && !gullet.mouthstack.is_empty()
         };
         if cross {

--- a/latexml_core/src/gullet.rs
+++ b/latexml_core/src/gullet.rs
@@ -1823,7 +1823,14 @@ pub fn read_arg(expansion_level: ExpansionLevel) -> Result<Tokens> {
       if token.get_catcode() == Catcode::BEGIN {
         read_balanced(expansion_level, false, false)
       } else if matches!(expansion_level, ExpansionLevel::Off) {
-        Ok(Tokens!(token))
+        // A `\noexpand`'d token captured as an (undelimited) macro argument
+        // reverts to its plain shadowed identity — faithful to TeX, where the
+        // `no_expand_flag` is transient and never stored in the captured arg
+        // (`#1` is `cur_cs`, the plain token). This lets `\ifx\X#1` match (xint's
+        // `\def\XINTfstop{\noexpand\XINTfstop}` f-stop, witness 1804.01117).
+        // `\let`/`\ifx` of the LIVE token read via `read_token` (the `Token`
+        // param), NOT here, so their relax-meaning capture is unaffected.
+        Ok(Tokens!(token.noexpand_shadowed().unwrap_or(token)))
       } else {
         // Perl Gullet.pm `readArg`:
         //   return $self->readingFromMouth(Tokens(T_BEGIN, $token, T_END), sub {

--- a/latexml_core/src/gullet.rs
+++ b/latexml_core/src/gullet.rs
@@ -1347,8 +1347,25 @@ pub fn read_balanced(
               generate_error_stub(&token)?;
             }
           }
-          // if no special handling triggered above, just return the token
-          tokens.push(token);
+          // If no special handling triggered above, return the token — EXCEPT a
+          // \special_relax (noexpand'd) family token collected into an expanded
+          // token list reverts to its plain shadowed identity. TeX's
+          // no_expand_flag is transient (tex.web §1149-1153), so \edef/\xdef
+          // store the PLAIN token, not a relax marker. etex/pdflatex ground
+          // truth:
+          //   \def\s{\noexpand\s}\edef\r{\romannumeral0\s} => \meaning\r is
+          //   "macro:->\s"  (xint's self-noexpanding f-stop idiom).
+          // Without this, the family token persists into the \edef body and a
+          // later number scan (\the/\romannumeral) lands on it ("Missing
+          // number"). Mirrors the macro-arg-capture decode in read_arg. Gated
+          // on CS/active so the hot per-token push pays only a cheap catcode
+          // check (only CS/active tokens are ever family tokens, and minting
+          // only happens while expanding).
+          if cc.is_active_or_cs() {
+            tokens.push(token.noexpand_shadowed().unwrap_or(token));
+          } else {
+            tokens.push(token);
+          }
         },
       },
     }

--- a/latexml_core/src/lib.rs
+++ b/latexml_core/src/lib.rs
@@ -133,6 +133,10 @@ pub fn ensure_libxml_init() { libxml::init_parser(); }
 pub fn reset_thread_engine() {
   state::reset_thread_state();
   common::arena::reset();
+  // The error REPORT's `undefined`/`missing` maps are keyed by arena `SymStr`s,
+  // so they MUST be cleared together with the arena — otherwise a stale key
+  // resolves, in the renumbered arena, to a different string (phantom undefined).
+  common::error::reset_arena_keyed_reports();
 }
 
 pub use crate::common::error::*;

--- a/latexml_core/src/lib.rs
+++ b/latexml_core/src/lib.rs
@@ -136,7 +136,8 @@ pub fn reset_thread_engine() {
   // The error REPORT's `undefined`/`missing` maps are keyed by arena `SymStr`s,
   // so they MUST be cleared together with the arena — otherwise a stale key
   // resolves, in the renumbered arena, to a different string (phantom undefined).
-  common::error::reset_arena_keyed_reports();
+  // (`reset_arena_keyed_reports` is in scope via `pub use crate::common::error::*`.)
+  reset_arena_keyed_reports();
 }
 
 pub use crate::common::error::*;

--- a/latexml_core/src/runtime_bindings_reentrancy_model.rs
+++ b/latexml_core/src/runtime_bindings_reentrancy_model.rs
@@ -110,7 +110,11 @@ fn nested_trampoline(document: &mut Doc) {
   });
 }
 
-/// `\myemph{X}` alone: a single (non-nested) constructor body. Baseline.
+/// `\myemph{X}` alone: a single (non-nested) constructor body. Baseline. This
+/// also models the SIBLING `WHATSIT_CTX` re-mint (`engine.rs::setProperty`,
+/// `&mut *ptr`): after-digest hooks run one-pass/sequentially on a fresh-local
+/// whatsit and never re-enter on the SAME whatsit, so the whatsit case is ALWAYS
+/// this single-body pattern (no nested same-object re-mint).
 #[test]
 fn reentrancy_model_single_body_sound() {
   let mut doc = Doc { n: 0 };

--- a/latexml_core/src/state.rs
+++ b/latexml_core/src/state.rs
@@ -1003,7 +1003,11 @@ impl State {
     let lookupname: Option<SymStr> = if (cc == Catcode::ACTIVE) || (cc == Catcode::CS) {
       // `\special_relax`-family tokens all resolve under the bare `\special_relax`
       // name (shared `\relax` meaning; identity lives in `noexpand_shadowed`).
-      if name == pin!("") { None } else { Some(meaning_key(key)) }
+      if name == pin!("") {
+        None
+      } else {
+        Some(meaning_key(key))
+      }
     } else {
       key.get_executable_primitive_name().map(arena::pin)
     };

--- a/latexml_core/src/state.rs
+++ b/latexml_core/src/state.rs
@@ -1001,7 +1001,9 @@ impl State {
     let cc = key.get_catcode();
     let name = key.get_sym();
     let lookupname: Option<SymStr> = if (cc == Catcode::ACTIVE) || (cc == Catcode::CS) {
-      if name == pin!("") { None } else { Some(name) }
+      // `\special_relax`-family tokens all resolve under the bare `\special_relax`
+      // name (shared `\relax` meaning; identity lives in `noexpand_shadowed`).
+      if name == pin!("") { None } else { Some(meaning_key(key)) }
     } else {
       key.get_executable_primitive_name().map(arena::pin)
     };
@@ -1828,7 +1830,7 @@ pub fn is_dont_expandable(token: &Token) -> bool {
   // Basically: a CS or Active token that is either not defined, or is expandable
   // (but not \let to a token)
   if token.get_catcode().is_active_or_cs() {
-    let lookupname = token.text;
+    let lookupname = meaning_key(token);
     if lookupname != pin!("") {
       match state!().meaning.get(&lookupname) {
         Some(entry) => {
@@ -2129,9 +2131,27 @@ pub fn assign_delcode<T: Into<u16>>(key: char, value: T, scope: Option<Scope>) {
 /// Get the `Meaning' of a token.  For active control sequences
 /// this may give the definition object (if defined) or another token (if \let) or undef
 /// Any other token is returned as is.
+/// The key under which a token's meaning is stored. **All** `\special_relax`-family
+/// tokens (`\noexpand`'d forms — the bare `\special_relax` and every
+/// `\special_relax\x01<shadowed>`) resolve under the bare `\special_relax` name:
+/// they share its `\relax` meaning, faithful to TeX where a `\noexpand`'d token
+/// has relax meaning regardless of which token it shadows. The shadowed identity
+/// is recovered separately via [`Token::noexpand_shadowed`] (delimited matching
+/// only). Use this anywhere a token's *name* keys a meaning lookup or a
+/// "same control sequence?" comparison. Cheap on the common path: non-CS tokens
+/// short-circuit before any string access.
+#[inline]
+pub fn meaning_key(token: &Token) -> SymStr {
+  if token.is_noexpand_family() {
+    pin!("\\special_relax")
+  } else {
+    token.text
+  }
+}
+
 pub fn lookup_meaning(token: &Token) -> Option<Stored> {
   if token.get_catcode().is_active_or_cs() && token.text != pin!("") {
-    match state!().meaning.get(&token.text) {
+    match state!().meaning.get(&meaning_key(token)) {
       Some(entry) => match entry.front() {
         None | Some(Stored::None) => None,
         Some(other) => Some(other.clone()),
@@ -2157,7 +2177,7 @@ pub fn lookup_meaning(token: &Token) -> Option<Stored> {
 pub fn with_meaning<R>(token: &Token, f: impl FnOnce(Option<&Stored>) -> R) -> R {
   let state = state!();
   if token.get_catcode().is_active_or_cs() && token.text != pin!("") {
-    match state.meaning.get(&token.text) {
+    match state.meaning.get(&meaning_key(token)) {
       Some(entry) => match entry.front() {
         None | Some(Stored::None) => f(None),
         Some(other) => f(Some(other)),
@@ -2223,7 +2243,7 @@ pub fn assign_meaning<T: Into<Stored>>(token: &Token, meaning: T, scope: Option<
 // keep this in sync with `lookup_meaning`, it is copied over for optimization purposes
 pub fn has_meaning(token: &Token) -> bool {
   if token.get_catcode().is_active_or_cs() && token.text != pin!("") {
-    match state!().meaning.get(&token.text) {
+    match state!().meaning.get(&meaning_key(token)) {
       Some(entry) => match entry.front() {
         None | Some(Stored::None) => false,
         Some(_) => true,
@@ -2317,7 +2337,8 @@ pub fn lookup_digestable_definition(token: &Token) -> Option<Stored> {
       && lookup_bool_sym(crate::pin!("IN_MATH"))
       && (lookup_mathcode_sym(t_sym).unwrap_or(0) == 0x8000))
   {
-    t_sym
+    // `\special_relax`-family tokens digest under the bare `\special_relax` no-op.
+    meaning_key(token)
   } else {
     // Use cached SymStr from `Catcode::name_sym` instead of re-interning
     // `cc.name()` (a &'static str) on every non-active-or-cs token —

--- a/latexml_core/src/telemetry.rs
+++ b/latexml_core/src/telemetry.rs
@@ -35,7 +35,7 @@ pub enum Phase {
   PostScan = 6,
   Bibliography = 7,
   Crossref = 8,
-  /// External-tool dispatch for `\includegraphics` (convert / gs / inkscape).
+  /// External-tool dispatch for `\includegraphics` (mutool / pdftocairo / convert / gs).
   Graphics = 9,
   /// External-tool dispatch for picture/latex/math image rendering
   /// (`picture_images.rs` + `latex_images.rs` + `math_images.rs`).

--- a/latexml_core/src/token.rs
+++ b/latexml_core/src/token.rs
@@ -330,6 +330,31 @@ impl PartialEq for Token {
   }
 }
 
+/// Name of the bare no-op control sequence `\noexpand` collapses to, and the
+/// prefix of every member of the no-expand family. See [`Token::is_noexpand_family`].
+pub const NOEXPAND_PREFIX: &str = "\\special_relax";
+/// Separator byte between the `\special_relax` prefix and the shadowed token's
+/// text in a family token's name. `\x01` is never valid in a CS name or active
+/// char, so `\special_relax\x01\foo` is unambiguous and cannot collide with a
+/// real CS such as a (hypothetical) `\special_relaxfoo`.
+pub const NOEXPAND_SEP: u8 = 1;
+
+/// Build the no-expand family token shadowing `shadowed` — the per-token,
+/// dump-safe representation of `\noexpand <shadowed>` (faithful to TeX's
+/// `no_expand_flag`: the shadowed identity is preserved in the name; the family
+/// resolves to `\relax` meaning). `shadowed` is an expandable/undefined CS or
+/// active token (the only things `\noexpand` wraps; see `is_dont_expandable`).
+pub fn noexpand_family(shadowed: &Token) -> Token {
+  let text =
+    shadowed.with_str(|s| format!("{NOEXPAND_PREFIX}{}{s}", NOEXPAND_SEP as char));
+  Token {
+    text: arena::pin(text),
+    code: Catcode::CS,
+    #[cfg(feature = "token-locators")]
+    loc: 0,
+  }
+}
+
 // Note: given that we are pinning the strings in an arena,
 //  once we have a token of a certain kind it is now faster to clone
 //  a known token than it is to build a new one
@@ -822,6 +847,47 @@ impl Token {
   pub fn with_str<R, FnR>(&self, caller: FnR) -> R
   where FnR: FnOnce(&str) -> R {
     arena::with(self.text, caller)
+  }
+
+  /// True for any member of the `\special_relax` no-expand family — the
+  /// representation of a `\noexpand`'d (expandable or undefined) CS/active token.
+  /// Such a token is a CS whose NAME is `\special_relax` `\x01` `<shadowed text>`,
+  /// carrying the shadowed token's identity PER-TOKEN (faithful to TeX's
+  /// `no_expand_flag`, which preserves `cur_cs`), while the whole family resolves
+  /// to `\special_relax`'s `\relax` meaning ([`crate::state::lookup_meaning`]
+  /// fallback). The bare `\special_relax` (no suffix) is the no-shadow case
+  /// (`\dont_expand` at end-of-input). `\x01` is never valid in a CS name or as
+  /// an active char, so the encoding is unambiguous.
+  pub fn is_noexpand_family(&self) -> bool {
+    self.code == Catcode::CS
+      && self.with_str(|s| {
+        s.starts_with(NOEXPAND_PREFIX)
+          && (s.len() == NOEXPAND_PREFIX.len() || s.as_bytes()[NOEXPAND_PREFIX.len()] == NOEXPAND_SEP)
+      })
+  }
+
+  /// Recover the shadowed token from a `\special_relax`-family token, if it
+  /// shadows one (i.e. not the bare `\special_relax`). The shadowed token is a
+  /// CS (text begins `\`) or an active char.
+  pub fn noexpand_shadowed(&self) -> Option<Token> {
+    if self.code != Catcode::CS {
+      return None;
+    }
+    self.with_str(|s| {
+      let rest = s.strip_prefix(NOEXPAND_PREFIX)?;
+      let rest = rest.strip_prefix(NOEXPAND_SEP as char)?;
+      let code = if rest.starts_with('\\') {
+        Catcode::CS
+      } else {
+        Catcode::ACTIVE
+      };
+      Some(Token {
+        text: arena::pin(rest.to_string()),
+        code,
+        #[cfg(feature = "token-locators")]
+        loc: 0,
+      })
+    })
   }
 
   /// Return the character code of  character part of the token, or 256 if it is a control

--- a/latexml_core/src/token.rs
+++ b/latexml_core/src/token.rs
@@ -873,7 +873,13 @@ impl Token {
     if self.code != Catcode::CS {
       return None;
     }
-    self.with_str(|s| {
+    // Compute the owned shadowed name + its catcode INSIDE the `with_str`
+    // borrow, then `arena::pin` it OUTSIDE. `with_str`'s `s` (hence `rest`)
+    // aliases the arena's append-only buffer; a re-entrant `arena::pin(rest)`
+    // could reallocate that buffer mid-intern and read freed memory. Owning the
+    // name first (and pinning after the borrow ends) removes the hazard — and
+    // satisfies clippy::unnecessary_to_owned, which can't see the aliasing.
+    let (name, code) = self.with_str(|s| {
       let rest = s.strip_prefix(NOEXPAND_PREFIX)?;
       let rest = rest.strip_prefix(NOEXPAND_SEP as char)?;
       let code = if rest.starts_with('\\') {
@@ -881,12 +887,13 @@ impl Token {
       } else {
         Catcode::ACTIVE
       };
-      Some(Token {
-        text: arena::pin(rest.to_string()),
-        code,
-        #[cfg(feature = "token-locators")]
-        loc: 0,
-      })
+      Some((rest.to_string(), code))
+    })?;
+    Some(Token {
+      text: arena::pin(name),
+      code,
+      #[cfg(feature = "token-locators")]
+      loc: 0,
     })
   }
 

--- a/latexml_core/src/token.rs
+++ b/latexml_core/src/token.rs
@@ -345,8 +345,7 @@ pub const NOEXPAND_SEP: u8 = 1;
 /// resolves to `\relax` meaning). `shadowed` is an expandable/undefined CS or
 /// active token (the only things `\noexpand` wraps; see `is_dont_expandable`).
 pub fn noexpand_family(shadowed: &Token) -> Token {
-  let text =
-    shadowed.with_str(|s| format!("{NOEXPAND_PREFIX}{}{s}", NOEXPAND_SEP as char));
+  let text = shadowed.with_str(|s| format!("{NOEXPAND_PREFIX}{}{s}", NOEXPAND_SEP as char));
   Token {
     text: arena::pin(text),
     code: Catcode::CS,
@@ -862,7 +861,8 @@ impl Token {
     self.code == Catcode::CS
       && self.with_str(|s| {
         s.starts_with(NOEXPAND_PREFIX)
-          && (s.len() == NOEXPAND_PREFIX.len() || s.as_bytes()[NOEXPAND_PREFIX.len()] == NOEXPAND_SEP)
+          && (s.len() == NOEXPAND_PREFIX.len()
+            || s.as_bytes()[NOEXPAND_PREFIX.len()] == NOEXPAND_SEP)
       })
   }
 

--- a/latexml_core/src/util/logger.rs
+++ b/latexml_core/src/util/logger.rs
@@ -62,6 +62,24 @@ fn strip_ansi(s: &str) -> String {
   result
 }
 
+/// Append a progress note to the capture buffer as INLINE flowing text — the
+/// faithful Perl LaTeXML / tex.web terminal-progress format. `note_begin`
+/// carries a leading '\n' so each stage opens on a fresh line; `note_end`
+/// (` )`) and `note_progress` (`[1][2]…`, `N formulae …`) append inline so a
+/// load's closing paren and the page markers stay on the SAME line as their
+/// opener, and nested closes chain (`… 0.00 sec) 0.05 sec)`). A leading '\n'
+/// is collapsed against an existing trailing '\n' (or buffer start) so we never
+/// emit a blank line. Replaces the old unconditional `push('\n')` per note,
+/// which put every `)` on its own line and doubled newlines into blank lines
+/// (the reported `.latexml.log` noise on corpora.latexml.rs).
+fn append_note(buf: &mut String, note: &str) {
+  if note.starts_with('\n') && (buf.is_empty() || buf.ends_with('\n')) {
+    buf.push_str(&note[1..]);
+  } else {
+    buf.push_str(note);
+  }
+}
+
 /// prints a single line to STDERR
 #[macro_export]
 macro_rules! println_stderr(
@@ -95,16 +113,17 @@ impl log::Log for LatexmlLogger {
       let details = record.args();
       if record_target == "note" {
         let note = details.to_string();
-        // A note (e.g. `(Loading foo.sty… )`) is a live stderr progress indicator — but when a
-        // capture buffer is active it must ALSO land there (on its own line), so it reaches the
-        // flushed `cortex.log` and CorTeX's `loaded_file` parser, which anchors on `^(Loading …`.
-        // Its own line both lets that `^`-anchored regex match and keeps the note from gluing onto a
-        // following `Info:/Warning:` line (which would break that line's own anchor).
+        // A note (e.g. `(Loading foo.sty… )`) is a live progress indicator — but when a capture
+        // buffer is active it must ALSO land there so it reaches the flushed `cortex.log` and
+        // CorTeX's `loaded_file` parser, which anchors on `^(Loading …`. `append_note` keeps it
+        // INLINE (Perl-faithful: `(Loading X… )` on one line, `[1][2]…` chained) while preserving
+        // the `^(Loading` anchor — every `note_begin` carries a leading '\n', so each load still
+        // opens at line start. The following `Info:/Warning:` record re-asserts its own line break
+        // (see the diagnostic-record path below), so the note can't glue onto its anchor.
         if let Ok(mut buf) = LOG_BUFFER.try_borrow_mut()
           && let Some(ref mut log) = *buf
         {
-          log.push_str(&strip_ansi(&note));
-          log.push('\n');
+          append_note(log, &strip_ansi(&note));
         }
         print_stderr!("{}", note);
         return;
@@ -145,12 +164,25 @@ impl log::Log for LatexmlLogger {
         _ => paint(ANSI_WHITE, &message),
       } + &details.to_string();
 
-      // Capture to log buffer if active (strip ANSI for clean log text)
+      // Capture to log buffer if active (strip ANSI for clean log text).
+      // A diagnostic record (Info/Warning/Error/Fatal) must start on a fresh
+      // line so CorTeX's line-anchored parser (^Error:/^Warning:/^Info:)
+      // matches and the record never glues onto an in-flight progress note
+      // (notes no longer force a trailing newline — see append_note).
       if let Ok(mut buf) = LOG_BUFFER.try_borrow_mut()
         && let Some(ref mut log) = *buf
       {
+        if !log.is_empty() && !log.ends_with('\n') {
+          log.push('\n');
+        }
         log.push_str(&strip_ansi(&painted_message));
-        log.push('\n');
+        // Exactly one trailing newline — a multi-detail message (e.g.
+        // `Info:…loaded …\n\tat …\n\tIn …`) already ends with '\n', so an
+        // unconditional push would double it into a blank line before the next
+        // `(Loading …` note.
+        if !log.ends_with('\n') {
+          log.push('\n');
+        }
       }
 
       // Use `\n` (not `\r`) to guarantee each log line starts on a fresh
@@ -194,6 +226,27 @@ pub fn init(level: LevelFilter) -> Result<(), SetLoggerError> {
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[test]
+  fn append_note_inline_and_no_blank_lines() {
+    // note_begin opens a fresh line; note_end / note_progress stay inline.
+    let mut b = String::new();
+    append_note(&mut b, "\n(Loading keyval.sty..."); // note_begin (buffer empty: no leading blank)
+    append_note(&mut b, " )"); // note_end inline
+    assert_eq!(b, "(Loading keyval.sty... )");
+    append_note(&mut b, "\n(Loading graphics.sty..."); // mid-line: keep the break
+    append_note(&mut b, " )");
+    assert_eq!(b, "(Loading keyval.sty... )\n(Loading graphics.sty... )");
+    // page markers chain inline
+    append_note(&mut b, "\n410 formulae ...");
+    append_note(&mut b, "[1]");
+    append_note(&mut b, "[2]");
+    assert!(b.ends_with("410 formulae ...[1][2]"));
+    // a leading '\n' note after a buffer already at line-start collapses (no blank line)
+    let mut c = String::from("Info:foo\n");
+    append_note(&mut c, "\n(Building...");
+    assert_eq!(c, "Info:foo\n(Building...");
+  }
 
   #[test]
   fn strip_ansi_removes_color_codes() {

--- a/latexml_core/src/util/logger.rs
+++ b/latexml_core/src/util/logger.rs
@@ -43,6 +43,55 @@ pub fn bind_log() { *LOG_BUFFER.borrow_mut() = Some(String::new()); }
 /// Flush and return the captured log output, stopping capture (Perl: flush_log).
 pub fn flush_log() -> String { LOG_BUFFER.borrow_mut().take().unwrap_or_default() }
 
+/// Diagnostics captured from a worker thread by [`capture`], for the main thread
+/// to fold back in via [`replay_captured`]. Carries both the already-formatted
+/// log text AND the `REPORT` count deltas — `LOG_BUFFER` and `REPORT` are BOTH
+/// `#[thread_local]`, so forwarding only the text would still leave
+/// `status_code` blind to a worker's failures.
+pub struct CapturedDiagnostics {
+  pub log:    String,
+  pub counts: crate::common::error::ReportCounts,
+}
+
+/// Run `f` on the CURRENT (worker) thread with diagnostic capture. Binds a fresh
+/// thread-local log buffer for the duration so any `Error!`/`Warn!`/`Info!` `f`
+/// emits (directly or deep inside a conversion helper) is recorded instead of
+/// lost, and snapshots the worker's `REPORT` counters afterward. The returned
+/// [`CapturedDiagnostics`] is replayed on the main thread by [`replay_captured`]
+/// after the worker is joined, so the messages reach the bound `cortex.log` and
+/// the failures register in `status_code`.
+///
+/// Assumes the worker thread has no pre-bound buffer (the spawned post-processing
+/// pool threads start clean); it does not save/restore a prior binding.
+pub fn capture<R>(f: impl FnOnce() -> R) -> (R, CapturedDiagnostics) {
+  bind_log();
+  let result = f();
+  let log = flush_log();
+  let counts = crate::common::error::snapshot_report_counts();
+  (result, CapturedDiagnostics { log, counts })
+}
+
+/// Fold worker-thread diagnostics (from [`capture`]) into the main thread: append
+/// the captured log text to the bound `LOG_BUFFER` and merge the count deltas
+/// into the main `REPORT`. Call on the MAIN thread, in a deterministic order
+/// (e.g. worker/job order), after the workers join. The worker already echoed
+/// each line to the shared stderr fd in real time, so this does NOT re-print to
+/// stderr — it only repairs the captured log + status tally.
+pub fn replay_captured(d: CapturedDiagnostics) {
+  if !d.log.is_empty()
+    && let Ok(mut buf) = LOG_BUFFER.try_borrow_mut()
+    && let Some(ref mut log) = *buf
+  {
+    // The captured text is already per-record newline-terminated; just make
+    // sure it starts on a fresh line so it can't glue onto an in-flight note.
+    if !log.is_empty() && !log.ends_with('\n') {
+      log.push('\n');
+    }
+    log.push_str(&d.log);
+  }
+  crate::common::error::merge_report_counts(d.counts);
+}
+
 /// Strip ANSI escape sequences from a string for log file output.
 fn strip_ansi(s: &str) -> String {
   // Match ESC[ ... m sequences

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -659,8 +659,15 @@ LoadDefinitions!({
   // frontmatter so that the annotation inherits it as label (!!)
   // Typically would \let\label to this so that a \ref within a parent frontmatter
   // will get an annotation with corresponding \label will be attached.
-  DefPrimitive!("\\lx@set@frontmatter@label Semiverbatim", sub[(label)] {
-    let label = clean_frontmatter_labels(&label.to_string(), "LABEL").into_iter().next();
+  DefPrimitive!("\\lx@set@frontmatter@label [] Semiverbatim", sub[(prefix, label)] {
+    // Optional prefix (default "LABEL"). The superscript heuristic passes the
+    // role ("affiliation") so the label exactly matches the corresponding
+    // \lx@request@frontmatter@annotation[affiliation] on the author; otherwise
+    // relocate_annotations falls back to prefix-stripped matching and conflates
+    // it with the creator's own "author:N" sequence label (double-attach).
+    let prefix = prefix.as_ref().map(ToString::to_string)
+      .filter(|p| !p.is_empty()).unwrap_or_else(|| "LABEL".to_string());
+    let label = clean_frontmatter_labels(&label.to_string(), &prefix).into_iter().next();
     with_pending_entry_attr(move |attr| {
       match label {
         Some(label) => {
@@ -896,13 +903,21 @@ LoadDefinitions!({
     Ok(Tokens::new(calls))
   });
 
+  // Superscript markers in author/affiliation blocks carry the affiliation
+  // number. Both sides use the "affiliation" prefix so the author's requested
+  // annotation ("affiliation:N") exactly matches the affiliation's label
+  // ("affiliation:N") in relocate_annotations -- avoiding the prefix-stripped
+  // fallback that would otherwise conflate them with a creator's own "author:N"
+  // sequence label and double-attach.
+  DefMacro!("\\lx@sup@request@affiliation", "\\lx@request@frontmatter@annotation[affiliation]");
+  DefMacro!("\\lx@sup@setlabel@affiliation", "\\lx@set@frontmatter@label[affiliation]");
   DefMacro!(
     "\\lx@author@withsup{}",
-    "\\bgroup\\let^\\lx@request@frontmatter@annotation\\let\\textsuperscript\\lx@request@frontmatter@annotation#1\\egroup"
+    "\\bgroup\\let^\\lx@sup@request@affiliation\\let\\textsuperscript\\lx@sup@request@affiliation#1\\egroup"
   );
   DefMacro!(
     "\\lx@affiliation@withsup{}",
-    "\\bgroup\\let^\\lx@set@frontmatter@label\\let\\textsuperscript\\lx@set@frontmatter@label#1\\egroup"
+    "\\bgroup\\let^\\lx@sup@setlabel@affiliation\\let\\textsuperscript\\lx@sup@setlabel@affiliation#1\\egroup"
   );
 
   DefMacro!("\\lx@add@affiliations[]{}", sub[(attr, stuff)] {
@@ -910,10 +925,20 @@ LoadDefinitions!({
     dequeue_front_matter("ltx:contact", &[("role", "affiliation")]);
     let with_sup = position_of(&stuff, &authorsup_markers()).is_some();
     for line in split_tokens(stuff, affil_splits()) {
+      // Skip empty segments (e.g. a trailing \\ or a line that was wholly
+      // consumed by an \email/\url) so they don't become blank affiliations.
+      // Mirrors \lx@add@authors.
+      if line.is_empty() {
+        continue;
+      }
       if with_sup {
+        // The superscript markers ARE the affiliation labels here, so drop any
+        // caller-supplied labelseq: applying both double-labels each affiliation
+        // and duplicates it onto every \inst{n} author. Mirrors \lx@add@authors,
+        // which likewise passes no attr in its with-superscript branch.
         let withsup = Invocation!(T_CS!("\\lx@affiliation@withsup"), vec![Some(line)]);
         calls.extend(
-          Invocation!(T_CS!("\\lx@add@affiliation"), vec![attr.clone(), Some(withsup)]).unlist());
+          Invocation!(T_CS!("\\lx@add@affiliation"), vec![None, Some(withsup)]).unlist());
       } else {
         calls.extend(
           Invocation!(T_CS!("\\lx@add@affiliation"), vec![attr.clone(), Some(line)]).unlist());
@@ -3198,6 +3223,16 @@ fn author_affil_splits() -> Vec<SplitDelim> {
 }
 fn affil_splits() -> Vec<SplitDelim> {
   vec![
+    // The \and CONTROL-SEQUENCE family is added (vs upstream, which splits
+    // affiliations only on \quad/\qquad/\\): it lets the shared affiliation
+    // parser handle \and-separated institute/affiliation lists (e.g. LNCS
+    // \institute{A \and B}). NOTE: the literal word " and " is deliberately NOT
+    // included (unlike author_affil_splits) — institution names routinely
+    // contain "and" ("Electrical and Computer Engineering"), so splitting on it
+    // wrongly fragments them. Affiliations never use ',' as a separator either.
+    T_CS!("\\and").into(),
+    T_CS!("\\And").into(),
+    T_CS!("\\AND").into(),
     T_CS!("\\quad").into(),
     T_CS!("\\qquad").into(),
     T_CS!("\\\\").into(),

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -909,8 +909,14 @@ LoadDefinitions!({
   // ("affiliation:N") in relocate_annotations -- avoiding the prefix-stripped
   // fallback that would otherwise conflate them with a creator's own "author:N"
   // sequence label and double-attach.
-  DefMacro!("\\lx@sup@request@affiliation", "\\lx@request@frontmatter@annotation[affiliation]");
-  DefMacro!("\\lx@sup@setlabel@affiliation", "\\lx@set@frontmatter@label[affiliation]");
+  DefMacro!(
+    "\\lx@sup@request@affiliation",
+    "\\lx@request@frontmatter@annotation[affiliation]"
+  );
+  DefMacro!(
+    "\\lx@sup@setlabel@affiliation",
+    "\\lx@set@frontmatter@label[affiliation]"
+  );
   DefMacro!(
     "\\lx@author@withsup{}",
     "\\bgroup\\let^\\lx@sup@request@affiliation\\let\\textsuperscript\\lx@sup@request@affiliation#1\\egroup"

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -7724,11 +7724,26 @@ LoadDefinitions!({
     // branch on the first phase only.
     let first_is_bbl = with(bib_config[0], |s| s == "bbl");
     if first_is_bbl {
-      if bbl_path.is_none() {
-        Info!("expected", "bbl", "Couldn't find bbl file, bibliography may be empty.");
-        return Ok(Tokens!());
+      if bbl_path.is_some() {
+        return Ok(bbl_clause);
       }
-      Ok(bbl_clause)
+      // bbl-first precedence (e.g. ar5iv's bibconfig=bbl,bib) but no
+      // <jobname>.bbl on disk: fall through to a configured 'bib' phase, BUT
+      // only when the .bib files actually exist. Emitting \lx@bibliography
+      // unconditionally would add an empty placeholder "References"; when the
+      // real entries instead arrive via a manual \input{refs.bbl} (witness
+      // 2107.03065, which ships refs.bbl and NO refs.bib) that produces a
+      // duplicate, content-less bibliography. Requiring a real .bib delivers
+      // true "bbl-over-bib" precedence (prefer .bbl, else .bib) without the
+      // double. Witness 2605.16562 (refs.bib, no .bbl) now gets a bibliography.
+      let bib_in_config = bib_config.iter().any(|p| with(*p, |s| s == "bib"));
+      let all_bibs_exist = bib_in_config
+        && bib_files.split(',').all(|bf| FindFile!(bf, type => "bib").is_some());
+      if all_bibs_exist {
+        return Ok(bib_clause);
+      }
+      Info!("expected", "bbl", "Couldn't find bbl file, bibliography may be empty.");
+      Ok(Tokens!())
     } else {
       // 'bib' phase — check if .bib files exist
       let mut missing_bibs = String::new();

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -7201,7 +7201,15 @@ LoadDefinitions!({
   Let!("\\reversemarginpar", "\\@reversemargintrue");
   Let!("\\normalmarginpar", "\\@reversemarginfalse");
   // Perl: latex_constructs.pool.ltxml lines 3543-3546
-  DefConstructor!("\\marginpar[]{}", r###"?#1(<ltx:note role='margin' class='ltx_marginpar_left'><ltx:inline-logical-block>#1</ltx:inline-logical-block></ltx:note>?#2(<ltx:note role='margin' class='ltx_marginpar_right'><ltx:inline-logical-block>#2</ltx:inline-logical-block></ltx:note>))(<ltx:note role='margin' class='ltx_marginpar'><ltx:inline-logical-block>#2</ltx:inline-logical-block></ltx:note>)"###);
+  // `bounded => true` scopes font/catcode changes inside the margin note to the
+  // note itself. This is an INTENTIONAL surpass-Perl divergence (OXIDIZED_DESIGN
+  // #39, KNOWN_PERL_ERRORS): upstream Perl LaTeXML's `\marginpar` is NOT bounded,
+  // so a `\marginpar{\Large …}` leaks the size switch into the body text after
+  // it (real pdflatex scopes it to the margin box — the leak is a LaTeXML bug,
+  // shared by both engines). Mirrors `\mbox`'s `bounded => true`. Witness:
+  // mhchem.tex `\marginpar{\Large !}` made the entire manual render at 144%.
+  DefConstructor!("\\marginpar[]{}", r###"?#1(<ltx:note role='margin' class='ltx_marginpar_left'><ltx:inline-logical-block>#1</ltx:inline-logical-block></ltx:note>?#2(<ltx:note role='margin' class='ltx_marginpar_right'><ltx:inline-logical-block>#2</ltx:inline-logical-block></ltx:note>))(<ltx:note role='margin' class='ltx_marginpar'><ltx:inline-logical-block>#2</ltx:inline-logical-block></ltx:note>)"###,
+    bounded => true);
 
   DefRegister!("\\marginparpush", Dimension::new(0));
 

--- a/latexml_engine/src/pdftex.rs
+++ b/latexml_engine/src/pdftex.rs
@@ -75,6 +75,26 @@ LoadDefinitions!({
   DefRegister!("\\pdfpageresources" => Tokens!());
   DefRegister!("\\pdfpkmode"        => Tokens!());
 
+  // \Ucharcat <charcode> <catcode> — XeTeX/LuaTeX Unicode-engine primitive that
+  // builds a single char token of the given Unicode scalar + catcode. LaTeXML is
+  // Unicode-native, so we provide it (real pdfTeX lacks it). Defining it flips
+  // expl3's `\char_generate` (`\if_cs_exist:N \tex_Ucharcat:D`, expl3-code.tex
+  // L9210) from the 8-bit `\lowercase{\noexpand~}` active-char trick — which our
+  // `\special_relax`/`\noexpand` representation cannot store faithfully (it drops
+  // the shadowed char, baking 246 bare `\special_relax` into the dump, e.g.
+  // l3text's `\c__text_purify_*` accent tables, and breaking `\codepoint_generate`
+  // for combining marks like U+0300) — to the direct charcode+catcode path.
+  // Blast radius is tiny: `\Ucharcat` appears only in `\char_generate` across all
+  // of expl3 (3 mentions, all there).
+  DefMacro!(T_CS!("\\Ucharcat"), None, {
+    let charcode = read_number()?.value_of();
+    let catcode = read_number()?.value_of();
+    match char::from_u32(charcode as u32) {
+      Some(ch) => vec![CharToken!(ch, Catcode::from(catcode as u8))],
+      None => Vec::new(),
+    }
+  });
+
   // Expandable Commands
   DefMacro!("\\pdftexrevision", "19");
   def_macro_noop("\\pdftexbanner")?;

--- a/latexml_engine/src/tex_fonts.rs
+++ b/latexml_engine/src/tex_fonts.rs
@@ -23,7 +23,10 @@ LoadDefinitions!({
   // Perl: FontDef param type — for \textfont/\scriptfont/\scriptscriptfont, reads family
   // number and looks up the stored font CS token.  For \font, returns current_FontDef.
   DefParameterType!(FontToken, sub[_inner, _extra] {
-    let token = read_token()?.unwrap();
+    // \textfont/\scriptfont/\scriptscriptfont/\font require a following token; on
+    // input-exhaustion emit the parity "file ended" error and fall back to the
+    // default font CS (which flows through the `else` arm below) rather than panic.
+    let token = read_token_required("\\font")?.unwrap_or_else(|| T_CS!("\\lx@default@font"));
     if let Some(font_type) = token.with_str(|ts| {
       if ts.starts_with("\\textfont") && ts == "\\textfont" { Some("textfont") }
       else if ts.starts_with("\\scriptscriptfont") && ts == "\\scriptscriptfont" { Some("scriptscriptfont") }

--- a/latexml_engine/src/tex_math.rs
+++ b/latexml_engine/src/tex_math.rs
@@ -1776,7 +1776,9 @@ LoadDefinitions!({
         script_sizer(w.get_arg(1).unwrap(), None, None, "SUBSCRIPT", "post") }
   );
 
-  // Rewrite: floating superscript in frontmatter → plain text sup/sub
+  // Rewrite: a floating super/subscript that is really text — a plain-text
+  // frontmatter mark, or a text-mode `\mbox{…}` of rendered markup (e.g. an
+  // ORCID logo) — into an HTML ltx:sup/ltx:sub rather than empty-base math.
   //
   // Performance note (R35.D, 2026-05-22). The original XPath included
   // a `not(./*/*[not(self::ltx:XMTok)])` predicate (every XMApp
@@ -1835,51 +1837,91 @@ LoadDefinitions!({
           let xmarg_children: Vec<Node> = xmapp.get_child_nodes().into_iter()
             .filter(|n| n.get_type() == Some(NodeType::ElementNode)).collect();
           if xmarg_children.len() != 1 { return restore(document, math); }
-          let only_xmtok_grandchildren = xmarg_children.iter().all(|c| {
-            c.get_child_nodes().into_iter()
+          let qname = if role == "FLOATSUPERSCRIPT" { "ltx:sup" } else { "ltx:sub" };
+          let content_box = xmarg_children.first().unwrap();
+          // Locate a text-mode box (`ltx:XMText`, from `\mbox{…}`): either the
+          // float's argument itself, or — the argument is still wrapped at
+          // rewrite time — the sole XMText inside its XMArg wrapper, ignoring
+          // any spacing hints (the `\,` in `\orcidID` becomes an XMHint sibling).
+          let text_box = if document::with_node_qname(content_box, |q| q == "ltx:XMText") {
+            Some(content_box.clone())
+          } else {
+            let inner: Vec<Node> = content_box.get_child_nodes().into_iter()
               .filter(|n| n.get_type() == Some(NodeType::ElementNode))
-              .all(|gc| document::with_node_qname(&gc, |q| q == "ltx:XMTok"))
+              .filter(|n| !document::with_node_qname(n, |q| q == "ltx:XMHint"))
+              .collect();
+            match inner.first() {
+              Some(n) if inner.len() == 1
+                && document::with_node_qname(n, |q| q == "ltx:XMText") => Some(n.clone()),
+              _ => None,
+            }
+          };
+          // A text-mode box carrying rendered elements rather than math tokens
+          // is not math at all. LNCS `\orcidID` expands to
+          // `$^{\,\mbox{\scriptsize\orcidlink{…}}}$` — an ORCID logo `<ref>`/`<svg>`;
+          // the plain-text path below (`get_content()`) would drop that markup
+          // and leave an empty script, so move the box's children verbatim into
+          // the new sup/sub instead. Witness 2605.16562.
+          let markup_box = text_box.filter(|tb| {
+            tb.get_child_nodes().into_iter()
+              .filter(|n| n.get_type() == Some(NodeType::ElementNode))
+              .any(|gc| !document::with_node_qname(&gc, |q| q == "ltx:XMTok"))
           });
-          if !only_xmtok_grandchildren { return restore(document, math); }
-          if let Some(xmarg) = xmarg_children.first() {
-            let text = xmarg.get_content();
-            let qname = if role == "FLOATSUPERSCRIPT" { "ltx:sup" } else { "ltx:sub" };
-            let font_attr = {
-              let from_attr = xmarg.get_child_nodes().into_iter()
-                .filter(|n| n.get_type() == Some(NodeType::ElementNode))
-                .find_map(|n| {
-                  let attr = n.get_attribute("font");
-                  if attr.is_some() { return attr; }
-                  let node_font = document.get_node_font(&n);
-                  node_font.get_shape().and_then(|s|
-                    if s.as_ref() == "italic" { Some("italic".to_string()) } else { None }
-                  )
-                });
-              if from_attr.is_some() {
-                from_attr
-              } else {
-                document.get_node_box(xmarg).and_then(|tbox| {
-                  tbox.get_font().ok().flatten().and_then(|font| {
-                    if font.get_family().map(|f| f.as_ref() == "math").unwrap_or(false) {
-                      Some("italic".to_string())
-                    } else {
-                      None
-                    }
-                  })
-                })
-              }
-            };
+          if let Some(tb) = markup_box {
             document.open_element(qname, None, None)?;
-            if let Some(ref font) = font_attr {
-              let mut text_node = document.open_element("ltx:text", None, None)?;
-              document.set_attribute(&mut text_node, "font", font)?;
-              document.get_node_mut().append_text(&text)?;
-              document.close_element("ltx:text")?;
-            } else {
-              document.get_node_mut().append_text(&text)?;
+            for mut child in tb.get_child_nodes() {
+              document.get_node_mut().add_child(&mut child)?;
             }
             document.close_element(qname)?;
             replaced = true;
+          } else {
+            // Original frontmatter case: a plain-text float (all XMTok), e.g. an
+            // author affiliation mark. Extract its text into the sup/sub.
+            let only_xmtok_grandchildren = xmarg_children.iter().all(|c| {
+              c.get_child_nodes().into_iter()
+                .filter(|n| n.get_type() == Some(NodeType::ElementNode))
+                .all(|gc| document::with_node_qname(&gc, |q| q == "ltx:XMTok"))
+            });
+            if !only_xmtok_grandchildren { return restore(document, math); }
+            if let Some(xmarg) = xmarg_children.first() {
+              let text = xmarg.get_content();
+              let font_attr = {
+                let from_attr = xmarg.get_child_nodes().into_iter()
+                  .filter(|n| n.get_type() == Some(NodeType::ElementNode))
+                  .find_map(|n| {
+                    let attr = n.get_attribute("font");
+                    if attr.is_some() { return attr; }
+                    let node_font = document.get_node_font(&n);
+                    node_font.get_shape().and_then(|s|
+                      if s.as_ref() == "italic" { Some("italic".to_string()) } else { None }
+                    )
+                  });
+                if from_attr.is_some() {
+                  from_attr
+                } else {
+                  document.get_node_box(xmarg).and_then(|tbox| {
+                    tbox.get_font().ok().flatten().and_then(|font| {
+                      if font.get_family().map(|f| f.as_ref() == "math").unwrap_or(false) {
+                        Some("italic".to_string())
+                      } else {
+                        None
+                      }
+                    })
+                  })
+                }
+              };
+              document.open_element(qname, None, None)?;
+              if let Some(ref font) = font_attr {
+                let mut text_node = document.open_element("ltx:text", None, None)?;
+                document.set_attribute(&mut text_node, "font", font)?;
+                document.get_node_mut().append_text(&text)?;
+                document.close_element("ltx:text")?;
+              } else {
+                document.get_node_mut().append_text(&text)?;
+              }
+              document.close_element(qname)?;
+              replaced = true;
+            }
           }
         }
       }

--- a/latexml_engine/src/tex_paragraph.rs
+++ b/latexml_engine/src/tex_paragraph.rs
@@ -169,7 +169,9 @@ LoadDefinitions!({
         // Per eTeX spec, \interlinepenalties (like \parshape) is reset after each paragraph.
         { assign_value("interlinepenalties", Stored::None, None); }
         // Fish out flags for next ltx:para, to be used when the next \par closes:
-        if lookup_register("\\parindent",Vec::new())?.unwrap().value_of() == 0 {
+        // `\parindent` is normally defined; if it isn't (None), don't assume zero
+        // and force noindent — skip the override. Witness: 1502.07281.
+        if lookup_register("\\parindent", Vec::new())?.is_some_and(|r| r.value_of() == 0) {
           // respect \parindent if no overrides are given
           { assign_value("next_para_class", "ltx_noindent", None); }
         }

--- a/latexml_math_parser/src/parser.rs
+++ b/latexml_math_parser/src/parser.rs
@@ -1,4 +1,10 @@
-use std::{borrow::Cow, cell::RefCell, io::Cursor};
+use std::{
+  borrow::Cow,
+  cell::RefCell,
+  collections::HashSet,
+  hash::{Hash, Hasher},
+  io::Cursor,
+};
 
 use latexml_core::{
   Warn,
@@ -412,8 +418,13 @@ pub struct MathParser {
   n_parsed:                  usize,
   /// Grammar tree count from the last successful parse (for \ltx@count@parses)
   pub last_parsetrees_count: usize,
+  /// Hashes of the distinct formula token streams that have already emitted an `ambiguous_math` /
+  /// `unparsed_math` warning in THIS document. Perl LaTeXML warns once per distinct formula per
+  /// document — a formula repeated N times still warns once. The parser is built per document
+  /// (`core_interface`), so this set's lifetime IS the document scope. Hashed (not stored whole) to
+  /// stay O(8 bytes) per formula under the worker fleet.
+  warned_formulas:           HashSet<u64>,
   // strict: bool,
-  // warned: bool,
   // xnode: Option<Node>,
 }
 impl Default for MathParser {
@@ -438,8 +449,8 @@ impl Default for MathParser {
       // idrefs: Vec::new(),
       n_parsed: 0,
       last_parsetrees_count: 0,
+      warned_formulas: HashSet::new(),
       // strict: true,
-      // warned: false,
       // xnode: None,
     }
   }
@@ -2027,21 +2038,37 @@ impl MathParser {
     // Use post-dedup count (distinct semantic trees), not raw grammar count
     self.last_parsetrees_count = parses.len();
 
-    if ok_trees + pruned_trees > 10 {
-      // Diagnostic only — high ambiguity isn't a Perl-side Error in
-      // MathParser.pm; the warn target uses a Rust-internal class.
-      log_math_warn!(
-        "ambiguous",
-        "math",
-        "Ambiguous math: {} enumerated ({} semantic, {} pruned, {} deduped→{} unique) in {:?} for: {}",
-        ok_trees + pruned_trees + deduped,
-        ok_trees + deduped,
-        pruned_trees,
-        deduped,
-        parses.len(),
-        start.elapsed(),
-        input.trim()
-      );
+    // Diagnostic only — neither high ambiguity nor a parse failure is a Perl-side MathParser.pm
+    // Error; the warn target uses a Rust-internal class. One message, two categories:
+    //   * `unparsed_math`  — the formula produced no parse at all (the `Err` returned below), or
+    //   * `ambiguous_math` — the grammar enumerated many derivations (>10).
+    // The `what` field is a structural FOOTPRINT of the token stream (see `token_type_footprint`),
+    // so the dashboard buckets formulas by shape instead of one unique token dump per paper.
+    let diagnostic_category = if parses.is_empty() {
+      Some("unparsed_math")
+    } else if ok_trees + pruned_trees > 10 {
+      Some("ambiguous_math")
+    } else {
+      None
+    };
+    if let Some(category) = diagnostic_category {
+      // Warn once per DISTINCT formula per document (Perl LaTeXML's rule): a formula repeated N
+      // times in one document emits a single warning. Keyed on the exact token stream — true only
+      // the first time this document sees it; repeats are silently skipped.
+      if warn_formula_once(&mut self.warned_formulas, input.trim()) {
+        log_math_warn!(
+          category,
+          token_type_footprint(input.trim()),
+          "Ambiguous math: {} enumerated ({} semantic, {} pruned, {} deduped→{} unique) in {:?} for: {}",
+          ok_trees + pruned_trees + deduped,
+          ok_trees + deduped,
+          pruned_trees,
+          deduped,
+          parses.len(),
+          start.elapsed(),
+          input.trim()
+        );
+      }
     }
     // Diagnostic: report parse counts when LATEXML_PARSE_AUDIT is set.
     // Useful for identifying grammar ambiguity hotspots across the test suite.
@@ -2654,6 +2681,58 @@ fn textrec(
   }
 }
 
+/// Structural footprint of a formula's token stream — the `what` field of the `ambiguous_math` /
+/// `unparsed_math` math-parser diagnostics. Joins the token *types* (the segment before the first
+/// `:` of each `TYPE:value:position` triple) with `_`, bounded to fit CorTeX's `what` column, and
+/// appends `_cntd` when the stream is truncated. Space-free, so it slots into CorTeX's
+/// `severity:category:what` log parser as a groupable frequency key — collapsing a per-formula
+/// token dump into a shape signature the dashboard can bucket (the full token stream stays in the
+/// message `details`). E.g. arXiv 0708.2155's `UNKNOWN:rho:1 OPEN:(:2 UNKNOWN:p:3 …` →
+/// `UNKNOWN_OPEN_UNKNOWN_CLOSE_RELOP_…` (truncated with `_cntd` once it would pass the budget).
+/// Records `formula` in the per-document `seen` set and returns whether this is its FIRST sighting
+/// — the gate for Perl LaTeXML's "warn once per distinct formula per document" rule. The token
+/// stream is hashed (SipHash) so the set stays 8 bytes per distinct formula no matter how long the
+/// formula is; a hash collision at worst suppresses one warning, which is harmless.
+fn warn_formula_once(seen: &mut HashSet<u64>, formula: &str) -> bool {
+  let mut hasher = std::collections::hash_map::DefaultHasher::new();
+  formula.hash(&mut hasher);
+  seen.insert(hasher.finish())
+}
+
+fn token_type_footprint(tokens: &str) -> String {
+  // CorTeX's log `what` column is varchar(200) and a btree index key (category, what, task_id), so
+  // bound the footprint to fit by construction: append token types until the next would pass the
+  // budget, then mark the truncation with `_cntd`. Reserving the suffix length keeps a truncated
+  // footprint within 200 chars (195 types + "_cntd"), so the dispatcher's insert never silently
+  // chops the marker.
+  const SUFFIX: &str = "_cntd";
+  const BUDGET: usize = 200 - SUFFIX.len();
+  let mut out = String::new();
+  let mut truncated = false;
+  for token in tokens.split_whitespace() {
+    let ty = token.split(':').next().unwrap_or(token);
+    // First type always lands (a lone >budget type is backstopped by CorTeX's 200-char cap); every
+    // subsequent one must fit the budget WITH its separator, else we stop and mark `_cntd`.
+    if !out.is_empty() && out.len() + 1 + ty.len() > BUDGET {
+      truncated = true;
+      break;
+    }
+    if !out.is_empty() {
+      out.push('_');
+    }
+    out.push_str(ty);
+  }
+  if truncated {
+    out.push_str(SUFFIX);
+  }
+  // A formula with no tokens would yield an empty `what`, which CorTeX's parser can't key on —
+  // emit a placeholder so the line still groups.
+  if out.is_empty() {
+    out.push_str("none");
+  }
+  out
+}
+
 fn textrec_apply(name: &str, op: &Node, args: Vec<Node>, document: &Document) -> (usize, String) {
   let role = op
     .get_attribute("role")
@@ -2922,6 +3001,62 @@ mod tests {
   use libxml::parser::Parser as XmlParser;
 
   use super::*;
+
+  #[test]
+  fn token_type_footprint_bounds_to_varchar200_with_cntd() {
+    // arXiv 0708.2155 — a short slice fits whole: just the token TYPES, no suffix.
+    let short = "UNKNOWN:rho:1 OPEN:(:2 UNKNOWN:p:3 CLOSE:):4 RELOP:equals:5 \
+                 start_POSTSUBSCRIPT:start:9 NUMBER:0:10";
+    assert_eq!(
+      token_type_footprint(short),
+      "UNKNOWN_OPEN_UNKNOWN_CLOSE_RELOP_start_POSTSUBSCRIPT_NUMBER"
+    );
+    // The type is the segment before the first `:` (value/position dropped); empty → placeholder.
+    assert_eq!(token_type_footprint("UNKNOWN:x:1 OPEN:(:2"), "UNKNOWN_OPEN");
+    assert_eq!(token_type_footprint(""), "none");
+    // A long formula is bounded to the varchar(200) `what` column and carries the `_cntd` marker;
+    // the result never exceeds 200 chars so the dispatcher insert can't chop the marker.
+    let many = (0..120)
+      .map(|i| format!("UNKNOWN:x{i}:{i}"))
+      .collect::<Vec<_>>()
+      .join(" ");
+    let fp = token_type_footprint(&many);
+    assert!(
+      fp.len() <= 200,
+      "footprint {} exceeds varchar(200)",
+      fp.len()
+    );
+    assert!(
+      fp.ends_with("_cntd"),
+      "a truncated footprint must mark it: {fp}"
+    );
+    assert!(fp.starts_with("UNKNOWN_UNKNOWN"));
+  }
+
+  #[test]
+  fn warns_once_per_distinct_formula_per_document() {
+    // Per-document scope = one `seen` set per document (the parser is built per document).
+    let mut doc = HashSet::new();
+    let f1 = "UNKNOWN:x:1 RELOP:=:2 NUMBER:0:3";
+    let f2 = "UNKNOWN:y:1 ADDOP:+:2 UNKNOWN:z:3";
+    assert!(warn_formula_once(&mut doc, f1), "first sighting warns");
+    assert!(
+      !warn_formula_once(&mut doc, f1),
+      "the same formula repeated is suppressed"
+    );
+    assert!(
+      !warn_formula_once(&mut doc, f1),
+      "still suppressed on the 3rd repeat"
+    );
+    assert!(
+      warn_formula_once(&mut doc, f2),
+      "a DISTINCT formula warns once of its own"
+    );
+    assert!(!warn_formula_once(&mut doc, f2));
+    // A new document (fresh set) warns again for the same formula — dedup is document-scoped.
+    let mut other_doc = HashSet::new();
+    assert!(warn_formula_once(&mut other_doc, f1));
+  }
 
   /// Pin the message↔classifier coupling for the string-fallback path of
   /// resource-fatal recovery (P1-4). The PRIMARY transport is the structured

--- a/latexml_oxide/Cargo.toml
+++ b/latexml_oxide/Cargo.toml
@@ -168,11 +168,12 @@ arXiv corpus."""
 depends = "$auto, imagemagick, mupdf-tools, texlive-latex-base, texlive-latex-extra, texlive-science"
 # Secondary graphics/PDF helpers are SHELLED OUT at runtime (not linked) and only
 # needed for specific source content, so they stay in Recommends: pdftocairo
-# (poppler-utils), gs/ps2pdf (ghostscript), dvipng.
+# (poppler-utils — also the second-choice vector-SVG converter), gs/ps2pdf
+# (ghostscript), dvipng.
 recommends = "poppler-utils, ghostscript, dvipng"
-# inkscape (SVG conversion) is optional and pulls a large GTK stack — keep it a
-# soft suggestion rather than a recommend.
-suggests = "inkscape"
+# NOTE: no inkscape suggestion. The vector-SVG path uses only mutool → pdftocairo;
+# a heavyweight GTK-stack inkscape fallback was deliberately dropped (raster PNG
+# is the fallback instead).
 section = "tex"
 priority = "optional"
 assets = [

--- a/latexml_oxide/bin/cortex_worker.rs
+++ b/latexml_oxide/bin/cortex_worker.rs
@@ -386,7 +386,7 @@ impl LatexmlWorker {
     let dest_html_str = dest_html.to_string_lossy().to_string();
 
     // 5. Post-process: MathML + XSLT (matching CorTeX tex_to_html settings)
-    let html = latexml::post::run_post_processing(&xml, &latexml::post::PostOptions {
+    let post = latexml::post::run_post_processing_logged(&xml, &latexml::post::PostOptions {
       pmml:                      self.profile.pmml,
       // Presentation MathML only — matches Perl LaTeXML's CorTeX `tex_to_html`
       // (whose output carries zero Content MathML) and the ar5iv profile, whose
@@ -431,8 +431,16 @@ impl LatexmlWorker {
       whatsout:                  latexml_post::extract::Whatsout::Document,
     });
 
-    // 6. Get log and status (Perl: status line is last line of log)
-    let status_str = format!("Status:conversion:{}", response.status_code);
+    // 6. Get log and status (Perl: status line is last line of log).
+    //
+    // Fold the post-processing status into the verdict — Perl LaTeXML reports `max(core, post)`
+    // (LaTeXML.pm L631-634), so a post-only fatal (a Graphics/MathML/XSLT failure on a cleanly
+    // digested core) marks the document fatal instead of passing as the core's status. The
+    // `PostOutcome.status_code` is already the combined core+post code (the REPORT counter is not
+    // reset between phases); `max()` with the core code is the documented belt-and-suspenders.
+    let status_code = response.status_code.max(post.status_code);
+    let status_str = format!("Status:conversion:{}", status_code);
+    let html = post.html;
     // Emit the total job wall-time as a CorTeX log message so the dispatcher persists it: CorTeX
     // parses `Info:runtime_ms:<N>` into log_infos (category=runtime_ms, what=N, details=empty), so
     // the conversion time surfaces as its own report category whose drill-down subreport is the
@@ -440,10 +448,21 @@ impl LatexmlWorker {
     // conversions. Captured for graceful conversion-fatals too (TokenLimit/PushbackLimit/… still
     // come through here). Placed before the Status line, which must remain the last line of the log.
     let runtime_ms = wall_start.elapsed().as_millis();
-    let log = format!(
-      "{}\nInfo:runtime_ms:{runtime_ms}\n{}",
-      response.log, status_str
-    );
+    // Append the post-processing log (Graphics/MathML/XSLT `Info!`/`Warn!`/`post_error` lines,
+    // incl. silent EPS→PNG failures) after the core conversion log so post-phase messages reach
+    // cortex.log and the dashboard reports — the Rust equivalent of Perl LaTeXML's single
+    // `flush_log()` after `convert_post`. Omit the segment (no blank line) when post logged nothing.
+    let log = if post.log.is_empty() {
+      format!(
+        "{}\nInfo:runtime_ms:{runtime_ms}\n{}",
+        response.log, status_str
+      )
+    } else {
+      format!(
+        "{}\n{}\nInfo:runtime_ms:{runtime_ms}\n{}",
+        response.log, post.log, status_str
+      )
+    };
 
     // 7. Finalize per-job telemetry. Phase counters were populated by the converter/post guards;
     //    here we fill in identifiers, wall, and resource peaks before serializing.
@@ -454,12 +473,12 @@ impl LatexmlWorker {
       };
       telemetry::set_paper_id(&arxiv_id);
       telemetry::set_wall_us(wall_start.elapsed().as_micros() as u64);
-      telemetry::set_category(match response.status_code {
+      telemetry::set_category(match status_code {
         0 | 1 => "ok",
         2 => "conversion_error",
         _ => "conversion_fatal",
       });
-      telemetry::set_exit_code(response.status_code as i32);
+      telemetry::set_exit_code(status_code as i32);
       telemetry::set_output_bytes(html.len() as u64);
       telemetry::set_max_rss_kb(read_max_rss_kb_proc());
       let (cu, cs) = read_child_rusage_us_proc();

--- a/latexml_oxide/bin/cortex_worker.rs
+++ b/latexml_oxide/bin/cortex_worker.rs
@@ -432,13 +432,14 @@ impl LatexmlWorker {
     // 6. Get log and status (Perl: status line is last line of log)
     let status_str = format!("Status:conversion:{}", response.status_code);
     // Emit the total job wall-time as a CorTeX log message so the dispatcher persists it: CorTeX
-    // parses `Info:cortex:runtime_ms <N>` into log_infos (category=cortex, what=runtime_ms,
-    // details=N), giving a per-paper conversion-time handle for ranking the slowest conversions —
-    // captured for graceful conversion-fatals too (TokenLimit/PushbackLimit/… still come through
-    // here). Placed before the Status line, which must remain the last line of the log.
+    // parses `Info:runtime_ms:<N>` into log_infos (category=runtime_ms, what=N, details=empty), so
+    // the conversion time surfaces as its own report category whose drill-down subreport is the
+    // per-value distribution — and still gives a per-paper handle for ranking the slowest
+    // conversions. Captured for graceful conversion-fatals too (TokenLimit/PushbackLimit/… still
+    // come through here). Placed before the Status line, which must remain the last line of the log.
     let runtime_ms = wall_start.elapsed().as_millis();
     let log = format!(
-      "{}\nInfo:cortex:runtime_ms {runtime_ms}\n{}",
+      "{}\nInfo:runtime_ms:{runtime_ms}\n{}",
       response.log, status_str
     );
 

--- a/latexml_oxide/bin/cortex_worker.rs
+++ b/latexml_oxide/bin/cortex_worker.rs
@@ -415,11 +415,12 @@ impl LatexmlWorker {
       schemadocs:                false,
       // Vector-SVG fast path. 0 = auto-detect: scan the PDF header for
       // `/Subtype /Image` markers; if absent (and the file is at most
-      // 500 KB), route through inkscape→SVG for vector-clean output
-      // and the documented 100×+ speedup over ImageMagick rasterisation
-      // on pgfplots/matplotlib PDFs (PERFORMANCE.md §"Vector-SVG fast
-      // path"). Raster-bearing PDFs detect their image XObject and
-      // stay on the gs/convert path. Override with a positive integer
+      // 500 KB), route through the vector-SVG converters (mutool →
+      // pdftocairo) for vector-clean output and the documented 100×+
+      // speedup over ImageMagick rasterisation on pgfplots/matplotlib
+      // PDFs (PERFORMANCE.md §"Vector-SVG fast path"). Raster-bearing
+      // PDFs detect their image XObject and stay on the gs/convert path.
+      // Override with a positive integer
       // (KB threshold) to force the legacy size-only gate, or set
       // `LATEXML_GRAPHICS_VECTOR_AUTO_OFF=1` to disable auto-detect
       // entirely. Replaces the prior hard-coded 200 KB cutoff (which

--- a/latexml_oxide/bin/cortex_worker.rs
+++ b/latexml_oxide/bin/cortex_worker.rs
@@ -60,8 +60,10 @@ struct Cli {
   /// the sink re-validates each returned result's service name against the
   /// task's service id (`src/dispatcher/sink.rs`) — a mismatch silently
   /// discards the result. The CorTeX preview registers this service as
-  /// `oxidized-tex-to-html` (hyphenated), so that is the default.
-  #[arg(long, default_value = "oxidized-tex-to-html")]
+  /// `oxidized_tex_to_html` (underscored — names use underscores consistently,
+  /// matching the `oxidized_tex_to_html.zip` result bundle), so that is the
+  /// default.
+  #[arg(long, default_value = "oxidized_tex_to_html")]
   service: String,
 
   /// Number of parallel worker threads

--- a/latexml_oxide/bin/latexml_oxide.rs
+++ b/latexml_oxide/bin/latexml_oxide.rs
@@ -115,8 +115,8 @@ struct Cli {
   ///
   /// `0` (default) → **auto-detect**: scan the PDF header for
   /// `/Subtype /Image`; if absent AND the file is at most 500 KB, route
-  /// through inkscape→SVG for vector-clean output. Raster-bearing PDFs
-  /// stay on the gs/convert path.
+  /// through the vector-SVG converters (mutool → pdftocairo) for
+  /// vector-clean output. Raster-bearing PDFs stay on the gs/convert path.
   ///
   /// `N > 0` → explicit size threshold (legacy): try SVG for PDFs at
   /// most `N` KB regardless of content. Use this when the auto-detector

--- a/latexml_oxide/src/post.rs
+++ b/latexml_oxide/src/post.rs
@@ -44,9 +44,10 @@ pub struct PostOptions<'a> {
   pub split_xpath:               Option<String>,
   pub split_naming:              Option<&'a str>,
   pub xslt_parameters:           &'a [String],
-  /// If > 0, try `inkscape` for PDF graphics smaller than this many KB
-  /// (vector-preservation path). Fall back to ImageMagick `convert` on
-  /// failure or timeout. Tracks upstream brucemiller/LaTeXML#902.
+  /// If > 0, try the vector-SVG converters (mutool → pdftocairo) for PDF
+  /// graphics smaller than this many KB (vector-preservation path). Fall
+  /// back to the raster ImageMagick `convert`/`gs` → PNG path on failure
+  /// or timeout. Tracks upstream brucemiller/LaTeXML#902.
   pub graphics_svg_threshold_kb: u32,
   /// Output extraction mode (Perl `LaTeXML::Util::Pack::whatsout`).
   /// `Document` (default) → serialize the full post-processed

--- a/latexml_oxide/src/util/test.rs
+++ b/latexml_oxide/src/util/test.rs
@@ -11,6 +11,13 @@ use crate::core_interface::DigestionAPI;
 static TEST_LOG: Lazy<bool> = Lazy::new(|| std::env::var("LATEXML_TEST_LOG").is_ok());
 static SIGSEGV_TRACE: Lazy<bool> = Lazy::new(|| std::env::var("LATEXML_SIGSEGV_TRACE").is_ok());
 static SAVE_ACTUAL: Lazy<bool> = Lazy::new(|| std::env::var("LATEXML_SAVE_ACTUAL").is_ok());
+/// "Bless" / regenerate mode — the Rust equivalent of Perl's `tools/maketests`.
+/// When `LATEXML_BLESS=1`, a `…_ok` test writes the ACTUAL conversion output to
+/// its golden `.xml` (overwriting it) instead of comparing+asserting. Run via
+/// `tools/maketests.sh` (optionally with a test-name filter). Because it reuses
+/// the exact harness conversion + serialization (`process_texfile`), the
+/// regenerated golden is byte-identical to what the comparison expects.
+static BLESS: Lazy<bool> = Lazy::new(|| std::env::var("LATEXML_BLESS").is_ok());
 
 pub fn latexml_tests(
   dirpath: &str,
@@ -311,6 +318,20 @@ fn latexml_ok_internal(
   extra_bindings_dispatcher: Option<BindingDispatcher>,
 ) {
   let tex_strings = process_texfile(tex_path, name, extra_bindings_dispatcher);
+  // Bless / regenerate mode (Perl `tools/maketests` equivalent): overwrite the
+  // golden with the actual output instead of comparing. Git is the backup.
+  if *BLESS {
+    if tex_strings.is_empty() {
+      eprintln!("BLESS skip {name:?}: conversion produced no output (not overwriting {xml_path})");
+      return;
+    }
+    let body = format!("{}\n", tex_strings.join("\n"));
+    match std::fs::write(xml_path, &body) {
+      Ok(()) => eprintln!("BLESS wrote {xml_path} ({} lines)", tex_strings.len()),
+      Err(e) => eprintln!("BLESS FAILED to write {xml_path}: {e}"),
+    }
+    return;
+  }
   if !tex_strings.is_empty() {
     let xml_strings = process_xmlfile(xml_path, name);
     if !xml_strings.is_empty() {

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -81,6 +81,15 @@ fn cluster_setdec_dec() { convert_clean("tests/cluster_regressions/setdec_dec.te
 #[test]
 fn cluster_cite_uppercase() { convert_clean("tests/cluster_regressions/cite_uppercase.tex"); }
 
+/// `\let\cline\cmidrule` (a common booktabs idiom) must NOT create a
+/// `\cmidrule`->`\cline`->`\cmidrule` infinite expansion. LaTeXML's booktabs
+/// binding defines `\cmidrule` via `\cline`, so the `\let` would loop until the
+/// 8M-conditional IfLimit fatal unless `\cmidrule` routes through a private
+/// saved `\cline` (`booktabs_sty.rs` `\ltx@saved@cline`). Shared with Perl
+/// LaTeXML (which hangs); Rust surpasses. Witnesses: arXiv 2506.23179, 2511.17056.
+#[test]
+fn cluster_cmidrule_cline_let() { convert_clean("tests/cluster_regressions/cmidrule_cline_let.tex"); }
+
 /// Twemoji-style csname construction with accent macros (`\'`, `\^`, `\~`)
 /// and `\textquoteright` apostrophe — must produce 0 errors after the
 /// csname-stream soft-substitute fixes for `\lx@applyaccent`, the canonical

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -102,6 +102,21 @@ fn cluster_omnibus_natbib_bbl_sideload() {
   convert_clean("tests/cluster_regressions/omnibus_natbib_bbl_sideload.tex");
 }
 
+/// A bare `\url` at end-of-input previously panicked: `\url`'s reader did
+/// `read_token()?.unwrap()` and the `None` (input exhausted) hit the `.unwrap()`.
+/// Real TeX raises a clean "Emergency stop" ("File ended while scanning use of
+/// \url"); now `read_token_required` emits that parity Error and the macro
+/// degrades (closes its group) instead of crashing. Guards the whole
+/// `read_token_required` family (hyperref/url.sty `\url`, `\path`, amscd `\cd@`,
+/// `\textfont`). Witnesses: 1401.5000, 1502.05051, 2204.10457. `convert_to_xml`
+/// panics if the conversion produced no result — i.e. it catches a regressed
+/// panic — while tolerating the one intentional `expected` Error.
+#[test]
+fn cluster_url_at_eof_no_panic() {
+  let xml = convert_to_xml("tests/cluster_regressions/url_eof_no_panic.tex");
+  assert!(!xml.is_empty(), "url-at-EOF conversion produced empty output");
+}
+
 /// Twemoji-style csname construction with accent macros (`\'`, `\^`, `\~`)
 /// and `\textquoteright` apostrophe — must produce 0 errors after the
 /// csname-stream soft-substitute fixes for `\lx@applyaccent`, the canonical

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -88,7 +88,9 @@ fn cluster_cite_uppercase() { convert_clean("tests/cluster_regressions/cite_uppe
 /// saved `\cline` (`booktabs_sty.rs` `\ltx@saved@cline`). Shared with Perl
 /// LaTeXML (which hangs); Rust surpasses. Witnesses: arXiv 2506.23179, 2511.17056.
 #[test]
-fn cluster_cmidrule_cline_let() { convert_clean("tests/cluster_regressions/cmidrule_cline_let.tex"); }
+fn cluster_cmidrule_cline_let() {
+  convert_clean("tests/cluster_regressions/cmidrule_cline_let.tex");
+}
 
 /// An unbound class (->OmniBus) whose `.bbl` `\bibitem[\protect\citeauthoryear…]`
 /// side-loads natbib must not leave a body `\citep` looping. The side-load runs
@@ -114,7 +116,10 @@ fn cluster_omnibus_natbib_bbl_sideload() {
 #[test]
 fn cluster_url_at_eof_no_panic() {
   let xml = convert_to_xml("tests/cluster_regressions/url_eof_no_panic.tex");
-  assert!(!xml.is_empty(), "url-at-EOF conversion produced empty output");
+  assert!(
+    !xml.is_empty(),
+    "url-at-EOF conversion produced empty output"
+  );
 }
 
 /// Twemoji-style csname construction with accent macros (`\'`, `\^`, `\~`)

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -90,6 +90,18 @@ fn cluster_cite_uppercase() { convert_clean("tests/cluster_regressions/cite_uppe
 #[test]
 fn cluster_cmidrule_cline_let() { convert_clean("tests/cluster_regressions/cmidrule_cline_let.tex"); }
 
+/// An unbound class (->OmniBus) whose `.bbl` `\bibitem[\protect\citeauthoryear…]`
+/// side-loads natbib must not leave a body `\citep` looping. The side-load runs
+/// inside the `thebibliography` group, so natbib's `\citep` would be popped on
+/// `\end{thebibliography}` and revert to its (now `sty_loaded`) `def_autoload`
+/// trigger, whose already-loaded re-emit then loops to the token limit. Fixed by
+/// hoisting the side-loaded package's defs to global (`\lx@late@usepackage`,
+/// omnibus_cls.rs). Witness: arXiv 2209.11799 (200s TokenLimit fatal -> 1s/0err).
+#[test]
+fn cluster_omnibus_natbib_bbl_sideload() {
+  convert_clean("tests/cluster_regressions/omnibus_natbib_bbl_sideload.tex");
+}
+
 /// Twemoji-style csname construction with accent macros (`\'`, `\^`, `\~`)
 /// and `\textquoteright` apostrophe — must produce 0 errors after the
 /// csname-stream soft-substitute fixes for `\lx@applyaccent`, the canonical

--- a/latexml_oxide/tests/08_xslt_head_keywords.rs
+++ b/latexml_oxide/tests/08_xslt_head_keywords.rs
@@ -1,0 +1,64 @@
+//! XSLT `head-keywords` index-dedup regression guard (full pipeline, runs XSLT).
+//!
+//! Guards the Muenchian-key rewrite in `resources/XSLT/LaTeXML-webpage-xhtml.xsl`
+//! (ARXIV_PERFORMANCE Hotspot #3): the `<meta name="keywords">` content is the set of
+//! DISTINCT-by-string-value `ltx:indexphrase`s, sorted. Upstream LaTeXML computes that
+//! distinct set with `//ltx:indexphrase[not(.=preceding::ltx:indexphrase)]`, an O(n²)
+//! scan (each indexphrase walks the `preceding::` axis) — the XSLT hotspot on
+//! index-bearing docs (witness 1802.06435: 78s → 17s; 2208.07515: 95s → 33s). The fix
+//! replaces it with a hashed `xsl:key` (Muenchian method), O(n), and MUST stay
+//! output-neutral: same distinct phrases, same sort order, same first-occurrence pick.
+//!
+//! Like the seclev guard, this can only be checked end-to-end via the binary (the
+//! in-process `Converter` stops at Core XML and never runs post-processing/XSLT).
+
+use std::{path::Path, process::Command};
+
+fn run(cwd: &Path, args: &[&str]) -> std::process::Output {
+  Command::new(env!("CARGO_BIN_EXE_latexml_oxide"))
+    .args(args)
+    .current_dir(cwd)
+    .output()
+    .expect("spawn latexml_oxide")
+}
+
+/// `\index` entries with a duplicate ("banana" twice) and out-of-order keys exercise
+/// every property of the dedup: distinctness (one "banana", not two), document-order
+/// first-occurrence (Muenchian `key(...)[1]`), and the `<xsl:sort>` (alphabetical
+/// output regardless of source order). The keywords meta content must be exactly
+/// "apple, banana, cherry" — a regression in the dedup/sort would drop, duplicate, or
+/// reorder a phrase.
+#[test]
+fn head_keywords_distinct_sorted() {
+  const DOC: &str = "\\documentclass{article}\n\
+                     \\begin{document}\n\
+                     \\section{S}\n\
+                     Text\\index{banana} more\\index{apple} and\\index{banana} \
+                     also\\index{cherry}.\n\
+                     \\printindex\n\
+                     \\end{document}\n";
+  let work = tempfile::tempdir().expect("tempdir");
+  std::fs::write(work.path().join("idx.tex"), DOC).unwrap();
+  let out = run(work.path(), &["idx.tex", "--dest", "idx.html"]);
+  assert!(
+    out.status.success(),
+    "conversion failed (status {:?}):\n{}",
+    out.status.code(),
+    String::from_utf8_lossy(&out.stderr)
+  );
+  let html = std::fs::read_to_string(work.path().join("idx.html")).expect("read idx.html");
+  // Pull the content="..." of <meta name="keywords" ...>.
+  let meta = html
+    .split("<meta name=\"keywords\"")
+    .nth(1)
+    .expect("keywords meta present");
+  let content = meta
+    .split("content=\"")
+    .nth(1)
+    .and_then(|s| s.split('"').next())
+    .expect("keywords content attr");
+  assert_eq!(
+    content, "apple, banana, cherry",
+    "head-keywords distinct/sort changed (Muenchian-key regression?):\n{html}"
+  );
+}

--- a/latexml_oxide/tests/cluster_regressions/cmidrule_cline_let.tex
+++ b/latexml_oxide/tests/cluster_regressions/cmidrule_cline_let.tex
@@ -1,0 +1,16 @@
+\documentclass{article}
+\usepackage{booktabs}
+% A common idiom: make \cline render like a booktabs partial rule. LaTeXML's
+% booktabs binding defines \cmidrule in terms of \cline, so this \let would
+% create a \cmidrule->\cline->\cmidrule infinite expansion (8M-conditional
+% IfLimit fatal) unless \cmidrule routes through a saved private \cline.
+% Witnesses: arXiv 2506.23179, 2511.17056. Shared with Perl LaTeXML (which
+% hangs); Rust surpasses (see booktabs_sty.rs, KNOWN_PERL_ERRORS).
+\let\cline\cmidrule
+\begin{document}
+\begin{tabular}{ccccc}
+a & b & c & d & e \\
+\cline{2-5}
+f & g & h & i & j \\
+\end{tabular}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/omnibus_natbib_bbl_sideload.tex
+++ b/latexml_oxide/tests/cluster_regressions/omnibus_natbib_bbl_sideload.tex
@@ -1,0 +1,8 @@
+\documentclass{sn-jnl}
+\begin{document}
+Some text.
+\begin{thebibliography}{}
+\bibitem[\protect\citeauthoryear{Foo et~al.}{2020}]{a} Foo, A.: Title. (2020)
+\end{thebibliography}
+\citep{a}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/url_eof_no_panic.tex
+++ b/latexml_oxide/tests/cluster_regressions/url_eof_no_panic.tex
@@ -1,0 +1,2 @@
+\documentclass{article}\usepackage{hyperref}\begin{document}
+a\url

--- a/latexml_package/src/package/amscd_sty.rs
+++ b/latexml_package/src/package/amscd_sty.rs
@@ -30,7 +30,9 @@ LoadDefinitions!({
   DefPrimitive!(T_CS!("\\cd@"), None, {
     // `\cd@` requires a following token to build the `@<token>` connector CS; on
     // input-exhaustion emit the parity "file ended" error instead of panicking.
-    let Some(token) = read_token_required("\\cd@")? else { return Ok(vec![]); };
+    let Some(token) = read_token_required("\\cd@")? else {
+      return Ok(vec![]);
+    };
     let cs_name = token.with_str(|s| format!("@{s}"));
     unread(Tokens::from(T_CS!(&*cs_name)));
   });

--- a/latexml_package/src/package/amscd_sty.rs
+++ b/latexml_package/src/package/amscd_sty.rs
@@ -28,7 +28,9 @@ LoadDefinitions!({
   //     (T_CS('@' . ToString($token))); });
   // Implemented as a primitive that reads a token and unreads the appropriate CS.
   DefPrimitive!(T_CS!("\\cd@"), None, {
-    let token = read_token()?.unwrap();
+    // `\cd@` requires a following token to build the `@<token>` connector CS; on
+    // input-exhaustion emit the parity "file ended" error instead of panicking.
+    let Some(token) = read_token_required("\\cd@")? else { return Ok(vec![]); };
     let cs_name = token.with_str(|s| format!("@{s}"));
     unread(Tokens::from(T_CS!(&*cs_name)));
   });

--- a/latexml_package/src/package/booktabs_sty.rs
+++ b/latexml_package/src/package/booktabs_sty.rs
@@ -17,8 +17,18 @@ LoadDefinitions!({
   DefMacro!("\\cmidrule[]",
     r"\@ifnextchar({\ifx.#1.\expandafter\ltx@@cmidrule\else\@afterfi\ltx@@cmidrule[#1]\fi}{\ifx.#1.\expandafter\ltx@cmidrule\else\@afterfi\ltx@cmidrule[#1]\fi}"
   );
-  DefMacro!("\\ltx@@cmidrule[Dimension] SkipMatch:( Until:){}", "\\cline{#3}");
-  DefMacro!("\\ltx@cmidrule[Dimension]{}", "\\cline{#2}");
+  // The cmidrule helpers draw the partial rule via `\cline`. They route through
+  // a PRIVATE saved copy (`\ltx@saved@cline`, captured at load below) rather than
+  // the public `\cline`, so a document `\let\cline\cmidrule` (a common idiom to
+  // make `\cline` render like a booktabs rule) does NOT create a
+  // `\cmidrule`→`\cline`→`\cmidrule` infinite expansion. Real LaTeX avoids the
+  // cycle because its `\cmidrule` draws the rule directly; LaTeXML's simplified
+  // `\cmidrule`→`\cline` binding (shared with Perl, which hangs on this — see
+  // KNOWN_PERL_ERRORS) would otherwise loop until the conditional limit.
+  // Witnesses: arXiv 2506.23179, 2511.17056 (both `\let\cline\cmidrule`).
+  // Output-neutral for ordinary `\cmidrule` (saved CS == `\cline` at load).
+  DefMacro!("\\ltx@@cmidrule[Dimension] SkipMatch:( Until:){}", "\\ltx@saved@cline{#3}");
+  DefMacro!("\\ltx@cmidrule[Dimension]{}", "\\ltx@saved@cline{#2}");
 
   // add vspace
   def_macro_noop("\\addlinespace[Dimension]")?;
@@ -26,6 +36,10 @@ LoadDefinitions!({
   def_macro_noop("\\morecmidrules")?;
   // \specialrule{thickness}{above}{below}
   DefMacro!("\\specialrule{Dimension}{Dimension}{Dimension}", "\\hline");
+
+  // Capture the real `\cline` at load time (before any document redefinition)
+  // so `\cmidrule` can draw its rule without depending on the live `\cline`.
+  TeX!(r"\let\ltx@saved@cline\cline");
 
   TeX!(r"\newdimen\heavyrulewidth
 \newdimen\lightrulewidth

--- a/latexml_package/src/package/hyperref_sty.rs
+++ b/latexml_package/src/package/hyperref_sty.rs
@@ -360,7 +360,13 @@ LoadDefinitions!({
   // It's slightly different in that it expands the argument
   // Redefine \@url to sanitize the argument less
   DefMacro!("\\lx@hyper@url Token", sub[(cmd)] {
-    let open = read_token()?.unwrap();
+    // `\url` requires a following delimiter/argument token; on input-exhaustion
+    // `read_token_required` emits the parity "file ended while scanning use of
+    // \url" error (real TeX "Emergency stop"). Don't panic — close the
+    // `\begingroup` `\url` opened (see the `\url` def below) and emit nothing.
+    let Some(open) = read_token_required(&cmd.to_string())? else {
+      return Ok(Tokens::new(vec![T_CS!("\\endgroup")]));
+    };
     begin_semiverbatim(Some(&['%']));
     let_i(&T_ACTIVE!('~'), &T_OTHER!("~"), None); // Needs special protection?
     // URLs are verbatim: any character a shorthand package made ACTIVE must

--- a/latexml_package/src/package/llncs_cls.rs
+++ b/latexml_package/src/package/llncs_cls.rs
@@ -49,19 +49,29 @@ LoadDefinitions!({
   // Single \institute, with multiple institutions separated by \and.
   // The n-th institution is attached to the author which has that n in its \inst labels.
   //
-  // IMPROVEMENT over upstream llncs.cls.ltxml: upstream splits \institute ONLY on
-  // \and. The very common lazy LNCS style instead writes ONE \institute block with
-  // hand-typed superscripts ("$^1$..\quad $^2$..") and no \and; upstream then makes
-  // a single affiliation = the whole block, attached to every \inst{1} author
-  // (duplicating it) while \inst{2}+ authors get nothing (witness 2606.19939;
-  // reproduces identically in Perl LaTeXML 0.8.8). Instead we route through the
-  // shared smart affiliation parser \lx@add@affiliations, which already handles
-  // BOTH forms: with superscript markers it splits on \quad/\qquad/\\ and extracts
-  // each superscript as the affiliation label that \inst{N} links to; without them
-  // it splits on \and (affil_splits() was extended to include \and). labelseq gives
-  // the \and-separated form its sequential 1,2,.. labels for \inst linking.
+  // Two shapes occur in the wild and need different splitting:
+  //  (a) Well-formed: institutions separated by \and, each possibly with an
+  //      internal "\\" line break between its name and its \email/\url
+  //      (witness 2605.16562). Here we MUST split on \and ONLY -- splitting on
+  //      "\\" too would break each institution into name + email as separate
+  //      affiliations and mis-align the labelseq with \inst{N}, scrambling which
+  //      author gets which affiliation/email. \email inside an affiliation
+  //      inherits that affiliation's label, so it attaches to the right authors.
+  //  (b) Lazy: ONE block, no \and, hand-typed superscripts ("$^1$..\quad $^2$..")
+  //      (witness 2606.19939). Upstream makes a single affiliation = the whole
+  //      block attached to every \inst{1} author (duplicating it) while \inst{2}+
+  //      get nothing (reproduces identically in Perl LaTeXML 0.8.8). The shared
+  //      \lx@add@affiliations parser handles this: it splits on \quad/\qquad/\\
+  //      and extracts each superscript as the affiliation label \inst{N} links to.
+  // So: branch on whether \and is present.
   DefMacro!("\\institute{}",
-    "\\lx@add@affiliations[labelseq={affiliation}]{#1}");
+    "\\in@{\\and}{#1}\\ifin@\
+       \\lx@clear@frontmatter{ltx:contact}[role=affiliation]\
+       \\lx@splitting{\\lx@llncs@affiliation}{\\and}{#1}\
+     \\else\
+       \\lx@add@affiliations[labelseq={affiliation}]{#1}\
+     \\fi");
+  DefMacro!("\\lx@llncs@affiliation{}", "\\lx@add@affiliation[labelseq={affiliation}]{#1}");
   DefMacro!("\\inst{}",                 "\\lx@request@frontmatter@annotation[affiliation]{#1}");
   // \orcidID should be used within each author in \author
   DefMacro!("\\orcidID{}", "\\lx@add@orcid{#1}");

--- a/latexml_package/src/package/llncs_cls.rs
+++ b/latexml_package/src/package/llncs_cls.rs
@@ -37,11 +37,22 @@ LoadDefinitions!({
   // \inst{labels} can be used within each author to identify which affiliations apply
   DefMacro!("\\author{}",
     "\\lx@clear@creators[role=author]\\lx@splitting{\\lx@add@author}{\\and\\And,}{#1}");
-  // Single \institute, with multiple institutions separated by \and
+  // Single \institute, with multiple institutions separated by \and.
   // The n-th institution is attached to the author which has that n in its \inst labels.
+  //
+  // IMPROVEMENT over upstream llncs.cls.ltxml: upstream splits \institute ONLY on
+  // \and. The very common lazy LNCS style instead writes ONE \institute block with
+  // hand-typed superscripts ("$^1$..\quad $^2$..") and no \and; upstream then makes
+  // a single affiliation = the whole block, attached to every \inst{1} author
+  // (duplicating it) while \inst{2}+ authors get nothing (witness 2606.19939;
+  // reproduces identically in Perl LaTeXML 0.8.8). Instead we route through the
+  // shared smart affiliation parser \lx@add@affiliations, which already handles
+  // BOTH forms: with superscript markers it splits on \quad/\qquad/\\ and extracts
+  // each superscript as the affiliation label that \inst{N} links to; without them
+  // it splits on \and (affil_splits() was extended to include \and). labelseq gives
+  // the \and-separated form its sequential 1,2,.. labels for \inst linking.
   DefMacro!("\\institute{}",
-    "\\lx@clear@frontmatter{ltx:contact}[role=affiliation]\\lx@splitting{\\lx@llncs@affiliation}{\\and}{#1}");
-  DefMacro!("\\lx@llncs@affiliation{}", "\\lx@add@affiliation[labelseq={affiliation}]{#1}");
+    "\\lx@add@affiliations[labelseq={affiliation}]{#1}");
   DefMacro!("\\inst{}",                 "\\lx@request@frontmatter@annotation[affiliation]{#1}");
   // \orcidID should be used within each author in \author
   DefMacro!("\\orcidID{}", "\\lx@add@orcid{#1}");

--- a/latexml_package/src/package/llncs_cls.rs
+++ b/latexml_package/src/package/llncs_cls.rs
@@ -14,6 +14,12 @@ LoadDefinitions!({
   });
   ProcessOptions!();
   LoadClass!("article");
+  // Real llncs.cls L244 sets secnumdepth to 2, so subsubsections are NOT
+  // numbered. Both the Perl llncs.cls.ltxml and this port previously omitted it
+  // and inherited article's default of 3, giving a plain \subsubsection a
+  // printed number ("7.0.1") that the PDF never shows. Witness 2605.16562
+  // ("Author contributions.").
+  SetCounter!("secnumdepth", Number::new(2));
 
   RequirePackage!("multicol");
   // LLNCS authors routinely use \boldsymbol (amsbsy) and \mathbb / \mathfrak

--- a/latexml_package/src/package/llncs_cls.rs
+++ b/latexml_package/src/package/llncs_cls.rs
@@ -34,9 +34,12 @@ LoadDefinitions!({
   DefMacro!("\\mailname",  "\\textit{Correspondence to}:");
 
   // Single \author, with multiple authors separated by \and  (Perl PR #2767)
-  // \inst{labels} can be used within each author to identify which affiliations apply
+  // \inst{labels} can be used within each author to identify which affiliations apply.
+  // IMPROVEMENT over upstream: also split on \\ -- authors commonly use a manual
+  // row break in place of \and ("A\inst{1} \\ B\inst{2}"), which upstream merges
+  // into a single creator (witness 2606.19939: "Hiuyi Cheng \\ Dezhi Peng").
   DefMacro!("\\author{}",
-    "\\lx@clear@creators[role=author]\\lx@splitting{\\lx@add@author}{\\and\\And,}{#1}");
+    "\\lx@clear@creators[role=author]\\lx@splitting{\\lx@add@author}{\\and\\And,\\\\}{#1}");
   // Single \institute, with multiple institutions separated by \and.
   // The n-th institution is attached to the author which has that n in its \inst labels.
   //

--- a/latexml_package/src/package/omnibus_cls.rs
+++ b/latexml_package/src/package/omnibus_cls.rs
@@ -74,7 +74,20 @@ LoadDefinitions!({
   // argument uses \protect\citeauthoryear.
   Let!("\\lx@OmniBus@saved@bibitem", "\\bibitem");
   DefPrimitive!("\\lx@late@usepackage Semiverbatim", sub[(pkg)] {
+    // This fires from inside `\bibitem` processing — i.e. inside the
+    // `thebibliography` group. Package definitions installed at that frame are
+    // popped on `\end{thebibliography}`, so natbib's real `\citep`/`\citet`
+    // would vanish and `\citep` reverts to its (still-installed, now
+    // `*.sty_loaded`-true) `def_autoload` trigger; a later body `\citep` then
+    // re-fires the trigger's already-loaded early-return, re-emits `\citep`, and
+    // loops to the token limit. Mirror `def_autoload`: snapshot the calling
+    // frame's meanings, load, then hoist natbib's freshly-installed defs to
+    // GLOBAL so they survive the group pop (matching a top-level
+    // `\usepackage{natbib}`). Witness: 2209.11799 (sn-jnl, `\citep` after a
+    // `\citeauthoryear` `\bibitem`-triggered natbib load).
+    let pre_keys = snapshot_top_frame_meaning_keys();
     require_package(&pkg.to_string(), RequireOptions::default())?;
+    hoist_top_frame_meaning_delta(&pre_keys);
   });
   DefMacro!("\\bibitem",
     "\\@ifnext@n{[\\protect\\citeauthoryear}{\\lx@late@usepackage{natbib}\\bibitem}{\\lx@OmniBus@saved@bibitem}");

--- a/latexml_package/src/package/url_sty.rs
+++ b/latexml_package/src/package/url_sty.rs
@@ -41,7 +41,14 @@ LoadDefinitions!({
   DefMacro!("\\lx@url@url Token", sub[(cmd)] {
     let perc = vec!['%'];
    begin_semiverbatim(Some(&perc));
-    let mut open = read_token()?.unwrap();
+    // `\url`/`\path` requires a following delimiter/argument token; on
+    // input-exhaustion `read_token_required` emits the parity "file ended while
+    // scanning use of \url" error. Don't panic — unwind the semiverbatim frame
+    // and close the `\begingroup` `\url`/`\path` opened, emitting nothing.
+    let Some(mut open) = read_token_required(&cmd.to_string())? else {
+      end_semiverbatim()?;
+      return Ok(Tokens::new(vec![T_CS!("\\endgroup")]));
+    };
     let close;
     let url = if open.get_catcode() == Catcode::BEGIN {
       open = T_OTHER!("{");

--- a/latexml_package/src/package/wrapfig_sty.rs
+++ b/latexml_package/src/package/wrapfig_sty.rs
@@ -65,11 +65,27 @@ LoadDefinitions!({
 // width) as the float's `width` property so it renders as a CSS `width:`,
 // capping the float (image + caption) to that width. Perl's wrapfig binding
 // discards this arg; applying it is an intentional ar5iv-rendering divergence.
+//
+// Emit it as a PERCENTAGE of \textwidth, not the resolved absolute pt. A
+// wrapfigure width is a layout reservation -- the fraction of the line the float
+// occupies (authors write it proportionally, e.g. 0.48\linewidth). In print the
+// column is fixed so absolute == relative; in responsive HTML the main column is
+// far wider than the print \textwidth, so an absolute pt renders far narrower
+// than the intended fraction (0.48\linewidth -> ~165pt -> ~26% of an 832px
+// column instead of ~48%). A percentage preserves the proportion and scales.
+// This also makes wrapfig consistent with the floatfig/floatflt sibling
+// packages, which already emit `100 * dimen / \textwidth . '%'` (Perl toPercent).
 fn set_wrap_width(whatsit: &mut Whatsit) {
-  if let Some(width_arg) = whatsit.get_arg(4) {
-    let v = width_arg.value_of();
-    if v != 0 {
-      whatsit.set_property("width", Stored::Dimension(Dimension::new(v)));
-    }
+  let Some(width_arg) = whatsit.get_arg(4) else { return };
+  let v = width_arg.value_of();
+  if v == 0 {
+    return;
   }
+  let Some(tw) = lookup_dimension("\\textwidth") else { return };
+  let tw_sp = tw.value_of();
+  if tw_sp == 0 {
+    return;
+  }
+  let pct = (100 * v) / tw_sp;
+  whatsit.set_property("width", Stored::from(s!("{pct}%")));
 }

--- a/latexml_package/src/package/wrapfig_sty.rs
+++ b/latexml_package/src/package/wrapfig_sty.rs
@@ -76,12 +76,16 @@ LoadDefinitions!({
 // This also makes wrapfig consistent with the floatfig/floatflt sibling
 // packages, which already emit `100 * dimen / \textwidth . '%'` (Perl toPercent).
 fn set_wrap_width(whatsit: &mut Whatsit) {
-  let Some(width_arg) = whatsit.get_arg(4) else { return };
+  let Some(width_arg) = whatsit.get_arg(4) else {
+    return;
+  };
   let v = width_arg.value_of();
   if v == 0 {
     return;
   }
-  let Some(tw) = lookup_dimension("\\textwidth") else { return };
+  let Some(tw) = lookup_dimension("\\textwidth") else {
+    return;
+  };
   let tw_sp = tw.value_of();
   if tw_sp == 0 {
     return;

--- a/latexml_post/src/diag.rs
+++ b/latexml_post/src/diag.rs
@@ -6,8 +6,19 @@
 //! `latexml_post` does not need to import `latexml_core::common::error`
 //! just to emit diagnostics. The macro names deliberately shadow the
 //! identically-named macros from `latexml_core` — same shape (`(category,
-//! object, …)`), simpler implementation (no `note_status` counter,
-//! no error-cap unwinding, no location trace appended).
+//! object, …)`), simpler implementation (no error-cap → Fatal unwinding,
+//! no location trace appended). They DO bump the shared `latexml_core`
+//! `REPORT` status counters via `note_status`, so a post-processing
+//! `Warn!`/`Error!`/`Fatal!` raises the conversion's `status_code` exactly
+//! like a core-phase one — the run's severity is the combined worst of the
+//! core and post phases (`cortex_worker` folds them as `max(core, post)`).
+//! Without this a post-only failure (e.g. an image that fails every
+//! converter) logged its line but left `status_code` at 0.
+//!
+//! For diagnostics raised on a post-processing WORKER THREAD (the graphics
+//! conversion pool), both the log text AND these counter bumps are
+//! `#[thread_local]`, so they are captured per-worker and replayed on the
+//! main thread via `latexml_core::util::logger::capture`/`replay_captured`.
 //!
 //! Output format goes through the shared `latexml_core::util::logger`
 //! formatter via `log::info!`/`warn!`/`error!` with an explicit
@@ -45,45 +56,49 @@ macro_rules! Note {
   }};
 }
 
+// The single-message arms delegate to the format arms (`"{}", $msg`) so the
+// `note_status` count + the `log::*!` emission live in exactly ONE place per
+// macro — mirroring `latexml_core`'s own `Error!` self-delegation.
 #[macro_export]
 macro_rules! Info {
   ($category:expr_2021, $object:expr_2021, $msg:expr_2021) => {
-    log::info!(target: &format!("{}:{}", $category, $object), "{}", $msg)
+    $crate::Info!($category, $object, "{}", $msg)
   };
-  ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {
+  ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {{
+    latexml_core::common::error::note_status(latexml_core::common::error::LogStatus::Info, None);
     log::info!(target: &format!("{}:{}", $category, $object), $fmt, $($arg)+)
-  };
+  }};
 }
 
 #[macro_export]
 macro_rules! Warn {
   ($category:expr_2021, $object:expr_2021, $msg:expr_2021) => {
-    log::warn!(target: &format!("{}:{}", $category, $object), "{}", $msg)
+    $crate::Warn!($category, $object, "{}", $msg)
   };
-  ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {
+  ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {{
+    latexml_core::common::error::note_status(latexml_core::common::error::LogStatus::Warning, None);
     log::warn!(target: &format!("{}:{}", $category, $object), $fmt, $($arg)+)
-  };
+  }};
 }
 
 #[macro_export]
 macro_rules! Error {
   ($category:expr_2021, $object:expr_2021, $msg:expr_2021) => {
-    log::error!(target: &format!("{}:{}", $category, $object), "{}", $msg)
+    $crate::Error!($category, $object, "{}", $msg)
   };
-  ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {
+  ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {{
+    latexml_core::common::error::note_status(latexml_core::common::error::LogStatus::Error, None);
     log::error!(target: &format!("{}:{}", $category, $object), $fmt, $($arg)+)
-  };
+  }};
 }
 
 #[macro_export]
 macro_rules! Fatal {
-  ($category:expr_2021, $object:expr_2021, $msg:expr_2021) => {{
-    log::error!(target: &format!("Fatal:{}:{}", $category, $object), "{}", $msg);
-    return Err($crate::processor::PostError::Processing(
-      format!("{}:{}: {}", $category, $object, $msg)
-    ));
-  }};
+  ($category:expr_2021, $object:expr_2021, $msg:expr_2021) => {
+    $crate::Fatal!($category, $object, "{}", $msg)
+  };
   ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {{
+    latexml_core::common::error::note_status(latexml_core::common::error::LogStatus::Fatal, None);
     let __m = format!($fmt, $($arg)+);
     log::error!(target: &format!("Fatal:{}:{}", $category, $object), "{}", __m);
     return Err($crate::processor::PostError::Processing(

--- a/latexml_post/src/document.rs
+++ b/latexml_post/src/document.rs
@@ -561,37 +561,93 @@ impl PostDocument {
     let xpath = xpath.trim_start_matches('!').trim();
     let mut results = Vec::new();
 
-    // Parse simple patterns: "ltx:elem" or "ltx:elem[@attr='val']" or "ltx:elem/ltx:child"
-    let parts: Vec<&str> = xpath.split('/').collect();
+    // Parse simple patterns: "ltx:elem" or "ltx:elem[@attr='val']" or "ltx:elem/ltx:child".
+    // Split on '/' only at bracket depth 0, so a '/' inside a predicate (e.g. the
+    // `../` in `[not(../ltx:bib-related[@bibrefs])]`) does not fragment the step.
+    let parts: Vec<&str> = split_steps(xpath);
     if parts.is_empty() {
       return results;
     }
 
+    // Split a path into steps on '/' at bracket depth 0.
+    fn split_steps(xpath: &str) -> Vec<&str> {
+      let mut steps = Vec::new();
+      let mut depth = 0i32;
+      let mut start = 0;
+      for (i, b) in xpath.bytes().enumerate() {
+        match b {
+          b'[' => depth += 1,
+          b']' => depth -= 1,
+          b'/' if depth == 0 => {
+            steps.push(&xpath[start..i]);
+            start = i + 1;
+          },
+          _ => {},
+        }
+      }
+      steps.push(&xpath[start..]);
+      steps
+    }
+
+    // Extract the top-level `[...]` predicate bodies from a step, respecting
+    // nested brackets: `[@type][not(../ltx:bib-related[@bibrefs])]`
+    // → ["@type", "not(../ltx:bib-related[@bibrefs])"].
+    fn extract_predicates(s: &str) -> Vec<&str> {
+      let mut preds = Vec::new();
+      let mut depth = 0i32;
+      let mut start = 0;
+      for (i, b) in s.bytes().enumerate() {
+        match b {
+          b'[' => {
+            if depth == 0 {
+              start = i + 1;
+            }
+            depth += 1;
+          },
+          b']' => {
+            depth -= 1;
+            if depth == 0 {
+              preds.push(&s[start..i]);
+            }
+          },
+          _ => {},
+        }
+      }
+      preds
+    }
+
     fn match_element(node: &Node, pattern: &str) -> bool {
       let pattern = pattern.trim().trim_start_matches("ltx:");
-      if let Some(bracket_pos) = pattern.find('[') {
-        let elem_name = &pattern[..bracket_pos];
-        let attr_part = &pattern[bracket_pos + 1..pattern.len() - 1]; // strip [ and ]
-        if node.get_name() != elem_name {
-          return false;
-        }
-        // Parse @attr='value'
-        if let Some(eq_pos) = attr_part.find('=') {
-          let attr_name = attr_part[1..eq_pos].trim(); // skip @
-          let attr_val = attr_part[eq_pos + 1..]
-            .trim()
-            .trim_matches('\'')
-            .trim_matches('"');
-          node
-            .get_attribute(attr_name)
-            .map(|v| v == attr_val)
-            .unwrap_or(false)
-        } else {
-          true
-        }
-      } else {
-        node.get_name() == pattern
+      let bracket_pos = match pattern.find('[') {
+        None => return node.get_name() == pattern,
+        Some(p) => p,
+      };
+      let elem_name = &pattern[..bracket_pos];
+      if node.get_name() != elem_name {
+        return false;
       }
+      // Every top-level predicate must hold. Supported forms: `@attr` (the
+      // attribute must exist) and `@attr='value'` (equality). Function
+      // predicates such as `not(../ltx:bib-related[@bibrefs])` are beyond this
+      // lightweight matcher and are treated as satisfied (best-effort).
+      for pred in extract_predicates(&pattern[bracket_pos..]) {
+        let pred = pred.trim();
+        if pred.contains('(') {
+          continue;
+        }
+        if let Some(attr) = pred.strip_prefix('@') {
+          if let Some(eq) = attr.find('=') {
+            let name = attr[..eq].trim();
+            let val = attr[eq + 1..].trim().trim_matches('\'').trim_matches('"');
+            if node.get_attribute(name).as_deref() != Some(val) {
+              return false;
+            }
+          } else if node.get_attribute(attr.trim()).is_none() {
+            return false;
+          }
+        }
+      }
+      true
     }
 
     fn collect_matching(node: &Node, parts: &[&str], results: &mut Vec<Node>) {

--- a/latexml_post/src/graphics.rs
+++ b/latexml_post/src/graphics.rs
@@ -1618,10 +1618,22 @@ impl Graphics {
       .arg(dest);
     let timeout = std::time::Duration::from_secs(Self::convert_timeout_secs());
     match Self::run_with_timeout(cmd, timeout) {
-      // Mirror the original `cmd.output()` semantics: report success based
-      // on exit status alone, not on whether `dest` was actually written.
-      // (The fake-convert test fixture exits 0 without producing a file.)
-      Some(status) => status.success(),
+      Some(status) => {
+        // A clean exit is NOT sufficient: ImageMagick `convert` (and the `gs`
+        // it drives) exits 0 on some corrupt/unrenderable inputs while writing
+        // no file. Require an actual non-empty output so a genuine "no image"
+        // failure surfaces (returns false → the caller's imageprocessing
+        // Error) instead of being mistaken for success and emitting a
+        // broken/empty <img>. The fast PDF/EPS paths already verify their
+        // output (mutool/pdftocairo check `dest.exists()`); this brings the
+        // final `convert` fallback in line.
+        if status.success() && Self::produced_output(dest) {
+          true
+        } else {
+          let _ = std::fs::remove_file(dest); // drop any partial/empty output
+          false
+        }
+      },
       None => {
         Warn!(
           "shell",
@@ -1634,6 +1646,16 @@ impl Graphics {
         false
       },
     }
+  }
+
+  /// True iff `dest` was actually written as a usable (non-empty) file. Used to
+  /// validate a subprocess conversion whose exit code alone is unreliable
+  /// (`convert`/`gs` can exit 0 having produced nothing). A 0-byte file counts
+  /// as failure — it would render as a broken image.
+  fn produced_output(dest: &str) -> bool {
+    std::fs::metadata(dest)
+      .map(|m| m.len() > 0)
+      .unwrap_or(false)
   }
 
   /// Hard timeout (seconds) for the `convert` subprocess. Mirrors
@@ -2595,9 +2617,12 @@ endobj
     std::fs::write(&source, "%!PS-Adobe-3.0\n%%BoundingBox: 0 0 100 100\n").unwrap();
     let log = tmp.join("convert.log");
     let fake_convert = tmp.join("convert");
+    // Log the args AND write a non-empty file at the dest (the last positional
+    // arg) — `convert_image` now requires actual output, not just exit 0.
     std::fs::write(
       &fake_convert,
-      "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$LATEXML_FAKE_CONVERT_LOG\"\nexit 0\n",
+      "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$LATEXML_FAKE_CONVERT_LOG\"\n\
+       for a in \"$@\"; do d=\"$a\"; done\nprintf x > \"$d\"\nexit 0\n",
     )
     .unwrap();
     let mut perms = std::fs::metadata(&fake_convert).unwrap().permissions();
@@ -2702,5 +2727,32 @@ endobj
       before.error + 2,
       "both workers' Error! must increment the main REPORT error count via the fold"
     );
+  }
+
+  /// `produced_output` is the guard that turns a `convert`/`gs` exit-0-but-no-file
+  /// into a reported failure: a usable conversion is a non-empty file, not just a
+  /// clean exit. Missing OR empty (0-byte) => not output.
+  #[test]
+  fn produced_output_requires_a_nonempty_file() {
+    let tmp = std::env::temp_dir().join(format!("latexml_produced_{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let missing = tmp.join("missing.png");
+    let empty = tmp.join("empty.png");
+    let real = tmp.join("real.png");
+    std::fs::write(&empty, b"").unwrap();
+    std::fs::write(&real, b"\x89PNG").unwrap();
+    assert!(
+      !Graphics::produced_output(&missing.to_string_lossy()),
+      "a missing file is not usable output"
+    );
+    assert!(
+      !Graphics::produced_output(&empty.to_string_lossy()),
+      "a 0-byte file is not usable output (would render as a broken image)"
+    );
+    assert!(
+      Graphics::produced_output(&real.to_string_lossy()),
+      "a non-empty file is usable output"
+    );
+    std::fs::remove_dir_all(&tmp).ok();
   }
 }

--- a/latexml_post/src/graphics.rs
+++ b/latexml_post/src/graphics.rs
@@ -2052,131 +2052,147 @@ impl Processor for Graphics {
       // workers pick up the remaining jobs via the shared `next`
       // counter. If every spawn fails, run all jobs on the current
       // thread instead of crashing.
-      let worker_outcomes: Vec<Vec<ConvertOutcome>> = std::thread::scope(|s| {
+      type WorkerResult = (
+        Vec<ConvertOutcome>,
+        latexml_core::util::logger::CapturedDiagnostics,
+      );
+      let worker_outcomes: Vec<WorkerResult> = std::thread::scope(|s| {
         let handles: Vec<_> = (0..n_workers)
           .filter_map(|_| {
             std::thread::Builder::new()
               .stack_size(2 * 1024 * 1024)
               .spawn_scoped(s, || {
-                let mut local = Vec::<ConvertOutcome>::new();
-                loop {
-                  let i = next.fetch_add(1, Ordering::Relaxed);
-                  if i >= jobs.len() {
-                    break;
-                  }
-                  let ConvertJob {
-                    job_id,
-                    source,
-                    page,
-                    rel_dest,
-                    abs_dest_str,
-                    svg_paths,
-                  } = jobs[i];
-                  // Try vector-SVG path first if requested for this source.
-                  // The cache layer (graphics_cache) hardlinks/copies a
-                  // matching cached output before any subprocess fires and
-                  // round-trips the dimensions through a .dims sidecar so
-                  // hits skip the `read_*_dimensions` re-measure too.
-                  // Misses fall through to the real conversion + measure
-                  // and write back on success. Disable via
-                  // LATEXML_GRAPHICS_CACHE_OFF=1.
-                  let svg_outcome = if let Some((rel_svg, abs_svg)) = svg_paths {
-                    let svg_key = crate::graphics_cache::RenderKey {
-                      page:    *page,
-                      density: 0,
-                      ext:     "svg",
-                    };
-                    let svg_res = crate::graphics_cache::with_cache_dims(
-                      source,
-                      abs_svg,
-                      svg_key,
-                      || {
-                        subproc_ref.fetch_add(1, Ordering::Relaxed);
-                        Self::convert_image_svg(source, abs_svg, *page)
-                      },
-                      || {
-                        Self::read_svg_dimensions(abs_svg)
-                          .map(|(w, h)| crate::graphics_cache::CachedDims { width: w, height: h })
-                      },
-                    );
-                    match svg_res {
-                      crate::graphics_cache::ConvertResult::Ok { dims } => Some(ConvertOutcome {
-                        job_id:   *job_id,
-                        imagesrc: Some(rel_svg.clone()),
-                        raw_dims: dims.map(|d| (d.width, d.height)),
-                      }),
-                      crate::graphics_cache::ConvertResult::Failed => {
-                        Warn!(
-                          "shell",
-                          "inkscape",
-                          "Graphics: inkscape SVG path failed for {}, falling back to convert",
-                          source
-                        );
-                        None
-                      },
+                // Capture this worker's diagnostics and hand them back on join.
+                // LOG_BUFFER + REPORT are #[thread_local], so an Error!/Warn! a
+                // conversion raises on this worker would otherwise be lost from
+                // cortex.log AND from status_code. The main thread replays them
+                // (text + count deltas) in worker order after the scope joins.
+                latexml_core::util::logger::capture(|| {
+                  let mut local = Vec::<ConvertOutcome>::new();
+                  loop {
+                    let i = next.fetch_add(1, Ordering::Relaxed);
+                    if i >= jobs.len() {
+                      break;
                     }
-                  } else {
-                    None
-                  };
-                  let raster_res = if svg_outcome.is_none() {
-                    let raster_key = crate::graphics_cache::RenderKey {
-                      page:    *page,
-                      density: Self::raster_density_for_source(source),
-                      ext:     ext_from_path(abs_dest_str),
-                    };
-                    crate::graphics_cache::with_cache_dims(
+                    let ConvertJob {
+                      job_id,
                       source,
+                      page,
+                      rel_dest,
                       abs_dest_str,
-                      raster_key,
-                      || {
-                        subproc_ref.fetch_add(1, Ordering::Relaxed);
-                        Self::convert_image(source, abs_dest_str, dpi, *page)
-                      },
-                      || {
-                        Self::read_image_dimensions(abs_dest_str)
-                          .map(|(w, h)| crate::graphics_cache::CachedDims { width: w, height: h })
-                      },
-                    )
-                  } else {
-                    crate::graphics_cache::ConvertResult::Failed
-                  };
-                  let outcome = if let Some(o) = svg_outcome {
-                    o
-                  } else if raster_res.is_ok() {
-                    ConvertOutcome {
-                      job_id:   *job_id,
-                      imagesrc: Some(rel_dest.clone()),
-                      raw_dims: raster_res.dims().map(|d| (d.width, d.height)),
-                    }
-                  } else {
-                    // Final-failure: every conversion path exhausted. Mirror
-                    // Perl Graphics.pm L324-329 (Error + `return` with NO
-                    // imagesrc) — do NOT fall back to copying the raw source.
-                    // A raw .eps/.ps/.pdf is never usable on the web; copying it
-                    // would emit a broken `<img src="fig.eps">`. Leaving
-                    // @imagesrc unset makes the HTML5 XSLT
-                    // (LaTeXML-misc-xhtml.xsl L154) render the node as
-                    // `class="ltx_missing ltx_missing_image"` (empty src) — the
-                    // correct "couldn't render" signal. (User directive
-                    // 2026-06-22; raw .eps/.pdf are never web-native.)
-                    // Error class/object mirror Perl Graphics.pm:274 so the
-                    // harness aggregates with engine/package emissions.
-                    Error!(
-                      "imageprocessing",
-                      source,
-                      "Graphics: Failed to convert {} to {}",
-                      source,
-                      abs_dest_str
-                    );
-                    ConvertOutcome {
-                      job_id:   *job_id,
-                      imagesrc: None,
-                      raw_dims: None,
-                    }
-                  };
-                  local.push(outcome);
-                }
-                local
+                      svg_paths,
+                    } = jobs[i];
+                    // Try vector-SVG path first if requested for this source.
+                    // The cache layer (graphics_cache) hardlinks/copies a
+                    // matching cached output before any subprocess fires and
+                    // round-trips the dimensions through a .dims sidecar so
+                    // hits skip the `read_*_dimensions` re-measure too.
+                    // Misses fall through to the real conversion + measure
+                    // and write back on success. Disable via
+                    // LATEXML_GRAPHICS_CACHE_OFF=1.
+                    let svg_outcome = if let Some((rel_svg, abs_svg)) = svg_paths {
+                      let svg_key = crate::graphics_cache::RenderKey {
+                        page:    *page,
+                        density: 0,
+                        ext:     "svg",
+                      };
+                      let svg_res = crate::graphics_cache::with_cache_dims(
+                        source,
+                        abs_svg,
+                        svg_key,
+                        || {
+                          subproc_ref.fetch_add(1, Ordering::Relaxed);
+                          Self::convert_image_svg(source, abs_svg, *page)
+                        },
+                        || {
+                          Self::read_svg_dimensions(abs_svg).map(|(w, h)| {
+                            crate::graphics_cache::CachedDims { width: w, height: h }
+                          })
+                        },
+                      );
+                      match svg_res {
+                        crate::graphics_cache::ConvertResult::Ok { dims } => Some(ConvertOutcome {
+                          job_id:   *job_id,
+                          imagesrc: Some(rel_svg.clone()),
+                          raw_dims: dims.map(|d| (d.width, d.height)),
+                        }),
+                        crate::graphics_cache::ConvertResult::Failed => {
+                          Warn!(
+                            "shell",
+                            "inkscape",
+                            "Graphics: inkscape SVG path failed for {}, falling back to convert",
+                            source
+                          );
+                          None
+                        },
+                      }
+                    } else {
+                      None
+                    };
+                    let raster_res = if svg_outcome.is_none() {
+                      let raster_key = crate::graphics_cache::RenderKey {
+                        page:    *page,
+                        density: Self::raster_density_for_source(source),
+                        ext:     ext_from_path(abs_dest_str),
+                      };
+                      crate::graphics_cache::with_cache_dims(
+                        source,
+                        abs_dest_str,
+                        raster_key,
+                        || {
+                          subproc_ref.fetch_add(1, Ordering::Relaxed);
+                          Self::convert_image(source, abs_dest_str, dpi, *page)
+                        },
+                        || {
+                          Self::read_image_dimensions(abs_dest_str).map(|(w, h)| {
+                            crate::graphics_cache::CachedDims { width: w, height: h }
+                          })
+                        },
+                      )
+                    } else {
+                      crate::graphics_cache::ConvertResult::Failed
+                    };
+                    let outcome = if let Some(o) = svg_outcome {
+                      o
+                    } else if raster_res.is_ok() {
+                      ConvertOutcome {
+                        job_id:   *job_id,
+                        imagesrc: Some(rel_dest.clone()),
+                        raw_dims: raster_res.dims().map(|d| (d.width, d.height)),
+                      }
+                    } else {
+                      // Final-failure: every conversion path exhausted. Mirror
+                      // Perl Graphics.pm L324-329 (Error + `return` with NO
+                      // imagesrc) — do NOT fall back to copying the raw source.
+                      // A raw .eps/.ps/.pdf is never usable on the web; copying it
+                      // would emit a broken `<img src="fig.eps">`. Leaving
+                      // @imagesrc unset makes the HTML5 XSLT
+                      // (LaTeXML-misc-xhtml.xsl L154) render the node as
+                      // `class="ltx_missing ltx_missing_image"` (empty src) — the
+                      // correct "couldn't render" signal. (User directive
+                      // 2026-06-22; raw .eps/.pdf are never web-native.)
+                      // Error class/object mirror Perl Graphics.pm:274 so the
+                      // harness aggregates with engine/package emissions.
+                      // Object is the failure TYPE (not the filename) so the
+                      // harness can aggregate by failure mode; the filenames are
+                      // in the details that follow.
+                      Error!(
+                        "imageprocessing",
+                        "failed_to_convert",
+                        "Graphics: Failed to convert {} to {}",
+                        source,
+                        abs_dest_str
+                      );
+                      ConvertOutcome {
+                        job_id:   *job_id,
+                        imagesrc: None,
+                        raw_dims: None,
+                      }
+                    };
+                    local.push(outcome);
+                  }
+                  local
+                })
               })
               .ok()
           })
@@ -2189,8 +2205,12 @@ impl Processor for Graphics {
         // enough to complete all jobs.
         handles.into_iter().map(|h| h.join().unwrap()).collect()
       });
-      for v in worker_outcomes {
+      // Merge each worker's outcomes AND replay its captured diagnostics on the
+      // main thread (in worker order), so any conversion Error!/Warn! reaches the
+      // bound cortex.log and registers in the main REPORT / status_code.
+      for (v, diags) in worker_outcomes {
         outcomes.extend(v);
+        latexml_core::util::logger::replay_captured(diags);
       }
       outcomes.sort_by_key(|o| o.job_id);
       latexml_core::telemetry::add_graphics_subprocess(subproc_count.load(Ordering::Relaxed));
@@ -2617,5 +2637,70 @@ endobj
     assert_eq!(out.matches(r#"imagesrc="x1.png""#).count(), 1);
 
     std::fs::remove_dir_all(&tmp).ok();
+  }
+
+  /// A post-processing diagnostic raised on a WORKER THREAD must reach the MAIN
+  /// thread's bound log AND register in the main `REPORT` status counters — both
+  /// `LOG_BUFFER` and `REPORT` are `#[thread_local]`, so a worker's `Error!`
+  /// would otherwise be lost from cortex.log and from `status_code`. This
+  /// exercises the exact "thread join + fold" the graphics pool uses: each
+  /// worker returns its [`CapturedDiagnostics`] from `logger::capture`, and the
+  /// main thread folds them in via `replay_captured` after join — no shared
+  /// writeable state, no lock, no env mutation. (Companion: the real pipeline is
+  /// validated end-to-end by converting a document with an unconvertible image;
+  /// see docs and the manual `--preload`/`--dest` smoke.)
+  #[test]
+  fn worker_diagnostics_fold_into_main_thread_on_join() {
+    // The `log` macros are inert until a logger + level are installed (the
+    // CLI/cortex do this at startup). `init` is process-global + idempotent
+    // across tests; force the level since `init` skips it if already installed.
+    let _ = latexml_core::util::logger::init(log::LevelFilter::Info);
+    log::set_max_level(log::LevelFilter::Info);
+
+    latexml_core::util::logger::bind_log();
+    let before = latexml_core::common::error::snapshot_report_counts();
+
+    // Two workers, each emitting a post Error! under capture (so the diagnostic
+    // lands in the worker's own thread-local buffer + REPORT), returning their
+    // CapturedDiagnostics on join — exactly the graphics pool's pattern.
+    let captured: Vec<latexml_core::util::logger::CapturedDiagnostics> = std::thread::scope(|s| {
+      (0..2)
+        .map(|i| {
+          s.spawn(move || {
+            latexml_core::util::logger::capture(|| {
+              Error!(
+                "imageprocessing",
+                "failed_to_convert",
+                "Graphics: Failed to convert {} to {}",
+                format!("w{i}.pdf"),
+                format!("w{i}.png")
+              );
+            })
+            .1
+          })
+        })
+        .collect::<Vec<_>>()
+        .into_iter()
+        .map(|h| h.join().unwrap())
+        .collect()
+    });
+
+    // Fold the per-worker diagnostics into the main thread.
+    for diags in captured {
+      latexml_core::util::logger::replay_captured(diags);
+    }
+
+    let after = latexml_core::common::error::snapshot_report_counts();
+    let log = latexml_core::util::logger::flush_log();
+
+    assert!(
+      log.contains("imageprocessing:failed_to_convert") && log.contains("Failed to convert"),
+      "worker Error! must reach the main-thread log; got: {log:?}"
+    );
+    assert_eq!(
+      after.error,
+      before.error + 2,
+      "both workers' Error! must increment the main REPORT error count via the fold"
+    );
   }
 }

--- a/latexml_post/src/graphics.rs
+++ b/latexml_post/src/graphics.rs
@@ -2196,12 +2196,16 @@ impl Processor for Graphics {
                       // Error class/object mirror Perl Graphics.pm:274 so the
                       // harness aggregates with engine/package emissions.
                       // Object is the failure TYPE (not the filename) so the
-                      // harness can aggregate by failure mode; the filenames are
-                      // in the details that follow.
+                      // harness can aggregate by failure mode. The message marks
+                      // the SOURCE asset (the input that failed) as the subject —
+                      // NOT the target — so the log clearly identifies which
+                      // input could not be rendered; the intended target is
+                      // secondary context.
                       Error!(
                         "imageprocessing",
                         "failed_to_convert",
-                        "Graphics: Failed to convert {} to {}",
+                        "Graphics: failed to convert source asset {} — every converter \
+                         failed, no usable image produced (intended target {})",
                         source,
                         abs_dest_str
                       );

--- a/latexml_post/src/graphics.rs
+++ b/latexml_post/src/graphics.rs
@@ -18,6 +18,27 @@ use crate::{
   processor::{ProcessResult, Processor},
 };
 
+thread_local! {
+  /// The most recent converter-subprocess diagnostic on this thread: the program
+  /// name plus its captured stderr (or the spawn error). Surfaced into the
+  /// `imageprocessing:failed_to_convert` Error so an ENVIRONMENT failure is
+  /// self-explaining in the log instead of needing a strace — e.g. `gs` not
+  /// installed (`could not start … No such file or directory`), an AppArmor
+  /// denial (`gs: … /undefinedfilename …` while gs exits 0), or an ImageMagick
+  /// policy block. Set by `run_with_timeout`, cleared per node in `process`'s
+  /// worker loop, read+cleared at the Error site. Worker-thread-local — it rides
+  /// the same `logger::capture`/`replay_captured` fold to the main thread as the
+  /// Error itself.
+  static LAST_CONVERTER_DIAG: std::cell::RefCell<Option<String>> =
+    const { std::cell::RefCell::new(None) };
+}
+
+/// Record (overwrite) the latest converter diagnostic on this thread.
+fn record_converter_diag(msg: String) { LAST_CONVERTER_DIAG.with(|c| *c.borrow_mut() = Some(msg)); }
+
+/// Take (read + clear) this thread's latest converter diagnostic.
+fn take_converter_diag() -> Option<String> { LAST_CONVERTER_DIAG.with(|c| c.borrow_mut().take()) }
+
 // Diagnostic emission: `Error!` (and friends) live in
 // `crate::diag` and are exposed crate-wide via `#[macro_use] pub mod
 // diag;` in `lib.rs`. They emit harness-compatible structured Error
@@ -892,10 +913,15 @@ impl Graphics {
     mut cmd: std::process::Command,
     timeout: std::time::Duration,
   ) -> Option<std::process::ExitStatus> {
-    // Redirect stdio so a slow inkscape doesn't block on a full pipe.
+    // Capture the program name for the failure diagnostic before `cmd` is moved.
+    let prog = cmd.get_program().to_string_lossy().into_owned();
+    // stdout is uninteresting (null); stderr is PIPED so a converter's error text
+    // (gs `/undefinedfilename`, an ImageMagick policy block, a missing delegate)
+    // can be surfaced into the failed_to_convert Error. A draining reader thread
+    // (below) keeps the child from blocking on a full stderr pipe.
     cmd
       .stdout(std::process::Stdio::null())
-      .stderr(std::process::Stdio::null());
+      .stderr(std::process::Stdio::piped());
     #[cfg(unix)]
     {
       use std::os::unix::process::CommandExt;
@@ -932,7 +958,35 @@ impl Graphics {
         });
       }
     }
-    let mut child = cmd.spawn().ok()?;
+    let mut child = match cmd.spawn() {
+      Ok(c) => c,
+      Err(e) => {
+        // Spawn failure is the "converter not installed / not on PATH" case
+        // (e.g. `gs` absent in a minimal image): record it so the Error names
+        // the missing tool instead of a bare "failed to convert".
+        record_converter_diag(format!("could not start `{prog}`: {e}"));
+        return None;
+      },
+    };
+    // Drain stderr concurrently into a bounded (8 KiB) buffer so the child never
+    // blocks on a full pipe; joined after it exits.
+    let stderr_reader = child.stderr.take().map(|mut se| {
+      std::thread::spawn(move || {
+        use std::io::Read;
+        let mut kept: Vec<u8> = Vec::new();
+        let mut chunk = [0u8; 4096];
+        while let Ok(n) = se.read(&mut chunk) {
+          if n == 0 {
+            break;
+          }
+          if kept.len() < 8192 {
+            let room = 8192 - kept.len();
+            kept.extend_from_slice(&chunk[..n.min(room)]);
+          }
+        }
+        String::from_utf8_lossy(&kept).trim().to_string()
+      })
+    });
     let pid = child.id() as i32;
     let kill_group = || {
       #[cfg(unix)]
@@ -959,15 +1013,15 @@ impl Graphics {
       }
     };
     let start = std::time::Instant::now();
-    loop {
+    let status = loop {
       match child.try_wait() {
-        Ok(Some(status)) => return Some(status),
+        Ok(Some(status)) => break Some(status),
         Ok(None) => {
           if start.elapsed() >= timeout {
             kill_group();
             let _ = child.kill();
             let _ = child.wait();
-            return None;
+            break None;
           }
           std::thread::sleep(std::time::Duration::from_millis(50));
         },
@@ -975,10 +1029,27 @@ impl Graphics {
           kill_group();
           let _ = child.kill();
           let _ = child.wait();
-          return None;
+          break None;
         },
       }
+    };
+    // Join the stderr drainer and record a diagnostic. gs can print a fatal
+    // error (e.g. `/undefinedfilename` under an AppArmor denial) to stderr yet
+    // still exit 0, so a non-empty stderr is always worth surfacing — not only
+    // on a non-zero exit.
+    let stderr_text = stderr_reader
+      .and_then(|h| h.join().ok())
+      .unwrap_or_default();
+    if !stderr_text.is_empty() {
+      record_converter_diag(format!("`{prog}`: {stderr_text}"));
+    } else if status.map(|s| !s.success()).unwrap_or(true) {
+      let how = match status {
+        Some(s) => format!("exited {s}"),
+        None => format!("timed out after {}s / killed", timeout.as_secs()),
+      };
+      record_converter_diag(format!("`{prog}`: {how}, no stderr"));
     }
+    status
   }
 
   /// Parse SVG viewBox ("minX minY width height") and return (width, height).
@@ -2104,6 +2175,10 @@ impl Processor for Graphics {
                       abs_dest_str,
                       svg_paths,
                     } = jobs[i];
+                    // Fresh converter-diagnostic slate for this node, so the
+                    // failed_to_convert Error (if it fires) reports THIS asset's
+                    // converter error, not a previous job's.
+                    take_converter_diag();
                     // Try vector-SVG path first if requested for this source.
                     // The cache layer (graphics_cache) hardlinks/copies a
                     // matching cached output before any subprocess fires and
@@ -2201,13 +2276,20 @@ impl Processor for Graphics {
                       // NOT the target — so the log clearly identifies which
                       // input could not be rendered; the intended target is
                       // secondary context.
+                      // Surface the last converter's stderr / spawn error so an
+                      // environment failure (gs not installed, AppArmor denial,
+                      // ImageMagick policy block) is self-diagnosing in the log.
+                      let why = take_converter_diag()
+                        .unwrap_or_else(|| "no converter diagnostic captured".to_string());
                       Error!(
                         "imageprocessing",
                         "failed_to_convert",
                         "Graphics: failed to convert source asset {} — every converter \
-                         failed, no usable image produced (intended target {})",
+                         failed, no usable image produced (intended target {}); last \
+                         converter error: {}",
                         source,
-                        abs_dest_str
+                        abs_dest_str,
+                        why
                       );
                       ConvertOutcome {
                         job_id:   *job_id,
@@ -2758,5 +2840,39 @@ endobj
       "a non-empty file is usable output"
     );
     std::fs::remove_dir_all(&tmp).ok();
+  }
+
+  /// A converter that fails must leave its stderr in the thread-local diagnostic,
+  /// so the failed_to_convert Error can name WHY (e.g. gs `/undefinedfilename`).
+  #[test]
+  fn run_with_timeout_captures_stderr_into_diag() {
+    take_converter_diag(); // clear
+    let mut cmd = std::process::Command::new("sh");
+    cmd.arg("-c").arg("echo 'boom on stderr' >&2; exit 3");
+    let status = Graphics::run_with_timeout(cmd, std::time::Duration::from_secs(5));
+    assert!(
+      status.map(|s| !s.success()).unwrap_or(false),
+      "command should report failure"
+    );
+    let diag = take_converter_diag().expect("a diagnostic must be recorded");
+    assert!(
+      diag.contains("boom on stderr") && diag.contains("sh"),
+      "diag should name the program + its stderr; got: {diag}"
+    );
+  }
+
+  /// A converter that can't be spawned (not installed / not on PATH — e.g. `gs`
+  /// missing in a minimal image) must record a "could not start" diagnostic.
+  #[test]
+  fn run_with_timeout_records_spawn_failure() {
+    take_converter_diag();
+    let cmd = std::process::Command::new("definitely_not_a_real_binary_xyz_123");
+    let status = Graphics::run_with_timeout(cmd, std::time::Duration::from_secs(5));
+    assert!(status.is_none(), "spawn failure returns None");
+    let diag = take_converter_diag().expect("a spawn diagnostic must be recorded");
+    assert!(
+      diag.contains("could not start") && diag.contains("definitely_not_a_real_binary_xyz_123"),
+      "diag should name the missing tool; got: {diag}"
+    );
   }
 }

--- a/latexml_post/src/graphics.rs
+++ b/latexml_post/src/graphics.rs
@@ -48,10 +48,10 @@ fn take_converter_diag() -> Option<String> { LAST_CONVERTER_DIAG.with(|c| c.borr
 // Process-once cached env var (see WISDOM #56 — getenv hot-path race).
 // Parsed-and-validated at init: only positive integer values are
 // honored; everything else (unset, empty, "0", malformed) leaves
-// `INKSCAPE_TIMEOUT_SECS` at None and the caller falls back to the
-// 15-second default in `inkscape_timeout_secs`.
-static INKSCAPE_TIMEOUT_SECS: LazyLock<Option<u64>> = LazyLock::new(|| {
-  std::env::var("LATEXML_INKSCAPE_TIMEOUT_SECS")
+// `SVG_CONVERT_TIMEOUT_SECS` at None and the caller falls back to the
+// 15-second default in `svg_convert_timeout_secs`.
+static SVG_CONVERT_TIMEOUT_SECS: LazyLock<Option<u64>> = LazyLock::new(|| {
+  std::env::var("LATEXML_SVG_CONVERT_TIMEOUT_SECS")
     .ok()
     .and_then(|s| s.parse::<u64>().ok())
     .filter(|&n| n > 0)
@@ -59,7 +59,7 @@ static INKSCAPE_TIMEOUT_SECS: LazyLock<Option<u64>> = LazyLock::new(|| {
 
 /// Wall-clock timeout for the `convert` (ImageMagick / gs) subprocess.
 /// Defaults to 60 s; override via `LATEXML_CONVERT_TIMEOUT_SECS`. Same
-/// pattern as `INKSCAPE_TIMEOUT_SECS` — see WISDOM #56.
+/// pattern as `SVG_CONVERT_TIMEOUT_SECS` — see WISDOM #56.
 static CONVERT_TIMEOUT_SECS: LazyLock<Option<u64>> = LazyLock::new(|| {
   std::env::var("LATEXML_CONVERT_TIMEOUT_SECS")
     .ok()
@@ -124,8 +124,9 @@ pub struct Graphics {
   type_properties:  HashMap<String, TypeProperties>,
   background:       String,
   /// Opt-in vector-SVG path for PDF graphics. When > 0, PDFs under this
-  /// many KB are first attempted via `inkscape`; fall back to ImageMagick
-  /// `convert` on failure or timeout. 0 disables the path entirely.
+  /// many KB are first attempted via the vector converters (mutool, then
+  /// pdftocairo); fall back to the raster (`convert`/`gs` → PNG) path on
+  /// failure or timeout. 0 disables the path entirely.
   /// Tracks upstream brucemiller/LaTeXML#902.
   svg_threshold_kb: u32,
 }
@@ -695,84 +696,47 @@ impl Graphics {
     None
   }
 
-  /// Try to convert a PDF to plain SVG via `inkscape`, preserving vector
-  /// content. Returns `true` on success. Tracks upstream
-  /// brucemiller/LaTeXML#902.
+  /// Try to convert a PDF to plain SVG, preserving vector content. Returns
+  /// `true` on success. Tracks upstream brucemiller/LaTeXML#902.
   ///
   /// Caller decides when to attempt this — typically only for PDF sources
-  /// below a file-size threshold, because inkscape on raster-embedded PDFs
-  /// produces massive output (>100 MB) and can take 40+ seconds
-  /// (measured: Fade.pdf 1.7 MB → 46 s / 102 MB SVG vs `convert` 1.4 s /
-  /// 61 KB PNG).
+  /// below a file-size threshold (`should_try_svg_path`), because vector
+  /// converters on raster-embedded PDFs produce massive output (>100 MB).
+  /// On any failure the function returns `false` and the worker falls back
+  /// to the raster (PNG) path — so a PDF that no vector tool can handle is
+  /// never lost, just rasterized instead.
   ///
-  /// `page` is 1-based (graphicx convention); converted to 0-based for
-  /// inkscape's `--pdf-page`.
+  /// `page` is 1-based (graphicx convention).
   ///
-  /// Guarded by a **hard timeout** (15 s default; see
-  /// `inkscape_timeout_secs`). Pathological small-PDF cases have been
-  /// observed — if inkscape is still running after the deadline we SIGKILL
-  /// it and return `false` so the caller falls back to ImageMagick. The
-  /// timeout is generous enough (15 s) for all well-behaved small vector
-  /// plots and strict enough to prevent the 46 s+ runaway behaviour seen
-  /// on Fade.pdf-class inputs.
+  /// Each converter is guarded by a **hard timeout** (15 s default; see
+  /// `svg_convert_timeout_secs`) and an output-size cap
+  /// (`MAX_SVG_OUTPUT_BYTES`): a converter still running after the deadline
+  /// is SIGKILLed, and oversized output is discarded — either way we fall
+  /// through to the next converter, then to raster.
   fn convert_image_svg(source: &str, dest: &str, page: Option<u32>) -> bool {
-    // Try fast vector rasterizers in order of measured speed +
+    // Try the two fast vector converters in order of measured speed +
     // gzip-compressibility on the canvas slow-tail. Each is gated by
     // `MAX_SVG_OUTPUT_BYTES`; pathological vector-heavy PDFs (e.g.
-    // R-Graphics `W.pdf`) can emit >100 MB SVG which we discard so
-    // the caller falls back to raster.
+    // R-Graphics `W.pdf`) can emit >100 MB SVG which we discard so the
+    // caller falls back to raster.
     //
     // Order (subprocess; library license doesn't propagate):
     //   1. mutool (MuPDF CLI) — fastest, plus ~4× more gzip-compressible SVG output than pdftocairo
     //      (1.5 MB vs 6.0 MB gz on matplotlib scatter).
-    //   2. pdftocairo (poppler) — universally available with TeX Live. 20-40× faster than inkscape
-    //      on benign vector PDFs.
-    //   3. inkscape — last vector resort. Some PDFs that fail poppler still render via inkscape
-    //      (but it can time out).
+    //   2. pdftocairo (poppler) — universally available with TeX Live; parses vector PDFs directly,
+    //      so it's fast even on the inputs that make ImageMagick/gs rasterization crawl.
+    //
+    // A heavyweight third resort (inkscape) was removed deliberately: it
+    // pulls a GTK/X11 stack, is 20-40× slower, and is timeout-prone, while
+    // adding no real coverage — when both converters above fail, the worker
+    // rasterizes to PNG anyway.
     if Self::convert_image_svg_mutool(source, dest, page) {
       return true;
     }
     if Self::convert_image_svg_pdftocairo(source, dest, page) {
       return true;
     }
-    let mut cmd = std::process::Command::new("inkscape");
-    cmd
-      .arg("--export-type=svg")
-      .arg("--export-plain-svg")
-      .arg(format!("--export-filename={}", dest));
-    if let Some(p) = page {
-      cmd.arg(format!("--pdf-page={}", p.saturating_sub(1)));
-    }
-    cmd.arg(source);
-    let timeout = std::time::Duration::from_secs(Self::inkscape_timeout_secs());
-    match Self::run_with_timeout(cmd, timeout) {
-      Some(status) => {
-        if !(status.success() && Path::new(dest).exists()) {
-          return false;
-        }
-        // Reject pathological inkscape output that explodes to >100 MB
-        // — keep the dest hole open so the worker falls back to raster.
-        if Self::svg_output_too_large(dest) {
-          let _ = std::fs::remove_file(dest);
-          return false;
-        }
-        true
-      },
-      None => {
-        // Subprocess wall-clock timeout; class=`shell` mirrors Perl
-        // LaTeXImages.pm:293 `Error('shell', $cmd, …)`.
-        Warn!(
-          "shell",
-          "inkscape",
-          "Graphics: inkscape SVG conversion for {} exceeded {} s — killed",
-          source,
-          timeout.as_secs()
-        );
-        // Best-effort cleanup of a partial output.
-        let _ = std::fs::remove_file(dest);
-        false
-      },
-    }
+    false
   }
 
   /// Maximum acceptable SVG output size from a vector conversion. Above
@@ -828,7 +792,7 @@ impl Graphics {
       .arg(&tmp_pattern_str)
       .arg(source)
       .arg(p1.to_string());
-    let timeout = std::time::Duration::from_secs(Self::inkscape_timeout_secs());
+    let timeout = std::time::Duration::from_secs(Self::svg_convert_timeout_secs());
     let ok = Self::run_with_timeout(cmd, timeout)
       .map(|status| status.success())
       .unwrap_or(false)
@@ -854,10 +818,10 @@ impl Graphics {
   }
 
   /// `pdftocairo -svg` rasterizes the page's vector content to SVG via
-  /// poppler/cairo. Much faster than inkscape on the kind of vector PDFs
-  /// matplotlib/pgfplots produce. Returns true ONLY if the output is
-  /// reasonably-sized; otherwise we discard and let the caller try
-  /// inkscape (which sometimes simplifies further).
+  /// poppler/cairo — the second-choice vector converter after mutool, and
+  /// universally available with TeX Live. Returns true ONLY if the output
+  /// is reasonably-sized; otherwise we discard it and the caller falls
+  /// through to the raster (PNG) path.
   fn convert_image_svg_pdftocairo(source: &str, dest: &str, page: Option<u32>) -> bool {
     let mut cmd = std::process::Command::new("pdftocairo");
     cmd.arg("-svg");
@@ -872,7 +836,7 @@ impl Graphics {
       cmd.arg("-f").arg("1").arg("-l").arg("1");
     }
     cmd.arg(source).arg(dest);
-    let timeout = std::time::Duration::from_secs(Self::inkscape_timeout_secs());
+    let timeout = std::time::Duration::from_secs(Self::svg_convert_timeout_secs());
     match Self::run_with_timeout(cmd, timeout) {
       Some(status) => {
         if !(status.success() && Path::new(dest).exists()) {
@@ -892,12 +856,12 @@ impl Graphics {
     }
   }
 
-  /// Hard timeout (seconds) for the `inkscape` subprocess. Overridable via
-  /// the `LATEXML_INKSCAPE_TIMEOUT_SECS` environment variable for
-  /// debugging; defaults to 15 s — enough for all benign vector-authored
-  /// plots we've measured (< 1 s typical), strict enough to cut off the
-  /// Fade.pdf-class 40 s+ runaway cases.
-  fn inkscape_timeout_secs() -> u64 { INKSCAPE_TIMEOUT_SECS.unwrap_or(15) }
+  /// Hard timeout (seconds) for a vector-SVG converter subprocess (mutool /
+  /// pdftocairo). Overridable via the `LATEXML_SVG_CONVERT_TIMEOUT_SECS`
+  /// environment variable for debugging; defaults to 15 s — enough for all
+  /// benign vector-authored plots we've measured (< 1 s typical), strict
+  /// enough to cut off the Fade.pdf-class 40 s+ runaway cases.
+  fn svg_convert_timeout_secs() -> u64 { SVG_CONVERT_TIMEOUT_SECS.unwrap_or(15) }
 
   /// Run `cmd` and enforce a wall-clock timeout. Returns `Some(status)` on
   /// clean exit, `None` if the child was killed on timeout or spawn
@@ -908,7 +872,7 @@ impl Graphics {
   /// Without that, ImageMagick's `convert` was spawning `gs` and dying
   /// on SIGKILL while leaving gs orphaned — those gs processes held on
   /// for 10+ minutes per pathological PDF and stalled large sandbox
-  /// runs. The same hardening protects inkscape / pdftocairo / ps2pdf.
+  /// runs. The same hardening protects mutool / pdftocairo / ps2pdf.
   fn run_with_timeout(
     mut cmd: std::process::Command,
     timeout: std::time::Duration,
@@ -938,7 +902,7 @@ impl Graphics {
           // process group, so if the process running `run_with_timeout` is
           // itself killed (e.g. the LSP server SIGKILLs a preempted body
           // child mid-post-processing), nothing would ever time out or kill
-          // a runaway gs/inkscape — the exact orphan pathology this
+          // a runaway gs/convert — the exact orphan pathology this
           // function's group-kill solves, reintroduced one level up.
           // PR_SET_PDEATHSIG makes the kernel SIGKILL the converter when its
           // spawning thread dies; it survives execve, so setting it here
@@ -1127,9 +1091,9 @@ impl Graphics {
   /// `LATEXML_GRAPHICS_VECTOR_AUTO_OFF=1` (auto-detect only — leaves
   /// the explicit-threshold path active).
   ///
-  /// Safety net: any false positive falls back to ImageMagick when
-  /// inkscape emits >`MAX_SVG_OUTPUT_BYTES` (8 MB) of SVG, so a misread
-  /// raster PDF degrades to "tried SVG, got too-big output, used
+  /// Safety net: any false positive falls back to the raster path when a
+  /// vector converter emits >`MAX_SVG_OUTPUT_BYTES` (8 MB) of SVG, so a
+  /// misread raster PDF degrades to "tried SVG, got too-big output, used
   /// convert" instead of a stuck pipeline.
   fn should_try_svg_path(source: &str, threshold_kb: u32) -> bool {
     if !source.to_lowercase().ends_with(".pdf") {
@@ -1152,7 +1116,7 @@ impl Graphics {
     };
     // Hard upper bound: even if the detector misses an image
     // somewhere deeper in the file, a 500 KB cap keeps the
-    // worst-case wasted inkscape work bounded (~1-2 s before the
+    // worst-case wasted vector-conversion work bounded (~1-2 s before the
     // 8 MB output cap kicks in or the conversion finishes anyway).
     const AUTO_MAX_BYTES: u64 = 500 * 1024;
     if len > AUTO_MAX_BYTES {
@@ -1288,7 +1252,7 @@ impl Graphics {
   /// `-f`/`-l` page selector. Empirical: for vector-heavy PDFs (e.g.
   /// R-Graphics output) `pdftocairo` rasterizes 25× faster than
   /// ImageMagick-via-Ghostscript and produces a clean PNG, where the
-  /// inkscape SVG path explodes to >100 MB and `convert`/`gs` runs into
+  /// vector-SVG path explodes to >100 MB and `convert`/`gs` runs into
   /// tens of seconds on a single page.
   fn should_try_pdf_cairo_path(source: &str) -> bool { source.to_lowercase().ends_with(".pdf") }
 
@@ -1670,7 +1634,7 @@ impl Graphics {
     }
     // Wall-clock timeout to bound `gs`-via-`convert` runaways on
     // pathological PDFs (raster-heavy or with broken xref tables).
-    // Matches the inkscape path's defensive bound; without this, an
+    // Matches the vector-SVG path's defensive bound; without this, an
     // arbitrary `convert` invocation could run for minutes and stall
     // the entire post-processing phase. 60 s is enough for any
     // reasonably-sized graphic; tune via `LATEXML_CONVERT_TIMEOUT_SECS`.
@@ -1730,7 +1694,7 @@ impl Graphics {
   }
 
   /// Hard timeout (seconds) for the `convert` subprocess. Mirrors
-  /// `inkscape_timeout_secs`; default 60 s. Override via
+  /// `svg_convert_timeout_secs`; default 60 s. Override via
   /// `LATEXML_CONVERT_TIMEOUT_SECS` for debugging.
   fn convert_timeout_secs() -> u64 { CONVERT_TIMEOUT_SECS.unwrap_or(60) }
 }
@@ -1954,9 +1918,9 @@ impl Processor for Graphics {
       rel_dest:     String,
       abs_dest_str: String,
       /// `Some((rel_svg, abs_svg_str))` when the worker should
-      /// first attempt the inkscape-SVG path and only fall back
-      /// to `convert` on failure. `None` means the classic
-      /// raster-only path.
+      /// first attempt the vector-SVG path and only fall back
+      /// to the raster `convert` path on failure. `None` means
+      /// the classic raster-only path.
       svg_paths:    Option<(String, String)>,
     }
     struct ConvertOutcome {
@@ -2055,7 +2019,7 @@ impl Processor for Graphics {
           convert_source_counts.insert(source.clone(), prior_source_jobs + 1);
           // Vector-SVG path: opt-in for small PDFs only. We prepare an
           // alternate `.svg` destination path alongside the normal raster
-          // destination so the worker can try inkscape first, then fall
+          // destination so the worker can try the vector-SVG path first, then fall
           // back. The file-size heuristic gates this — see
           // `should_try_svg_path`.
           let try_svg = Self::should_try_svg_path(&source, self.svg_threshold_kb);
@@ -2216,8 +2180,8 @@ impl Processor for Graphics {
                         crate::graphics_cache::ConvertResult::Failed => {
                           Warn!(
                             "shell",
-                            "inkscape",
-                            "Graphics: inkscape SVG path failed for {}, falling back to convert",
+                            "svg",
+                            "Graphics: vector-SVG path failed for {}, falling back to raster",
                             source
                           );
                           None
@@ -2485,7 +2449,7 @@ mod tests {
 
   /// `run_with_timeout` kills the child and returns `None` when the
   /// process exceeds the deadline. Uses `sleep` as a stand-in for any
-  /// runaway subprocess (inkscape, convert, …).
+  /// runaway subprocess (convert, gs, mutool, …).
   #[test]
   fn run_with_timeout_kills_slow_child() {
     let start = std::time::Instant::now();

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -1213,47 +1213,10 @@ impl MakeBibliography {
       }
     }
 
-    // META_BLOCK: Note and External Links
-    if let Some(ref bibentry) = entry.bibentry {
-      // Note block
-      if !PostDocument::findnodes_foreign("ltx:bib-note", bibentry).is_empty() {
-        let notes = PostDocument::findnodes_foreign("ltx:bib-note", bibentry);
-        let content: Vec<NodeData> = notes
-          .iter()
-          .map(|n| NodeData::Text(n.get_content()))
-          .collect();
-        if !content.is_empty() {
-          let mut items = vec![NodeData::Text("Note: ".to_string())];
-          items.push(NodeData::Element {
-            tag:        "ltx:text".to_string(),
-            attributes: Some(HashMap::from_iter([(
-              "class".to_string(),
-              "ltx_bib_note".to_string(),
-            )])),
-            children:   content,
-          });
-          blocks.push(make_bibblock("", &items));
-        }
-      }
-      // External Links block
-      let links_xpath = "ltx:bib-links | ltx:bib-review | ltx:bib-identifier | ltx:bib-url";
-      let link_nodes = PostDocument::findnodes_foreign(links_xpath, bibentry);
-      if !link_nodes.is_empty() {
-        let link_items = format_links(doc, &link_nodes);
-        if !link_items.is_empty() {
-          let mut items = vec![NodeData::Text("External Links: ".to_string())];
-          items.push(NodeData::Element {
-            tag:        "ltx:text".to_string(),
-            attributes: Some(HashMap::from_iter([(
-              "class".to_string(),
-              "ltx_bib_links".to_string(),
-            )])),
-            children:   link_items,
-          });
-          blocks.push(make_bibblock("", &items));
-        }
-      }
-    }
+    // Note + External Links are part of every type's FMT_SPEC via the
+    // `meta_block` appended in get_fmt_spec, so the loop above already emits
+    // them. (A second, hard-coded copy here previously duplicated every
+    // entry's final Note/External-Links bibblock.)
 
     blocks
   }

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -2961,6 +2961,30 @@ fn strip_braces(s: &str) -> String {
   result
 }
 
+/// True if `s` is a single brace group wrapping its entire content, e.g.
+/// `{W3C Math Working Group}` — i.e. the opening brace's match is the final
+/// character. Used to detect brace-protected corporate author names.
+fn is_braced_group(s: &str) -> bool {
+  let s = s.trim();
+  if s.len() < 2 || !s.starts_with('{') || !s.ends_with('}') {
+    return false;
+  }
+  let mut depth = 0i32;
+  for (i, b) in s.bytes().enumerate() {
+    match b {
+      b'{' => depth += 1,
+      b'}' => {
+        depth -= 1;
+        if depth == 0 {
+          return i == s.len() - 1;
+        }
+      },
+      _ => {},
+    }
+  }
+  false
+}
+
 /// Parse BibTeX author field into individual author names.
 /// "Lastname, Firstname and Lastname2, Firstname2" → vec of (surname, givenname)
 fn parse_bib_authors(authors_str: &str) -> Vec<(String, String)> {
@@ -2970,6 +2994,15 @@ fn parse_bib_authors(authors_str: &str) -> Vec<(String, String)> {
   for part in parts {
     let part = part.trim();
     if part.is_empty() {
+      continue;
+    }
+    // Corporate/institutional author wrapped in braces, e.g.
+    // `{W3C Math Working Group}`. BibTeX treats a fully brace-protected name as
+    // a single unit (a "last" name with no first/von parts), so keep it verbatim
+    // as the surname instead of splitting "last word = surname" (which produced
+    // "W. M. W. Group"). Witness 2605.16562.
+    if is_braced_group(part) {
+      result.push((strip_braces(part).trim().to_string(), String::new()));
       continue;
     }
     let clean = strip_braces(part);

--- a/latexml_post/tests/integration.rs
+++ b/latexml_post/tests/integration.rs
@@ -151,27 +151,42 @@ fn test_namespace_registration() {
   );
 }
 
+/// True if a vector-SVG converter (`mutool` or `pdftocairo`) is on PATH.
+/// The Graphics vector-SVG path tries mutool first, then pdftocairo; if
+/// neither is installed the path can't fire and these tests self-skip.
+///
+/// Presence is detected by whether the binary *spawns* (`output().is_ok()`),
+/// NOT by exit status: unlike inkscape, `mutool`/`pdftocairo` exit non-zero
+/// on `--version` (unknown/usage), so a `status.success()` gate would
+/// silently skip even when the tool is installed — a false-negative that
+/// would mask the coverage entirely.
+fn svg_converter_available() -> bool {
+  ["mutool", "pdftocairo"].iter().any(|tool| {
+    std::process::Command::new(tool)
+      .arg("--version")
+      .output()
+      .is_ok()
+  })
+}
+
 /// Regression test for the vector-SVG graphics path (opt-in via
 /// `--graphics-svg-threshold-kb N`). Uses the cifar10 plot PDF from the
 /// upstream [brucemiller/LaTeXML#902](https://github.com/brucemiller/LaTeXML/issues/902)
-/// thread — a 41 KB vector-authored matplotlib chart that's the canonical
-/// "inkscape preserves vectors better than ImageMagick" example.
+/// thread — a 41 KB vector-authored matplotlib chart exercising the
+/// vector-SVG converters (mutool → pdftocairo) that preserve vectors
+/// rather than rasterizing via ImageMagick.
 ///
 /// Test behaviour:
-/// - If `inkscape` is missing from PATH, the test exits silently. This keeps the suite green on
-///   minimal runners; CI installs inkscape so the branch is covered on GH Actions.
-/// - If `inkscape` is present, exercise the Graphics processor with `svg_threshold_kb = 200` and
-///   assert the output is a real SVG file.
+/// - If no vector converter (mutool/pdftocairo) is on PATH, the test exits silently. This keeps the
+///   suite green on minimal runners; CI installs poppler/mupdf so the branch is covered on GH Actions.
+/// - Otherwise, exercise the Graphics processor with `svg_threshold_kb = 200` and assert the output
+///   is a real SVG file.
 #[test]
 fn test_vector_svg_graphics_path() {
-  if std::process::Command::new("inkscape")
-    .arg("--version")
-    .output()
-    .ok()
-    .filter(|o| o.status.success())
-    .is_none()
-  {
-    eprintln!("inkscape not installed; skipping vector-SVG regression test");
+  if !svg_converter_available() {
+    eprintln!(
+      "no vector-SVG converter (mutool/pdftocairo) on PATH; skipping vector-SVG regression test"
+    );
     return;
   }
 
@@ -213,7 +228,7 @@ fn test_vector_svg_graphics_path() {
   let svg_path = work.join("cifar10_vector.svg");
   assert!(
     svg_path.exists(),
-    "expected SVG at {} — inkscape path should have fired for a 41 KB vector PDF",
+    "expected SVG at {} — the vector-SVG path should have fired for a 41 KB vector PDF",
     svg_path.display()
   );
   let svg_bytes = std::fs::read(&svg_path).expect("read svg");
@@ -221,9 +236,9 @@ fn test_vector_svg_graphics_path() {
     svg_bytes.windows(4).any(|w| w == b"<svg"),
     "SVG root element not found in output"
   );
-  // Upper bound sanity — inkscape on a vector-authored plot produces tens
-  // of KB, not hundreds of MB. Raster-embedded PDFs blow up to 100+ MB —
-  // that's the case the file-size heuristic must exclude upstream.
+  // Upper bound sanity — a vector converter on a vector-authored plot
+  // produces tens of KB, not hundreds of MB. Raster-embedded PDFs blow up
+  // to 100+ MB — that's the case the file-size heuristic must exclude.
   assert!(
     svg_bytes.len() < 2 * 1024 * 1024,
     "SVG is {} bytes — vector-authored PDFs should yield <2 MB SVG",
@@ -239,22 +254,19 @@ fn test_vector_svg_graphics_path() {
 /// [brucemiller/LaTeXML#902](https://github.com/brucemiller/LaTeXML/issues/902)
 /// and called out from arxiv:1807.01606) is a 41 KB vector-authored PDF
 /// that triggers a 30+ second rasterisation in `convert` via ghostscript.
-/// Inkscape parses the same PDF directly and emits SVG in ~250 ms —
-/// measured 130× speedup on the round-17 dev machine.
+/// mutool/pdftocairo parse the same PDF's vectors directly and emit SVG in
+/// well under a second — the same direct-vector advantage, without a
+/// heavyweight GTK dependency.
 ///
-/// This test asserts the inkscape path *completes* (doesn't time out)
-/// and does NOT exercise the slow convert path (would blow the suite
-/// runtime). Silent skip if inkscape is missing.
+/// This test asserts the vector-SVG path *completes* fast (doesn't time
+/// out) and does NOT exercise the slow convert path (would blow the suite
+/// runtime). Silent skip if no vector converter is installed.
 #[test]
 fn test_vector_svg_pathological_convert_case() {
-  if std::process::Command::new("inkscape")
-    .arg("--version")
-    .output()
-    .ok()
-    .filter(|o| o.status.success())
-    .is_none()
-  {
-    eprintln!("inkscape not installed; skipping pathological-PDF regression test");
+  if !svg_converter_available() {
+    eprintln!(
+      "no vector-SVG converter (mutool/pdftocairo) on PATH; skipping pathological-PDF regression test"
+    );
     return;
   }
 
@@ -299,16 +311,16 @@ fn test_vector_svg_pathological_convert_case() {
   let svg_path = work.join("pathological_vector.svg");
   assert!(
     svg_path.exists(),
-    "expected SVG at {} — inkscape should succeed on this pathological-for-convert PDF",
+    "expected SVG at {} — a vector converter should succeed on this pathological-for-convert PDF",
     svg_path.display()
   );
-  // Upper bound: inkscape SVG of a 41 KB vector-authored PDF is ~100 KB
-  // and completes in well under a second on any machine. Give generous
-  // CI slack (5 s) — convert takes 30+ s, so there's no way a 5 s bound
-  // accidentally masks a fallback to the raster path.
+  // Upper bound: a vector converter's SVG of a 41 KB vector-authored PDF is
+  // ~100 KB and completes in well under a second on any machine. Give
+  // generous CI slack (5 s) — convert takes 30+ s, so there's no way a 5 s
+  // bound accidentally masks a fallback to the raster path.
   assert!(
     elapsed < std::time::Duration::from_secs(5),
-    "inkscape path on fig8.pdf took {:?} — should be <1 s, way under the 30s+ convert path",
+    "vector-SVG path on fig8.pdf took {:?} — should be <1 s, way under the 30s+ convert path",
     elapsed
   );
 

--- a/resources/XSLT/LaTeXML-webpage-xhtml.xsl
+++ b/resources/XSLT/LaTeXML-webpage-xhtml.xsl
@@ -348,6 +348,12 @@
     </xsl:element>
   </xsl:template>
 
+  <!-- Distinct-by-string-value index for indexphrases, so head-keywords can
+       deduplicate in O(n) (Muenchian method) instead of the O(n^2)
+       not(.=preceding::ltx:indexphrase) scan. Local perf divergence from
+       upstream LaTeXML (output-neutral); candidate to upstream. -->
+  <xsl:key name="f:indexphrase-by-value" match="ltx:indexphrase" use="."/>
+
   <!-- Generate a keywords meta entry for the head; typically from indexphrase's or keywords-->
   <xsl:template match="/" mode="head-keywords">
     <xsl:if test="//ltx:indexphrase | //ltx:keywords">
@@ -362,7 +368,7 @@
           <xsl:if test="//ltx:indexphrase and //ltx:keywords">
             <xsl:text>, </xsl:text>
           </xsl:if>
-          <xsl:for-each select="//ltx:indexphrase[not(.=preceding::ltx:indexphrase)]">
+          <xsl:for-each select="//ltx:indexphrase[generate-id() = generate-id(key('f:indexphrase-by-value',.)[1])]">
             <xsl:sort select="text()"/>
             <xsl:if test="position() &gt; 1">, </xsl:if>
             <xsl:value-of select="text()"/>

--- a/tools/maketests.sh
+++ b/tools/maketests.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# maketests.sh — regenerate (".bless") the golden test XML files.
+#
+# The Rust equivalent of Perl LaTeXML's `tools/maketests`. It runs the normal
+# test harness with `LATEXML_BLESS=1`, which makes every `…_ok` test OVERWRITE
+# its golden `<name>.xml` with the actual conversion output instead of
+# comparing+asserting. Because it reuses the exact harness conversion and
+# serialization path (`latexml_oxide/src/util/test.rs::process_texfile`), the
+# regenerated goldens are byte-identical to what the comparison expects — there
+# is no risk of config/serialization drift between "generate" and "check".
+#
+# Git is the backup: ALWAYS review `git diff` afterwards and commit deliberately.
+# A clean working tree before running is strongly recommended so the diff is
+# exactly the intended golden churn.
+#
+# Usage:
+#   tools/maketests.sh                 # regenerate ALL goldens (whole suite)
+#   tools/maketests.sh <filter>        # regenerate only tests matching <filter>
+#   tools/maketests.sh -- <cargo args> # pass extra args through to cargo test
+#
+# Examples:
+#   tools/maketests.sh                       # bless everything
+#   tools/maketests.sh 06_cluster            # bless one test binary
+#   tools/maketests.sh array_pcolumn         # bless tests matching a name
+#
+# After running, verify nothing unexpected changed:
+#   git diff --stat
+#   cargo test --tests        # should now be green
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+  echo "WARNING: working tree is not clean; the blessed diff will mix with your"
+  echo "         existing changes. Consider stashing first. Continuing in 3s…" >&2
+  sleep 3
+fi
+
+filter=()
+if [ "$#" -ge 1 ] && [ "$1" != "--" ]; then
+  filter=("$1"); shift
+fi
+# Drop a leading `--` separator if present.
+[ "${1:-}" = "--" ] && shift || true
+
+echo "==> Regenerating goldens (LATEXML_BLESS=1 cargo test --tests ${filter[*]} $*)" >&2
+LATEXML_BLESS=1 cargo test --tests --no-fail-fast "${filter[@]}" "$@" -- --nocapture 2>&1 \
+  | grep -E '^BLESS ' || true
+
+echo "" >&2
+echo "==> Done. Review the golden churn:" >&2
+echo "      git diff --stat" >&2
+echo "    then re-run the suite to confirm green:" >&2
+echo "      cargo test --tests" >&2

--- a/tools/sweep_worker_count.sh
+++ b/tools/sweep_worker_count.sh
@@ -21,7 +21,7 @@ rss() { ps --no-headers -o rss -C cortex_worker 2>/dev/null | awk '{s+=$1}END{pr
 printf '%-8s %-9s %-10s %-11s %-6s %-7s\n' workers tasks_s peakRSSgb minMemAvgb sheds wall_s
 for N in $COUNTS; do
   ( cd ~/git/cortex && DATABASE_URL="$DB" "$CORTEX" rerun \
-      sandbox-arxiv-10k-shuffle oxidized-tex-to-html --yes --owner claude-agent \
+      sandbox-arxiv-10k-shuffle oxidized_tex_to_html --yes --owner claude-agent \
       --description "wc-sweep N=$N" ) >/dev/null 2>&1
   log="/tmp/swc_N${N}.log"
   setsid "$BIN" --harness --workers "$N" >"$log" 2>&1 &


### PR DESCRIPTION
High-level summary of the contributions on this branch (41 commits since `main`).

## Engine / parity — xint & ar5iv (1804.01117 now converts fully)
**arXiv:1804.01117 now converts fully under `--preload=ar5iv.sty`** — a genuine beyond-Perl win (Perl LaTeXML degrades to a 459-byte error stub):
- `read_balanced` crosses `\scantokens` autoclose mouths, faithful to tex.web `get_next` §362-365 (kills the `\xintexprSafeCatcodes \begingroup` leak).
- A `\noexpand`'d token reverts to its plain identity when captured as a macro arg / collected into an `\edef` body (TeX's transient `no_expand_flag`); matches etex + pdflatex.
- Per-token `\special_relax` representation (survives storage + dump); native `\Ucharcat` fixes expl3 `\char_generate` for active/Unicode chars.
- `REPORT` `SymStr` maps hardened against arena reuse (phantom-undefined fix).

## Post-processing failure reporting (fail toward reporting)
- **True post failures now reach `cortex.log` AND raise `status_code`.** The post `diag.rs` macros count via `note_status`, so every `Warn!`/`Error!`/`Fatal!` registers; graphics worker-thread diagnostics are forwarded to the main thread via a lock-free `capture`/`replay` thread-join+fold. `cortex_worker` folds the post log + status into `cortex.log` (combined `max(core, post)` severity).
- **`convert_image` no longer trusts a converter's exit code alone** — success now requires a non-empty output file, so an exit-0-but-no-file failure surfaces as `imageprocessing:failed_to_convert` instead of a broken `<img>`.

## Logger fidelity
- Progress notes flow inline in the captured log, Perl-faithful: `(Loading X… )` on one line, `[1][2]…` inline, zero spurious blank lines.

## Robustness (panics → graceful errors)
- Guard remaining singleton unwraps (alignment / parindent / wrap_nodes), self-referential box `try_borrow`, `read_token_required` at EOF, UTF-8-safe CS-name truncation; booktabs `\cmidrule` infinite loop; omnibus natbib `\citep` token loop.

## Frontmatter (llncs)
- `\author`/`\institute` splitting on `\and`/`\\`, per-author affiliation linking, `secnumdepth=2` to match real `llncs.cls`; ORCID logo scripts → `ltx:sup/sub`.

## Bibliography
- Native `.bib`: corporate authors + dropped booktitle; bbl-first config falls back to `.bib` when no `.bbl` exists.

## Performance
- XSLT head-keywords index dedup O(n²)→O(n) via a Muenchian key.

## Packages & parser
- mhchem: raw-load the real `mhchem.sty` (retire the stub) + bindings for missing packages; marginpar font/catcode scoping; wrapfig width as % of `\textwidth`; math-parser `ambiguous_math`/`unparsed_math` diagnostics keyed by token-type footprint.

## Tooling
- `maketests` bless mode (`LATEXML_BLESS=1`); `Info:runtime_ms` as its own cortex report category.

---
**Verification:** `cargo test --tests` 1496/0/0; `cargo +nightly clippy --workspace --all-targets -- -D warnings` clean; `cargo +nightly fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
