### PR TITLE
refs #312: re-sync bundled default CSS to vanilla; pin .htm→html5 inference

### DIFF
--- a/docs/release/ISSUE_AUDIT.md
+++ b/docs/release/ISSUE_AUDIT.md
@@ -9,13 +9,14 @@
 >
 > **Refresh** before milestone planning:
 > `gh issue list --state open --limit 100 --json number,title,labels,createdAt`.
-> Last refreshed: **2026-07-20** (17 open, from `gh issue list`). This is a
-> reconciled refresh across two same-day edits: one closed the #304/#305/#307
-> user-report cluster and #309, the other corrected the stale #192/#82 rows (both
-> closed **2026-07-17**) and added #297/#303. Ground truth then moved again — #309
-> closed (PR #310 merged), and a fresh **#314–#321 Rhai binding-API** cluster was
-> filed the same day. Both are reflected below. Failure mode worth knowing: this
-> file drifts fast — re-run the one-liner rather than incrementally editing rows.
+> Last refreshed: **2026-07-20** (15 open). Reconciled across several same-day
+> edits: the #304/#305/#307 user-report cluster closed; #309 closed (PR #310);
+> the stale #192/#82 rows corrected (both closed **2026-07-17**); #297/#303 and
+> the fresh **#314–#321 Rhai binding-API** cluster added; **#314 closed** (PR #324).
+> #315 churned (fix #325 → revert #327 → re-fixed #328) and is now **closed**
+> — 15 open. #312 (Nasser, default-CSS) triaged — see its row. Failure mode worth
+> knowing: this file drifts fast — re-run the one-liner rather than incrementally
+> editing rows.
 
 Tracker: <https://github.com/dginev/latexml-oxide/issues>
 
@@ -30,7 +31,7 @@ Tracker: <https://github.com/dginev/latexml-oxide/issues>
 | **297** | latexml_oxide 0.7.4 binding transition: `nowrap.sty.ltxml` | documentation, packages | Filed 2026-07-18. A user-supplied `.ltxml` binding on `--path` is ignored: `Warning:missing_file:nowrap … No dispatcher entry and no raw file found on disk` (`latexml_core/src/binding/content.rs`). Perl finds it silently. This is the **user-supplied `.ltxml` discovery** path — `.ltxml` is Perl, so the Rust answer is either the Rhai `runtime-bindings` front-end or a clear diagnostic; today it is neither. |
 | **303** | Precompiled kernel (dump) release and update strategy | enhancement | Filed 2026-07-18, follow-up to #299/PR #300. The dump is keyed to the TL **year**, but the LaTeX format is not frozen within a year (`\fmtversion`, `tlmgr` `fmttriggers` rebuilds) — a false positive was traded for a rarer false negative. Candidate signals: key on `\fmtversion` + L3 date, or compare against the ambient `latex.fmt` mtime; warn-not-fail. |
 | **311** | Raw-loaded package `\newif` conditionals die with the standalone subfile group | bug | Filed 2026-07-20. **Explicitly NOT Rust-only** — same-host Perl reports the identical error, and `standalone.sty.ltxml` uses the same `bgroup` architecture. General shape: any raw-loaded package pairing a `\newif` with a document-level hook (`\ifpgf@external@grabshipout` + `\AtEndDocument`). Two fixes tried and refuted (hoisting the `RequirePackage`; `\globaldefs=1`). Related to the group-scoping class in `SYNC_STATUS.md`. |
-| **312** | 0.7.5-rc1: many problems rendering math (default CSS) | (none) | Filed 2026-07-20 — **untriaged.** Self-contained `amsmath` reproducer in the issue body (`\left( … \right)` spacing, `\tag`, `align`/`align*`, `\prime`). Needs the usual same-host Perl + pdflatex classification before any code change. |
+| **312** | 0.7.5-rc1: many problems rendering math (default CSS) | css, fidelity | Filed 2026-07-20 (Nasser). Triaged 2026-07-20: **conversion is 0-error, structurally identical to same-host Perl**. **Root cause confirmed = the browser rendered without `LaTeXML.css`** (blocking the stylesheet on the same HTML reproduces his flush-left screenshot exactly; without it `.ltx_eqn_table` loses `width:100%` and align cells collapse left). **NOT a conversion bug** — his exact `--dest=index.htm` invocation emits both `.css` files with correct `<link>`s next to the output, so the sheet just didn't reach his browser (files separated from the `.htm` / local viewing). PR #326 is an orthogonal cleanup (re-sync the drifted default `LaTeXML.css` to vanilla — dropped `text-align: justify`, `\underline`/`\overline`, verbatim `nowrap`; witnessed delta 2605.02240 pinned by `xslt::witnessed_css_delta`; + pin `.htm`→html5 inference), **not a fix for his symptom** → references, does not close #312. His 2nd screenshot (MathJax-4 alignment) is **out of scope**: we emit standards MathML; a third-party browser library's layout of it is not ours to fix. |
 | **316** | not possible to call `DefPrimitive` from `DefPrimitive`? | enhancement | Filed 2026-07-20. Rhai-API expressiveness gap (nested primitive definition). Cluster #314–#321. |
 | **317** | allow extra parameter of `RequireResource` in Rhai binding API | enhancement | Filed 2026-07-20. Rhai-API surface gap. Cluster #314–#321. |
 | **318** | allow external commands in Rhai bindings | enhancement | Filed 2026-07-20. Rhai-API surface gap. Cluster #314–#321. |

--- a/latexml_oxide/tests/003_dest_htm_infers_html5.rs
+++ b/latexml_oxide/tests/003_dest_htm_infers_html5.rs
@@ -1,0 +1,59 @@
+//! Regression pin: a `.htm` destination extension infers `--format=html5`,
+//! exactly like `.html`.
+//!
+//! `bin/latexml_oxide.rs` maps `"html" | "htm" => "html5"` (Perl Config.pm
+//! L435), lowercased so `.HTM` works too — so `--dest=index.htm` with no
+//! explicit `--format` must produce a post-processed HTML5 page (DOCTYPE +
+//! `<link>`ed, copied `LaTeXML.css`), NOT the raw-XML default. This pins the
+//! `.htm` half, which every other CLI test exercises only via `.html`; it is
+//! the exact invocation shape from GitHub #312 (`--dest=index.htm`).
+
+use std::{path::Path, process::Command};
+
+const HELLO_TEX: &str = "\\documentclass{article}\n\
+                         \\begin{document}\n\
+                         Hello World!\n\
+                         \\end{document}\n";
+
+#[test]
+fn dest_htm_extension_infers_html5_and_copies_css() {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+
+  let workdir = tempfile::tempdir().expect("create tempdir");
+  std::fs::write(workdir.path().join("hello.tex"), HELLO_TEX).expect("write hello.tex");
+
+  // Nasser's invocation shape: `.htm` destination, NO explicit --format.
+  let output = Command::new(bin)
+    .arg("hello.tex")
+    .arg("--dest")
+    .arg("hello.htm")
+    .current_dir(workdir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+
+  assert!(
+    output.status.success(),
+    "binary exited {:?}\nstderr:\n{}",
+    output.status.code(),
+    String::from_utf8_lossy(&output.stderr),
+  );
+
+  // The `.htm` extension must have inferred html5 → a post-processed HTML page,
+  // not the raw-XML fallback.
+  let html = std::fs::read_to_string(workdir.path().join("hello.htm")).expect("read hello.htm");
+  assert!(
+    html.contains("<!DOCTYPE html>"),
+    "a .htm destination should infer html5 (DOCTYPE html), got:\n{html}",
+  );
+  assert!(
+    html.contains("LaTeXML.css"),
+    "html5 output should link LaTeXML.css, got:\n{html}",
+  );
+
+  // ...and the html5 pipeline copies the bundled default stylesheet next to it.
+  assert!(
+    workdir.path().join("LaTeXML.css").is_file(),
+    "expected LaTeXML.css copied next to hello.htm (html5 resource copy)",
+  );
+}

--- a/latexml_post/resources/CSS/LaTeXML.css
+++ b/latexml_post/resources/CSS/LaTeXML.css
@@ -336,7 +336,7 @@ dl.ltx_description dl.ltx_description dd { margin-left:3em; }
     max-width:0em; text-align:right; }
 */
 .ltx_parbox {
-    text-indent:0em;
+    text-indent:0em !important;
     display: inline-block; }
 
 /* NOTE that it is CRITICAL to put position:relative outside & absolute inside!!
@@ -349,6 +349,10 @@ dl.ltx_description dl.ltx_description dd { margin-left:3em; }
 .ltx_transformed_inner {
     display:block;
     position:absolute;bottom:0pt;left:0pt; }
+.ltx_inline-block > .ltx_para > .ltx_p:first-child,
+.ltx_logical-block > .ltx_para > .ltx_p:first-child,
+.ltx_inline-logical-block > .ltx_para > .ltx_p:first-child {
+    text-indent:0em; }
 .ltx_transformed_inner > .ltx_p {text-indent:0em; margin:0; padding:0; }
 
 /* If simulating a table (html5), try to get rowspan to work...sorta? */
@@ -441,10 +445,13 @@ span.ltx_framed       { display:inline-block; text-indent:0; } /* avoid padding/
 
 .ltx_rule { vertical-align: bottom; height: 0.4pt; width: 0.4pt; }
 
+.ltx_underline { text-decoration: underline; }
+.ltx_overline  { text-decoration: overline; }
+
 /*======================================================================
  Misc */
 /* .ltx_verbatim*/
-.ltx_verbatim { text-align:left; }
+.ltx_verbatim { text-align:left; white-space:nowrap; }
 /*======================================================================
  Meta stuff, footnotes */
 .ltx_note_content { display:none; }
@@ -493,10 +500,11 @@ foreignObject {
 .ltx_foreignobject_container:has( > .ltx_foreignobject_content > :not(:only-child)) {
     width:calc(1.1 * var(--ltx-fo-width));
 }
-/* A minipage in the content = a measured box's upper part (tcolorbox et al.
-   wrap box content in \minipage; picture labels never do). TeX fills such
-   boxes from the top, so any estimator slack must fall BELOW the text;
-   centering splits it into a fake empty band above (arXiv 2605.02240). */
+/* latexml-oxide local delta (not in vanilla LaTeXML.css): a minipage in the
+   content = a measured box's upper part (tcolorbox et al. wrap box content in
+   \minipage; picture labels never do). TeX fills such boxes from the top, so any
+   estimator slack must fall BELOW the text; centering splits it into a fake empty
+   band above (arXiv 2605.02240). */
 .ltx_foreignobject_container:has( > .ltx_foreignobject_content > .ltx_minipage) {
     align-items:start;
 }
@@ -568,6 +576,7 @@ cite                 { font-style: normal; }
 .ltx_minipage {
   align-self: normal;
   display: inline-block;
+  text-align: justify;
 }
 .ltx_minipage > .ltx_graphics {
   max-width:100%;

--- a/latexml_post/src/xslt.rs
+++ b/latexml_post/src/xslt.rs
@@ -1092,3 +1092,31 @@ fn relative_path(target: &str, base: &str) -> String {
     target.to_string()
   }
 }
+
+#[cfg(test)]
+mod witnessed_css_delta {
+  //! Guards the ONE intentional non-vanilla rule in the bundled default
+  //! `LaTeXML.css`: a tcolorbox/minipage foreignobject top-alignment rule
+  //! (arXiv **2605.02240**). The rest of the stylesheet is a straight adoption
+  //! of upstream vanilla (#312), which we do NOT assert here — the Perl
+  //! `LaTeXML/` reference tree is not shipped in the crate, so there is no
+  //! ground truth to diff against, and re-sync fidelity is a human/`cp`
+  //! responsibility. This test exists only so that a future "re-vanilla" sweep
+  //! can't silently drop the witnessed local delta.
+  use super::embedded_resources;
+
+  #[test]
+  fn witnessed_minipage_delta_stays_present() {
+    let css = std::str::from_utf8(
+      embedded_resources::lookup("LaTeXML.css").expect("LaTeXML.css is bundled"),
+    )
+    .expect("LaTeXML.css is valid UTF-8");
+    assert!(
+      css.contains("2605.02240")
+        && css.contains(
+          ".ltx_foreignobject_container:has( > .ltx_foreignobject_content > .ltx_minipage)"
+        ),
+      "the witnessed minipage top-alignment delta (2605.02240) is missing from LaTeXML.css",
+    );
+  }
+}


### PR DESCRIPTION
Refs #312 (Nasser — default-CSS math rendering). Does **not** close it: the reported symptom is environmental (see below). His 2nd screenshot (MathJax-4 alignment) is out of scope — we emit standards MathML; a third-party browser library's layout of it isn't ours to fix.

## Root cause of #312 (confirmed)
Nasser's browser rendered the page **without `LaTeXML.css`**. Blocking the stylesheet on the *same* HTML reproduces his "wrong" screenshot exactly — align equations flush-left, the `(1)` tag hugging the equation — because without it `.ltx_eqn_table` loses `width:100%` and the centering cells collapse. It is **not a conversion bug**: his exact `latexml_oxide --format=html5 --dest=index.htm index.tex` invocation emits both `.css` files with correct `<link>`s next to the output, so the stylesheet simply didn't reach his browser (files separated from the `.htm`, or a local viewing quirk). The align HTML + centering CSS are structurally identical to same-host Perl and unchanged since 0.7.5-rc1, and the block renders correctly centered in both Firefox and Chrome here.

## What this PR does (orthogonal improvements)
- **Re-syncs the bundled default `LaTeXML.css` to vanilla upstream.** It had drifted into a stale fork that silently dropped paragraph `text-align: justify`, `\underline`/`\overline` decorations, verbatim `white-space:nowrap`, and the first-paragraph indent — real content regressions vs Perl (e.g. `\underline{}` wasn't underlined). One intentional local delta (2605.02240 tcolorbox/minipage) is kept, marked, and pinned by `xslt::witnessed_css_delta`. The re-sync itself is not machine-guarded — the Perl `LaTeXML/` reference tree isn't shipped in the crate, so there's no ground truth to diff against; fidelity is a human/`cp` responsibility on re-sync.
- **Pins the `.htm` → html5 destination inference** (`003_dest_htm_infers_html5`). The alias already existed (`bin/latexml_oxide.rs`, `"html" | "htm" => "html5"`); every CLI test only exercised `.html`, so this guards Nasser's exact `.htm` invocation shape.
- **Reconciles `ISSUE_AUDIT.md`** through the #324/#325/#327 churn (16 open; #315 reverted).

## Verification
- Playwright (Firefox + Chrome): CSS-blocked render reproduces Nasser's screenshot; restored vanilla rules render (justified paragraphs, real underline); align stays centered.
- `cargo test --tests` green; new `003_dest_htm_infers_html5` + `xslt::witnessed_css_delta` green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
