### PR TITLE
Fix --whatsin=math: port \ensuremathfollows/\ensuremathpreceeds (automath)

### DIFF
--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -34,6 +34,13 @@ use crate::{
 // into an unused-global.
 static OPTS_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"\s*,\s*").unwrap());
 
+// Perl `\ensuremathfollows` already-math test (latex_constructs.pool.ltxml
+// L2083/L2098): `$MATHENVS = 'displaymath|equation*?|eqnarray*?'` and the guard
+// `$csname !~ /^Math|\(|\[|(?:$MATHENVS)/o`. Kept verbatim (not hand-expanded)
+// so the automath wrapper matches Perl exactly.
+static AUTOMATH_ALREADY_MATH: Lazy<Regex> =
+  Lazy::new(|| Regex::new(r"^Math|\\\(|\\\[|(?:displaymath|equation*?|eqnarray*?)").unwrap());
+
 // Perl `\documentclass` (latex_constructs.pool.ltxml L78) wraps the
 // raw option string in `TrimmedCommaList(...)` — i.e. comma-split AND
 // strip whitespace from EACH element including the first/last.
@@ -6121,11 +6128,61 @@ LoadDefinitions!({
     }
   });
 
-  // Perl: latex_constructs.pool.ltxml L2142-2163 — automath wrapping
-  // Simplified: \ensuremathfollows checks if next content is already math,
-  // if not wraps with \( ... \). Used by equation labels / alt text.
-  def_macro_noop("\\ensuremathfollows")?; // stub — automath needs gullet lookahead
-  def_macro_noop("\\ensuremathpreceeds")?; // stub — pairs with ensuremathfollows
+  // Perl: latex_constructs.pool.ltxml L2085-2107 — automath wrapping.
+  // The pair brackets a fragment (used by `--whatsin=math`, i.e. the
+  // `latexmlmath`-style CLI mode, and by alt/label math): if the content
+  // isn't ALREADY explicit math, `\ensuremathfollows` opens `\(` and
+  // `\ensuremathpreceeds` closes `\)`. Perl `$MATHENVS`:
+  //   displaymath|equation*?|eqnarray*?
+  DefMacro!("\\ensuremathfollows", {
+    // The preamble mouth (`literal:\begin{document}\ensuremathfollows`) is
+    // exhausted at this point; cross into the mouth holding the actual
+    // fragment so `read_token` peeks the real content. Perl:
+    // `$gullet->closeMouth unless ($gullet->getMouth->hasMoreInput)`.
+    if !has_more_input() {
+      close_mouth(false)?;
+    }
+    let mut expansion = Tokens!();
+    if let Some(tok) = read_token()? {
+      // Perl `$tok->getCSName`: the CS name for a control sequence, else undef.
+      let mut csname = if tok.get_catcode() == Catcode::CS {
+        Some(tok.with_str(|s| s.to_string()))
+      } else {
+        None
+      };
+      if csname.as_deref() == Some("\\begin") {
+        // Peek the environment name to test against the math envs, then put
+        // the `{env}` group back exactly as read. Perl:
+        // `unread(T_BEGIN, $arg->unlist, T_END)`.
+        let arg = read_arg(ExpansionLevel::Off)?;
+        csname = Some(arg.to_string());
+        let mut group = vec![T_BEGIN!()];
+        group.extend(arg.unlist());
+        group.push(T_END!());
+        unread(Tokens::new(group));
+      }
+      unread_one(tok);
+      // Perl: `$csname !~ /^Math|\(|\[|(?:$MATHENVS)/` — already-explicit math.
+      // undef csname (a non-CS first token) is a non-match, so it DOES wrap.
+      let already_math = csname
+        .as_deref()
+        .is_some_and(|c| AUTOMATH_ALREADY_MATH.is_match(c));
+      if !already_math {
+        assign_value("automath_triggered", true, Some(Scope::Global));
+        expansion = Tokens!(T_CS!("\\("));
+      }
+    }
+    Ok(expansion)
+  });
+
+  DefMacro!("\\ensuremathpreceeds", {
+    let triggered = matches!(lookup_value("automath_triggered"), Some(Stored::Bool(true)));
+    Ok(if triggered {
+      Tokens!(T_CS!("\\)"))
+    } else {
+      Tokens!()
+    })
+  });
 
   // Perl: latex_constructs.pool.ltxml L2166
   // Since the arXMLiv folks keep wanting ids on all math, let's try this!

