### PR TITLE
feat: raw-load Perl-bound style packages (sTeX) instead of misreading the .ltxml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,16 @@
     previously hit OOM/timeout; `scrartcl` `\titlehead` frontmatter capture; and
     frontmatter bindings for `fairmeta`, `selfevolagent` and `openmoss` classes.
   - **A deferred package-load miss no longer poisons a later raw load.**
+  - **Perl `.ltxml` bindings are never read as TeX.** When raw-loading a style
+    package that also ships a Perl LaTeXML binding (e.g. sTeX's `stex.sty.ltxml`),
+    file resolution used to hand back the `.ltxml` — Perl source — and the loader
+    tokenized it as TeX, emitting spurious errors. latexml-oxide can't run Perl
+    bindings; binding availability is decided by its own dispatcher, so a missing
+    binding now falls through to the raw `.sty`, matching pdflatex. The
+    `standalone` binding also regained standalone.sty's real `xkeyval` +
+    `currfile → filehook` dependencies, so the package-file hooks
+    (`\AtEndOfPackageFile`, …) and `\define@key` exist — enough for raw sTeX 3.x
+    to load cleanly.
 
 ## [0.7.4] (Windows target; third-party license notices; crates.io)
 

--- a/latexml_contrib/src/lib.rs
+++ b/latexml_contrib/src/lib.rs
@@ -78,7 +78,6 @@ pub mod colt2024_cls;
 pub mod combine_cls;
 pub mod commath_sty;
 pub mod crckapb_sty;
-pub mod currfile_sty;
 pub mod curve2e_sty;
 pub mod cvpr_sty;
 pub mod czjphys_cls;
@@ -400,7 +399,6 @@ pub const BINDINGS: &[(&str, &str, BindingLoader)] = &[
   ("arydshln", "sty", arydshln_sty::load_definitions),
   ("autofe", "sty", autofe_sty::load_definitions),
   ("changes", "sty", changes_sty::load_definitions),
-  ("currfile", "sty", currfile_sty::load_definitions),
   ("diagrams", "tex", diagrams_tex::load_definitions),
   ("equations", "sty", equations_sty::load_definitions),
   ("eso-pic", "sty", eso_pic_sty::load_definitions),

--- a/latexml_core/src/binding/content.rs
+++ b/latexml_core/src/binding/content.rs
@@ -2663,12 +2663,10 @@ fn find_file_aux(file: &str, options: &FindFileOptions) -> Option<String> {
     //       return $file . '.ltxml' if -f ($file . '.ltxml'); }
     //     return $file if -f $file;
     //     return; }
-    if !options.forbid_ltxml {
-      let ltxml = s!("{}.ltxml", file);
-      if Path::new(&ltxml).exists() {
-        return Some(ltxml);
-      }
-    }
+    // No `<file>.ltxml` lookup (Perl checked one here): a `.ltxml` is a Perl
+    // LaTeXML binding latexml-oxide can never read. Binding availability is
+    // decided by the DISPATCHER (compiled + Rhai) in the relative-path branch's
+    // `notex` fast-path, not by a file on disk.
     if Path::new(file).exists() {
       Some(file.to_string())
     } else {
@@ -2779,12 +2777,17 @@ fn find_file_aux(file: &str, options: &FindFileOptions) -> Option<String> {
     if options.search_paths_only {
       return None;
     }
+    // NB: we do NOT add a `<file>.ltxml` candidate. That was Perl's logic —
+    // a `.ltxml` is a Perl LaTeXML binding, and latexml-oxide can never read
+    // one (as TeX or otherwise). The Rust equivalent of "is there a binding for
+    // this name?" is the BINDING DISPATCHER (the `get_binding_names()` /
+    // `{file}_binding_available` fast-path above, gated on `notex`), not a
+    // `.ltxml` on disk. Otherwise kpsewhich returns e.g. `stex.sty.ltxml` (it
+    // ships in TeX Live) ahead of the raw `stex.sty`, and the raw-loader
+    // tokenizes the Perl source as TeX (`$out =~ s/^\s+//;` → "Script ^…",
+    // `\DefMacroI` undefined, …). A missing binding falls through to the raw
+    // `.sty`, matching pdflatex.
     let mut candidates: Vec<String> = Vec::new();
-    if !options.forbid_ltxml {
-      // Perl `!nopaths` (REMOTE_REQUEST) gate not yet modeled in Rust;
-      // we always include the .ltxml candidate when ltxml is allowed.
-      candidates.push(s!("{}.ltxml", file));
-    }
     if !options.notex {
       candidates.push(file.to_string());
     }

--- a/latexml_oxide/tests/15_stex_raw_ltxml.rs
+++ b/latexml_oxide/tests/15_stex_raw_ltxml.rs
@@ -1,0 +1,118 @@
+//! Raw-loading a style package under `--includestyles` must (a) never read a
+//! Perl `.ltxml` binding as TeX, and (b) restore the `standalone → currfile →
+//! filehook` dependency chain so the package-file hooks exist.
+//!
+//! Origin: raw `stex.sty` (sTeX 3.x) under the ar5iv config. stex ships BOTH
+//! `stex.sty` (real TeX) and `stex.sty.ltxml` (a Perl LaTeXML binding) in TeX
+//! Live, and `stex.sty` uses `\AtEndOfPackageFile` (filehook, reached via
+//! standalone → currfile) and `\define@key` (xkeyval). Two bugs surfaced:
+//!   1. `find_file` returned `stex.sty.ltxml` (kpsewhich lists it) ahead of the
+//!      raw `stex.sty`, and the raw-loader tokenized the Perl source as TeX
+//!      (`$out =~ s/^\s+//;` → "Script ^…", `\DefMacroI`/`\stex@backend`
+//!      undefined). latexml-oxide can never read a `.ltxml`; binding availability
+//!      is decided by the dispatcher, not a `.ltxml` on disk.
+//!   2. the simplified `standalone` binding dropped standalone.sty's unconditional
+//!      `\RequirePackage{xkeyval}` / `\RequirePackage{currfile}` (→ filehook), so
+//!      `\AtEndOfPackageFile` / `\define@key` were undefined.
+
+use std::{path::Path, process::Command};
+
+fn strip_ansi(s: &str) -> String {
+  // Drop CSI sequences `\x1b[ … m` so `Error:`/`Fatal:` counting is reliable.
+  let mut out = String::with_capacity(s.len());
+  let mut chars = s.chars().peekable();
+  while let Some(c) = chars.next() {
+    if c == '\x1b' {
+      // Skip until the final byte of the CSI sequence (a letter).
+      for d in chars.by_ref() {
+        if d.is_ascii_alphabetic() {
+          break;
+        }
+      }
+    } else {
+      out.push(c);
+    }
+  }
+  out
+}
+
+fn convert(work: &Path, doc: &str) -> String {
+  std::fs::write(work.join("doc.tex"), doc).expect("write doc.tex");
+  let out = Command::new(env!("CARGO_BIN_EXE_latexml_oxide"))
+    .args(["--includestyles", "--dest", "doc.xml", "doc.tex"])
+    .current_dir(work)
+    .output()
+    .expect("spawn latexml_oxide");
+  strip_ansi(&String::from_utf8_lossy(&out.stderr))
+}
+
+fn error_count(log: &str) -> usize {
+  log
+    .lines()
+    .filter(|l| l.starts_with("Error:") || l.starts_with("Fatal:"))
+    .count()
+}
+
+fn kpsewhich_has(name: &str) -> bool {
+  Command::new("kpsewhich")
+    .arg(name)
+    .output()
+    .map(|o| o.status.success() && !o.stdout.is_empty())
+    .unwrap_or(false)
+}
+
+/// Self-contained (all bindings are compiled in — no TeX Live package needed):
+/// under `--includestyles`, `\usepackage{standalone}` must pull in the
+/// `xkeyval` + `currfile → filehook` chain so `\AtEndOfPackageFile` is defined.
+#[test]
+fn standalone_under_includestyles_provides_filehook_hooks() {
+  let work = tempfile::tempdir().expect("tempdir");
+  let log = convert(
+    work.path(),
+    "\\documentclass{article}\n\
+     \\usepackage{standalone}\n\
+     \\AtEndOfPackageFile{graphicx}{\\typeout{DEFERRED}}\n\
+     \\begin{document}\nHello.\n\\end{document}\n",
+  );
+  assert!(
+    !log.contains("AtEndOfPackageFile") && !log.contains("define@key"),
+    "standalone under --includestyles must define the filehook/xkeyval hooks \
+     (standalone → currfile → filehook, standalone → xkeyval); log:\n{log}"
+  );
+  assert_eq!(
+    error_count(&log),
+    0,
+    "expected a clean conversion; log:\n{log}"
+  );
+}
+
+/// The real witness: raw `stex.sty` must load — never its Perl `stex.sty.ltxml`
+/// — and convert cleanly. Skipped where TeX Live lacks stex.
+#[test]
+fn raw_stex_sty_loads_not_the_perl_ltxml() {
+  if !kpsewhich_has("stex.sty") || !kpsewhich_has("stex.sty.ltxml") {
+    eprintln!("stex.sty / stex.sty.ltxml not in TeX Live — skipping");
+    return;
+  }
+  let work = tempfile::tempdir().expect("tempdir");
+  let log = convert(
+    work.path(),
+    "\\documentclass{article}\n\\usepackage{stex}\n\
+     \\begin{document}\nHello sTeX.\n\\end{document}\n",
+  );
+  // The Perl binding must never be read as TeX.
+  assert!(
+    !log.contains("stex.sty.ltxml"),
+    "the Perl stex.sty.ltxml must never be read (latexml-oxide can't read .ltxml); log:\n{log}"
+  );
+  assert!(
+    !log.contains("DefMacroI") && !log.contains("stex@backend"),
+    "Perl-syntax-as-TeX errors present — the .ltxml was misread; log:\n{log}"
+  );
+  // And the raw load (stex → standalone → currfile → filehook, xkeyval) is clean.
+  assert_eq!(
+    error_count(&log),
+    0,
+    "raw stex.sty must convert with 0 errors; log:\n{log}"
+  );
+}

--- a/latexml_package/src/lib.rs
+++ b/latexml_package/src/lib.rs
@@ -292,6 +292,7 @@ pub const BINDINGS: &[(&str, &str, BindingLoader)] = &[
   ("fullpage", "sty", package::fullpage_sty::load_definitions),
   ("comment", "sty", package::comment_sty::load_definitions),
   ("csquotes", "sty", package::csquotes_sty::load_definitions),
+  ("currfile", "sty", package::currfile_sty::load_definitions),
   ("ctable", "sty", package::ctable_sty::load_definitions),
   ("dcolumn", "sty", package::dcolumn_sty::load_definitions),
   ("delarray", "sty", package::delarray_sty::load_definitions),

--- a/latexml_package/src/package.rs
+++ b/latexml_package/src/package.rs
@@ -124,6 +124,7 @@ pub mod crop_sty;
 pub mod cropmark_sty;
 pub mod csquotes_sty;
 pub mod ctable_sty;
+pub mod currfile_sty;
 pub mod datatool_base_sty;
 pub mod dcolumn_sty;
 pub mod delarray_sty;

--- a/latexml_package/src/package/currfile_sty.rs
+++ b/latexml_package/src/package/currfile_sty.rs
@@ -1,11 +1,12 @@
-use latexml_package::prelude::*;
+use crate::prelude::*;
 
 LoadDefinitions!({
-  Warn!(
-    "missing_file",
-    "currfile.sty",
-    "currfile.sty is only minimally stubbed and will not be interpreted raw."
-  );
+  // Real currfile.sty L30 `\RequirePackage{filehook}` — currfile is built on
+  // filehook's input-file hooks, and downstream packages (e.g. sTeX 3.x's
+  // `\AtEndOfPackageFile{…}`) rely on filehook being present transitively via
+  // currfile. Even though the currfile macros below are only stubbed, the
+  // filehook dependency is real and cheap (Rust ships a `filehook` binding).
+  RequirePackage!("filehook");
   def_macro_noop("\\currfiledir")?;
   def_macro_noop("\\currfilebase")?;
   def_macro_noop("\\currfileext")?;

--- a/latexml_package/src/package/standalone_sty.rs
+++ b/latexml_package/src/package/standalone_sty.rs
@@ -11,6 +11,24 @@ const CLASS_OPTION_PACKAGES: [&str; 5] = ["tikz", "pstricks", "preview", "varwid
 
 #[rustfmt::skip]
 LoadDefinitions!({
+  // BEYOND PERL (the Perl standalone.sty.ltxml omits these): the real
+  // standalone.sty has exactly TWO *unconditional* `\RequirePackage`s —
+  // `xkeyval` (L107) and `currfile` (L305). (Every other require is guarded:
+  // engine probes `ifpdf`/`ifluatex`/`ifxetex`/`shellesc`, and the
+  // `\IfFileExists`/option-gated `varwidth`/`trimclip`/`adjustbox`/`gincltex`/
+  // `filemod-expmin`.) Restore just those two, which real LaTeX always provides:
+  //   * `xkeyval` defines `\define@key` (and the wider keyval family);
+  //   * `currfile` `\RequirePackage{filehook}` (currfile.sty L30), and filehook
+  //     defines the package-file hooks `\AtEndOfPackageFile`/`\AtBeginOfPackageFile`/…
+  // sTeX 3.x leans on both: `\AtEndOfPackageFile{graphicx}{\define@key{Gin}
+  // {archive}{…}}` (stex.sty L2134) — without them the hook is undefined and its
+  // deferred body runs prematurely (`\define@key` undefined). Rust ships bindings
+  // for all three. Witness: raw stex.sty under ar5iv. (Unconditional — a binding
+  // emulates the package identically regardless of INCLUDE_STYLES; both requires
+  // resolve to always-available package bindings.)
+  RequirePackage!("xkeyval");
+  RequirePackage!("currfile");
+
   DefMacro!("\\@standalone@end@input", "\\egroup\\endinput");
 
   // Perl L21-23: DefPrimitiveI \@standalone@start@input — sets inPreamble = 0.


### PR DESCRIPTION
**Diagnostic.** Raw-loading a style package that also ships a Perl LaTeXML binding (`<pkg>.sty.ltxml`) misread the Perl source as TeX. sTeX's `stex.sty.ltxml` is the witness: `find_file` preferred the `.ltxml` (kpsewhich lists it) over the raw `stex.sty`, and the loader tokenized Perl as TeX — `$out =~ s/^\s+//;` → "Script ^ can only appear in math mode", `\DefMacroI`/`\stex@backend` undefined.

**Approach.** A `.ltxml` is always Perl and latexml-oxide can never read one; the Rust equivalent of "is there a binding for this name?" is the binding **dispatcher** (compiled + Rhai), already consulted by `find_file`'s `notex` fast-path. So the disk `.ltxml` candidate is dropped — a file we intend to open/read never resolves to a `.ltxml`, and a missing binding falls through to the raw `.sty`, matching pdflatex. With that fixed, raw sTeX 3.x needed standalone.sty's two unconditional requires restored: `xkeyval` (`\define@key`) and `currfile` → `filehook` (the `\AtEndOfPackageFile` hooks) — added unconditionally (a binding emulates its package identically regardless of `INCLUDE_STYLES`). `currfile` moves latexml_contrib → latexml_package (a package binding must not depend on a contrib-only one).

**Validation.** Raw `stex.sty` — and an `smodule` with a `\symdef` symbol — convert with **0 errors**, semantics preserved (`\symdef` operators carry `meaning=`). Guards: `15_stex_raw_ltxml` (self-contained standalone→filehook chain; a stex witness that skips where TeX Live lacks stex). Full suite **1644/0**; clippy + fmt clean; pdflatex parity confirmed.

cc @Jazzpirate — raw sTeX 3.x now loads cleanly under latexml-oxide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)