### PR TITLE
fix: faithful siunitx complex numbers + the v3 command/option surface

### DIFF
--- a/latexml_oxide/tests/80_complex.rs
+++ b/latexml_oxide/tests/80_complex.rs
@@ -78,5 +78,11 @@ fn physics_test() { complex("physics"); }
 #[test]
 fn si_test() { complex("si"); }
 
+// siunitx v3 surface layered on the v2 vocabulary (arXiv/html_feedback#6624).
+// Kept apart from si_test so that fixture stays byte-comparable with the Perl
+// golden LaTeXML/t/complex/si.xml, which has no v3 coverage to compare against.
+#[test]
+fn siunitx_v3_test() { complex("siunitx_v3"); }
+
 #[test]
 fn tcilatex_minimal_test() { complex("tcilatex_minimal"); }

--- a/latexml_oxide/tests/complex/si.xml
+++ b/latexml_oxide/tests/complex/si.xml
@@ -382,101 +382,120 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
             <XMath>
               <XMTok meaning="123" role="NUMBER">123</XMTok>
             </XMath>
-          </Math><break/><Math mode="inline" tex="123+234\mathrm{i}" text="123 + 234 * i" xml:id="S1.SS1.p4.m3">
+          </Math><break/><Math mode="inline" tex="123+234\text{$\mathrm{i}$}" text="123 + 234 * imaginary-unit" xml:id="S1.SS1.p4.m3">
             <XMath>
               <XMApp>
                 <XMTok meaning="plus" role="ADDOP">+</XMTok>
                 <XMTok meaning="123" role="NUMBER">123</XMTok>
-                <XMApp>
+                <XMApp xml:id="S1.SS1.p4.m3.3">
                   <XMTok meaning="times" role="MULOP">⁢</XMTok>
                   <XMTok meaning="234" role="NUMBER">234</XMTok>
-                  <XMTok role="UNKNOWN">i</XMTok>
+                  <XMTok meaning="imaginary-unit" role="ID">i</XMTok>
                 </XMApp>
               </XMApp>
             </XMath>
-          </Math><break/><Math mode="inline" tex="123+234\mathrm{i}\text{\times}{10}^{3}" text="(123 + 234 * i) * power@(10, 3)" xml:id="S1.SS1.p4.m4">
+          </Math><break/><Math mode="inline" tex="(123+234\text{$\mathrm{i}$})\text{\times}{10}^{3}" text="(123 + 234 * imaginary-unit) * power@(10, 3)" xml:id="S1.SS1.p4.m4">
             <XMath>
               <XMApp>
                 <XMText meaning="times" role="MULOP" xml:id="S1.SS1.p4.m4.1">×</XMText>
-                <XMApp xml:id="S1.SS1.p4.m4.2">
-                  <XMTok meaning="plus" role="ADDOP">+</XMTok>
-                  <XMTok meaning="123" role="NUMBER">123</XMTok>
+                <XMDual xml:id="S1.SS1.p4.m4.2">
                   <XMApp>
-                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                    <XMTok meaning="234" role="NUMBER">234</XMTok>
-                    <XMTok role="UNKNOWN">i</XMTok>
+                    <XMRef idref="S1.SS1.p4.m4.4"/>
+                    <XMRef idref="S1.SS1.p4.m4.5"/>
+                    <XMRef idref="S1.SS1.p4.m4.6"/>
                   </XMApp>
-                </XMApp>
-                <XMApp xml:id="S1.SS1.p4.m4.3">
+                  <XMWrap>
+                    <XMTok role="OPEN" stretchy="false">(</XMTok>
+                    <XMApp xml:id="S1.SS1.p4.m4.3">
+                      <XMTok meaning="plus" role="ADDOP" xml:id="S1.SS1.p4.m4.4">+</XMTok>
+                      <XMTok meaning="123" role="NUMBER" xml:id="S1.SS1.p4.m4.5">123</XMTok>
+                      <XMApp xml:id="S1.SS1.p4.m4.6">
+                        <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                        <XMTok meaning="234" role="NUMBER">234</XMTok>
+                        <XMTok meaning="imaginary-unit" role="ID">i</XMTok>
+                      </XMApp>
+                    </XMApp>
+                    <XMTok role="CLOSE" stretchy="false">)</XMTok>
+                  </XMWrap>
+                </XMDual>
+                <XMApp xml:id="S1.SS1.p4.m4.10">
                   <XMTok meaning="power" role="SUPERSCRIPTOP" scriptpos="post1"/>
                   <XMTok meaning="10" role="NUMBER">10</XMTok>
                   <XMTok fontsize="70%" meaning="3" role="NUMBER">3</XMTok>
                 </XMApp>
               </XMApp>
             </XMath>
-          </Math><break/><Math mode="inline" tex="123(1)+234(1)\mathrm{i}\text{\times}{10}^{3}" text="(123 * 1 + 234 * 1 * i) * power@(10, 3)" xml:id="S1.SS1.p4.m5">
+          </Math><break/><Math mode="inline" tex="(123(1)+234(1)\text{$\mathrm{i}$})\text{\times}{10}^{3}" text="(123 * 1 + 234 * 1 * imaginary-unit) * power@(10, 3)" xml:id="S1.SS1.p4.m5">
             <XMath>
               <XMApp>
                 <XMText meaning="times" role="MULOP" xml:id="S1.SS1.p4.m5.1">×</XMText>
-                <XMApp xml:id="S1.SS1.p4.m5.2">
-                  <XMTok meaning="plus" role="ADDOP">+</XMTok>
+                <XMDual xml:id="S1.SS1.p4.m5.2">
                   <XMApp>
-                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                    <XMTok meaning="123" role="NUMBER">123</XMTok>
-                    <XMDual>
-                      <XMRef idref="S1.SS1.p4.m5.3"/>
-                      <XMWrap>
-                        <XMTok role="OPEN" stretchy="false">(</XMTok>
-                        <XMTok meaning="1" role="NUMBER" xml:id="S1.SS1.p4.m5.3">1</XMTok>
-                        <XMTok role="CLOSE" stretchy="false">)</XMTok>
-                      </XMWrap>
-                    </XMDual>
+                    <XMRef idref="S1.SS1.p4.m5.4"/>
+                    <XMRef idref="S1.SS1.p4.m5.5"/>
+                    <XMRef idref="S1.SS1.p4.m5.7"/>
                   </XMApp>
