### PR TITLE
Add TL2026 to the release dump window

### DIFF
--- a/.github/workflows/release-dumps.yml
+++ b/.github/workflows/release-dumps.yml
@@ -107,33 +107,114 @@ jobs:
             image: ghcr.io/tkw1536/texlive-docker:2024
           - year: 2025
             image: ghcr.io/tkw1536/texlive-docker:2025
-          # TODO(#217): re-add 2026 once ghcr.io/tkw1536/texlive-docker:2026
-          # is published (tkw1536/historic-texlive-docker#1, still OPEN). The
-          # islandoftex `latest` image is NOT a usable interim: it is Debian
-          # testing (libxml2 2.15 → soname libxml2.so.16, apt pkg `libxml2-16`),
-          # so the dumper binary — built on ubuntu-22.04 against libxml2.so.2 —
-          # cannot run there at all (the apt-get even lacks a `libxml2`
-          # candidate). The whole single-binary-serves-all-containers design
-          # relies on the tkw1536 family sharing one (bookworm/.so.2) base.
-          # Until then the window is 2022–2025; a TL2026 host falls back to the
-          # most-recent embedded dump (2025) at runtime.
-    container:
-      image: ${{ matrix.image }}
-      options: --entrypoint ""
+          # 2026 restored 2026-07-23, clearing the former TODO(#217) marker
+          # here (#217 is the long-closed macOS-portability issue this
+          # pipeline descends from — it was a back-reference, not a live
+          # ticket). Both of the two INDEPENDENT blockers that had held 2026
+          # out of the window are now measured clear
+          # (locally, with a kpathsea-unlinked dumper built exactly as
+          # `build-dumper` does, run inside the real image):
+          #   1. Container. tkw1536/historic-texlive-docker#1 merged
+          #      2026-06-08 and `:2026` is published. It shares the SAME
+          #      `none-5.42.0` / debian:trixie base as `:2025`, so libxml2's
+          #      apt candidate is 2.9.14 → soname libxml2.so.2 and glibc is
+          #      2.41 (≥ the ubuntu-22.04 build host's 2.35). The one binary
+          #      therefore still serves every container — which is precisely
+          #      what the islandoftex `latest` interim could NOT do (Debian
+          #      testing, libxml2 2.15 → libxml2.so.16, no `libxml2` apt
+          #      candidate at all). Do not swap the image family.
+          #   2. Zero-error init gate. TL2026's expanded l3 `text-case`
+          #      module used to trip the expl3 raw-load catcode gap:
+          #      `--init=latex.ltx` measured 137 errors on 2026-07-12 (90 ×
+          #      `unexpected:_`, 29 × catcode PARAM, ~18 undefined l3
+          #      case-change internals). The two expl3 fixes that landed
+          #      2026-07-20 (force `\ExplSyntaxOff` when `_` is still LETTER;
+          #      global `:`/`_`/`~` restore) closed it: both inits are now
+          #      exit 0 / 0 errors, latex dump 24,221 entries (2025: 21,997 —
+          #      the delta IS text-case), plain dump byte-identical to 2025.
+          - year: 2026
+            image: ghcr.io/tkw1536/texlive-docker:2026
+    # DELIBERATELY NOT a job-level `container:`. That pulls the image during
+    # "Initialize containers", BEFORE any step can run, so nothing can free
+    # disk first. Measured 2026-07-23: the SAME 2026 leg passed one run and
+    # failed the next with `failed to register layer: … no space left on
+    # device` (all 3 pull retries out of space). 2026 is the fattest image —
+    # 6.2 GB compressed / 9.8 GB extracted, and every year is bigger than the
+    # last (2022=4.6, 2023=5.0, 2024=5.4, 2025=5.7 GB compressed) — so it falls
+    # over first.
+    #
+    # NOTE the diagnosis, because the obvious one is wrong: this is NOT a
+    # steady-state capacity ceiling. `/` reports 145 GB total / 88 GB free
+    # BEFORE cleanup, ~5x the ~16 GB the pull peaks at. The pass and the fail
+    # drew different runner image versions (ubuntu-24.04 20260714 passed,
+    # 20260720 failed), and GitHub-hosted runners cannot pin an image version —
+    # so some runners simply come up with much less headroom and we must be
+    # tolerant rather than merely "big enough". Two layers of tolerance:
+    # (1) free ~28 GB up front (58 GB used -> 30 GB), and (2) an explicit
+    # `docker pull` retry step (below) that reclaims space and backs off
+    # between attempts. Do NOT assume more capacity is the fix.
+    #
+    # Every release.yml build leg hard-requires the full window, so one flaky
+    # leg blocks a whole release. Do NOT "simplify" this back to `container:`.
     steps:
-      # The binary needs libxml2/libxslt runtime libs inside the container.
-      - name: install runtime libraries
+      - name: free runner disk space
         run: |
-          apt-get update
-          apt-get install -y --no-install-recommends libxml2 libxslt1.1 ca-certificates
+          echo "before:"; df -h / | tail -1
+          # Preinstalled toolchains this job never uses. ~15-25 GB total; the
+          # Android SDK alone is the biggest single win. `|| true` throughout:
+          # a path missing on a future runner image must not fail the release.
+          sudo rm -rf /usr/local/lib/android /opt/ghc /usr/local/.ghcup \
+                      /usr/share/dotnet /usr/share/swift /usr/local/share/powershell \
+                      /opt/hostedtoolcache/CodeQL /usr/local/share/chromium \
+                      /usr/local/share/boost 2>/dev/null || true
+          sudo docker image prune -af >/dev/null 2>&1 || true
+          echo "after:"; df -h / | tail -1
+      # Explicit, retry-tolerant pull BEFORE `docker run` (whose implicit pull
+      # is a single non-retried attempt). The images are large and the runner
+      # fleet is heterogeneous, so a first-attempt transient failure — network,
+      # or a marginal `no space left on device` — often clears on retry once a
+      # partial/aborted layer is pruned. Reclaim + linear backoff between tries.
+      - name: pull TL image (retry-tolerant)
+        env:
+          TL_IMAGE: ${{ matrix.image }}
+        run: |
+          set -u
+          ok=0
+          for attempt in 1 2 3 4; do
+            echo "=== docker pull attempt $attempt: $TL_IMAGE ==="
+            if docker pull "$TL_IMAGE"; then ok=1; break; fi
+            echo "pull attempt $attempt failed; reclaiming space, backing off"
+            df -h / | tail -1
+            # Drop anything half-pulled / any stale cache so the next attempt
+            # starts from maximum free space.
+            docker system prune -af >/dev/null 2>&1 || true
+            sleep $(( attempt * 10 ))
+          done
+          if [ "$ok" -ne 1 ]; then
+            echo "::error::docker pull failed for $TL_IMAGE after 4 attempts"
+            df -h / | tail -1
+            exit 1
+          fi
       - uses: actions/download-artifact@v6
         with:
           name: dumper-binary
       - name: generate and gate dumps
+        env:
+          TL_YEAR: ${{ matrix.year }}
+          TL_IMAGE: ${{ matrix.image }}
         run: |
           set -u
-          chmod +x ./latexml_oxide
           mkdir -p resources/dumps
+
+          # The in-container half. Quoted heredoc: nothing is expanded by the
+          # host shell, so `$` stays intact; the year arrives via `-e TL_YEAR`.
+          cat > gate.sh <<'GATE'
+          set -u
+          cd /work
+          # The binary needs libxml2/libxslt runtime libs inside the container.
+          apt-get update
+          apt-get install -y --no-install-recommends libxml2 libxslt1.1 ca-certificates
+          chmod +x ./latexml_oxide
 
           # Sanity: the container's TL year must match the matrix year
           # (guards against image drift, e.g. a `latest` tag moving on).
@@ -141,22 +222,22 @@ jobs:
           if [ -z "$AMBIENT" ]; then
             AMBIENT="$(pdflatex --version | head -3 | sed -n 's:.*TeX Live \([0-9]\{4\}\).*:\1:p' | head -1)"
           fi
