### PR TITLE
ci: re-audit cc at 1.4.0 to unblock the vendored-native gate

### DIFF
--- a/tools/audit_vendored_natives.py
+++ b/tools/audit_vendored_natives.py
@@ -121,9 +121,12 @@ AUDITED = {
     # ---- Build-tooling and test fixtures: native files present, NOT linked into any
     # shipped binary, so no disclosure is owed. Each verdict verified by looking at the
     # file, not at the name. Recorded so the gate stays loud on substance and quiet here.
-    "cc": ("1.3.0",
+    "cc": ("1.4.0",
         "src/detect_compiler_family.c -- a probe compiled to identify the host "
-        "toolchain, never linked into our binary. The crate itself is pure Rust.",
+        "toolchain, never linked into our binary. The crate itself is pure Rust. "
+        "Re-verified at 1.4.0: still the only non-Rust file in the crate, and still "
+        "nothing but #ifdef/#pragma message lines, so it emits diagnostics and no "
+        "object code.",
     ),
     "walkdir": ("2.5.0",
         "compare/nftw.c -- a benchmark comparison against C's nftw(3), not built.",


### PR DESCRIPTION
## Why CI is red without a code change

Upstream published **`cc` 1.4.0** on 2026-07-24, between main's last green run (11:37Z) and the evening's PR runs (22:08Z). `Cargo.lock` is gitignored, so CI re-resolves dependencies from scratch on every run and picked it up immediately. `tools/audit_vendored_natives.py` pins its recorded verdict at 1.3.0 and fails:

```
ERROR: audited crate(s) changed version — the recorded verdict may no longer hold:
  cc: audited at v1.3.0, tree has v1.4.0
```

This blocks the `lint` job on **main and every open PR** — nothing to do with the code in any of them. (Main still shows green only because it hasn't re-run since 11:37.)

## What I checked

The audit file's own rule is "each verdict verified by looking at the file, not at the name," so I re-verified rather than just moving the version string:

- `cc` 1.4.0 carries **exactly one** non-Rust file, `src/detect_compiler_family.c` — same as 1.3.0.
- That file is still nothing but `#ifdef` / `#pragma message` lines (`__clang__`, `__GNUC__`, `__EMSCRIPTEN__`, `__VXWORKS__`). It emits compiler diagnostics to identify the host toolchain and produces **no object code**.
- Nothing is linked into our binary, so no disclosure is owed and the recorded verdict holds unchanged.

Pin bumped to 1.4.0 with the re-verification noted inline. `LICENSE_INVENTORY.md` needs no edit — it carries no per-version pin for `cc`.

## Verification

`python3 tools/audit_vendored_natives.py --verbose` → exit 0, "all 18 native-code crates in the shipped tree are audited", with `cc` 1.4.0 actually resolved in the local lock (not a stale-lock pass).

## Follow-ups (not in this PR)

- The pre-push hook runs only 3 of CI's 6 lint checks, which is how two separate lint failures reached CI on #363. A shared `tools/lint.sh` for both callers is next.
- The gitignored `Cargo.lock` is the root cause of this *class* of failure — CI floats on latest-compatible deps and can go red with no code change. Flagged for separate discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)