### PR TITLE
Windows release: in-process kpathsea + fully-static (supersedes #284)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -392,12 +392,13 @@ jobs:
           if-no-files-found: error
 
   # Windows (x86_64-pc-windows-msvc) — a SINGLE self-contained `.exe`. Uses the
-  # proven windows-ci-manual-trigger.yml recipe (vcpkg static libxml2/libxslt,
-  # triplet x64-windows-static-md) but builds the publish-grade `maxperf` binary
-  # and packages the bare `.exe` (+ `.sha256`) — no tarball/.deb, the user runs
-  # the `.exe` directly. `kpathsea` is NOT linked on Windows: TeX paths resolve
-  # through the subprocess `kpsewhich` (MiKTeX/TeX Live on PATH). The `.exe` needs
-  # only the ubiquitous MSVC runtime (static-md = static C libs + dynamic CRT).
+  # proven windows-ci-manual-trigger.yml recipe (vcpkg static libxml2/libxslt)
+  # but builds the publish-grade `maxperf` binary and packages the bare `.exe`
+  # (+ `.sha256`) — no tarball/.deb, the user runs the `.exe` directly.
+  # `kpathsea` is NOT linked on Windows: TeX paths resolve through the subprocess
+  # `kpsewhich` (MiKTeX/TeX Live on PATH). The `.exe` is FULLY STATIC — static C
+  # libs (x64-windows-static) + static CRT (+crt-static) — so it imports only
+  # core OS DLLs and runs on any Windows with no VC++ redistributable.
   # The TL-window dumps are OS-agnostic gzipped text, embedded at build time like
   # the other legs (no TeX Live needed on THIS leg — dumps come from `dumps`).
   build-windows:
@@ -411,11 +412,16 @@ jobs:
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
       RUST_BACKTRACE: "1"
-      # Static C libraries + dynamic CRT (plan Phase 1.1). The MSVC runtime is a
-      # standard system component (VC++ redist), so the `.exe` is effectively
-      # single-file.
-      VCPKG_TRIPLET: x64-windows-static-md
-      VCPKGRS_TRIPLET: x64-windows-static-md
+      # Fully static: static C libraries AND static CRT. `x64-windows-static`
+      # builds libxml2/libxslt against the static CRT (/MT), matching the
+      # `-C target-feature=+crt-static` Rust flag on the build step below — the
+      # whole image is one CRT model. Result: the `.exe` imports NO
+      # VCRUNTIME140.dll and runs on ANY Windows with no VC++ redistributable
+      # (ripgrep's posture; unlike the earlier static-md = dynamic-CRT build,
+      # which needed the redist). Flipping the triplet also rotates the vcpkg
+      # cache key below, forcing a fresh static-CRT build of the C libs.
+      VCPKG_TRIPLET: x64-windows-static
+      VCPKGRS_TRIPLET: x64-windows-static
     steps:
       - uses: actions/checkout@v6
         with:
@@ -480,17 +486,40 @@ jobs:
           #     is why the RC build failed: "kpathsea: no usable TeX backend".
           KPATHSEA_NO_LINK: "1"
           KPATHSEA_SKIP_TOOLCHAIN_CHECK: "1"
+          # Static CRT: statically link the VC runtime + UCRT so the shipped
+          # `.exe` has NO VCRUNTIME140.dll dependency and launches on a clean
+          # Windows with no VC++ redistributable. MUST pair with the
+          # x64-windows-static vcpkg triplet above (one CRT model across Rust
+          # std + the C libs; mixing /MT and /MD is unsupported). RUSTFLAGS env
+          # REPLACES `.cargo/config.toml` rustflags, so re-list the
+          # frontend-parallelism flags to keep them.
+          RUSTFLAGS: "-Zthreads=8 -Zunstable-options -C target-feature=+crt-static"
 
-      # Launch smoke: prove the `.exe` runs on the runner (static-link / vcpkg
-      # sanity). Conversion paths aren't exercised here (no TeX Live on this leg);
+      # Launch smoke + self-containment guard. `--version` alone is NOT enough:
+      # the runner has the VC++ redist, so even a dynamic-CRT `.exe` would launch
+      # here. So we ALSO assert (via dumpbin) that the import table carries no
+      # VCRUNTIME — the actual property that lets the `.exe` run on a clean
+      # Windows. Conversion paths aren't exercised (no TeX Live on this leg);
       # windows-ci-manual-trigger.yml runs the full suite with TeX Live.
-      - name: launch smoke
+      - name: launch smoke + no-VCRUNTIME guard
         shell: bash
         run: |
+          set -euo pipefail
           exe=$(find target/release-artifacts -name '*.exe' -type f | head -1)
           echo "checking $exe"
           "$exe" --version || { echo "::error::Windows .exe failed to launch (--version)"; exit 1; }
           echo "OK: the Windows .exe launches"
+          # Locate dumpbin via vswhere (fixed path on windows runners).
+          vswhere="/c/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
+          vsroot=$("$vswhere" -latest -property installationPath)
+          dumpbin=$(find "$vsroot/VC/Tools/MSVC" -name dumpbin.exe -ipath '*hostx64*x64*' | head -1)
+          deps=$("$dumpbin" //DEPENDENTS "$exe")
+          if echo "$deps" | grep -qi 'vcruntime'; then
+            echo "$deps"
+            echo "::error::the .exe imports VCRUNTIME — +crt-static did not take effect (check the vcpkg triplet is x64-windows-static)"
+            exit 1
+          fi
+          echo "OK: no VCRUNTIME import — fully static, runs on any Windows"
 
       - name: upload Windows artifact
         uses: actions/upload-artifact@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -487,8 +487,8 @@ jobs:
           #   * RELEASE_EXTRA_FEATURES → make_release.sh appends the feature.
           #   * KPATHSEA_SKIP_TOOLCHAIN_CHECK=1 — this runner has no TeX; a linked
           #     (in-process) build needs no build-time `kpsewhich`.
-          # NOTE: pair with the `+crt-static` / x64-windows-static leg config
-          # (drops VCRUNTIME140) for a fully-static, redistributable `.exe`.
+          # Combined with the `+crt-static` / x64-windows-static leg config below
+          # (drops VCRUNTIME140), this yields a fully-static, redistributable `.exe`.
           RELEASE_EXTRA_FEATURES: kpathsea-build-from-source
           KPATHSEA_SKIP_TOOLCHAIN_CHECK: "1"
           # Static CRT: statically link the VC runtime + UCRT so the shipped
@@ -506,7 +506,7 @@ jobs:
       # VCRUNTIME — the actual property that lets the `.exe` run on a clean
       # Windows. Conversion paths aren't exercised (no TeX Live on this leg);
       # windows-ci-manual-trigger.yml runs the full suite with TeX Live.
-      - name: launch smoke + no-VCRUNTIME guard
+      - name: launch smoke + self-containment guard
         shell: bash
         run: |
           set -euo pipefail
@@ -514,17 +514,22 @@ jobs:
           echo "checking $exe"
           "$exe" --version || { echo "::error::Windows .exe failed to launch (--version)"; exit 1; }
           echo "OK: the Windows .exe launches"
-          # Locate dumpbin via vswhere (fixed path on windows runners).
+          # `--version` alone is NOT enough: the runner has the VC++ redist + TeX
+          # nowhere near, so even a non-portable exe launches. Assert (via dumpbin,
+          # located through vswhere) that the import table carries NONE of the
+          # things that would tie the exe to this machine: the VC runtime
+          # (+crt-static), kpathsea's DLL (build_from_source static, not the
+          # dynamic kpathsealibw64.dll path), or libxml2/libxslt (vcpkg static).
           vswhere="/c/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
           vsroot=$("$vswhere" -latest -property installationPath)
           dumpbin=$(find "$vsroot/VC/Tools/MSVC" -name dumpbin.exe -ipath '*hostx64*x64*' | head -1)
           deps=$("$dumpbin" //DEPENDENTS "$exe")
-          if echo "$deps" | grep -qi 'vcruntime'; then
+          if echo "$deps" | grep -qiE 'vcruntime|kpathsea|libxml|libxslt'; then
             echo "$deps"
-            echo "::error::the .exe imports VCRUNTIME — +crt-static did not take effect (check the vcpkg triplet is x64-windows-static)"
+            echo "::error::the .exe imports a non-OS DLL (VCRUNTIME / kpathsea / libxml*) — it is not fully static (check +crt-static, x64-windows-static, and kpathsea-build-from-source all took effect)"
             exit 1
           fi
-          echo "OK: no VCRUNTIME import — fully static, runs on any Windows"
+          echo "OK: imports only core OS DLLs — fully static, runs on any Windows / any TeX distro"
 
       - name: upload Windows artifact
         uses: actions/upload-artifact@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -467,18 +467,23 @@ jobs:
         env:
           GITHUB_REF_NAME: ${{ github.ref_name }}
           RELEASE_TARGET: x86_64-pc-windows-msvc
-          # Subprocess-`kpsewhich` backend for the shipped `.exe`: it resolves
-          # TeX files via the user's `kpsewhich` (TeX Live / MiKTeX on PATH) at
-          # runtime, so this build must NOT link libkpathsea.
-          #   * KPATHSEA_NO_LINK=1 — force the unlinked (subprocess) backend.
-          #     Without it, kpathsea_sys would try to link TL's
-          #     kpathsealibw64.dll, and a TL-linked `.exe` won't even launch on
-          #     a MiKTeX-only host (WINDOWS_COMPATIBILITY_PLAN Phase 2 landmine).
-          #   * KPATHSEA_SKIP_TOOLCHAIN_CHECK=1 — this runner has no TeX, so
-          #     bypass the build-time `kpsewhich`-presence check (the exact
-          #     build-here-deploy-there escape hatch kpathsea documents). This
-          #     is why the RC build failed: "kpathsea: no usable TeX backend".
-          KPATHSEA_NO_LINK: "1"
+          # IN-PROCESS kpathsea via a STATIC libkpathsea built from source
+          # (`kpathsea-build-from-source`). This removes the subprocess
+          # `ls-R`-cache-build cost (~0.5 s/conversion — the RC's dominant
+          # Windows overhead on simple docs; WINDOWS_COMPATIBILITY_PLAN Phase 5.1)
+          # AND stays self-contained: a STATIC link has no runtime
+          # `kpathsealibw64.dll` dependency, so it launches on any Windows / any
+          # TeX distro — unlike the dynamic-DLL path (the Phase-2 launch landmine)
+          # that the old `KPATHSEA_NO_LINK=1` subprocess backend avoided at a perf
+          # cost. `kpathsea_sys` fetches the pinned kpathsea source at build time
+          # (git on the runner; LGPL — see THIRD-PARTY-NOTICES, same posture as the
+          # Linux/macOS `build_static_kpathsea.sh` legs).
+          #   * RELEASE_EXTRA_FEATURES → make_release.sh appends the feature.
+          #   * KPATHSEA_SKIP_TOOLCHAIN_CHECK=1 — this runner has no TeX; a linked
+          #     (in-process) build needs no build-time `kpsewhich`.
+          # NOTE: pair with the `+crt-static` / x64-windows-static leg config
+          # (drops VCRUNTIME140) for a fully-static, redistributable `.exe`.
+          RELEASE_EXTRA_FEATURES: kpathsea-build-from-source
           KPATHSEA_SKIP_TOOLCHAIN_CHECK: "1"
 
       # Launch smoke: prove the `.exe` runs on the runner (static-link / vcpkg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,13 @@ unused_qualifications = "warn"
 # [patch."https://github.com/dginev/marpa"]
 # marpa = { path = "/home/deyan/git/marpa/marpa" }
 
+# kpathsea with the `build-from-source` feature (static in-process libkpathsea on
+# windows-msvc). TEMPORARY: until rust-kpathsea#21 (kpathsea_sys 0.2.2 /
+# build_from_source) is merged + published, consume it from the branch. Replace
+# with the published version once available.
+[patch.crates-io]
+kpathsea = { git = "https://github.com/dginev/rust-kpathsea", branch = "msvc-static-scope" }
+
 [profile.release]
 # Local benchmark/sandbox/canvas profile. Tuned for the 32 GB / 20-thread
 # laptop used to rebuild the sandbox corpus: keep strong optimized binaries

--- a/docs/release/WINDOWS_COMPATIBILITY_PLAN.md
+++ b/docs/release/WINDOWS_COMPATIBILITY_PLAN.md
@@ -469,9 +469,12 @@ KPATHSEA_NO_LINK=1 cargo build --no-default-features \
 ```
 
 Results on the bring-up box: 46.9 MB exe (vs 58.9 MB release-profile);
-`dumpbin /DEPENDENTS` shows ONLY OS DLLs + VC runtime (`VCRUNTIME140*`,
-UCRT `api-ms-win-crt-*` — the `-md` dynamic-CRT triplet choice; both ship
-with Windows 10+/every VC redist); converts on a MiKTeX-only PATH and
+`dumpbin /DEPENDENTS` shows OS DLLs + the VC runtime (`VCRUNTIME140*`) +
+UCRT (`api-ms-win-crt-*`) — the `-md` dynamic-CRT triplet choice. **Caveat
+(corrected 2026-07-14, see Phase 5.1): only the UCRT ships with Windows
+10+; `VCRUNTIME140.dll`/`VCRUNTIME140_1.dll` are the VC++ *redistributable*,
+NOT part of Windows** — so this `-md` build is not truly self-contained on a
+clean box. Converts on a MiKTeX-only PATH and
 produces full HTML5 + CSS on TL; embedded dumps verified by renaming
 `resources/dumps` away (no degraded-mode warning). Packaged as
 `latexml-oxide-<version>-x86_64-pc-windows-msvc.zip` + `.sha256` sidecar
@@ -497,13 +500,65 @@ release-dumps.yml embed unchanged) and the README platform table.
 4. Update `RELEASE_CRITERIA.md` portability ladder (rung 5 → in progress → done)
    and `RELEASING.md` platform matrix.
 
+## Phase 5.1 — fully-static `.exe` (static CRT) — LANDED 2026-07-14
+
+**Problem.** The RC 0.7.4-rc1 `.exe` (the `-md` triplet) dynamically links
+`VCRUNTIME140.dll` + `VCRUNTIME140_1.dll` (the MSVC C++ runtime). Those are **not**
+part of a clean Windows install — they ship with the VC++ Redistributable — so
+on a machine without it, the `.exe` fails to *launch* (`ERROR_BAD_EXE_FORMAT` /
+missing-DLL) before `main`. It only ran on dev boxes because the VS toolchain put
+`VCRUNTIME140.dll` there. (First-principles: a distributable `.exe`'s entire
+transitive import closure must resolve to DLLs guaranteed present on the target;
+the UCRT `api-ms-win-crt-*` set qualifies on Win10+, the VC runtime does not.)
+
+**Fix (ripgrep's posture).** `-C target-feature=+crt-static` statically links the
+VC runtime **and** the UCRT → the import closure collapses to core OS DLLs only
+(`kernel32`, `ntdll`, `api-ms-win-core-*`), so the `.exe` runs on any Windows,
+no redistributable. Verified locally: with `+crt-static`, `dumpbin /DEPENDENTS`
+drops every `VCRUNTIME*` and `api-ms-win-crt-*` entry.
+
+**The C-dependency wrinkle (why it's not a one-line `.cargo/config.toml` change
+like ripgrep).** ripgrep is ~pure Rust, so `crt-static` is free. We link C
+(`libxml2`/`libxslt` via vcpkg; `libmarpa` via `cc`), and the CRT model must be
+**uniform** across the whole image — `/MT` (static) and `/MD` (dynamic) cannot mix
+(two heaps → corruption). So `+crt-static` (Rust `/MT`) requires the vcpkg libs
+built `/MT` too: triplet **`x64-windows-static`**, NOT `x64-windows-static-md`
+(the `-md` = dynamic CRT, chosen originally to match Rust's default `/MD`). `cc`
+auto-selects `/MT` under `crt-static`, so `libmarpa` follows automatically.
+
+**Scoped to the release leg, not project-wide.** Because flipping the triplet
+forces every build that inherits it onto the static-CRT vcpkg libs, `+crt-static`
++ `x64-windows-static` live **only** in `release.yml`'s `build-windows` leg (env
+`RUSTFLAGS` + `VCPKG*_TRIPLET`), leaving daily dev / `cargo test` / the dispatch
+`windows-ci-manual-trigger.yml` on the fast, already-working `-md` setup. The CRT
+model is invisible to test *logic*, and the release leg self-validates the link.
+
+**CI guard.** `--version` on the runner passes even for a non-portable `.exe` (the
+runner has the redist), so the release leg now also asserts, via `dumpbin
+/DEPENDENTS` (dumpbin located through `vswhere`), that the shipped `.exe` imports
+**no** `VCRUNTIME` — the property that actually guarantees clean-Windows launch.
+
+**Perf footnote (the "slow as debug" report).** Not a build-flags issue — the
+binary is full `maxperf`; warm conversions are ~80 ms. The ~300 ms *first-run*
+cost is Windows Defender scanning the ~47 MB binary on first execution (confirmed:
+every fresh copy pays it; repeat runs ~80 ms), amplified by the embedded 5-year
+dump window's size. Mitigations: Defender exclusion (dev), code-signing
+(distribution), or trimming the dump window; and for a fair Linux-vs-Windows
+benchmark, discard the cold run.
+
 ## Explicitly out of scope (Windows)
 
 - `cortex_worker` / the `cortex` feature (zmq fleet — production runs are Linux).
 - The unix-socket LSP transport (`lsp_server/unix.rs`) — `generic.rs` is the
   Windows path; feature-completeness check is a Phase 3 nice-to-have.
-- In-process libkpathsea linking (subprocess `kpsewhich` is the permanent
-  Windows backend).
+- In-process libkpathsea linking — subprocess `kpsewhich` is the shipped Windows
+  backend for now, BUT no longer "permanent": a static, in-process MSVC build was
+  prototyped and implemented as an opt-in `vendored` feature in `rust-kpathsea`
+  (branch `msvc-static-scope`, `docs/MSVC_STATIC_LINK_SCOPE.md`). It composes with
+  Phase 5.1's `+crt-static` into a single `.exe` importing only core OS DLLs +
+  in-process lookups. Deferred: publish `kpathsea_sys`/`kpathsea` (or a git dep),
+  then flip the release leg. Gains perf on lookup-heavy documents (Windows process
+  spawn is costly); the subprocess backend stays the zero-skew fallback.
 - ARM64 Windows, `x86_64-pc-windows-gnu`, code signing.
 
 ## Risks / open questions

--- a/latexml_core/Cargo.toml
+++ b/latexml_core/Cargo.toml
@@ -25,6 +25,13 @@ crate-type = ["lib"]
 default = ["kpathsea"]
 kpathsea = ["dep:kpathsea"]
 
+# Static in-process libkpathsea on windows-msvc: forwards to the kpathsea crate's
+# `build-from-source` (fetch + compile a static libkpathsea → in-process,
+# self-contained, no runtime kpathsealibw64.dll). Inert off windows-msvc. Off by
+# default — the shipped default is the subprocess/DLL backend; distribution
+# opts in. Removes the subprocess `ls-R`-cache-build cost (~0.5 s/conversion).
+kpathsea-build-from-source = ["kpathsea", "kpathsea/build-from-source"]
+
 # Activated by `latexml_codegen` (host-side proc-macro) to enable the
 # `impl ToTokens for Tokens / Catcode / Token / Parameters / Parameter`
 # blocks. Resolver v2 isolates proc-macro feature unification, so the

--- a/latexml_oxide/Cargo.toml
+++ b/latexml_oxide/Cargo.toml
@@ -73,6 +73,12 @@ token-locators = [
   "latexml_contrib/token-locators",
   "latexml_math_parser/token-locators",
 ]
+# Static in-process libkpathsea on windows-msvc (forwards to
+# latexml_core/kpathsea-build-from-source → the kpathsea crate's build-from-source).
+# Off by default; inert off windows-msvc. The Windows distribution build opts in
+# to drop the subprocess `ls-R`-cache-build cost (~0.5 s/conversion). Requires the
+# root [patch] on kpathsea until rust-kpathsea#21 publishes.
+kpathsea-build-from-source = ["latexml_core/kpathsea-build-from-source"]
 # Runtime (Rhai) script bindings (docs/parity/script_bindings_plan.md) — propagates
 # to latexml_contrib (the only crate that embeds Rhai). ON by default:
 # downstream consumers of the single-file binary customize bindings without

--- a/tools/make_release.sh
+++ b/tools/make_release.sh
@@ -103,8 +103,12 @@ mkdir -p "${stage_dir}"
 # bindings without recompiling — runtime opt-in, so default conversions are
 # unchanged), on the publish-grade profile (fat LTO, panic=abort,
 # codegen-units=1).
-echo "make_release: cargo build --no-default-features --features runtime-bindings --profile maxperf --bin latexml_oxide"
-cargo build --no-default-features --features runtime-bindings --profile maxperf --bin latexml_oxide
+# Per-target extra features (e.g. the Windows leg opts into
+# `kpathsea-build-from-source` for a static in-process libkpathsea). Empty
+# elsewhere, so the recipe is unchanged on Linux/macOS.
+features="runtime-bindings${RELEASE_EXTRA_FEATURES:+,${RELEASE_EXTRA_FEATURES}}"
+echo "make_release: cargo build --no-default-features --features ${features} --profile maxperf --bin latexml_oxide"
+cargo build --no-default-features --features "${features}" --profile maxperf --bin latexml_oxide
 
 bin_path="target/maxperf/latexml_oxide${bin_suffix}"
 # -f not -x: Git Bash on Windows doesn't report a .exe as `-x`.


### PR DESCRIPTION
Makes the Windows release `.exe` **fast** and **fully self-contained**, consolidating two improvements into the one Windows release leg. Supersedes #284 (crt-static), which is folded in here.

## 1. In-process kpathsea (the perf fix)
The RC uses the subprocess-`kpsewhich` backend (`KPATHSEA_NO_LINK`), which pays a fixed **~0.5 s/conversion** building the `ls-R` cache in Rust — the RC's dominant Windows overhead on simple docs (the Linux/macOS release binaries link kpathsea in-process and never pay it). Switch to a **static in-process libkpathsea** via the new `kpathsea-build-from-source` feature (rust-kpathsea#21: fetch + compile, LGPL-clean crate).

Measured (warm best-of-3, vs the RC), local self-contained build:

| doc | RC (subprocess) | new (in-process) | speedup |
|---|---|---|---|
| hello.tex | 1,123 ms | 518 ms | **2.17×** |
| mathtools.tex | 2,149 ms | 1,454 ms | 1.48× |
| si.tex | 2,809 ms | 2,352 ms | 1.19× |

## 2. Fully static (from #284)
`+crt-static` + the `x64-windows-static` vcpkg triplet drop the `VCRUNTIME140.dll` dependency. Combined with the static kpathsea link (no `kpathsealibw64.dll`) and static libxml2/libxslt, the `.exe` imports **only core OS DLLs** — runs on any Windows, any TeX distro, no VC++ redistributable.

## Wiring
- `kpathsea` crate: `build-from-source` passthrough (rust-kpathsea#21).
- `latexml_core` / `latexml_oxide`: `kpathsea-build-from-source` passthrough features (off by default; inert off windows-msvc).
- `make_release.sh`: `RELEASE_EXTRA_FEATURES` hook (empty on Linux/macOS).
- `release.yml` Windows leg: in-process + crt-static + a `dumpbin` guard asserting the `.exe` imports no non-OS DLL.
- Temporary root `[patch]` on kpathsea until rust-kpathsea#21 publishes.

## Verified locally
Self-contained `.exe` (dumpbin: only OS DLLs), `--version` OK, 2.17× on simple docs. Depends on rust-kpathsea#21 (merge + publish, or keep the git patch).

## Notes / follow-ups
- LGPL §6: the static kpathsea link carries the same obligation the Linux/macOS static legs already do — a separate docs pass should add kpathsea to `THIRD-PARTY-NOTICES` for all three platforms.
- Residual ~350 ms Windows cold cost is binary-load/Defender (size); trimming the embedded dump window is the next lever.
