### PR TITLE
feat(math): parse fences split by TeX's null delimiter instead of giving up

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -1958,6 +1958,41 @@ branch in Perl, faithfully ported in `document.rs::append_tree`. Perl simply nev
 chains its parser to it. Accepting fragments therefore inserts more of the author's
 content correctly and can never emit *fewer* errors than Perl.
 
+### 67. A fence split by TeX's null delimiter is re-balanced before it is given up on
+
+**Perl.** `\left( a+b \right.` is a fence whose right delimiter is *empty*, and
+digestion emits no token for the `.` at all. When such a fence is split across an
+alignment break — the standard way to break a long parenthesised expression:
+
+```latex
+\begin{align}
+  H & = \frac{\hbar}{2} \left( \Omega_{IX} IX + \ldots \right. \nonumber \\
+    & \quad \left. + \Omega_{ZX} ZX + \ldots \right).
+\end{align}
+```
+
+each cell is left holding one unmatched delimiter. Perl's MathGrammar has no rule
+for that, so it reports `not_parsed` (four warnings on the minimal case) and the
+formula degrades to unstructured markup.
+
+**Rust.** The XMath we build is byte-identical to Perl's — same `XMWrap` with an
+unmatched `OPEN`, same bare `CLOSE` — so this is purely a parser difference. When
+the grammar returns **zero** derivations, `parser.rs::balance_null_delimiters`
+re-supplies the delimiter TeX says is there and retries once. The synthesized
+`XMTok` carries the fence `role` but empty text, so it renders as nothing, which
+is exactly `\right.`'s meaning; `tex=` reversions stay verbatim
+(`\left(a+b\right.`). The cells then parse through the *existing* open/close
+fence semantics as `delimited-(@(…)` / `delimited-)@(…)`.
+
+**Why this is safe rather than a parity break.** It is gated on total parse
+failure, so no formula that already parses can be re-read — the repair is
+unreachable for them. That gate is load-bearing, not incidental: an earlier
+unconditional version read the `⟩` of a ket `|f⟩` as a dangling close (its partner
+is a `VERTBAR`, not an `OPEN`), prepended a bogus `(`, and broke formulae that had
+been fine. Guarded by `tests/math/split_fence.tex`, which pins the ket case
+alongside the split fence. Emitting *more* structure than Perl on input Perl
+cannot parse never yields fewer errors than Perl. Witness: arXiv 2606.13010.
+
 **What did NOT loosen.** Parser recovery stays OFF in both attempts. libxml's
 recovery mode silently destroys author content — measured: `<b>a</b> <i>b</i>`
 salvaged to just `<b>a</b>`, `a&nbsp;b` to `ab`, `a & b` to `a  b` — so malformed

--- a/latexml_math_parser/src/parser.rs
+++ b/latexml_math_parser/src/parser.rs
@@ -424,6 +424,11 @@ pub struct MathParser {
   /// (`core_interface`), so this set's lifetime IS the document scope. Hashed (not stored whole) to
   /// stay O(8 bytes) per formula under the worker fleet.
   warned_formulas:           HashSet<u64>,
+  /// Set while running the SPECULATIVE first parse of a fence-unbalanced
+  /// formula, whose failure is expected and is rescued by the
+  /// `balance_null_delimiters` retry. Without it the log would carry an
+  /// `unparsed_math` warning for a formula that ends up fully parsed.
+  suppress_unparsed_warning: bool,
   // strict: bool,
   // xnode: Option<Node>,
 }
@@ -450,6 +455,7 @@ impl Default for MathParser {
       n_parsed: 0,
       last_parsetrees_count: 0,
       warned_formulas: HashSet::new(),
+      suppress_unparsed_warning: false,
       // strict: true,
       // xnode: None,
     }
