### PR TITLE
crossref: split-page navigation-link parity with Perl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@
     document date, matching Perl — a shared post-processing XPath defect had been
     dropping resources, processing instructions, and other relative-path lookups
     (also repairing split navigation and cross-reference/glossary resolution).
+  - **Split-page navigation links reach Perl parity.** Each page now emits the full
+    `<link rel=…>` head set — `prev` back to the parent for a first child, the
+    relation-typed `chapter`/`section`/`subsection` sibling and ancestor links, and
+    full-breadcrumb `title=` attributes on all of them (previously the relation-typed
+    links and `prev`-for-first-child were missing and the titles were empty).
   - **Generator identifier** now spells out the full product name ("LaTeXML oxide")
     and stamps the version into the XSLT output to match Perl.
   - **A `standalone` document class's options are no longer mis-loaded as packages.**

--- a/latexml_oxide/tests/14_split_nav_relations.rs
+++ b/latexml_oxide/tests/14_split_nav_relations.rs
@@ -1,0 +1,114 @@
+//! Split-page navigation-relation parity guard (full pipeline: split + CrossRef + XSLT).
+//!
+//! Same-host Perl (`latexmlc --format=html5 --splitat=section`) emits, on each split
+//! page, a full set of `<link rel=…>` head entries: `prev` (the parent page for a
+//! first-child section), the relation-typed sibling/ancestor links
+//! (`rel="chapter"`/`rel="section"`/…), and full-breadcrumb `title=` attributes on
+//! all of them. Rust had ported only the first half of `CrossRef::fill_in_relations`
+//! (up/start/prev/next) — dropping `prev` for first-children, the entire
+//! relation-typed block, and the `fulltitle` attribute the XSLT head-links template
+//! prefers — so split pages carried a truncated, mostly-untitled nav set.
+
+use std::{path::Path, process::Command};
+
+fn run(cwd: &Path, args: &[&str]) -> std::process::Output {
+  Command::new(env!("CARGO_BIN_EXE_latexml_oxide"))
+    .args(args)
+    .current_dir(cwd)
+    .output()
+    .expect("spawn latexml_oxide")
+}
+
+/// A first `\section` of a `\chapter`, split at `section`, must carry: a `rel="prev"`
+/// back to the chapter page (with the chapter's title), the relation-typed
+/// `rel="chapter"` link, and full-breadcrumb titles — matching Perl.
+#[test]
+fn split_page_navigation_relations_match_perl() {
+  const DOC: &str = "\\documentclass[12pt]{book}\n\
+                     \\begin{document}\n\
+                     \\chapter{Alpha}\n\
+                     \\section{Beta}\n\
+                     \\subsection{Gamma}\n\
+                     \\section{Delta}\n\
+                     \\chapter{Epsilon}\n\
+                     \\end{document}\n";
+  let work = tempfile::tempdir().expect("tempdir");
+  std::fs::write(work.path().join("index.tex"), DOC).unwrap();
+  let out = run(work.path(), &[
+    "index.tex",
+    "--splitat",
+    "section",
+    "--format",
+    "html5",
+    "--dest",
+    "index.html",
+  ]);
+  assert!(
+    out.status.success(),
+    "conversion failed (status {:?}):\n{}",
+    out.status.code(),
+    String::from_utf8_lossy(&out.stderr)
+  );
+
+  let page = std::fs::read_to_string(work.path().join("Ch1.S1.html")).expect("read Ch1.S1.html");
+  // The <head> nav links only.
+  let head = page.split("</head>").next().unwrap_or(&page);
+  let links: Vec<&str> = head
+    .match_indices("<link rel=")
+    .map(|(i, _)| {
+      let rest = &head[i..];
+      &rest[..rest.find('>').map(|j| j + 1).unwrap_or(rest.len())]
+    })
+    .filter(|l| !l.contains("stylesheet"))
+    .collect();
+  let joined = links.join("\n");
+
+  // 1. prev-for-first-child: Ch1.S1 is the first section of Ch1, so prev is the
+  //    chapter page itself (the old `?` dropped this link entirely).
+  assert!(
+    links
+      .iter()
+      .any(|l| l.contains("rel=\"prev\"") && l.contains("href=\"Ch1.html\"")),
+    "missing rel=\"prev\" -> parent chapter page (first-child prev):\n{joined}"
+  );
+  // 2. relation-typed links: the second half of fill_in_relations (chapter/section).
+  assert!(
+    links
+      .iter()
+      .any(|l| l.contains("rel=\"chapter\"") && l.contains("href=\"Ch1.html\"")),
+    "missing relation-typed rel=\"chapter\" link:\n{joined}"
+  );
+  assert!(
+    links.iter().any(|l| l.contains("rel=\"section\"")),
+    "missing relation-typed rel=\"section\" link:\n{joined}"
+  );
+  // 3. full-breadcrumb titles (fulltitle, not empty and not the "In X" collapse):
+  //    the `up`/`prev` links point to the parent chapter, so carry its own title.
+  for l in links
+    .iter()
+    .filter(|l| l.contains("rel=\"up\"") || l.contains("rel=\"prev\""))
+  {
+    assert!(
+      l.contains("title=\"Chapter 1 Alpha\""),
+      "up/prev nav link should carry the parent chapter title \"Chapter 1 Alpha\", got:\n{l}"
+    );
+  }
+  // Every non-start nav link must carry a NON-empty title that is not the buggy
+  // "In <context>" collapse (the previous behavior emitted empty or "In X").
+  for l in links
+    .iter()
+    .filter(|l| !l.contains("rel=\"start\"") && !l.contains("rel=\"up up"))
+  {
+    assert!(
+      !l.contains("title=\"\"") && !l.contains("title=\"In "),
+      "nav link has an empty / \"In X\" collapsed title (fulltitle missing):\n{l}"
+    );
+  }
+  // The deeper next/section links carry the multi-level breadcrumb (‣ separator).
+  assert!(
+    links
+      .iter()
+      .any(|l| l.contains("rel=\"next\"") && l.contains('\u{2023}')),
+    "rel=\"next\" should carry the full breadcrumb title (with \u{2023}):\n{joined}"
+  );
+}

