### PR TITLE
Rhai Def* option-bag parity: digest hooks + afterDigestBody

### DIFF
--- a/docs/parity/script_bindings_plan.md
+++ b/docs/parity/script_bindings_plan.md
@@ -414,11 +414,21 @@ registration lowers to the same native function its macro does):
   `DeclareOption`, `ProcessOptions([inorder])`, `ExecuteOptions`,
   `PassOptions`, `RequireResource`, `Tag(name, #{autoOpen, autoClose})`,
   `MergeFont(#{family,…})`, `Warn`/`Error` (with MAX_ERRORS escalation).
-- **Option bags everywhere**: `DefMacro`/`DefPrimitive` now also take a
+- **Option bags everywhere**: `DefMacro`/`DefPrimitive`/`DefMath` take a
   trailing `#{…}` (scope/locked/protected/robust/… via per-struct mappers);
   constructors/environments add `afterDigestBegin`, `beforeDigestEnd`,
-  `before/afterConstruct` (document context published; whatsit TBD),
-  string-form `reversion`, and `font: #{family: …}` directives.
+  `afterDigestBody`, `before/afterConstruct` (document context published; whatsit
+  TBD), string-form `reversion`, and `font: #{family: …}` directives.
+- **Digest-hook option parity (2026-07-21):** the `beforeDigest`/`afterDigest`
+  **closures** now work in the `DefPrimitive`/`DefMath` option bag (they were
+  scalar-only, silently dropping the keys), and `afterDigestBody` was added to the
+  constructor/environment bag — closing the gaps against the compile-time
+  `Def*!` macros. These are structural, not just tested: the primitive/math
+  mappers populate the SAME `PrimitiveOptions`/`MathPrimitiveOptions`
+  `before_digest`/`after_digest` fields the macro's `defi_opts!` sets, and
+  `afterDigestBody` routes through a new shared `ConstructorBuilder` setter — so
+  the two front-ends cannot drift. Guards: `primitive_option_bag_runs_before_and_after_digest`,
+  `math_option_bag_runs_digest_hooks`, `30_script_bindings::option_bag_digest_hooks_end_to_end`.
 
 **Load semantics fixed (load-bearing):** `load_script` now caches only the
 COMPILATION; the script RUNS on every load and each `Def…`/side-effect call

--- a/latexml_contrib/src/script_bindings/engine.rs
+++ b/latexml_contrib/src/script_bindings/engine.rs
@@ -73,7 +73,7 @@ pub(super) fn make_engine() -> Engine {
   engine.register_fn(
     "DefPrimitive",
     |proto: &str, body: FnPtr, opts: Map| -> std::result::Result<(), Box<EvalAltResult>> {
-      wire_now(|e, a| wire_primitive(e, a, proto, body, primitive_options_from_map(opts)))
+      wire_now(|e, a| wire_primitive(e, a, proto, body, primitive_options_from_map(opts, e, a)))
     },
   );
   // Class/package option. Mirrors the `DeclareOption!` macro's lowering
@@ -650,7 +650,10 @@ pub(super) fn make_engine() -> Engine {
     "DefMath",
     |proto: &str, presentation: &str, opts: Map| -> std::result::Result<(), Box<EvalAltResult>> {
       let (cs, params) = parse_prototype(proto, true).map_err(rhai_err)?;
-      let options = math_options_from_map(opts).map_err(rhai_err)?;
+      // Loading-script handles for the digest-hook trampolines (DefMath doesn't
+      // route through `wire_now`, so fetch them directly like `wire_now` does).
+      let (engine, ast) = current_script()?;
+      let options = math_options_from_map(opts, &engine, &ast).map_err(rhai_err)?;
       latexml_core::binding::def::dialect::def_math(cs, params, presentation.to_string(), options)
         .map_err(rhai_err)
     },

--- a/latexml_contrib/src/script_bindings/tests.rs
+++ b/latexml_contrib/src/script_bindings/tests.rs
@@ -299,6 +299,59 @@ fn constructor_options_map_runs_afterdigest() {
   latexml_core::reset_thread_engine();
 }
 
+/// Option-bag parity: `DefPrimitive(proto, body, #{ beforeDigest, afterDigest })`
+/// must accept the digest-hook CLOSURES, exactly as the compile-time
+/// `DefPrimitive!` macro does (`defi_opts!`'s generic `before_digest`/`after_digest`
+/// arms). Previously the Rhai primitive option map was scalar-only, silently
+/// dropping the hook keys. Order: beforeDigest → body → afterDigest.
+#[test]
+fn primitive_option_bag_runs_before_and_after_digest() {
+  fresh_state();
+  load_script(
+    r#"
+      DefPrimitive("\\optbagprim", || { assign_global("optbag:primlog", LookupString("optbag:primlog") + "X"); }, #{
+        beforeDigest: || { assign_global("optbag:primlog", LookupString("optbag:primlog") + "B"); },
+        afterDigest:  || { assign_global("optbag:primlog", LookupString("optbag:primlog") + "A"); }
+      });
+    "#,
+  )
+  .expect("DefPrimitive with a beforeDigest/afterDigest option bag must load");
+  latexml_core::stomach::digest(mouth::tokenize_internal(r"\optbagprim"))
+    .expect("digest \\optbagprim");
+  assert_eq!(
+    lookup_str("optbag:primlog"),
+    "BXA",
+    "beforeDigest, primitive body, afterDigest must run in order"
+  );
+  latexml_core::reset_thread_engine();
+}
+
+/// Option-bag parity: `DefMath(proto, pres, #{ beforeDigest, afterDigest })` — a
+/// `MathPrimitive` runs only the digest pair, and both must fire from the option
+/// bag (previously scalar-only). Driven in math mode via `$\optbagmath$`.
+#[test]
+fn math_option_bag_runs_digest_hooks() {
+  fresh_state();
+  load_script(
+    r#"
+      DefMath("\\optbagmath", "∑", #{
+        role: "SUMOP",
+        beforeDigest: || { assign_global("optbag:mathlog", LookupString("optbag:mathlog") + "B"); },
+        afterDigest:  || { assign_global("optbag:mathlog", LookupString("optbag:mathlog") + "A"); }
+      });
+    "#,
+  )
+  .expect("DefMath with a beforeDigest/afterDigest option bag must load");
+  latexml_core::stomach::digest(mouth::tokenize_internal(r"$\optbagmath$"))
+    .expect("digest $\\optbagmath$");
+  assert_eq!(
+    lookup_str("optbag:mathlog"),
+    "BA",
+    "DefMath beforeDigest then afterDigest must both run"
+  );
+  latexml_core::reset_thread_engine();
+}
+
 /// Regression for #314: `LookupTokens("class_options")` panicked with
 /// "RefCell already borrowed". `class_options` is a `Stored::VecDequeStored`,
 /// whose branch in `state::lookup_tokens` reverts each item to Tokens via