--- a/latexml_oxide/tests/91_whatsinout.rs
+++ b/latexml_oxide/tests/91_whatsinout.rs
@@ -61,16 +61,13 @@ fn whatsin_math_wraps_literal_as_mathml() {
   // macros were no-ops, so `\sqrt{x}` became a bare `<ltx:XMApp>` outside any
   // `<ltx:Math>` container → `malformed:ltx:XMApp isn't allowed` → no MathML.
   let work = tempfile::tempdir().expect("tempdir");
-  let out = run(
-    work.path(),
-    &[
-      "literal:\\sqrt{x}",
-      "--whatsin=math",
-      "--format=html5",
-      "--dest",
-      "m.html",
-    ],
-  );
+  let out = run(work.path(), &[
+    "literal:\\sqrt{x}",
+    "--whatsin=math",
+    "--format=html5",
+    "--dest",
+    "m.html",
+  ]);
   assert!(
     out.status.success(),
     "status {:?}\nstderr:\n{}",

--- a/latexml_oxide/tests/91_whatsinout.rs
+++ b/latexml_oxide/tests/91_whatsinout.rs
@@ -54,6 +54,37 @@ fn whatsout_document_is_full_page() {
 }
 
 #[test]
+fn whatsin_math_wraps_literal_as_mathml() {
+  // `--whatsin=math` must digest the literal AS math (Perl LaTeXML.pm:166-168
+  // wraps it `\begin{document}\ensuremathfollows … \ensuremathpreceeds\end{document}`,
+  // and those macros open/close `\(…\)`). Before the automath port, the wrapper
+  // macros were no-ops, so `\sqrt{x}` became a bare `<ltx:XMApp>` outside any
+  // `<ltx:Math>` container → `malformed:ltx:XMApp isn't allowed` → no MathML.
+  let work = tempfile::tempdir().expect("tempdir");
+  let out = run(
+    work.path(),
+    &[
+      "literal:\\sqrt{x}",
+      "--whatsin=math",
+      "--format=html5",
+      "--dest",
+      "m.html",
+    ],
+  );
+  assert!(
+    out.status.success(),
+    "status {:?}\nstderr:\n{}",
+    out.status.code(),
+    stderr_of(&out)
+  );
+  let html = std::fs::read_to_string(work.path().join("m.html")).expect("read m.html");
+  assert!(
+    html.contains("msqrt"),
+    "expected MathML <msqrt> from `--whatsin=math`:\n{html}"
+  );
+}
+
+#[test]
 fn whatsout_fragment_strips_page_chrome() {
   let work = tempfile::tempdir().expect("tempdir");
   std::fs::write(work.path().join("hello.tex"), HELLO_TEX).unwrap();


### PR DESCRIPTION
## Problem

`latexml_oxide 'literal:\sqrt{x}' --whatsin=math --format=html5` produced **no MathML** — the log showed `malformed:ltx:XMApp <ltx:XMApp> isn't allowed in <ltx:document>`. The math *was* digested, but landed in the document without a `<ltx:Math>` container, so it was dropped.

## Root cause

`--whatsin=math` wraps the input like Perl LaTeXML.pm:166-168:
```
\begin{document}\ensuremathfollows … \ensuremathpreceeds\end{document}
```
Our driver (`converter.rs::resolve_amble`) already mirrors that verbatim. But the two wrapper macros — defined in a **different** Perl file, `latex_constructs.pool.ltxml:2085-2107` — were **no-op stubs** in the engine:
```rust
def_macro_noop("\\ensuremathfollows")?;   // stub — automath needs gullet lookahead
def_macro_noop("\\ensuremathpreceeds")?;  // stub — pairs with ensuremathfollows
```
So the wrapper did nothing and `\sqrt{x}` fell out of math mode. Platform-independent (not Windows-specific) — surfaced while testing the Windows RC.

## Fix

Faithful port of the two gullet macros:
- `\ensuremathfollows` — crosses the exhausted preamble mouth, peeks the next token, and unless the content is already explicit math (`$MATHENVS` regex kept verbatim: `^Math|\(|\[|displaymath|equation*?|eqnarray*?`) sets `automath_triggered` and opens `\(`.
- `\ensuremathpreceeds` — closes `\)` when triggered.

## Verification

- `literal:\sqrt{x} --whatsin=math` → `<math>`/`<msqrt>`, **0 errors** (was 1 error, empty math).
- Already-math `\(\sqrt{x}\)` → correctly **not** double-wrapped, 0 errors.
- New regression test `whatsin_math_wraps_literal_as_mathml` in `91_whatsinout.rs`; suite 5/5; clippy clean.