-          if [ "$AMBIENT" != "${{ matrix.year }}" ]; then
-            echo "::error::container TL year is '$AMBIENT', expected ${{ matrix.year }}"
+          if [ "$AMBIENT" != "$TL_YEAR" ]; then
+            echo "::error::container TL year is '$AMBIENT', expected $TL_YEAR"
             exit 1
           fi
 
           # Zero-error gate per init (see workflow header).
           run_init() {
-            local init="$1" log="init-$1.log"
-            echo "=== --init=$init (TL ${{ matrix.year }}) ==="
+            init="$1"; log="init-$1.log"
+            echo "=== --init=$init (TL $TL_YEAR) ==="
             LATEXML_INIT_DEBUG=1 ./latexml_oxide --init="$init" >"$log" 2>&1
             status=$?
             # ANSI-strip defensively, then strict error count.
             errors=$(sed 's/\x1b\[[0-9;]*m//g' "$log" | grep -acE '^(Error|Fatal):' || true)
             tail -5 "$log"
             if [ "$status" -ne 0 ] || [ "$errors" -ne 0 ]; then
-              echo "::error::--init=$init on TL ${{ matrix.year }}: exit=$status errors=$errors"
+              echo "::error::--init=$init on TL $TL_YEAR: exit=$status errors=$errors"
               sed 's/\x1b\[[0-9;]*m//g' "$log" | grep -aE '^(Error|Fatal):' | head -20
               exit 1
             fi
@@ -164,8 +245,18 @@ jobs:
           run_init plain.tex
           run_init latex.ltx
 
-          # All three artifacts must exist and be non-trivial.
-          for f in plain.${{ matrix.year }}.dump.txt latex.${{ matrix.year }}.dump.txt texlive.${{ matrix.year }}.version; do
+          # Written as root inside the container; make them readable to the
+          # runner user so actions/upload-artifact can pick them up.
+          chmod -R a+rX resources/dumps
+          GATE
+
+          docker run --rm --entrypoint "" -e TL_YEAR \
+            -v "$PWD":/work -w /work "$TL_IMAGE" bash /work/gate.sh
+
+          # All three artifacts must exist and be non-trivial. Checked on the
+          # HOST, after the container exits, so this also proves the bind mount
+          # round-tripped what upload-artifact is about to read.
+          for f in plain.$TL_YEAR.dump.txt latex.$TL_YEAR.dump.txt texlive.$TL_YEAR.version; do
             if [ ! -s "resources/dumps/$f" ]; then
               echo "::error::missing or empty resources/dumps/$f"
               ls -la resources/dumps/ || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,7 @@ jobs:
       - name: verify dump window completeness
         run: |
           ls -la resources/dumps/
-          for year in 2022 2023 2024 2025; do
+          for year in 2022 2023 2024 2025 2026; do
             for f in plain.$year.dump.txt latex.$year.dump.txt texlive.$year.version; do
               if [ ! -s "resources/dumps/$f" ]; then
                 echo "::error::release dump window incomplete: missing resources/dumps/$f"
@@ -307,7 +307,7 @@ jobs:
       - name: verify dump window completeness
         run: |
           ls -la resources/dumps/
-          for year in 2022 2023 2024 2025; do
+          for year in 2022 2023 2024 2025 2026; do
             for f in plain.$year.dump.txt latex.$year.dump.txt texlive.$year.version; do
               if [ ! -s "resources/dumps/$f" ]; then
                 echo "::error::release dump window incomplete: missing resources/dumps/$f"
@@ -417,7 +417,7 @@ jobs:
       - name: verify dump window completeness
         run: |
           ls -la resources/dumps/
-          for year in 2022 2023 2024 2025; do
+          for year in 2022 2023 2024 2025 2026; do
             for f in plain.$year.dump.txt latex.$year.dump.txt texlive.$year.version; do
               if [ ! -s "resources/dumps/$f" ]; then
                 echo "::error::release dump window incomplete: missing resources/dumps/$f"
@@ -577,7 +577,7 @@ jobs:
         shell: bash
         run: |
           ls -la resources/dumps/
-          for year in 2022 2023 2024 2025; do
+          for year in 2022 2023 2024 2025 2026; do
             for f in plain.$year.dump.txt latex.$year.dump.txt texlive.$year.version; do
               if [ ! -s "resources/dumps/$f" ]; then
                 echo "::error::release dump window incomplete: missing resources/dumps/$f"
@@ -728,10 +728,11 @@ jobs:
       - name: verify dump window completeness
         run: |
           ls -la resources/dumps/
-          # 2026 is temporarily out of the window: no usable TL2026 container
-          # exists yet (see release-dumps.yml — tkw1536:2026 / PR #1 pending).
-          # TL2026 hosts fall back to the most-recent embedded dump at runtime.
-          for year in 2022 2023 2024 2025; do
+          # The full 5-year moving window. 2026 rejoined it 2026-07-23 (the
+          # TL2026 container and the zero-error init gate both cleared — see
+          # the matrix comment in release-dumps.yml), so a TL2026 host now gets
+          # an exact-year dump instead of falling back to the 2025 one.
+          for year in 2022 2023 2024 2025 2026; do
             for f in plain.$year.dump.txt latex.$year.dump.txt texlive.$year.version; do
               if [ ! -s "resources/dumps/$f" ]; then
                 echo "::error::release dump window incomplete: missing resources/dumps/$f"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,9 @@ are **NOT committed to the repo**. They are generated at release time by
 push, dispatchable standalone): a 5-year moving TL window — currently
 2022–2026 — each generated inside a pinned TL-year container
 (`ghcr.io/tkw1536/texlive-docker:YYYY`, the image family behind Perl
-LaTeXML's CI; 2026 interim: islandoftex `latest` until
-tkw1536/historic-texlive-docker#1 publishes). One kpathsea-UNLINKED
+LaTeXML's CI; 2026 joined the window 2026-07-23 — upstream published
+`:2026` on the same trixie/`libxml2.so.2` base, and the TL2026
+`latex.ltx` init reached the zero-error gate). One kpathsea-UNLINKED
 dumper binary (subprocess-`kpsewhich` backend) serves all containers.
 Each `--init` runs under `LATEXML_INIT_DEBUG=1` with a strict
 zero-`Error:`/`Fatal:` gate (init output is suppressed otherwise —

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -694,10 +694,97 @@ output with Perl. Not a regression from that work — which is verified byte-ide
 Perl modulo whitespace on formulas that do convert.
 
 
-### TL2026 `latex.ltx` dump init is NOT release-gate-clean — expl3 catcode gap (2026-07-12) — OPEN
+### TL2026 `latex.ltx` dump init is NOT release-gate-clean — expl3 catcode gap (2026-07-12) — ✅ CLOSED 2026-07-23
 
-Blocks adding **2026** to the release dump window (`release-dumps.yml`,
-currently 2022–2025; see also the container blocker TODO(#217) — the two are
+> **✅ RE-MEASURED 2026-07-23 — BOTH TL2026 blockers are clear; 2026 is IN the
+> release dump window.** Measured the way the release actually runs it, rather
+> than on a local install: a kpathsea-UNLINKED dumper built exactly as
+> `release-dumps.yml`'s `build-dumper` job does (`KPATHSEA_NO_LINK=1
+> KPATHSEA_SKIP_TOOLCHAIN_CHECK=1 cargo build --release`, `ldd` asserted
+> kpathsea-free), run inside the real `ghcr.io/tkw1536/texlive-docker:2026`
+> under the verbatim gate (`LATEXML_INIT_DEBUG=1`, ANSI-strip, `grep -acE
+> '^(Error|Fatal):'`):
+>
+> | init | 2026-07-12 | 2026-07-23 |
+> |---|---|---|
+> | `--init=plain.tex` | exit 0, 0 errors | exit 0, **0 errors** |
+> | `--init=latex.ltx` | exit 0, **137 errors** | exit 0, **0 errors** |
+>
+> The **likely** closers (not bisected — the 0/0 result is measured, the
+> attribution is inferred) are the two expl3 fixes that landed **2026-07-20**,
+> after the measurement below: force `\ExplSyntaxOff` when `_` is still LETTER
+> (`latex_constructs.rs`) and the global `:`/`_`/`~` restore (`expl3_sty.rs`).
+> They are the same pair credited with closing
+> [`EXPL3_CATCODE_GAP_2026-06-08.md`](parity/diagnostics/EXPL3_CATCODE_GAP_2026-06-08.md),
+> and all three error families listed below are now gone (the 90 ×
+> `unexpected:_` was the bulk). Dump is sound, not degenerate: **24,221** latex entries vs
+> 2025's 21,997 — the delta IS TL2026's expanded l3 `text-case` module — and
+> the plain dump is byte-identical to 2025's.
+>
+> The **container** blocker (TODO(#217), independent) cleared too:
+> tkw1536/historic-texlive-docker#1 merged 2026-06-08 and `:2026` publishes on
+> the SAME `none-5.42.0`/debian:trixie base as `:2025` — libxml2 apt candidate
+> 2.9.14 → `libxml2.so.2`, glibc 2.41 ≥ the ubuntu-22.04 build host's 2.35 — so
+> the one-binary-serves-all-containers design holds unchanged.
+>
+> Landed: `release-dumps.yml` matrix + **all five** of `release.yml`'s
+> `verify dump window completeness` gates (they are duplicated per build leg —
+> `build-macos`, `build-macos-intel`, `build-linux-arm64`, `build-windows`,
+> `release`; update them together or the legs disagree about the window) now
+> span **2022–2026**. Validated end-to-end, not just at the gate: a binary embedding
+> only TL2025 warns `latex_dump:mismatch loaded the TL2025 kernel dump, but the
+> ambient TeX Live is 2026` on a TL2026 host; rebuilt with the 2026 dump the
+> warning is gone and the conversion is clean. Cost: 48.1 → 49.0 MB (`release`
+> profile), i.e. ~876 KB gzipped, against the 64 MB RELEASE_CRITERIA §2 cap.
+> `release-dumps.yml` was also dispatched for real (run 30014067643): all five
+> legs green.
+>
+> **Runner-disk flake on the 2026 leg — `generate` no longer uses a job-level
+> `container:`.** The first CI run went 5/5 green; an identical re-run failed
+> *only* the 2026 leg with `failed to register layer: … no space left on
+> device` (3 pull retries, all out of space). 2026 is the fattest image —
+> compressed 2022=4.6, 2023=5.0, 2024=5.4, 2025=5.7, **2026=6.2 GB** (9.8 GB
+> extracted), monotonically worse each year — so it is the first to fall over.
+>
+> **Careful with the diagnosis** (an earlier draft of this note got it wrong):
+> this is *not* a steady-state capacity ceiling. Instrumenting the job shows
+> `/` at **145 GB total, 88 GB free before any cleanup** — roughly 5× the ~16 GB
+> the pull peaks at. The pass and the fail landed on *different runner image
+> versions* (`ubuntu-24.04` `20260714.240.1` passed, `20260720.247.2` failed),
+> so the fleet is heterogeneous and some images come up with far less headroom.
+> There is no way to pin a runner image *version* on GitHub-hosted runners, so
+> the fix has to be tolerance, not capacity.
+>
+> Fix, in two layers of *tolerance* (not capacity): (1) drop `container:` (it
+> pulls during "Initialize containers", *before* any step can run, so nothing
+> can free space first) and `docker run` the image explicitly after a
+> `free runner disk space` step that drops the preinstalled Android SDK / ghc /
+> dotnet / CodeQL trees — measured 58 GB used → 30 GB, ~28 GB of margin ahead of
+> the pull; and (2) a `pull TL image (retry-tolerant)` step that does an
+> explicit `docker pull` with reclaim + linear backoff (10/20/30/40 s) across 4
+> attempts, so a transient network / marginal-disk first failure clears on
+> retry (`docker run`'s implicit pull is a single, non-retried attempt).
+> Verified by extracting each step's script straight out of the YAML and running
+> it verbatim — the gate against the real `:2026` image (byte-identical
+> artifacts), the retry loop's control flow via a failing-`docker` stub (4 tries
+> then exit 1) — plus a 5/5 green CI run. **Do not "simplify" back to
+> `container:`.** This matters more than it used to, because every `release.yml`
+> build leg now hard-requires the full window, so one flaky leg blocks a whole
+> release.
+>
+> **Observed in passing — dumps are not bit-reproducible (pre-existing, ALL
+> years, not introduced here).** The CI-produced `latex.2026.dump.txt` and the
+> local one are identical in size and entry count but differ in exactly ONE
+> byte-range: `V\ttexsys.aux_contents` embeds a wall-clock stamp
+> (`2026/07/23:13:54` local vs `:14:13` in CI). Harmless today (cosmetic
+> `texsys.cfg` capture), but it means two dumps of the same TL year + same
+> revision never compare equal, so any future "did the dump change?" check must
+> normalize that field rather than `cmp`.
+>
+> History below kept for the root-cause trail.
+
+Blocked adding **2026** to the release dump window (`release-dumps.yml`,
+then 2022–2025; see also the container blocker TODO(#217) — the two are
 independent). Measured on a full local TL2026 install (`x86_64-pc-windows-msvc`,
 but Linux-equivalent — this is the raw-load path, not a platform issue), using
 the exact release gate (`LATEXML_INIT_DEBUG=1 ./latexml_oxide --init=<init>`,

--- a/docs/parity/DUMP_DESIGN.md
+++ b/docs/parity/DUMP_DESIGN.md
@@ -51,9 +51,9 @@ are generated explicitly by `tools/make_formats.sh` (which builds
 the binary, detects the TL year, and writes the versioned files).
 Dump files are **NOT tracked in git** (decision 2026-06-07; all of
 `resources/dumps/` is gitignored). Release binaries embed a 5-year
-moving TL window (**currently 2022–2025**; 2026 is blocked on the upstream TL
-container — TODO(#217) in `release-dumps.yml` — and a TL2026 host falls back to
-the most-recent embedded dump) generated at tag time by
+moving TL window (**currently 2022–2026**; 2026 rejoined it 2026-07-23 once
+both the upstream TL container and the zero-error init gate cleared — see
+`release-dumps.yml`) generated at tag time by
 `.github/workflows/release-dumps.yml` — each year produced inside a
 pinned TL-year container with a strict zero-error `--init` gate
 (`LATEXML_INIT_DEBUG=1`, since init suppresses error output by
@@ -212,7 +212,7 @@ regenerated per release. `.github/workflows/release-dumps.yml` (called from
 `release.yml` on a tag, dispatchable standalone) builds one kpathsea-UNLINKED
 dumper (subprocess-`kpsewhich` backend) and runs it inside each pinned
 `texlive-docker:YYYY` container across a 5-year moving window (currently
-2022–2025), gating each `--init` on a strict zero-`Error:`/`Fatal:` check
+2022–2026), gating each `--init` on a strict zero-`Error:`/`Fatal:` check
 (`LATEXML_INIT_DEBUG=1`); the maxperf build then embeds the window via
 `build.rs`. Dev/CI generate just the ambient year with `tools/make_formats.sh`,
 and `resources/dumps/` stays gitignored. Full operational detail: `../release/RELEASING.md`

--- a/docs/release/WINDOWS_COMPATIBILITY_PLAN.md
+++ b/docs/release/WINDOWS_COMPATIBILITY_PLAN.md
@@ -11,10 +11,12 @@ Decisions locked with the maintainer (2026-07-12): **MSVC** target
 MiKTeX** must both work at runtime; a self-contained `.exe` alongside the
 Linux/macOS assets. No MinGW/GNU bring-up phase.
 
-> **Release-dump caveat:** Windows test-suite green does NOT imply TL2026
-> release-readiness — `--init=latex.ltx` on TL2026 is not dump-gate-clean (137
-> expl3-catcode errors; see REMAINING and `SYNC_STATUS.md`). 2026 is out of the
-> release dump window; TL2026 hosts fall back to the newest embedded dump.
+> **Release-dump caveat — RESOLVED 2026-07-23.** This used to read: Windows
+> test-suite green does NOT imply TL2026 release-readiness, because
+> `--init=latex.ltx` on TL2026 emitted 137 expl3-catcode errors and 2026 was
+> out of the release dump window. Both halves are now closed — the init is
+> **0 errors** and **2026 is IN the window** (2022–2026). See `SYNC_STATUS.md`
+> ("TL2026 `latex.ltx` dump init … ✅ CLOSED 2026-07-23").
 
 ## Toolchain & native deps (reproduce the build from here)
 
@@ -178,12 +180,14 @@ cold run for a fair Linux-vs-Windows benchmark.
   `kpathsea_sys` row, and the §D.3 relink discharge; **F5 was closed 2026-07-14**
   ("libkpathsea: an undisclosed static LGPL-2.1 link"). `RELEASING.md` cites the
   same discharge.
-- [ ] **expl3 / TL2026 `latex.ltx` dump gate.** `--init=latex.ltx` on TL2026
-  emits 137 raw-load expl3-catcode-gap errors
-  (`EXPL3_CATCODE_GAP_2026-06-08.md`), so 2026 cannot join the release dump
-  window (`SYNC_STATUS.md`: "TL2026 latex.ltx dump init is NOT
-  release-gate-clean"). Deep, pre-existing, Linux-equivalent gap — first
-  post-release work.
+- [x] **expl3 / TL2026 `latex.ltx` dump gate — DONE 2026-07-23.** Was: 137
+  raw-load expl3-catcode-gap errors (`EXPL3_CATCODE_GAP_2026-06-08.md`)
+  blocking 2026 from the release dump window. The two expl3 fixes landed
+  2026-07-20 closed it; re-measured inside the real
+  `ghcr.io/tkw1536/texlive-docker:2026` under the verbatim release gate:
+  `plain.tex` and `latex.ltx` both exit 0 with **0 errors**. 2026 is now in the
+  window (`SYNC_STATUS.md`: "TL2026 `latex.ltx` dump init … ✅ CLOSED
+  2026-07-23").
 - [ ] **Fast TeX-ecosystem CI install** (DEFERRED). The cold
   `setup-texlive-action` download (~1–2 GB) is the slowest CI step. Target: a
   pinned, content-hash-keyed minimal texmf snapshot (fast + deterministic +


### PR DESCRIPTION
Restores the 5-year moving TeX Live dump window to **2022–2026**. TL2026 hosts currently fall back to the 2025 dump; after this they get an exact-year dump.

Two independent blockers on 2026 are now clear:

**1. Container.** [tkw1536/historic-texlive-docker#1](https://github.com/tkw1536/historic-texlive-docker/pull/1) published `ghcr.io/tkw1536/texlive-docker:2026` on the same `debian:trixie` base as `:2025` — libxml2 apt candidate 2.9.14 → `libxml2.so.2`, glibc 2.41 — so the single kpathsea-unlinked dumper still serves every container. (The former `TODO(#217)` marker was a back-reference to the long-closed macOS-portability issue; this PR closes no issue.)

**2. Zero-error init gate.** TL2026 `--init=latex.ltx` measured 137 errors on 2026-07-12 (expl3 raw-load catcode gap in TL2026's expanded l3 `text-case` module). The two expl3 fixes that landed 2026-07-20 (force `\ExplSyntaxOff` when `_` is still LETTER; global `:`/`_`/`~` restore) closed it — both inits now exit 0 with 0 errors.

## Verification

Reproduced the release path: a dumper built as the `build-dumper` job does (`KPATHSEA_NO_LINK=1`, `ldd`-asserted kpathsea-free), run inside the real `:2026` image under the verbatim gate. Both inits 0 errors; latex dump 24,221 entries (2025: 21,997 — the delta is `text-case`); plain dump byte-identical to 2025's. `release-dumps.yml` dispatched on this branch: all five legs green, CI 2026 artifact matches local.

**End-to-end:** a 2025-only binary on a TL2026 host warns `latex_dump:mismatch loaded the TL2025 kernel dump, but the ambient TeX Live is 2026`; rebuilt with the 2026 dump embedded, the warning is gone and the conversion is clean. Binary cost 48.1 → 49.0 MB (`release`), ~876 KB gzipped, against the 64 MB `RELEASE_CRITERIA` §2 cap.

## Changes

- `release-dumps.yml`: add the 2026 matrix leg.
- `release.yml`: extend all **five** `verify dump window completeness` gates (one per build leg) to 2022–2026.
- `release-dumps.yml`: the `generate` job no longer uses a job-level `container:`. Runner disk on `ubuntu-latest` is heterogeneous by image version (the 2026 leg passed one run, then failed an identical re-run with `no space left on device`), and a job-level container pulls before any step can free space. Now: free ~28 GB of preinstalled toolchains, then a retry-tolerant explicit `docker pull` (reclaim + backoff, 4 attempts), then `docker run`. Do not revert to `container:`.
- Docs: `CLAUDE.md`, `DUMP_DESIGN.md`, `SYNC_STATUS.md`, `WINDOWS_COMPATIBILITY_PLAN.md` updated to the 2022–2026 window.

No Rust change — `latexml_engine/build.rs` scans `resources/dumps/` and embeds whatever years are present. Does not address #303 (within-year format staleness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)