### PR TITLE
fix(memory): make --max-memory win over LATEXML_RSS_CAP_BYTES, and resync the #361 doc

### DIFF
--- a/docs/performance/ISSUE_361_MEMORY_TIME_PROFILE_2026-07-24.md
+++ b/docs/performance/ISSUE_361_MEMORY_TIME_PROFILE_2026-07-24.md
@@ -10,15 +10,24 @@ subsubsections**, tikz/tabular/array/verbatim-heavy, CRLF line endings. Command:
 **beats Perl** on the same host (Perl throws many `\FancyVerbGetLine`
 unbalanced-input errors at the CRLF EOF and had not finished at 2 min). The
 user's reported fatals are the **default resource guards** being too tight for a
-legit huge single doc (they are FLEET-tuned): peak RSS trips the 4.5 GB stomach
-fuse (`LATEXML_RSS_CAP_BYTES`), and the ~20 s digestion trips the 60 s
-`--timeout` on the reporter's slower VM. The reporter is unblocked via the
-runtime knobs (`LATEXML_RSS_CAP_BYTES=<big> --max-memory <big> --timeout 0`);
-this doc is the **performance follow-up** to shrink RAM + time faithfully.
+legit huge single doc (they are FLEET-tuned): peak RSS trips the cooperative
+stomach fuse (~4.5 GB at the default ceiling), and the ~20 s digestion trips the
+60 s `--timeout` on the reporter's slower VM. The reporter is unblocked via the
+runtime knobs — **`--max-memory 0 --timeout 0`**; this doc is the **performance
+follow-up** to shrink RAM + time faithfully.
+
+> **Knob note (post-PR #363).** `--max-memory` is now the *single* memory knob:
+> the soft stomach fuse is derived from it (`soft_cap_from_ceiling`, 75 % of the
+> ceiling — which reproduces the historical ~4.5 GB fuse at the 6144 MiB
+> default), and a `0` from any source resolves to "disabled" for **both** the
+> soft fuse and the hard watchdog. `LATEXML_RSS_CAP_BYTES` survives only as a
+> fallback when no ceiling is given (and as the test-harness override), so it is
+> no longer the thing to reach for. The measurements below were taken with both
+> guards off and are unaffected; only the invocation is simpler now.
 
 ## Baseline (fast dev box, release build, guards off)
 
-`LATEXML_RSS_CAP_BYTES=60000000000 latexml_oxide --timeout 0 --max-memory 0 --splitat=subsection --format=html5 --dest=out/index.htm index.tex`
+`latexml_oxide --max-memory 0 --timeout 0 --splitat=subsection --format=html5 --dest=out/index.htm index.tex`
 
 - **Peak RSS 9.05 GB**, **wall 38.8 s**, 0 errors, 3007 split pages / 79 MB out.
 - Perl same-host: **7.36 GB and climbing, unfinished at 2 min, many errors.**
@@ -42,8 +51,8 @@ building the DOM, then drop. **Peak = boxes + DOM together.** During pure
 digestion the boxes sit on the boxing stack in one context
 (`localized_box_list_total ≈ 236 832` top-level entries at 6 GB, each a subtree
 — recursive box count far higher). Diagnose with
-`LATEXML_DEBUG_MEMBUDGET=1 LATEXML_RSS_CAP_BYTES=<N>` (dumps box_list /
-localized_box_list sizes + a backtrace at the cap).
+`LATEXML_DEBUG_MEMBUDGET=1 --max-memory <MiB>` (dumps box_list /
+localized_box_list sizes + a backtrace when the derived soft fuse trips).
 
 ### TIME — flat, no silver bullet
 

--- a/docs/performance/ISSUE_361_MEMORY_TIME_PROFILE_2026-07-24.md
+++ b/docs/performance/ISSUE_361_MEMORY_TIME_PROFILE_2026-07-24.md
@@ -19,11 +19,15 @@ follow-up** to shrink RAM + time faithfully.
 > **Knob note (post-PR #363).** `--max-memory` is now the *single* memory knob:
 > the soft stomach fuse is derived from it (`soft_cap_from_ceiling`, 75 % of the
 > ceiling — which reproduces the historical ~4.5 GB fuse at the 6144 MiB
-> default), and a `0` from any source resolves to "disabled" for **both** the
-> soft fuse and the hard watchdog. `LATEXML_RSS_CAP_BYTES` survives only as a
-> fallback when no ceiling is given (and as the test-harness override), so it is
-> no longer the thing to reach for. The measurements below were taken with both
-> guards off and are unaffected; only the invocation is simpler now.
+> default), and `--max-memory=0` disables **both** the soft fuse and the hard
+> watchdog. It is also the *winner*: it overrides `LATEXML_RSS_CAP_BYTES`, so no
+> env var can quietly countermand what you typed. That env still governs
+> embedders which never parse CLI flags — the library test harness and the
+> `cortex_worker` fleet, which pins each child to its `--max-rss-mb` — but in the
+> binary it is no longer the thing to reach for. Note `LATEXML_RSS_CAP_BYTES=0`
+> is NOT equivalent to `--max-memory=0`: it only silences the soft fuse where it
+> still applies, and never touches the watchdog. The measurements below were
+> taken with both guards off and are unaffected; only the invocation is simpler.
 
 ## Baseline (fast dev box, release build, guards off)
 
@@ -51,8 +55,9 @@ building the DOM, then drop. **Peak = boxes + DOM together.** During pure
 digestion the boxes sit on the boxing stack in one context
 (`localized_box_list_total ≈ 236 832` top-level entries at 6 GB, each a subtree
 — recursive box count far higher). Diagnose with
-`LATEXML_DEBUG_MEMBUDGET=1 --max-memory <MiB>` (dumps box_list /
-localized_box_list sizes + a backtrace when the derived soft fuse trips).
+`LATEXML_DEBUG_MEMBUDGET=1 latexml_oxide --max-memory <MiB>` (dumps box_list /
+localized_box_list sizes + a backtrace when the derived soft fuse trips, i.e. at
+75 % of `<MiB>` — so pick a ceiling whose 75 % is where you want the dump).
 
 ### TIME — flat, no silver bullet
 

--- a/latexml_core/src/stomach.rs
+++ b/latexml_core/src/stomach.rs
@@ -73,19 +73,21 @@ pub fn soft_cap_from_ceiling(max_memory_mib: u64) -> u64 {
 
 /// Apply the single `--max-memory` ceiling (MiB) to this thread's cooperative
 /// soft fuse, so the one knob means the same thing on every conversion path.
-/// Returns `false` — leaving the fuse alone — when `LATEXML_RSS_CAP_BYTES` pins
-/// it explicitly, which is the fleet/test decoupling escape hatch.
 ///
-/// Callers must be BOTH the plain conversion path and the `--server` forked
-/// body child. When only the former called it, `--server --max-memory=0` still
-/// ran against a live 4.5 GB fuse while the help text promised the limit was
-/// off — the hard Watchdog was the only guard the LSP path wired to the knob.
-pub fn apply_memory_ceiling(max_memory_mib: u64) -> bool {
-  if std::env::var_os("LATEXML_RSS_CAP_BYTES").is_some() {
-    return false;
-  }
+/// **`--max-memory` wins over `LATEXML_RSS_CAP_BYTES`, unconditionally.** The
+/// flag is the single knob; an env var must not silently override what the user
+/// typed. This deliberately overwrites the env, which is why the env keeps its
+/// meaning exactly where no flag exists to contradict it: embedders that never
+/// parse CLI arguments and so never reach this function — the library test
+/// harness (`util::test`, which pins 9 GB) and the `cortex_worker` fleet (which
+/// pins each child to its `--max-rss-mb`). Both are unaffected.
+///
+/// Callers must be EVERY conversion path: the plain one, the `--server` forked
+/// body child, and the in-process fallback. When only the first called it,
+/// `--server --max-memory=0` still ran against a live 4.5 GB fuse while the help
+/// text promised the limit was off.
+pub fn apply_memory_ceiling(max_memory_mib: u64) {
   set_memory_cap(Some(soft_cap_from_ceiling(max_memory_mib)));
-  true
 }
 
 /// Resolve the effective soft-RSS budget: `None` = disabled (no ceiling),
@@ -94,6 +96,10 @@ pub fn apply_memory_ceiling(max_memory_mib: u64) -> bool {
 /// default. A cap of `0` from EITHER source resolves to `None`, so
 /// `--max-memory=0` / `LATEXML_RSS_CAP_BYTES=0` mean "no limit" — not "abort
 /// immediately" (a literal `0` compared as `rss_bytes > 0` is always true).
+///
+/// Note the env is consulted only when nothing set the override — i.e. only for
+/// embedders that never call [`apply_memory_ceiling`]. Every path in the
+/// `latexml_oxide` binary calls it, so there `--max-memory` always wins.
 fn resolve_rss_cap() -> Option<u64> {
   let cap = RSS_CAP_OVERRIDE.with(|c| c.get()).unwrap_or_else(|| {
     std::env::var("LATEXML_RSS_CAP_BYTES")
@@ -1795,18 +1801,25 @@ mod memory_cap_tests {
   // what every conversion path calls. `--max-memory=0` has to leave NO ceiling:
   // the plain path, the `--server` forked body child and the in-process fallback
   // all rely on this one function, and the LSP pair used to skip it entirely.
+  //
+  // The env-precedence half is deliberately NOT asserted here: proving it needs
+  // `set_var`, and this workspace has a standing rule against touching the
+  // process env from tests (a concurrent read races glibc's getenv). It holds by
+  // construction instead — `apply_memory_ceiling` sets the override
+  // unconditionally, and `resolve_rss_cap` only consults the env when no
+  // override is present.
   #[test]
   fn apply_memory_ceiling_drives_the_fuse() {
-    assert!(apply_memory_ceiling(6144), "no env pin, so it applies");
+    apply_memory_ceiling(6144);
     assert_eq!(resolve_rss_cap(), Some(4608 * 1024 * 1024));
 
     // 0 means "no limit", not "abort immediately".
-    assert!(apply_memory_ceiling(0));
+    apply_memory_ceiling(0);
     assert_eq!(resolve_rss_cap(), None, "--max-memory=0 leaves no ceiling");
 
     // A tight ceiling is honored rather than ignored in favour of the old
     // built-in 4.5 GB default, which sat far ABOVE such a ceiling.
-    assert!(apply_memory_ceiling(2000));
+    apply_memory_ceiling(2000);
     assert_eq!(resolve_rss_cap(), Some(1500 * 1024 * 1024));
 
     set_memory_cap(None);

--- a/latexml_oxide/bin/latexml_oxide.rs
+++ b/latexml_oxide/bin/latexml_oxide.rs
@@ -777,11 +777,13 @@ fn real_main() -> Result<(), Box<dyn Error>> {
     // knob. The hard Watchdog ceiling above rides it directly; the cooperative
     // stomach RSS fuse is DERIVED from it (a fixed fraction below, leaving
     // post-processing headroom) rather than being an independent number — so
-    // one flag governs one limit and `--max-memory=0` disables both. An
-    // explicit `LATEXML_RSS_CAP_BYTES` still overrides just the soft fuse (the
-    // fleet/test decoupling escape hatch), so honor it when present.
-    let ceiling_applied = latexml_core::stomach::apply_memory_ceiling(cli.max_memory);
-    if cli.max_memory == 0 && ceiling_applied {
+    // one flag governs one limit and `--max-memory=0` disables both. It also
+    // WINS over `LATEXML_RSS_CAP_BYTES`: no env var may quietly override what
+    // the user typed. That env still governs embedders which never parse CLI
+    // flags and so never get here (the library test harness, the cortex_worker
+    // fleet) — see `stomach::apply_memory_ceiling`.
+    latexml_core::stomach::apply_memory_ceiling(cli.max_memory);
+    if cli.max_memory == 0 {
       // Removing the surprise of one flag silently disabling two guards: say
       // so, out loud, when the whole memory limit is off.
       latexml_core::Warn!(


### PR DESCRIPTION
PR #363 made `--max-memory` the single memory knob (the cooperative stomach fuse is derived from it at 75% of the ceiling; `--max-memory=0` disables both guards). It landed alongside the #361 memory work, which left the #361 profile doc telling readers to reach for `LATEXML_RSS_CAP_BYTES`.

## The precedence was backwards

Writing the doc surfaced a real bug: it described the *intended* behaviour, and the code did the opposite. `apply_memory_ceiling()` bailed out whenever `LATEXML_RSS_CAP_BYTES` was set, so **the env var overrode the flag**. Measured on `equality_big.tex`:

```
LATEXML_RSS_CAP_BYTES=1000 latexml_oxide --max-memory=6144 …   →  1 fatal (memory budget)
```

A 1 KB env cap beating an explicit 6 GiB ceiling. An env var must not quietly countermand what the user typed — least of all for the knob we just declared to be the only one. Same invocation now reports **0 fatals**.

## Why applying it unconditionally is safe

The env keeps its meaning exactly where no flag exists to contradict it — embedders that never parse CLI arguments and so never reach this function:

- **`util::test`**, the library test harness, which pins 9 GB;
- **`cortex_worker`**, which has no `--max-memory` at all and pins each spawned child to its own `--max-rss-mb` (it sets the env on *its own* harness re-spawns, not on `latexml_oxide`).

Both verified not to call `apply_memory_ceiling`, and no test spawns the binary with the env set.

## Doc corrections

Two claims in the original doc didn't survive checking:

1. *"a `0` from any source disables both guards"* — false. `LATEXML_RSS_CAP_BYTES=0` silences only the soft fuse where that still applies, and never the watchdog: `LATEXML_RSS_CAP_BYTES=0 --max-memory=1` still exits **137**.
2. The membudget recipe read `LATEXML_DEBUG_MEMBUDGET=1 --max-memory <MiB>` — missing its binary, so the flag looked like an env var. Also notes the dump now fires at 75% of `<MiB>`.

## Testing

`tools/lint.sh` — all 7 checks green. `memory_cap` unit tests pass. Behaviour verified end-to-end before/after, plus the `137` check above.

The measurements in the doc are unaffected — they were taken with both guards off either way; only the invocation is simpler now.

Refs #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)