### PR TITLE
fix: pin LC_ALL=C in the xml:id lint so its verdict stops depending on locale

### DIFF
--- a/tools/lint_xmlid_accessor.sh
+++ b/tools/lint_xmlid_accessor.sh
@@ -24,6 +24,21 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+# Byte-exact, locale-independent collation. NOT optional: the baseline is a
+# CHECKED-IN sorted file diffed with `comm`, which pairs lines byte-wise, while
+# `sort` under a UTF-8 locale collates punctuation-insensitively. The two
+# variants below then compare EQUAL to `sort` and may be blessed in any order:
+#     ...get_attribute("xml:id"))
+#     ...get_attribute("xml:id"));
+# The file passes `sort -c` yet is unsorted to `comm`, which prints
+# "comm: file N is not in sorted order" and reports already-baselined sites as
+# NEW -- a false failure that blocks `git push` (this lint is a pre-push hook)
+# on a tree with no Rust changes at all. It also made the verdict depend on the
+# runner's locale: green on CI's C.UTF-8, red on an en_US.UTF-8 dev box, for
+# the same commit. Pinning here covers `sort`, `comm` and `grep` together, so
+# a baseline blessed anywhere compares identically everywhere.
+export LC_ALL=C
+
 BASELINE="tools/xmlid_lint_baseline.txt"
 CRATES=(latexml_core latexml_engine latexml_package latexml_post
         latexml_math_parser latexml_contrib latexml_oxide latexml_codegen)

--- a/tools/xmlid_lint_baseline.txt
+++ b/tools/xmlid_lint_baseline.txt
@@ -1,23 +1,23 @@
 latexml_core/src/document.rs	&& !current.has_attribute("xml:id")
 latexml_core/src/document.rs	&& !dual.has_attribute("xml:id")