@@ -1493,7 +1499,8 @@ impl MathParser {
     } else {
       // Use pre-filtered content_nodes to avoid double-filtering (filter_hints already called
       // above)
-      let (lexemes, mut nodes) = node_to_grammar_lexemes_from(mathnode, content_nodes, &mut idx);
+      let (mut lexemes, mut nodes) =
+        node_to_grammar_lexemes_from(mathnode, content_nodes, &mut idx);
       // Skip the full grammar parse for a pathologically huge formula —
       // Marpa's Earley recognizer would exhaust memory and `abort()`
       // (uncatchable). Fall through to the kludge parser instead (the
@@ -1534,7 +1541,22 @@ impl MathParser {
           warn_fn().ok();
           Ok(None)
         },
-        _ => self.parse_lexemes(lexemes, &nodes, document),
+        _ => {
+          // A fence-unbalanced stream is the one shape the retry below can
+          // rescue, so keep this attempt's expected failure out of the log —
+          // and keep the lexemes, which the retry needs. Balanced formulae (the
+          // overwhelming majority) hand theirs over and pay no copy.
+          let retryable = Self::fence_imbalance(&lexemes).is_some();
+          self.suppress_unparsed_warning = retryable;
+          let attempt = if retryable {
+            lexemes.clone()
+          } else {
+            std::mem::take(&mut lexemes)
+          };
+          let out = self.parse_lexemes(attempt, &nodes, document);
+          self.suppress_unparsed_warning = false;
+          out
+        },
       };
       // Resource fatals must propagate, not be dropped by the if-let below
       // (PR #249 review P1-4); other Errs keep the old treated-as-failure
