### PR TITLE
ci: run one lint script in both CI and the pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -4,31 +4,17 @@
 #
 # Installed automatically: the `latexml` (latexml_oxide) build script points
 # this checkout's `core.hooksPath` at `.githooks/` on first build, so every
-# contributor gets this gate without a manual `git config` step. CI runs the
-# same three checks (see .github/workflows/CI.yml `lint` job) as a backstop.
+# contributor gets this gate without a manual `git config` step.
+#
+# The checks themselves live in tools/lint.sh, which CI's `lint` job runs too —
+# one script, both callers, so the hook and CI cannot drift. They used to be
+# hand-maintained copies and had: this hook ran the xml:id ratchet, fmt and
+# clippy; CI ran fmt, clippy, rustdoc, cargo-deny, the vendored-native audit and
+# cargo-machete. Neither was a superset, so a clean push could still fail CI on
+# a check the hook never ran.
 #
 # It BLOCKS the push (non-zero exit) when any check fails — it does NOT silently
 # rewrite your tree. Fix locally, then push again. To bypass in an emergency:
 #   git push --no-verify
 #
-set -e
-
-# 1. Cheap source ratchet first (fails fast, no compile): ban new string-keyed
-#    xml: attribute accessors. See docs/XMLID_ACCESSOR_AUDIT_2026-06-08.md.
-tools/lint_xmlid_accessor.sh
-
-# 2. Formatting must already be applied (check, don't rewrite).
-if ! cargo +nightly fmt --all --check; then
-  echo >&2
-  echo "✗ pre-push: code is not formatted. Run:  cargo +nightly fmt --all" >&2
-  exit 1
-fi
-
-# 3. Clippy must be clean across the whole workspace and all targets
-#    (tests/benches/bins), matching CI. The old hook checked only the default
-#    package/targets and missed most crates.
-if ! cargo +nightly clippy --workspace --all-targets -- --deny warnings; then
-  echo >&2
-  echo "✗ pre-push: clippy warnings present. Fix them (try: cargo +nightly clippy --fix)." >&2
-  exit 1
-fi
+exec tools/lint.sh

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,10 +13,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Fast-failing quality gate, mirroring the local pre-push hook
-  # (.githooks/pre-push). No TeX Live: the engine compiles without on-disk
-  # dumps (self-contained / embedded-fallback invariant), so clippy only needs
-  # the C library headers, not a texmf tree. Runs in parallel with `test`.
+  # Quality gate, running the SAME script as the local pre-push hook
+  # (tools/lint.sh — see the comment on the gate step below). No TeX Live: the
+  # engine compiles without on-disk dumps (self-contained / embedded-fallback
+  # invariant), so clippy only needs the C library headers, not a texmf tree.
+  # Runs in parallel with `test`.
+  #
+  # The gate deliberately does NOT stop at the first failed check: it reports
+  # every failure in one run. Fail-fast costs a whole CI cycle per failure when
+  # several checks are broken at once, which is worse than the few extra
+  # minutes. (tools/lint.sh --fail-fast restores the old behaviour.)
+  #
+  # `name:` is load-bearing — it is the check name branch protection matches.
+  # Don't rename it casually, even though the gate now covers more than three
+  # tools.
   lint:
     name: lint (fmt + clippy + deny)
     runs-on: ubuntu-latest
@@ -41,19 +51,29 @@ jobs:
         with:
           cache-on-failure: true
           key: lint
-      - name: rustfmt (check)
-        run: cargo fmt --all --check
-      - name: clippy (deny warnings, whole workspace + all targets)
-        run: cargo clippy --workspace --all-targets --profile ci -- -D warnings
-      # Gate the docs HERE, on the pull_request, not only in rustdoc.yml — that
-      # workflow runs on push to main, so a doc warning introduced by a PR would
-      # only surface once it had already landed. A broken rustdoc link is
-      # invisible on the deployed site (it renders as dead text, not an error),
-      # so the warning is the only signal there is.
-      - name: rustdoc (deny warnings)
+      # cargo-machete is installed BEFORE the gate below, which runs it.
+      - name: install cargo-machete
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-machete
+
+      # The gate itself: xml:id ratchet, rustfmt, clippy, rustdoc, the
+      # vendored-native audit and cargo-machete. It lives in tools/lint.sh
+      # because .githooks/pre-push runs the SAME script — one source of truth,
+      # so the hook and CI cannot drift. (They were hand-maintained copies and
+      # did drift: neither was a superset of the other, so a push could pass the
+      # hook and still fail here on a check the hook never ran.) The per-check
+      # rationale lives in that script, next to each check.
+      #
+      # LINT_PROFILE=ci keeps the RAM-tuned profile for this 16 GB runner;
+      # LINT_STRICT=1 makes a missing tool an error here rather than the loud
+      # skip a local run is allowed to take.
+      - name: lint gate (tools/lint.sh — same script as .githooks/pre-push)
         env:
-          RUSTDOCFLAGS: -D warnings
-        run: cargo doc --workspace --no-deps --profile ci
+          LINT_PROFILE: ci
+          LINT_STRICT: "1"
+        run: tools/lint.sh
+
       - name: cargo-deny (advisories + licenses + bans + sources)
         # The action's default arguments inject `--all-features`, so this audits
         # feature-gated trees too (e.g. the off-by-default `cortex` worker deps).
@@ -68,23 +88,10 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@v2.0.20
         with:
           command: check
-
-      # The complement to cargo-deny, which reasons over crate MANIFESTS and so is
-      # blind to vendored C: a `-sys` crate reports its Rust wrapper's license, not
-      # the native library's. That gap is why libmarpa statically linked
-      # MIT + LGPL-3.0/LGPL-2.1 code into every binary we ever shipped, attributed
-      # nowhere, while `cargo deny check licenses` said "licenses ok" throughout.
-      # This fails when a crate compiling native code shows up unaudited.
-      # See docs/release/LICENSE_INVENTORY.md §D.2 / §A "Scope limit".
-      - name: audit vendored native code (cargo-deny's blind spot)
-        run: python3 tools/audit_vendored_natives.py --verbose
-
-      - name: install cargo-machete
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-machete
-      - name: cargo-machete (unused dependencies)
-        run: cargo machete
+        # Stays a separate step, and stays CI's real gate for licenses: it is a
+        # Docker action, so tools/lint.sh cannot invoke it. That script runs
+        # `cargo deny` only when the binary happens to be installed locally, as
+        # a pre-push convenience — it is not a substitute for this step.
 
   # Miri (UB detector) over the FFI-FREE pure-Rust `unsafe` — the string
   # interner / arena bounds-skip (resolve_unchecked) + re-entrant `&mut *ptr`

--- a/latexml_oxide/build.rs
+++ b/latexml_oxide/build.rs
@@ -1,16 +1,20 @@
 //! Build script for the top-level `latexml` crate.
 //!
 //! Its only job is a developer convenience: point this checkout's git at the
-//! repo's tracked hooks (`.githooks/`) so every contributor gets the
-//! fmt + clippy pre-push gate automatically on their first `cargo build`/`test`
-//! — no manual `git config core.hooksPath` step (which is easy to forget, and
-//! its absence is exactly how unformatted / clippy-dirty branches reach CI).
+//! repo's tracked hooks (`.githooks/`) so every contributor gets the pre-push
+//! lint gate (`tools/lint.sh`, the same script CI runs) automatically on their
+//! first `cargo build`/`test` — no manual `git config core.hooksPath` step
+//! (which is easy to forget, and its absence is exactly how unformatted /
+//! clippy-dirty branches reach CI).
 //!
 //! It is a strict no-op outside a source git checkout — packaged crates,
 //! `cargo install`, and release tarballs have no `.git`, so distribution builds
 //! are unaffected — and it never fails the build (every git call is best-effort).
 
-use std::{path::Path, process::Command};
+use std::{
+  path::{Path, PathBuf},
+  process::Command,
+};
 
 fn main() {
   install_git_hooks();
@@ -76,28 +80,71 @@ fn install_git_hooks() {
     return;
   }
 
-  // Idempotent: leave it alone if it already points at our hooks.
   let current = Command::new("git")
     .current_dir(repo_root)
     .args(["config", "--local", "--get", "core.hooksPath"])
     .output();
-  if let Ok(out) = &current
-    && String::from_utf8_lossy(&out.stdout).trim() == ".githooks"
-  {
+  let current_raw = current
+    .as_ref()
+    .ok()
+    .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+    .unwrap_or_default();
+
+  // Resolve a configured hooksPath the way git does — relative to the repo root
+  // — so we compare DIRECTORIES, not strings.
+  let resolve = |value: &str| -> Option<PathBuf> {
+    let trimmed = Path::new(value.trim_end_matches('/'));
+    let abs = if trimmed.is_absolute() {
+      trimmed.to_path_buf()
+    } else {
+      repo_root.join(trimmed)
+    };
+    std::fs::canonicalize(abs).ok()
+  };
+  let same_dir = |a: &str, b: &Path| -> bool {
+    matches!((resolve(a), std::fs::canonicalize(b).ok()), (Some(x), Some(y)) if x == y)
+  };
+
+  // Idempotent: leave it alone if it already points at our hooks. This compares
+  // resolved paths because a string compare against ".githooks" missed both
+  // ".githooks/" — the trailing-slash form CLAUDE.md tells contributors to use —
+  // and any absolute path to the same directory. Those fell through to the
+  // "custom hooksPath" branch below, so the gate stayed off while this script
+  // believed the user had deliberately chosen that.
+  if !current_raw.is_empty() && same_dir(&current_raw, &repo_root.join(".githooks")) {
     return;
   }
 
+  // A hooksPath pointing at git's OWN default (<repo>/.git/hooks) is not a
+  // deliberate choice — it is where git looks anyway — so treat it as unset and
+  // wire up the gate. Without this, a checkout whose hooksPath had been set to
+  // the default kept the gate silently disabled forever: the notice below goes
+  // to stderr, which cargo shows only under `-vv` or on failure. That is how
+  // three unformatted/doc-broken pushes reached CI on 2026-07-24.
+  //
+  // Unless the directory actually carries a hook, that is — everything git ships
+  // there is a `.sample`. If a real one is present, it is someone's, so respect it.
+  let default_hooks = repo_root.join(".git/hooks");
+  let default_carries_hooks = std::fs::read_dir(&default_hooks)
+    .map(|entries| {
+      entries
+        .flatten()
+        .any(|e| e.path().is_file() && !e.file_name().to_string_lossy().ends_with(".sample"))
+    })
+    .unwrap_or(false);
+  let redundant_default = same_dir(&current_raw, &default_hooks) && !default_carries_hooks;
+
   // Respect a deliberately-set custom hooksPath rather than clobbering it; just
   // nudge. Otherwise (the common unset case) wire up the gate.
-  let already_custom = matches!(&current, Ok(out) if !out.stdout.is_empty());
+  let already_custom = !current_raw.is_empty() && !redundant_default;
   if already_custom {
     // Print to stderr, NOT `cargo:warning=` — cargo replays build-script
     // warnings on every build until the script re-runs, which would turn a
     // one-time notice into perpetual noise. Build-script stderr is surfaced
     // only under `cargo build -vv` or on failure.
     eprintln!(
-      "latexml: git core.hooksPath is set to a custom value; the fmt+clippy \
-       pre-push gate lives in .githooks/ — point core.hooksPath there to enable it."
+      "latexml: git core.hooksPath is set to a custom value; the pre-push lint \
+       gate lives in .githooks/ — point core.hooksPath there to enable it."
     );
     return;
   }
@@ -109,7 +156,7 @@ fn install_git_hooks() {
   if matches!(set, Ok(s) if s.success()) {
     // stderr, not `cargo:warning=` (see the note above re: per-build replay).
     eprintln!(
-      "latexml: enabled the fmt+clippy pre-push gate \
+      "latexml: enabled the pre-push lint gate \
        (set git core.hooksPath=.githooks). Bypass once with `git push --no-verify`."
     );
   }

--- a/tools/audit_vendored_natives.py
+++ b/tools/audit_vendored_natives.py
@@ -121,9 +121,12 @@ AUDITED = {
     # ---- Build-tooling and test fixtures: native files present, NOT linked into any
     # shipped binary, so no disclosure is owed. Each verdict verified by looking at the
     # file, not at the name. Recorded so the gate stays loud on substance and quiet here.
-    "cc": ("1.3.0",
+    "cc": ("1.4.0",
         "src/detect_compiler_family.c -- a probe compiled to identify the host "
-        "toolchain, never linked into our binary. The crate itself is pure Rust.",
+        "toolchain, never linked into our binary. The crate itself is pure Rust. "
+        "Re-verified at 1.4.0: still the only non-Rust file in the crate, and still "
+        "nothing but #ifdef/#pragma message lines, so it emits diagnostics and no "
+        "object code.",
     ),
     "walkdir": ("2.5.0",
         "compare/nftw.c -- a benchmark comparison against C's nftw(3), not built.",

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# tools/lint.sh — the single source of truth for the quality gate.
+#
+# Called by BOTH `.github/workflows/CI.yml` (the `lint` job) and
+# `.githooks/pre-push`, so the two cannot drift. They had: the hook ran the
+# xml:id ratchet, fmt and clippy; CI ran fmt, clippy, rustdoc, cargo-deny, the
+# vendored-native audit and cargo-machete. Neither was a superset, so a push
+# could pass the hook and still fail CI on a check the hook never ran (and the
+# ratchet was never enforced in CI at all). This script runs the union.
+#
+# Unlike CI, it does NOT stop at the first failure: it runs every check and
+# reports all of them at the end. CI's fail-fast hides check N+1 behind check
+# N, which turns one bad push into a sequence of one-fix-per-run cycles.
+#
+# Usage:
+#   tools/lint.sh                # run everything, summarize failures
+#   tools/lint.sh --fail-fast    # stop at the first failure (CI-like)
+#
+# Env:
+#   LINT_PROFILE  cargo profile for clippy/rustdoc. CI sets `ci` (tuned for the
+#                 RAM-bounded runner). Local default is the dev profile — per
+#                 CLAUDE.md, local dev should not mimic CI's stripped profile.
+#   LINT_STRICT   1 = a missing required tool is an error (CI sets this).
+#                 unset/0 = warn loudly and continue (local convenience).
+#
+# Bypass in an emergency: `git push --no-verify`.
+
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail_fast=0
+[ "${1:-}" = "--fail-fast" ] && fail_fast=1
+
+profile_args=()
+[ -n "${LINT_PROFILE:-}" ] && profile_args=(--profile "$LINT_PROFILE")
+
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  BOLD=$'\033[1m'; RED=$'\033[31m'; GREEN=$'\033[32m'; YELLOW=$'\033[33m'; OFF=$'\033[0m'
+else
+  BOLD=''; RED=''; GREEN=''; YELLOW=''; OFF=''
+fi
+
+failed=()   # names of checks that failed
+skipped=()  # names of checks skipped for a missing tool
+
+step=0
+# run <name> <fix-hint> -- <command...>
+run() {
+  local name="$1" hint="$2"; shift 3   # drop the literal `--`
+  step=$((step + 1))
+  printf '%s\n' "${BOLD}[$step] $name${OFF}"
+  if "$@"; then
+    printf '%s\n\n' "    ${GREEN}ok${OFF}"
+  else
+    printf '%s\n\n' "    ${RED}FAILED${OFF} — $hint"
+    failed+=("$name")
+    if [ "$fail_fast" = 1 ]; then
+      summarize
+      exit 1
+    fi
+  fi
+}
+
+# skip <name> <why> — record loudly. A skip must never read as a pass.
+skip() {
+  step=$((step + 1))
+  printf '%s\n' "${BOLD}[$step] $1${OFF}"
+  printf '%s\n\n' "    ${YELLOW}SKIPPED${OFF} — $2"
+  skipped+=("$1")
+}
+
+summarize() {
+  printf '%s\n' "${BOLD}── summary ──${OFF}"
+  if [ ${#skipped[@]} -gt 0 ]; then
+    printf '%s\n' "${YELLOW}skipped:${OFF} ${skipped[*]}"
+  fi
+  if [ ${#failed[@]} -gt 0 ]; then
+    printf '%s\n' "${RED}failed:${OFF} ${failed[*]}"
+    printf '%s\n' "${RED}✗ lint gate failed (${#failed[@]} check(s))${OFF}"
+  else
+    printf '%s\n' "${GREEN}✓ all checks passed${OFF}"
+  fi
+}
+
+# A required tool is missing: an error under LINT_STRICT (CI), else a loud skip.
+require_or_skip() {
+  local tool="$1" name="$2" hint="$3"
+  if command -v "$tool" >/dev/null 2>&1; then
+    return 0
+  fi
+  if [ "${LINT_STRICT:-0}" = 1 ]; then
+    step=$((step + 1))
+    printf '%s\n' "${BOLD}[$step] $name${OFF}"
+    printf '%s\n\n' "    ${RED}FAILED${OFF} — $tool not installed (LINT_STRICT=1)"
+    failed+=("$name")
+  else
+    skip "$name" "$tool not installed — $hint"
+  fi
+  return 1
+}
+
+# 1. Cheap source ratchet first (no compile): ban new string-keyed xml: attribute
+#    accessors. See docs/archive/XMLID_ACCESSOR_AUDIT_2026-06-08.md.
+run "xml:id accessor ratchet" \
+  "a new string-keyed xml: accessor landed; use the *_ns form" -- \
+  tools/lint_xmlid_accessor.sh
+
+# 2. Formatting must already be applied (check, don't rewrite).
+run "rustfmt (check)" \
+  "run: cargo fmt --all" -- \
+  cargo fmt --all --check
+
+# 3. Clippy across the whole workspace and all targets (tests/benches/bins).
+run "clippy (deny warnings, workspace + all targets)" \
+  "fix them (try: cargo clippy --fix)" -- \
+  cargo clippy --workspace --all-targets "${profile_args[@]}" -- -D warnings
+
+# 4. Rustdoc. Gated HERE, on every push/PR, not only in rustdoc.yml — that
+#    workflow runs on push to main, so a doc warning introduced by a PR would
+#    only surface once it had already landed. A broken intra-doc link is
+#    invisible on the deployed site (it renders as dead text, not an error), so
+#    the warning is the only signal there is.
+run "rustdoc (deny warnings)" \
+  "fix the doc warning; do not #[allow] it — the link still dies on the site" -- \
+  env RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps "${profile_args[@]}"
+
+# 5. The complement to cargo-deny, which reasons over crate MANIFESTS and so is
+#    blind to vendored C: a `-sys` crate reports its Rust wrapper's license, not
+#    the native library's. That gap is why libmarpa statically linked
+#    MIT + LGPL-3.0/LGPL-2.1 code into every binary we ever shipped, attributed
+#    nowhere, while `cargo deny check licenses` said "licenses ok" throughout.
+#    This fails when a crate compiling native code shows up unaudited.
+#    See docs/release/LICENSE_INVENTORY.md §D.2 / §A "Scope limit".
+#    Note it can also fail with no local change at all: Cargo.lock is gitignored,
+#    so a fresh resolution picks up new upstream versions of audited crates
+#    (cc 1.3.0 -> 1.4.0 broke main and every open PR on 2026-07-24).
+run "vendored native code audit" \
+  "re-check what the new version compiles, then update AUDITED + LICENSE_INVENTORY §D.2" -- \
+  python3 tools/audit_vendored_natives.py --verbose
+
+# 6. cargo-deny. Best-effort by design: CI covers this with the PINNED
+#    EmbarkStudios/cargo-deny-action (see the rationale in CI.yml — the floating
+#    @v2 tag broke main once), so the action, not this line, is CI's gate. Here
+#    it just lets a local run catch a license/advisory problem before pushing.
+if command -v cargo-deny >/dev/null 2>&1; then
+  run "cargo-deny (advisories + licenses + bans + sources)" \
+    "see deny.toml and docs/release/LICENSE_INVENTORY.md" -- \
+    cargo deny --all-features check
+else
+  skip "cargo-deny" "not installed (CI covers it via the pinned action; install: cargo install --locked cargo-deny)"
+fi
+
+# 7. Unused dependencies.
+if require_or_skip cargo-machete "cargo-machete (unused dependencies)" \
+     "install: cargo install --locked cargo-machete"; then
+  run "cargo-machete (unused dependencies)" \
+    "drop the unused dep, or allow it in Cargo.toml [package.metadata.cargo-machete]" -- \
+    cargo machete
+fi
+
+summarize
+[ ${#failed[@]} -eq 0 ]

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -34,6 +34,12 @@ fail_fast=0
 
 profile_args=()
 [ -n "${LINT_PROFILE:-}" ] && profile_args=(--profile "$LINT_PROFILE")
+# NOTE: expand this as ${profile_args[@]+"${profile_args[@]}"}, never as a bare
+# "${profile_args[@]}". Under `set -u`, bash before 4.4 treats an EMPTY array's
+# expansion as an unbound variable and exits. profile_args is empty on every
+# local run (LINT_PROFILE unset — the pre-push path) and macOS ships bash 3.2 as
+# /bin/bash, so the bare form would kill the hook there while passing on this
+# ubuntu CI and on any bash 5 dev box.
 
 if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
   BOLD=$'\033[1m'; RED=$'\033[31m'; GREEN=$'\033[32m'; YELLOW=$'\033[33m'; OFF=$'\033[0m'
@@ -114,7 +120,7 @@ run "rustfmt (check)" \
 # 3. Clippy across the whole workspace and all targets (tests/benches/bins).
 run "clippy (deny warnings, workspace + all targets)" \
   "fix them (try: cargo clippy --fix)" -- \
-  cargo clippy --workspace --all-targets "${profile_args[@]}" -- -D warnings
+  cargo clippy --workspace --all-targets ${profile_args[@]+"${profile_args[@]}"} -- -D warnings
 
 # 4. Rustdoc. Gated HERE, on every push/PR, not only in rustdoc.yml — that
 #    workflow runs on push to main, so a doc warning introduced by a PR would
@@ -123,7 +129,7 @@ run "clippy (deny warnings, workspace + all targets)" \
 #    the warning is the only signal there is.
 run "rustdoc (deny warnings)" \
   "fix the doc warning; do not #[allow] it — the link still dies on the site" -- \
-  env RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps "${profile_args[@]}"
+  env RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps ${profile_args[@]+"${profile_args[@]}"}
 
 # 5. The complement to cargo-deny, which reasons over crate MANIFESTS and so is
 #    blind to vendored C: a `-sys` crate reports its Rust wrapper's license, not


### PR DESCRIPTION
> **Stacked on #364** (the `cc` audit unblock). Until that merges, this PR's diff shows both commits; afterwards only the lint changes remain.

## The problem

CI's `lint` job and `.githooks/pre-push` were hand-maintained copies that had drifted, and **neither was a superset**:

| Check | pre-push | CI |
|---|:--:|:--:|
| xml:id accessor ratchet | ✅ | ❌ |
| rustfmt | ✅ | ✅ |
| clippy | ✅ | ✅ |
| rustdoc `-D warnings` | ❌ | ✅ |
| cargo-deny | ❌ | ✅ |
| vendored-native audit | ❌ | ✅ |
| cargo-machete | ❌ | ✅ |

So a push could pass the hook and still fail CI on a check the hook never ran — and the ratchet was never enforced in CI at all. #363 hit this twice in a row: first rustfmt, then rustdoc, one CI cycle each.

## The fix

Both callers now run **`tools/lint.sh`**, which performs the union. Two deliberate differences from the old CI job:

- **It does not stop at the first failure.** Fail-fast hides check N+1 behind check N, which turns one bad push into a sequence of one-fix-per-run cycles — precisely what #363 became. The script runs everything and reports all failures at the end. `--fail-fast` restores the old behaviour.
- **cargo-deny stays a separate CI step.** It's a Docker action (pinned, for the reason recorded in `CI.yml`), so the script can't invoke it. The script runs `cargo deny` only when the binary is installed locally, as a pre-push convenience, and *says so* rather than passing silently.

Skips are loud and never read as a pass, per the canvas signal-integrity rule; `LINT_STRICT=1` (set by CI) turns a missing tool into an error instead. `LINT_PROFILE` keeps CI on the RAM-tuned `ci` profile while local runs use dev, per CLAUDE.md.

Per-check rationale moved into the script next to each check, including the libmarpa LGPL story behind the vendored-native audit and why rustdoc is gated on the PR rather than only in `rustdoc.yml`.

## Why none of this was running locally

Worth flagging, because it's the same class of bug one level down: **the pre-push gate was silently inert on my checkout**, which is how three unformatted/doc-broken pushes reached CI in the first place.

`build.rs` compared `core.hooksPath` against the literal string `".githooks"`. That fails to recognise:
1. `".githooks/"` — the trailing-slash form **CLAUDE.md itself tells contributors to use**, and
2. any absolute path to the same directory.

Both fall through to the "custom hooksPath" branch, which respects the value and only warns on **stderr** — where cargo shows it under `-vv` or on failure, i.e. effectively never. On this checkout `hooksPath` had been set to git's *own default* (`<repo>/.git/hooks`, holding nothing but `.sample` files), so `build.rs` concluded the user had deliberately chosen it and stood down, permanently.

It now compares **resolved directories** and treats a redundant default as unset, while still respecting a hooksPath that carries a real hook.

## Verification

- `tools/lint.sh` → all 7 checks, exit 0; `LINT_PROFILE=nonexistent` → 2 failures collected in one run, exit 1 (confirms it doesn't stop at the first).
- `build.rs`: set `hooksPath` to the absolute default → next build adopts `.githooks`. Set it to `.githooks/` → recognised as ours, left alone, no warning.
- End-to-end: the first push of this branch was **blocked by the repaired hook** for an unformatted `build.rs` — caught locally instead of in CI, which is the whole point. Second push: all seven green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)