--- a/latexml_contrib/src/script_bindings/wire.rs
+++ b/latexml_contrib/src/script_bindings/wire.rs
@@ -166,6 +166,7 @@ pub(super) trait BindingBuilder: Sized {
   fn set_option(self, key: &str, value: OptionValue) -> Result<Self>;
   fn after_digest(self, hook: DigestionClosure) -> Self;
   fn after_digest_begin(self, hook: DigestionClosure) -> Self;
+  fn after_digest_body(self, hook: DigestionClosure) -> Self;
   fn before_digest(self, hook: BeforeDigestClosure) -> Self;
   fn before_digest_end(self, hook: BeforeDigestClosure) -> Self;
   fn before_construct(self, hook: ConstructionClosure) -> Self;
@@ -187,6 +188,9 @@ macro_rules! impl_binding_builder {
       fn after_digest(self, hook: DigestionClosure) -> Self { <$t>::after_digest(self, hook) }
       fn after_digest_begin(self, hook: DigestionClosure) -> Self {
         <$t>::after_digest_begin(self, hook)
+      }
+      fn after_digest_body(self, hook: DigestionClosure) -> Self {
+        <$t>::after_digest_body(self, hook)
       }
       fn before_digest(self, hook: BeforeDigestClosure) -> Self { <$t>::before_digest(self, hook) }
       fn before_digest_end(self, hook: BeforeDigestClosure) -> Self {
@@ -232,6 +236,10 @@ pub(super) fn apply_opts<B: BindingBuilder>(
           "afterDigestBegin" => {
             builder =
               builder.after_digest_begin(after_digest_trampoline(fp, engine.clone(), ast.clone()));
+          },
+          "afterDigestBody" => {
+            builder =
+              builder.after_digest_body(after_digest_trampoline(fp, engine.clone(), ast.clone()));
           },
           "properties" => {
             builder = builder.properties(properties_trampoline(fp, engine.clone(), ast.clone()));
@@ -648,8 +656,17 @@ pub(super) fn expandable_options_from_map(opts: Map) -> ExpandableOptions {
   o
 }
 
-/// Map a Rhai option bag onto `PrimitiveOptions` (the `DefPrimitive!` scalar set).
-pub(super) fn primitive_options_from_map(opts: Map) -> PrimitiveOptions {
+/// Map a Rhai option bag onto `PrimitiveOptions` — the full `DefPrimitive!` set:
+/// scalars PLUS the `beforeDigest`/`afterDigest` closures, wired through the same
+/// trampolines the constructor option-bag uses (the compile-time `DefPrimitive!`
+/// macro accepts these via `defi_opts!`'s generic digest-hook arms, so the two
+/// front-ends match). `engine`/`ast` are the loading script's handles, captured by
+/// the hook trampolines. Unknown keys are ignored (Perl `%options` forgiveness).
+pub(super) fn primitive_options_from_map(
+  opts: Map,
+  engine: &Rc<Engine>,
+  ast: &Rc<AST>,
+) -> PrimitiveOptions {
   let mut o = PrimitiveOptions::default();
   for (key, val) in opts {
     let b = dynamic_to_bool(&val);
@@ -665,6 +682,18 @@ pub(super) fn primitive_options_from_map(opts: Map) -> PrimitiveOptions {
       "scope" => o.scope = scope_of(&dynamic_to_string(val.clone())),
       "mode" => o.mode = Some(dynamic_to_string(val.clone())),
       "nargs" => o.nargs = val.as_int().ok().map(|i| i as usize),
+      "beforeDigest" => {
+        if let Some(fp) = val.clone().try_cast::<FnPtr>() {
+          o.before_digest
+            .push(before_digest_trampoline(fp, engine.clone(), ast.clone()));
+        }
+      },
+      "afterDigest" => {
+        if let Some(fp) = val.clone().try_cast::<FnPtr>() {
+          o.after_digest
+            .push(after_digest_trampoline(fp, engine.clone(), ast.clone()));
+        }
+      },
       _ => {},
     }
   }
@@ -728,9 +757,16 @@ pub(super) fn wire_columntype(
   Ok(())
 }
 
-/// Map a Rhai option bag onto `MathPrimitiveOptions` (the `DefMath!` scalar
-/// option set; unknown keys are ignored, matching Perl %options forgiveness).
-pub(super) fn math_options_from_map(opts: Map) -> Result<MathPrimitiveOptions> {
+/// Map a Rhai option bag onto `MathPrimitiveOptions` — the full `DefMath!` set:
+/// scalars PLUS the `beforeDigest`/`afterDigest` closures (a `MathPrimitive` runs
+/// only the digest pair; its construct fields are never executed). Wired through
+/// the same trampolines as the other front-ends, so the Rhai and compile-time
+/// surfaces match. Unknown keys are ignored (Perl %options forgiveness).
+pub(super) fn math_options_from_map(
+  opts: Map,
+  engine: &Rc<Engine>,
+  ast: &Rc<AST>,
+) -> Result<MathPrimitiveOptions> {
   let mut o = MathPrimitiveOptions::default();
   for (key, val) in opts {
     let s = || dynamic_to_string(val.clone());
@@ -761,6 +797,18 @@ pub(super) fn math_options_from_map(opts: Map) -> Result<MathPrimitiveOptions> {
       "hide_content_reversion" => o.hide_content_reversion = b(),
       "lpadding" => o.lpadding = val.as_int().ok().map(|i| i as usize),
       "rpadding" => o.rpadding = val.as_int().ok().map(|i| i as usize),
+      "beforeDigest" => {
+        if let Some(fp) = val.clone().try_cast::<FnPtr>() {
+          o.before_digest
+            .push(before_digest_trampoline(fp, engine.clone(), ast.clone()));
+        }
+      },
+      "afterDigest" => {
+        if let Some(fp) = val.clone().try_cast::<FnPtr>() {
+          o.after_digest
+            .push(after_digest_trampoline(fp, engine.clone(), ast.clone()));
+        }
+      },
       _ => {},
     }
   }

--- a/latexml_core/src/binding/def/builder.rs
+++ b/latexml_core/src/binding/def/builder.rs
@@ -49,6 +49,13 @@ macro_rules! shared_hook_setters {
       self
     }
 
+    /// Push an `afterDigestBody` hook (environments / box constructors: runs on
+    /// the whatsit after the captured body digests — Perl's `afterDigestBody`).
+    pub fn after_digest_body(mut self, hook: DigestionClosure) -> Self {
+      self.options.after_digest_body.push(hook);
+      self
+    }
+
     /// Push a `beforeDigest` hook (runs before the arguments are digested —
     /// Perl's `beforeDigest => sub {…}`, e.g. `\footnote`'s `neutralize_font`).
     pub fn before_digest(mut self, hook: BeforeDigestClosure) -> Self {

--- a/latexml_oxide/tests/30_script_bindings.rs
+++ b/latexml_oxide/tests/30_script_bindings.rs
@@ -573,6 +573,80 @@ fn lookup_definition_pushes_construct_hooks_end_to_end() {
   latexml_core::reset_thread_engine();
 }
 
+/// Option-bag parity, end-to-end: `DefPrimitive`/`DefMath` accept
+/// `beforeDigest`/`afterDigest` closures and `DefEnvironment` accepts
+/// `afterDigestBody` — the same flexary, unordered options the compile-time
+/// `Def*!` macros take. Driven through a real conversion (afterDigestBody needs a
+/// captured environment body). Each hook records a state side-effect we read back.
+const OPTBAG_SAMPLE: &str = r##"
+  DefPrimitive("\\optbagprim", || { AssignValue("optbag:body", "X", "global"); }, #{
+    beforeDigest: || { AssignValue("optbag:before", "B", "global"); },
+    afterDigest:  || { AssignValue("optbag:after", "A", "global"); }
+  });
+  DefEnvironment("{optbagenv}", "<ltx:text class=\"optbagenv\">#body</ltx:text>", #{
+    mode: "text",
+    afterDigestBody: || { AssignValue("optbag:afterbody", "yes", "global"); }
+  });
+"##;
+
+fn optbag_dispatch(request: &str) -> Option<Result<()>> {
+  let base = request.split('.').next().unwrap_or(request);
+  if base == "lxoptbagtest" {
+    Some(latexml_contrib::script_bindings::load_script(OPTBAG_SAMPLE).map(|_| ()))
+  } else {
+    None
+  }
+}
+
+#[test]
+fn option_bag_digest_hooks_end_to_end() {
+  let mut latexml = Core::new(CoreOptions {
+    verbosity: Some(-2),
+    include_comments: Some(false),
+    ..CoreOptions::default()
+  });
+  state::set_bindings_dispatch(Rc::new(latexml_package::dispatch));
+  state::add_binding_names(latexml_package::binding_names());
+  state::set_extra_bindings_dispatch(Rc::new(optbag_dispatch));
+
+  let tex = concat!(
+    "literal:\\documentclass{article}\\usepackage{lxoptbagtest}",
+    "\\begin{document}\\optbagprim\\begin{optbagenv}Z\\end{optbagenv}\\end{document}"
+  );
+  let doc = latexml
+    .convert_file(tex.to_string())
+    .expect("conversion with option-bag digest hooks should succeed");
+  let _ = doc.serialize_to_string();
+
+  let g = |k: &str| match state::lookup_value(k) {
+    Some(latexml_core::common::store::Stored::String(s)) => {
+      latexml_core::common::arena::to_string(s)
+    },
+    _ => String::new(),
+  };
+  // DefPrimitive option-bag beforeDigest + body + afterDigest all fired.
+  assert_eq!(
+    g("optbag:before"),
+    "B",
+    "DefPrimitive beforeDigest option did not run"
+  );
+  assert_eq!(g("optbag:body"), "X", "DefPrimitive body did not run");
+  assert_eq!(
+    g("optbag:after"),
+    "A",
+    "DefPrimitive afterDigest option did not run"
+  );
+  // DefEnvironment afterDigestBody fired after the captured body digested.
+  assert_eq!(
+    g("optbag:afterbody"),
+    "yes",
+    "DefEnvironment afterDigestBody option did not run"
+  );
+
+  drop(latexml);
+  latexml_core::reset_thread_engine();
+}
+
 /// Default `.rhai` FILE discovery (no embedder dispatcher): a
 /// `<name>.sty.rhai` next to the document is found via the searchpath
 /// machinery and loaded on `\usepackage{<name>}` — the downstream


### PR DESCRIPTION
Brings the runtime (Rhai) `Def*` option bags to parity with the compile-time `Def*!` macros, so the same flexary, unordered options work the same way in both binding layers.

- **DefPrimitive** / **DefMath**: their `#{…}` option map was scalar-only and silently dropped the `beforeDigest`/`afterDigest` closures — now wired, using the same hook trampolines as the constructor bag.
- **DefConstructor** / **DefEnvironment**: add `afterDigestBody` (already accepted by the macro), via a new shared builder setter.
- Parity is structural, not just tested: the primitive/math mappers populate the same option fields the macro sets, and `afterDigestBody` goes through the shared `ConstructorBuilder`, so the two front-ends can't drift.

Tested with contrib unit tests (DefPrimitive/DefMath digest-hook order) and an end-to-end conversion test (DefPrimitive before/afterDigest + DefEnvironment afterDigestBody all fire). Full suite 1634/0, clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)