--- a/latexml_post/src/crossref.rs
+++ b/latexml_post/src/crossref.rs
@@ -565,6 +565,46 @@ impl CrossRef {
     if let Some(next) = self.find_next_page_id(&page_id) {
       doc.add_navigation("next", &next);
     }
+
+    // 4. Relation-typed links (Perl CrossRef.pm L105-130). "Dig around for other
+    // interesting related documents": the sibling pages of each ancestor (walking
+    // up), then this page's own child pages. Each is keyed by the page's own
+    // element-name relation (`chapter`/`section`/`subsection`/…) if it is a
+    // primary page, else `sidebar`. This is what gives split pages their
+    // `rel="chapter"`/`rel="section"`/… head links; the whole block was unported.
+    let mut xentry = page_id.clone();
+    while let Some(parent) = self.get_parent_page_id(&xentry) {
+      for sib in self.child_pages(&parent).ids.iter() {
+        if *sib == page_id {
+          continue;
+        }
+        self.add_typed_navigation(doc, sib);
+      }
+      xentry = parent;
+    }
+    for child in self.child_pages(&page_id).ids.iter() {
+      self.add_typed_navigation(doc, child);
+    }
+  }
+
+  /// Add a navigation link to `related_id` keyed by its own element-name
+  /// relation (Perl: `$type =~ s/^(\w+)://` → `chapter`/`section`/…) when it is
+  /// a primary page, else `sidebar`. Port of the per-entry arm of Perl
+  /// `CrossRef::fill_in_relations`'s second half.
+  fn add_typed_navigation(&self, doc: &mut PostDocument, related_id: &str) {
+    if self.is_primary_page(related_id) {
+      let rel = self
+        .db
+        .lookup(&format!("ID:{}", related_id))
+        .and_then(|e| e.get_string("type").map(String::from))
+        // Strip the namespace prefix: `ltx:chapter` → `chapter`.
+        .map(|t| t.rsplit(':').next().unwrap_or(&t).to_string());
+      if let Some(rel) = rel.filter(|r| !r.is_empty()) {
+        doc.add_navigation(&rel, related_id);
+      }
+    } else {
+      doc.add_navigation("sidebar", related_id);
+    }
   }
 
   /// Return whether the given xml:id is registered as a primary page.
