### PR TITLE
feat(memory): make --max-memory the single memory knob; 0 disables entirely

### DIFF
--- a/latexml_core/src/stomach.rs
+++ b/latexml_core/src/stomach.rs
@@ -36,6 +36,56 @@ pub fn set_timeout(seconds: u64) {
   }
 }
 
+// Explicit override for the cooperative soft-RSS budget (bytes). When set it
+// takes precedence over the `LATEXML_RSS_CAP_BYTES` env; when `None` the env /
+// built-in default applies. The binary sets it from the single `--max-memory`
+// knob (via [`soft_cap_from_ceiling`]) so that ONE flag governs the whole
+// memory limit — this cooperative fuse rides a fixed fraction below the hard
+// Watchdog ceiling rather than being an independent number, and `--max-memory=0`
+// disables both (this fuse via a `0` cap → `None`, the Watchdog via
+// `max_rss_kb == 0`).
+thread_local! {
+  static RSS_CAP_OVERRIDE: Cell<Option<u64>> = const { Cell::new(None) };
+}
+
+/// Override the cooperative soft-RSS memory budget, in bytes. `Some(0)`
+/// disables the budget; `Some(n)` caps at `n` bytes; `None` restores the
+/// `LATEXML_RSS_CAP_BYTES` env / built-in default. Mirrors the `--max-memory`
+/// CLI convention where `0` means "no limit". See [`resolve_rss_cap`].
+pub fn set_memory_cap(bytes: Option<u64>) { RSS_CAP_OVERRIDE.with(|c| c.set(bytes)); }
+
+/// Derive the cooperative soft-RSS budget (bytes) from the hard `--max-memory`
+/// ceiling (MiB). The soft fuse sits at 75% of the ceiling, leaving ~25%
+/// headroom for the post-processing phase (libxml DOM + XSLT) that runs above
+/// digestion and which this cooperative guard cannot see. `0` in → `0` out
+/// (disabled), so `--max-memory=0` disables the whole memory limit. This keeps
+/// `--max-memory` the single knob: the hard Watchdog rides the ceiling, this
+/// fuse rides a fixed fraction below it — no independent second number.
+///
+/// The 75% factor reproduces the historical ~4.5 GB-under-6 GiB relationship at
+/// the 6144 MiB default (→ 4608 MiB) while scaling with any user-chosen ceiling
+/// (so a tight `--max-memory` also gets the graceful cooperative failure first,
+/// and a generous one raises both guards together).
+pub fn soft_cap_from_ceiling(max_memory_mib: u64) -> u64 {
+  (max_memory_mib.saturating_mul(3) / 4).saturating_mul(1024 * 1024)
+}
+
+/// Resolve the effective soft-RSS budget: `None` = disabled (no ceiling),
+/// `Some(n)` = abort above `n` bytes. Precedence: the explicit
+/// [`set_memory_cap`] override, else `LATEXML_RSS_CAP_BYTES`, else the 4.5 GB
+/// default. A cap of `0` from EITHER source resolves to `None`, so
+/// `--max-memory=0` / `LATEXML_RSS_CAP_BYTES=0` mean "no limit" — not "abort
+/// immediately" (a literal `0` compared as `rss_bytes > 0` is always true).
+fn resolve_rss_cap() -> Option<u64> {
+  let cap = RSS_CAP_OVERRIDE.with(|c| c.get()).unwrap_or_else(|| {
+    std::env::var("LATEXML_RSS_CAP_BYTES")
+      .ok()
+      .and_then(|v| v.parse::<u64>().ok())
+      .unwrap_or(4_500_000_000)
+  });
+  (cap > 0).then_some(cap)
+}
+
 /// Check if conversion has timed out. Returns Err if deadline exceeded.
 ///
 /// Also samples RSS via /proc/self/status every ~1024 calls and raises
