### PR TITLE
Whatsit audit: port the missing environment locator range, and settle the reversion-cache question

### DIFF
--- a/latexml_core/src/whatsit.rs
+++ b/latexml_core/src/whatsit.rs
@@ -394,6 +394,25 @@ impl Object for Whatsit {
     // Now cache it, in case it's needed again (Perl does: `Whatsit.pm` L134-138).
     // TODO: DG: We can't yet cache reversions, because we lack mutability on .revert()
     //       should we reorganize? is it worth it?
+    //
+    // MEASURED — **not worth it**. Classifying each `revert()` at call time as a
+    // first (a memo would MISS) or a repeat (would HIT) gives the exact hit rate
+    // a cache would achieve:
+    //
+    //   #361 witness, 232 K lines / 11.5 M boxes / 37 s :  78 572 calls,  0.0 % hit
+    //   equality_big (math benchmark)                    :   1 106 calls,  0.0 % hit
+    //   si (siunitx)                                     :  22 728 calls, 63.8 % hit
+    //   mathtools                                        :   1 867 calls, 50.5 % hit
+    //
+    // Repeats track *packages that re-read their arguments* (siunitx, mathtools),
+    // not document scale — and on the large document, the one case where time
+    // actually matters, the cache would never fire once in 78 K reverts. Where it
+    // does hit, the volume is trivial. Perl's "big performance boost" reflects
+    // Perl's per-call cost (interpreted, object-heavy), not call volume; our
+    // per-call cost is far lower, so the same hit rate buys far less. Don't build
+    // this without a payload showing BOTH a high hit rate and a material share of
+    // runtime (`revert` does not appear in the #361 profile's top self-time).
+    //
     // NB: both slots are `Option<Box<_>>` (issue #361 M4) — keep the `Box::new`
     // below if this is ever re-enabled.
     //

--- a/latexml_core/src/whatsit.rs
+++ b/latexml_core/src/whatsit.rs
@@ -175,6 +175,23 @@ impl Whatsit {
     self.properties.insert("body", Digested::from(list).into());
     if let Some(digested) = trailer_opt {
       self.properties.insert("trailer", digested.clone().into());
+      // Perl `Whatsit.pm` L84: the whatsit's locator becomes the RANGE from its
+      // own start to the trailer's end, so an environment reports the extent it
+      // actually covers instead of collapsing to its `\begin`. Perl writes
+      // `$$self{properties}{locator}`, which is what its inherited
+      // `Box::getLocator` reads (`Box.pm` L85-87); our `get_locator` reads the
+      // struct field, so the field is the faithful sink here — a `"locator"`
+      // property would be inert.
+      //
+      // `new_range` yields `None` when the two ends sit in different sources (an
+      // environment spanning an `\input`), and Perl's `newRange` likewise
+      // declines to fuse them; keep the opening locator in that case rather than
+      // inventing a cross-file span.
+      if let (Some(from), Some(to)) = (self.locator, digested.get_locator())
+        && let Some(range) = Locator::new_range(from, to)
+      {
+        self.locator = Some(range);
+      }
       // And copy any otherwise undefined properties from the trailer
       // Perl: copies properties from trailer (typically a Whatsit for \end{...})
       match digested.data() {
@@ -210,8 +227,6 @@ impl Whatsit {
         },
         _ => {},
       }
-      // TODO: Perl line 84 — create locator range from self to trailer
-      // $$self{properties}{locator} = Locator->newRange($self->getLocator, $trailer->getLocator);
     }
   }
 

--- a/latexml_oxide/tests/52_source_map.rs
+++ b/latexml_oxide/tests/52_source_map.rs
@@ -159,8 +159,15 @@ fn source_map_on_emits_data_sourcepos_in_core_xml() {
 /// `data:sourcepos`, for the **default (heuristic) source-map** — the shipped
 /// behavior. Guards the locator pipeline (constructor capture, user-source
 /// filter, the `get_locator` `from` heuristic) against coverage or accuracy
-/// regressions. Values are line-accurate, construct-line spans. Update
-/// deliberately if the conversion legitimately changes.
+/// regressions. Values are line-accurate. Update deliberately if the conversion
+/// legitimately changes.
+///
+/// Note the two span shapes, which is the point of several of these rows:
+/// a **command** (`\section`, `\item`) spans just its own construct line, while
+/// an **environment** spans `\begin` → `\end` — `Whatsit::set_body` fuses its
+/// opening locator with the trailer's via `Locator::new_range`, porting Perl
+/// `Whatsit.pm` L84. Nested environments correctly take the OUTER `\end`
+/// (`itemize` ends at line 47, not the inner 46).
 ///
 /// Feature-OFF only: under `token-locators` the located-span recovery makes
 /// these content-exact (e.g. `section` `0:12:1-0:12:24` → `0:12:10-0:12:22`),
@@ -173,11 +180,11 @@ fn source_map_pins_key_structural_locators() {
   // cross-checked against tests/structure/article.tex line numbers.
   let golden: &[(&str, &str)] = &[
     ("section", "0:12:1-0:12:24"),     // \section{First Section}  (line 12)
-    ("equation", "0:14:1-0:14:17"),    // \begin{equation}         (line 14)
-    ("itemize", "0:40:1-0:40:16"),     // \begin{itemize}          (line 40)
+    ("equation", "0:14:1-0:16:15"),    // \begin{equation}..\end   (lines 14-16)
+    ("itemize", "0:40:1-0:47:14"),     // \begin{itemize}..\end    (lines 40-47)
     ("item", "0:41:9-0:41:9"),         // \item one                (line 41)
-    ("enumerate", "0:49:1-0:49:18"),   // \begin{enumerate}        (line 49)
-    ("description", "0:58:1-0:58:20"), // \begin{description}      (line 58)
+    ("enumerate", "0:49:1-0:56:16"),   // \begin{enumerate}..\end  (lines 49-56)
+    ("description", "0:58:1-0:63:18"), // \begin{description}..\end(lines 58-63)
     ("subsection", "0:65:1-0:65:26"),  // \subsection{A Subsection}(line 65)
     ("subsubsection", "0:70:1-0:70:32"), // \subsubsection{...}      (line 70)
   ];


### PR DESCRIPTION
Ports Perl `Whatsit.pm` L84, which `Whatsit::set_body` had carried as a TODO:

```perl
$$self{properties}{locator} = Locator->newRange($self->getLocator, $trailer->getLocator);
```

Perl's path is live; ours did nothing, and nothing errored — so **every environment collapsed to the position of its `\begin`** instead of spanning to its `\end`. `Locator::new_range` already existed and is used by `List::new` and the alignment code, so `List`s reported true extents while `Whatsit`s did not.

## Effect

Pinned in the `--source-map` golden; each value re-checked against the fixture's actual line lengths rather than blanket-blessed:

| construct | before | after |
|---|---|---|
| `equation` | `0:14:1-0:14:17` | `0:14:1-0:16:15` |
| `itemize` | `0:40:1-0:40:16` | `0:40:1-0:47:14` |
| `enumerate` | `0:49:1-0:49:18` | `0:49:1-0:56:16` |
| `description` | `0:58:1-0:58:20` | `0:58:1-0:63:18` |

Nested environments correctly take the **outer** `\end` (itemize ends at 47, not the inner 46). Commands (`\section`, `\item`, `\subsection`, `\subsubsection`) are unchanged — they have no trailer.

This matters for the source-provenance showcase (#47/#92): an editor mapping preview→source can now select the environment a construct lives in, not just its opening line.

## Faithfulness detail

Perl writes `properties{locator}` because its inherited `Box::getLocator` (`Box.pm` L85-87) reads that key. Our `get_locator` reads the **struct field**, so the field is the correct sink — writing a `"locator"` property would have compiled fine and been inert, which is precisely the failure shape this came from. Placed before the trailer property-copy, mirroring Perl's order.

`new_range` returns `None` when the ends have different sources (an environment spanning an `\input`); Perl's `newRange` declines too, so we keep the opening locator rather than invent a cross-file span.

## Verification

- Full suite **1682/0**. No golden moved except the four above, so default output is untouched — `data:sourcepos` only materialises under `--source-map`.
- One behaviour note not covered by any golden: errors raised inside an environment now print the span rather than the opening line, since `Locator`'s `Display` renders a range when set. Also the Perl behaviour.

Found by auditing commented-out ports for silent no-ops — of 15 candidates this was the only genuine gap; the rest are deliberate, benign, or already-documented deferrals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)