@@ -649,12 +689,18 @@ impl CrossRef {
     // Our position among the parent's child pages (None = "broken database").
     let pos = *siblings.index_of.get(page_id)?;
     // Nearest primary sibling strictly before us (Perl: peel following sibs,
-    // drop self, keep primaries, take the last one).
-    let mut current = siblings.ids[..pos]
+    // drop self, keep primaries, take the last one). If there is NONE, Perl's
+    // `$pentry` is still the PARENT page, so the previous page is the parent
+    // itself (e.g. the first `\section` of a `\chapter` → the chapter page).
+    // The old `?` returned None here, dropping the `rel="prev"` link entirely.
+    let mut current = match siblings.ids[..pos]
       .iter()
       .rev()
-      .find(|s| self.is_primary_page(s))?
-      .clone();
+      .find(|s| self.is_primary_page(s))
+    {
+      Some(sib) => sib.clone(),
+      None => return Some(parent_id),
+    };
     // Drill into the rightmost primary descendant.
     loop {
       let kids = self.child_pages(&current);
@@ -1109,6 +1155,20 @@ impl CrossRef {
         if ref_mut.get_attribute("title").is_none() {
           if let Some(titlestring) = self.generate_title(doc, id_str, &show) {
             ref_mut.set_attribute("title", &titlestring).ok();
+          }
+          // Perl CrossRef.pm L358-361: a ref carrying a `rel` (a navigation ref)
+          // ALSO gets a `fulltitle` — `generateTitle($doc, $id)` with an EMPTY
+          // `show`, i.e. the full contextual breadcrumb with NO "In <context>"
+          // dup-collapse (that collapse only fires for `show=~/title/`). The XSLT
+          // `head-links` template prefers `@fulltitle` over `@title` for the head
+          // `<link rel=… title=…>` entries, so without this split pages emitted
+          // empty (or "In X") nav-link titles.
+          if let Some(rel) = ref_mut.get_attribute("rel") {
+            if !rel.is_empty() {
+              if let Some(fulltitle) = self.generate_title(doc, id_str, "") {
+                ref_mut.set_attribute("fulltitle", &fulltitle).ok();
+              }
+            }
           }
         }
         if ref_mut.get_first_child().is_none() && tag != "ltx:graphics" && tag != "ltx:picture" {


### PR DESCRIPTION
**Diagnostic.** Rust ported only the first half of `Post::CrossRef::fill_in_relations` (up/start/prev/next). The second half — relation-typed sibling/ancestor links — was unported, `prev` was dropped for a first child, and `fill_in_refs` never set `fulltitle`. So split pages carried a truncated, mostly-untitled `<link rel=…>` head set vs same-host Perl.

**Approach.** Three faithful ports: `find_previous_page_id` returns the parent page when there's no preceding primary sibling (`CrossRef.pm` findPreviousPage); the relation-typed link block (`CrossRef.pm` L105-130) keyed by each page's element-name relation (`chapter`/`section`/…, `sidebar` for non-primary); and the `fulltitle` attribute for rel-refs (`CrossRef.pm` L358-361 — `generateTitle` with empty `show`, the full breadcrumb) which the XSLT `head-links` template prefers over `@title`.

**Validation.** Guard `14_split_nav_relations::split_page_navigation_relations_match_perl`; full suite 1643/0; clippy + fmt clean; Perl parity verified page-by-page (`latexmlc --format=html5 --splitat`). One cosmetic residual left as-is: the root page href form (`index.html` vs Perl's `./`) is functionally identical and tied to `generateURL` urlstyle config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)