### PR TITLE
test: strict 0-error gate for hand-written conversion tests

### DIFF
--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -47,8 +47,22 @@ fn convert_clean(source: &str) {
 }
 
 /// Convert and return the serialized XML (for structural assertions that the
-/// 0-error `convert_clean` cannot express).
-fn convert_to_xml(source: &str) -> String {
+/// 0-error `convert_clean` cannot express). STRICT: like `convert_clean`, this
+/// asserts the conversion logged **zero** `Error:` markers — a structural test
+/// that silently tolerates a conversion error is exactly the false-negative the
+/// project's signal-integrity rule forbids. An input that is *supposed* to error
+/// (a malformed / EOF-truncated specimen, parity with Perl) must use
+/// `convert_expecting_errors`, which asserts the exact intended count.
+fn convert_to_xml(source: &str) -> String { convert_expecting_errors(source, 0) }
+
+/// Convert an input EXPECTED to emit exactly `n` soft `Error:` markers, returning
+/// the serialized XML. `n == 0` is the strict/clean case (`convert_to_xml`); a
+/// nonzero `n` is for an intentionally-malformed specimen whose error is the
+/// correct, Perl-parity outcome. Mirrors `util::test`'s `INTENTIONALLY_FAILING`
+/// contract: drift fails BOTH ways — *more* errors = a handling regression,
+/// *fewer* = we silently stopped detecting the bad input — and a `Fatal:`
+/// (status_code 3) is always a regression, since the point is graceful recovery.
+fn convert_expecting_errors(source: &str, n: usize) -> String {
   // Raise the RSS fuse to the harness cap (9 GB): these hand-written helpers
   // drive `Converter` directly, bypassing `latexml_test_single`, so without
   // this they run under the low production default and a full-file
@@ -63,6 +77,18 @@ fn convert_to_xml(source: &str) -> String {
   let mut c = Converter::from_config(cfg);
   c.initialize_session().expect("initialize");
   let r = c.convert(source.to_string());
+  // Shared lax `Error:<class>:` counter — see util::test::error_count.
+  let n_errors = latexml::util::test::error_count(&r.log);
+  assert_eq!(
+    n_errors, n,
+    "{source}: expected {n} error(s) but log contained {n_errors} Error:<class>: markers (status_code={})",
+    r.status_code
+  );
+  assert!(
+    r.status_code < 3,
+    "{source}: conversion hit a Fatal (status_code={}) — must degrade gracefully",
+    r.status_code
+  );
   r.result
     .unwrap_or_else(|| panic!("{source}: conversion produced no result"))
 }
@@ -193,12 +219,15 @@ fn cluster_omnibus_natbib_bbl_sideload() {
 /// \url"); now `read_token_required` emits that parity Error and the macro
 /// degrades (closes its group) instead of crashing. Guards the whole
 /// `read_token_required` family (hyperref/url.sty `\url`, `\path`, amscd `\cd@`,
-/// `\textfont`). Witnesses: 1401.5000, 1502.05051, 2204.10457. `convert_to_xml`
-/// panics if the conversion produced no result — i.e. it catches a regressed
-/// panic — while tolerating the one intentional `expected` Error.
+/// `\textfont`). Witnesses: 1401.5000, 1502.05051, 2204.10457. The specimen
+/// truncates `\url` at EOF, so the ONE intentional `expected:` Error (input
+/// ended while scanning use of `\url`) is the correct outcome — Perl emits the
+/// same. `convert_expecting_errors(…, 1)` asserts EXACTLY that error (not merely
+/// "non-empty output"): a drift to 0 means we stopped detecting the truncation,
+/// >1 or a Fatal means the graceful recovery regressed.
 #[test]
 fn cluster_url_at_eof_no_panic() {
-  let xml = convert_to_xml("tests/cluster_regressions/url_eof_no_panic.tex");
+  let xml = convert_expecting_errors("tests/cluster_regressions/url_eof_no_panic.tex", 1);
   assert!(
     !xml.is_empty(),
     "url-at-EOF conversion produced empty output"

--- a/latexml_oxide/tests/59_natbib_label_dotless_i.rs
+++ b/latexml_oxide/tests/59_natbib_label_dotless_i.rs
@@ -16,6 +16,15 @@
 //! (`\i`, `\j`, `\ss`, `\oe`, …). The `(year)` is always a literal paren in
 //! natbib/BibTeX output, so the raw label is sufficient.
 //!
+//! Fixture faithfulness: the label wraps its author in `\citenamefont`, which
+//! is supplied by the revtex4-1 `.bbl` `\providecommand` preamble
+//! (aipnum4-1.bst), NOT by natbib/revtex. The distilled reproducer originally
+//! dropped that preamble, so the conversion logged a (parity, both-engine)
+//! `undefined:\citenamefont` Error that the test silently tolerated. Restoring
+//! the preamble mirrors a real `.bbl`, drops the run to 0 errors, AND
+//! strengthens the guard test — `\citenamefont{…}` now expands to the dotless
+//! `\i` inside `\lx@NAT@parselabel`, the exact path that must not loop.
+//!
 //! Conditional: needs the kernel dump (so expl3/pgf load cleanly) AND
 //! revtex4-1 + mathptmx + pgfplots installed (the exact package set drives
 //! the encoding state into the looping `\T1-cmd` form).
@@ -54,6 +63,19 @@ fn natbib_dotless_i_label_does_not_loop() {
   assert!(
     r.status_code < 3,
     "conversion hit a fatal (status_code={}) — expected a clean run",
+    r.status_code
+  );
+  // Strict: the faithful `.bbl` `\providecommand` preamble (aipnum4-1.bst)
+  // supplies `\citenamefont` et al., so the conversion is now fully clean.
+  // Previously the distilled fixture dropped that preamble and silently
+  // tolerated an `undefined:\citenamefont` Error — a passing test that emitted
+  // an error. Assert 0 so any future regression (a re-emerging loop-recovery
+  // error, or a real binding gap) fails here rather than hiding in the log.
+  let n_errors = latexml::util::test::error_count(&r.log);
+  assert_eq!(
+    n_errors, 0,
+    "expected 0 errors but the conversion log carried {n_errors} Error:<class>: \
+     markers (status_code={})",
     r.status_code
   );
 }

--- a/latexml_oxide/tests/cluster_regressions/natbib_label_dotless_i.tex
+++ b/latexml_oxide/tests/cluster_regressions/natbib_label_dotless_i.tex
@@ -14,6 +14,17 @@
 \usepackage{siunitx}\usepackage[caption=false]{subfig}\usepackage[hidelinks, colorlinks]{hyperref}
 \begin{document}
 Body text.
+% The `\providecommand` preamble every revtex4-1 `.bbl` (aipnum4-1.bst) emits
+% ahead of \begin{thebibliography}. \citenamefont et al. are supplied by the
+% .bbl itself -- NOT by natbib/revtex -- so a faithful reproducer must define
+% them here; without them both Perl and Rust (correctly) log
+% `undefined:\citenamefont`. Keeping them makes the loop-guard stronger too:
+% \citenamefont{...} now actually expands to the dotless \i during
+% \lx@NAT@parselabel, exercising the exact path the guard protects.
+\providecommand \bibnamefont  [1]{#1}%
+\providecommand \bibfnamefont [1]{#1}%
+\providecommand \citenamefont [1]{#1}%
+\providecommand \natexlab     [1]{#1}%
 \begin{thebibliography}{9}
 \bibitem [{\citenamefont {M{\'\i}guez}(2009)}]{miguez2009}%
 A reference with a dotless-i author name.


### PR DESCRIPTION
## Problem

Two hand-written integration tests reached the engine via *lenient* helpers (`convert_to_xml` / `convert_fixture`) that only checked "produced output" or "not fatal", so they **passed while emitting an `Error:` during conversion** — exactly the false negative the project's signal-integrity rule forbids.

The compile-time golden-pair harness (`latexml_test_single`) already gates every normal `.tex`/`.xml` test on `Error + Fatal == 0`, with explicit `INTENTIONALLY_FAILING` / `ERROR_DEBT` exemption tables. This PR brings the hand-written path under the **same** discipline rather than adding a new global switch.

## The two tests

**`natbib_dotless_i_label_does_not_loop` — `Error:undefined:\citenamefont`** (a real leak, now fixed)

`\citenamefont` (and `\bibnamefont` / `\bibfnamefont` / `\natexlab`) is supplied by the `\providecommand` preamble every revtex4-1 `.bbl` (`aipnum4-1.bst`) emits — **not** by natbib or revtex. The distilled reproducer dropped that preamble, so both engines (parity) logged an `undefined:\citenamefont` that the test silently tolerated.

Fix: restore the faithful `.bbl` preamble. The run is now **0-error** *and* the guard is stronger — `\citenamefont{…}` now actually expands to the dotless `\i` inside `\lx@NAT@parselabel`, the exact loop-path it protects (verified: no `PushbackLimit`, `Míguez` renders). Test asserts `error_count == 0`.

**`cluster_url_at_eof_no_panic` — `Error:expected:\url`** (legitimately intentional, now asserted)

The specimen truncates `\url` at EOF, so the one `expected:` error is the correct, Perl-parity outcome. It now asserts **exactly 1** error (via the new `convert_expecting_errors`) instead of merely "non-empty output": drift to 0 = we stopped detecting the truncation; >1 or Fatal = graceful recovery regressed.

## Mechanism

- `convert_to_xml` is now **strict** (asserts 0 errors, like `convert_clean`), so its ~24 structural-test callers all become error-regression sentinels.
- Intentional-error inputs opt into `convert_expecting_errors(source, n)` — an exact-count contract mirroring `util::test`'s `INTENTIONALLY_FAILING` (drift fails both ways; a Fatal is always a regression).

## Verification

- Full suite: **1614 passed / 0 failed**
- `cargo clippy -D warnings` clean on both changed targets
- Only remaining `Error:` on a green run is `worker_diagnostics_fold_into_main_thread_on_join`'s synthetic `w0/w1` — a unit test whose *subject* is the error-folding plumbing (asserted), not a conversion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)