-                  <XMApp>
-                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                    <XMTok meaning="234" role="NUMBER">234</XMTok>
-                    <XMDual>
-                      <XMRef idref="S1.SS1.p4.m5.4"/>
-                      <XMWrap>
-                        <XMTok role="OPEN" stretchy="false">(</XMTok>
-                        <XMTok meaning="1" role="NUMBER" xml:id="S1.SS1.p4.m5.4">1</XMTok>
-                        <XMTok role="CLOSE" stretchy="false">)</XMTok>
-                      </XMWrap>
-                    </XMDual>
-                    <XMTok role="UNKNOWN">i</XMTok>
-                  </XMApp>
-                </XMApp>
-                <XMApp xml:id="S1.SS1.p4.m5.5">
+                  <XMWrap>
+                    <XMTok role="OPEN" stretchy="false">(</XMTok>
+                    <XMApp xml:id="S1.SS1.p4.m5.3">
+                      <XMTok meaning="plus" role="ADDOP" xml:id="S1.SS1.p4.m5.4">+</XMTok>
+                      <XMApp xml:id="S1.SS1.p4.m5.5">
+                        <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                        <XMTok meaning="123" role="NUMBER">123</XMTok>
+                        <XMDual>
+                          <XMRef idref="S1.SS1.p4.m5.6"/>
+                          <XMWrap>
+                            <XMTok role="OPEN" stretchy="false">(</XMTok>
+                            <XMTok meaning="1" role="NUMBER" xml:id="S1.SS1.p4.m5.6">1</XMTok>
+                            <XMTok role="CLOSE" stretchy="false">)</XMTok>
+                          </XMWrap>
+                        </XMDual>
+                      </XMApp>
+                      <XMApp xml:id="S1.SS1.p4.m5.7">
+                        <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                        <XMApp xml:id="S1.SS1.p4.m5.9">
+                          <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                          <XMTok meaning="234" role="NUMBER">234</XMTok>
+                          <XMDual>
+                            <XMRef idref="S1.SS1.p4.m5.10"/>
+                            <XMWrap>
+                              <XMTok role="OPEN" stretchy="false">(</XMTok>
+                              <XMTok meaning="1" role="NUMBER" xml:id="S1.SS1.p4.m5.10">1</XMTok>
+                              <XMTok role="CLOSE" stretchy="false">)</XMTok>
+                            </XMWrap>
+                          </XMDual>
+                        </XMApp>
+                        <XMTok meaning="imaginary-unit" role="ID">i</XMTok>
+                      </XMApp>
+                    </XMApp>
+                    <XMTok role="CLOSE" stretchy="false">)</XMTok>
+                  </XMWrap>
+                </XMDual>
+                <XMApp xml:id="S1.SS1.p4.m5.12">
                   <XMTok meaning="power" role="SUPERSCRIPTOP" scriptpos="post1"/>
                   <XMTok meaning="10" role="NUMBER">10</XMTok>
                   <XMTok fontsize="70%" meaning="3" role="NUMBER">3</XMTok>
                 </XMApp>
               </XMApp>
             </XMath>
-          </Math><break/><Math mode="inline" tex="+3\mathrm{i}" text="+ 3 * i" xml:id="S1.SS1.p4.m6">
+          </Math><break/><Math mode="inline" tex="3\text{$\mathrm{i}$}" text="3 * imaginary-unit" xml:id="S1.SS1.p4.m6">
             <XMath>
               <XMApp>
-                <XMTok meaning="plus" role="ADDOP">+</XMTok>
-                <XMApp>
-                  <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                  <XMTok meaning="3" role="NUMBER">3</XMTok>
-                  <XMTok role="UNKNOWN">i</XMTok>
-                </XMApp>
+                <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                <XMTok meaning="3" role="NUMBER">3</XMTok>
+                <XMTok meaning="imaginary-unit" role="ID">i</XMTok>
               </XMApp>
             </XMath>
-          </Math><break/><Math mode="inline" tex="+3\mathrm{i}\text{\times}{10}^{4}" text="(+ 3 * i) * power@(10, 4)" xml:id="S1.SS1.p4.m7">
+          </Math><break/><Math mode="inline" tex="3\text{$\mathrm{i}$}\text{\times}{10}^{4}" text="(3 * imaginary-unit) * power@(10, 4)" xml:id="S1.SS1.p4.m7">
             <XMath>
               <XMApp>
                 <XMText meaning="times" role="MULOP" xml:id="S1.SS1.p4.m7.1">×</XMText>
                 <XMApp xml:id="S1.SS1.p4.m7.2">
-                  <XMTok meaning="plus" role="ADDOP">+</XMTok>
-                  <XMApp>
-                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                    <XMTok meaning="3" role="NUMBER">3</XMTok>
-                    <XMTok role="UNKNOWN">i</XMTok>
-                  </XMApp>
+                  <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                  <XMTok meaning="3" role="NUMBER">3</XMTok>
+                  <XMTok meaning="imaginary-unit" role="ID">i</XMTok>
                 </XMApp>
-                <XMApp xml:id="S1.SS1.p4.m7.3">
+                <XMApp xml:id="S1.SS1.p4.m7.6">
                   <XMTok meaning="power" role="SUPERSCRIPTOP" scriptpos="post1"/>
                   <XMTok meaning="10" role="NUMBER">10</XMTok>
                   <XMTok fontsize="70%" meaning="4" role="NUMBER">4</XMTok>
@@ -790,27 +809,27 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
         </tags>
         <title><tag close=" ">1.2.5</tag>input-complex-roots</title>
         <para xml:id="S1.SS2.SSS5.p1">
-          <p><Math mode="inline" tex="9.99+88.8\mathrm{i}" text="9.99 + 88.8 * i" xml:id="S1.SS2.SSS5.p1.m1">
+          <p><Math mode="inline" tex="9.99+88.8\text{$\mathrm{i}$}" text="9.99 + 88.8 * imaginary-unit" xml:id="S1.SS2.SSS5.p1.m1">
               <XMath>
                 <XMApp>
                   <XMTok meaning="plus" role="ADDOP">+</XMTok>
                   <XMTok meaning="9.99" role="NUMBER">9.99</XMTok>
-                  <XMApp>
+                  <XMApp xml:id="S1.SS2.SSS5.p1.m1.3">
                     <XMTok meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok meaning="88.8" role="NUMBER">88.8</XMTok>
-                    <XMTok role="UNKNOWN">i</XMTok>
+                    <XMTok meaning="imaginary-unit" role="ID">i</XMTok>
                   </XMApp>
                 </XMApp>
               </XMath>
-            </Math> <break/><Math mode="inline" tex="9.99+88.8\mathrm{i}" text="9.99 + 88.8 * i" xml:id="S1.SS2.SSS5.p1.m2">
+            </Math> <break/><Math mode="inline" tex="9.99+88.8\text{$\mathrm{i}$}" text="9.99 + 88.8 * imaginary-unit" xml:id="S1.SS2.SSS5.p1.m2">
               <XMath>
                 <XMApp>
                   <XMTok meaning="plus" role="ADDOP">+</XMTok>
                   <XMTok meaning="9.99" role="NUMBER">9.99</XMTok>
-                  <XMApp>
+                  <XMApp xml:id="S1.SS2.SSS5.p1.m2.3">
                     <XMTok meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok meaning="88.8" role="NUMBER">88.8</XMTok>
-                    <XMTok role="UNKNOWN">i</XMTok>
+                    <XMTok meaning="imaginary-unit" role="ID">i</XMTok>
                   </XMApp>
                 </XMApp>
               </XMath>
@@ -1413,51 +1432,51 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
                   </XMWrap>
                 </XMDual>
               </XMath>
-            </Math> <break/><Math mode="inline" tex="1+2\mathrm{i}" text="1 + 2 * i" xml:id="S1.SS4.SSS3.p1.m3">
+            </Math> <break/><Math mode="inline" tex="1+2\text{$\mathrm{i}$}" text="1 + 2 * imaginary-unit" xml:id="S1.SS4.SSS3.p1.m3">
               <XMath>
                 <XMApp>
                   <XMTok meaning="plus" role="ADDOP">+</XMTok>
                   <XMTok meaning="1" role="NUMBER">1</XMTok>
-                  <XMApp>
+                  <XMApp xml:id="S1.SS4.SSS3.p1.m3.3">
                     <XMTok meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok meaning="2" role="NUMBER">2</XMTok>
-                    <XMTok role="UNKNOWN">i</XMTok>
+                    <XMTok meaning="imaginary-unit" role="ID">i</XMTok>
                   </XMApp>
                 </XMApp>
               </XMath>