@@ -1542,6 +1564,21 @@ impl MathParser {
       let parse_outcome = match parse_outcome {
         Err(e) if matches!(e.target, latexml_core::common::error::ErrorTarget::Timeout) => {
           return Err(e);
+        },
+        other => other,
+      };
+      // Second chance for a formula the grammar could not parse AT ALL: if its
+      // fences are unbalanced, re-supply TeX's null delimiter and retry once.
+      // Gating on failure is what makes this safe — a stream that already
+      // parses is never touched, so no working formula can be re-interpreted.
+      // (An earlier unconditional version did exactly that: it read the `⟩` of
+      // a ket `|f⟩` as an unmatched CLOSE and prepended a bogus `(`, breaking
+      // formulae that had been fine.)
+      let parse_outcome = match parse_outcome {
+        Ok(None) | Err(_)
+          if Self::balance_null_delimiters(&mut lexemes, &mut nodes, mathnode, document)? =>
+        {
+          self.parse_lexemes(lexemes, &nodes, document)
         },
         other => other,
       };
@@ -1640,6 +1677,89 @@ impl MathParser {
     document.close_element_at(&mut xmwrap)?;
     document.close_element_at(&mut dual)?;
     Ok(dual)
+  }
+
+  /// Count the fence delimiters a stream is missing: `(closes_needed_in_front,
+  /// opens_needed_at_end)`, or `None` when it is balanced — or so lopsided that
+  /// it is garbled rather than null-delimited, where synthesizing a pile of
+  /// fences would only invent structure that isn't there.
+  fn fence_imbalance(lexemes: &[String]) -> Option<(i32, i32)> {
+    const MAX_SYNTHETIC_DELIMITERS: i32 = 2;
+    let (mut depth, mut min_depth) = (0i32, 0i32);
+    for lex in lexemes {
+      // The ROLE is the first `:`-segment. (Not `distill_lexeme`, which splits
+      // at the LAST separator to recover the trailing lexeme text.)
+      match lex.split(':').next().unwrap_or("") {
+        "OPEN" | "OTHER_OPEN" => depth += 1,
+        "CLOSE" | "OTHER_CLOSE" => depth -= 1,
+        _ => {},
+      }
+      min_depth = min_depth.min(depth);
+    }
+    let unmatched_closes = -min_depth;
+    let unmatched_opens = depth - min_depth;
+    let lopsided =
+      unmatched_closes > MAX_SYNTHETIC_DELIMITERS || unmatched_opens > MAX_SYNTHETIC_DELIMITERS;
+    match (unmatched_closes, unmatched_opens) {
+      (0, 0) => None,
+      _ if lopsided => None,
+      pair => Some(pair),
+    }
+  }
+
+  /// Restore the fence partner that TeX's *null delimiter* leaves implicit.
+  ///
+  /// `\left( a+b \right.` is a genuine fence whose right delimiter is empty, but
+  /// digestion emits no token for the `.` at all (Perl does the same — the XMath
+  /// is byte-identical), so the parser sees an `OPEN` with no `CLOSE`. The
+  /// grammar's `open_fenced`/`close_fenced` rules only cover the `ARRAY`
+  /// terminal (a fenced matrix), not general expressions, whose fence rules in
+  /// `fenced_factor` are balanced-only. The result is a hard parse failure —
+  /// **zero** derivations — so the whole formula falls back to
+  /// `ltx_math_unparsed`, losing every unrelated structure in it (fractions,
+  /// subscripts, operator trees).
+  ///
+  /// Rather than add open-ended grammar rules — which would make every balanced
+  /// `( … )` ambiguous with a dangling reading and inflate the parse forest on
+  /// the ~99 % of math that is balanced — we re-supply the delimiter that TeX
+  /// says is there. The synthesized `XMTok` carries the fence `role` but **empty
+  /// text**, so it renders as nothing, which is exactly `\right.`'s semantics.
+  ///
+  /// Balanced input is untouched: the scan finds no imbalance and returns.
+  ///
+  /// Witness: 2606.13010 appendix (CR Hamiltonian split across an `align` break).
+  fn balance_null_delimiters(
+    lexemes: &mut Vec<String>,
+    nodes: &mut Vec<Node>,
+    mathnode: &mut Node,
+    document: &mut Document,
+  ) -> Result<bool> {
+    // The lexeme's trailing `:N` is a 1-based index into `nodes`, so a lexeme's
+    // position in the stream is independent of where its node sits — we can
+    // insert at the front while pushing its node at the back.
+    if lexemes.len() != nodes.len() {
+      return Ok(false); // defensive: never repair a stream we can't index safely
+    }
+    let Some((unmatched_closes, unmatched_opens)) = Self::fence_imbalance(lexemes) else {
+      return Ok(false);
+    };
+    let mut synth = |role: &str, text: &str, nodes: &mut Vec<Node>| -> Result<String> {
+      let mut tok = document.open_element_at(mathnode, "ltx:XMTok", None, None)?;
+      document.set_attribute(&mut tok, "role", role)?;
+      document.close_element_at(&mut tok)?;
+      tok.unlink();
+      nodes.push(tok);
+      Ok(format!("{role}:{text}:{}", nodes.len()))
+    };
+    for _ in 0..unmatched_closes {
+      let lex = synth("OPEN", "(", nodes)?;
+      lexemes.insert(0, lex);
+    }
+    for _ in 0..unmatched_opens {
+      let lex = synth("CLOSE", ")", nodes)?;
+      lexemes.push(lex);
+    }
+    Ok(true)
   }
 
   pub fn parse_marpa(
@@ -2112,6 +2232,11 @@ impl MathParser {
       Some("ambiguous_math")
     } else {
       None
+    };
+    let diagnostic_category = match diagnostic_category {
+      // The retry below may still rescue this formula — stay quiet until it has had its turn.
+      Some("unparsed_math") if self.suppress_unparsed_warning => None,
+      other => other,
     };
     if let Some(category) = diagnostic_category {
       // Warn once per DISTINCT formula per document (Perl LaTeXML's rule): a formula repeated N

--- a/latexml_oxide/tests/math/split_fence.tex
+++ b/latexml_oxide/tests/math/split_fence.tex
@@ -1,0 +1,30 @@
+% TeX's null delimiter: `\left( ... \right.` is a fence whose right delimiter is
+% empty. Digestion emits no token for the `.` (Perl does the same — the XMath is
+% byte-identical), so a fence split across an alignment break leaves each cell
+% with an unmatched delimiter. The grammar's fence rules for general
+% expressions are balanced-only, so this used to yield ZERO parses and drop the
+% whole formula — fractions and subscripts included — to ltx_math_unparsed.
+% Witness: arXiv 2606.13010 appendix (CR Hamiltonian).
+\documentclass{article}
+\usepackage{amsmath}
+\begin{document}
+
+% The split fence itself: both cells must parse, and neither may gain a
+% delimiter the author did not write.
+\begin{align}
+  H & = \frac{\hbar}{2} \left( a + b \right. \nonumber \\
+    & \quad \left. + c + d \right).
+\end{align}
+
+% Balanced control — must be completely unaffected by the repair.
+\begin{equation}
+  H = \frac{\hbar}{2} \left( a + b + c + d \right)
+\end{equation}
+
+% REGRESSION GUARD. A ket's closing `⟩` pairs with a VERTBAR, not with an OPEN,
+% so a naive "unbalanced ⇒ synthesize a partner" pass reads it as a dangling
+% close and prepends a bogus `(`. These parsed before the repair existed and
+% must keep parsing; an earlier unconditional version broke exactly these.
+\(|f\rangle\) and \(\langle g|\) and \(\langle f | g \rangle\)
+
+\end{document}

--- a/latexml_oxide/tests/math/split_fence.xml
+++ b/latexml_oxide/tests/math/split_fence.xml
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article"?>
+<?latexml package="amsmath"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <para xml:id="p1">
+    <equationgroup class="ltx_eqn_align" xml:id="S0.EGx1">
+      <equation xml:id="S0.Ex1">
+        <MathFork>
+          <Math tex="\displaystyle H=\frac{\hbar}{2}\left(a+b\right." text="H = (Planck-constant-over-2-pi / 2) * delimited-(@(a + b)" xml:id="S0.Ex1.m3">
+            <XMath>
+              <XMApp>
+                <XMTok meaning="equals" role="RELOP">=</XMTok>
+                <XMTok font="italic" role="UNKNOWN">H</XMTok>
+                <XMApp>
+                  <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                  <XMApp>
+                    <XMTok mathstyle="display" meaning="divide" role="FRACOP"/>
+                    <XMTok meaning="Planck-constant-over-2-pi" name="hbar" role="ID">ℏ</XMTok>
+                    <XMTok meaning="2" role="NUMBER">2</XMTok>
+                  </XMApp>
+                  <XMDual>
+                    <XMApp>
+                      <XMTok meaning="delimited-("/>
+                      <XMRef idref="S0.Ex1.m3.1"/>
+                    </XMApp>
+                    <XMWrap>
+                      <XMTok role="OPEN" stretchy="true">(</XMTok>
+                      <XMApp xml:id="S0.Ex1.m3.1">
+                        <XMTok meaning="plus" role="ADDOP">+</XMTok>
+                        <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                        <XMTok font="italic" role="UNKNOWN">b</XMTok>
+                      </XMApp>
+                      <XMTok role="CLOSE"/>
+                    </XMWrap>
+                  </XMDual>
+                </XMApp>
+              </XMApp>
+            </XMath>
+          </Math>
+          <MathBranch>
+            <td align="right"><Math mode="inline" tex="\displaystyle H" text="H" xml:id="S0.Ex1.m1">
+                <XMath>
+                  <XMTok font="italic" role="UNKNOWN">H</XMTok>
+                </XMath>
+              </Math></td>
+            <td align="left"><Math mode="inline" tex="\displaystyle=\frac{\hbar}{2}\left(a+b\right." text="absent = (Planck-constant-over-2-pi / 2) * delimited-(@(a + b)" xml:id="S0.Ex1.m2">
+                <XMath>
+                  <XMApp>
+                    <XMTok meaning="equals" role="RELOP">=</XMTok>
+                    <XMTok meaning="absent"/>
+                    <XMApp>
+                      <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                      <XMApp>
+                        <XMTok mathstyle="display" meaning="divide" role="FRACOP"/>
+                        <XMTok meaning="Planck-constant-over-2-pi" name="hbar" role="ID">ℏ</XMTok>
+                        <XMTok meaning="2" role="NUMBER">2</XMTok>
+                      </XMApp>
+                      <XMDual>
+                        <XMApp>
+                          <XMTok meaning="delimited-("/>
+                          <XMRef idref="S0.Ex1.m2.1"/>
+                        </XMApp>
+                        <XMWrap>
+                          <XMTok role="OPEN" stretchy="true">(</XMTok>
+                          <XMApp xml:id="S0.Ex1.m2.1">
+                            <XMTok meaning="plus" role="ADDOP">+</XMTok>
+                            <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                            <XMTok font="italic" role="UNKNOWN">b</XMTok>
+                          </XMApp>
+                          <XMTok role="CLOSE"/>
+                        </XMWrap>
+                      </XMDual>
+                    </XMApp>
+                  </XMApp>
+                </XMath>
+              </Math></td>
+          </MathBranch>
+        </MathFork>
+      </equation>
+      <equation xml:id="S0.E1">
+        <tags>
+          <tag>(1)</tag>
+          <tag role="refnum">1</tag>
+        </tags>
+        <MathFork>
+          <Math tex="\displaystyle\quad\left.+c+d\right)." text="delimited-)@(+ c + d)" xml:id="S0.E1.m2">
+            <XMath>
+              <XMDual>
+                <XMRef idref="S0.E1.m2.1"/>
+                <XMWrap>
+                  <XMDual xml:id="S0.E1.m2.1">
+                    <XMApp>
+                      <XMTok meaning="delimited-)"/>
+                      <XMRef idref="S0.E1.m2.2"/>
+                    </XMApp>
+                    <XMWrap>
+                      <XMTok role="OPEN"/>
+                      <XMApp xml:id="S0.E1.m2.2">
+                        <XMTok meaning="plus" role="ADDOP">+</XMTok>
+                        <XMApp>
+                          <XMTok lpadding="10.0pt" meaning="plus" role="ADDOP">+</XMTok>
+                          <XMTok font="italic" role="UNKNOWN">c</XMTok>
+                        </XMApp>
+                        <XMTok font="italic" role="UNKNOWN">d</XMTok>
+                      </XMApp>
+                      <XMTok role="CLOSE" stretchy="true">)</XMTok>
+                    </XMWrap>
+                  </XMDual>
+                  <XMTok role="PERIOD">.</XMTok>
+                </XMWrap>
+              </XMDual>
+            </XMath>
+          </Math>
+          <MathBranch>
+            <td/>
+            <td align="left"><Math mode="inline" tex="\displaystyle\quad\left.+c+d\right)." text="delimited-)@(+ c + d)" xml:id="S0.E1.m1">
+                <XMath>
+                  <XMDual>
+                    <XMRef idref="S0.E1.m1.1"/>
+                    <XMWrap>
+                      <XMDual xml:id="S0.E1.m1.1">
+                        <XMApp>
+                          <XMTok meaning="delimited-)"/>
+                          <XMRef idref="S0.E1.m1.2"/>
+                        </XMApp>
+                        <XMWrap>
+                          <XMTok role="OPEN"/>
+                          <XMApp xml:id="S0.E1.m1.2">
+                            <XMTok meaning="plus" role="ADDOP">+</XMTok>
+                            <XMApp>
+                              <XMTok lpadding="10.0pt" meaning="plus" role="ADDOP">+</XMTok>
+                              <XMTok font="italic" role="UNKNOWN">c</XMTok>
+                            </XMApp>
+                            <XMTok font="italic" role="UNKNOWN">d</XMTok>
+                          </XMApp>
+                          <XMTok role="CLOSE" stretchy="true">)</XMTok>
+                        </XMWrap>
+                      </XMDual>
+                      <XMTok role="PERIOD">.</XMTok>
+                    </XMWrap>
+                  </XMDual>
+                </XMath>
+              </Math></td>
+          </MathBranch>
+        </MathFork>
+      </equation>
+    </equationgroup>
+  </para>
+  <para xml:id="p2">
+    <equation xml:id="S0.E2">
+      <tags>
+        <tag>(2)</tag>
+        <tag role="refnum">2</tag>
+      </tags>
+      <Math mode="display" tex="H=\frac{\hbar}{2}\left(a+b+c+d\right)" text="H = (Planck-constant-over-2-pi / 2) * (a + b + c + d)" xml:id="S0.E2.m1">
+        <XMath>
+          <XMApp>
+            <XMTok meaning="equals" role="RELOP">=</XMTok>
+            <XMTok font="italic" role="UNKNOWN">H</XMTok>
+            <XMApp>
+              <XMTok meaning="times" role="MULOP">⁢</XMTok>
+              <XMApp>
+                <XMTok mathstyle="display" meaning="divide" role="FRACOP"/>
+                <XMTok meaning="Planck-constant-over-2-pi" name="hbar" role="ID">ℏ</XMTok>
+                <XMTok meaning="2" role="NUMBER">2</XMTok>
+              </XMApp>
+              <XMDual>
+                <XMRef idref="S0.E2.m1.1"/>
+                <XMWrap>
+                  <XMTok role="OPEN" stretchy="true">(</XMTok>
+                  <XMApp xml:id="S0.E2.m1.1">
+                    <XMTok meaning="plus" role="ADDOP">+</XMTok>
+                    <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                    <XMTok font="italic" role="UNKNOWN">b</XMTok>
+                    <XMTok font="italic" role="UNKNOWN">c</XMTok>
+                    <XMTok font="italic" role="UNKNOWN">d</XMTok>
+                  </XMApp>
+                  <XMTok role="CLOSE" stretchy="true">)</XMTok>
+                </XMWrap>
+              </XMDual>
+            </XMApp>
+          </XMApp>
+        </XMath>
+      </Math>
+    </equation>
+  </para>
+  <para xml:id="p3">
+    <p><Math mode="inline" tex="|f\rangle" text="ket@(f)" xml:id="p3.m1">
+        <XMath>
+          <XMDual>
+            <XMApp>
+              <XMTok meaning="ket"/>
+              <XMRef idref="p3.m1.1"/>
+            </XMApp>
+            <XMWrap>
+              <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+              <XMTok font="italic" role="UNKNOWN" xml:id="p3.m1.1">f</XMTok>
+              <XMTok name="rangle" role="CLOSE" stretchy="false">⟩</XMTok>
+            </XMWrap>
+          </XMDual>
+        </XMath>
+      </Math> and <Math mode="inline" tex="\langle g|" text="bra@(g)" xml:id="p3.m2">
+        <XMath>
+          <XMDual>
+            <XMApp>
+              <XMTok meaning="bra"/>
+              <XMRef idref="p3.m2.1"/>
+            </XMApp>
+            <XMWrap>
+              <XMTok name="langle" role="OPEN" stretchy="false">⟨</XMTok>
+              <XMTok font="italic" role="UNKNOWN" xml:id="p3.m2.1">g</XMTok>
+              <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+            </XMWrap>
+          </XMDual>
+        </XMath>
+      </Math> and <Math mode="inline" tex="\langle f|g\rangle" text="inner-product@(f, g)" xml:id="p3.m3">
+        <XMath>
+          <XMDual>
+            <XMApp>
+              <XMTok meaning="inner-product"/>
+              <XMRef idref="p3.m3.1"/>
+              <XMRef idref="p3.m3.2"/>
+            </XMApp>
+            <XMWrap>
+              <XMTok name="langle" role="OPEN" stretchy="false">⟨</XMTok>
+              <XMTok font="italic" role="UNKNOWN" xml:id="p3.m3.1">f</XMTok>
+              <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+              <XMTok font="italic" role="UNKNOWN" xml:id="p3.m3.2">g</XMTok>
+              <XMTok name="rangle" role="CLOSE" stretchy="false">⟩</XMTok>
+            </XMWrap>
+          </XMDual>
+        </XMath>
+      </Math></p>
+  </para>
+</document>


### PR DESCRIPTION
**Diagnostic.** `\left( … \right.` split across an alignment break leaves each cell with one unmatched delimiter. `fenced_array`'s `open_fenced`/`close_fenced` rules look like they cover this, but `array` is `token!(array ~ "ARRAY")` — the XMArray terminal — so they only ever applied to an unmatched fence around a *matrix*; general-expression fences are balanced-only. The grammar returned **zero** derivations and the entire formula, fractions and subscripts included, fell back to `ltx_math_unparsed`.

**Approach.** Re-supply the delimiter TeX says is there and retry, rather than adding open-ended grammar rules that would make every balanced `( … )` ambiguous with a dangling reading. The synthesized `XMTok` has the fence role but empty text, so it renders as nothing and `tex=` reversions stay verbatim. **Gated on total parse failure**, which is what makes it safe — a formula that already parses is unreachable for it. That gate is load-bearing: an unconditional version read the `⟩` of a ket `|f⟩` as a dangling close and prepended a bogus `(`, breaking formulae that had been fine.

**Validation.** Guard `split_fence_test` pins the split fence, a balanced control, and the ket regression. Suite **1684/0** (baseline 1683/0, +1 new); clippy/fmt clean; `si.tex` 4.07s vs 4.02s on main — within run variance.

Measured over 24 arXiv 2606 papers containing the pattern, branch vs main binaries:

| | main | branch |
|---|---|---|
| `unparsed_math` | 177 | **102** (−42 %) |
| errors + fatals | 35 | 35 |
| papers improved | — | 19 / 24 |
| papers regressed | — | 0 |

Witness 2606.13010: 2 unparsed → **0**, with real `<mfrac>`/`<msub>`. The pattern occurs in **4 %** of papers (24 of 600 sampled) — an earlier 9.2 % figure quoted here was wrong, from a looser probe matching `\left.` anywhere rather than a line-ending `\right.`. The remaining 102 are other unparsed causes plus streams too lopsided for the 2-delimiter cap; this fixes a slice, not all of it.

This makes Rust parse input Perl cannot (Perl reports 4 `not_parsed` on the minimal case), so it is documented as divergence #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
