### PR TITLE
docs: correct the test-suite verification stamp and its graphics caveat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,16 @@ Two co-equal targets drive current work:
    [`docs/performance/SOURCE_PROVENANCE.md`](docs/performance/SOURCE_PROVENANCE.md)).
 
 Current verification (tracked in `SYNC_STATUS.md`): `cargo test --tests` is
-**1677 passing** (2026-07-24, 90 targets, on `main`; one `latexml_post` graphics test needs a host image tool and is green on CI); `cargo clippy --workspace --all-targets -- -D warnings` is clean
+**1678 passing** (2026-07-24, 91 targets, on `main`; the two `latexml_post`
+vector-SVG tests self-skip — silently, and *green* — unless `mutool` or
+`pdftocairo` is on PATH, so a green local run does not by itself prove that
+branch ran; CI installs poppler/mupdf). **A fully green suite still prints
+`Error:` lines to stderr** — several tests deliberately raise diagnostics to
+prove they get reported (the `graphics.rs` worker-thread fold emits
+`failed_to_convert` for a nonexistent `w0.pdf`; the Rhai script-binding tests
+emit `boom`). Judge a test run by its `test result:` lines and exit code, never
+by grepping its output for `Error:` — that heuristic is for *conversion* logs
+(below), and it inverts here. `cargo clippy --workspace --all-targets -- -D warnings` is clean
 (policy in `[workspace.lints]`, gated by CI's `lint` job and the pre-push hook —
 `latexml_oxide/build.rs` sets `core.hooksPath`). `cargo doc --workspace` is
 **rustdoc-warning-clean** and gated on `-D warnings` in the same `lint` job (and

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -15,9 +15,21 @@
 
 ## Current status
 
-- `cargo test --tests`: **1677 passing / 90 targets** (2026-07-24, on `main`;
-  the one `latexml_post` graphics failure needs a
-  host image tool and is green on CI). Previously 1675 (`feat-347-cprotect`), 1657 (`fix-311-standalone-newif-group`)
+- `cargo test --tests`: **1678 passing / 91 targets, 0 failed, 0 ignored**
+  (2026-07-24, on `main` @ `7d3963646e`, dev box with ImageMagick + ghostscript +
+  poppler installed, `mutool` absent). This supersedes the carried-forward
+  "one `latexml_post` graphics failure needs a host image tool" caveat (added
+  2026-07-23 in `28223835aa` at 1657/90, then bumped without re-deriving the
+  target count): **that failure did not reproduce, and no `latexml_post` test
+  can produce it as written.** The only tool-dependent tests there are the two
+  vector-SVG ones (`test_vector_svg_graphics_path`,
+  `test_vector_svg_pathological_convert_case`), and they do not go red on a bare
+  host — `svg_converter_available()` (`tests/integration.rs`) makes them `return`
+  early and report **ok** when neither `mutool` nor `pdftocairo` is on PATH.
+  Their real risk is the opposite one: **coverage lost silently to a green
+  tick**, since the skip `eprintln!` is swallowed without `--nocapture`. CI
+  installs poppler/mupdf, so the branch is exercised there.
+  Previously 1675 (`feat-347-cprotect`), 1657 (`fix-311-standalone-newif-group`)
   and 1577 (on `public-release-prep-week` after
   merging `origin/main`'s Windows release hardening; the completed 2026-07
   session logs are archived — see the pointer below).

--- a/tools/audit_vendored_natives.py
+++ b/tools/audit_vendored_natives.py
@@ -121,7 +121,7 @@ AUDITED = {
     # ---- Build-tooling and test fixtures: native files present, NOT linked into any
     # shipped binary, so no disclosure is owed. Each verdict verified by looking at the
     # file, not at the name. Recorded so the gate stays loud on substance and quiet here.
-    "cc": ("1.3.0",
+    "cc": ("1.4.0",
         "src/detect_compiler_family.c -- a probe compiled to identify the host "
         "toolchain, never linked into our binary. The crate itself is pure Rust.",
     ),


### PR DESCRIPTION
Two commits: a docs correction, plus an unrelated one-line CI unblock that surfaced while pushing it.

## 1. `docs:` correct the test-suite verification stamp and its graphics caveat

Refreshes the `cargo test --tests` stamp in `CLAUDE.md` and `docs/SYNC_STATUS.md`, and retires a caveat that turned out to be wrong rather than merely stale.

### Stamp refresh

**1677 passing / 90 targets → 1678 passing / 91 targets, 0 failed, 0 ignored** (2026-07-24, `main` @ `7d3963646e`). Host had ImageMagick + ghostscript + poppler; `mutool` absent. Recorded alongside the figure so a future reader can compare instead of guess.

### The graphics caveat was inaccurate

Both files described "the one `latexml_post` graphics **failure**" as needing a host image tool and being green only on CI. That does not reproduce, and no `latexml_post` test can produce it as written:

- The only tool-dependent tests in the crate are `test_vector_svg_graphics_path` and `test_vector_svg_pathological_convert_case`, and they do **not** go red on a bare host — `svg_converter_available()` (`tests/integration.rs`) makes them `return` early and report **ok** when neither `mutool` nor `pdftocairo` is on PATH.
- The remaining graphics tests are tool-independent: fake `convert` shims on `PATH`, or pure byte-inspection of the PDF fixtures.

The caveat entered in 28223835aa at 1657/90 and was bumped since without re-deriving the target count. `1677 + 1` / `90 + 1` is exactly the arithmetic of one target that was FAILED-not-ok when the stamp was taken — i.e. the target count was carried forward, not recounted.

The docs now record the actual hazard, which is the inverse of the one documented: **coverage lost silently to a green tick**, since the skip `eprintln!` is swallowed without `--nocapture`.

### A green suite still prints `Error:` lines

Noted explicitly, with both sources named: `graphics.rs`'s worker-thread diagnostic fold emits `failed_to_convert` for a nonexistent `w0.pdf`, and the Rhai script-binding tests emit `boom`. Both are deliberate — they exist to prove those diagnostics get reported.

This matters because `CLAUDE.md` elsewhere instructs, at length and correctly, to grep logs for `Error:` and never treat a parse failure as success. That rule is for **conversion** logs and **inverts** on test output. The docs now say to judge a test run by its `test result:` lines and exit code.

### Verification

`cargo test --tests` → 1678 passed, 0 failed, 0 ignored across 91 targets, exit 0. Separately confirmed the two vector-SVG tests genuinely run here rather than self-skipping (this host's `pdftocairo` satisfies the gate; ~50 ms on `cifar10_vector.pdf`).

## 2. `chore:` re-audit cc's vendored native at v1.4.0

The first push went red on `lint` for a reason unrelated to this PR, and repo-wide: `cc` published **1.4.0**, and since `Cargo.lock` is untracked every run re-resolves to it and trips the vendored-natives gate — *"audited crate(s) changed version — the recorded verdict may no longer hold"*. `main` passed at 11:37 today only because it resolved 1.3.0; a re-run now would fail identically. This blocks every PR until the record moves.

Re-checked the substance rather than bumping the string blind: v1.4.0 vendors **exactly the same single native file**, `src/detect_compiler_family.c` — 15 lines of `#pragma message` preprocessor probes, no linkable code — and the license is unchanged (`MIT OR Apache-2.0`). The recorded verdict holds verbatim, so only the version needed updating. `LICENSE_INVENTORY` §D.2 mentions `cc::Build` with no sources and pins no version, so no companion edit is owed there.

`python3 tools/audit_vendored_natives.py --verbose` now exits 0: all 18 native-code crates in the shipped tree audited.

---

Also found while pushing and **not** addressed here, since it needs a re-`--bless` and is worth its own record: `tools/lint_xmlid_accessor.sh` fails spuriously under a UTF-8 locale, blocking `git push` on an unmodified tree. The baseline is blessed with `sort` under locale collation (which ignores punctuation, so the `))` and `));` variants compare equal and may sort in any order) while `comm` compares byte-wise — so it mis-pairs them and reports phantom additions, preceded by `comm: file 1 is not in sorted order`. Under `LC_ALL=C` the same lint exits 0. Fix is pinning `LC_ALL=C` in the script plus a re-`--bless`, which would also retire one now-removed site (51 → 50 entries). Both pushes here ran the full hook under `LC_ALL=C` rather than `--no-verify`, so fmt and clippy did run and did pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