-            </Math> <break/><Math mode="inline" tex="1+2\text{$i$}" text="1 + 2 * i" xml:id="S1.SS4.SSS3.p1.m4">
+            </Math> <break/><Math mode="inline" tex="1+2\text{\text{$i$}}" text="1 + 2 * imaginary-unit" xml:id="S1.SS4.SSS3.p1.m4">
               <XMath>
                 <XMApp>
                   <XMTok meaning="plus" role="ADDOP">+</XMTok>
                   <XMTok meaning="1" role="NUMBER">1</XMTok>
-                  <XMApp>
+                  <XMApp xml:id="S1.SS4.SSS3.p1.m4.3">
                     <XMTok meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok meaning="2" role="NUMBER">2</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">i</XMTok>
+                    <XMTok font="italic" meaning="imaginary-unit" role="ID">i</XMTok>
                   </XMApp>
                 </XMApp>
               </XMath>
-            </Math> <break/><Math mode="inline" tex="1+2j" text="1 + 2 * j" xml:id="S1.SS4.SSS3.p1.m5">
+            </Math> <break/><Math mode="inline" tex="1+2\text{j}" text="1 + 2 * imaginary-unit" xml:id="S1.SS4.SSS3.p1.m5">
               <XMath>
                 <XMApp>
                   <XMTok meaning="plus" role="ADDOP">+</XMTok>
                   <XMTok meaning="1" role="NUMBER">1</XMTok>
-                  <XMApp>
+                  <XMApp xml:id="S1.SS4.SSS3.p1.m5.3">
                     <XMTok meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok meaning="2" role="NUMBER">2</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">j</XMTok>
+                    <XMText meaning="imaginary-unit" role="ID" xml:id="S1.SS4.SSS3.p1.m5.6">j</XMText>
                   </XMApp>
                 </XMApp>
               </XMath>
-            </Math> <break/><Math mode="inline" tex="1+2j" text="1 + 2 * j" xml:id="S1.SS4.SSS3.p1.m6">
+            </Math> <break/><Math mode="inline" tex="1+2\text{j}" text="1 + 2 * imaginary-unit" xml:id="S1.SS4.SSS3.p1.m6">
               <XMath>
                 <XMApp>
                   <XMTok meaning="plus" role="ADDOP">+</XMTok>
                   <XMTok meaning="1" role="NUMBER">1</XMTok>
-                  <XMApp>
+                  <XMApp xml:id="S1.SS4.SSS3.p1.m6.3">
                     <XMTok meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok meaning="2" role="NUMBER">2</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">j</XMTok>
+                    <XMText meaning="imaginary-unit" role="ID" xml:id="S1.SS4.SSS3.p1.m6.6">j</XMText>
                   </XMApp>
                 </XMApp>
               </XMath>
@@ -1476,39 +1495,39 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
         </tags>
         <title><tag close=" ">1.4.4</tag>complex-root-position</title>
         <para xml:id="S1.SS4.SSS4.p1">
-          <p><Math mode="inline" tex="67-0.9\mathrm{i}" text="67 - 0.9 * i" xml:id="S1.SS4.SSS4.p1.m1">
+          <p><Math mode="inline" tex="67-0.9\text{$\mathrm{i}$}" text="67 - 0.9 * imaginary-unit" xml:id="S1.SS4.SSS4.p1.m1">
               <XMath>
                 <XMApp>
                   <XMTok meaning="minus" role="ADDOP">-</XMTok>
                   <XMTok meaning="67" role="NUMBER">67</XMTok>
-                  <XMApp>
+                  <XMApp xml:id="S1.SS4.SSS4.p1.m1.3">
                     <XMTok meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok meaning="0.9" role="NUMBER">0.9</XMTok>
-                    <XMTok role="UNKNOWN">i</XMTok>
+                    <XMTok meaning="imaginary-unit" role="ID">i</XMTok>
                   </XMApp>
                 </XMApp>
               </XMath>
-            </Math> <break/><Math mode="inline" tex="67-0.9\mathrm{i}" text="67 - 0.9 * i" xml:id="S1.SS4.SSS4.p1.m2">
+            </Math> <break/><Math mode="inline" tex="67-\text{$\mathrm{i}$}0.9" text="67 - imaginary-unit * 0.9" xml:id="S1.SS4.SSS4.p1.m2">
               <XMath>
                 <XMApp>
                   <XMTok meaning="minus" role="ADDOP">-</XMTok>
                   <XMTok meaning="67" role="NUMBER">67</XMTok>
-                  <XMApp>
+                  <XMApp xml:id="S1.SS4.SSS4.p1.m2.3">
                     <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                    <XMTok meaning="imaginary-unit" role="ID">i</XMTok>
                     <XMTok meaning="0.9" role="NUMBER">0.9</XMTok>
-                    <XMTok role="UNKNOWN">i</XMTok>
                   </XMApp>
                 </XMApp>
               </XMath>
-            </Math> <break/><Math mode="inline" tex="67-0.9\mathrm{i}" text="67 - 0.9 * i" xml:id="S1.SS4.SSS4.p1.m3">
+            </Math> <break/><Math mode="inline" tex="67-0.9\text{$\mathrm{i}$}" text="67 - 0.9 * imaginary-unit" xml:id="S1.SS4.SSS4.p1.m3">
               <XMath>
                 <XMApp>
                   <XMTok meaning="minus" role="ADDOP">-</XMTok>
                   <XMTok meaning="67" role="NUMBER">67</XMTok>
-                  <XMApp>
+                  <XMApp xml:id="S1.SS4.SSS4.p1.m3.3">
                     <XMTok meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok meaning="0.9" role="NUMBER">0.9</XMTok>
-                    <XMTok role="UNKNOWN">i</XMTok>
+                    <XMTok meaning="imaginary-unit" role="ID">i</XMTok>
                   </XMApp>
                 </XMApp>
               </XMath>
@@ -1836,56 +1855,67 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
                   </XMApp>
                 </XMApp>
               </XMath>
-            </Math> <break/><Math mode="inline" tex="2\mathrm{i}\text{\times}{10}^{10}" text="(2 * i) * power@(10, 10)" xml:id="S1.SS4.SSS8.p1.m2">
+            </Math> <break/><Math mode="inline" tex="2\text{$\mathrm{i}$}\text{\times}{10}^{10}" text="(2 * imaginary-unit) * power@(10, 10)" xml:id="S1.SS4.SSS8.p1.m2">
               <XMath>
                 <XMApp>
                   <XMText meaning="times" role="MULOP" xml:id="S1.SS4.SSS8.p1.m2.1">×</XMText>
                   <XMApp xml:id="S1.SS4.SSS8.p1.m2.2">
                     <XMTok meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok meaning="2" role="NUMBER">2</XMTok>
-                    <XMTok role="UNKNOWN">i</XMTok>
+                    <XMTok meaning="imaginary-unit" role="ID">i</XMTok>
                   </XMApp>
-                  <XMApp xml:id="S1.SS4.SSS8.p1.m2.3">
+                  <XMApp xml:id="S1.SS4.SSS8.p1.m2.6">
                     <XMTok meaning="power" role="SUPERSCRIPTOP" scriptpos="post1"/>
                     <XMTok meaning="10" role="NUMBER">10</XMTok>
                     <XMTok fontsize="70%" meaning="10" role="NUMBER">10</XMTok>
                   </XMApp>
                 </XMApp>
               </XMath>
-            </Math> <break/><Math mode="inline" tex="1+2\mathrm{i}\text{\times}{10}^{10}" text="(1 + 2 * i) * power@(10, 10)" xml:id="S1.SS4.SSS8.p1.m3">
+            </Math> <break/><Math mode="inline" tex="(1+2\text{$\mathrm{i}$})\text{\times}{10}^{10}" text="(1 + 2 * imaginary-unit) * power@(10, 10)" xml:id="S1.SS4.SSS8.p1.m3">
               <XMath>
                 <XMApp>
                   <XMText meaning="times" role="MULOP" xml:id="S1.SS4.SSS8.p1.m3.1">×</XMText>
