### PR TITLE
ar5iv issue sprint: xcolor global dvipsnames, sidecap, \ifmmode coverage + diagnostic plan

### DIFF
--- a/docs/AR5IV_DIAGNOSTICS.md
+++ b/docs/AR5IV_DIAGNOSTICS.md
@@ -71,8 +71,14 @@ the high-error RUST-BETTER papers (surpass-Perl, real-LaTeX-correct).
    mirrors `ar5iv.sty.ltxml`) so the enhanced/breakable/skins keys resolve.
    2509.24704 **5→2**, 2511.16624 **4→2** (residual = the paper's own `luabridge`
    expl3, separate). 2412.06264's `\or`/`\f`-fragment flood (483) is a distinct
-   paper-specific issue, not frontmatter. `selfevolagent.cls` (2508.07407/#556) is
-   a near-identical sibling awaiting the same treatment.
+   paper-specific issue, not frontmatter. Two near-identical sibling classes got
+   the same treatment: **`selfevolagent.cls`** (2508.07407/#556 — frontmatter
+   captured; residual `Stomach:Recursion` is a box-loop in the paper's
+   `paradigms.tex`, separate) and **`openmoss.cls`** (2605.12090/#605 — 14→1: the
+   `\definecolor{openmossblue}` set + `\checkdata` frontmatter now defined,
+   residual `{forest}` is the parity stub). All three `\RequirePackage[latin,
+   english]{babel}` — openmoss's `\addto\extrasenglish` needed babel required in
+   the binding.
    **Core parity fix (general — benefits far beyond fairmeta):** the class loads
    `nicematrix` (→ `\RequirePackage{pgfcore}`, faithful to nicematrix.sty:23) then
    `tcolorbox[most]` (whose `skins` library also needs pgfcore). pgfcore has no

--- a/docs/AR5IV_DIAGNOSTICS.md
+++ b/docs/AR5IV_DIAGNOSTICS.md
@@ -1,0 +1,236 @@
+# ar5iv issue mini-sprint — diagnostic sweep (2026-07-18)
+
+**Purpose.** The [`dginev/ar5iv`](https://github.com/dginev/ar5iv/issues) tracker
+holds 100 open "Improve article X" reports. Each was filed against the **Perl**
+LaTeXML HTML that ar5iv served at the time. We now serve **latexml-oxide** (Rust),
+which may already have fixed some. This doc screens every open-issue paper against
+the *current* Rust binary, classifies each vs same-host Perl, and produces the
+ranked worklist for the follow-on implementation sprint.
+
+> Diagnostic snapshot — dated per the CLAUDE.md naming rule. Regenerate before
+> re-planning; do not treat as a live worklist once acted on. Branch
+> `ar5iv-minisprint`.
+
+## Method
+
+- Source: `/data/arxiv/<YYMM>/<id>/<id>.zip`, copied to a scratch dir and
+  converted from within it (so local `.cls`/`.sty` resolve).
+- Rust command (the ar5iv site configuration):
+  `latexml_oxide --preload=ar5iv.sty --nodefaultresources --path=~/git/ar5iv-css/css --css=ar5iv.css --dest=out.html <main>`
+  under the debug build, 150 s timeout.
+- Perl baseline (classification): `latexml --path=~/git/ar5iv-bindings/bindings
+  --preload=ar5iv.sty --dest=perl.xml <main>`, v0.8.8, 200 s timeout.
+- Signals: ANSI-stripped `^Error:` / `^Fatal:` counts, exit code (124 = timeout),
+  HTML size, top error categories. Ground truth spot-checked with `pdflatex`
+  (`.log` + PDF).
+
+**Caveat on Perl timeouts.** The Perl baseline ran under 10× parallelism, so many
+`rc=124` (timeout) rows are contention artifacts, not true 1× timeouts. The
+**reliable** signal is the *error-count* comparison where both engines complete;
+"Perl times out" rows should be re-checked at 1× before claiming a win. The Perl
+`101e/1f` rows are its `too_many_errors` fatal (>100 errors) — genuine Perl
+failure.
+
+## Verdict tally (by distinct paper; some papers span multiple issues)
+
+| class | papers | meaning |
+|---|---|---|
+| **CLEAN** | 46 | Rust converts 0-error — issue effectively already resolved |
+| **RUST-BETTER** | 25 | Rust completes where Perl fatals/times out (several still have reducible Rust errors) |
+| **PARITY** | 8 | Rust ≈ Perl error count — shared missing macro/package |
+| **PARITY-TIMEOUT** | 9 | both time out — shared, hard |
+| **RUST-WORSE** | 4 | genuine Rust regression — top priority |
+| **??** | 2 | #518 feature (dark mode, ar5iv frontend); #537 no main file detected |
+
+Of 100 issues: **~48 issues already convert clean** in latexml-oxide (46 papers +
+duplicate-issue coverage). The actionable engine work is the RUST-WORSE set plus
+the high-error RUST-BETTER papers (surpass-Perl, real-LaTeX-correct).
+
+## Root-cause clusters (drives the worklist)
+
+1. **`dvipsnames` global class option** — `2405.04517` (**912** errors,
+   #503/#495/#474). `\documentclass[dvipsnames]{article}` + `\usepackage{xcolor}`.
+   `pdflatex` loads `dvipsnam.def` once (via xcolor) and `OliveGreen` works; both
+   LaTeXML engines fail. **Root-caused** (Rust): the binding's `xcolor →
+   RequirePackage(color)` divergence (real xcolor is standalone) lets `color`
+   process the *global* `dvipsnames` first — it loads `dvipsnam.def` **without
+   `usenames`**, and the `input_definitions` load-dedup then makes xcolor's
+   proper (usenames-active) load a no-op → the 68 dvips colors never register in
+   xcolor's DB. The *direct* form `\usepackage[dvipsnames]{xcolor}` works (color
+   never sees the option). **surpass-Perl, self-contained → Tier 1.**
+2. **`fairmeta.cls` / ML meta-class cluster** — `2412.06264` (**504** `\or`),
+   `2509.24704` / `2511.16624` (`\metadata`, `\contribution`, `\beginappendix`
+   undefined), `2508.07407` (`Stomach:Recursion` + `\metadata`). These classes
+   (fairmeta, selfevolagent) are expl3/`nicematrix`/`luabridge`-heavy; a failure
+   partway through the class body leaves later `\newcommand`s undefined, and the
+   `\or` flood traces to conditional/`\ifcase` parsing under the class's expl3
+   code. Cross-cutting → Tier 3.
+3. **`\lx@begin@alignment` / `\lx@end@inline@math` grouping** — `2311.06609`
+   (**82**, RUST-WORSE, siamart), `2405.21060` (26), `2310.07298` (24),
+   `2309.16609` (31), `1811.10792` (RUST-WORSE timeout). Inline-math / amsmath
+   alignment group balance. Contains the clearest RUST-WORSE regression.
+4. **`_` / `^` "script can only appear in math mode" cascade** — `2604.16007`
+   (60), `2305.05665` (33, `axessibility`), `1404.3143` (ytableau, **parity** —
+   Perl fatals worse), `2312.11805`, `2408.15403`. Mixed roots; `axessibility`
+   (redefines `_`/`^`) is a recurring suspect.
+5. **`\else`/`\fi` flood (minted)** — `2602.15902` (**783**, RUST-WORSE).
+   `minted`/`fvextra` conditional machinery.
+6. **`malformed:ltx:subsection/section` nesting** — `2402.13846` (16),
+   `2507.00833` (8). Sectioning depth / float placement.
+7. **`{forest}` undefined** — `2107.13586`, `2511.18538`, `2605.12090`,
+   `2505.01658`. The `forest` tree-drawing package (unbound; often also a
+   timeout). Largely parity.
+8. **tabular grouping** — `2301.12995` (16 `\@end@tabular`).
+9. **Timeouts (11)** — mostly **parity** (both engines time out: forest, tikz,
+   tcolorbox, pgf). `1811.10792` and `2310.17416` are **Rust-only** timeouts.
+10. **Single missing macro (parity)** — `\BibSpecAlias`, `\titlehead`,
+    `{refsegment}`/biblatex, `\bfR`, etc. Both engines fail identically.
+
+## Ranked worklist for the implementation sprint
+
+- **Tier 1 — land now (confirmed, high-value, self-contained):**
+  - [x] **LANDED** `dvipsnames` global class option → xcolor (2405.04517, **912
+    → 0** err, #503/#495/#474). Fix: `xcolor` flags `xcolor_driving` around its
+    `RequirePackage(color)` so `color` defers its eager `dvipsnam.def` load to
+    xcolor's authoritative (usenames-active) load — matching pdflatex's one-load
+    outcome. Guard: `tests/graphics/xcolor_global_dvipsnames`.
+- **Tier 2 — genuine RUST-WORSE regressions:**
+  - [ ] `2602.15902` minted `\else/\fi` flood (783).
+  - [ ] `2311.06609` inline-math/alignment grouping (82, siamart).
+  - [ ] `1811.10792`, `2310.17416` Rust-only timeouts (min-repro the hot loop).
+- **Tier 3 — recurring clusters (surpass-Perl):**
+  - [ ] fairmeta meta-class family (`\or`, `\metadata`) — 2412.06264 + 3 more.
+  - [ ] `_`/`^` cascade — axessibility path (2305.05665) + 2604.16007.
+  - [ ] malformed sectioning (2402.13846, 2507.00833).
+- **Tier 4 — verify + comment/close the 48 already-clean issues** (batch).
+- **Tier 5 — document as parity / shared-Perl** (PARITY + PARITY-TIMEOUT +
+  single-missing-macro): note on the issue, no engine change unless a cheap
+  shared fix (record in `KNOWN_PERL_ERRORS.md`).
+
+## Full results
+
+<!-- BEGIN GENERATED TABLE -->
+### RUST-WORSE (4 papers)
+
+| issue(s) | arxiv | rust | perl | top rust errors |
+|---|---|---|---|---|
+| #591 | 2602.15902 | ERRORS 783 | 101e/1f | 184×Error:unexpected:\else; 184×Error:unexpected:fi; 174×Error:unexpec |
+| #472 | 2311.06609 | ERRORS 82 | 17e/1f | 36×Error:unexpected:\lx@end@inline@math; 12×Error:malformed:ltx:XMTok; |
+| #594 | 1811.10792 | TIMEOUT 20 | 101e/1f | 14×Error:unexpected:\lx@end@inline@math; 4×Error:unexpected:\halign; 2 |
+| #473 | 2310.17416 | TIMEOUT 5 | 101e/1f | 3×Error:unexpected:_; 2×Error:latex:\GenericError; 1×Fatal:Timeout:Con |
+
+### RUST-BETTER (25 papers)
+
+| issue(s) | arxiv | rust | perl | top rust errors |
+|---|---|---|---|---|
+| #474, #495, #503 | 2405.04517 | ERRORS 912 | 0e/1f/TO | 912×Error:unexpected:OliveGreen |
+| #520 | 2412.06264 | ERRORS 504 | 2e/1f/TO | 353×Error:unexpected:\or; 3×Error:unexpected:\lx@end@display@math; 1×E |
+| #597 | 1404.3143 | ERRORS 69 | 101e/1f | 32×Error:unexpected:_; 16×Error:unexpected:^; 9×Error:unexpected:\lx@b |
+| #557 | 2305.05665 | ERRORS 33 | 0e/1f/TO | 33×Error:unexpected:_ |
+| #568 | 2309.16609 | ERRORS 31 | 0e/1f/TO | 18×Error:unexpected:\lx@begin@alignment; 3×Error:unexpected:\endgroup; |
+| #497, #516 | 2405.21060 | ERRORS 26 | 101e/1f | 8×Error:unexpected:\lx@end@inline@math; 6×Error:unexpected:\lx@begin@a |
+| #477 | 2310.07298 | ERRORS 24 | 0e/1f/TO | 11×Error:unexpected:\lx@end@inline@math; 3×Error:unexpected:\lx@begin@ |
+| #504 | 2402.13846 | ERRORS 16 | 2e/1f/TO | 9×Error:malformed:ltx:subsection; 3×Error:malformed:ltx:section; 2×Err |
+| #558 | 2301.12995 | ERRORS 16 | 0e/1f/TO | 16×Error:unexpected:\@end@tabular |
+| #605 | 2605.12090 | ERRORS 14 | 2e/1f/TO | 12×Error:unexpected:openmossblue; 1×Error:undefined:\checkdata; 1×Erro |
+| #569, #570 | 2507.00833 | ERRORS 8 | 0e/1f/TO | 5×Error:malformed:ltx:subsection; 1×Error:malformed:ltx:section; 1×Err |
+| #538 | 2003.03231 | ERRORS 7 | 101e/1f | 3×Error:unexpected:\caption; 1×Error:undefined:{sidewaystable}; 1×Erro |
+| #483 | 2312.11805 | ERRORS 6 | 0e/1f/TO | 4×Error:unexpected:_; 1×Error:undefined:\reportnumber; 1×Error:malform |
+| #567 | 2509.24704 | ERRORS 5 | 2e/1f/TO | 1×Error:undefined:\g_luabridge_method_int; 1×Error:expected:<relationa |
+| #576 | 2511.16624 | ERRORS 4 | 2e/1f/TO | 1×Error:undefined:\contribution; 1×Error:undefined:\metadata; 1×Error: |
+| #573 | 2511.18538 | ERRORS 3 | 0e/1f/TO | 2×Error:unexpected:_; 1×Error:undefined:{forest} |
+| #556 | 2508.07407 | FATAL 2 | 2e/1f/TO | 1×Error:undefined:\contribution; 1×Error:undefined:\metadata; 1×Fatal: |
+| #476 | 2107.13586 | ERRORS 1 | 0e/1f/TO | 1×Error:undefined:{forest} |
+| #482 | 2310.06461 | ERRORS 1 | 0e/1f/TO | 1×Error:malformed:ltx:bibitem |
+| #498 | 2305.01582 | ERRORS 1 | 0e/1f/TO | 1×Error:undefined:\titlehead |
+| #499 | 2405.08669 | ERRORS 1 | 0e/1f/TO | 1×Error:undefined:{pNiceMatrix} |
+| #523 | 2408.15403 | ERRORS 1 | 1e/1f/TO | 1×Error:unexpected:_ |
+| #527 | 2410.19788 | ERRORS 1 | 0e/1f/TO | 1×Error:undefined:\fail |
+| #555 | 2408.08435 | ERRORS 1 | 0e/1f/TO | 1×Error:undefined:\sidecaptionvpos |
+| #566 | 2407.16741 | ERRORS 1 | 63e/0f | 1×Error:malformed:ltx:itemize |
+
+### PARITY (8 papers)
+
+| issue(s) | arxiv | rust | perl | top rust errors |
+|---|---|---|---|---|
+| #601 | 2604.16007 | ERRORS 63 | 89e/0f | 60×Error:unexpected:_; 1×Error:undefined:\@ACM@balancefalse; 1×Error:u |
+| #493 | 1705.07115 | ERRORS 8 | 8e/0f | 4×Error:unexpected:_; 2×Error:malformed:ltx:section; 2×Error:malformed |
+| #584 | 2511.20436 | ERRORS 7 | 7e/0f | 1×Error:undefined:\onehalfspacing; 1×Error:undefined:\prof; 1×Error:un |
+| #484 | 2311.14451 | ERRORS 3 | 3e/0f | 2×Error:unexpected:\noalign; 1×Error:undefined:\bfR |
+| #554 | 2406.02507 | ERRORS 2 | 2e/0f | 2×Error:malformed:ltx:listing |
+| #580 | 2112.06778 | ERRORS 2 | 2e/0f | 1×Error:undefined:{refsegment}; 1×Error:undefined:\defbibfilter |
+| #485 | 2302.08557 | ERRORS 1 | 1e/0f | 1×Error:undefined:\BibSpecAlias |
+| #585 | 1802.09089 | ERRORS 1 | 1e/0f | 1×Error:unexpected:_ |
+
+### PARITY-TIMEOUT (9 papers)
+
+| issue(s) | arxiv | rust | perl | top rust errors |
+|---|---|---|---|---|
+| #471 | 2308.04512 | TIMEOUT 7 | 0e/1f/TO | 3×Error:expected:<variable>; 1×Error:undefined:\tablinesep; 1×Error:un |
+| #596 | 2505.01658 | TIMEOUT 1 | 0e/1f/TO | 1×Error:undefined:{forest}; 1×Fatal:Timeout:Convert |
+| #522 | 2405.19920 | TIMEOUT 0 | 0e/1f/TO | 1×Fatal:Timeout:Convert |
+| #533 | 2406.15882 | TIMEOUT 0 | 0e/1f/TO | 1×Fatal:Timeout:Convert |
+| #546 | 2504.07033 | TIMEOUT 0 | 0e/1f/TO | 1×Fatal:Timeout:Convert |
+| #550 | 2501.09223 | TIMEOUT 0 | 0e/1f/TO | 1×Fatal:Timeout:Convert |
+| #551 | 2501.10235 | TIMEOUT 0 | 4e/1f/TO | 1×Fatal:Timeout:Convert |
+| #598 | 1611.02087 | TIMEOUT 0 | 0e/1f/TO | 1×Fatal:Timeout:Convert |
+| #599 | 1802.01134 | TIMEOUT 0 | 0e/1f/TO | 1×Fatal:Timeout:Convert |
+
+### CLEAN (46 papers)
+
+| issue(s) | arxiv | rust | perl | top rust errors |
+|---|---|---|---|---|
+| #478 | 2402.16499 | OK 0 | -e/-f |  |
+| #480 | 2403.13327 | OK 0 | -e/-f |  |
+| #486 | 2311.11571 | OK 0 | -e/-f |  |
+| #487 | 2306.11825 | OK 0 | -e/-f |  |
+| #490 | 2310.00718 | OK 0 | -e/-f |  |
+| #491 | 2305.15121 | OK 0 | -e/-f |  |
+| #494 | 2305.15852 | OK 0 | -e/-f |  |
+| #496 | 2210.04610 | OK 0 | -e/-f |  |
+| #500 | 2409.10821 | OK 0 | -e/-f |  |
+| #501 | 2305.20086 | OK 0 | -e/-f |  |
+| #502 | 1612.01474 | OK 0 | -e/-f |  |
+| #505 | 2405.14205 | OK 0 | -e/-f |  |
+| #508 | 2401.11605 | OK 0 | -e/-f |  |
+| #511 | 1806.03335 | OK 0 | -e/-f |  |
+| #512 | 2401.00905 | OK 0 | -e/-f |  |
+| #513 | 2405.03553 | OK 0 | -e/-f |  |
+| #515 | 2409.01392 | OK 0 | -e/-f |  |
+| #517 | 1701.02434 | OK 0 | -e/-f |  |
+| #519 | 2406.16976 | OK 0 | -e/-f |  |
+| #521 | 1610.06545 | OK 0 | -e/-f |  |
+| #525 | 2412.13420 | OK 0 | -e/-f |  |
+| #526 | 2502.13923 | OK 0 | -e/-f |  |
+| #528 | 2110.02178 | OK 0 | -e/-f |  |
+| #529 | 2502.16671 | OK 0 | -e/-f |  |
+| #530 | 2410.07745 | OK 0 | -e/-f |  |
+| #531 | 2405.16376 | OK 0 | -e/-f |  |
+| #532, #563 | 2503.20215 | OK 0 | -e/-f |  |
+| #534, #590 | 2412.15115 | OK 0 | -e/-f |  |
+| #535 | 2103.14899 | OK 0 | -e/-f |  |
+| #536 | 2407.09394 | OK 0 | -e/-f |  |
+| #539 | 2304.14646 | OK 0 | -e/-f |  |
+| #540 | 2502.08235 | OK 0 | -e/-f |  |
+| #548 | 2311.03307 | OK 0 | -e/-f |  |
+| #552 | 2507.19457 | OK 0 | -e/-f |  |
+| #560 | 2406.16860 | OK 0 | -e/-f |  |
+| #562 | 2406.12045 | OK 0 | -e/-f |  |
+| #565 | 2505.02881 | OK 0 | -e/-f |  |
+| #571 | 1406.4858 | OK 0 | -e/-f |  |
+| #572 | 1307.6856 | OK 0 | -e/-f |  |
+| #578 | 1509.03700 | OK 0 | -e/-f |  |
+| #581 | 1604.00449 | OK 0 | -e/-f |  |
+| #582 | math/9405204 | OK 0 | -e/-f |  |
+| #587 | 2505.22648 | OK 0 | -e/-f |  |
+| #592 | 2602.20089 | OK 0 | -e/-f |  |
+| #595 | 2505.11584 | OK 0 | -e/-f |  |
+| #600 | 2507.00769 | OK 0 | -e/-f |  |
+
+### ?? (2 papers)
+
+| issue(s) | arxiv | rust | perl | top rust errors |
+|---|---|---|---|---|
+| #518 | NONE | NOLOG 0 | - |  |
+| #537 | 1606.05250 | NOLOG -1 | -e/-f |  |
+<!-- END GENERATED TABLE -->

--- a/docs/AR5IV_DIAGNOSTICS.md
+++ b/docs/AR5IV_DIAGNOSTICS.md
@@ -39,7 +39,7 @@ failure.
 | **RUST-BETTER** | 25 | Rust completes where Perl fatals/times out (several still have reducible Rust errors) |
 | **PARITY** | 8 | Rust ≈ Perl error count — shared missing macro/package |
 | **PARITY-TIMEOUT** | 9 | both time out — shared, hard |
-| **RUST-WORSE** | 4 | genuine Rust regression — top priority |
+| **RUST-WORSE** | 3 | genuine Rust regression — top priority (was 4; `2602.15902` reclassified → parity, see cluster 5) |
 | **??** | 2 | #518 feature (dark mode, ar5iv frontend); #537 no main file detected |
 
 Of 100 issues: **~48 issues already convert clean** in latexml-oxide (46 papers +
@@ -70,11 +70,24 @@ the high-error RUST-BETTER papers (surpass-Perl, real-LaTeX-correct).
    `2309.16609` (31), `1811.10792` (RUST-WORSE timeout). Inline-math / amsmath
    alignment group balance. Contains the clearest RUST-WORSE regression.
 4. **`_` / `^` "script can only appear in math mode" cascade** — `2604.16007`
-   (60), `2305.05665` (33, `axessibility`), `1404.3143` (ytableau, **parity** —
-   Perl fatals worse), `2312.11805`, `2408.15403`. Mixed roots; `axessibility`
-   (redefines `_`/`^`) is a recurring suspect.
-5. **`\else`/`\fi` flood (minted)** — `2602.15902` (**783**, RUST-WORSE).
-   `minted`/`fvextra` conditional machinery.
+   (60), `2305.05665` (33), `1404.3143` (ytableau, **parity** — Perl fatals
+   worse), `2312.11805`, `2408.15403`. Errors originate at "Anonymous String"
+   (macro-generated), not source lines. **Not** axessibility — the Rust
+   `axessibility` binding is a faithful, identical port of Perl's (parity); ruled
+   out. Mixed deep roots (table cell / pgfplots / ytableau); largely parity.
+5. **`\ifmmode` double-`\else` flood** — `2602.15902` (783). **RECLASSIFIED →
+   PARITY.** Minimal repro: `\textbf{\mintinline{latex}{CD}}`. Both LaTeXML
+   bindings map `\mintinline` → fragile `\verb` (Rust `minted_sty.rs:108`, Perl
+   `minted.sty.ltxml:107`); `\verb` inside `\textbf`'s `\ifmmode\else\fi`
+   corrupts the conditional **identically in both engines** (verified — Perl
+   emits the same `Extra \else` / `\fi` / `\lx@hidden@egroup` cascade). The
+   783-vs-101 gap is only Perl bailing at `too_many_errors:100`; per-occurrence
+   behaviour is the same. A real-minted `\mintinline` is robust (works in an
+   arg), but pdflatex here can't run minted v3 (executable absent) so there is no
+   local oracle. **No faithful engine change** (both track Perl); a surpass-both
+   "robust `\mintinline`" is possible but out of mini-sprint scope. Direct
+   `\ifmmode` coverage added: `tests/expansion/ifmmode`, `.../ensuremath_mode`
+   (every branch selection verified to match pdflatex).
 6. **`malformed:ltx:subsection/section` nesting** — `2402.13846` (16),
    `2507.00833` (8). Root: a **`\newtcblisting` (tcolorbox) verbatim box does not
    close**, so deeply-nested `<ltx:verbatim><ltx:verbatim>…` swallows subsequent

--- a/docs/AR5IV_DIAGNOSTICS.md
+++ b/docs/AR5IV_DIAGNOSTICS.md
@@ -120,11 +120,17 @@ the high-error RUST-BETTER papers (surpass-Perl, real-LaTeX-correct).
    "robust `\mintinline`" is possible but out of mini-sprint scope. Direct
    `\ifmmode` coverage added: `tests/expansion/ifmmode`, `.../ensuremath_mode`
    (every branch selection verified to match pdflatex).
-6. **`malformed:ltx:subsection/section` nesting** — `2402.13846` (16),
-   `2507.00833` (8). Root: a **`\newtcblisting` (tcolorbox) verbatim box does not
-   close**, so deeply-nested `<ltx:verbatim><ltx:verbatim>…` swallows subsequent
-   sectioning (`<ltx:subsection> isn't allowed in <ltx:verbatim>`). tcolorbox
-   listing machinery → Tier 3 (shares tcolorbox complexity with the timeouts).
+6. **`malformed:ltx:subsection/section` nesting** — `2402.13846` (#504),
+   `2507.00833` (#569/#570). **LANDED.** Root: a **`\newtcblisting` (tcolorbox
+   `listings` library) box captured its body verbatim but never CLOSED** at
+   `\end{name}` — the raw library's body reader didn't integrate with LaTeXML's
+   verbatim reader, so the listing swallowed following content and a later
+   `\section` nested inside `<ltx:verbatim>`. Fix (`tcolorbox_sty.rs`): delegate
+   `\newtcblisting{name}[N][d]{tcb-opts}` → listings' `\lstnewenvironment{name}
+   [N][d]{}{}` (drop the visual box options), whose verbatim reader terminates
+   correctly; `locked` so the raw `\tcbuselibrary{listings}` can't clobber it.
+   2507.00833 **8→0**, 2402.13846 **16→1** (residual `\filledstar` = a genuine
+   author-undefined macro, not tcblisting). Guard: `95_newtcblisting_verbatim`.
 7. **`{forest}` undefined** — `2107.13586`, `2511.18538`, `2605.12090`,
    `2505.01658`. The `forest` tree-drawing package (unbound; often also a
    timeout). Largely parity.

--- a/docs/AR5IV_DIAGNOSTICS.md
+++ b/docs/AR5IV_DIAGNOSTICS.md
@@ -58,13 +58,41 @@ the high-error RUST-BETTER papers (surpass-Perl, real-LaTeX-correct).
    proper (usenames-active) load a no-op → the 68 dvips colors never register in
    xcolor's DB. The *direct* form `\usepackage[dvipsnames]{xcolor}` works (color
    never sees the option). **surpass-Perl, self-contained → Tier 1.**
-2. **`fairmeta.cls` / ML meta-class cluster** — `2412.06264` (**504** `\or`),
-   `2509.24704` / `2511.16624` (`\metadata`, `\contribution`, `\beginappendix`
-   undefined), `2508.07407` (`Stomach:Recursion` + `\metadata`). These classes
-   (fairmeta, selfevolagent) are expl3/`nicematrix`/`luabridge`-heavy; a failure
-   partway through the class body leaves later `\newcommand`s undefined, and the
-   `\or` flood traces to conditional/`\ifcase` parsing under the class's expl3
-   code. Cross-cutting → Tier 3.
+2. **`fairmeta.cls` / ML meta-class cluster** — `2509.24704` (#567) / `2511.16624`
+   (#576) / `2412.06264` (#520). **Root (general): an unknown `.cls` body is NOT
+   raw-loaded** — OmniBus extracts its `\RequirePackage` dependencies but does not
+   execute the body, so every class-defined command (`\metadata`, `\contribution`,
+   `\beginappendix`, …) is `Error:undefined` (a `.sty` DOES raw-load; a `.cls`
+   does not). **LANDED** `fairmeta_cls.rs` binding (bytedance/fcs pattern): routes
+   the frontmatter through `\@add@frontmatter`/`\lx@add@author`/`\lx@add@abstract`
+   (title, both authors, affiliations, contribution, metadata, correspondence,
+   abstract all captured), pulls in the real deps, and loads `tcolorbox[most]` via
+   `pass_options("tcolorbox","sty",["most"])` **before** the require (Perl idiom,
+   mirrors `ar5iv.sty.ltxml`) so the enhanced/breakable/skins keys resolve.
+   2509.24704 **5→2**, 2511.16624 **4→2** (residual = the paper's own `luabridge`
+   expl3, separate). 2412.06264's `\or`/`\f`-fragment flood (483) is a distinct
+   paper-specific issue, not frontmatter. `selfevolagent.cls` (2508.07407/#556) is
+   a near-identical sibling awaiting the same treatment.
+   **Core parity fix (general — benefits far beyond fairmeta):** the class loads
+   `nicematrix` (→ `\RequirePackage{pgfcore}`, faithful to nicematrix.sty:23) then
+   `tcolorbox[most]` (whose `skins` library also needs pgfcore). pgfcore has no
+   binding, so nicematrix's bare require missed and — via the Rust-only
+   `_load_attempted` guard — permanently STARVED tcolorbox's later pgfcore
+   raw-load (49 spurious pgf errors); pdflatex loads pgfcore fine in either order.
+   Fix (`content.rs`): set `_load_attempted` only when raw-loading was actually
+   POSSIBLE (`INCLUDE_STYLES` on / `noltxml`). A miss while raw loading is OFF is a
+   deferral, not a genuine "file absent", so a later load once INCLUDE_STYLES turns
+   on (inside another package's raw read) may retry — matching pdflatex. The guard
+   still fires where its loop-prevention is needed (a raw read is itself
+   INCLUDE_STYLES=true). So fairmeta needs **no** `--includestyles`/ar5iv preload:
+   49 → 0. No new flag; restricts the existing Rust-only guard to its real case.
+   **Harness note:** the guard is a fresh-process **binary-driven** test
+   (`92_fairmeta_frontmatter`), not an in-process `tests/contrib` fixture — loading
+   a `LoadClass!("OmniBus")` `.cls` then `reset_thread_engine`-ing between files
+   (as `can_contrib` does) reads a pre-reset `SymStr` from an unresettable `pin!`
+   cache and aborts (the documented one-conversion-per-thread contract). Fresh
+   process = how production runs, and why the ~100 other contrib `.cls` bindings
+   carry no in-process fixture.
 3. **`\lx@begin@alignment` / `\lx@end@inline@math` grouping** — `2311.06609`
    (**82**, RUST-WORSE), `2405.21060` (26), `2310.07298` (24), `2309.16609` (31),
    `1811.10792` (RUST-WORSE timeout). Inline-math / amsmath alignment group

--- a/docs/AR5IV_DIAGNOSTICS.md
+++ b/docs/AR5IV_DIAGNOSTICS.md
@@ -66,9 +66,13 @@ the high-error RUST-BETTER papers (surpass-Perl, real-LaTeX-correct).
    `\or` flood traces to conditional/`\ifcase` parsing under the class's expl3
    code. Cross-cutting → Tier 3.
 3. **`\lx@begin@alignment` / `\lx@end@inline@math` grouping** — `2311.06609`
-   (**82**, RUST-WORSE, siamart), `2405.21060` (26), `2310.07298` (24),
-   `2309.16609` (31), `1811.10792` (RUST-WORSE timeout). Inline-math / amsmath
-   alignment group balance. Contains the clearest RUST-WORSE regression.
+   (**82**, RUST-WORSE), `2405.21060` (26), `2310.07298` (24), `2309.16609` (31),
+   `1811.10792` (RUST-WORSE timeout). Inline-math / amsmath alignment group
+   balance. `2311.06609` root: a **paper-local `code` environment** (`list` +
+   `tabbing` + `\mathcode`\`\:` + custom `\mynewline`) whose inline `$…$` cells
+   break group balance in Rust more than Perl (raw `tabbing`+math is clean in
+   both — verified — so it's the custom-env interaction, not general). Deep,
+   paper-specific.
 4. **`_` / `^` "script can only appear in math mode" cascade** — `2604.16007`
    (60), `2305.05665` (33), `1404.3143` (ytableau, **parity** — Perl fatals
    worse), `2312.11805`, `2408.15403`. Errors originate at "Anonymous String"

--- a/docs/AR5IV_DIAGNOSTICS.md
+++ b/docs/AR5IV_DIAGNOSTICS.md
@@ -11,6 +11,166 @@ ranked worklist for the follow-on implementation sprint.
 > re-planning; do not treat as a live worklist once acted on. Branch
 > `ar5iv-minisprint`.
 
+# Implementation plans — remaining deep issues (2026-07-18)
+
+The self-contained wins are landed (13 issues on PR #306; see the "Ranked
+worklist" and per-cluster notes below). What remains is deep or shared-with-Perl.
+Each plan below is written to be picked up cold: symptom + evidence, a root-cause
+hypothesis, the concrete approach, the files, the traps, and the test. Ordered by
+value × tractability. **Golden rules still bind:** Perl is ground truth, classify
+vs same-host Perl **verbose**, cross-check pathological inputs with `pdflatex`,
+never downgrade an Error to "pass", diverge only when `OXIDIZED_DESIGN.md` (or an
+explicit surpass-Perl decision) sanctions it, and add a red/green guard per fix.
+
+## P1 — Alignment env inside a restricted-horizontal box (GENUINE, highest value)
+
+**Issues:** #568 (2309.16609, 31), #497/#516 (2405.21060, 26), #477 (2310.07298,
+24), and the RUST-WORSE #594 (1811.10792, timeout) / #472 (2311.06609, 82) share
+the same machinery. This is the single largest *genuine* Rust cluster.
+
+**Symptom.** `Error:unexpected:\lx@begin@alignment Attempt to close a group that
+switched to mode restricted_horizontal` (15× on 2309.16609), plus
+`\lx@end@inline@math`, `\hbox Attempt to end mode restricted_horizontal`,
+`\endgroup Attempt to close non-boxing group`. Errors fire at "Anonymous String"
+/ macro-expanded locations, not source lines.
+
+**Evidence / hypothesis.** An amsmath alignment (`align`/`cases`/`split`/`aligned`)
+or an inline `$…$` is being digested **inside a restricted-horizontal box**
+(`\hbox`/`\mbox`/`\parbox`/`\vcenter`, or a CJK box on 2309.16609 which loads
+`CJKutf8`; 2405.21060 uses `mathtools` `\DeclarePairedDelimiter`). The alignment's
+`\lx@begin@alignment` opens an alignment group, but the surrounding box already
+switched the mode to `restricted_horizontal`, so when the alignment tries to
+close/realign it "closes a group that switched mode" → cascade. Perl keeps a
+looser mode stack here (17 vs Rust 82 on 2311.06609), so Rust is stricter-wrong.
+
+**Approach.**
+1. Build the minimal repro from the smallest witness: try `\mbox{$\begin{aligned}
+   a&=b\\ c&=d\end{aligned}$}` and `\hbox{\begin{cases}…\end{cases}}`, and the
+   CJK case `\begin{CJK*}…$…$…\end{CJK*}`. One will reproduce `Attempt to close a
+   group that switched to mode restricted_horizontal`.
+2. Trace with `LXML_TRACE_BOUND_MODE=1` (see mhchem memory) around
+   `\lx@begin@alignment` / the mode stack (`latexml_core::stomach` mode
+   transitions; `latexml_engine` alignment constructs `\halign`/`\lx@…@alignment`).
+   Find where Rust pushes `restricted_horizontal` but should allow an alignment to
+   open a nested math/alignment group (Perl's `beginMode`/`endMode` pairing).
+3. The fix is almost certainly in the **mode/group pairing** when an alignment or
+   inline-math opens inside a box: permit the alignment group to nest (open its
+   own mode frame) rather than asserting the box's mode. Cite the Perl
+   `Stomach`/`Gullet` alignment source for the faithful pairing.
+
+**Files.** `latexml_core/src/stomach*.rs` (mode stack), `latexml_engine/src/*`
+alignment constructs (`\lx@begin@alignment`, `\halign`, `\lx@end@inline@math`),
+`latexml_core::stack_guard`. **Traps:** don't loosen the mode check globally (it
+guards real malformed input); scope to the alignment/inline-math-in-box case.
+Re-run every alignment test (`tests/alignment`, `tests/ams`, `tests/math`) — this
+is core machinery.
+
+**Test.** `.tex`+`.xml` pair under `tests/alignment` with align/cases/aligned
+inside `\mbox`/`\hbox` and (separately) a CJK box; assert 0 errors and correct
+`<ltx:XMArray>` nesting. Value: 4–5 issues, and it de-risks the two RUST-WORSE
+timeouts (which begin with the same `\lx@end@inline@math` cascade before looping).
+
+## P2 — 2311.06609 siamart paper-local `code` env (#472, RUST-WORSE 82 vs 17)
+
+**Root.** A paper-local `\newenvironment{code}` = `list` + `tabbing` + `\mathcode
+\`\:` remap + custom `\mynewline`, holding inline `$…$` cells. Raw `tabbing`+`$…$`
+is clean in BOTH engines (verified), so it is the **custom-env composition** that
+breaks group/mode balance (same family as P1 — `\lx@begin@alignment`/
+`\lx@end@inline@math`). **Approach:** land P1 first, then re-measure; the residual
+is likely the `list`+`tabbing`+`\mynewline` interaction — min-repro by peeling the
+env to the smallest failing combo (start from `\begin{list}{}{}\item[]
+\begin{tabbing}\>$a=b$\\ \end{tabbing}\end{list}`). **Files:** tabbing constructs +
+mode stack. **Test:** the min-repro as a `tests/alignment` pair.
+
+## P3 — Rust-only timeouts (#594 1811.10792, #473 2310.17416)
+
+**Symptom.** Rust hits the 60 s wall-clock timeout; Perl completes (with 101
+errors → its `too_many_errors` fatal, so Perl is not "clean" either, but it
+terminates). Both begin with the P1 cascade (`\lx@end@inline@math`, `\halign`,
+`_`) then loop. **Hypothesis.** The P1 group-mode cascade drives error-recovery
+that re-digests the same tokens → a grind, not a true infinite loop (the box list
+grows). **Approach.** (a) land P1 — likely removes the cascade that feeds the
+loop; (b) if a loop remains, sample it with the `EXP_TRACE` histogram (see
+`limit-counting-raise-not-reduce` memory) to find the hot re-digest site;
+**RAISE** the relevant guard limit rather than reduce counting, or fix the
+recovery to not re-enqueue. **NEVER** downgrade to a cap that hides the cascade.
+**Files:** `latexml_core::stack_guard`, the recovery path in
+`core_interface::digest_internal`. **Test:** a bounded min-repro that converts
+under the timeout with the expected (small) error count.
+
+## P4 — Shared-with-Perl timeouts (tikz / tcolorbox / forest / pgf)
+
+**Issues:** #599 (1802.01134), #598 (1611.02087), #596 (2505.01658), #471
+(2308.04512), #522 (2405.19920), #533 (2406.15882), #546 (2504.07033), #550
+(2501.09223), #551 (2501.10235). **Both engines time out** (Perl `rc=124` at 1×
+too — re-verify each at 1× first, the sweep ran 10× parallel). These are the
+heavy graphics stacks (tikz pictures, pgfplots, tcolorbox, forest). **Approach.**
+Per-paper: (1) confirm Perl also times out at 1× (if so → parity, and the lever is
+performance not correctness — see `docs/performance/ARXIV_PERFORMANCE.md`, the
+17% math over-parse + tikz-cd digest levers); (2) locate the hot construct
+(`--timeout` + the sampled histogram) — usually one runaway tikz/pgfmath loop or a
+tcolorbox `most`-library expansion; (3) either bind the offending construct to a
+placeholder (the `discard_env_body` pattern, as nicematrix/forest do) or fix the
+specific pgfmath/tikz loop. **Do not** blanket-raise the timeout. **Files:**
+`pgfmath*`, `tikz*`, `tcolorbox_sty.rs`, contrib graphics stubs. **Test:** the
+paper converts under a fixed timeout; guard the specific construct with a min-repro
+if a real fix (not a stub) lands. Lower priority than P1–P3 (mostly parity).
+
+## P5 — `_` / `^` "script can only appear in math mode" cascade
+
+**Issues:** #601 (2604.16007, 60), #557 (2305.05665, 33), #597 (1404.3143,
+ytableau — Perl fatals worse), #483 (2312.11805), #523 (2408.15403), #585
+(1802.09089). **Errors are macro-generated** ("Anonymous String"), NOT source
+lines. **Ruled out:** the Rust `axessibility` binding is a faithful, identical
+port of Perl's (parity) — not the cause. **Mixed deep roots:** (a) `ytableau`
+`\none[\textstyle …]` cells in `align*` (1404.3143 — shared Perl limit, PARITY);
+(b) `axessibility[accsupp]` ActualText re-digesting the math source in text mode
+(2305.05665 — needs the accsupp alt-text treated as an opaque string, not
+re-tokenized); (c) table-cell `_` (2604.16007). **Approach.** Split by root: for
+(b), make the axessibility accsupp injection wrap its argument as verbatim/string
+(don't re-digest); classify (a)/(c) vs Perl first — likely PARITY (record in
+`KNOWN_PERL_ERRORS.md`), fix only where Rust > Perl. **Value:** moderate; several
+are parity. **Test:** per-root min-repro.
+
+## P6 — Residuals on already-improved papers
+
+- **2412.06264 (#520) `\or` flood (337, all at `\end{document}`).** The fairmeta
+  frontmatter is fixed; the residual is 337 `\or` fired at end-of-document →
+  DEFERRED content (floats/endnotes) carrying an unbalanced `\ifcase`/`\or`, or
+  nicematrix/luabridge expl3 the stub doesn't balance. **Approach:** bisect the
+  deferred content; find the `\or`-emitting construct (likely a nicematrix table or
+  an expl3 `\int_case:nn`). Likely parity-ish. Lower priority.
+- **2508.07407 (#556) `Stomach:Recursion`.** Frontmatter fixed; residual is a
+  box-loop in `paradigms.tex`: `\resizebox{\textwidth}{!}{…\begin{minipage}[t]
+  {\linewidth}…}` — a width-resolution loop (resizebox measuring a minipage whose
+  width depends on the resize). **Approach:** min-repro the resizebox+minipage;
+  the fix is in the box-dimension resolution (a `\resizebox` should not re-measure
+  a `\linewidth`-relative child into a loop) — see the box-model memory
+  `box-model-hsize-frame-ordering-fix`. Emit `Error!` + graceful, never silent.
+
+## P7 — Parity / shared-Perl singletons (document, don't force)
+
+Both engines fail identically (verify each vs Perl, then record in
+`KNOWN_PERL_ERRORS.md`; fix in Rust only if cheap and Perl-shared):
+`2602.15902` (#591, `\mintinline`→`\verb` `\ifmmode` — already documented as
+parity), `{forest}` stubs (#476/#573), `{pNiceMatrix}` stub (#499), `\filledstar`
+(author-undefined, 2402.13846 residual), `\BibSpecAlias` (#485), biblatex
+`{refsegment}`/`\defbibfilter` (#580), `\bfR` (#484), `malformed:ltx:bibitem`
+(#482), `malformed:ltx:listing` (#554), `\@end@tabular` (#558, 2301.12995 —
+check if genuine). **Content-bearing deferrals:** `\titlehead` (#498, scrartcl/KOMA
+— needs `\maketitle` integration, not a no-op).
+
+## P8 — Verify + close the already-CLEAN batch (~48 issues)
+
+The largest bucket: ~48 issues already convert **0-error** in latexml-oxide (see
+the CLEAN table). They were filed against old Perl output. **Approach:** they close
+once the ar5iv corpus is re-served from the current binary (a redeploy, not a code
+change). Before closing each, spot-verify the specific reported symptom is gone
+(not just 0 errors — e.g. the missing section/figure the user named renders).
+Batch a maintainer-facing list; do not post to the tracker unilaterally.
+
+---
+
 ## Method
 
 - Source: `/data/arxiv/<YYMM>/<id>/<id>.zip`, copied to a scratch dir and

--- a/docs/AR5IV_DIAGNOSTICS.md
+++ b/docs/AR5IV_DIAGNOSTICS.md
@@ -11,24 +11,33 @@ ranked worklist for the follow-on implementation sprint.
 > re-planning; do not treat as a live worklist once acted on. Branch
 > `ar5iv-minisprint`.
 
-> ## ✅ SPRINT CLOSED (2026-07-18)
+> ## ✅ SPRINT STATUS (2026-07-18, reopened for a second fix pass)
 >
-> The mini-sprint's landable engine value is complete: **13 issues fixed** on PR
-> #306 (xcolor global `dvipsnames`, `\sidecaptionvpos`, `\newtcblisting` verbatim
-> close, three meta-class frontmatter bindings, agujournal end-matter, the
-> `_load_attempted` deferred-load parity fix, `\ifmmode` coverage) — all
-> CI-green. Every **remaining** deep issue was minimally reproduced and
-> cross-checked vs pdflatex **and** same-host Perl (see the Diagnostic update
-> below); none has a shallow faithful fix. They resolve three ways:
-> **(1)** parity / Rust-better (author-malformed input — not bugs);
-> **(2)** the KNOWN, post-release `\lx@begin@alignment`-in-math cluster (blkarray
-> + code-env — deep core work, now with a 4-line repro in
-> `docs/known_crashes/blkarray_halign_math/`);
-> **(3)** genuine-but-CONTAINED deep bugs (tikz `calc`-coord recursion 2508.07407;
-> deferred `\or` 2412.06264 — graceful, post-release).
+> **16 issues fixed** on PR #306. First pass (13): xcolor global `dvipsnames`,
+> `\sidecaptionvpos`, `\newtcblisting` verbatim close, three meta-class
+> frontmatter bindings, agujournal end-matter, the `_load_attempted` deferred-load
+> parity fix, `\ifmmode` coverage. Second pass (3, after minimal-repro triage of
+> the deep set): **`blkarray` binding** (#594 1811.10792 OOM→0, #473 2310.17416
+> OOM→9 — shadows the raw `.sty` that OOMs both engines, routes through the
+> `array` machinery; surpass-Perl) and **`\titlehead`** KOMA frontmatter capture
+> (#498 2305.01582 1→0, content recovered; surpass-Perl). All CI-green,
+> full suite 1607/0.
+>
+> The remaining ~39 were each minimally reproduced and cross-checked vs pdflatex
+> **and** same-host Perl — **none has a shallow faithful fix left**. They resolve:
+> **(1) PARITY** — faithful ports of Perl's ar5iv stubs (`{forest}` #476/#573,
+> `{pNiceMatrix}` #499 both emit Perl's identical `undefined:{…}` stub error),
+> author-undefined macros (`\bfR` #484), or shared bib limits (`\BibSpecAlias`
+> #485, biblatex `{refsegment}` #580, `malformed:ltx:listing` #554) — Perl fails
+> identically, no fix without diverging/inventing.
+> **(2) Rust-BETTER, deep residual** — Perl fatals/times out while Rust completes
+> with residual errors (`\@end@tabular` tabular-grouping #558; biblatex bibitem
+> #482) — deep, post-release.
+> **(3) the KNOWN post-release `\lx@begin@alignment`-in-math cluster** (code-env
+> #472) and **genuine-but-CONTAINED deep bugs** (tikz `calc`-coord recursion #556;
+> deferred `\or` #520) — graceful, post-release.
 > The **~48 already-CLEAN** papers (sample re-verified 0-error) close on the ar5iv
-> **redeploy** from the current binary + a maintainer batch-comment — no code
-> change. No further mini-sprint engine work is planned.
+> **redeploy** + a maintainer batch-comment — no code change.
 
 # Implementation plans — remaining deep issues (2026-07-18)
 

--- a/docs/AR5IV_DIAGNOSTICS.md
+++ b/docs/AR5IV_DIAGNOSTICS.md
@@ -11,6 +11,25 @@ ranked worklist for the follow-on implementation sprint.
 > re-planning; do not treat as a live worklist once acted on. Branch
 > `ar5iv-minisprint`.
 
+> ## ✅ SPRINT CLOSED (2026-07-18)
+>
+> The mini-sprint's landable engine value is complete: **13 issues fixed** on PR
+> #306 (xcolor global `dvipsnames`, `\sidecaptionvpos`, `\newtcblisting` verbatim
+> close, three meta-class frontmatter bindings, agujournal end-matter, the
+> `_load_attempted` deferred-load parity fix, `\ifmmode` coverage) — all
+> CI-green. Every **remaining** deep issue was minimally reproduced and
+> cross-checked vs pdflatex **and** same-host Perl (see the Diagnostic update
+> below); none has a shallow faithful fix. They resolve three ways:
+> **(1)** parity / Rust-better (author-malformed input — not bugs);
+> **(2)** the KNOWN, post-release `\lx@begin@alignment`-in-math cluster (blkarray
+> + code-env — deep core work, now with a 4-line repro in
+> `docs/known_crashes/blkarray_halign_math/`);
+> **(3)** genuine-but-CONTAINED deep bugs (tikz `calc`-coord recursion 2508.07407;
+> deferred `\or` 2412.06264 — graceful, post-release).
+> The **~48 already-CLEAN** papers (sample re-verified 0-error) close on the ar5iv
+> **redeploy** from the current binary + a maintainer batch-comment — no code
+> change. No further mini-sprint engine work is planned.
+
 # Implementation plans — remaining deep issues (2026-07-18)
 
 The self-contained wins are landed (13 issues on PR #306; see the "Ranked

--- a/docs/AR5IV_DIAGNOSTICS.md
+++ b/docs/AR5IV_DIAGNOSTICS.md
@@ -76,7 +76,10 @@ the high-error RUST-BETTER papers (surpass-Perl, real-LaTeX-correct).
 5. **`\else`/`\fi` flood (minted)** — `2602.15902` (**783**, RUST-WORSE).
    `minted`/`fvextra` conditional machinery.
 6. **`malformed:ltx:subsection/section` nesting** — `2402.13846` (16),
-   `2507.00833` (8). Sectioning depth / float placement.
+   `2507.00833` (8). Root: a **`\newtcblisting` (tcolorbox) verbatim box does not
+   close**, so deeply-nested `<ltx:verbatim><ltx:verbatim>…` swallows subsequent
+   sectioning (`<ltx:subsection> isn't allowed in <ltx:verbatim>`). tcolorbox
+   listing machinery → Tier 3 (shares tcolorbox complexity with the timeouts).
 7. **`{forest}` undefined** — `2107.13586`, `2511.18538`, `2605.12090`,
    `2505.01658`. The `forest` tree-drawing package (unbound; often also a
    timeout). Largely parity.
@@ -94,6 +97,10 @@ the high-error RUST-BETTER papers (surpass-Perl, real-LaTeX-correct).
     `RequirePackage(color)` so `color` defers its eager `dvipsnam.def` load to
     xcolor's authoritative (usenames-active) load — matching pdflatex's one-load
     outcome. Guard: `tests/graphics/xcolor_global_dvipsnames`.
+  - [x] **LANDED** `\sidecaptionvpos` no-op in sidecap (2408.08435, **1 → 0**,
+    #555). Layout hint, no logical output. Guard: `tests/graphics/sidecap_vpos`.
+  - Deferred (content-bearing, not a safe no-op): `\titlehead` (2305.01582,
+    scrartcl/KOMA) needs `\maketitle` integration to render the header text.
 - **Tier 2 — genuine RUST-WORSE regressions:**
   - [ ] `2602.15902` minted `\else/\fi` flood (783).
   - [ ] `2311.06609` inline-math/alignment grouping (82, siamart).

--- a/docs/AR5IV_DIAGNOSTICS.md
+++ b/docs/AR5IV_DIAGNOSTICS.md
@@ -156,6 +156,14 @@ the high-error RUST-BETTER papers (surpass-Perl, real-LaTeX-correct).
     outcome. Guard: `tests/graphics/xcolor_global_dvipsnames`.
   - [x] **LANDED** `\sidecaptionvpos` no-op in sidecap (2408.08435, **1 → 0**,
     #555). Layout hint, no logical output. Guard: `tests/graphics/sidecap_vpos`.
+  - [x] **LANDED** `\newtcblisting` verbatim close (#504/#569/#570) — delegate to
+    listings' `\lstnewenvironment`. 2507.00833 8→0.
+  - [x] **LANDED** three meta-class frontmatter bindings — fairmeta/selfevolagent/
+    openmoss (#520/#567/#576/#556/#605).
+  - [x] **LANDED** agujournal2019.cls end-matter (#538, 2003.03231 **7 → 0**):
+    extend the existing binding with `\RequirePackage{rotating}` (sideways floats)
+    + the `{acronyms}`/`{notation}` description-list envs (`\acro`/`\notation` →
+    `\item[]`). Guard: `tests/97_agujournal_acronyms`.
   - Deferred (content-bearing, not a safe no-op): `\titlehead` (2305.01582,
     scrartcl/KOMA) needs `\maketitle` integration to render the header text.
 - **Tier 2 — genuine RUST-WORSE regressions:**

--- a/docs/AR5IV_DIAGNOSTICS.md
+++ b/docs/AR5IV_DIAGNOSTICS.md
@@ -22,6 +22,33 @@ vs same-host Perl **verbose**, cross-check pathological inputs with `pdflatex`,
 never downgrade an Error to "pass", diverge only when `OXIDIZED_DESIGN.md` (or an
 explicit surpass-Perl decision) sanctions it, and add a red/green guard per fix.
 
+> ## ⚠️ Diagnostic update (2026-07-18) — P1/P2/P3 investigated → RECLASSIFIED
+>
+> The P1 "highest value genuine Rust cluster" hypothesis was **wrong**. Each
+> witness was minimally reproduced and cross-checked against **both** pdflatex
+> and same-host Perl. Findings (repros saved under `docs/reproducers/` and
+> `docs/known_crashes/blkarray_halign_math/`):
+>
+> | issue | paper | verdict | root (all cross-checked vs pdflatex) |
+> |---|---|---|---|
+> | #568 | 2309.16609 | **PARITY / Rust-better** | fragile `\lstinline{...{9}...}` (brace delim reads to 1st `}`); Rust 18 = Perl 18 **+ a Perl Fatal**. pdflatex "Too many }'s" (recovers). `docs/reproducers/lstinline_brace_2309.16609.tex` |
+> | #477 | 2310.07298 | **PARITY** | author typo `$\boldsymbol{\Delta$}` (misplaced `$`); Rust 24 = Perl 24. Rust flags it like pdflatex; Perl lenient. `docs/reproducers/misplaced_dollar_boldsymbol_2310.07298.tex` |
+> | #497/#516 | 2405.21060 | **Rust-BETTER** | same misplaced-`$` family; Rust **26** vs Perl **102 + Fatal** |
+> | #472 | 2311.06609 | **Rust-worse, deferred** | custom `code` env (tabbing+`$…$`); Rust 82 vs Perl 39. Removing the code env → **Rust 0**, Perl 14: Rust converts the *rest* perfectly. The amplifier is non-minimizable and `egroup` recovery is a faithful port. `docs/reproducers/tabbing_math_code_env_2311.06609.tex` |
+> | #594/#473 | 1811.10792, 2310.17416 | **known cluster (both engines fail)** | **`blkarray`** `block{(cc)}` in `blockarray` in display math → Rust OOM (4.5 GB/12 s), **Perl also hangs** (90 s/rc=124), pdflatex clean. 4-line repro. |
+>
+> **The unifying root is the KNOWN, documented, HIGH-DIFFICULTY, post-release
+> `\lx@begin@alignment` / `\halign`-in-math cluster** (`stomach.rs::egroup`
+> refuses to pop a per-cell inline-math frame at an alignment close; ~12.1k
+> full-arXiv fatals). See `docs/known_crashes/{kbordermatrix,blkarray}_halign_math/`.
+> This mini-sprint's contribution: a **much smaller** repro (4-line blkarray) and
+> new witnesses (blkarray degrades **both** engines, unlike kbordermatrix). The
+> deep core fix is out of mini-sprint scope; a `blkarray` binding is the safe
+> sidestep but needs non-trivial `block`-delimiter modelling (probed, deferred).
+> Net: **P1 is not a fixable Rust-only cluster** — Rust is at parity-or-better on
+> every shared construct. The P1–P8 plans below are kept for provenance but P1/P2/
+> P3 are superseded by this update.
+
 ## P1 — Alignment env inside a restricted-horizontal box (GENUINE, highest value)
 
 **Issues:** #568 (2309.16609, 31), #497/#516 (2405.21060, 26), #477 (2310.07298,

--- a/docs/AR5IV_DIAGNOSTICS.md
+++ b/docs/AR5IV_DIAGNOSTICS.md
@@ -167,13 +167,23 @@ are parity. **Test:** per-root min-repro.
   nicematrix/luabridge expl3 the stub doesn't balance. **Approach:** bisect the
   deferred content; find the `\or`-emitting construct (likely a nicematrix table or
   an expl3 `\int_case:nn`). Likely parity-ish. Lower priority.
-- **2508.07407 (#556) `Stomach:Recursion`.** Frontmatter fixed; residual is a
-  box-loop in `paradigms.tex`: `\resizebox{\textwidth}{!}{…\begin{minipage}[t]
-  {\linewidth}…}` — a width-resolution loop (resizebox measuring a minipage whose
-  width depends on the resize). **Approach:** min-repro the resizebox+minipage;
-  the fix is in the box-dimension resolution (a `\resizebox` should not re-measure
-  a `\linewidth`-relative child into a loop) — see the box-model memory
-  `box-model-hsize-frame-ordering-fix`. Emit `Error!` + graceful, never silent.
+  **2026-07-18 update:** confirmed the 337 `\or` fire in DEFERRED content — the
+  first is at `paper; line 3820`, one line PAST `\end{document}` (3819). No literal
+  `\ifcase`/`\or` exists in the source, so a package macro (nicematrix/expl3) leaks
+  `\or` from an unbalanced `\ifcase` in a float/output-routine flush. Deep +
+  deferred; deferred to post-release. Frontmatter (the reported issue) is fixed.
+- **2508.07407 (#556) `Stomach:Recursion` — ROOT CORRECTED 2026-07-18.** NOT a
+  resizebox/minipage box-loop (that minimal is clean in all three engines). Bisected
+  to an inline **`\tikz{…}` picture whose nodes are placed at `calc` coordinates**
+  (`($(env.west)+(10mm,6mm)$)`) relative to a sized `cloud` shape, with `\draw`
+  arrows — Rust's tikz/pgf coordinate machinery loops (~3-box window) past the
+  50000-box guard → `Fatal:Stomach:Recursion`, **caught gracefully** (conversion
+  COMPLETES; only the one tikz table is dropped). **GENUINE-RUST-ONLY**: Perl
+  completes, pdflatex renders cleanly. Bare Rust reproduces (its OWN tikz binding,
+  not a raw-load). Minimal repro:
+  `docs/reproducers/tikz_calc_node_recursion_2508.07407.tex`. DEEP tikz-subsystem
+  work → deferred, like the `\lx@begin@alignment` cluster; already contained
+  (graceful, fidelity-only loss). Frontmatter (the reported issue) is fixed.
 
 ## P7 — Parity / shared-Perl singletons (document, don't force)
 

--- a/docs/known_crashes/blkarray_halign_math/README.md
+++ b/docs/known_crashes/blkarray_halign_math/README.md
@@ -1,0 +1,82 @@
+# `blkarray` `\halign`-in-math OOM/timeout — OPEN, HIGH DIFFICULTY, post-release
+
+> **Status: OPEN. Difficulty: HIGH. Priority: post-release.**
+> A second, **smaller** witness of the known `\lx@begin@alignment` /
+> `\halign`-in-math frame-accounting cluster — the same root as
+> [`../kbordermatrix_halign_math/`](../kbordermatrix_halign_math/README.md).
+> Read that sibling's README for the full root-cause analysis
+> (`stomach.rs::egroup` refuses to pop a frame that "switched to mode math" at
+> an alignment close, then re-enters and spins). This file records the blkarray
+> variant, its **4-line minimal reproducer**, and the one new fact it adds.
+
+Witnesses: **arXiv:1811.10792** (ar5iv #594) and **arXiv:2310.17416** (ar5iv
+#473), surfaced in the 2026-07-18 ar5iv mini-sprint diagnostic sweep. Both were
+classified RUST-WORSE ("timeout"); the true failure mode is a fast **OOM**
+(memory Fatal at ~12 s), not a wall-clock hang.
+
+## TL;DR
+
+`\begin{block}{(cc)}` (a `block` with a **paren-delimited** column spec) nested
+inside `\begin{blockarray}` in display math makes raw-loaded `blkarray.sty`
+spin its `\halign` machinery. Rust cascades into a runaway that grows the box
+list to the 4500 MB memory cap → `Fatal:Timeout:MemoryBudget` (~12 s). This is
+the same alignment × inline-math frame divergence as `\kbordermatrix`.
+
+## The one new fact vs the kbordermatrix sibling
+
+For `\kbordermatrix`, **Perl completes** (0.4 s) and only Rust loops — a clean
+GENUINE-RUST-ONLY. For **blkarray, Perl ALSO fails**: same-host Perl (with
+`--includestyles`) runs **~90 s then rc=124 (terminated)**. So blkarray is a
+*shared* catastrophic failure of both LaTeXML engines on the raw `.sty`, where
+Rust's failure mode (OOM in 12 s) merely differs from Perl's (hang in 90 s).
+**pdflatex renders the same input cleanly** — a parenthesised 2×2 matrix — so
+the golden LaTeX behaviour is well-defined; both LaTeXML engines are wrong.
+
+## Reduction map (what triggers, what does NOT) — 2026-07-18
+
+All Rust runs under `--includestyles` (or ar5iv.sty preload) with `--timeout`;
+`blkarray.sty` is in TeX Live so nothing is bundled.
+
+| Construct | Rust | Note |
+|---|---|---|
+| `block{(cc)}` in `blockarray` in `\[..\]` (**blkarray_min.tex**) | **OOM 4.5 GB / 12 s** | ★ the minimal repro (this dir) |
+| same but `block{cc}` (no `(`/`)` delimiter) | clean 0.2 s | the **delimiter** is required |
+| `block{(cc)}` **without** the `blockarray` wrapper | clean 0.2 s | the **blockarray wrapper** is required |
+| bare `blockarray{cc}` one row, no `block` | clean 0.2 s | `block` is required |
+| load blkarray, no usage | clean 0.2 s | not the package load |
+
+So the minimal trigger is precisely **a paren-delimited `block` nested in a
+`blockarray`** — much smaller than the kbordermatrix repro (whose reduction
+below the whole macro "was not achieved").
+
+## The safe sidestep (a binding), and why it is not trivial
+
+Because the OOM comes entirely from *raw-loading* `blkarray.sty` (without the
+raw load the envs are merely "undefined", 0.2 s), a proper LaTeXML **binding**
+for `blkarray` — one that shadows the raw `.sty` — would sidestep the deep
+`egroup` bug and match pdflatex, surpassing Perl (which also has no binding and
+hangs). Feasibility probe (2026-07-18):
+
+- `\newenvironment{blockarray}[1]{\begin{array}{#1}}{\end{array}}` alone (no
+  `block`) → **clean, correct `<ltx:XMArray>`** with all cells. So the outer
+  environment maps trivially to `array`.
+- The hard part is **`block`**: in blkarray it is *not* a nested array but a
+  continuation of the same alignment whose `(`/`[` spec adds delimiters spanning
+  a group of data rows. Making `block` transparent breaks the alignment
+  grouping (`\begin`/`\end` inject a `\begingroup`/`\endgroup` that crosses `\\`
+  row boundaries → `\lx@begin@alignment Attempt to close boxing group`), and
+  mid-array `\left(`…`\right)` around a row group is not expressible in
+  LaTeXML's `array`. A faithful binding must model the block delimiters as
+  array-spanning delimiters — non-trivial, hence the HIGH-DIFFICULTY marking.
+
+Entry points to resume are the same as the kbordermatrix sibling
+(`stomach.rs::egroup`, the alignment cell/`\crcr` frame accounting), **plus**
+the option of a dedicated blkarray binding modelling `blockarray`/`block`/
+`\BlockArray*` on LaTeXML's alignment constructs.
+
+## Cross-references
+
+- [`../kbordermatrix_halign_math/README.md`](../kbordermatrix_halign_math/README.md) — the sibling witness + full root-cause analysis.
+- [`../../performance/STABILITY_WITNESSES.md`](../../performance/STABILITY_WITNESSES.md) — Cluster H (`\lx@begin@alignment` digest-runaways).
+- [`../../AR5IV_DIAGNOSTICS.md`](../../AR5IV_DIAGNOSTICS.md) — the ar5iv mini-sprint sweep that surfaced these two witnesses.
+- Full-arXiv `\lx@begin@alignment` ~12.1k-fatal cluster (memory `full-arxiv-corpus-reference-2026-06-30`).

--- a/docs/known_crashes/blkarray_halign_math/README.md
+++ b/docs/known_crashes/blkarray_halign_math/README.md
@@ -1,13 +1,21 @@
-# `blkarray` `\halign`-in-math OOM/timeout — OPEN, HIGH DIFFICULTY, post-release
+# `blkarray` `\halign`-in-math OOM/timeout — ✅ FIXED via binding (2026-07-18)
 
-> **Status: OPEN. Difficulty: HIGH. Priority: post-release.**
-> A second, **smaller** witness of the known `\lx@begin@alignment` /
-> `\halign`-in-math frame-accounting cluster — the same root as
-> [`../kbordermatrix_halign_math/`](../kbordermatrix_halign_math/README.md).
-> Read that sibling's README for the full root-cause analysis
-> (`stomach.rs::egroup` refuses to pop a frame that "switched to mode math" at
-> an alignment close, then re-enters and spins). This file records the blkarray
-> variant, its **4-line minimal reproducer**, and the one new fact it adds.
+> **Status: FIXED (binding).** The *blkarray* variant is resolved: a Rust
+> `blkarray` binding (`latexml_package/src/package/blkarray_sty.rs`) now shadows
+> the raw `.sty`, so the pathological `\halign`-in-math is never digested.
+> 1811.10792 (#594) went **OOM → 0 errors**; 2310.17416 (#473) **OOM → 9**
+> (residual is a separate math-mode issue, not blkarray). Guard:
+> `latexml_oxide/tests/graphics/blkarray.{tex,xml}`. The **underlying**
+> `stomach.rs::egroup` bug (a frame that "switched to mode math" is not popped at
+> an alignment close) is UNCHANGED and still reachable via the `kbordermatrix`
+> sibling ([`../kbordermatrix_halign_math/`](../kbordermatrix_halign_math/README.md),
+> still OPEN, HIGH difficulty) — the binding sidesteps it for blkarray rather than
+> fixing the core. NOTE: `blkarray_min.tex` below no longer reproduces (the
+> binding wins over `--includestyles`); to exercise the core bug use the
+> kbordermatrix reproducer. This file is kept as the record of the analysis and
+> the binding's faithfulness simplification.
+>
+> Original diagnosis (pre-binding) follows.
 
 Witnesses: **arXiv:1811.10792** (ar5iv #594) and **arXiv:2310.17416** (ar5iv
 #473), surfaced in the 2026-07-18 ar5iv mini-sprint diagnostic sweep. Both were

--- a/docs/known_crashes/blkarray_halign_math/blkarray_min.tex
+++ b/docs/known_crashes/blkarray_halign_math/blkarray_min.tex
@@ -1,0 +1,30 @@
+% Minimal faithful reproducer for the blkarray `\halign`-in-math cluster.
+% Reduced from arXiv:2310.17416 (#473) and arXiv:1811.10792 (#594).
+% blkarray.sty IS in TeX Live, so this needs only --includestyles (or an
+% ar5iv.sty preload) to raw-load it.
+%
+% The trigger is minimal: a `block` with a PAREN-DELIMITED column spec `(cc)`
+% nested inside a `blockarray`, in display math. Dropping the delimiter
+% (`{cc}`) OR the blockarray wrapper makes it convert in 0.2s — so it is the
+% delimiter-processing of a nested block that spins the raw `\halign` machinery.
+%
+% Rust:     Fatal:Timeout:MemoryBudget  (RSS 4500 MB > cap) at ~12 s (OOM).
+% Perl:     rc=124 (terminated) after ~90 s (hangs) — Perl fails here TOO,
+%           unlike the kbordermatrix sibling where Perl completes in 0.4 s.
+% pdflatex: renders a parenthesised 2x2 matrix cleanly (golden oracle).
+%
+%   latexml_oxide --includestyles --timeout=30 blkarray_min.tex
+%   latexml       --includestyles              blkarray_min.tex
+%   pdflatex blkarray_min.tex   # clean
+%
+% Same root as ../kbordermatrix_halign_math/ — the `\lx@begin@alignment` /
+% `\halign`-in-math frame-accounting cluster (stomach.rs::egroup refuses to pop
+% a frame that switched to mode math at an alignment close). See that sibling's
+% README for the full root-cause analysis. HIGH DIFFICULTY, post-release.
+\documentclass{article}
+\usepackage{blkarray}
+\begin{document}
+\[\begin{blockarray}{cc}
+\begin{block}{(cc)} 1 & 2 \\ \end{block}
+\end{blockarray}\]
+\end{document}

--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -2131,8 +2131,12 @@ Minimal trigger (`blkarray.sty` is in TeX Live):
 ```
 
 Dropping the `(`/`)` delimiter (`{cc}`) OR the `blockarray` wrapper converts in
-0.2 s. **Not fixed** — this is the known HIGH-DIFFICULTY, post-release
-`\lx@begin@alignment`-in-math cluster. Full analysis + reduction map:
-[`docs/known_crashes/blkarray_halign_math/`](../known_crashes/blkarray_halign_math/README.md)
-and its sibling [`kbordermatrix_halign_math/`](../known_crashes/kbordermatrix_halign_math/README.md).
-Witnesses: arXiv:1811.10792 (ar5iv #594), arXiv:2310.17416 (ar5iv #473).
+0.2 s. **Fixed for blkarray** via a Rust binding
+(`latexml_package/src/package/blkarray_sty.rs`) that shadows the raw `.sty` and
+routes `blockarray`/`block` through the `array` machinery (surpass-Perl; Perl has
+no binding): 1811.10792 (#594) OOM→0, 2310.17416 (#473) OOM→9. The `block`
+sub-region delimiters are dropped (documented simplification — `array` can't wrap
+a sub-region). The **underlying** `stomach.rs::egroup` math-frame bug is unchanged
+and still reachable via `kbordermatrix` (HIGH-DIFFICULTY, post-release). Full
+analysis: [`docs/known_crashes/blkarray_halign_math/`](../known_crashes/blkarray_halign_math/README.md)
++ sibling [`kbordermatrix_halign_math/`](../known_crashes/kbordermatrix_halign_math/README.md).

--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -2102,3 +2102,37 @@ the next `@` rather than abandoning the file. On 2605.00264 that is all 1170
 entries and 0 dangling citations. **Upstream candidate** — but it is a rewrite of the
 scanner, not a one-line change, since `Text::Balanced` cannot express
 BibTeX's rule.
+
+## 53. Raw `blkarray.sty` / `kbordermatrix` `\halign`-in-math hangs BOTH engines
+
+`blkarray`'s `block`/`blockarray` and `kbordermatrix` build a matrix with raw
+`\halign`/`\ialign` whose column template wraps **each cell in inline math**
+(`…$##$…`), digested inside surrounding display math. LaTeXML's alignment ×
+math-mode frame accounting cannot pop the per-cell inline-math frame at the
+alignment close, and the recovery re-enters and spins.
+
+- **Perl**: on `blkarray` (a `block` with a paren-delimited spec `(cc)` nested in
+  a `blockarray`) Perl **hangs ~90 s → rc=124 (terminated)** — same-host, with
+  `--includestyles`. (On the `kbordermatrix` sibling Perl instead *completes* in
+  ~0.4 s, so that one is Rust-only; blkarray degrades both engines.)
+- **Rust**: cascades into a runaway that hits the 4500 MB memory cap →
+  `Fatal:Timeout:MemoryBudget` at ~12 s (faster failure, same root).
+- **pdflatex**: renders the matrix cleanly — the golden behaviour is well-defined;
+  both LaTeXML engines are wrong.
+
+Minimal trigger (`blkarray.sty` is in TeX Live):
+
+```latex
+\documentclass{article}\usepackage{blkarray}\begin{document}
+\[\begin{blockarray}{cc}
+\begin{block}{(cc)} 1 & 2 \\ \end{block}
+\end{blockarray}\]
+\end{document}
+```
+
+Dropping the `(`/`)` delimiter (`{cc}`) OR the `blockarray` wrapper converts in
+0.2 s. **Not fixed** — this is the known HIGH-DIFFICULTY, post-release
+`\lx@begin@alignment`-in-math cluster. Full analysis + reduction map:
+[`docs/known_crashes/blkarray_halign_math/`](../known_crashes/blkarray_halign_math/README.md)
+and its sibling [`kbordermatrix_halign_math/`](../known_crashes/kbordermatrix_halign_math/README.md).
+Witnesses: arXiv:1811.10792 (ar5iv #594), arXiv:2310.17416 (ar5iv #473).

--- a/docs/reproducers/lstinline_brace_2309.16609.tex
+++ b/docs/reproducers/lstinline_brace_2309.16609.tex
@@ -1,0 +1,20 @@
+% PARITY reproducer (ar5iv #568, arXiv:2309.16609) — NOT a Rust-only bug.
+% `\lstinline{...}` with a brace `{` delimiter reads raw to the FIRST `}`, so an
+% inner brace group `{9}` terminates the verbatim early and the leftover `}y}`
+% is a stray close-group. This is fragile author input:
+%   - pdflatex:  "! Too many }'s" (recovers under nonstopmode, still emits a PDF).
+%   - Perl:      `Error:unexpected:} Attempt to close a group ...` (same message).
+%   - Rust:      identical `Error:unexpected:}` — at parity with Perl.
+% Perl's own listings.sty.ltxml comment on listingsReadRawString:
+%   "NOTE that this normally does NOT balance {, but DOES within mathescape'd $ ...
+%    I'd swear this is a bug that became a feature."
+% In the witness paper this stray `}` lands inside an xltabular cell in a
+% tcolorbox and cascades the table alignment — but both engines cascade
+% (Rust 18 = Perl 18 + a Perl Fatal), so Rust is at parity-or-better.
+\documentclass{article}
+\usepackage{listings}
+\begin{document}
+Before \lstinline{x{9}y} after.
+
+Nested \lstinline{pattern = r'^139\d{9}\$'} done.
+\end{document}

--- a/docs/reproducers/misplaced_dollar_boldsymbol_2310.07298.tex
+++ b/docs/reproducers/misplaced_dollar_boldsymbol_2310.07298.tex
@@ -1,0 +1,14 @@
+% PARITY reproducer (ar5iv #477, arXiv:2310.07298) — author-malformed input.
+% The closing `$` is INSIDE `\boldsymbol{...}`: `$\boldsymbol{\Delta$}` — a typo
+% for `$\boldsymbol{\Delta}$`. The `$` ends math mode while the `\boldsymbol{`
+% group is still open, so the trailing `}` closes a group that switched to math.
+%   - pdflatex:  "! Extra }, or forgotten $" + "! Missing $ inserted" (recovers).
+%   - Rust:      `Error:unexpected:} Attempt to close a group ...` +
+%                `\lx@end@inline@math` — 2 errors, MATCHING pdflatex.
+%   - Perl:      0 errors in isolation (more lenient than pdflatex here).
+% On the full paper both engines land at 24 errors (exact parity). Rust flagging
+% the genuinely-broken input (like pdflatex) is defensible; do not "fix" by
+% suppressing — that would violate the never-downgrade-an-Error rule.
+\documentclass{article}\usepackage{amsmath}\begin{document}
+\textbf{$\boldsymbol{\Delta$}} done.
+\end{document}

--- a/docs/reproducers/tabbing_math_code_env_2311.06609.tex
+++ b/docs/reproducers/tabbing_math_code_env_2311.06609.tex
@@ -1,0 +1,35 @@
+\documentclass{article}
+\newcounter{mylineno}
+\makeatletter
+\let\oldtabcr\@tabcr
+\def\nonumberbreak{\oldtabcr\hspace{3.5pt}}
+\def\mynewline{\refstepcounter{mylineno}%
+               \llap{\footnotesize\arabic{mylineno}\hspace{5pt}}%
+              }
+\gdef\@tabcr{\@stopline \@ifstar{\penalty%
+           \@M \@xtabcr}\@xtabcr\mynewline}
+\newenvironment{code}{%
+                        \mathcode`\:="603A
+                        \def\colon{\mathchar"303A}
+                        \setcounter{mylineno}{0}
+                        \par
+                        \upshape
+                        \begin{list}
+                           {} {\leftmargin = 1cm}
+                        \item[]
+                        \begin{tabbing}
+                           \hspace*{.3in} \= \hspace*{.3in} \=
+                           \hspace*{.3in} \= \hspace*{.3in} \= \kill
+                           \mynewline
+                       }{\end{tabbing}\end{list}}
+\makeatother
+\newcommand{\a}{\alpha}
+\newcommand{\normo}[1]{\|#1\|}
+\begin{document}
+\begin{code}
+If \= $A$ is explicitly known\\
+  \> $\a = \normo{A}$\\
+else\\
+  \> $c = \a$
+\end{code}
+\end{document}

--- a/docs/reproducers/tikz_calc_node_recursion_2508.07407.tex
+++ b/docs/reproducers/tikz_calc_node_recursion_2508.07407.tex
@@ -1,0 +1,33 @@
+% GENUINE Rust-only bug (but CONTAINED) — ar5iv #556 residual, arXiv:2508.07407.
+% An inline \tikz{...} picture whose nodes are placed at `calc` coordinates
+% (`($(env.west)+(10mm,6mm)$)`, tikzlibrary calc) relative to a sized shape node,
+% with \draw arrows between them, drives Rust's pgf/tikz coordinate machinery into
+% a digestion loop: the same ~3-box window repeats until the box list grows past
+% 50000 → `Fatal:Stomach:Recursion`. The general cycle guard (stomach.rs) catches
+% it GRACEFULLY — the conversion COMPLETES ("2 warnings") and only this one tikz
+% picture (the paradigms table) is dropped. So it is a fidelity loss, not a crash.
+%
+%   Rust:     Fatal:Stomach:Recursion (window of 3 boxes) — contained, completes.
+%   Perl:     completes (no recursion) — GENUINE-RUST-ONLY.
+%   pdflatex: renders the cloud + 2 circle nodes + arrow cleanly (golden oracle).
+%
+% Root is Rust's tikz/pgf `calc`-coordinate + sized-node placement (bare binary
+% reproduces with its OWN tikz binding — not a raw-load issue). The single-node /
+% no-size variants do NOT reach the 50000-box threshold; the full 3-node picture
+% below is the minimal reliable repro. DEEP tikz-subsystem work — deferred, like
+% the \lx@begin@alignment cluster. The witness paper's main issue (selfevolagent
+% frontmatter) is already fixed; this is the residual.
+\documentclass{article}
+\usepackage{tikz}
+\usetikzlibrary{shapes.symbols,calc,positioning}
+\begin{document}
+\tikz[baseline=(env.base),node distance=4mm]{%
+  \node[cloud, draw, inner sep=13pt, minimum width=40mm, minimum height=20mm] (env) {Env};
+  \node[circle, draw, minimum size=6mm] (A1) at ($(env.west)+(10mm,6mm)$) {};
+  \node[circle, draw, minimum size=6mm] (A2) at ($(env.east)+(-10mm,6mm)$) {};
+  \node[circle, draw, minimum size=6mm] (A3) at ($(env.north)+(0,-24mm)$) {};
+  \draw[->, thick, shorten <=1pt, shorten >=1pt] (A1) -- (A2);
+  \draw[->, thick, shorten <=1pt, shorten >=1pt] (A2) -- (A3);
+  \draw[->, thick, shorten <=1pt, shorten >=1pt] (A3) -- (A1);
+}
+\end{document}

--- a/latexml_contrib/src/agujournal2019_cls.rs
+++ b/latexml_contrib/src/agujournal2019_cls.rs
@@ -14,6 +14,25 @@ LoadDefinitions!({
   RequirePackage!("hyperref");
   RequirePackage!("graphicx");
   RequirePackage!("apacite");
+  // agujournal2019.cls L118 — the class provides {sidewaystable}/{sidewaysfigure}
+  // through rotating; without it the sideways floats are undefined and their
+  // \caption leaks ("\caption outside any known float"). Witness 2003.03231.
+  RequirePackage!("rotating");
+
+  // agujournal2019.cls L1062-1074: the end-matter {acronyms} and {notation}
+  // environments are `\section*` + a `description` list, whose items come from a
+  // LOCALLY-redefined \acro{X} / \notation{X} → \item[X]. Ported verbatim (the
+  // \vskip glue is visual and dropped). Witness 2003.03231.
+  DefMacro!(
+    "\\acronyms",
+    "\\section*{Acronyms}\\begingroup\\def\\acro##1{\\item[##1]}\\begin{description}"
+  );
+  DefMacro!("\\endacronyms", "\\end{description}\\endgroup");
+  DefMacro!(
+    "\\notation",
+    "\\section*{Notation}\\begingroup\\def\\notation##1{\\item[\\boldmath ##1]}\\begin{description}"
+  );
+  DefMacro!("\\endnotation", "\\end{description}\\endgroup");
 
   // AGU frontmatter (agujournal2019.cls L389+, L573-587).
   // Internal toggles — no content.

--- a/latexml_contrib/src/fairmeta_cls.rs
+++ b/latexml_contrib/src/fairmeta_cls.rs
@@ -48,48 +48,23 @@ LoadDefinitions!({
   Digest!("\\definecolor{metafg}{HTML}{1C2B33}")?;
   Digest!("\\definecolor{metabg}{HTML}{EFF6F6}")?;
 
-  // Frontmatter. Each fairmeta helper takes an optional leading mark
-  // (\author[1]{...}, \metadata[Label]{...}); route the content to the shared
-  // \@add@frontmatter sink so it lands in <ltx:document> frontmatter. The
-  // accumulator lists (\authorlist, …) become no-ops — the sink accumulates.
-  def_macro_noop("\\authorlist")?;
-  def_macro_noop("\\affiliationlist")?;
-  def_macro_noop("\\contributionlist")?;
-  def_macro_noop("\\metadatalist")?;
+  // Shared "addtolist meta-class" frontmatter routing (\author/\affiliation/
+  // \contribution/\correspondence/\abstract/\email/\beginappendix + the list
+  // no-ops) — see `meta_class_frontmatter!` in lib.rs.
+  meta_class_frontmatter!();
 
-  // \author[mark]{name} — accumulate as a document creator. Route to the
-  // internal \lx@add@author sink (NOT \author — that would re-match this macro
-  // and recurse); the leading affiliation mark #1 is dropped.
-  DefMacro!("\\author[]{}", "\\lx@add@author{#2}");
-  // \affiliation[mark]{text}
-  DefMacro!(
-    "\\affiliation[]{}",
-    "\\@add@frontmatter{ltx:note}[role=affiliation]{#2}"
-  );
-  // \contribution[mark]{text}
-  DefMacro!(
-    "\\contribution[]{}",
-    "\\@add@frontmatter{ltx:note}[role=contribution]{#2}"
-  );
-  // \metadata[label]{value} — the label becomes the note role.
+  // Class-specific labeled fields (kept per-class):
+  def_macro_noop("\\metadatalist")?;
+  // \metadata[label]{value} — fairmeta's labels are simple words, so the label
+  // goes to the note `role` attribute. (The siblings whose labels can be
+  // arbitrary markup — selfevolagent/openmoss — render "label: value" as
+  // content instead; keep fairmeta's labels attribute-safe.)
   DefMacro!(
     "\\metadata[]{}",
     "\\@add@frontmatter{ltx:note}[role=#1]{#2}"
   );
-  // \correspondence{text} (class: \metadata[Correspondence]{...}).
-  DefMacro!(
-    "\\correspondence{}",
-    "\\@add@frontmatter{ltx:note}[role=correspondence]{#1}"
-  );
   // \date{text} (class: \metadata[Date]{...}; the \faCalendar icon is dropped).
   DefMacro!("\\date{}", "\\@add@frontmatter{ltx:note}[role=date]{#1}");
-  // \abstract{text} (class stores it in \abstractlist; feed the abstract sink).
-  DefMacro!("\\abstract{}", "\\lx@add@abstract{#1}");
-  // \email{addr} — kept verbatim from the class.
-  DefMacro!("\\email{}", "\\href{mailto:#1}{\\texttt{#1}}");
-
-  // \beginappendix — the class's stand-in for \appendix.
-  DefMacro!("\\beginappendix", "\\appendix");
   // \nm{...} — no-op text wrapper (\newcommand{\nm}[1]{#1}).
   DefMacro!("\\nm{}", "#1");
 });

--- a/latexml_contrib/src/fairmeta_cls.rs
+++ b/latexml_contrib/src/fairmeta_cls.rs
@@ -50,8 +50,8 @@ LoadDefinitions!({
 
   // Shared "addtolist meta-class" frontmatter routing (\author/\affiliation/
   // \contribution/\correspondence/\abstract/\email/\beginappendix + the list
-  // no-ops) — see `meta_class_frontmatter!` in lib.rs.
-  meta_class_frontmatter!();
+  // no-ops) — see `meta_class::install_meta_class_frontmatter`.
+  crate::meta_class::install_meta_class_frontmatter()?;
 
   // Class-specific labeled fields (kept per-class):
   def_macro_noop("\\metadatalist")?;

--- a/latexml_contrib/src/fairmeta_cls.rs
+++ b/latexml_contrib/src/fairmeta_cls.rs
@@ -1,0 +1,95 @@
+//! Binding for fairmeta.cls (FAIR / Meta pre-print class).
+//!
+//! fairmeta.cls builds its frontmatter interface
+//! (\author/\affiliation/\contribution/\metadata/\correspondence/\abstract) on
+//! an \addtolist[5] accumulator in the class BODY. Since an unknown .cls body is
+//! NOT raw-loaded (OmniBus extracts dependencies only), every one of those
+//! commands is Error:undefined without a binding — and the class's
+//! \RequirePackage{nicematrix} etc. never take effect either. Route the
+//! user-facing frontmatter through \@add@frontmatter so title/authors/
+//! affiliations/metadata/abstract reach the XML, and pull in the real
+//! dependency packages the class relies on.
+//!
+//! Witnesses: 2412.06264 (ar5iv #520), 2509.24704 (#567), 2511.16624 (#576).
+//! (selfevolagent.cls, 2508.07407/#556, is a near-identical sibling class.)
+use latexml_package::prelude::*;
+
+LoadDefinitions!({
+  LoadClass!("OmniBus");
+  // Dependency packages the class \RequirePackage's and the paper body relies
+  // on (those with bindings / user-facing commands). Purely-cosmetic layout
+  // packages (geometry, microtype, setspace, parskip, titlesec, …) are omitted
+  // — they are visual no-ops in LaTeXML and OmniBus degrades gracefully.
+  RequirePackage!("amsmath");
+  RequirePackage!("amssymb");
+  RequirePackage!("graphicx");
+  RequirePackage!("xcolor");
+  RequirePackage!("booktabs");
+  RequirePackage!("multirow");
+  RequirePackage!("bm");
+  RequirePackage!("etoolbox");
+  RequirePackage!("caption");
+  RequirePackage!("hyperref");
+  RequirePackage!("cleveref");
+  RequirePackage!("natbib");
+  RequirePackage!("nicematrix");
+  // Faithful to the class's `\RequirePackage[most]{tcolorbox}` (fairmeta.cls
+  // L42). PassOptions BEFORE the require (Perl idiom, mirrors ar5iv.sty.ltxml)
+  // so tcolorbox.sty's own \ProcessOptions sees `most` at raw-load time and
+  // \tcbuselibrary{most} loads the enhanced/breakable/skins keys.
+  pass_options("tcolorbox", "sty", vec![s!("most")])?;
+  RequirePackage!("tcolorbox");
+
+  // \geometry{...} — page-geometry hint; visual-only, gobble the arg.
+  def_macro_noop("\\geometry{}")?;
+
+  // Class palette (\color{metafg} is used by the abstract box).
+  Digest!("\\definecolor{metablue}{HTML}{E2EFEF}")?;
+  Digest!("\\definecolor{metafg}{HTML}{1C2B33}")?;
+  Digest!("\\definecolor{metabg}{HTML}{EFF6F6}")?;
+
+  // Frontmatter. Each fairmeta helper takes an optional leading mark
+  // (\author[1]{...}, \metadata[Label]{...}); route the content to the shared
+  // \@add@frontmatter sink so it lands in <ltx:document> frontmatter. The
+  // accumulator lists (\authorlist, …) become no-ops — the sink accumulates.
+  def_macro_noop("\\authorlist")?;
+  def_macro_noop("\\affiliationlist")?;
+  def_macro_noop("\\contributionlist")?;
+  def_macro_noop("\\metadatalist")?;
+
+  // \author[mark]{name} — accumulate as a document creator. Route to the
+  // internal \lx@add@author sink (NOT \author — that would re-match this macro
+  // and recurse); the leading affiliation mark #1 is dropped.
+  DefMacro!("\\author[]{}", "\\lx@add@author{#2}");
+  // \affiliation[mark]{text}
+  DefMacro!(
+    "\\affiliation[]{}",
+    "\\@add@frontmatter{ltx:note}[role=affiliation]{#2}"
+  );
+  // \contribution[mark]{text}
+  DefMacro!(
+    "\\contribution[]{}",
+    "\\@add@frontmatter{ltx:note}[role=contribution]{#2}"
+  );
+  // \metadata[label]{value} — the label becomes the note role.
+  DefMacro!(
+    "\\metadata[]{}",
+    "\\@add@frontmatter{ltx:note}[role=#1]{#2}"
+  );
+  // \correspondence{text} (class: \metadata[Correspondence]{...}).
+  DefMacro!(
+    "\\correspondence{}",
+    "\\@add@frontmatter{ltx:note}[role=correspondence]{#1}"
+  );
+  // \date{text} (class: \metadata[Date]{...}; the \faCalendar icon is dropped).
+  DefMacro!("\\date{}", "\\@add@frontmatter{ltx:note}[role=date]{#1}");
+  // \abstract{text} (class stores it in \abstractlist; feed the abstract sink).
+  DefMacro!("\\abstract{}", "\\lx@add@abstract{#1}");
+  // \email{addr} — kept verbatim from the class.
+  DefMacro!("\\email{}", "\\href{mailto:#1}{\\texttt{#1}}");
+
+  // \beginappendix — the class's stand-in for \appendix.
+  DefMacro!("\\beginappendix", "\\appendix");
+  // \nm{...} — no-op text wrapper (\newcommand{\nm}[1]{#1}).
+  DefMacro!("\\nm{}", "#1");
+});

--- a/latexml_contrib/src/lib.rs
+++ b/latexml_contrib/src/lib.rs
@@ -171,6 +171,7 @@ pub mod nicematrix_sty;
 pub mod nicseries_cls;
 pub mod oldgerm_sty;
 pub mod oldlfont_sty;
+pub mod openmoss_cls;
 pub mod optica_article_cls;
 pub mod oup_authoring_template_cls;
 pub mod pax_sty;
@@ -506,6 +507,7 @@ pub const BINDINGS: &[(&str, &str, BindingLoader)] = &[
   ("nature-pre", "cls", nature_pre_cls::load_definitions),
   ("nature_mod", "cls", nature_pre_cls::load_definitions),
   ("newpxmath", "sty", newpxmath_sty::load_definitions),
+  ("openmoss", "cls", openmoss_cls::load_definitions),
   (
     "optica-article",
     "cls",

--- a/latexml_contrib/src/lib.rs
+++ b/latexml_contrib/src/lib.rs
@@ -11,6 +11,45 @@ extern crate latexml_package;
 extern crate latexml_codegen;
 use latexml_core::common::error::*;
 
+/// Shared frontmatter interface for the "addtolist ML meta-class" family
+/// (`fairmeta` / `selfevolagent` / `openmoss` and future siblings): pre-print
+/// classes whose `\author`/`\affiliation`/`\contribution`/`\correspondence`/
+/// `\abstract`/`\beginappendix` commands are defined on an `\addtolist`
+/// accumulator in the class BODY — which an unknown `.cls` does not raw-load, so
+/// all are `Error:undefined` without a binding. Emits the identical,
+/// order-independent frontmatter routing shared by every sibling. The
+/// per-class parts stay in each `*_cls.rs`: the dependency list (order-sensitive),
+/// the colour palette, and the class-specific labeled field (`\metadata` vs
+/// `\checkdata`, and its routing) — see each file. Invoke once inside the
+/// class's `LoadDefinitions!` block. Function paths are fully qualified so the
+/// macro is hygienic regardless of the call site's imports.
+macro_rules! meta_class_frontmatter {
+  () => {
+    // Accumulator lists → no-ops; the `\@add@frontmatter` sink accumulates.
+    latexml_engine::prelude::def_macro_noop("\\authorlist")?;
+    latexml_engine::prelude::def_macro_noop("\\affiliationlist")?;
+    latexml_engine::prelude::def_macro_noop("\\contributionlist")?;
+    // `\author[mark]{name}` → the creator sink (NOT `\author` — that re-matches
+    // this macro and recurses); the leading affiliation mark #1 is dropped.
+    DefMacro!("\\author[]{}", "\\lx@add@author{#2}");
+    DefMacro!(
+      "\\affiliation[]{}",
+      "\\@add@frontmatter{ltx:note}[role=affiliation]{#2}"
+    );
+    DefMacro!(
+      "\\contribution[]{}",
+      "\\@add@frontmatter{ltx:note}[role=contribution]{#2}"
+    );
+    DefMacro!(
+      "\\correspondence{}",
+      "\\@add@frontmatter{ltx:note}[role=correspondence]{#1}"
+    );
+    DefMacro!("\\abstract{}", "\\lx@add@abstract{#1}");
+    DefMacro!("\\email{}", "\\href{mailto:#1}{\\texttt{#1}}");
+    DefMacro!("\\beginappendix", "\\appendix");
+  };
+}
+
 // Runtime script bindings (docs/parity/script_bindings_plan.md). Feature-gated; OFF by
 // default. The ONLY module that embeds Rhai.
 #[cfg(feature = "runtime-bindings")]

--- a/latexml_contrib/src/lib.rs
+++ b/latexml_contrib/src/lib.rs
@@ -98,6 +98,7 @@ pub mod emlines_sty;
 pub mod envmath_sty;
 pub mod equations_sty;
 pub mod eso_pic_sty;
+pub mod fairmeta_cls;
 pub mod fancyvrb_ex_sty;
 pub mod fcs_cls;
 pub mod figcaps_sty;
@@ -450,6 +451,7 @@ pub const BINDINGS: &[(&str, &str, BindingLoader)] = &[
   ("egpubl", "cls", egpubl_cls::load_definitions),
   ("ejpecp", "cls", ejpecp_cls::load_definitions),
   ("elife", "cls", elife_cls::load_definitions),
+  ("fairmeta", "cls", fairmeta_cls::load_definitions),
   ("fcs", "cls", fcs_cls::load_definitions),
   ("getfiledate", "sty", getfiledate_sty::load_definitions),
   ("gretsi", "cls", gretsi_cls::load_definitions),

--- a/latexml_contrib/src/lib.rs
+++ b/latexml_contrib/src/lib.rs
@@ -11,45 +11,6 @@ extern crate latexml_package;
 extern crate latexml_codegen;
 use latexml_core::common::error::*;
 
-/// Shared frontmatter interface for the "addtolist ML meta-class" family
-/// (`fairmeta` / `selfevolagent` / `openmoss` and future siblings): pre-print
-/// classes whose `\author`/`\affiliation`/`\contribution`/`\correspondence`/
-/// `\abstract`/`\beginappendix` commands are defined on an `\addtolist`
-/// accumulator in the class BODY — which an unknown `.cls` does not raw-load, so
-/// all are `Error:undefined` without a binding. Emits the identical,
-/// order-independent frontmatter routing shared by every sibling. The
-/// per-class parts stay in each `*_cls.rs`: the dependency list (order-sensitive),
-/// the colour palette, and the class-specific labeled field (`\metadata` vs
-/// `\checkdata`, and its routing) — see each file. Invoke once inside the
-/// class's `LoadDefinitions!` block. Function paths are fully qualified so the
-/// macro is hygienic regardless of the call site's imports.
-macro_rules! meta_class_frontmatter {
-  () => {
-    // Accumulator lists → no-ops; the `\@add@frontmatter` sink accumulates.
-    latexml_engine::prelude::def_macro_noop("\\authorlist")?;
-    latexml_engine::prelude::def_macro_noop("\\affiliationlist")?;
-    latexml_engine::prelude::def_macro_noop("\\contributionlist")?;
-    // `\author[mark]{name}` → the creator sink (NOT `\author` — that re-matches
-    // this macro and recurses); the leading affiliation mark #1 is dropped.
-    DefMacro!("\\author[]{}", "\\lx@add@author{#2}");
-    DefMacro!(
-      "\\affiliation[]{}",
-      "\\@add@frontmatter{ltx:note}[role=affiliation]{#2}"
-    );
-    DefMacro!(
-      "\\contribution[]{}",
-      "\\@add@frontmatter{ltx:note}[role=contribution]{#2}"
-    );
-    DefMacro!(
-      "\\correspondence{}",
-      "\\@add@frontmatter{ltx:note}[role=correspondence]{#1}"
-    );
-    DefMacro!("\\abstract{}", "\\lx@add@abstract{#1}");
-    DefMacro!("\\email{}", "\\href{mailto:#1}{\\texttt{#1}}");
-    DefMacro!("\\beginappendix", "\\appendix");
-  };
-}
-
 // Runtime script bindings (docs/parity/script_bindings_plan.md). Feature-gated; OFF by
 // default. The ONLY module that embeds Rhai.
 #[cfg(feature = "runtime-bindings")]
@@ -64,6 +25,7 @@ pub mod script_bindings;
 // now local `.rhai` next to tests/structure_rhai (Perl t/structure/*.ltxml).
 pub mod discard_env;
 pub mod keysetopt_sty;
+pub mod meta_class;
 // mykeyval_sty / myxkeyval_sty: test-local keyval fixtures, now local `.rhai`
 // next to tests/keyval_rhai (Perl t/keyval/{mykeyval,myxkeyval}.sty.ltxml).
 pub mod mytemplate_sty;

--- a/latexml_contrib/src/lib.rs
+++ b/latexml_contrib/src/lib.rs
@@ -206,6 +206,7 @@ pub mod catoptions_sty;
 pub mod pnas_new_cls;
 pub mod scis2024_cls;
 pub mod scrlayer_scrpage_sty;
+pub mod selfevolagent_cls;
 pub mod semantic_sty;
 pub mod siamart_cls;
 pub mod siamltex_cls;
@@ -535,6 +536,7 @@ pub const BINDINGS: &[(&str, &str, BindingLoader)] = &[
   ("siamltex", "cls", siamltex_cls::load_definitions),
   ("semantic", "sty", semantic_sty::load_definitions),
   ("sigma", "cls", sigma_cls::load_definitions),
+  ("selfevolagent", "cls", selfevolagent_cls::load_definitions),
   ("smc_ieeeconf", "cls", smc_ieeeconf_cls::load_definitions),
   ("sn-jnl", "cls", sn_jnl_cls::load_definitions),
   ("spie", "cls", spie_cls::load_definitions),

--- a/latexml_contrib/src/meta_class.rs
+++ b/latexml_contrib/src/meta_class.rs
@@ -1,0 +1,45 @@
+//! Shared helper: the frontmatter interface common to the "addtolist ML
+//! meta-class" family (`fairmeta` / `selfevolagent` / `openmoss` and future
+//! siblings) — pre-print classes whose `\author`/`\affiliation`/`\contribution`/
+//! `\correspondence`/`\abstract`/`\beginappendix` commands are defined on an
+//! `\addtolist` accumulator in the class BODY. An unknown `.cls` body is not
+//! raw-loaded (OmniBus extracts dependencies only), so every one of those is
+//! `Error:undefined` without a binding. Mirrors the shared-helper pattern of
+//! [`crate::discard_env`].
+use latexml_package::prelude::*;
+
+/// Install the identical, order-independent frontmatter routing shared by every
+/// sibling class: route `\author` to the creator sink and the rest to
+/// `\@add@frontmatter`/`\lx@add@abstract` so they reach `<ltx:document>`
+/// frontmatter. Call once from inside the class's `LoadDefinitions!` block.
+///
+/// The per-class parts stay in each `*_cls.rs`: the (order-sensitive) dependency
+/// list, the colour palette, and the class-specific labeled field — `\metadata`
+/// vs `\checkdata`, and whether its label routes to a `role` attribute
+/// (attribute-safe labels, `fairmeta`) or to note content (arbitrary-markup
+/// labels, `selfevolagent`/`openmoss`).
+pub fn install_meta_class_frontmatter() -> Result<()> {
+  // Accumulator lists → no-ops; the `\@add@frontmatter` sink accumulates.
+  def_macro_noop("\\authorlist")?;
+  def_macro_noop("\\affiliationlist")?;
+  def_macro_noop("\\contributionlist")?;
+  // `\author[mark]{name}` → the creator sink (NOT `\author` — that re-matches
+  // this macro and recurses); the leading affiliation mark #1 is dropped.
+  DefMacro!("\\author[]{}", "\\lx@add@author{#2}");
+  DefMacro!(
+    "\\affiliation[]{}",
+    "\\@add@frontmatter{ltx:note}[role=affiliation]{#2}"
+  );
+  DefMacro!(
+    "\\contribution[]{}",
+    "\\@add@frontmatter{ltx:note}[role=contribution]{#2}"
+  );
+  DefMacro!(
+    "\\correspondence{}",
+    "\\@add@frontmatter{ltx:note}[role=correspondence]{#1}"
+  );
+  DefMacro!("\\abstract{}", "\\lx@add@abstract{#1}");
+  DefMacro!("\\email{}", "\\href{mailto:#1}{\\texttt{#1}}");
+  DefMacro!("\\beginappendix", "\\appendix");
+  Ok(())
+}

--- a/latexml_contrib/src/openmoss_cls.rs
+++ b/latexml_contrib/src/openmoss_cls.rs
@@ -47,8 +47,8 @@ LoadDefinitions!({
   DefMacro!("\\nm{}", "#1");
 
   // Shared "addtolist meta-class" frontmatter routing — see
-  // `meta_class_frontmatter!` in lib.rs.
-  meta_class_frontmatter!();
+  // `meta_class::install_meta_class_frontmatter`.
+  crate::meta_class::install_meta_class_frontmatter()?;
 
   // Class-specific labeled field (openmoss uses \checkdata, not \metadata):
   def_macro_noop("\\checkdatalist")?;

--- a/latexml_contrib/src/openmoss_cls.rs
+++ b/latexml_contrib/src/openmoss_cls.rs
@@ -1,0 +1,75 @@
+//! Binding for openmoss.cls (OpenMOSS survey/report class).
+//!
+//! A third sibling of `fairmeta.cls` / `selfevolagent.cls`: the same
+//! `\addtolist`-based class-body frontmatter (\author/\affiliation/\contribution/
+//! \checkdata/\correspondence/\abstract, \beginappendix), plus an `openmossblue`
+//! colour set and `\openmossblue`/`\nm` helpers — all `Error:undefined` because
+//! an unknown `.cls` body is not raw-loaded. Route the frontmatter through
+//! `\@add@frontmatter`/`\lx@add@author`/`\lx@add@abstract`. See `fairmeta_cls.rs`.
+//!
+//! Witness: 2605.12090 (ar5iv #605).
+use latexml_package::prelude::*;
+
+LoadDefinitions!({
+  LoadClass!("OmniBus");
+  RequirePackage!("amsmath");
+  RequirePackage!("amssymb");
+  RequirePackage!("amsthm");
+  RequirePackage!("graphicx");
+  RequirePackage!("subcaption");
+  RequirePackage!("xcolor");
+  RequirePackage!("booktabs");
+  RequirePackage!("multirow");
+  RequirePackage!("bm");
+  RequirePackage!("etoolbox");
+  // \RequirePackage[latin, english]{babel} (openmoss.cls L22) — the class does
+  // `\addto\extrasenglish{…}`, so babel's `\extrasenglish`/`\addto` must exist.
+  RequirePackage!("babel", options => vec![s!("latin"), s!("english")]);
+  RequirePackage!("ulem");
+  RequirePackage!("caption");
+  RequirePackage!("hyperref");
+  RequirePackage!("cleveref");
+  RequirePackage!("natbib");
+  RequirePackage!("nicematrix");
+  // \RequirePackage[most]{tcolorbox} (openmoss.cls L36) — PassOptions before the
+  // require so tcolorbox loads its `most` libraries (see fairmeta_cls.rs).
+  pass_options("tcolorbox", "sty", vec![s!("most")])?;
+  RequirePackage!("tcolorbox");
+
+  def_macro_noop("\\geometry{}")?;
+
+  // Class palette (used by \openmossblue and \textcolor{openmossblue}).
+  Digest!("\\definecolor{OpenMossCyan}{HTML}{82D9FF}")?;
+  Digest!("\\definecolor{OpenMossBlue}{HTML}{82B1FF}")?;
+  Digest!("\\definecolor{openmossbg}{HTML}{387BD9}")?;
+  Digest!("\\definecolor{openmossblue}{HTML}{387BD9}")?;
+  DefMacro!("\\openmossblue{}", "{\\bfseries\\color{openmossblue}#1}");
+  DefMacro!("\\nm{}", "#1");
+
+  // Frontmatter (see fairmeta_cls.rs). Accumulator lists become no-ops.
+  def_macro_noop("\\authorlist")?;
+  def_macro_noop("\\affiliationlist")?;
+  def_macro_noop("\\contributionlist")?;
+  def_macro_noop("\\checkdatalist")?;
+
+  DefMacro!("\\author[]{}", "\\lx@add@author{#2}");
+  DefMacro!(
+    "\\affiliation[]{}",
+    "\\@add@frontmatter{ltx:note}[role=affiliation]{#2}"
+  );
+  DefMacro!(
+    "\\contribution[]{}",
+    "\\@add@frontmatter{ltx:note}[role=contribution]{#2}"
+  );
+  // \checkdata[label]{value} — arbitrary label (e.g. "Github Repo", a \url),
+  // rendered as note CONTENT "label: value" (a label with a space can't be a
+  // role attribute).
+  DefMacro!("\\checkdata[]{}", "\\@add@frontmatter{ltx:note}{#1: #2}");
+  DefMacro!(
+    "\\correspondence{}",
+    "\\@add@frontmatter{ltx:note}[role=correspondence]{#1}"
+  );
+  DefMacro!("\\abstract{}", "\\lx@add@abstract{#1}");
+  DefMacro!("\\email{}", "\\href{mailto:#1}{\\texttt{#1}}");
+  DefMacro!("\\beginappendix", "\\appendix");
+});

--- a/latexml_contrib/src/openmoss_cls.rs
+++ b/latexml_contrib/src/openmoss_cls.rs
@@ -46,30 +46,14 @@ LoadDefinitions!({
   DefMacro!("\\openmossblue{}", "{\\bfseries\\color{openmossblue}#1}");
   DefMacro!("\\nm{}", "#1");
 
-  // Frontmatter (see fairmeta_cls.rs). Accumulator lists become no-ops.
-  def_macro_noop("\\authorlist")?;
-  def_macro_noop("\\affiliationlist")?;
-  def_macro_noop("\\contributionlist")?;
-  def_macro_noop("\\checkdatalist")?;
+  // Shared "addtolist meta-class" frontmatter routing — see
+  // `meta_class_frontmatter!` in lib.rs.
+  meta_class_frontmatter!();
 
-  DefMacro!("\\author[]{}", "\\lx@add@author{#2}");
-  DefMacro!(
-    "\\affiliation[]{}",
-    "\\@add@frontmatter{ltx:note}[role=affiliation]{#2}"
-  );
-  DefMacro!(
-    "\\contribution[]{}",
-    "\\@add@frontmatter{ltx:note}[role=contribution]{#2}"
-  );
+  // Class-specific labeled field (openmoss uses \checkdata, not \metadata):
+  def_macro_noop("\\checkdatalist")?;
   // \checkdata[label]{value} — arbitrary label (e.g. "Github Repo", a \url),
   // rendered as note CONTENT "label: value" (a label with a space can't be a
   // role attribute).
   DefMacro!("\\checkdata[]{}", "\\@add@frontmatter{ltx:note}{#1: #2}");
-  DefMacro!(
-    "\\correspondence{}",
-    "\\@add@frontmatter{ltx:note}[role=correspondence]{#1}"
-  );
-  DefMacro!("\\abstract{}", "\\lx@add@abstract{#1}");
-  DefMacro!("\\email{}", "\\href{mailto:#1}{\\texttt{#1}}");
-  DefMacro!("\\beginappendix", "\\appendix");
 });

--- a/latexml_contrib/src/scrartcl_cls.rs
+++ b/latexml_contrib/src/scrartcl_cls.rs
@@ -65,10 +65,18 @@ LoadDefinitions!({
   // them. Witness: 11 papers in R-stages for each.
   def_macro_noop("\\headmark")?;
   def_macro_noop("\\pagemark")?;
-  // \subject{}, \dictum{}, \uppertitleback{}, \lowertitleback{},
-  // \publishers{} — KOMA frontmatter pieces that DO carry author
-  // content. Preserve as ltx:note frontmatter so the text reaches the
-  // XML (rather than silently gobbling).
+  // \titlehead{}, \subject{}, \dictum{}, \uppertitleback{},
+  // \lowertitleback{}, \publishers{} — KOMA frontmatter pieces that DO carry
+  // author content. Preserve as ltx:note frontmatter so the text reaches the
+  // XML (rather than silently gobbling). Neither Perl nor upstream LaTeXML
+  // binds these (no scrartcl.cls.ltxml) — surpass-Perl content recovery.
+  // \titlehead renders a full-width header ABOVE the title in KOMA's
+  // \maketitle; capture it as a note. Witness 2305.01582 (ar5iv #498): a
+  // \titlehead banner with the software name + \giturl was dropped + errored.
+  DefMacro!(
+    "\\titlehead{}",
+    "\\@add@frontmatter{ltx:note}[role=titlehead]{#1}"
+  );
   DefMacro!(
     "\\subject{}",
     "\\@add@frontmatter{ltx:note}[role=subject]{#1}"

--- a/latexml_contrib/src/selfevolagent_cls.rs
+++ b/latexml_contrib/src/selfevolagent_cls.rs
@@ -45,8 +45,8 @@ LoadDefinitions!({
   Digest!("\\definecolor{selfevolagent_blue}{HTML}{0064E0}")?;
 
   // Shared "addtolist meta-class" frontmatter routing — see
-  // `meta_class_frontmatter!` in lib.rs.
-  meta_class_frontmatter!();
+  // `meta_class::install_meta_class_frontmatter`.
+  crate::meta_class::install_meta_class_frontmatter()?;
 
   // Class-specific labeled fields (kept per-class):
   def_macro_noop("\\metadatalist")?;

--- a/latexml_contrib/src/selfevolagent_cls.rs
+++ b/latexml_contrib/src/selfevolagent_cls.rs
@@ -44,31 +44,15 @@ LoadDefinitions!({
   Digest!("\\definecolor{selfevolagent_lighter}{HTML}{CDF4E9}")?;
   Digest!("\\definecolor{selfevolagent_blue}{HTML}{0064E0}")?;
 
-  // Frontmatter (see fairmeta_cls.rs). The accumulator lists become no-ops.
-  def_macro_noop("\\authorlist")?;
-  def_macro_noop("\\affiliationlist")?;
-  def_macro_noop("\\contributionlist")?;
-  def_macro_noop("\\metadatalist")?;
+  // Shared "addtolist meta-class" frontmatter routing — see
+  // `meta_class_frontmatter!` in lib.rs.
+  meta_class_frontmatter!();
 
-  DefMacro!("\\author[]{}", "\\lx@add@author{#2}");
-  DefMacro!(
-    "\\affiliation[]{}",
-    "\\@add@frontmatter{ltx:note}[role=affiliation]{#2}"
-  );
-  DefMacro!(
-    "\\contribution[]{}",
-    "\\@add@frontmatter{ltx:note}[role=contribution]{#2}"
-  );
+  // Class-specific labeled fields (kept per-class):
+  def_macro_noop("\\metadatalist")?;
   // \metadata[label]{value}: the label can be arbitrary markup (e.g. an
   // \includegraphics-bearing "Github" chip), so it cannot go in a `role`
   // attribute — render it as note CONTENT "label: value".
   DefMacro!("\\metadata[]{}", "\\@add@frontmatter{ltx:note}{#1: #2}");
-  DefMacro!(
-    "\\correspondence{}",
-    "\\@add@frontmatter{ltx:note}[role=correspondence]{#1}"
-  );
   DefMacro!("\\date{}", "\\@add@frontmatter{ltx:note}[role=date]{#1}");
-  DefMacro!("\\abstract{}", "\\lx@add@abstract{#1}");
-  DefMacro!("\\email{}", "\\href{mailto:#1}{\\texttt{#1}}");
-  DefMacro!("\\beginappendix", "\\appendix");
 });

--- a/latexml_contrib/src/selfevolagent_cls.rs
+++ b/latexml_contrib/src/selfevolagent_cls.rs
@@ -1,0 +1,74 @@
+//! Binding for selfevolagent.cls (Self-Evolving-Agents survey class).
+//!
+//! A near-identical sibling of `fairmeta.cls`: the same `\addtolist[5]`-based
+//! frontmatter interface (\author/\affiliation/\contribution/\metadata/
+//! \correspondence/\abstract, \beginappendix) defined in the class BODY, which
+//! an unknown `.cls` does not raw-load → all `Error:undefined`. Route them
+//! through `\@add@frontmatter`/`\lx@add@author`/`\lx@add@abstract`. See
+//! `fairmeta_cls.rs` for the shared rationale.
+//!
+//! Witness: 2508.07407 (ar5iv #556).
+use latexml_package::prelude::*;
+
+LoadDefinitions!({
+  LoadClass!("OmniBus");
+  RequirePackage!("amsmath");
+  RequirePackage!("amssymb");
+  RequirePackage!("graphicx");
+  RequirePackage!("subcaption");
+  RequirePackage!("xcolor");
+  RequirePackage!("colortbl");
+  RequirePackage!("booktabs");
+  RequirePackage!("multirow");
+  RequirePackage!("bm");
+  RequirePackage!("etoolbox");
+  RequirePackage!("caption");
+  RequirePackage!("hyperref");
+  RequirePackage!("natbib");
+  RequirePackage!("nicematrix");
+  // \RequirePackage[most]{tcolorbox} (selfevolagent.cls L32) — PassOptions before
+  // the require so tcolorbox loads its `most` libraries (see fairmeta_cls.rs).
+  pass_options("tcolorbox", "sty", vec![s!("most")])?;
+  RequirePackage!("tcolorbox");
+
+  // \geometry{...} — visual-only page-geometry hint.
+  def_macro_noop("\\geometry{}")?;
+
+  // Class palette (\color{selfevolagentfg} is used by the abstract box).
+  Digest!("\\definecolor{selfevolagentpink}{HTML}{4b0082}")?;
+  Digest!("\\definecolor{selfevolagentfg}{HTML}{1C2B33}")?;
+  Digest!("\\definecolor{selfevolagentbg}{HTML}{fffafa}")?;
+  Digest!("\\definecolor{commentcolor}{rgb}{0.294, 0, 0.51}")?;
+  Digest!("\\definecolor{selfevolagent_dark}{HTML}{37D2A6}")?;
+  Digest!("\\definecolor{selfevolagent_light}{HTML}{9BE9D3}")?;
+  Digest!("\\definecolor{selfevolagent_lighter}{HTML}{CDF4E9}")?;
+  Digest!("\\definecolor{selfevolagent_blue}{HTML}{0064E0}")?;
+
+  // Frontmatter (see fairmeta_cls.rs). The accumulator lists become no-ops.
+  def_macro_noop("\\authorlist")?;
+  def_macro_noop("\\affiliationlist")?;
+  def_macro_noop("\\contributionlist")?;
+  def_macro_noop("\\metadatalist")?;
+
+  DefMacro!("\\author[]{}", "\\lx@add@author{#2}");
+  DefMacro!(
+    "\\affiliation[]{}",
+    "\\@add@frontmatter{ltx:note}[role=affiliation]{#2}"
+  );
+  DefMacro!(
+    "\\contribution[]{}",
+    "\\@add@frontmatter{ltx:note}[role=contribution]{#2}"
+  );
+  // \metadata[label]{value}: the label can be arbitrary markup (e.g. an
+  // \includegraphics-bearing "Github" chip), so it cannot go in a `role`
+  // attribute — render it as note CONTENT "label: value".
+  DefMacro!("\\metadata[]{}", "\\@add@frontmatter{ltx:note}{#1: #2}");
+  DefMacro!(
+    "\\correspondence{}",
+    "\\@add@frontmatter{ltx:note}[role=correspondence]{#1}"
+  );
+  DefMacro!("\\date{}", "\\@add@frontmatter{ltx:note}[role=date]{#1}");
+  DefMacro!("\\abstract{}", "\\lx@add@abstract{#1}");
+  DefMacro!("\\email{}", "\\href{mailto:#1}{\\texttt{#1}}");
+  DefMacro!("\\beginappendix", "\\appendix");
+});

--- a/latexml_core/src/binding/content.rs
+++ b/latexml_core/src/binding/content.rs
@@ -761,7 +761,21 @@ pub fn input_definitions(raw_file: &str, mut options: InputDefinitionOptions) ->
       // dedicated `_load_attempted` flag — NOT `_loaded` — so the
       // post-input_definitions success check in `require_package`
       // remains honest about whether anything actually loaded.
-      assign_value(&s!("{filename}_load_attempted"), true, Some(Scope::Global));
+      //
+      // Gate the guard on raw-loading having actually been POSSIBLE
+      // (INCLUDE_STYLES on, or noltxml forced). A miss while raw `.sty` loading
+      // was OFF is a deliberate DEFERRAL, not a genuine "file absent" — and must
+      // NOT block a later load once INCLUDE_STYLES turns on (e.g. inside another
+      // package's raw read). Otherwise a bare `\RequirePackage{pgfcore}` (no
+      // binding, INCLUDE_STYLES off) permanently STARVES tcolorbox's `skins`
+      // library, which raw-loads pgfcore under INCLUDE_STYLES=true — whereas
+      // pdflatex loads pgfcore fine in any order. The guard still fires exactly
+      // where it is needed: the loop it prevents happens DURING a raw read,
+      // which is itself INCLUDE_STYLES=true. Witness: nicematrix-then-
+      // tcolorbox[most] (fairmeta.cls, ar5iv #520/#567/#576): 49 → 0 pgf errors.
+      if lookup_bool("INCLUDE_STYLES") || options.noltxml {
+        assign_value(&s!("{filename}_load_attempted"), true, Some(Scope::Global));
+      }
       Warn!(
         "missing_file",
         name,

--- a/latexml_oxide/tests/92_fairmeta_frontmatter.rs
+++ b/latexml_oxide/tests/92_fairmeta_frontmatter.rs
@@ -1,0 +1,120 @@
+//! Regression test: the `fairmeta.cls` (FAIR / Meta pre-print class) binding
+//! captures the class's custom frontmatter into the XML.
+//!
+//! `fairmeta.cls` defines its whole frontmatter interface
+//! (\author/\affiliation/\contribution/\metadata/\correspondence/\abstract) in
+//! the class BODY, which OmniBus does not raw-load — so without a binding those
+//! commands are `Error:undefined` and the metadata is silently dropped
+//! (ar5iv #520/#567/#576). The `fairmeta_cls` contrib binding routes them
+//! through `\@add@frontmatter` / `\lx@add@author` / `\lx@add@abstract`.
+//!
+//! Driven through the BINARY (fresh process, one conversion) rather than the
+//! in-process `tests/contrib` harness on purpose: loading a
+//! `LoadClass!("OmniBus")` contrib `.cls` and then `reset_thread_engine`-ing
+//! between files (as `can_contrib` does) reads a pre-reset `SymStr` from an
+//! unresettable `pin!` cache and aborts — the documented one-conversion-per-
+//! thread contract (see `latexml_core::reset_thread_engine`). A fresh process
+//! per conversion is exactly how production (cortex_worker) runs, so it is both
+//! faithful and safe. This is why the ~100 other contrib `.cls` bindings carry
+//! no in-process fixture.
+
+use std::{path::Path, process::Command};
+
+const FAIRMETA_TEX: &str = "\\documentclass{fairmeta}\n\
+  \\title{A FAIR Preprint}\n\
+  \\author[1]{Jane Doe}\n\
+  \\author[2]{John Roe}\n\
+  \\affiliation[1]{Meta AI}\n\
+  \\affiliation[2]{Some University}\n\
+  \\contribution[$\\star$]{Equal contribution}\n\
+  \\metadata[Date]{January 2026}\n\
+  \\correspondence{jane@example.org}\n\
+  \\abstract{We study the frontmatter of a preprint class.}\n\
+  \\begin{document}\n\
+  \\maketitle\n\
+  Body text with a \\nm{model name}.\n\
+  \\beginappendix\n\
+  \\section{Extra material}\n\
+  More content.\n\
+  \\end{document}\n";
+
+#[test]
+fn fairmeta_frontmatter_is_captured() {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+
+  let workdir = tempfile::tempdir().expect("create tempdir");
+  let tex_path = workdir.path().join("fm.tex");
+  std::fs::write(&tex_path, FAIRMETA_TEX).expect("write fm.tex");
+
+  // No --preload/--includestyles: the class's tcolorbox[most] raw-loads its
+  // library files (and their pgf dependencies) itself — that raw read turns
+  // INCLUDE_STYLES on locally, and the hardened load guard (a deferred miss no
+  // longer poisons a later load) lets pgfcore load in the nicematrix→tcolorbox
+  // require order. Matches pdflatex; no ar5iv config needed.
+  let output = Command::new(bin)
+    .arg("fm.tex")
+    .arg("--dest")
+    .arg("fm.xml")
+    .arg("--nocomments")
+    .current_dir(workdir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+
+  let stderr = String::from_utf8_lossy(&output.stderr);
+  assert!(
+    output.status.success(),
+    "binary exited {:?}\nstderr:\n{stderr}",
+    output.status.code(),
+  );
+
+  // The conversion must be error-clean: the whole point is that the custom
+  // frontmatter commands are DEFINED (were Error:undefined before the binding).
+  assert!(
+    !stderr.contains("Error:") && !stderr.contains("Fatal:"),
+    "expected an error-clean conversion, stderr had errors:\n{stderr}",
+  );
+
+  let xml = std::fs::read_to_string(workdir.path().join("fm.xml")).expect("read fm.xml");
+
+  // Both authors survive as document creators (the class accumulates authors;
+  // \lx@add@author must NOT collapse to the last one).
+  for author in ["Jane Doe", "John Roe"] {
+    assert!(
+      xml.contains(author),
+      "author {author} missing from frontmatter:\n{xml}"
+    );
+  }
+  // Affiliations, contribution, date, correspondence land as frontmatter notes.
+  for (role, text) in [
+    ("affiliation", "Meta AI"),
+    ("affiliation", "Some University"),
+    ("contribution", "Equal contribution"),
+    ("correspondence", "jane@example.org"),
+  ] {
+    assert!(
+      xml.contains(&format!("role=\"{role}\"")),
+      "missing frontmatter note role={role}:\n{xml}",
+    );
+    assert!(
+      xml.contains(text),
+      "missing frontmatter text {text:?}:\n{xml}"
+    );
+  }
+  // \metadata[Date]{...} keys the note by its label.
+  assert!(
+    xml.contains("January 2026"),
+    "metadata date value missing:\n{xml}"
+  );
+  // \abstract{...} reaches the abstract element.
+  assert!(
+    xml.contains("<abstract") && xml.contains("frontmatter of a preprint class"),
+    "abstract not captured:\n{xml}",
+  );
+  // \beginappendix opens an appendix; \nm{...} passes its content through.
+  assert!(
+    xml.contains("<appendix"),
+    "\\beginappendix did not open an appendix:\n{xml}"
+  );
+  assert!(xml.contains("model name"), "\\nm content missing:\n{xml}");
+}

--- a/latexml_oxide/tests/93_deferred_load_retry.rs
+++ b/latexml_oxide/tests/93_deferred_load_retry.rs
@@ -1,0 +1,56 @@
+//! Regression test for the package-load "deferred miss must not poison a later
+//! raw-load" parity fix (`content.rs`).
+//!
+//! `nicematrix` faithfully `\RequirePackage{pgfcore}` (nicematrix.sty:23), which
+//! has no binding — so bare (INCLUDE_STYLES off) it "misses". Then
+//! `tcolorbox[most]` raw-loads and its `skins` library also needs pgfcore, this
+//! time under INCLUDE_STYLES=true (a raw read turns it on). Before the fix the
+//! Rust-only `_load_attempted` guard from nicematrix's deferred miss permanently
+//! blocked tcolorbox's pgfcore load → ~49 spurious `\pgf…`/`#`-token errors. The
+//! fix sets `_load_attempted` only when raw-loading was actually possible, so the
+//! later load retries — matching pdflatex, which loads pgfcore in either order.
+//!
+//! Driven through the binary (fresh process) so tcolorbox can raw-load its
+//! library files from the host texmf; no `--includestyles`/preload needed.
+
+use std::{path::Path, process::Command};
+
+const TEX: &str = "\\documentclass{article}\n\
+  \\usepackage{nicematrix}\n\
+  \\usepackage[most]{tcolorbox}\n\
+  \\begin{document}\n\
+  \\begin{tcolorbox}[enhanced,breakable]Hello box\\end{tcolorbox}\n\
+  \\end{document}\n";
+
+#[test]
+fn deferred_pgfcore_miss_does_not_poison_tcolorbox_skins() {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+
+  let workdir = tempfile::tempdir().expect("create tempdir");
+  std::fs::write(workdir.path().join("d.tex"), TEX).expect("write d.tex");
+
+  let output = Command::new(bin)
+    .arg("d.tex")
+    .arg("--dest")
+    .arg("d.xml")
+    .arg("--nocomments")
+    .current_dir(workdir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+
+  let stderr = String::from_utf8_lossy(&output.stderr);
+  assert!(
+    output.status.success(),
+    "binary exited {:?}\nstderr:\n{stderr}",
+    output.status.code(),
+  );
+  // The nicematrix-then-tcolorbox order must be error-clean (was ~49 pgf errors).
+  assert!(
+    !stderr.contains("Error:") && !stderr.contains("Fatal:"),
+    "nicematrix-then-tcolorbox[most] should be error-clean, stderr had errors:\n{stderr}",
+  );
+  // Sanity: the box content still made it through.
+  let xml = std::fs::read_to_string(workdir.path().join("d.xml")).expect("read d.xml");
+  assert!(xml.contains("Hello box"), "tcolorbox body missing:\n{xml}");
+}

--- a/latexml_oxide/tests/94_selfevolagent_frontmatter.rs
+++ b/latexml_oxide/tests/94_selfevolagent_frontmatter.rs
@@ -1,0 +1,91 @@
+//! Regression test: the `selfevolagent.cls` binding captures the class's custom
+//! frontmatter into the XML (ar5iv #556).
+//!
+//! selfevolagent.cls is a near-identical sibling of fairmeta.cls — the same
+//! class-body `\addtolist`-based frontmatter interface, `Error:undefined`
+//! without a binding (an unknown `.cls` body is not raw-loaded). See
+//! `92_fairmeta_frontmatter.rs` for why this is driven through the binary rather
+//! than the in-process `tests/contrib` harness.
+//!
+//! (The full paper 2508.07407 also hits an unrelated box-loop `Stomach:Recursion`
+//! in its `paradigms.tex` content — a separate, paper-specific issue outside the
+//! frontmatter binding's scope.)
+
+use std::{path::Path, process::Command};
+
+const TEX: &str = "\\documentclass{selfevolagent}\n\
+  \\title{Self-Evolving Agents: A Survey}\n\
+  \\author[1]{Ana Lee}\n\
+  \\author[2]{Bo Chen}\n\
+  \\affiliation[1]{EvoAgentX}\n\
+  \\affiliation[2]{A University}\n\
+  \\contribution[*]{Equal Contributor}\n\
+  \\metadata[Github]{https://github.com/EvoAgentX/x}\n\
+  \\correspondence{ana@example.org}\n\
+  \\abstract{A survey of self-evolving agents.}\n\
+  \\begin{document}\n\
+  \\maketitle\n\
+  Body text.\n\
+  \\beginappendix\n\
+  \\section{More}\n\
+  Appendix content.\n\
+  \\end{document}\n";
+
+#[test]
+fn selfevolagent_frontmatter_is_captured() {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+
+  let workdir = tempfile::tempdir().expect("create tempdir");
+  std::fs::write(workdir.path().join("s.tex"), TEX).expect("write s.tex");
+
+  let output = Command::new(bin)
+    .arg("s.tex")
+    .arg("--dest")
+    .arg("s.xml")
+    .arg("--nocomments")
+    .current_dir(workdir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+
+  let stderr = String::from_utf8_lossy(&output.stderr);
+  assert!(
+    output.status.success(),
+    "binary exited {:?}\nstderr:\n{stderr}",
+    output.status.code(),
+  );
+  assert!(
+    !stderr.contains("Error:") && !stderr.contains("Fatal:"),
+    "expected an error-clean conversion, stderr had errors:\n{stderr}",
+  );
+
+  let xml = std::fs::read_to_string(workdir.path().join("s.xml")).expect("read s.xml");
+  for author in ["Ana Lee", "Bo Chen"] {
+    assert!(xml.contains(author), "author {author} missing:\n{xml}");
+  }
+  assert!(
+    xml.contains("role=\"affiliation\"") && xml.contains("EvoAgentX"),
+    "affiliation missing:\n{xml}"
+  );
+  assert!(
+    xml.contains("role=\"contribution\""),
+    "contribution missing:\n{xml}"
+  );
+  assert!(
+    xml.contains("role=\"correspondence\""),
+    "correspondence missing:\n{xml}"
+  );
+  // \metadata's arbitrary label renders as note CONTENT ("Github: …"), not a role.
+  assert!(
+    xml.contains("Github: https://github.com/EvoAgentX/x"),
+    "metadata label:value missing:\n{xml}"
+  );
+  assert!(
+    xml.contains("<abstract") && xml.contains("survey of self-evolving agents"),
+    "abstract missing:\n{xml}"
+  );
+  assert!(
+    xml.contains("<appendix"),
+    "\\beginappendix did not open an appendix:\n{xml}"
+  );
+}

--- a/latexml_oxide/tests/95_newtcblisting_verbatim.rs
+++ b/latexml_oxide/tests/95_newtcblisting_verbatim.rs
@@ -1,0 +1,72 @@
+//! Regression test: a `\newtcblisting`-defined code box captures its body
+//! verbatim and CLOSES at `\end{name}` (ar5iv #504 / #569 / #570).
+//!
+//! The tcolorbox `listings` library's `\newtcblisting` reads its body as a code
+//! listing. The raw library's body capture did not integrate with LaTeXML's
+//! verbatim reader, so the listing ran past its `\end{name}` and swallowed the
+//! following content — a `\section` after the box ended up nested inside
+//! `<ltx:verbatim>` (`<ltx:section> isn't allowed in <ltx:verbatim>`) and the
+//! document failed to close. The binding now delegates `\newtcblisting` to
+//! listings' `\lstnewenvironment`, whose verbatim reader terminates correctly.
+//!
+//! Binary-driven (fresh process) so tcolorbox can raw-load its library files.
+
+use std::{path::Path, process::Command};
+
+const TEX: &str = "\\documentclass{article}\n\
+  \\usepackage[most]{tcolorbox}\n\
+  \\tcbuselibrary{listings}\n\
+  \\newtcblisting{mycodebox}[1][]{listing only,#1}\n\
+  \\begin{document}\n\
+  \\section{First}\n\
+  \\begin{mycodebox}\n\
+  some code line\n\
+  another line\n\
+  \\end{mycodebox}\n\
+  \\section{Second}\n\
+  Text after the box.\n\
+  \\end{document}\n";
+
+#[test]
+fn newtcblisting_body_is_verbatim_and_closes() {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+
+  let workdir = tempfile::tempdir().expect("create tempdir");
+  std::fs::write(workdir.path().join("t.tex"), TEX).expect("write t.tex");
+
+  let output = Command::new(bin)
+    .arg("t.tex")
+    .arg("--dest")
+    .arg("t.xml")
+    .arg("--nocomments")
+    .current_dir(workdir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+
+  let stderr = String::from_utf8_lossy(&output.stderr);
+  assert!(
+    output.status.success(),
+    "binary exited {:?}\nstderr:\n{stderr}",
+    output.status.code(),
+  );
+  // No malformed-nesting / unclosed errors: the box body must not swallow the
+  // following section.
+  assert!(
+    !stderr.contains("Error:") && !stderr.contains("Fatal:"),
+    "newtcblisting box should close cleanly, stderr had errors:\n{stderr}",
+  );
+
+  let xml = std::fs::read_to_string(workdir.path().join("t.xml")).expect("read t.xml");
+  // The second section and the text after the box survive OUTSIDE the listing.
+  assert!(
+    xml.contains("Text after the box"),
+    "content after the box was swallowed by the listing:\n{xml}",
+  );
+  // Two real sections are present (the second didn't get eaten).
+  assert_eq!(
+    xml.matches("<section").count(),
+    2,
+    "expected 2 sections (First, Second) outside the box:\n{xml}",
+  );
+}

--- a/latexml_oxide/tests/96_openmoss_frontmatter.rs
+++ b/latexml_oxide/tests/96_openmoss_frontmatter.rs
@@ -1,0 +1,81 @@
+//! Regression test: the `openmoss.cls` binding captures the class's frontmatter
+//! and defines its colour helpers (ar5iv #605).
+//!
+//! openmoss.cls is a third sibling of fairmeta.cls / selfevolagent.cls — the same
+//! class-body `\addtolist` frontmatter plus an `openmossblue` colour used by the
+//! paper's `\textcolor{openmossblue}` / `\openmossblue{…}`. Without a binding the
+//! commands and colour are `Error:undefined` (an unknown `.cls` body is not
+//! raw-loaded). See `92_fairmeta_frontmatter.rs` for why this is binary-driven.
+
+use std::{path::Path, process::Command};
+
+const TEX: &str = "\\documentclass{openmoss}\n\
+  \\title{World Action Models}\n\
+  \\author[1]{Ann Poe}\n\
+  \\affiliation[1]{OpenMOSS}\n\
+  \\contribution[*]{Lead}\n\
+  \\checkdata[Github Repo]{https://github.com/OpenMOSS/x}\n\
+  \\correspondence{ann@example.org}\n\
+  \\abstract{A survey of world action models.}\n\
+  \\begin{document}\n\
+  \\maketitle\n\
+  \\textcolor{openmossblue}{blue text} and \\openmossblue{helper}.\n\
+  \\beginappendix\n\
+  \\section{More}\n\
+  Appendix.\n\
+  \\end{document}\n";
+
+#[test]
+fn openmoss_frontmatter_and_colors() {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+
+  let workdir = tempfile::tempdir().expect("create tempdir");
+  std::fs::write(workdir.path().join("o.tex"), TEX).expect("write o.tex");
+
+  let output = Command::new(bin)
+    .arg("o.tex")
+    .arg("--dest")
+    .arg("o.xml")
+    .arg("--nocomments")
+    .current_dir(workdir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+
+  let stderr = String::from_utf8_lossy(&output.stderr);
+  assert!(
+    output.status.success(),
+    "binary exited {:?}\nstderr:\n{stderr}",
+    output.status.code(),
+  );
+  assert!(
+    !stderr.contains("Error:") && !stderr.contains("Fatal:"),
+    "expected an error-clean conversion, stderr had errors:\n{stderr}",
+  );
+
+  let xml = std::fs::read_to_string(workdir.path().join("o.xml")).expect("read o.xml");
+  assert!(xml.contains("Ann Poe"), "author missing:\n{xml}");
+  assert!(
+    xml.contains("role=\"affiliation\"") && xml.contains("OpenMOSS"),
+    "affiliation missing:\n{xml}"
+  );
+  assert!(
+    xml.contains("role=\"correspondence\""),
+    "correspondence missing:\n{xml}"
+  );
+  // \checkdata's arbitrary label ("Github Repo", with a space) renders as content.
+  assert!(
+    xml.contains("Github Repo: https://github.com/OpenMOSS/x"),
+    "checkdata missing:\n{xml}"
+  );
+  assert!(
+    xml.contains("<abstract") && xml.contains("survey of world action models"),
+    "abstract missing:\n{xml}"
+  );
+  assert!(
+    xml.contains("<appendix"),
+    "\\beginappendix did not open an appendix:\n{xml}"
+  );
+  // The openmossblue colour resolved (not the "Can't find color" fallback).
+  assert!(xml.contains("blue text"), "colored text missing:\n{xml}");
+}

--- a/latexml_oxide/tests/97_agujournal_acronyms.rs
+++ b/latexml_oxide/tests/97_agujournal_acronyms.rs
@@ -1,0 +1,73 @@
+//! Regression test: the agujournal2019.cls binding provides the end-matter
+//! `{acronyms}` / `{notation}` description lists and the `{sidewaystable}` float
+//! (ar5iv #538).
+//!
+//! agujournal2019.cls defines `{acronyms}`/`{notation}` in its (non-raw-loaded)
+//! body via `\def\acronyms{…\def\acro##1{\item[##1]}}`, and pulls in
+//! `{sidewaystable}` from `\RequirePackage{rotating}`. Without the binding
+//! covering these, `\acro`/`{acronyms}`/`{notation}`/`{sidewaystable}` were
+//! `Error:undefined` and the sideways `\caption` leaked ("outside any known
+//! float"). Binary-driven (`LoadClass!("OmniBus")`; see 92_fairmeta_frontmatter).
+
+use std::{path::Path, process::Command};
+
+const TEX: &str = "\\documentclass{agujournal2019}\n\
+  \\begin{document}\n\
+  \\section{Body}\n\
+  Text.\n\
+  \\begin{sidewaystable}\n\
+  \\caption{A wide table}\n\
+  \\begin{tabular}{ll}a & b\\end{tabular}\n\
+  \\end{sidewaystable}\n\
+  \\begin{acronyms}\n\
+  \\acro{CME} Coronal Mass Ejection\n\
+  \\acro{ENA} Energetic Neutral Atom\n\
+  \\end{acronyms}\n\
+  \\begin{notation}\n\
+  \\notation{r} radial distance\n\
+  \\end{notation}\n\
+  \\end{document}\n";
+
+#[test]
+fn agujournal_acronyms_notation_and_sideways() {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+
+  let workdir = tempfile::tempdir().expect("create tempdir");
+  std::fs::write(workdir.path().join("a.tex"), TEX).expect("write a.tex");
+
+  let output = Command::new(bin)
+    .arg("a.tex")
+    .arg("--dest")
+    .arg("a.xml")
+    .arg("--nocomments")
+    .current_dir(workdir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+
+  let stderr = String::from_utf8_lossy(&output.stderr);
+  assert!(
+    output.status.success(),
+    "binary exited {:?}\nstderr:\n{stderr}",
+    output.status.code(),
+  );
+  assert!(
+    !stderr.contains("Error:") && !stderr.contains("Fatal:"),
+    "expected an error-clean conversion, stderr had errors:\n{stderr}",
+  );
+
+  let xml = std::fs::read_to_string(workdir.path().join("a.xml")).expect("read a.xml");
+  // {acronyms}/{notation} render as description lists carrying their items.
+  assert!(
+    xml.matches("<description").count() >= 2,
+    "expected 2 description lists (acronyms + notation):\n{xml}",
+  );
+  for token in [
+    "CME",
+    "Coronal Mass Ejection",
+    "radial distance",
+    "A wide table",
+  ] {
+    assert!(xml.contains(token), "missing {token:?}:\n{xml}");
+  }
+}

--- a/latexml_oxide/tests/99_scrartcl_titlehead.rs
+++ b/latexml_oxide/tests/99_scrartcl_titlehead.rs
@@ -1,0 +1,64 @@
+//! Regression test: the scrartcl (KOMA) binding captures `\titlehead` — a
+//! full-width header rendered ABOVE the title in KOMA's `\maketitle` — as
+//! frontmatter, instead of leaving it `Error:undefined` and dropping its
+//! content (ar5iv #498, arXiv:2305.01582).
+//!
+//! Neither Perl nor upstream LaTeXML binds `\titlehead` (no scrartcl.cls.ltxml),
+//! so both errored + dropped the banner; this is a surpass-Perl content
+//! recovery, a sibling of the existing `\subject`/`\publishers` frontmatter
+//! notes in `scrartcl_cls.rs`. Binary-driven because scrartcl `LoadClass!`es
+//! OmniBus (see `92_fairmeta_frontmatter` for why in-process aborts).
+
+use std::{path::Path, process::Command};
+
+const TEX: &str = "\\documentclass{scrartcl}\n\
+  \\newcommand\\giturl{github.com/example/repo}\n\
+  \\titlehead{\\begin{center}\\emph{MySoftware} \\hspace{1in} \\giturl\\end{center}}\n\
+  \\title{A KOMA Title}\n\
+  \\author{Ann Poe}\n\
+  \\begin{document}\n\
+  \\maketitle\n\
+  \\section{Body}\n\
+  Text.\n\
+  \\end{document}\n";
+
+#[test]
+fn scrartcl_titlehead_captured() {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+
+  let workdir = tempfile::tempdir().expect("create tempdir");
+  std::fs::write(workdir.path().join("s.tex"), TEX).expect("write s.tex");
+
+  let output = Command::new(bin)
+    .arg("s.tex")
+    .arg("--dest")
+    .arg("s.xml")
+    .arg("--nocomments")
+    .current_dir(workdir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+
+  let stderr = String::from_utf8_lossy(&output.stderr);
+  assert!(
+    output.status.success(),
+    "binary exited {:?}\nstderr:\n{stderr}",
+    output.status.code(),
+  );
+  assert!(
+    !stderr.contains("Error:") && !stderr.contains("Fatal:"),
+    "expected an error-clean conversion (no \\titlehead undefined), stderr:\n{stderr}",
+  );
+
+  let xml = std::fs::read_to_string(workdir.path().join("s.xml")).expect("read s.xml");
+  assert!(
+    xml.contains("role=\"titlehead\""),
+    "expected a role=titlehead frontmatter note:\n{xml}"
+  );
+  for token in ["MySoftware", "github.com/example/repo"] {
+    assert!(
+      xml.contains(token),
+      "titlehead content {token:?} missing:\n{xml}"
+    );
+  }
+}

--- a/latexml_oxide/tests/expansion/ensuremath_mode.tex
+++ b/latexml_oxide/tests/expansion/ensuremath_mode.tex
@@ -1,0 +1,12 @@
+\documentclass{article}
+\begin{document}
+% Companion to ifmmode.tex: the canonical mode-FORCING macros probed with
+% \ifmmode. \ensuremath forces math mode regardless of the surrounding mode;
+% \mbox forces text mode even inside math. M = math-branch, T = text-branch.
+
+In text, \string\ensuremath\ forces math: \ensuremath{\ifmmode M\else T\fi}.
+
+Already in math, \string\ensuremath\ is a no-op: $\ensuremath{\ifmmode M\else T\fi}$.
+
+In math, a box forces text: $\ifmmode M\else T\fi\ \mbox{\ifmmode M\else T\fi}$.
+\end{document}

--- a/latexml_oxide/tests/expansion/ensuremath_mode.xml
+++ b/latexml_oxide/tests/expansion/ensuremath_mode.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <para xml:id="p1">
+    <p>In text, “ensuremath forces math: <Math mode="inline" tex="M" text="M" xml:id="p1.m1">
+        <XMath>
+          <XMTok font="italic" role="UNKNOWN">M</XMTok>
+        </XMath>
+      </Math>.</p>
+  </para>
+  <para xml:id="p2">
+    <p>Already in math, “ensuremath is a no-op: <Math mode="inline" tex="M" text="M" xml:id="p2.m1">
+        <XMath>
+          <XMTok font="italic" role="UNKNOWN">M</XMTok>
+        </XMath>
+      </Math>.</p>
+  </para>
+  <para xml:id="p3">
+    <p>In math, a box forces text: <Math mode="inline" tex="M\ \mbox{T}" text="M * [T]" xml:id="p3.m1">
+        <XMath>
+          <XMApp>
+            <XMTok meaning="times" role="MULOP">⁢</XMTok>
+            <XMTok font="italic" role="UNKNOWN" rpadding="5.0pt">M</XMTok>
+            <XMText>T</XMText>
+          </XMApp>
+        </XMath>
+      </Math>.</p>
+  </para>
+</document>

--- a/latexml_oxide/tests/expansion/ifmmode.tex
+++ b/latexml_oxide/tests/expansion/ifmmode.tex
@@ -1,0 +1,22 @@
+\documentclass{article}
+\begin{document}
+% \ifmmode selects its true branch in math mode, its \else branch in text
+% mode. Minimal illumination of the mode-sensing conditional across the mode
+% transitions LaTeX cares about. Companion to structure/eqnums.tex (which
+% exercises \ifmmode inside \tag). Marker convention: M = math-branch taken,
+% T = text-branch taken.
+
+Plain text: \ifmmode M\else T\fi.
+
+Inline math: $\ifmmode M\else T\fi$.
+
+Display math: \[\ifmmode M\else T\fi\]
+
+A box resets to text inside math: $\mbox{\ifmmode M\else T\fi}$.
+
+Inside a robust font command: \textbf{\ifmmode M\else T\fi}.
+
+Nested in text: \ifmmode M\else\ifmmode M\else T\fi\fi.
+
+Nested in math: $\ifmmode\ifmmode A\else B\fi\else C\fi$.
+\end{document}

--- a/latexml_oxide/tests/expansion/ifmmode.xml
+++ b/latexml_oxide/tests/expansion/ifmmode.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <para xml:id="p1">
+    <p>Plain text: T.</p>
+  </para>
+  <para xml:id="p2">
+    <p>Inline math: <Math mode="inline" tex="M" text="M" xml:id="p2.m1">
+        <XMath>
+          <XMTok font="italic" role="UNKNOWN">M</XMTok>
+        </XMath>
+      </Math>.</p>
+  </para>
+  <para xml:id="p3">
+    <p>Display math:</p>
+    <equation xml:id="S0.Ex1">
+      <Math mode="display" tex="M" text="M" xml:id="S0.Ex1.m1">
+        <XMath>
+          <XMTok font="italic" role="UNKNOWN">M</XMTok>
+        </XMath>
+      </Math>
+    </equation>
+  </para>
+  <para xml:id="p4">
+    <p>A box resets to text inside math: <text class="ltx_markedasmath">T</text>.</p>
+  </para>
+  <para xml:id="p5">
+    <p>Inside a robust font command: <text font="bold">T</text>.</p>
+  </para>
+  <para xml:id="p6">
+    <p>Nested in text: T.</p>
+  </para>
+  <para xml:id="p7">
+    <p>Nested in math: <Math mode="inline" tex="A" text="A" xml:id="p7.m1">
+        <XMath>
+          <XMTok font="italic" role="UNKNOWN">A</XMTok>
+        </XMath>
+      </Math>.</p>
+  </para>
+</document>

--- a/latexml_oxide/tests/graphics/blkarray.tex
+++ b/latexml_oxide/tests/graphics/blkarray.tex
@@ -1,0 +1,21 @@
+\documentclass{article}
+\usepackage{amsmath}
+\usepackage{blkarray}
+% blkarray binding: the raw blkarray.sty builds each cell as inline math inside a
+% raw \halign, which OOMs Rust (4.5GB) and hangs Perl on a `block` with a
+% delimiter spec in display math (docs/known_crashes/blkarray_halign_math).
+% The binding routes blockarray/block through the array machinery; `block`s are
+% transparent (their sub-region delimiters cannot be rendered) so rows flow into
+% the one alignment. Regression guard for ar5iv #594 (1811.10792) / #473
+% (2310.17416). Witness: block{(cc)} paren delimiter must NOT loop/OOM.
+\begin{document}
+\[
+\begin{blockarray}{ccc}
+ & a & b \\
+\begin{block}{c(cc)}
+r & 1 & 2 \\
+s & 3 & 4 \\
+\end{block}
+\end{blockarray}
+\]
+\end{document}

--- a/latexml_oxide/tests/graphics/blkarray.xml
+++ b/latexml_oxide/tests/graphics/blkarray.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article"?>
+<?latexml package="amsmath"?>
+<?latexml package="blkarray"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <para xml:id="p1">
+    <equation xml:id="S0.Ex1">
+      <Math mode="display" tex="\begin{array}[]{ccc}&amp;a&amp;b\\&#10;r&amp;1&amp;2\\&#10;s&amp;3&amp;4\\&#10;\end{array}" text="Array[[, a, b], [r, 1, 2], [s, 3, 4]]" xml:id="S0.Ex1.m1">
+        <XMath>
+          <XMArray role="ARRAY" vattach="middle">
+            <XMRow>
+              <XMCell/>
+              <XMCell align="center">
+                <XMTok font="italic" role="UNKNOWN">a</XMTok>
+              </XMCell>
+              <XMCell align="center">
+                <XMTok font="italic" role="UNKNOWN">b</XMTok>
+              </XMCell>
+            </XMRow>
+            <XMRow>
+              <XMCell align="center">
+                <XMTok font="italic" role="UNKNOWN">r</XMTok>
+              </XMCell>
+              <XMCell align="center">
+                <XMTok meaning="1" role="NUMBER">1</XMTok>
+              </XMCell>
+              <XMCell align="center">
+                <XMTok meaning="2" role="NUMBER">2</XMTok>
+              </XMCell>
+            </XMRow>
+            <XMRow>
+              <XMCell align="center">
+                <XMTok font="italic" role="UNKNOWN">s</XMTok>
+              </XMCell>
+              <XMCell align="center">
+                <XMTok meaning="3" role="NUMBER">3</XMTok>
+              </XMCell>
+              <XMCell align="center">
+                <XMTok meaning="4" role="NUMBER">4</XMTok>
+              </XMCell>
+            </XMRow>
+          </XMArray>
+        </XMath>
+      </Math>
+    </equation>
+  </para>
+</document>

--- a/latexml_oxide/tests/graphics/sidecap_vpos.tex
+++ b/latexml_oxide/tests/graphics/sidecap_vpos.tex
@@ -1,0 +1,10 @@
+\documentclass{article}
+\usepackage{sidecap}
+% \sidecaptionvpos{<float>}{<pos>} is a layout hint (real sidecap.sty:
+% \newcommand*\sidecaptionvpos[2]). No visible effect in HTML; must not error.
+% Regression guard for ar5iv #555 (2408.08435).
+\sidecaptionvpos{figure}{t}
+\sidecaptionvpos{table}{c}
+\begin{document}
+Body text.
+\end{document}

--- a/latexml_oxide/tests/graphics/sidecap_vpos.xml
+++ b/latexml_oxide/tests/graphics/sidecap_vpos.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article"?>
+<?latexml package="sidecap"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <para xml:id="p1">
+    <p>Body text.</p>
+  </para>
+</document>

--- a/latexml_oxide/tests/graphics/xcolor_global_dvipsnames.tex
+++ b/latexml_oxide/tests/graphics/xcolor_global_dvipsnames.tex
@@ -1,0 +1,14 @@
+\documentclass[dvipsnames]{article}
+% dvipsnames passed as a GLOBAL class option, then a bare \usepackage{xcolor}.
+% Real LaTeX (pdflatex) processes the global option in xcolor's ProcessOptions
+% and loads dvipsnam.def, so the 68 dvips names (OliveGreen, RoyalBlue, …) are
+% available. Regression guard for ar5iv #503/#495/#474 (2405.04517), where the
+% dvips names were undefined (912 x "Can't find color named 'OliveGreen'").
+\usepackage{xcolor}
+\begin{document}
+\textcolor{OliveGreen}{olive} and \textcolor{RoyalBlue}{royal} and
+\textcolor{BrickRed}{brick}.
+
+\definecolor{myolive}{named}{OliveGreen}
+named: \textcolor[named]{OliveGreen}{olive2} vs \textcolor{myolive}{olive3}.
+\end{document}

--- a/latexml_oxide/tests/graphics/xcolor_global_dvipsnames.xml
+++ b/latexml_oxide/tests/graphics/xcolor_global_dvipsnames.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article" options="dvipsnames"?>
+<?latexml package="xcolor"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <para xml:id="p1">
+    <p><text color="#009900">olive</text> and <text color="#0080FF">royal</text> and
+<text color="#B80000">brick</text>.</p>
+  </para>
+  <para xml:id="p2">
+    <p>named: <text color="#009900">olive2</text> vs <text color="#009900">olive3</text>.</p>
+  </para>
+</document>

--- a/latexml_package/src/lib.rs
+++ b/latexml_package/src/lib.rs
@@ -911,6 +911,7 @@ pub const BINDINGS: &[(&str, &str, BindingLoader)] = &[
   ("afterpage", "sty", package::afterpage_sty::load_definitions),
   ("mathrsfs", "sty", package::mathrsfs_sty::load_definitions),
   ("blindtext", "sty", package::blindtext_sty::load_definitions),
+  ("blkarray", "sty", package::blkarray_sty::load_definitions),
   ("bookmark", "sty", package::bookmark_sty::load_definitions),
   ("cmap", "sty", package::cmap_sty::load_definitions),
   ("doi", "sty", package::doi_sty::load_definitions),

--- a/latexml_package/src/package.rs
+++ b/latexml_package/src/package.rs
@@ -85,6 +85,7 @@ pub mod bigintcalc_sty;
 pub mod bigstrut_sty;
 pub mod bitset_sty;
 pub mod blindtext_sty;
+pub mod blkarray_sty;
 pub mod bm_sty;
 pub mod book_cls;
 pub mod bookman_sty;

--- a/latexml_package/src/package/blkarray_sty.rs
+++ b/latexml_package/src/package/blkarray_sty.rs
@@ -1,0 +1,53 @@
+//! blkarray — block-array matrices.
+//!
+//! The raw `blkarray.sty` builds each matrix cell as inline math inside a raw
+//! `\halign`/`\ialign`, and its `block` delimiter machinery, digested inside
+//! display math, drives BOTH LaTeXML engines into the `\halign`-in-math runaway
+//! (Rust OOMs at the 4.5 GB cap in ~12 s; same-host Perl hangs ~90 s → rc=124;
+//! `pdflatex` renders fine). Full analysis + 4-line reproducer:
+//! `docs/known_crashes/blkarray_halign_math/`. This binding SHADOWS the raw
+//! `.sty` (so it is never raw-loaded, even under `--includestyles`) and routes
+//! `blockarray`/`block` through the engine's well-behaved `array` alignment
+//! machinery instead. Surpass-Perl: upstream LaTeXML has no `blkarray.sty.ltxml`.
+//! Witnesses: arXiv:1811.10792 (ar5iv #594), arXiv:2310.17416 (ar5iv #473).
+//!
+//! **Faithfulness note (documented simplification).** In `blkarray`, a `block`'s
+//! column-spec delimiters (`(`/`[` in e.g. `block{c(cccccc)}`) wrap a SUB-REGION
+//! of the shared matrix — a construct LaTeXML's `array` cannot express (its
+//! `left=`/`right=` wrap the whole matrix). We render each `block` transparently:
+//! its rows flow into the single `blockarray` alignment (correct structure +
+//! content, and the label row/column are preserved), but the block's delimiter
+//! parentheses are DROPPED. This is chosen deliberately over the raw `.sty`'s OOM
+//! — a matrix without its outer parens beats losing the whole document section.
+use crate::prelude::*;
+
+LoadDefinitions!({
+  // `\begin{blockarray}[pos]{spec}` is defined as a MAGIC control sequence
+  // (`\begin{...}` takes the defined-CS fast path in latex_constructs.rs:3064,
+  // which does NOT inject a `\begingroup`). That is essential: a transparent
+  // `block` nested inside must not open a group that crosses the alignment's
+  // `\\` row boundaries. Route to the same machinery as `\array`
+  // (latex_constructs.rs `\@array@bindings`/`\@@array`/`\lx@begin@alignment`).
+  // blkarray's own blockarray column specs are plain (`c cccccc`, `cccc`) — the
+  // delimiters live on the block specs, which we gobble — so the spec passes to
+  // the AlignmentTemplate parser unchanged.
+  DefMacro!(
+    T_CS!("\\begin{blockarray}"),
+    "[]{}",
+    "\\@array@bindings[#1]{#2}\\@@array[#1]{#2}\\lx@begin@alignment"
+  );
+  DefMacro!(
+    T_CS!("\\end{blockarray}"),
+    None,
+    "\\lx@end@alignment\\@end@array"
+  );
+
+  // `block` / `block*` are transparent: gobble the column spec (which may carry
+  // `(`, `[`, `|` delimiters we cannot render sub-region-wise) and contribute
+  // their rows directly to the enclosing blockarray alignment. Magic CSes → no
+  // `\begingroup`, so the block boundary does not disturb the alignment grouping.
+  DefMacro!(T_CS!("\\begin{block}"), "{}", "");
+  DefMacro!(T_CS!("\\end{block}"), None, "");
+  DefMacro!(T_CS!("\\begin{block*}"), "{}", "");
+  DefMacro!(T_CS!("\\end{block*}"), None, "");
+});

--- a/latexml_package/src/package/color_sty.rs
+++ b/latexml_package/src/package/color_sty.rs
@@ -226,7 +226,14 @@ LoadDefinitions!({
   // Options that want the dvipsnam definitions
   for option in &["dvips", "xdvi", "oztex", "dvipsnames"] {
     DeclareOption!(*option, {
-      InputDefinitions!("dvipsnam", extension => Some(Cow::Borrowed("def")));
+      // Defer to xcolor when it is the driving package: xcolor requires us and
+      // then loads dvipsnam.def into ITS color DB. Loading here first would win
+      // the input_definitions load-dedup and leave xcolor's DB without the dvips
+      // names (see xcolor_sty.rs `xcolor_driving`; witness 2405.04517). Stays
+      // eager for a standalone `\usepackage[dvipsnames]{color}` (flag unset).
+      if !lookup_bool("xcolor_driving") {
+        InputDefinitions!("dvipsnam", extension => Some(Cow::Borrowed("def")));
+      }
     });
   }
 

--- a/latexml_package/src/package/sidecap_sty.rs
+++ b/latexml_package/src/package/sidecap_sty.rs
@@ -15,5 +15,12 @@ LoadDefinitions!({
   DefMacro!("\\csname SCfigure*\\endcsname[][]", "\\csname figure*\\endcsname[#2]");
   DefMacro!("\\csname endSCfigure*\\endcsname", "\\csname endfigure*\\endcsname");
 
+  // \sidecaptionvpos{<float type>}{<t|c|b>} — real sidecap.sty:
+  // `\newcommand*\sidecaptionvpos[2]` — configures the vertical alignment of a
+  // side caption. Purely a layout hint with no bearing on the logical HTML
+  // output (we already ignore side-caption-ness above), so consume both args
+  // and expand to nothing. Witness 2408.08435 (ar5iv #555).
+  DefMacro!("\\sidecaptionvpos{}{}", "");
+
   DefEnvironment!("{wide}", "#body");
 });

--- a/latexml_package/src/package/tcolorbox_sty.rs
+++ b/latexml_package/src/package/tcolorbox_sty.rs
@@ -26,4 +26,20 @@ LoadDefinitions!({
   // causing spurious "tcolorbox is not installed correctly" errors.
   // Make the check a no-op — the versions are always compatible in practice.
   DefMacro!("\\tcb@check@library@version", "", locked => true);
+
+  // \newtcblisting{name}[N][default]{tcb-options} (tcolorbox `listings`/`minted`
+  // library) — a code-listing box. Its box styling is purely visual; what
+  // matters for the logical output is the code BODY, which must be captured
+  // verbatim and CLOSED at \end{name}. The raw library's body capture does not
+  // integrate with LaTeXML's verbatim reader, so the listing runs past its
+  // \end{name} and swallows following content (sections leak into
+  // <ltx:verbatim>). Delegate to listings' \lstnewenvironment (same
+  // name/[N][default] shape; the tcb options are dropped), whose verbatim reader
+  // terminates correctly. `locked` so a later raw `\tcbuselibrary{listings}`
+  // can't clobber it. Witness: 2507.00833 (ar5iv #569/#570), 2402.13846 (#504).
+  DefMacro!(
+    "\\newtcblisting{}[][]{}",
+    "\\lstnewenvironment{#1}[#2][#3]{}{}",
+    locked => true
+  );
 });

--- a/latexml_package/src/package/xcolor_sty.rs
+++ b/latexml_package/src/package/xcolor_sty.rs
@@ -555,7 +555,25 @@ LoadDefinitions!({
   DefConditional!("\\ifxglobal@");
   RawTeX!("\\globalcolorsfalse\\definecolorstrue");
 
+  // Real xcolor is a STANDALONE color package: for
+  // `\documentclass[dvipsnames]{article}` + `\usepackage{xcolor}`, pdflatex
+  // reads only `xcolor.sty` + `dvipsnam.def` (color.sty is never loaded), so
+  // xcolor's own dvipsnames handling defines the 68 dvips names in xcolor's DB.
+  // Our binding instead layers xcolor ON TOP of `color`. A GLOBAL `dvipsnames`
+  // class option is therefore seen by `color` FIRST (during the RequirePackage
+  // below): color's eager `\ds@dvipsnames` pulls `dvipsnam.def` into color's DB
+  // (usenames-inactive → plain names not exposed) and the `input_definitions`
+  // load-dedup then makes xcolor's own (authoritative) `\ds@dvipsnames` load a
+  // no-op, leaving xcolor's DB without the dvips names → `\textcolor{OliveGreen}`
+  // fails. Flag xcolor as the driver so color DEFERS its eager dvips-name load;
+  // xcolor's `\ds@dvipsnames` (declared below, run at ProcessOptions) then
+  // performs the single DB-correct load — matching pdflatex's one-load outcome.
+  // Reset immediately after so a later standalone `\usepackage[dvips]{color}`
+  // still loads. Witness: 2405.04517 (`\documentclass[dvipsnames]{article}`,
+  // 912 × `unexpected:OliveGreen` → 0; ar5iv #503/#495/#474).
+  assign_value("xcolor_driving", true, Some(Scope::Global));
   RequirePackage!("color");
+  assign_value("xcolor_driving", false, Some(Scope::Global));
 
   // xcolor.sty L1035: \def\@ifundefinedcolor#1{\@ifundefined{\@backslashchar color@#1}}
   // Used by menukeys and other downstream packages to test if a color


### PR DESCRIPTION
**Diagnostic.** Screened all 100 open [dginev/ar5iv](https://github.com/dginev/ar5iv/issues) "Improve article X" reports against the current Rust binary and same-host Perl (`docs/AR5IV_DIAGNOSTICS.md`): ~48 already convert 0-error in latexml-oxide (filed against old Perl output), the rest classified into fixable Rust-only vs shared-Perl clusters with a ranked worklist.

**Fixes.**
- xcolor honors a **global** `dvipsnames`/`svgnames`/`x11names` class option (`\documentclass[dvipsnames]{article}`+`\usepackage{xcolor}`): flag `xcolor_driving` around its `RequirePackage(color)` so `color` defers its eager `dvipsnam.def` load to xcolor's authoritative one — matching pdflatex. Fixes dginev/ar5iv#503 / #495 / #474 (2405.04517: **912 → 0** errors).
- sidecap binds `\sidecaptionvpos` as a layout no-op. Fixes dginev/ar5iv#555 (2408.08435: 1 → 0).

**Tests.** Two direct `\ifmmode` mode-sensing fixtures (`tests/expansion/ifmmode`, `ensuremath_mode`) — every branch verified against pdflatex. Also documents that 2602.15902's `\mintinline`→`\verb` `\ifmmode` breakage is shared parity, not a regression.

**Validation.** Red→green guards (`xcolor_global_dvipsnames`, `sidecap_vpos`); full suite **1598/0**; clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)