### PR TITLE
release: fix the RC release-body CHANGELOG slice; refresh verification numbers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,12 @@ Two co-equal targets drive current work:
    [`docs/performance/SOURCE_PROVENANCE.md`](docs/performance/SOURCE_PROVENANCE.md)).
 
 Current verification (tracked in `SYNC_STATUS.md`): `cargo test --tests` is
-**1657 passing** (2026-07-23, 90 targets; one `latexml_post` graphics test needs a host image tool and is green on CI); `cargo clippy --workspace --all-targets -- -D warnings` is clean
+**1677 passing** (2026-07-24, 90 targets, on `main`; one `latexml_post` graphics test needs a host image tool and is green on CI); `cargo clippy --workspace --all-targets -- -D warnings` is clean
 (policy in `[workspace.lints]`, gated by CI's `lint` job and the pre-push hook —
-`latexml_oxide/build.rs` sets `core.hooksPath`). The 2026-07 full-arXiv rerun
+`latexml_oxide/build.rs` sets `core.hooksPath`). `cargo doc --workspace` is
+**rustdoc-warning-clean** and gated on `-D warnings` in the same `lint` job (and
+again in `rustdoc.yml` before publishing) — a broken intra-doc link renders as
+dead text on the deployed site, so the warning is the only signal there is. The 2026-07 full-arXiv rerun
 runs at ~44k docs/hr, avg 4.06 s/doc, fatal rate 0.78%.
 
 Durable parity rules (the dump/format boundary):

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -15,9 +15,9 @@
 
 ## Current status
 
-- `cargo test --tests`: **1675 passing / 90 targets** (2026-07-23, branch
-  `feat-347-cprotect`; the one `latexml_post` graphics failure needs a
-  host image tool and is green on CI). Previously 1657 (`fix-311-standalone-newif-group`)
+- `cargo test --tests`: **1677 passing / 90 targets** (2026-07-24, on `main`;
+  the one `latexml_post` graphics failure needs a
+  host image tool and is green on CI). Previously 1675 (`feat-347-cprotect`), 1657 (`fix-311-standalone-newif-group`)
   and 1577 (on `public-release-prep-week` after
   merging `origin/main`'s Windows release hardening; the completed 2026-07
   session logs are archived — see the pointer below).

--- a/tools/make_release.sh
+++ b/tools/make_release.sh
@@ -333,10 +333,19 @@ EOF
   # Slice the CHANGELOG section for this version. CHANGELOG entries use
   # `## [VERSION]` headers (CommonMark task-list style — see CHANGELOG.md
   # for shape). Extract from the matching header up to the next `## `.
-  if grep -qE "^## \[${version}\]" CHANGELOG.md; then
+  #
+  # An RC carries the notes of the version it is a CANDIDATE for: `0.7.5-rc2`
+  # has no section of its own, so fall back to `0.7.5`. Without this every RC
+  # body silently degraded to the bare link below — the notes were written and
+  # then dropped, with nothing in the output saying so.
+  changelog_version="${version}"
+  if ! grep -qE "^## \[${version}\]" CHANGELOG.md; then
+    changelog_version="${version%%-*}"
+  fi
+  if grep -qE "^## \[${changelog_version}\]" CHANGELOG.md; then
     echo "## Changelog"
     echo
-    awk -v ver="${version}" '
+    awk -v ver="${changelog_version}" '
       /^## \[/ {
         if (in_block) exit
         if ($0 ~ "^## \\[" ver "\\]") { in_block = 1; print; next }


### PR DESCRIPTION
Prep for re-cutting `0.7.5-rc2`.

- **An RC's release body was losing its CHANGELOG notes.** `make_release.sh` slices the section matching the Cargo.toml version, so `0.7.5-rc2` looked for `## [0.7.5-rc2]` — which does not exist — and fell back to a bare "see CHANGELOG.md" link without saying so. An RC now falls back to the version it is a candidate for. Every RC to date hit this.
- **Verification numbers refreshed** for the re-cut: 1677 passing / 90 targets on `main`; `cargo doc --workspace` is rustdoc-warning-clean and gated on `-D warnings`.

Verified the slice across version shapes: `0.7.5-rc2` and `0.7.5` both produce the same 129-line section, `0.7.4` still resolves to its own 36-line section (no over-matching), an unknown version still falls back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)