-                  <XMApp xml:id="S1.SS4.SSS8.p1.m3.2">
-                    <XMTok meaning="plus" role="ADDOP">+</XMTok>
-                    <XMTok meaning="1" role="NUMBER">1</XMTok>
+                  <XMDual xml:id="S1.SS4.SSS8.p1.m3.2">
                     <XMApp>
-                      <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                      <XMTok meaning="2" role="NUMBER">2</XMTok>
-                      <XMTok role="UNKNOWN">i</XMTok>
+                      <XMRef idref="S1.SS4.SSS8.p1.m3.4"/>
+                      <XMRef idref="S1.SS4.SSS8.p1.m3.5"/>
+                      <XMRef idref="S1.SS4.SSS8.p1.m3.6"/>
                     </XMApp>
-                  </XMApp>
-                  <XMApp xml:id="S1.SS4.SSS8.p1.m3.3">
+                    <XMWrap>
+                      <XMTok role="OPEN" stretchy="false">(</XMTok>
+                      <XMApp xml:id="S1.SS4.SSS8.p1.m3.3">
+                        <XMTok meaning="plus" role="ADDOP" xml:id="S1.SS4.SSS8.p1.m3.4">+</XMTok>
+                        <XMTok meaning="1" role="NUMBER" xml:id="S1.SS4.SSS8.p1.m3.5">1</XMTok>
+                        <XMApp xml:id="S1.SS4.SSS8.p1.m3.6">
+                          <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                          <XMTok meaning="2" role="NUMBER">2</XMTok>
+                          <XMTok meaning="imaginary-unit" role="ID">i</XMTok>
+                        </XMApp>
+                      </XMApp>
+                      <XMTok role="CLOSE" stretchy="false">)</XMTok>
+                    </XMWrap>
+                  </XMDual>
+                  <XMApp xml:id="S1.SS4.SSS8.p1.m3.10">
                     <XMTok meaning="power" role="SUPERSCRIPTOP" scriptpos="post1"/>
                     <XMTok meaning="10" role="NUMBER">10</XMTok>
                     <XMTok fontsize="70%" meaning="10" role="NUMBER">10</XMTok>
                   </XMApp>
                 </XMApp>
               </XMath>
-            </Math> <break/><Math mode="inline" tex="1+2\mathrm{i}\text{\times}{10}^{10}" text="(1 + 2 * i) * power@(10, 10)" xml:id="S1.SS4.SSS8.p1.m4">
+            </Math> <break/><Math mode="inline" tex="1+2\text{$\mathrm{i}$}\text{\times}{10}^{10}" text="(1 + 2 * imaginary-unit) * power@(10, 10)" xml:id="S1.SS4.SSS8.p1.m4">
               <XMath>
                 <XMApp>
                   <XMText meaning="times" role="MULOP" xml:id="S1.SS4.SSS8.p1.m4.1">×</XMText>
                   <XMApp xml:id="S1.SS4.SSS8.p1.m4.2">
                     <XMTok meaning="plus" role="ADDOP">+</XMTok>
                     <XMTok meaning="1" role="NUMBER">1</XMTok>
-                    <XMApp>
+                    <XMApp xml:id="S1.SS4.SSS8.p1.m4.5">
                       <XMTok meaning="times" role="MULOP">⁢</XMTok>
                       <XMTok meaning="2" role="NUMBER">2</XMTok>
-                      <XMTok role="UNKNOWN">i</XMTok>
+                      <XMTok meaning="imaginary-unit" role="ID">i</XMTok>
                     </XMApp>
                   </XMApp>
-                  <XMApp xml:id="S1.SS4.SSS8.p1.m4.3">
+                  <XMApp xml:id="S1.SS4.SSS8.p1.m4.9">
                     <XMTok meaning="power" role="SUPERSCRIPTOP" scriptpos="post1"/>
                     <XMTok meaning="10" role="NUMBER">10</XMTok>
                     <XMTok fontsize="70%" meaning="10" role="NUMBER">10</XMTok>
@@ -1893,20 +1923,31 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
                 </XMApp>
               </XMath>
             </Math> <break/>
-<Math mode="inline" tex="1+2\mathrm{i}\text{\times}{10}^{10}" text="(1 + 2 * i) * power@(10, 10)" xml:id="S1.SS4.SSS8.p1.m5">
+<Math mode="inline" tex="\{1+2\text{$\mathrm{i}$}\}\text{\times}{10}^{10}" text="(1 + 2 * imaginary-unit) * power@(10, 10)" xml:id="S1.SS4.SSS8.p1.m5">
               <XMath>
                 <XMApp>
                   <XMText meaning="times" role="MULOP" xml:id="S1.SS4.SSS8.p1.m5.1">×</XMText>
-                  <XMApp xml:id="S1.SS4.SSS8.p1.m5.2">
-                    <XMTok meaning="plus" role="ADDOP">+</XMTok>
-                    <XMTok meaning="1" role="NUMBER">1</XMTok>
+                  <XMDual xml:id="S1.SS4.SSS8.p1.m5.2">
                     <XMApp>
-                      <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                      <XMTok meaning="2" role="NUMBER">2</XMTok>
-                      <XMTok role="UNKNOWN">i</XMTok>
+                      <XMRef idref="S1.SS4.SSS8.p1.m5.4"/>
+                      <XMRef idref="S1.SS4.SSS8.p1.m5.5"/>
+                      <XMRef idref="S1.SS4.SSS8.p1.m5.6"/>
                     </XMApp>
-                  </XMApp>
-                  <XMApp xml:id="S1.SS4.SSS8.p1.m5.3">
+                    <XMWrap>
+                      <XMTok role="OPEN" stretchy="false">{</XMTok>
+                      <XMApp xml:id="S1.SS4.SSS8.p1.m5.3">
+                        <XMTok meaning="plus" role="ADDOP" xml:id="S1.SS4.SSS8.p1.m5.4">+</XMTok>
+                        <XMTok meaning="1" role="NUMBER" xml:id="S1.SS4.SSS8.p1.m5.5">1</XMTok>
+                        <XMApp xml:id="S1.SS4.SSS8.p1.m5.6">
+                          <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                          <XMTok meaning="2" role="NUMBER">2</XMTok>
+                          <XMTok meaning="imaginary-unit" role="ID">i</XMTok>
+                        </XMApp>
+                      </XMApp>
+                      <XMTok role="CLOSE" stretchy="false">}</XMTok>
+                    </XMWrap>
+                  </XMDual>
+                  <XMApp xml:id="S1.SS4.SSS8.p1.m5.10">
                     <XMTok meaning="power" role="SUPERSCRIPTOP" scriptpos="post1"/>
                     <XMTok meaning="10" role="NUMBER">10</XMTok>
                     <XMTok fontsize="70%" meaning="10" role="NUMBER">10</XMTok>