+latexml_core/src/document.rs	&& let Some(id) = pres.get_attribute("xml:id")
 latexml_core/src/document.rs	if let Some(id) = node.get_attribute("xml:id") {
 latexml_core/src/document.rs	let _ = pres.remove_attribute("xml:id");
 latexml_core/src/document.rs	let _ = tok.remove_attribute("xml:id");
 latexml_core/src/document.rs	let pres_had_id = pres.has_attribute("xml:id");
-latexml_core/src/document.rs	&& let Some(id) = pres.get_attribute("xml:id")
 latexml_core/src/document.rs	let to_has_id = to.has_attribute("xml:id")
-latexml_core/src/rewrite.rs	|| n.get_attribute("xml:id").as_deref() == Some(&target_id)
 latexml_core/src/rewrite.rs	.get_property("xml:id")
 latexml_core/src/rewrite.rs	.get_property("xml:id")
 latexml_core/src/rewrite.rs	let id = tree.get_attribute("xml:id").unwrap_or_default();
+latexml_core/src/rewrite.rs	|| n.get_attribute("xml:id").as_deref() == Some(&target_id)
 latexml_engine/src/base_xmath.rs	.get_attribute("xml:id")
 latexml_engine/src/base_xmath.rs	.or_else(|| eq.get_attribute("xml:id"))
 latexml_engine/src/base_xmath.rs	.or_else(|| eq.get_attribute("xml:id"))
-latexml_engine/src/base_xmath.rs	.or_else(|| eq.get_attribute("xml:id"));
 latexml_engine/src/base_xmath.rs	.or_else(|| eq.get_attribute("xml:id"))
+latexml_engine/src/base_xmath.rs	.or_else(|| eq.get_attribute("xml:id"));
 latexml_engine/src/base_xmath.rs	with(qname, |qstr| qstr.starts_with("ltx:XM")) && !node.has_attribute("xml:id") {
-latexml_engine/src/latex_constructs.rs	float.remove_attribute("xml:id").ok();
 latexml_engine/src/latex_constructs.rs	.get_attribute("xml:id")
+latexml_engine/src/latex_constructs.rs	float.remove_attribute("xml:id").ok();
 latexml_engine/src/latex_constructs.rs	if node.has_attribute("labels") && !node.has_attribute("xml:id") {
 latexml_engine/src/math_common.rs	not_node.remove_attribute("xml:id")?;
 latexml_math_parser/src/data.rs	if child.get_attribute("xml:id").as_deref() == Some(id) {
@@ -31,16 +31,15 @@ latexml_math_parser/src/parser.rs	let script_id = match script.get_attribute("xm
 latexml_math_parser/src/parser.rs	node.remove_attribute("xml:id")?;
 latexml_math_parser/src/util.rs	.get_attribute("xml:id")
 latexml_math_parser/src/util.rs	match node.get_attribute("xml:id") {
-latexml_oxide/src/core_interface.rs	let _ = node.remove_attribute("xml:id");
-latexml_oxide/src/core_interface.rs	let _ = node.remove_attribute("xml:id");
 latexml_oxide/src/core_interface.rs	.or_else(|| p.get_attribute("xml:id"))
+latexml_oxide/src/core_interface.rs	let _ = node.remove_attribute("xml:id");
+latexml_oxide/src/core_interface.rs	let _ = node.remove_attribute("xml:id");
 latexml_package/src/package/amsmath_sty.rs	.or_else(|| node.get_attribute("xml:id"))
 latexml_package/src/package/latexml_sty/declare.rs	.get_property("xml:id")
 latexml_post/src/collector.rs	let root_id = root.get_attribute("xml:id").unwrap_or_default();
-latexml_post/src/document.rs	if let Some(id) = idd.get_attribute("xml:id") {
-latexml_post/src/document.rs	if let Some(id) = n.get_attribute("xml:id") {
-latexml_post/src/document.rs	if let Some(id) = p.get_attribute("xml:id") {
 latexml_post/src/document.rs	.or_else(|| node.get_attribute("xml:id"))
+latexml_post/src/document.rs	if let Some(id) = idd.get_attribute("xml:id") {
+latexml_post/src/document.rs	if let Some(id) = p.get_attribute("xml:id") {
 latexml_post/src/make_bibliography.rs	.and_then(|r| r.get_attribute("xml:id"))
 latexml_post/src/make_bibliography.rs	.get_attribute("xml:id")
 latexml_post/src/make_bibliography.rs	let orig_id = bibentry.get_attribute("xml:id").unwrap_or_default();


### PR DESCRIPTION
Follow-up to #365, **stacked on it** (base is `docs-test-verification-refresh`, not `main`) so it stands green on its own — a branch off `main` would trip the cc-1.4.0 vendored-natives failure that #365 fixes. GitHub will retarget this to `main` when #365 merges; happy to rebase instead if you'd rather land them in the other order.

## The bug

`tools/lint_xmlid_accessor.sh` fails on a tree with **no Rust changes at all**, and it runs as a pre-push hook, so it blocks `git push` outright:

```
comm: file 1 is not in sorted order
xml:id accessor footgun — NEW string-keyed xml: accessor(s) found:
  + latexml_engine/src/base_xmath.rs	.or_else(|| eq.get_attribute("xml:id"))
  + latexml_engine/src/base_xmath.rs	.or_else(|| eq.get_attribute("xml:id"))
```

Both reported sites are **already baselined**. The baseline is a checked-in sorted file diffed with `comm`, which pairs lines byte-wise, while `sort` under a UTF-8 locale collates punctuation-insensitively — so these two

```
...get_attribute("xml:id"))
...get_attribute("xml:id"));
```

compare **equal** to `sort` and may be blessed in either order. The file then passes `sort -c` while being unsorted as far as `comm` is concerned, and `comm` mis-pairs the run, emitting already-baselined lines as new.

The sharper problem is that this made the gate's verdict a function of the runner's locale: **green on CI's `C.UTF-8`, red on an `en_US.UTF-8` dev box, for the identical commit.** A checked-in sorted artifact has to be collated deterministically, or it cannot be compared anywhere but where it was written.

## The fix

`export LC_ALL=C` for the whole script — covering `sort`, `comm` and `grep` together — plus a re-`--bless`.

The baseline also drops one site fixed since it was written (`latexml_post/src/document.rs`, `n.get_attribute("xml:id")`), which the lint had been reporting as a `NOTE`: **51 → 50** entries. The rest of that diff is byte-order reshuffling of identical lines.

## Verification

The point of a lint fix is that the lint doesn't go soft, so:

| | `LC_ALL=C` | `LC_ALL=en_US.UTF-8` |
|---|---|---|
| clean tree | exit 0 | exit 0 |
| fresh violation planted | exit 1, names the file | exit 1, names the file |

Before this change those two columns disagreed on a clean tree. The planted violation (`node.get_attribute("xml:lang")` in a scratch `.rs` under a scanned crate) is still caught and reported by path.

End-to-end: this branch was pushed from an ordinary `en_US.UTF-8` shell with **no** `LC_ALL` override — the exact configuration that previously refused to push — and the full hook (xml:id lint + `cargo fmt --check` + `cargo clippy -D warnings`) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)