### PR TITLE
fix #333 (r3623947537): hook-push splices at same-level scope, not global

### DIFF
--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -609,6 +609,24 @@ residuals stay here so the live worklist keeps them visible:
 
 ## Open tasks (actionable)
 
+### Rhai `LookupDefinition(cs).push*` hook-splice re-installs at same-level, not global — ✅ LANDED 2026-07-21
+
+Follow-up to the BookML/@xworld21 cluster: PR #333 review comment r3623947537 flagged that the
+`LookupDefinition(cs).push*/unshift*` hook-splice (#321) re-installed the patched def at
+`Scope::Global`, which **promotes a locally-bound def to global** and makes the patch survive
+group exit — a divergence from Perl, which mutates the shared def-hash *in place* (never touching
+the save stack). Harmless in practice (BookML only patches already-global `\hrule`/`\vrule`/`\rule`),
+but a real gap. Fix: ported Perl `State.pm:175`'s fourth scope, `'inplace'` ("Special case for
+`\box` & friends"), as first-class **`Scope::InPlace`** (`latexml_core/src/state.rs` enum +
+`assign_internal` arm; `\globaldefs` deliberately does NOT re-scope it, matching Perl's
+`$scope ne 'global' && ne 'local'` guard). The 9 `install_definition(d, Some(Scope::Global))` sites
+in `script_bindings/wire.rs::push_definition_hook` now pass `Scope::InPlace`. The Value-table
+`assign_value_inplace` fast path (WISDOM #19) was the pre-existing witness that this scope existed;
+this lifts it to the Meaning table too. Guards: `state::reentrancy_tests::inplace_scope_keeps_the_bindings_level`
+(proves neither-Global-nor-Local across a `push_frame`/`pop_frame` boundary) + the existing
+`script_bindings::tests::lookup_definition_*` (unchanged — top-level pushes, where in-place ≡ global).
+See WISDOM #48.
+
 ### XSLT `LATEXML_VERSION` param — generator-stamp parity gap + BookML `utils.xsl` — ✅ LANDED 2026-07-21 (branch `xslt-latexml-version-param`)
 
 Completes the BookML/@xworld21 cluster follow-up. `latexml_oxide/src/post.rs` now injects

--- a/docs/parity/WISDOM.md
+++ b/docs/parity/WISDOM.md
@@ -2409,3 +2409,31 @@ Neutrality argument worth reusing: the change is observable **only** by document
 that name `\@arraycr` (no Rust binding and no `.ltxml` references it) — measured
 at **6 of 6,000** 2605 papers, three via the direct `\let`. See
 `docs/known_crashes/kbordermatrix_halign_math/`.
+
+## 48. Patching an EXISTING definition in place → `Scope::InPlace`, never `Scope::Global`
+
+**Symptom / trigger:** the BookML `LookupDefinition(cs).push*/unshift*` idiom
+(Rhai #321) — and any code that clones an installed def, splices a hook, and
+re-installs it. The naive re-install uses `Scope::Global`.
+
+**Why Global is wrong:** Perl does NOT re-assign when BookML runs
+`push(@{ $$def{beforeConstruct} }, sub{…})`; it mutates the shared blessed
+def-hash **in place**, which never touches the save stack. `Scope::Global`
+instead collapses every frame down to the locked base and wipes lower-frame
+undo, **promoting a locally-bound def to global**. Harmless *only* because the
+sole user (BookML) patches already-global defs (`\hrule`/`\vrule`/`\rule`); a
+patch applied to a def bound inside a group would wrongly survive group exit
+(flagged by @xworld21, PR #333 r3623947537).
+
+**Fix — and the reusable fact:** Perl `State.pm:175` has a fourth scope,
+`'inplace'` ("Special case for `\box` & friends"): replace the front binding in
+its own frame, add no undo entry (or seed at the locked base if never bound).
+That is Knuth's "same level" / xworld21's tentative `scope => 'definition'`.
+Ported as **`Scope::InPlace`** (state.rs enum + `assign_internal` arm; the
+`\globaldefs` override deliberately does NOT re-scope it — Perl's guard is
+`$scope ne 'global' && $scope ne 'local'`). The Value-table fast path
+`assign_value_inplace` (mode changes, WISDOM #19) was the pre-existing witness
+that this scope existed; #48 just lifts it to a first-class scope so the Meaning
+table (definitions) can use it. Semantics pinned by
+`state::reentrancy_tests::inplace_scope_keeps_the_bindings_level` (proves it is
+neither Global nor Local across a `push_frame`/`pop_frame` boundary).

--- a/docs/parity/script_bindings_plan.md
+++ b/docs/parity/script_bindings_plan.md
@@ -447,11 +447,16 @@ hook family — the Rhai analog of Perl BookML's `push(@{ $$def{afterConstruct}
 construct/body push onto a Primitive/MathPrimitive/Macro is a clear script
 error — MathPrimitive's construct fields are never executed). Installed defs
 have no interior mutability, so each push clones the current front definition,
-splices the trampolined hook, and re-installs at **global** scope: the global
-`assign_internal` `push_front`s the patch and clears its lower-frame undo
-entries, so it is the active meaning immediately (sequential pushes accumulate
-by re-looking-up) and persists across group exits — faithful to Perl's
-in-place, globally-visible mutation of the shared def-hash. Hook arities match
+splices the trampolined hook, and re-installs at **`Scope::InPlace`** (Perl
+`State.pm:175` `'inplace'`, "same level"): the front binding is replaced without
+touching the save stack, so the patch is the active meaning immediately
+(sequential pushes accumulate by re-looking-up) and rides exactly as long as the
+definition's existing binding — faithful to Perl mutating the shared def-hash in
+place. (This corrects an earlier `Scope::Global` re-install that promoted a
+locally-bound def to global — harmless for BookML, which only patches
+already-global defs, but a real divergence flagged in PR #333 r3623947537
+by @xworld21; the `state::reentrancy_tests::inplace_scope_keeps_the_bindings_level`
+test pins the same-level semantics.) Hook arities match
 the option-bag form (digest = parameterless via `whatsit()`; construct =
 `|document|`). Guards: `script_bindings::tests::lookup_definition_*` and the
 end-to-end `30_script_bindings::lookup_definition_pushes_construct_hooks_end_to_end`.

--- a/latexml_contrib/src/script_bindings/tests.rs
+++ b/latexml_contrib/src/script_bindings/tests.rs
@@ -567,8 +567,9 @@ fn command_output_runs_by_default_and_is_blockable_via_env() {
 /// `push<Hook>`/`unshift<Hook>` splice a trampolined hook onto its list — the
 /// Rhai analog of BookML's `push(@{ $$def{afterDigest} }, sub{…})`. Perl mutates
 /// the shared blessed def-hash in place; we clone the current front def, splice,
-/// and re-install at GLOBAL scope, so sequential pushes ACCUMULATE and `unshift`
-/// PREPENDS. Exercised here on the digest path (the harness digests but builds no
+/// and re-install at `Scope::InPlace` (same-level; Perl `State.pm:175` 'inplace'),
+/// so sequential pushes ACCUMULATE and `unshift` PREPENDS. Exercised here on the
+/// digest path (the harness digests but builds no
 /// Document — the construct path is covered end-to-end in `30_script_bindings`).
 #[test]
 fn lookup_definition_pushes_and_accumulates_digest_hooks() {

--- a/latexml_contrib/src/script_bindings/wire.rs
+++ b/latexml_contrib/src/script_bindings/wire.rs
@@ -413,11 +413,15 @@ fn wrong_kind_err(cs: &str, family: HookFamily, stored: &Stored) -> Box<EvalAltR
 /// (#321 — the BookML `push(@{ $$def{afterConstruct} }, sub{…})` shape). Perl
 /// mutates the shared blessed def-hash in place; our installed defs have no
 /// interior mutability, so we clone the CURRENT front definition, splice the
-/// trampolined hook into the matching list, and re-install at GLOBAL scope. Global
-/// install `push_front`s the patched def and clears its lower-frame undo entries
-/// (`state::assign_internal`), so it is the active meaning immediately (sequential
-/// pushes accumulate by re-looking-up) and persists across group exits — a
-/// faithful match to Perl's in-place, globally-visible mutation.
+/// trampolined hook into the matching list, and re-install at `Scope::InPlace`.
+/// In-place replaces the front binding WITHOUT touching the save stack (Perl
+/// `State.pm:175` `'inplace'`), so the patch keeps the definition's existing
+/// level: it is the active meaning immediately, sequential pushes accumulate by
+/// re-looking-up, and it rides exactly as long as the current binding — a
+/// faithful match to Perl mutating the shared object in place. This corrects an
+/// earlier `Scope::Global` re-install that promoted a locally-bound def to
+/// global (harmless for BookML, which only patches already-global defs, but a
+/// real divergence — see PR #333 discussion r3623947537, @xworld21).
 pub(super) fn push_definition_hook(
   cs: &str,
   family: HookFamily,
@@ -445,17 +449,17 @@ pub(super) fn push_definition_hook(
         Stored::Constructor(rc) => {
           let mut d = (*rc).clone();
           insert_hook(&mut d.before_digest, at_front, hook);
-          install_definition(d, Some(Scope::Global));
+          install_definition(d, Some(Scope::InPlace));
         },
         Stored::Primitive(rc) => {
           let mut d = (*rc).clone();
           insert_hook(&mut d.before_digest, at_front, hook);
-          install_definition(d, Some(Scope::Global));
+          install_definition(d, Some(Scope::InPlace));
         },
         Stored::MathPrimitive(rc) => {
           let mut d = (*rc).clone();
           insert_hook(&mut d.options.before_digest, at_front, hook);
-          install_definition(d, Some(Scope::Global));
+          install_definition(d, Some(Scope::InPlace));
         },
         other => return Err(wrong_kind_err(cs, family, &other)),
       }
@@ -466,17 +470,17 @@ pub(super) fn push_definition_hook(
         Stored::Constructor(rc) => {
           let mut d = (*rc).clone();
           insert_hook(&mut d.after_digest, at_front, hook);
-          install_definition(d, Some(Scope::Global));
+          install_definition(d, Some(Scope::InPlace));
         },
         Stored::Primitive(rc) => {
           let mut d = (*rc).clone();
           insert_hook(&mut d.after_digest, at_front, hook);
-          install_definition(d, Some(Scope::Global));
+          install_definition(d, Some(Scope::InPlace));
         },
         Stored::MathPrimitive(rc) => {
           let mut d = (*rc).clone();
           insert_hook(&mut d.options.after_digest, at_front, hook);
-          install_definition(d, Some(Scope::Global));
+          install_definition(d, Some(Scope::InPlace));
         },
         other => return Err(wrong_kind_err(cs, family, &other)),
       }
@@ -487,7 +491,7 @@ pub(super) fn push_definition_hook(
         Stored::Constructor(rc) => {
           let mut d = (*rc).clone();
           insert_hook(&mut d.before_construct, at_front, hook);
-          install_definition(d, Some(Scope::Global));
+          install_definition(d, Some(Scope::InPlace));
         },
         other => return Err(wrong_kind_err(cs, family, &other)),
       }
@@ -498,7 +502,7 @@ pub(super) fn push_definition_hook(
         Stored::Constructor(rc) => {
           let mut d = (*rc).clone();
           insert_hook(&mut d.after_construct, at_front, hook);
-          install_definition(d, Some(Scope::Global));
+          install_definition(d, Some(Scope::InPlace));
         },
         other => return Err(wrong_kind_err(cs, family, &other)),
       }
@@ -509,7 +513,7 @@ pub(super) fn push_definition_hook(
         Stored::Constructor(rc) => {
           let mut d = (*rc).clone();
           insert_hook(&mut d.after_digest_body, at_front, hook);
-          install_definition(d, Some(Scope::Global));
+          install_definition(d, Some(Scope::InPlace));
         },
         other => return Err(wrong_kind_err(cs, family, &other)),
       }

--- a/latexml_core/src/rewrite.rs
+++ b/latexml_core/src/rewrite.rs
@@ -155,6 +155,9 @@ impl Rewrite {
         crate::state::Scope::Named(s) => arena::with(s, |r| r.to_string()),
         crate::state::Scope::Global => String::from("global"),
         crate::state::Scope::Local => String::from("local"),
+        // Rewrite rules never carry an in-place scope, but keep the match total
+        // (Perl's scope string for `assign_internal`'s 'inplace' branch).
+        crate::state::Scope::InPlace => String::from("inplace"),
       };
       clauses.push(RewriteClause {
         compiled: false,

--- a/latexml_core/src/state.rs
+++ b/latexml_core/src/state.rs
@@ -78,6 +78,17 @@ pub enum Scope {
   Local,
   /// a named scope - visible only when explicitly activated
   Named(SymStr),
+  /// in-place: replace the value in the frame it was last bound in, WITHOUT
+  /// recording a new undo entry (or globally, at the locked base frame, if it
+  /// was never bound). Perl `State.pm:175` `$scope eq 'inplace'` ("Special case
+  /// for `\box` & friends"). This is Knuth's "same level" reassignment / what
+  /// @xworld21 tentatively called `scope => 'definition'`: the binding keeps its
+  /// save-stack level, so a mutation rides exactly as long as the current
+  /// binding — persisting past the current group if the binding was made above
+  /// it, reverting with the group if it was made locally. Distinct from Global
+  /// (which promotes + wipes lower-frame undo) and Local (which pushes an outer
+  /// binding down a level). The Value-table fast path is `assign_value_inplace`.
+  InPlace,
 }
 
 /// the kinds of tables bookkept in the State
@@ -789,13 +800,15 @@ impl State {
     // strict `==1`/`==-1`; we slightly broaden to TeX's sign-based rule
     // (matches behavior for the canonical `\globaldefs=1`/`\globaldefs=-1`
     // uses while also handling rare `\globaldefs=2` etc).
-    // `Scope::Named(_)` is preserved per Perl's "ONLY override global/local/
-    // undef" rule (State.pm:146).
+    // `Scope::Named(_)` and `Scope::InPlace` are preserved per Perl's "ONLY
+    // override global/local/undef" rule (State.pm:146 — `$scope ne 'global' &&
+    // $scope ne 'local'` short-circuits the override): an in-place mutation of
+    // the existing binding is NOT re-scoped by `\globaldefs`.
     // Without this: pgfplots' `\pgfplots@pop@next@legend`
     // (`\def\foo{{\globaldefs=1 \let\x=\relax}}`) silently drops the `\let`
     // on group exit, leaving `\pgfplots@curlegend`/`@curplotlist` undefined
     // and looping `\pgfplots@createlegend` at the digest wall-clock cap.
-    let preserve = matches!(scope_opt, Some(Scope::Named(_)));
+    let preserve = matches!(scope_opt, Some(Scope::Named(_) | Scope::InPlace));
     if !preserve
       && let Some(globaldefs) = self.value.get(&pin!("\\globaldefs"))
       && let Some(global_value) = globaldefs.front()
@@ -882,6 +895,27 @@ impl State {
         }
         // 2.2 Add new value
         defs.push_front(value);
+      },
+      Scope::InPlace => {
+        // Perl `State.pm:175`: replace the front value in the frame it was last
+        // bound in, adding NO undo entry, so the mutation keeps the binding's
+        // save-stack level (the `\box` / same-level semantics). If the key was
+        // never bound, seed it at the locked base frame (Perl's "push globally"
+        // fallback). Mirrors the Value-table `assign_value_inplace` fast path.
+        let state_table = self.table_mut(table_name);
+        if let Some(defs) = state_table.get_mut(&key)
+          && let Some(front) = defs.front_mut()
+        {
+          *front = value;
+        } else {
+          state_table.entry(key).or_default().push_front(value);
+          for frame in &mut self.undo {
+            if frame.locked {
+              frame.table_mut(table_name).insert(key, 1);
+              break;
+            }
+          }
+        }
       },
       Scope::Named(scope_name) => {
         // initialize stash if empty
@@ -3555,5 +3589,53 @@ mod reentrancy_tests {
     // Same guarantee for the pop side.
     let r2 = pop_value("p1a_bug_key");
     assert!(r2.is_ok());
+  }
+
+  /// `Scope::InPlace` (Perl `State.pm:175` 'inplace') is the same-level
+  /// reassignment behind the Rhai `LookupDefinition(cs).push*` hook-splice
+  /// (`install_definition(d, Some(Scope::InPlace))`). It must be neither Global
+  /// nor Local across a group boundary — this is exactly the divergence
+  /// @xworld21 flagged in PR #333 (r3623947537). Exercised on the Value table,
+  /// which funnels through the identical `assign_internal` arm.
+  #[test]
+  fn inplace_scope_keeps_the_bindings_level() {
+    // Scenario 1: a value bound ABOVE the group, mutated in-place from INSIDE
+    // the group, PERSISTS past group exit (Local would have reverted it). This
+    // is BookML's real case: patch an already-global def, mutation stays.
+    assign_value("ip_above", Stored::Int(1), Some(Scope::Global));
+    push_frame();
+    assign_value("ip_above", Stored::Int(2), Some(Scope::InPlace));
+    assert_eq!(
+      lookup_int("ip_above"),
+      2,
+      "in-place mutation is active at once"
+    );
+    pop_frame().expect("pop group");
+    assert_eq!(
+      lookup_int("ip_above"),
+      2,
+      "in-place patch of an outer-bound value rode the outer binding past group \
+       exit (Local would revert to 1)"
+    );
+
+    // Scenario 2: a value LOCALLY redefined in the group, then mutated in-place,
+    // REVERTS to the outer value at group exit (Global would have kept the
+    // patch). The in-place edit rode the LOCAL binding, which is discarded.
+    assign_value("ip_local", Stored::Int(1), Some(Scope::Global));
+    push_frame();
+    assign_value("ip_local", Stored::Int(2), Some(Scope::Local));
+    assign_value("ip_local", Stored::Int(3), Some(Scope::InPlace));
+    assert_eq!(
+      lookup_int("ip_local"),
+      3,
+      "in-place mutated the local front"
+    );
+    pop_frame().expect("pop group");
+    assert_eq!(
+      lookup_int("ip_local"),
+      1,
+      "in-place patch of a locally-bound value was discarded with the group \
+       (Global would keep 3)"
+    );
   }
 }


### PR DESCRIPTION
Follow-up to the BookML/@xworld21 binding cluster. PR #333 review comment [r3623947537](https://github.com/dginev/latexml-oxide/pull/333#discussion_r3623947537) flagged that the Rhai `LookupDefinition(cs).push*/unshift*` hook-splice (#321) re-installed the patched definition at **global** scope.

## The gap

Perl does **not** re-assign when BookML runs `push(@{ $$def{beforeConstruct} }, sub{…})` — it mutates the shared blessed def-hash **in place**, which never touches the save stack. Our `Scope::Global` re-install instead collapses every frame down to the locked base and clears lower-frame undo, which **promotes a locally-bound definition to global** and makes the patch survive group exit. Harmless in practice — BookML only patches already-global `\hrule`/`\vrule`/`\rule` — but a real divergence, as @xworld21 noted.

## The fix

Perl `State.pm:175` already has the right scope: a fourth `'inplace'` branch ("Special case for `\box` & friends") that replaces the front binding in its own frame, adding no undo entry (or seeds at the locked base if the key was never bound). That is Knuth's "same level" reassignment / what @xworld21 tentatively called `scope => 'definition'`.

- Port it as a first-class **`Scope::InPlace`** (`latexml_core/src/state.rs` enum + `assign_internal` arm). The `\globaldefs` override deliberately does **not** re-scope it, matching Perl's `$scope ne 'global' && $scope ne 'local'` guard.
- The 9 `install_definition(d, Some(Scope::Global))` sites in `script_bindings/wire.rs::push_definition_hook` now pass `Scope::InPlace`.
- The Value-table `assign_value_inplace` fast path (mode changes, WISDOM #19) was the pre-existing witness that this scope existed; this lifts it to the Meaning table so definitions can use it.

## Tests

- **New** `state::reentrancy_tests::inplace_scope_keeps_the_bindings_level` — proves the scope is neither Global nor Local across a `push_frame`/`pop_frame` boundary (patch of an outer-bound value persists; patch of a locally-redefined value reverts).
- **Unchanged & green** `script_bindings::tests::lookup_definition_*` and the e2e `30_script_bindings::lookup_definition_pushes_construct_hooks_end_to_end` — all run at top level, where in-place ≡ global, so behavior is preserved on the real BookML path.

Docs: WISDOM #48, `script_bindings_plan.md`, `SYNC_STATUS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)