--- a/latexml_oxide/tests/complex/siunitx_v3.tex
+++ b/latexml_oxide/tests/complex/siunitx_v3.tex
@@ -1,0 +1,45 @@
+% siunitx v3 surface, on top of the v2 vocabulary this binding implements
+% (Perl LaTeXML/lib/LaTeXML/Package/siunitx.sty.ltxml). Guards
+% arXiv/html_feedback#6624. The v2 cases live in the Perl-shared si.tex
+% fixture; keep that one byte-comparable with LaTeXML/t/complex/si.xml and
+% put v3-only coverage here.
+\documentclass{article}
+\usepackage{siunitx}
+
+% v3-only option spellings must be known keys, not "unknown KeyVals key" warns.
+% Witness 2606.13010 (the reporting paper).
+\sisetup{mode = math, reset-text-family = false, unit-font-command = \mathrm}
+
+% \DeclareSIPower{<before>}{<after>}{<power>} declares one pre- and one
+% post-power, so both orders yield the same unit.
+\DeclareSIPower\quartic\tothefourth{4}
+
+% Deprecated upstream (v3 manual S6); accepted as a no-op.
+\SendSettingsToPgf
+
+% The reporting paper's attributive-quantity macro: the v3 key
+% quantity-product is the v2 number-unit-product, so the author's hyphen shows
+% while the MULOP/times semantics survive.
+\newcommand{\qtyhy}[2]{\qty[quantity-product = \text{-}]{#1}{#2}}
+
+\begin{document}
+
+\section{v3 command aliases}
+
+\complexnum{1+2i}\\
+\complexqty{1+2i}{\ohm}\\
+\numproduct{5 x 100 x 2}\\
+\qtyproduct{5 x 100 x 2}{\metre}\\
+\num{2i}\\
+\num[complex-root-position = before-number]{1+2i}\\
+
+\section{Declared powers}
+
+\unit{\quartic\metre} and \unit{\metre\tothefourth}\\
+
+\section{Quantity product}
+
+\qty{1.6}{\giga\hertz}\\
+\qtyhy{10}{\mega\hertz}\\
+
+\end{document}

--- a/latexml_oxide/tests/complex/siunitx_v3.xml
+++ b/latexml_oxide/tests/complex/siunitx_v3.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article"?>
+<?latexml package="siunitx"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <section inlist="toc" xml:id="S1">
+    <tags>
+      <tag>1</tag>
+      <tag role="refnum">1</tag>
+      <tag role="typerefnum">§1</tag>
+    </tags>
+    <title><tag close=" ">1</tag>v3 command aliases</title>
+    <para xml:id="S1.p1">
+      <p><Math mode="inline" tex="1+2\text{$\mathrm{i}$}" text="1 + 2 * imaginary-unit" xml:id="S1.p1.m1">
+          <XMath>
+            <XMApp>
+              <XMTok meaning="plus" role="ADDOP">+</XMTok>
+              <XMTok meaning="1" role="NUMBER">1</XMTok>
+              <XMApp xml:id="S1.p1.m1.3">
+                <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                <XMTok meaning="2" role="NUMBER">2</XMTok>
+                <XMTok meaning="imaginary-unit" role="ID">i</XMTok>
+              </XMApp>
+            </XMApp>
+          </XMath>
+        </Math><break/><Math mode="inline" tex="1+2\text{$\mathrm{i}$}\text{\,}\mathrm{\SIUnitSymbolOhm}" text="(1 + 2 * imaginary-unit) * ohm" xml:id="S1.p1.m2">
+          <XMath>
+            <XMApp>
+              <XMText meaning="times" role="MULOP" xml:id="S1.p1.m2.1"> </XMText>
+              <XMApp xml:id="S1.p1.m2.2">
+                <XMTok meaning="plus" role="ADDOP">+</XMTok>
+                <XMTok meaning="1" role="NUMBER">1</XMTok>
+                <XMApp xml:id="S1.p1.m2.5">
+                  <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                  <XMTok meaning="2" role="NUMBER">2</XMTok>
+                  <XMTok meaning="imaginary-unit" role="ID">i</XMTok>
+                </XMApp>
+              </XMApp>
+              <XMTok class="ltx_unit" meaning="ohm" name="SIUnitSymbolOhm" role="ID">Ω</XMTok>
+            </XMApp>
+          </XMath>
+        </Math><break/><Math mode="inline" tex="5\text{\times}100\text{\times}2" text="5 * 100 * 2" xml:id="S1.p1.m3">
+          <XMath>
+            <XMApp>
+              <XMText meaning="times" role="MULOP" xml:id="S1.p1.m3.1">×</XMText>
+              <XMApp xml:id="S1.p1.m3.2">
+                <XMText meaning="times" role="MULOP" xml:id="S1.p1.m3.3">×</XMText>
+                <XMTok meaning="5" role="NUMBER">5</XMTok>
+                <XMTok meaning="100" role="NUMBER">100</XMTok>
+              </XMApp>
+              <XMTok meaning="2" role="NUMBER">2</XMTok>
+            </XMApp>
+          </XMath>
+        </Math><break/><Math mode="inline" tex="5\text{\times}100\text{\times}2\text{\,}\mathrm{m}" text="5 * 100 * 2 * meter" xml:id="S1.p1.m4">
+          <XMath>
+            <XMApp>
+              <XMText meaning="times" role="MULOP" xml:id="S1.p1.m4.1"> </XMText>
+              <XMApp xml:id="S1.p1.m4.2">
+                <XMText meaning="times" role="MULOP" xml:id="S1.p1.m4.3">×</XMText>
+                <XMApp xml:id="S1.p1.m4.4">
+                  <XMText meaning="times" role="MULOP" xml:id="S1.p1.m4.5">×</XMText>
+                  <XMTok meaning="5" role="NUMBER">5</XMTok>
+                  <XMTok meaning="100" role="NUMBER">100</XMTok>
+                </XMApp>
+                <XMTok meaning="2" role="NUMBER">2</XMTok>
+              </XMApp>
+              <XMTok class="ltx_unit" meaning="meter" role="ID">m</XMTok>
+            </XMApp>
+          </XMath>
+        </Math><break/><Math mode="inline" tex="2\text{$\mathrm{i}$}" text="2 * imaginary-unit" xml:id="S1.p1.m5">
+          <XMath>
+            <XMApp>
+              <XMTok meaning="times" role="MULOP">⁢</XMTok>
+              <XMTok meaning="2" role="NUMBER">2</XMTok>
+              <XMTok meaning="imaginary-unit" role="ID">i</XMTok>
+            </XMApp>
+          </XMath>
+        </Math><break/><Math mode="inline" tex="1+\text{$\mathrm{i}$}2" text="1 + imaginary-unit * 2" xml:id="S1.p1.m6">
+          <XMath>
+            <XMApp>
+              <XMTok meaning="plus" role="ADDOP">+</XMTok>
+              <XMTok meaning="1" role="NUMBER">1</XMTok>
+              <XMApp xml:id="S1.p1.m6.3">
+                <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                <XMTok meaning="imaginary-unit" role="ID">i</XMTok>
+                <XMTok meaning="2" role="NUMBER">2</XMTok>
+              </XMApp>
+            </XMApp>
+          </XMath>
+        </Math><break/></p>
+    </para>
+  </section>
+  <section inlist="toc" xml:id="S2">
+    <tags>
+      <tag>2</tag>
+      <tag role="refnum">2</tag>
+      <tag role="typerefnum">§2</tag>
+    </tags>
+    <title><tag close=" ">2</tag>Declared powers</title>
+    <para xml:id="S2.p1">
+      <p><Math mode="inline" tex="{\mathrm{m}}^{4}" text="power@(meter, 4)" xml:id="S2.p1.m1">
+          <XMath>
+            <XMApp>
+              <XMTok meaning="power" role="SUPERSCRIPTOP" scriptpos="post1"/>
+              <XMTok class="ltx_unit" meaning="meter" role="ID">m</XMTok>
+              <XMTok fontsize="70%" meaning="4" role="NUMBER">4</XMTok>
+            </XMApp>
+          </XMath>
+        </Math> and <Math mode="inline" tex="{\mathrm{m}}^{4}" text="power@(meter, 4)" xml:id="S2.p1.m2">
+          <XMath>
+            <XMApp>
+              <XMTok meaning="power" role="SUPERSCRIPTOP" scriptpos="post1"/>
+              <XMTok class="ltx_unit" meaning="meter" role="ID">m</XMTok>
+              <XMTok fontsize="70%" meaning="4" role="NUMBER">4</XMTok>
+            </XMApp>
+          </XMath>
+        </Math><break/></p>
+    </para>
+  </section>
+  <section inlist="toc" xml:id="S3">
+    <tags>
+      <tag>3</tag>
+      <tag role="refnum">3</tag>
+      <tag role="typerefnum">§3</tag>
+    </tags>
+    <title><tag close=" ">3</tag>Quantity product</title>
+    <para xml:id="S3.p1">
+      <p><Math mode="inline" tex="1.6\text{\,}\mathrm{GHz}" text="1.6 * gigahertz" xml:id="S3.p1.m1">
+          <XMath>
+            <XMApp>
+              <XMText meaning="times" role="MULOP" xml:id="S3.p1.m1.1"> </XMText>
+              <XMTok meaning="1.6" role="NUMBER">1.6</XMTok>
+              <XMTok class="ltx_unit" meaning="gigahertz" role="ID">GHz</XMTok>
+            </XMApp>
+          </XMath>
+        </Math><break/><Math mode="inline" tex="10\text{\text{-}}\mathrm{MHz}" text="10 * megahertz" xml:id="S3.p1.m2">
+          <XMath>
+            <XMApp>
+              <XMText meaning="times" role="MULOP" xml:id="S3.p1.m2.1">-</XMText>
+              <XMTok meaning="10" role="NUMBER">10</XMTok>
+              <XMTok class="ltx_unit" meaning="megahertz" role="ID">MHz</XMTok>
+            </XMApp>
+          </XMath>
+        </Math><break/></p>
+    </para>
+  </section>
+</document>

--- a/latexml_package/src/package/siunitx_sty.rs
+++ b/latexml_package/src/package/siunitx_sty.rs
@@ -209,10 +209,25 @@ fn six_get_op_sym(kv: &[(&str, Tokens)], key: SymStr) -> Tokens {
   }
 }
 
+/// siunitx v3 renamed a handful of v2 option keys. This binding implements the
+/// v2 vocabulary (as Perl's does), so the v3 spelling is canonicalised to its v2
+/// name at the single point where every option is assigned — which routes it
+/// into the existing machinery instead of needing a parallel implementation.
+/// (Upstream ships the two versions as separate files via `\DeclareRelease`, so
+/// there is no upstream alias table to port; these come from the v3 manual.)
+fn six_canonical_key(key: &str) -> &str {
+  match key {
+    // Separator between the number and its unit. Witness 2606.13010, whose
+    // `\qtyhy` sets `quantity-product = \text{-}` for attributive "10-MHz".
+    "quantity-product" => "number-unit-product",
+    other => other,
+  }
+}
+
 /// Perl: six_setup — assign all keyvals to SIX_key state values
 fn six_setup(kv: &KeyVals) {
   for (key, value) in kv.get_pairs() {
-    let key_str = key.clone();
+    let key_str = six_canonical_key(key).to_string();
     match value {
       ArgWrap::Tokens(t) => {
         if t.is_empty() {
@@ -1160,30 +1175,67 @@ fn six_format_number_inner(number: &SixNumber, bracket: i32) -> Tokens {
           Tokens::new(tks)
         }
       },
+      // Perl six_format_complexnumber L555-576.
       "complex" => {
         if let SixNumber::Operator { arg1, arg2, sign, symbol, .. } = number {
           let real = arg1.as_deref().map(|n| six_format_number_inner(n, 0));
-          let imag = arg2.as_deref().map(|n| six_format_number_inner(n, 0));
-          let i_tok = if six_get_bool_sym(six_pin!("copy-complex-root")) {
+          // Perl L561: return $real unless $arg2
+          let Some(imag) = arg2.as_deref().map(|n| six_format_number_inner(n, 0)) else {
+            return real.unwrap_or_default();
+          };
+          // Perl L562: echo the root as the author typed it, or emit the configured one.
+          let root = if six_get_bool_sym(six_pin!("copy-complex-root")) {
             symbol
               .clone()
               .unwrap_or_else(|| six_get_tokens_sym(six_pin!("output-complex-root")))
           } else {
             six_get_tokens_sym(six_pin!("output-complex-root"))
           };
-
-          let mut result = Vec::new();
-          if let Some(r) = &real {
-            result.extend_from_slice(r.unlist_ref());
+          // Perl L563-564: the imaginary unit carries its own semantics.
+          let mut texed = vec![T_CS!("\\text"), T_BEGIN!()];
+          texed.extend(root.unlist());
+          texed.push(T_END!());
+          let root = i_wrap(
+            make_kv_content(&[
+              ("role", Tokenize!("ID")),
+              ("meaning", Tokenize!("imaginary-unit")),
+            ]),
+            Tokens::new(texed),
+          );
+          // Perl L565-566
+          let args = if six_get_choice_sym(six_pin!("complex-root-position")) == "before-number" {
+            vec![root, imag]
+          } else {
+            vec![imag, root]
+          };
+          let mut result = six_format_infix(
+            Tokens::new(vec![T_CS!("\\lx@InvisibleTimes")]),
+            None,
+            None,
+            args,
+          );
+          if let Some(real) = real {
+            // Perl L570-575
+            let (open, close) = if bracket > 0 {
+              (
+                Some(six_get_tokens_sym(six_pin!("open-bracket"))),
+                Some(six_get_tokens_sym(six_pin!("close-bracket"))),
+              )
+            } else {
+              (None, None)
+            };
+            result = six_format_infix(sign.clone().unwrap_or_default(), open, close, vec![
+              real, result,
+            ]);
+          } else if let Some(sign) = sign {
+            // Perl L567-569: force an explicit sign on a pure imaginary?
+            if sign.to_string() == "+" && six_get_bool_sym(six_pin!("retain-explicit-plus")) {
+              let mut tks = sign.unlist_ref().to_vec();
+              tks.extend(result.unlist());
+              result = i_wrap(None, Tokens::new(tks));
+            }
           }
-          if let Some(s) = sign {
-            result.extend_from_slice(s.unlist_ref());
-          }
-          if let Some(im) = &imag {
-            result.extend_from_slice(im.unlist_ref());
-          }
-          result.extend(i_tok.unlist());
-          Tokens::new(result)
+          result
         } else {
           Tokens::default()
         }
@@ -2193,6 +2245,27 @@ fn make_unitobject_expansion(name: &str) -> Tokens {
   Tokens::new(tks)
 }
 
+/// Shared body of `\DeclareSIPrePower` / `\DeclareSIPostPower` (Perl L1283-1305),
+/// and hence of v3's `\DeclareSIPower`, which declares one of each.
+/// `kind` is `prepower` (applies before the unit, `\square\metre`) or `postpower`
+/// (after it, `\metre\squared`).
+fn declare_si_power(cs: &Token, power: &Tokens, kind: &str) -> Result<()> {
+  let name = cs.to_string().trim_start_matches('\\').to_string();
+  let encoded = format!("{kind}|^{{{power}}}|{power}");
+  assign_mapping("siunitx_macros", &name, Some(Stored::from(encoded)));
+  register_unit_macro_name(&name);
+
+  define_macro_simple(
+    T_CS!(&format!("\\lx@six@{name}")),
+    make_unitobject_expansion(&name),
+  )?;
+  // Let \cs = \relax if not yet defined (prevents "undefined" errors)
+  if !has_meaning(cs) {
+    let_i(cs, &T_CS!("\\relax"), None);
+  }
+  Ok(())
+}
+
 /// Build expansion tokens: \lx@six@unitobject@collapsible{name}{presentation}
 /// Perl L1227-1249: If presentation expands to more \lx@six@unitobject tokens,
 /// pass them through (alias collapsing, e.g. \metre → \meter).
@@ -2297,6 +2370,30 @@ LoadDefinitions!({
     "table-figures-integer", "table-format",
     "table-number-alignment",
     "table-space-text-post", "table-space-text-pre",
+    // The rest of Perl's `\sisetup` defaults block (L1493-1632), mirrored
+    // verbatim below. Perl sets these without registering them; we register
+    // so our own defaults pass — and any document that sets them — is quiet.
+    "math-rm", "math-sf", "math-tt", "mode",
+    "text-rm", "text-sf", "text-tt",
+    "forbid-literal-units", "multi-part-units",
+    "table-unit-alignment", "table-align-comparator", "table-align-exponent",
+    "table-align-text-pre", "table-align-text-post", "table-align-uncertainty",
+    "table-omit-exponent", "table-parse-only", "table-text-alignment",
+    "redefine-symbols",
+    "math-angstrom", "math-arcminute", "math-arcsecond", "math-celsius",
+    "math-degree", "math-micro", "math-ohm",
+    "text-angstrom", "text-arcminute", "text-arcsecond", "text-celsius",
+    "text-degree", "text-micro", "text-ohm",
+    "detect-family", "detect-italic", "detect-mode", "detect-shape",
+    "detect-weight", "number-angle-separator",
+    // siunitx v3-only spellings with no v2 equivalent to route them to. They
+    // select fonts/families that LaTeXML models structurally rather than
+    // visually, so they are accepted and ignored — but accepting them keeps
+    // Warn meaningful. Witness 2606.13010 `\sisetup{reset-text-family,
+    // unit-font-command}`.
+    "reset-text-family", "unit-font-command",
+    // v3 spellings routed to their v2 names by `six_canonical_key`.
+    "quantity-product",
   ] {
     DefKeyVal!("SIX", key, "", "");
   }
@@ -2510,17 +2607,7 @@ LoadDefinitions!({
     let cs = read_si_declare_cs()?;
     skip_spaces()?;
     let power = read_arg(ExpansionLevel::Off)?;
-    let name = cs.to_string().trim_start_matches('\\').to_string();
-    let newcs_name = format!("\\lx@six@{name}");
-
-    let encoded = format!("prepower|^{{{}}}|{}", power, power);
-    assign_mapping("siunitx_macros", &name, Some(Stored::from(encoded)));
-    register_unit_macro_name(&name);
-
-    define_macro_simple(T_CS!(&newcs_name), make_unitobject_expansion(&name))?;
-    if !has_meaning(&cs) {
-      let_i(&cs, &T_CS!("\\relax"), None);
-    }
+    declare_si_power(&cs, &power, "prepower")?;
   });
 
   // \DeclareSIPostPower [kv] \cs {power}
@@ -2529,19 +2616,30 @@ LoadDefinitions!({
     let cs = read_si_declare_cs()?;
     skip_spaces()?;
     let power = read_arg(ExpansionLevel::Off)?;
-    let name = cs.to_string().trim_start_matches('\\').to_string();
-    let newcs_name = format!("\\lx@six@{name}");
-
-    let encoded = format!("postpower|^{{{}}}|{}", power, power);
-    assign_mapping("siunitx_macros", &name, Some(Stored::from(encoded)));
-    register_unit_macro_name(&name);
-
-    define_macro_simple(T_CS!(&newcs_name), make_unitobject_expansion(&name))?;
-    // Let \cs = \relax if not yet defined (prevents "undefined" errors)
-    if !has_meaning(&cs) {
-      let_i(&cs, &T_CS!("\\relax"), None);
-    }
+    declare_si_power(&cs, &power, "postpower")?;
   });
+
+  // siunitx v3 \DeclareSIPower [kv] \before \after {power} — "creates two
+  // symbols, one for use before a unit, the second for use after a unit, both
+  // of which are equivalent to the <power>" (manual §"\DeclareSIPower", e.g.
+  // `\DeclareSIPower\quartic\tothefourth{4}`). Exactly one \DeclareSIPrePower
+  // plus one \DeclareSIPostPower, so it reuses their shared body.
+  DefPrimitive!("\\DeclareSIPower[]", {
+    skip_spaces()?;
+    let before = read_si_declare_cs()?;
+    skip_spaces()?;
+    let after = read_si_declare_cs()?;
+    skip_spaces()?;
+    let power = read_arg(ExpansionLevel::Off)?;
+    declare_si_power(&before, &power, "prepower")?;
+    declare_si_power(&after, &power, "postpower")?;
+  });
+
+  // \SendSettingsToPgf — "deprecated, and should be replaced simply by setting
+  // the appropriate \pgfkeys in parallel to \sisetup" (manual §6). Takes no
+  // arguments; we model the deprecation as a no-op rather than leaving the CS
+  // undefined, since LaTeXML has no pgf key state to push settings into.
+  DefMacro!("\\SendSettingsToPgf", "");
 
   // \DeclareSIQualifier [kv] \cs {qualifier}
   DefPrimitive!("\\DeclareSIQualifier[]", {
@@ -2868,7 +2966,23 @@ LoadDefinitions!({
   RawTeX!("\\@ifundefined{qty}{\\let\\qty\\SI}{}");
   Let!("\\qtylist", "\\SIlist");
   Let!("\\qtyrange", "\\SIrange");
-  Let!("\\qtyproduct", "\\SIlist");
+
+  // siunitx v3 renamed some v2 spellings and added commands whose behaviour the
+  // v2 number grammar already covers, so they are aliases rather than new code:
+  //
+  // * `\numproduct{5 x 100 x 2}` / `\qtyproduct{...}{unit}` — a *product*
+  //   (`5 × 100 × 2`, siunitx manual §"product-mode"), which `six_parse_number`
+  //   already builds from `input-product` into an `operator => 'product'` node
+  //   (Perl L288-289) and formats through the MULOP/times op (Perl L625-627).
+  //   `\qtyproduct` previously aliased `\SIlist`, which rendered a product as a
+  //   comma-and-"and" *list* — wrong output, not just wrong semantics.
+  // * `\complexnum{1+2i}` / `\complexqty{1+2i}{unit}` — Cartesian `a+bi`/`a+ib`
+  //   or polar `r:θ`, "otherwise identical to the standard \num/\qty command"
+  //   (manual §3.5). `six_match_complexnumber` (Perl L251) already parses these.
+  Let!("\\numproduct", "\\num");
+  Let!("\\qtyproduct", "\\SI");
+  Let!("\\complexnum", "\\num");
+  Let!("\\complexqty", "\\SI");
 
   //======================================================================
   // Table column types S and s — Perl: DefColumnType('S Optional', ...) and
@@ -3020,64 +3134,150 @@ LoadDefinitions!({
   //======================================================================
   // Default options
   //======================================================================
+  // Default options — a verbatim mirror of Perl siunitx.sty.ltxml
+  // L1493-L1632 (including its comments, so the two blocks stay diffable).
+  // Perl sets 107 keys; we previously set 57. None of the 50 added here are
+  // read by this file (they are state parity only), so the port is inert —
+  // its value is that `\sisetup{mode = math}` & co. are now known keys.
   RawTeX!(r#"\sisetup{
   abbreviations,
   binary-units,
+
+  math-rm = \mathrm,
+  math-sf = \mathsf,
+  math-tt = \mathtt,
+  mode    = math,
+  text-rm = \rmfamily,
+  text-sf = \sffamily,
+  text-tt = \ttfamily,
+
   input-product  = x,
   input-quotient = /,
+%(
   input-close-uncertainty = ),
   input-complex-roots     = ij,
   input-comparators       = {<=>\approx\ge\geq\gg\le\leq\ll\sim},
   input-decimal-markers   = {.,},
   input-digits            = 0123456789,
   input-exponent-markers  = dDeE,
-  input-open-uncertainty  = (,
+  input-open-uncertainty  = (, % )
   input-protect-tokens    = \approx\dots\ge\geq\gg\le\leq\ll\mp\pi\pm\sim,
   input-signs             = +-\mp\pm,
   input-symbols           = \dots\pi,
   input-uncertainty-signs = \pm,
+
   add-decimal-zero      = true,
   add-integer-zero      = true,
   retain-unity-mantissa = true,
-  bracket-numbers           = true,
-  close-bracket             = ),
-  complex-root-position     = after-number,
-  copy-decimal-marker       = false,
-  exponent-base             = 10,
-  exponent-product          = \times,
-  group-digits              = true,
-  group-minimum-digits      = 5,
-  group-separator           = \,,
-  open-bracket              = (,
-  output-close-uncertainty  = ),
-  output-complex-root       = \ensuremath{\mathrm{i}},
-  output-decimal-marker     = .,
-  output-open-uncertainty   = (,
-  fraction-function = \frac,
-  output-product    = \times,
-  output-quotient   = /,
-  parse-numbers     = true,
+  round-half            = up,
+  round-minimum         = 0,
+  round-precision       = 2,
+
+  bracket-numbers           = true                          , % (
+  close-bracket             = )                             ,
+  complex-root-position     = after-number                  ,
+  copy-decimal-marker       = false                         ,
+  exponent-base             = 10                            ,
+  exponent-product          = \times                        ,
+  group-digits              = true                          ,
+  group-minimum-digits      = 5                             ,
+  group-separator           = \,                            ,
+  open-bracket              = (                             , % ) (
+  output-close-uncertainty  = )                             ,
+  output-complex-root       = \ensuremath { \mathrm { i } } ,
+  output-decimal-marker     = .                             ,
+  output-open-uncertainty   = (, % )
+
+  fraction-function = \frac  ,
+  output-product    = \times ,
+  output-quotient   = /      ,
+  parse-numbers     = true   ,
   quotient-mode     = symbol,
+
+
+  forbid-literal-units = false,
+  parse-units          = true,
+
   prefixes-as-symbols = true,
+
   bracket-unit-denominator     = true,
   inter-unit-product           = \,,
+  literal-superscript-as-power = true,
   per-mode                     = reciprocal,
   per-symbol                   = /,
+  power-font                   = number,
   qualifier-mode               = subscript,
-  number-unit-product = \,,
+  qualifier-phrase             = { ~ of ~ },
+
+  multi-part-units    = brackets,
+  number-unit-product = \,      ,
   product-units       = repeat,
-  list-final-separator = { and },
-  list-pair-separator  = { and },
-  list-separator       = {, },
+
+  list-final-separator = { and } ,
+  list-pair-separator  = { and } ,
+  list-separator       = {, }    ,
   list-units           = repeat,
+
   range-phrase = { to },
   range-units  = repeat,
-  bracket-numbers,
-  parse-numbers,
-  parse-units,
+
+  table-unit-alignment = center,
+
+  table-align-comparator  = true,
+  table-align-exponent    = true,
+  table-align-text-pre    = true,
+  table-align-text-post   = true,
+  table-align-uncertainty = true,
+  table-omit-exponent     = false,
+  table-parse-only        = false,
+  table-number-alignment  = center-decimal-marker,
+  table-text-alignment    = center,
+  table-figures-decimal   = 2,
+  table-figures-integer   = 3,
+
+  redefine-symbols = true,
+
+  math-angstrom  = \text { \AA },
+  math-arcminute = { } ^ { \prime },
+  math-arcsecond = { } ^ { \prime \prime },
+  math-celsius   = { } ^ { \circ } \kern - \scriptspace \__siunitx_unit_mathrm:n { C } ,
+  math-degree    = { } ^ { \circ },
+  math-micro     = \text { \c__siunitx_mu_tl },
+  math-ohm       = \text { \ensuremath { \c__siunitx_omega_tl } },
+
+  text-angstrom  = \AA,
+  text-arcminute = \ensuremath { { } ^ { \prime } },
+  text-arcsecond = \ensuremath { { } ^ { \prime \prime } },
+  text-celsius   =
+    \ensuremath { { } ^ { \circ } } \kern -\scriptspace C ,
+  text-degree    = \ensuremath { { } ^ { \circ } },
+  text-micro     = \c__siunitx_mu_tl ,
+  text-ohm       = \ensuremath { \c__siunitx_omega_tl },
+
+% if strict;
+% bracket-numbers  = true,
+% detect-family    = false,
+% detect-mode      = false,
+% detect-shape     = false,
+% detect-weight    = false,
+% multi-part-units = brackets,
+% parse-numbers    = true,
+% parse-units      = true,
+% product-units    = repeat,
+% otherwise
+  bracket-numbers  ,
+  detect-family    ,
+  detect-italic    ,
+  detect-mode      ,
+  detect-shape     ,
+  detect-weight    ,
+  multi-part-units ,
+  parse-numbers    ,
+  parse-units      ,
   product-units,
   number-angle-product=,
-  arc-separator=
+  number-angle-separator=,
+  arc-separator=,
 }"#);
 
   //======================================================================


### PR DESCRIPTION
**Diagnostic.** Our port of Perl's `six_format_complexnumber` (`siunitx.sty.ltxml` L555-576) was a flattened concatenation, dropping the `meaning="imaginary-unit"` enrichment, the `\lx@InvisibleTimes` infix, `complex-root-position`, and the brackets around a complex mantissa — and `tests/complex/si.xml` had blessed that output, so the test was green on wrong markup. Separately, five siunitx v3 commands were undefined, `\qtyproduct` aliased the *list* command `\SIlist`, and 50 of Perl's 107 `\sisetup` defaults were missing — `mode` among them, which is what made the reporting paper warn.

**Approach.** Port the Perl function in full; mirror Perl's defaults block verbatim (comments included, so the two stay diffable) and register those keys so `Warn` stays meaningful; map the v3 spelling `quantity-product` onto v2 `number-unit-product` at the single assignment point, so `\qty[quantity-product=\text{-}]` shows the author's hyphen while keeping `meaning="times"`. The v3 commands become aliases over the v2 number grammar we already own. `product-units` stays unimplemented, matching Perl, which registers it and never reads it.

**Validation.** Verified against the upstream Perl golden `LaTeXML/t/complex/si.xml` rather than a live Perl run: **0 of 20** imaginary-unit signatures matched before, **17 of 20** now (the 3 residuals are a pre-existing uncertainty-formatting gap that also affects non-complex input). All 18 changed signatures in the re-blessed `si_test` are complex-number cases. New guard `siunitx_v3_test`, kept separate from `si.tex` so that fixture stays byte-comparable with Perl's. Full suite 1683/0, clippy/fmt clean; witness 2606.13010 reconverts with 0 errors and 0 unknown-key warnings (was 4).

Refs arXiv/html_feedback#6624

🤖 Generated with [Claude Code](https://claude.com/claude-code)