### PR TITLE
release(windows): fully-static .exe via +crt-static (drop VCRUNTIME140 dep)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -392,12 +392,13 @@ jobs:
           if-no-files-found: error
 
   # Windows (x86_64-pc-windows-msvc) — a SINGLE self-contained `.exe`. Uses the
-  # proven windows-ci-manual-trigger.yml recipe (vcpkg static libxml2/libxslt,
-  # triplet x64-windows-static-md) but builds the publish-grade `maxperf` binary
-  # and packages the bare `.exe` (+ `.sha256`) — no tarball/.deb, the user runs
-  # the `.exe` directly. `kpathsea` is NOT linked on Windows: TeX paths resolve
-  # through the subprocess `kpsewhich` (MiKTeX/TeX Live on PATH). The `.exe` needs
-  # only the ubiquitous MSVC runtime (static-md = static C libs + dynamic CRT).
+  # proven windows-ci-manual-trigger.yml recipe (vcpkg static libxml2/libxslt)
+  # but builds the publish-grade `maxperf` binary and packages the bare `.exe`
+  # (+ `.sha256`) — no tarball/.deb, the user runs the `.exe` directly.
+  # `kpathsea` is NOT linked on Windows: TeX paths resolve through the subprocess
+  # `kpsewhich` (MiKTeX/TeX Live on PATH). The `.exe` is FULLY STATIC — static C
+  # libs (x64-windows-static) + static CRT (+crt-static) — so it imports only
+  # core OS DLLs and runs on any Windows with no VC++ redistributable.
   # The TL-window dumps are OS-agnostic gzipped text, embedded at build time like
   # the other legs (no TeX Live needed on THIS leg — dumps come from `dumps`).
   build-windows:
@@ -411,11 +412,16 @@ jobs:
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
       RUST_BACKTRACE: "1"
-      # Static C libraries + dynamic CRT (plan Phase 1.1). The MSVC runtime is a
-      # standard system component (VC++ redist), so the `.exe` is effectively
-      # single-file.
-      VCPKG_TRIPLET: x64-windows-static-md
-      VCPKGRS_TRIPLET: x64-windows-static-md
+      # Fully static: static C libraries AND static CRT. `x64-windows-static`
+      # builds libxml2/libxslt against the static CRT (/MT), matching the
+      # `-C target-feature=+crt-static` Rust flag on the build step below — the
+      # whole image is one CRT model. Result: the `.exe` imports NO
+      # VCRUNTIME140.dll and runs on ANY Windows with no VC++ redistributable
+      # (ripgrep's posture; unlike the earlier static-md = dynamic-CRT build,
+      # which needed the redist). Flipping the triplet also rotates the vcpkg
+      # cache key below, forcing a fresh static-CRT build of the C libs.
+      VCPKG_TRIPLET: x64-windows-static
+      VCPKGRS_TRIPLET: x64-windows-static
     steps:
       - uses: actions/checkout@v6
         with:
@@ -480,17 +486,40 @@ jobs:
           #     is why the RC build failed: "kpathsea: no usable TeX backend".
           KPATHSEA_NO_LINK: "1"
           KPATHSEA_SKIP_TOOLCHAIN_CHECK: "1"
+          # Static CRT: statically link the VC runtime + UCRT so the shipped
+          # `.exe` has NO VCRUNTIME140.dll dependency and launches on a clean
+          # Windows with no VC++ redistributable. MUST pair with the
+          # x64-windows-static vcpkg triplet above (one CRT model across Rust
+          # std + the C libs; mixing /MT and /MD is unsupported). RUSTFLAGS env
+          # REPLACES `.cargo/config.toml` rustflags, so re-list the
+          # frontend-parallelism flags to keep them.
+          RUSTFLAGS: "-Zthreads=8 -Zunstable-options -C target-feature=+crt-static"
 
-      # Launch smoke: prove the `.exe` runs on the runner (static-link / vcpkg
-      # sanity). Conversion paths aren't exercised here (no TeX Live on this leg);
+      # Launch smoke + self-containment guard. `--version` alone is NOT enough:
+      # the runner has the VC++ redist, so even a dynamic-CRT `.exe` would launch
+      # here. So we ALSO assert (via dumpbin) that the import table carries no
+      # VCRUNTIME — the actual property that lets the `.exe` run on a clean
+      # Windows. Conversion paths aren't exercised (no TeX Live on this leg);
       # windows-ci-manual-trigger.yml runs the full suite with TeX Live.
