### PR TITLE
harden: cortex_worker builds drop runtime-bindings (rhai-free untrusted worker)

### DIFF
--- a/docs/performance/PERFORMANCE.md
+++ b/docs/performance/PERFORMANCE.md
@@ -521,7 +521,9 @@ band vanish. `1005.1610` (2.83 s, 3.9 CPUs) is parallel external-graphics-bound
 ### Math-bound corpus measurement (HYBRID regression watch)
 
 ```bash
-cargo build --release --bin cortex_worker --features cortex
+# --no-default-features drops runtime-bindings (a default) so the untrusted-input
+# worker has no Rhai/command-exec surface (SAFETY.md); also drops test-utils.
+cargo build --release --bin cortex_worker --no-default-features --features cortex
 tools/benchmark_canvas.sh --input-dir <math-bound-100-zips>/in \
   --output-dir /tmp/out_hybrid --workers 8 --timeout 180
 # LEGACY control: prefix with `env LATEXML_MARPA_LEGACY=1`

--- a/tools/benchmark_canvas.sh
+++ b/tools/benchmark_canvas.sh
@@ -189,7 +189,10 @@ done
 echo "Building fresh release cortex_worker with ${BUILD_JOBS} cargo jobs ..."
 (
   cd "$REPO_ROOT"
-  RUSTFLAGS="$BUILD_RUSTFLAGS" cargo build --release --bin cortex_worker --features cortex --jobs "$BUILD_JOBS"
+  # --no-default-features drops runtime-bindings (a DEFAULT feature) so the
+  # untrusted-input arXiv worker has no Rhai/command-exec surface (auto-loaded
+  # `.rhai`; see docs/release/SAFETY.md). Also drops test-utils.
+  RUSTFLAGS="$BUILD_RUSTFLAGS" cargo build --release --bin cortex_worker --no-default-features --features cortex --jobs "$BUILD_JOBS"
 )
 
 if [[ "$CUSTOM_WORKER_BIN" == true ]]; then
@@ -198,7 +201,7 @@ fi
 
 if [[ ! -x "$WORKER_BIN" ]]; then
   echo "ERROR: cortex_worker binary not found after release build: $WORKER_BIN"
-  echo "  Expected build command: cargo build --release --bin cortex_worker --features cortex"
+  echo "  Expected build command: cargo build --release --bin cortex_worker --no-default-features --features cortex"
   exit 1
 fi
 

--- a/tools/triage_failure.sh
+++ b/tools/triage_failure.sh
@@ -98,8 +98,12 @@ cd "$(dirname "$0")/.."
 # release build; fall back to a fresh build if missing or stale.
 WORKER_BIN="${WORKER_BIN:-./target/release/cortex_worker}"
 if [[ ! -x "$WORKER_BIN" ]]; then
-  echo "[triage] building cortex_worker (release, --features cortex) ..."
-  cargo build --release --bin cortex_worker --features cortex
+  # --no-default-features drops runtime-bindings (a DEFAULT feature): the arXiv
+  # worker converts untrusted input, so it must NOT ship the Rhai binding
+  # surface — a `.rhai` beside a source auto-loads and (with #318) could run
+  # external commands. See docs/release/SAFETY.md. Also drops test-utils.
+  echo "[triage] building cortex_worker (release, --no-default-features --features cortex) ..."
+  cargo build --release --bin cortex_worker --no-default-features --features cortex
 fi
 
 # cortex_worker --standalone takes the .zip as input, not the .tex; emits


### PR DESCRIPTION
**Diagnostic.** The arXiv `cortex_worker` converts untrusted input, but every build recipe (`tools/triage_failure.sh`, `tools/benchmark_canvas.sh`, `docs/performance/PERFORMANCE.md`) used `cargo build --release --bin cortex_worker --features cortex` — which keeps the DEFAULT features (`test-utils`, **`runtime-bindings`**). So the worker shipped the Rhai surface: a `.rhai` beside a source auto-loads (`converter.rs::rhai_dispatch`), and with #318's `Command` could run external commands.

**Approach.** Switch the worker recipes to `--no-default-features --features cortex` (the build the Cargo `test-utils` comment already recommends), dropping `runtime-bindings` (and `test-utils`). Verified `cargo check --no-default-features --features cortex --bin cortex_worker` compiles clean. The release binary is unaffected — `tools/make_release.sh` explicitly keeps `runtime-bindings`.

**Validation.** `cargo check --no-default-features --features cortex --bin cortex_worker` → clean. Docs/scripts-only change.

Refs #318