### PR TITLE
Release infra: 0.7.4-rc1 draft mode + Windows single-.exe leg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,13 @@ on:
   push:
     tags:
       # Bare X.Y.Z — matches the repo's existing tag history (no v-prefix).
+      # Auto-publishes a public release (see the publish step).
       - '[0-9]+.[0-9]+.[0-9]+'
+      # Pre-release / RC tags, e.g. 0.7.4-rc1 (a valid semver pre-release, so it
+      # matches the Cargo.toml version — make_release.sh's version check passes
+      # and the artifacts are named `…-0.7.4-rc1-…`). Published as a DRAFT
+      # prerelease for cross-OS testing, not a public release (publish step).
+      - '[0-9]+.[0-9]+.[0-9]+-*'
 
 permissions:
   # softprops/action-gh-release needs to write the Release object.
@@ -385,11 +391,108 @@ jobs:
             target/release-artifacts/latexml-oxide_${{ github.ref_name }}-1_arm64.deb.sha256
           if-no-files-found: error
 
+  # Windows (x86_64-pc-windows-msvc) — a SINGLE self-contained `.exe`. Uses the
+  # proven windows-ci-manual-trigger.yml recipe (vcpkg static libxml2/libxslt,
+  # triplet x64-windows-static-md) but builds the publish-grade `maxperf` binary
+  # and packages the bare `.exe` (+ `.sha256`) — no tarball/.deb, the user runs
+  # the `.exe` directly. `kpathsea` is NOT linked on Windows: TeX paths resolve
+  # through the subprocess `kpsewhich` (MiKTeX/TeX Live on PATH). The `.exe` needs
+  # only the ubiquitous MSVC runtime (static-md = static C libs + dynamic CRT).
+  # The TL-window dumps are OS-agnostic gzipped text, embedded at build time like
+  # the other legs (no TeX Live needed on THIS leg — dumps come from `dumps`).
+  build-windows:
+    name: Build Windows x86_64 ${{ github.ref_name }}
+    runs-on: windows-latest
+    # First-ever Windows release artifact; maxperf (fat-LTO) is heavier than the
+    # bring-up job's `ci` profile — give generous wall-clock. Windows Actions
+    # minutes are metered 2x on this private repo (see windows-ci-manual-trigger).
+    timeout-minutes: 120
+    needs: dumps
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+      RUST_BACKTRACE: "1"
+      # Static C libraries + dynamic CRT (plan Phase 1.1). The MSVC runtime is a
+      # standard system component (VC++ redist), so the `.exe` is effectively
+      # single-file.
+      VCPKG_TRIPLET: x64-windows-static-md
+      VCPKGRS_TRIPLET: x64-windows-static-md
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          key: release-maxperf-windows
+
+      - name: cache vcpkg installed tree
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.VCPKG_INSTALLATION_ROOT }}\installed
+          key: vcpkg-${{ env.VCPKG_TRIPLET }}-libxml2-libxslt-v1
+      - name: vcpkg install libxml2 + libxslt (static)
+        run: |
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg" install `
+            "libxml2:$env:VCPKG_TRIPLET" "libxslt:$env:VCPKG_TRIPLET"
+      - name: export vcpkg root
+        run: '"VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" >> $env:GITHUB_ENV'
+
+      # Same TL-window dumps as the other legs (OS-agnostic gzipped text).
+      - name: collect TL-window dumps
+        uses: actions/download-artifact@v6
+        with:
+          pattern: dumps-*
+          path: resources/dumps/
+          merge-multiple: true
+      - name: verify dump window completeness
+        shell: bash
+        run: |
+          ls -la resources/dumps/
+          for year in 2022 2023 2024 2025; do
+            for f in plain.$year.dump.txt latex.$year.dump.txt texlive.$year.version; do
+              if [ ! -s "resources/dumps/$f" ]; then
+                echo "::error::release dump window incomplete: missing resources/dumps/$f"
+                exit 1
+              fi
+            done
+          done
+
+      # make_release.sh runs under Git Bash (present on windows-latest); its
+      # os_family=windows branch builds maxperf and packages the single `.exe`.
+      # libxml2/libxslt are discovered from the vcpkg env set above.
+      - name: build Windows release .exe
+        shell: bash
+        run: bash tools/make_release.sh
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          RELEASE_TARGET: x86_64-pc-windows-msvc
+
+      # Launch smoke: prove the `.exe` runs on the runner (static-link / vcpkg
+      # sanity). Conversion paths aren't exercised here (no TeX Live on this leg);
+      # windows-ci-manual-trigger.yml runs the full suite with TeX Live.
+      - name: launch smoke
+        shell: bash
+        run: |
+          exe=$(find target/release-artifacts -name '*.exe' -type f | head -1)
+          echo "checking $exe"
+          "$exe" --version || { echo "::error::Windows .exe failed to launch (--version)"; exit 1; }
+          echo "OK: the Windows .exe launches"
+
+      - name: upload Windows artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: windows-exe
+          path: |
+            target/release-artifacts/latexml-oxide-${{ github.ref_name }}-x86_64-pc-windows-msvc.exe
+            target/release-artifacts/latexml-oxide-${{ github.ref_name }}-x86_64-pc-windows-msvc.exe.sha256
+          if-no-files-found: error
+
   release:
     name: Build and publish ${{ github.ref_name }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
-    needs: [dumps, build-macos, build-macos-intel, build-linux-arm64]
+    needs: [dumps, build-macos, build-macos-intel, build-linux-arm64, build-windows]
 
     steps:
       - uses: actions/checkout@v6
@@ -496,6 +599,7 @@ jobs:
           RELEASE_MACOS_TARBALL: latexml-oxide-${{ github.ref_name }}-aarch64-apple-darwin.tar.gz
           RELEASE_MACOS_INTEL_TARBALL: latexml-oxide-${{ github.ref_name }}-x86_64-apple-darwin.tar.gz
           RELEASE_LINUX_ARM64_TARBALL: latexml-oxide-${{ github.ref_name }}-aarch64-unknown-linux-gnu.tar.gz
+          RELEASE_WINDOWS_EXE: latexml-oxide-${{ github.ref_name }}-x86_64-pc-windows-msvc.exe
 
       # Artifact-property gate (RELEASE_CRITERIA §2/§7): fail the release if the
       # stripped binary blows the size budget (a runaway-growth alarm), and stage
@@ -584,16 +688,24 @@ jobs:
           name: linux-arm64-artifacts
           path: target/release-artifacts/
 
-      # AUTO-PUBLISH (draft: false): a tag push produces a public Release with
-      # zero manual steps. This is safe because every asset is gated before it
-      # gets here: each build leg verifies static linkage (ldd/otool), runs a
+      # Pull the single Windows .exe (+ sidecar) built by build-windows.
+      - name: collect Windows .exe
+        uses: actions/download-artifact@v6
+        with:
+          name: windows-exe
+          path: target/release-artifacts/
+
+      # PUBLISH. Behaviour is chosen by the tag shape (see draft/prerelease below):
+      #   * Final tag  X.Y.Z      -> a PUBLIC release, zero manual steps.
+      #   * RC tag     X.Y.Z-rcN  -> a DRAFT prerelease for cross-OS testing.
+      # Auto-publishing a final tag is safe because every asset is gated before
+      # it gets here: each build leg verifies static linkage (ldd/otool), runs a
       # real conversion smoke (Linux legs) or a launch smoke + code-signature
-      # check (macOS legs), and enforces the size budget; macOS conversion paths
-      # are additionally covered by CI.yml's macOS test job on the same arch.
-      # The build stays tied to a release tag (no workflow_dispatch, no "random"
-      # builds). If a published asset is ever found broken, delete the Release +
-      # tag, bump to X.Y.(Z+1), and re-tag (RELEASING.md "Failure recovery").
-      # (To re-introduce a human review gate, set `draft: true`.)
+      # check (macOS legs) or a launch smoke (Windows leg), and enforces the size
+      # budget; macOS conversion paths are additionally covered by CI.yml's macOS
+      # test job. The build stays tied to a release tag (no workflow_dispatch, no
+      # "random" builds). If a published asset is ever found broken, delete the
+      # Release + tag, bump the patch, and re-tag (RELEASING.md "Failure recovery").
       - name: publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
@@ -618,7 +730,13 @@ jobs:
             target/release-artifacts/latexml-oxide-${{ github.ref_name }}-aarch64-apple-darwin.tar.gz.sha256
             target/release-artifacts/latexml-oxide-${{ github.ref_name }}-x86_64-apple-darwin.tar.gz
             target/release-artifacts/latexml-oxide-${{ github.ref_name }}-x86_64-apple-darwin.tar.gz.sha256
+            target/release-artifacts/latexml-oxide-${{ github.ref_name }}-x86_64-pc-windows-msvc.exe
+            target/release-artifacts/latexml-oxide-${{ github.ref_name }}-x86_64-pc-windows-msvc.exe.sha256
             target/release-artifacts/THIRD-PARTY-NOTICES
-          draft: false
-          prerelease: false
+          # RC / pre-release tags (containing a '-', e.g. 0.7.4-rc1) publish as a
+          # DRAFT prerelease — a maintainer tests the attached executables on each
+          # OS, then clicks Publish (or deletes the draft). Final tags (bare
+          # X.Y.Z) auto-publish a public release.
+          draft: ${{ contains(github.ref_name, '-') }}
+          prerelease: ${{ contains(github.ref_name, '-') }}
           fail_on_unmatched_files: true

--- a/.github/workflows/windows-ci-manual-trigger.yml
+++ b/.github/workflows/windows-ci-manual-trigger.yml
@@ -1,4 +1,7 @@
-# Windows bring-up — docs/release/WINDOWS_COMPATIBILITY_PLAN.md.
+# Windows CI (manual trigger) — build + full test suite on windows-latest.
+# Tracks docs/release/WINDOWS_COMPATIBILITY_PLAN.md. (The RELEASE artifact —
+# the single .exe — is built by release.yml's build-windows leg, which reuses
+# this file's vcpkg/static recipe.)
 #
 # NOT part of required CI yet (Phase 4 promotes this into CI.yml once the
 # job is stably green).
@@ -21,7 +24,7 @@
 on:
   workflow_dispatch:
 
-name: windows-bringup
+name: Windows CI (manual)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -46,7 +49,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-          key: windows-bringup
+          key: windows-ci-manual
 
       - name: cache vcpkg installed tree
         uses: actions/cache@v4

--- a/docs/release/WINDOWS_COMPATIBILITY_PLAN.md
+++ b/docs/release/WINDOWS_COMPATIBILITY_PLAN.md
@@ -86,7 +86,7 @@ These are cross-platform-neutral fixes validated by the existing Linux/macOS CI:
 - [x] **`/tmp` hardcodes → `std::env::temp_dir()`** in
   `latexml_oxide/src/util/test.rs` (SIGSEGV-handler dump file,
   `LATEXML_SAVE_ACTUAL` outputs).
-- [x] **Opt-in CI bring-up workflow** `.github/workflows/windows-bringup.yml`
+- [x] **Opt-in CI workflow** `.github/workflows/windows-ci-manual-trigger.yml`
   (`workflow_dispatch` + pushes to `windows-compatibility`), staged so each step
   reports its own failure. It is *expected* to fail in early phases — it exists
   to give every subsequent phase a live Windows probe without turning main CI red.
@@ -350,7 +350,7 @@ a code divergence. Full reasoning in the "tikz `ac_drive_components`" entry in
 ## Phase 4 — CI: `windows-latest` job as a required leg
 
 > **Resolved (2026-07-13): the `Repository access blocked` failure was a dead
-> action, not billing.** windows-bringup's early runs aborted at "Getting action
+> action, not billing.** the Windows CI job's early runs aborted at "Getting action
 > download info" because `teatimeguest/setup-texlive-action@v3` — the TeX Live
 > setup action — had its entire GitHub account go **404** (moved to the
 > `TeX-Live` org). GitHub reports an un-fetchable action as `Repository access
@@ -477,7 +477,7 @@ produces full HTML5 + CSS on TL; embedded dumps verified by renaming
 `latexml-oxide-<version>-x86_64-pc-windows-msvc.zip` + `.sha256` sidecar
 (Compress-Archive + Get-FileHash), matching the existing asset naming.
 Remaining for the real release leg: wire this into `release.yml`
-(vcpkg + setup-texlive as in windows-bringup.yml, dumps from
+(vcpkg + setup-texlive as in windows-ci-manual-trigger.yml, dumps from
 release-dumps.yml embed unchanged) and the README platform table.
 
 1. Extend `release.yml` with a `x86_64-pc-windows-msvc` leg: `maxperf` profile,

--- a/latexml_oxide/Cargo.toml
+++ b/latexml_oxide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml"
-version = "0.7.3"
+version = "0.7.4-rc1"
 edition = "2024"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
 license = "CC0-1.0"

--- a/tools/make_release.sh
+++ b/tools/make_release.sh
@@ -58,8 +58,13 @@ target_triple="${RELEASE_TARGET:-x86_64-unknown-linux-gnu}"
 case "${target_triple}" in
   *-linux-*)      os_family="linux" ;;
   *-apple-darwin) os_family="macos" ;;
+  *-pc-windows-*) os_family="windows" ;;
   *) echo "make_release: unsupported RELEASE_TARGET='${target_triple}'" >&2; exit 1 ;;
 esac
+
+# Windows executables carry a `.exe` suffix. Empty elsewhere.
+bin_suffix=""
+[[ "${os_family}" == "windows" ]] && bin_suffix=".exe"
 
 # Debian architecture label for the .deb FILENAME (Linux only). cargo-deb
 # derives the control-file `Architecture:` from the native build host itself;
@@ -101,8 +106,9 @@ mkdir -p "${stage_dir}"
 echo "make_release: cargo build --no-default-features --features runtime-bindings --profile maxperf --bin latexml_oxide"
 cargo build --no-default-features --features runtime-bindings --profile maxperf --bin latexml_oxide
 
-bin_path="target/maxperf/latexml_oxide"
-if [[ ! -x "${bin_path}" ]]; then
+bin_path="target/maxperf/latexml_oxide${bin_suffix}"
+# -f not -x: Git Bash on Windows doesn't report a .exe as `-x`.
+if [[ ! -f "${bin_path}" ]]; then
   echo "make_release: build did not produce ${bin_path}" >&2
   exit 1
 fi
@@ -123,29 +129,47 @@ if [[ "${os_family}" == "macos" ]]; then
   # xattr on terminal downloads). See docs/release/RELEASING.md "macOS
   # Gatekeeper & code signing".
   codesign --sign - --force "${bin_path}" 2>/dev/null || true
+elif [[ "${os_family}" == "windows" ]]; then
+  # No external `strip` on MSVC: debug info lives in a separate `.pdb`, so the
+  # linked `.exe` is already lean (the maxperf profile's `strip = "symbols"`
+  # covers what little remains). Nothing to do here.
+  :
 else
   strip --strip-all "${bin_path}" 2>/dev/null || true
 fi
 
-# --- stage tarball contents -------------------------------------------------
-cp "${bin_path}" "${stage_dir}/latexml_oxide"
-cp README.md "${stage_dir}/README.md"
-cp CHANGELOG.md "${stage_dir}/CHANGELOG.md"
-cp LICENSE "${stage_dir}/LICENSE"
-# THIRD-PARTY-NOTICES: prefer the release-time assembled file (hand-authored
-# sections 1-4 + the cargo-about Rust-crate appendix produced by
-# tools/gen_notices.sh); fall back to the committed hand-authored file so a
-# local `make_release.sh` without cargo-about still ships notices.
-if [[ -f THIRD-PARTY-NOTICES.dist ]]; then
-  cp THIRD-PARTY-NOTICES.dist "${stage_dir}/THIRD-PARTY-NOTICES"
+# Windows ships a SINGLE self-contained `.exe` (the user runs it directly), not a
+# tarball — so its packaging diverges from the Linux/macOS tarball flow. Static
+# libxml2/libxslt (vcpkg, x64-windows-static-md) + the ubiquitous dynamic MSVC
+# runtime; kpathsea is resolved via subprocess `kpsewhich`, never linked.
+tarball=""
+exe_asset=""
+if [[ "${os_family}" == "windows" ]]; then
+  exe_asset="latexml-oxide-${version}-${target_triple}.exe"
+  cp "${bin_path}" "${artifacts_dir}/${exe_asset}"
+  ( cd "${artifacts_dir}" && sha256_sidecar "${exe_asset}" )
+  echo "make_release: Windows single-exe asset ${exe_asset}"
 else
-  cp THIRD-PARTY-NOTICES "${stage_dir}/THIRD-PARTY-NOTICES"
-fi
+  # --- stage tarball contents -----------------------------------------------
+  cp "${bin_path}" "${stage_dir}/latexml_oxide"
+  cp README.md "${stage_dir}/README.md"
+  cp CHANGELOG.md "${stage_dir}/CHANGELOG.md"
+  cp LICENSE "${stage_dir}/LICENSE"
+  # THIRD-PARTY-NOTICES: prefer the release-time assembled file (hand-authored
+  # sections 1-4 + the cargo-about Rust-crate appendix produced by
+  # tools/gen_notices.sh); fall back to the committed hand-authored file so a
+  # local `make_release.sh` without cargo-about still ships notices.
+  if [[ -f THIRD-PARTY-NOTICES.dist ]]; then
+    cp THIRD-PARTY-NOTICES.dist "${stage_dir}/THIRD-PARTY-NOTICES"
+  else
+    cp THIRD-PARTY-NOTICES "${stage_dir}/THIRD-PARTY-NOTICES"
+  fi
 
-# --- build tarball ----------------------------------------------------------
-tarball="latexml-oxide-${version}-${target_triple}.tar.gz"
-( cd "${artifacts_dir}" && tar -czf "${tarball}" "${stage_dir_name}" )
-( cd "${artifacts_dir}" && sha256_sidecar "${tarball}" )
+  # --- build tarball --------------------------------------------------------
+  tarball="latexml-oxide-${version}-${target_triple}.tar.gz"
+  ( cd "${artifacts_dir}" && tar -czf "${tarball}" "${stage_dir_name}" )
+  ( cd "${artifacts_dir}" && sha256_sidecar "${tarball}" )
+fi
 
 # --- build .deb (Debian-family targets only) --------------------------------
 # macOS has no .deb equivalent in this pipeline (a Homebrew tap is the natural
@@ -265,6 +289,23 @@ sudo cp latexml-oxide-${version}-aarch64-unknown-linux-gnu/latexml_oxide /usr/lo
 EOF
   fi
 
+  if [[ -n "${RELEASE_WINDOWS_EXE:-}" ]]; then
+    cat <<EOF
+### Windows (x86_64)
+
+A single self-contained \`.exe\` — download it and run it directly (no installer,
+no tarball). Static libxml2/libxslt are baked in; it needs only the standard
+Microsoft Visual C++ runtime (present on modern Windows / the VC++ redistributable)
+and a TeX distribution (MiKTeX or TeX Live) on \`PATH\`, resolved via \`kpsewhich\`.
+
+\`\`\`powershell
+curl.exe -LO https://github.com/dginev/latexml-oxide/releases/download/${version}/${RELEASE_WINDOWS_EXE}
+.\\${RELEASE_WINDOWS_EXE} --version
+\`\`\`
+
+EOF
+  fi
+
   # Slice the CHANGELOG section for this version. CHANGELOG entries use
   # `## [VERSION]` headers (CommonMark task-list style — see CHANGELOG.md
   # for shape). Extract from the matching header up to the next `## `.
@@ -290,7 +331,12 @@ echo "make_release: artifacts in ${artifacts_dir}/"
 ls -la "${artifacts_dir}"
 echo
 echo "make_release: SHA-256 sidecars"
-cat "${artifacts_dir}/${tarball}.sha256"
+if [[ -n "${tarball}" ]]; then
+  cat "${artifacts_dir}/${tarball}.sha256"
+fi
+if [[ -n "${exe_asset}" ]]; then
+  cat "${artifacts_dir}/${exe_asset}.sha256"
+fi
 if [[ -n "${deb_path}" ]]; then
   cat "${artifacts_dir}/$(basename "${deb_path}").sha256"
 fi


### PR DESCRIPTION
Enables cutting a **0.7.4-rc1 draft release** with executables for **all OSes**,
for cross-platform testing before the public 0.7.4.

## What this adds
1. **RC / pre-release publish mode** (`release.yml`). A tag containing `-`
   (e.g. `0.7.4-rc1`) publishes a **DRAFT prerelease** for testing; bare `X.Y.Z`
   tags still auto-publish a public release. Driven by
   `draft/prerelease = contains(github.ref_name, '-')`; trigger now matches both
   `X.Y.Z` and `X.Y.Z-*`.
2. **Windows single-`.exe` release leg** (`build-windows` in `release.yml` +
   `make_release.sh`). **First-ever Windows release artifact.** Reuses the proven
   bring-up recipe (vcpkg static libxml2/libxslt, `x64-windows-static-md`) but
   builds the publish-grade `maxperf` binary and packages a bare
   `latexml-oxide-<ver>-x86_64-pc-windows-msvc.exe` (+ `.sha256`) — no tarball/.deb,
   the user runs it directly. `kpathsea` stays subprocess-only (MiKTeX/TeX Live on
   PATH). Static C libs + the ubiquitous dynamic MSVC runtime = effectively single-file.
   Includes a `--version` launch smoke.
3. **Version → `0.7.4-rc1`** (`latexml_oxide/Cargo.toml`). Valid semver
   pre-release, so tag == version (make_release's version gate passes, artifacts
   are named `-0.7.4-rc1-`, and the binary self-reports `0.7.4-rc1`).
4. **Rename** `windows-bringup.yml` → `windows-ci-manual-trigger.yml` (clearer;
   it's the manual test job, distinct from the new release leg) + doc refs.

## Resulting RC artifacts (5)
`x86_64-linux-gnu` tarball + `.deb`, `aarch64-linux-gnu` tarball + `.deb`,
`aarch64-apple-darwin` tarball, `x86_64-apple-darwin` tarball, **`x86_64-pc-windows-msvc.exe`**.

## Honest risk
- The **Windows leg is unproven** (never run for a maxperf/packaged build). Its
  first execution is this RC — appropriate, but if it fails, `fail_on_unmatched_files`
  means the whole rc1 publish fails; fix and re-tag `rc2`.
- `maxperf` fat-LTO on `windows-latest` (16 GB) is heavier than the bring-up's
  `ci` profile; the macOS legs prove maxperf fits 7 GB, so 16 GB should be fine.
- Full run is long + metered (macOS 10×, Windows 2×).

## To cut the RC (after merge)
```
git tag 0.7.4-rc1 && git push origin 0.7.4-rc1
```
→ builds all 5 artifacts, publishes a **draft** prerelease `0.7.4-rc1`. Download
each (authenticated `gh`, since the repo is private), test on each OS, then
Publish or delete the draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)