-      - name: launch smoke
+      - name: launch smoke + no-VCRUNTIME guard
         shell: bash
         run: |
+          set -euo pipefail
           exe=$(find target/release-artifacts -name '*.exe' -type f | head -1)
           echo "checking $exe"
           "$exe" --version || { echo "::error::Windows .exe failed to launch (--version)"; exit 1; }
           echo "OK: the Windows .exe launches"
+          # Locate dumpbin via vswhere (fixed path on windows runners).
+          vswhere="/c/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
+          vsroot=$("$vswhere" -latest -property installationPath)
+          dumpbin=$(find "$vsroot/VC/Tools/MSVC" -name dumpbin.exe -ipath '*hostx64*x64*' | head -1)
+          deps=$("$dumpbin" //DEPENDENTS "$exe")
+          if echo "$deps" | grep -qi 'vcruntime'; then
+            echo "$deps"
+            echo "::error::the .exe imports VCRUNTIME — +crt-static did not take effect (check the vcpkg triplet is x64-windows-static)"
+            exit 1
+          fi
+          echo "OK: no VCRUNTIME import — fully static, runs on any Windows"
 
       - name: upload Windows artifact
         uses: actions/upload-artifact@v5

--- a/docs/release/WINDOWS_COMPATIBILITY_PLAN.md
+++ b/docs/release/WINDOWS_COMPATIBILITY_PLAN.md
@@ -469,9 +469,12 @@ KPATHSEA_NO_LINK=1 cargo build --no-default-features \
 ```
 
 Results on the bring-up box: 46.9 MB exe (vs 58.9 MB release-profile);
-`dumpbin /DEPENDENTS` shows ONLY OS DLLs + VC runtime (`VCRUNTIME140*`,
-UCRT `api-ms-win-crt-*` — the `-md` dynamic-CRT triplet choice; both ship
-with Windows 10+/every VC redist); converts on a MiKTeX-only PATH and
+`dumpbin /DEPENDENTS` shows OS DLLs + the VC runtime (`VCRUNTIME140*`) +
+UCRT (`api-ms-win-crt-*`) — the `-md` dynamic-CRT triplet choice. **Caveat
+(corrected 2026-07-14, see Phase 5.1): only the UCRT ships with Windows
+10+; `VCRUNTIME140.dll`/`VCRUNTIME140_1.dll` are the VC++ *redistributable*,
+NOT part of Windows** — so this `-md` build is not truly self-contained on a
+clean box. Converts on a MiKTeX-only PATH and
 produces full HTML5 + CSS on TL; embedded dumps verified by renaming
 `resources/dumps` away (no degraded-mode warning). Packaged as
 `latexml-oxide-<version>-x86_64-pc-windows-msvc.zip` + `.sha256` sidecar
@@ -497,13 +500,65 @@ release-dumps.yml embed unchanged) and the README platform table.
 4. Update `RELEASE_CRITERIA.md` portability ladder (rung 5 → in progress → done)
    and `RELEASING.md` platform matrix.
 
+## Phase 5.1 — fully-static `.exe` (static CRT) — LANDED 2026-07-14
+
+**Problem.** The RC 0.7.4-rc1 `.exe` (the `-md` triplet) dynamically links
+`VCRUNTIME140.dll` + `VCRUNTIME140_1.dll` (the MSVC C++ runtime). Those are **not**
+part of a clean Windows install — they ship with the VC++ Redistributable — so
+on a machine without it, the `.exe` fails to *launch* (`ERROR_BAD_EXE_FORMAT` /
+missing-DLL) before `main`. It only ran on dev boxes because the VS toolchain put
+`VCRUNTIME140.dll` there. (First-principles: a distributable `.exe`'s entire
+transitive import closure must resolve to DLLs guaranteed present on the target;
+the UCRT `api-ms-win-crt-*` set qualifies on Win10+, the VC runtime does not.)
+
+**Fix (ripgrep's posture).** `-C target-feature=+crt-static` statically links the
+VC runtime **and** the UCRT → the import closure collapses to core OS DLLs only
+(`kernel32`, `ntdll`, `api-ms-win-core-*`), so the `.exe` runs on any Windows,
+no redistributable. Verified locally: with `+crt-static`, `dumpbin /DEPENDENTS`
+drops every `VCRUNTIME*` and `api-ms-win-crt-*` entry.
+
+**The C-dependency wrinkle (why it's not a one-line `.cargo/config.toml` change
+like ripgrep).** ripgrep is ~pure Rust, so `crt-static` is free. We link C
+(`libxml2`/`libxslt` via vcpkg; `libmarpa` via `cc`), and the CRT model must be
+**uniform** across the whole image — `/MT` (static) and `/MD` (dynamic) cannot mix
+(two heaps → corruption). So `+crt-static` (Rust `/MT`) requires the vcpkg libs
+built `/MT` too: triplet **`x64-windows-static`**, NOT `x64-windows-static-md`
+(the `-md` = dynamic CRT, chosen originally to match Rust's default `/MD`). `cc`
+auto-selects `/MT` under `crt-static`, so `libmarpa` follows automatically.
+
+**Scoped to the release leg, not project-wide.** Because flipping the triplet
+forces every build that inherits it onto the static-CRT vcpkg libs, `+crt-static`
++ `x64-windows-static` live **only** in `release.yml`'s `build-windows` leg (env
+`RUSTFLAGS` + `VCPKG*_TRIPLET`), leaving daily dev / `cargo test` / the dispatch
+`windows-ci-manual-trigger.yml` on the fast, already-working `-md` setup. The CRT
+model is invisible to test *logic*, and the release leg self-validates the link.
+
+**CI guard.** `--version` on the runner passes even for a non-portable `.exe` (the
+runner has the redist), so the release leg now also asserts, via `dumpbin
+/DEPENDENTS` (dumpbin located through `vswhere`), that the shipped `.exe` imports
+**no** `VCRUNTIME` — the property that actually guarantees clean-Windows launch.
+
+**Perf footnote (the "slow as debug" report).** Not a build-flags issue — the
+binary is full `maxperf`; warm conversions are ~80 ms. The ~300 ms *first-run*
+cost is Windows Defender scanning the ~47 MB binary on first execution (confirmed:
+every fresh copy pays it; repeat runs ~80 ms), amplified by the embedded 5-year
+dump window's size. Mitigations: Defender exclusion (dev), code-signing
+(distribution), or trimming the dump window; and for a fair Linux-vs-Windows
+benchmark, discard the cold run.
+
 ## Explicitly out of scope (Windows)
 
 - `cortex_worker` / the `cortex` feature (zmq fleet — production runs are Linux).
 - The unix-socket LSP transport (`lsp_server/unix.rs`) — `generic.rs` is the
   Windows path; feature-completeness check is a Phase 3 nice-to-have.
-- In-process libkpathsea linking (subprocess `kpsewhich` is the permanent
-  Windows backend).
+- In-process libkpathsea linking — subprocess `kpsewhich` is the shipped Windows
+  backend for now, BUT no longer "permanent": a static, in-process MSVC build was
+  prototyped and implemented as an opt-in `vendored` feature in `rust-kpathsea`
+  (branch `msvc-static-scope`, `docs/MSVC_STATIC_LINK_SCOPE.md`). It composes with
+  Phase 5.1's `+crt-static` into a single `.exe` importing only core OS DLLs +
+  in-process lookups. Deferred: publish `kpathsea_sys`/`kpathsea` (or a git dep),
+  then flip the release leg. Gains perf on lookup-heavy documents (Windows process
+  spawn is costly); the subprocess backend stays the zero-skew fallback.
 - ARM64 Windows, `x86_64-pc-windows-gnu`, code signing.
 
 ## Risks / open questions


### PR DESCRIPTION
Makes the Windows release .exe truly self-contained: statically links the CRT (+crt-static) with a matching x64-windows-static vcpkg triplet, so it imports only core OS DLLs and runs on any Windows with no VC++ redistributable. Scoped to the release leg; dev/test stay on -md. Adds a dumpbin no-VCRUNTIME CI guard. Verified locally (dumpbin: no VCRUNTIME/UCRT). See docs Phase 5.1.