### PR TITLE
fix #358: declare 'name' key in the Frontmatter keyset

### DIFF
--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -279,6 +279,7 @@ LoadDefinitions!({
   DefKeyVal!("Frontmatter", "labelref", "Semiverbatim");
   DefKeyVal!("Frontmatter", "labelseq", "");
   DefKeyVal!("Frontmatter", "annotate", "");
+  DefKeyVal!("Frontmatter", "name", "");
 
   // \lx@clear@frontmatter{tag}[kv]
   // Remove all pending frontmatter element matching $tag, and role (if given) in keyvals


### PR DESCRIPTION
Fixes #358.

## Symptom

A minimal `article` with a standard `\date{\today}` logged a spurious

```
Info:undefined:Encountered unknown KeyVals key 'name' with prefix 'KV' not defined in 'Frontmatter'
	at index; line 6 col 1 - line 6 col 14
```

pointing at the `\date` line — confusing, since the user never wrote a `name=` key.

## Cause

LaTeXML redefines `\date{...}` to expand into (mirroring Perl `latex_constructs.pool.ltxml`):

```tex
\lx@add@date[role=creation,name={\@ifundefined{datename}{}{\datename}}]{#1}
```

so the engine's *own* expansion hands a `name=` key to the `Frontmatter`
key/value set. `name` is a real, consumed key — `get_frontmatter_name`
(`base_utilities.rs`) turns it into the `name=` attribute — but it was not among
the keyset's declared keys.

oxide deliberately surfaces unknown keyval keys (an intentional divergence,
`keyvals.rs` — it catches genuine binding gaps like siunitx), downgraded to
`Info` for the `Frontmatter` keyset. `name` is a false positive on that radar.
(Upstream Perl stays silent for an unrelated reason — its single-keyset
`OptionalKeyVals:Frontmatter` reader trips the "emulate old behaviour"
`skipMissing=1` branch in `Base_ParameterTypes.pool.ltxml`, so it never emits the
`Info` at all, even at `-vv`.)

## Fix

Declare `name` in the `Frontmatter` keyset:

```rust
DefKeyVal!("Frontmatter", "name", "");
```

The `""` (default) type is deliberate — it reproduces the current (undeclared)
parse exactly. `Semiverbatim` would change the catcodes of
`name={\@ifundefined{datename}{}{\datename}}` and of creator `name=`s that carry
markup, a real regression risk.

## Verification

- Output is **byte-identical** before/after the declaration (2311-byte HTML5,
  date still renders `(July 24, 2026)`) — the fix silences the note without
  changing any attribute value.
- `cargo test --tests` green; `cargo clippy --workspace --all-targets -- -D warnings` clean.

Rust-only: upstream Perl already emits nothing here, so a Perl-side declaration
would be a no-op and a typed one would risk changing a working parse.