@@ -95,7 +145,9 @@ pub fn check_timeout() -> Result<()> {
           // canvas3 corpus stay below 1 GB peak RSS, so this is well
           // into pathological territory while leaving headroom for
           // post-processing (XSLT, MathML chain).
-          // Override via LATEXML_RSS_CAP_BYTES env.
+          // Override via LATEXML_RSS_CAP_BYTES env or `set_memory_cap`; a
+          // value of 0 (or `--max-memory=0`) disables it — see
+          // `resolve_rss_cap`.
           //
           // This is a *per-process* fuse, deliberately kept LOW. It must
           // bound ONE conversion: in production the binary is
@@ -116,11 +168,9 @@ pub fn check_timeout() -> Result<()> {
           // test setup (latexml_oxide `util::test::init_test_rss_cap`).
           // Any other single-process-many-conversion driver should do the
           // same.
-          let cap = std::env::var("LATEXML_RSS_CAP_BYTES")
-            .ok()
-            .and_then(|v| v.parse::<u64>().ok())
-            .unwrap_or(4_500_000_000);
-          if rss_bytes > cap {
+          if let Some(cap) = resolve_rss_cap()
+            && rss_bytes > cap
+          {
             // R35.A debug: when LATEXML_DEBUG_MEMBUDGET=1 is set, dump
             // a stack backtrace before exiting so we can identify the
             // expansion loop responsible. Backtrace allocation is
@@ -1717,4 +1767,43 @@ pub fn get_script_level() -> usize {
       boxlevel
     }
   })
+}
+
+#[cfg(test)]
+mod memory_cap_tests {
+  use super::{resolve_rss_cap, set_memory_cap, soft_cap_from_ceiling};
+
+  // The override path is thread-local (race-free across libtest threads) and
+  // never reads the process-global env, so these assertions are deterministic.
+  #[test]
+  fn override_zero_disables_budget() {
+    // `--max-memory=0` maps to `set_memory_cap(Some(0))`, which must resolve
+    // to "no ceiling" — NOT a 0-byte cap that fatals every conversion.
+    set_memory_cap(Some(0));
+    assert_eq!(resolve_rss_cap(), None, "cap 0 disables the soft budget");
+    // A positive override is honored verbatim.
+    set_memory_cap(Some(1_000));
+    assert_eq!(resolve_rss_cap(), Some(1_000));
+    // Restore the default so we don't leak state onto other tests sharing
+    // this thread.
+    set_memory_cap(None);
+  }
+
+  #[test]
+  fn soft_cap_tracks_the_single_knob() {
+    // 0 in → 0 out: `--max-memory=0` disables the soft fuse (and, via
+    // resolve_rss_cap, the whole memory limit).
+    assert_eq!(soft_cap_from_ceiling(0), 0);
+    // The soft fuse always sits strictly below the hard ceiling (graceful
+    // cooperative failure fires first), and reproduces the historical
+    // ~4.5 GB-under-6 GiB relationship at the 6144 MiB default.
+    let hard = 6144u64 * 1024 * 1024;
+    let soft = soft_cap_from_ceiling(6144);
+    assert_eq!(soft, 4608u64 * 1024 * 1024);
+    assert!(soft < hard, "soft fuse must be below the hard ceiling");
+    // It scales with the knob, so a tight ceiling still gets a cooperative
+    // guard below it (fixing the old fixed-4.5 GB decoupling).
+    assert!(soft_cap_from_ceiling(2000) < 2000 * 1024 * 1024);
+    assert!(soft_cap_from_ceiling(20000) > 6144 * 1024 * 1024);
+  }
 }

--- a/latexml_core/src/stomach.rs
+++ b/latexml_core/src/stomach.rs
@@ -51,7 +51,8 @@ thread_local! {
 /// Override the cooperative soft-RSS memory budget, in bytes. `Some(0)`
 /// disables the budget; `Some(n)` caps at `n` bytes; `None` restores the
 /// `LATEXML_RSS_CAP_BYTES` env / built-in default. Mirrors the `--max-memory`
-/// CLI convention where `0` means "no limit". See [`resolve_rss_cap`].
+/// CLI convention where `0` means "no limit". See `resolve_rss_cap` (private)
+/// for the precedence order.
 pub fn set_memory_cap(bytes: Option<u64>) { RSS_CAP_OVERRIDE.with(|c| c.set(bytes)); }
 
 /// Derive the cooperative soft-RSS budget (bytes) from the hard `--max-memory`

--- a/latexml_core/src/stomach.rs
+++ b/latexml_core/src/stomach.rs
@@ -71,6 +71,23 @@ pub fn soft_cap_from_ceiling(max_memory_mib: u64) -> u64 {
   (max_memory_mib.saturating_mul(3) / 4).saturating_mul(1024 * 1024)
 }
 
+/// Apply the single `--max-memory` ceiling (MiB) to this thread's cooperative
+/// soft fuse, so the one knob means the same thing on every conversion path.
+/// Returns `false` — leaving the fuse alone — when `LATEXML_RSS_CAP_BYTES` pins
+/// it explicitly, which is the fleet/test decoupling escape hatch.
+///
+/// Callers must be BOTH the plain conversion path and the `--server` forked
+/// body child. When only the former called it, `--server --max-memory=0` still
+/// ran against a live 4.5 GB fuse while the help text promised the limit was
+/// off — the hard Watchdog was the only guard the LSP path wired to the knob.
+pub fn apply_memory_ceiling(max_memory_mib: u64) -> bool {
+  if std::env::var_os("LATEXML_RSS_CAP_BYTES").is_some() {
+    return false;
+  }
+  set_memory_cap(Some(soft_cap_from_ceiling(max_memory_mib)));
+  true
+}
+
 /// Resolve the effective soft-RSS budget: `None` = disabled (no ceiling),
 /// `Some(n)` = abort above `n` bytes. Precedence: the explicit
 /// [`set_memory_cap`] override, else `LATEXML_RSS_CAP_BYTES`, else the 4.5 GB
@@ -1772,7 +1789,28 @@ pub fn get_script_level() -> usize {
 
 #[cfg(test)]
 mod memory_cap_tests {
-  use super::{resolve_rss_cap, set_memory_cap, soft_cap_from_ceiling};
+  use super::{apply_memory_ceiling, resolve_rss_cap, set_memory_cap, soft_cap_from_ceiling};
+
+  // The single knob must reach the fuse through `apply_memory_ceiling`, which is
+  // what every conversion path calls. `--max-memory=0` has to leave NO ceiling:
+  // the plain path, the `--server` forked body child and the in-process fallback
+  // all rely on this one function, and the LSP pair used to skip it entirely.
+  #[test]
+  fn apply_memory_ceiling_drives_the_fuse() {
+    assert!(apply_memory_ceiling(6144), "no env pin, so it applies");
+    assert_eq!(resolve_rss_cap(), Some(4608 * 1024 * 1024));
+
+    // 0 means "no limit", not "abort immediately".
+    assert!(apply_memory_ceiling(0));
+    assert_eq!(resolve_rss_cap(), None, "--max-memory=0 leaves no ceiling");
+
+    // A tight ceiling is honored rather than ignored in favour of the old
+    // built-in 4.5 GB default, which sat far ABOVE such a ceiling.
+    assert!(apply_memory_ceiling(2000));
+    assert_eq!(resolve_rss_cap(), Some(1500 * 1024 * 1024));
+
+    set_memory_cap(None);
+  }
 
   // The override path is thread-local (race-free across libtest threads) and
   // never reads the process-global env, so these assertions are deterministic.

--- a/latexml_oxide/Cargo.toml
+++ b/latexml_oxide/Cargo.toml
@@ -128,7 +128,7 @@ kpathsea-build-from-source = ["latexml_core/kpathsea-build-from-source"]
 runtime-bindings = ["latexml_contrib/runtime-bindings"]
 
 [dependencies]
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 flate2 = "1"
 # Used by latexml_oxide / cortex_worker binaries for `getrusage(RUSAGE_CHILDREN)`
 # child-process CPU/memory accounting in telemetry (see *.rs `peak_rss_kb`).

--- a/latexml_oxide/bin/latexml_oxide.rs
+++ b/latexml_oxide/bin/latexml_oxide.rs
@@ -237,9 +237,12 @@ struct Cli {
   #[arg(long, value_name = "SECONDS", default_value = "60")]
   timeout: u64,
 
-  /// Per-conversion memory ceiling in MiB (default: 6144 = 6 GiB); the process
-  /// aborts with exit 137 if exceeded. Use 0 to disable.
-  #[arg(long, value_name = "MIB", default_value = "6144")]
+  /// Per-conversion memory ceiling in MiB (default: 6144 = 6 GiB). The single
+  /// memory knob: a cooperative guard raises a graceful Fatal as digestion
+  /// nears it, and a hard watchdog aborts the process (exit 137) at the
+  /// ceiling. Use 0 to disable memory limiting entirely. Also settable via the
+  /// `LATEXML_MAX_MEMORY` env var; this flag wins when both are given.
+  #[arg(long, value_name = "MIB", env = "LATEXML_MAX_MEMORY", default_value = "6144")]
   max_memory: u64,
 
   /// Abort after processing this many tokens — guards against runaway macro
@@ -765,11 +768,36 @@ fn real_main() -> Result<(), Box<dyn Error>> {
       cli.timeout,
       cli.max_memory.saturating_mul(1024),
     );
+    // `--max-memory` (or its `LATEXML_MAX_MEMORY` env) is the SINGLE memory
+    // knob. The hard Watchdog ceiling above rides it directly; the cooperative
+    // stomach RSS fuse is DERIVED from it (a fixed fraction below, leaving
+    // post-processing headroom) rather than being an independent number — so
+    // one flag governs one limit and `--max-memory=0` disables both. An
+    // explicit `LATEXML_RSS_CAP_BYTES` still overrides just the soft fuse (the
+    // fleet/test decoupling escape hatch), so honor it when present.
+    let rss_cap_env_set = std::env::var_os("LATEXML_RSS_CAP_BYTES").is_some();
+    if !rss_cap_env_set {
+      latexml_core::stomach::set_memory_cap(Some(
+        latexml_core::stomach::soft_cap_from_ceiling(cli.max_memory),
+      ));
+    }
+    if cli.max_memory == 0 && !rss_cap_env_set {
+      // Removing the surprise of one flag silently disabling two guards: say
+      // so, out loud, when the whole memory limit is off.
+      latexml_core::Warn!(
+        "memory",
+        "unlimited",
+        "--max-memory=0: memory limiting disabled entirely (cooperative guard + hard watchdog); a runaway conversion may exhaust host RAM"
+      );
+    }
     if cli.timeout > 0 {
       latexml_core::stomach::set_timeout(cli.timeout);
     }
     if let Some(limit) = cli.token_limit {
-      latexml_core::gullet::set_token_limit(Some(limit));
+      // 0 disables (as documented), matching the LATEXML_TOKEN_LIMIT env
+      // convention (`Some(0) => None` at the gullet initializer). Passing a
+      // literal `Some(0)` would instead fatal on the first token.
+      latexml_core::gullet::set_token_limit((limit != 0).then_some(limit));
     }
 
     let source_for_post = source.clone();

--- a/latexml_oxide/bin/latexml_oxide.rs
+++ b/latexml_oxide/bin/latexml_oxide.rs
@@ -242,7 +242,12 @@ struct Cli {
   /// nears it, and a hard watchdog aborts the process (exit 137) at the
   /// ceiling. Use 0 to disable memory limiting entirely. Also settable via the
   /// `LATEXML_MAX_MEMORY` env var; this flag wins when both are given.
-  #[arg(long, value_name = "MIB", env = "LATEXML_MAX_MEMORY", default_value = "6144")]
+  #[arg(
+    long,
+    value_name = "MIB",
+    env = "LATEXML_MAX_MEMORY",
+    default_value = "6144"
+  )]
   max_memory: u64,
 
   /// Abort after processing this many tokens — guards against runaway macro
@@ -777,9 +782,9 @@ fn real_main() -> Result<(), Box<dyn Error>> {
     // fleet/test decoupling escape hatch), so honor it when present.
     let rss_cap_env_set = std::env::var_os("LATEXML_RSS_CAP_BYTES").is_some();
     if !rss_cap_env_set {
-      latexml_core::stomach::set_memory_cap(Some(
-        latexml_core::stomach::soft_cap_from_ceiling(cli.max_memory),
-      ));
+      latexml_core::stomach::set_memory_cap(Some(latexml_core::stomach::soft_cap_from_ceiling(
+        cli.max_memory,
+      )));
     }
     if cli.max_memory == 0 && !rss_cap_env_set {
       // Removing the surprise of one flag silently disabling two guards: say

--- a/latexml_oxide/bin/latexml_oxide.rs
+++ b/latexml_oxide/bin/latexml_oxide.rs
@@ -780,13 +780,8 @@ fn real_main() -> Result<(), Box<dyn Error>> {
     // one flag governs one limit and `--max-memory=0` disables both. An
     // explicit `LATEXML_RSS_CAP_BYTES` still overrides just the soft fuse (the
     // fleet/test decoupling escape hatch), so honor it when present.
-    let rss_cap_env_set = std::env::var_os("LATEXML_RSS_CAP_BYTES").is_some();
-    if !rss_cap_env_set {
-      latexml_core::stomach::set_memory_cap(Some(latexml_core::stomach::soft_cap_from_ceiling(
-        cli.max_memory,
-      )));
-    }
-    if cli.max_memory == 0 && !rss_cap_env_set {
+    let ceiling_applied = latexml_core::stomach::apply_memory_ceiling(cli.max_memory);
+    if cli.max_memory == 0 && ceiling_applied {
       // Removing the surprise of one flag silently disabling two guards: say
       // so, out loud, when the whole memory limit is off.
       latexml_core::Warn!(

--- a/latexml_oxide/src/lsp_server/server.rs
+++ b/latexml_oxide/src/lsp_server/server.rs
@@ -123,6 +123,11 @@ impl Server {
     // RAM/time backstops don't apply; the cooperative deadline + the engine's
     // RSS fuse are what bound a runaway fallback conversion.)
     latexml_core::stomach::set_timeout(self.timeout_secs);
+    // ...and that RSS fuse must come from `--max-memory` like everywhere else.
+    // It matters most here, precisely because there is no Watchdog to fall back
+    // on: before this the fuse sat at its built-in 4.5 GB default, so on this
+    // path the flag bounded nothing at all.
+    latexml_core::stomach::apply_memory_ceiling(self.max_rss_kb / 1024);
 
     let opts = make_config(uri);
     let mut converter = Converter::from_config(opts.clone());

--- a/latexml_oxide/src/lsp_server/unix.rs
+++ b/latexml_oxide/src/lsp_server/unix.rs
@@ -533,6 +533,13 @@ fn run_body_child(
     // already-expired) deadline. Digest loops raise Fatal:Timeout (caught
     // below) for the graceful common case; the Watchdog above is the backstop.
     latexml_core::stomach::set_timeout(timeout_secs);
+    // Same for the cooperative RSS fuse, which the Watchdog above does NOT
+    // cover: derive it from the very `--max-memory` that set `max_rss_kb`, so
+    // one knob governs one limit here exactly as on the plain conversion path.
+    // Without this the child kept the built-in 4.5 GB default, so
+    // `--server --max-memory=0` still ran against a live fuse while the help
+    // text promised the limit was off.
+    latexml_core::stomach::apply_memory_ceiling(max_rss_kb / 1024);
     // Bare Core over the inherited state — does NOT reset thread-local state.
     let mut core = latexml_core::Core {
       preload: make_config(uri).preload.unwrap_or_default(),


### PR DESCRIPTION
## Summary

Unifies latexml_oxide's two memory guards under a single user-facing knob, `--max-memory`, and makes `--max-memory=0` disable memory limiting **entirely**.

Previously there were two independent numbers:
- the **hard** `Watchdog` ceiling (`--max-memory`, default 6144 MiB → `exit 137`, covers all phases including native libxml2/libxslt/Marpa post-processing), and
- a **soft** cooperative fuse buried in the stomach (a hard-coded ~4.5 GB `LATEXML_RSS_CAP_BYTES`, digestion-phase only, graceful `Fatal:`).

Setting `--max-memory` alone left the soft fuse in place, so a conversion was never truly unlimited, and a *tight* `--max-memory` got no cooperative guard at all. Two unrelated magic numbers were also a maintenance smell.

## What changed

- **One knob.** The soft fuse is now **derived** from `--max-memory`: `soft = 75% of the hard ceiling`. At the 6144 MiB default that reproduces the historical ~4.6 GB soft cap (4608 MiB), while scaling with any ceiling the user picks — fixing the old wart where a small `--max-memory` had no cooperative guard.
- **`0` disables entirely.** `--max-memory=0` now turns off *both* the watchdog and the cooperative fuse, and logs a visible `Warning:memory:unlimited` line so the disable is never silent.
- **`LATEXML_MAX_MEMORY` env var** added (clap `env`), same behavior as the flag; **the CLI flag wins** when both are set. Self-documented in `--help`.
- **`LATEXML_RSS_CAP_BYTES`** retained as a soft-fuse-only escape hatch (overrides the derived value; also honors `0 = disable`).
- Drive-by: `--token-limit=0` now disables the token limit instead of firing immediately (was passing a literal `Some(0)`).

## Implementation notes

- Soft cap resolution moved into `stomach::resolve_rss_cap` / `soft_cap_from_ceiling`, wired from the binary via a thread-local `set_memory_cap` (avoids the glibc `getenv`/`setenv` concurrency hazard the codebase already warns about).
- `0`-means-disable is mapped to `None` at resolution time, so the guard is skipped rather than firing on `rss > 0`.

## Testing

- New `stomach::memory_cap_tests`: `override_zero_disables_budget`, `soft_cap_tracks_the_single_knob` (soft < hard, scaling at 2000/6144/20000 MiB, `soft_cap_from_ceiling(0) == 0`).
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Default conversion path unchanged (soft cap 4608 MiB ≈ prior 4.5 GB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)