### PR TITLE
fix: digest amsrefs \bib field values as live TeX (arXiv/html_feedback#6776)

### DIFF
--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -628,6 +628,51 @@ residuals stay here so the live worklist keeps them visible:
 
 ## Open tasks (actionable)
 
+### amsrefs `\bib` field values reached the XML as dead text (arXiv/html_feedback#6776) — ✅ LANDED 2026-07-25 (branch `fix-6776-2508.17585-refs`)
+
+Rust Error Fix. The **reported** symptom (2508.17585: "references are not
+loading", empty `<ul class="ltx_biblist">`) is the *Perl* defect already fixed
+here — KNOWN_PERL_ERRORS #49 / OXIDIZED_DESIGN #57, guarded by
+`amsrefs_inline_bibliography_is_not_dropped`; same-host Perl still emits
+`Warning:expected:bibkeys` + 0 bibitems where Rust emits 34 (pdflatex: 34).
+Verifying that surfaced four **genuine Rust-only** divergences *inside* the
+entries, all now matching Perl's core XML on all 34:
+
+* **Field values were not live TeX.** Perl `BibTeX.pool.ltxml:134-166`
+  (`\bibentry@create`) assembles the entry as TeX *source* and hands it to a
+  fresh `Mouth`; `bibtex.rs` built a pre-tokenized stream with `Explode!`
+  (catcode-12 OTHER throughout), so `\MR{849427}` reached the XML as literal
+  characters (`Review “MR–849427˝` — the OT1 rendering). Now ports the Mouth,
+  with `\csname …\endcsname` for the `@`-bearing handler names as Perl does.
+  Lazy tokenization is also what lets the handlers' `Verbatim`/`Semiverbatim`
+  params set catcodes first, so `%`/`#`/`~` in a `url` value stay intact — a
+  plain `Tokenize!` swap would have regressed that.
+* **`pages` rendered empty.** `\bib@@pages` stored `Stored::Tokens`, but
+  `prop_digested!` renders only `Digested`/`VecDigested` and fell through its
+  catch-all to nothing. Perl L674 is `Digest(Tokenize($pages))` — now digested.
+* **`id` was aliased onto `xml:id`.** `LaTeXML-bib.rnc:335,353` declare a real
+  `attribute id` on `ltx:bib-identifier`/`ltx:bib-review`; the blanket alias
+  turned the ISSN into an invalid-NCName `xml:id="0010-3640,1097-0312"`.
+  `document.rs::set_attribute` now normalises the key once (the port spells
+  `xml:id` as bare `id` in ~15 internal call sites — math parser, `base_xmath`,
+  alignment rows — so the alias stays, but yields where the model declares a
+  real `id`), then follows Perl `Core/Document.pm:1370-1386` verbatim. The
+  serializer's companion name-keyed fixup is gone: it emits the attribute's
+  resolved qname, ordering unchanged (local name, `xml:id` last).
+* **`<bib-review>` children were flattened.** Perl `MakeBibliography.pm:655-667`
+  `do_links` clones `$node->childNodes` in every branch; Rust used
+  `get_content()`, dropping the nested `<ltx:ref>` — the MathSciNet link
+  vanished. Now clones (27 live links on the witness).
+
+Also `amsrefs_sty.rs` uses `untex()` (Perl `UnTeX($v,1)`) for the keyval slot:
+the tokenizer eats a control word's terminating space, so `to_string()` wrote
+`661\ndash693` into the `<bib-data>` BibTeX dump. Guards: `amsrefs_basic`
+(structure pair, extended with the pages/ISSN/url/review band) +
+`amsrefs_inline_bibliography_is_not_dropped` (post layer). **Not fixed** (adjacent,
+pre-existing, out of scope): a `mrnumber` field synthesizes no
+`<bib-identifier scheme="mr">` in Rust where Perl's `default@complete` does; and
+Rust omits the trailing newline Perl writes inside `<bib-data>`.
+
 ### A package loaded in a LaTeXML subfile bracket lost its definitions (#311) — ✅ LANDED 2026-07-23 (branch `fix-311-standalone-newif-group`)
 
 Rust Error Fix; shared upstream defect fixed ahead of Perl (KNOWN_PERL_ERRORS

--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -1948,6 +1948,14 @@ Confirmed on the installed Perl 0.8.8 **and** the vendored tree
 (`perl -I LaTeXML/blib/lib`, rev `51fea96a`) — not a version skew. On
 arXiv:2605.01646 Perl yields 0 bibitems and 81 dangling citations.
 
+Reported in the wild as [arXiv/html_feedback#6776](https://github.com/arXiv/html_feedback/issues/6776)
+("the references are not loading") against **arXiv:2508.17585**
+(`PMTCornersSpinor.tex`, amsrefs + a shipped `.bbl` of 34 `\bib` entries). The
+deployed arXiv HTML — Perl-produced — carries `<ul id="bib.L1"
+class="ltx_biblist"></ul>`, empty; same-host Perl reproduces it exactly
+(`Warning:expected:bibkeys Missing bibkeys …`, 34 `<bibentry>` in the core XML,
+0 `ltx_bibitem` after `latexmlpost`). pdflatex and Rust both render all 34.
+
 **Fixed in Rust** (OXIDIZED_DESIGN #57): `get_bib_entries` also scans the main
 document for inline `ltx:bibentry`. Papers with an external `.bib`/`.bbl` carry
 no inline entries, so the scan is a no-op for them. All 40 corpus papers went

--- a/latexml_core/src/document.rs
+++ b/latexml_core/src/document.rs
@@ -1496,29 +1496,45 @@ impl Document {
         }
 
         let anodes = node.get_attributes();
-        let mut anodes_keys: Vec<&String> = anodes.keys().collect();
-        // Sort: xmlns:* declarations first (matching Perl's output order), then alphabetically
-        anodes_keys.sort_by(|a, b| {
-          let a_is_xmlns = a.starts_with("xmlns:");
-          let b_is_xmlns = b.starts_with("xmlns:");
-          match (a_is_xmlns, b_is_xmlns) {
-            (true, false) => std::cmp::Ordering::Less,
-            (false, true) => std::cmp::Ordering::Greater,
-            _ => a.cmp(b),
+        // `get_attributes()` reports LOCAL names, so an `xml:id` attribute comes
+        // back keyed as "id" -- by name alone indistinguishable from a genuine
+        // plain `id`, which the model really does declare (see
+        // `LaTeXML-bib.rnc:335,353`: `ltx:bib-identifier/@id`,
+        // `ltx:bib-review/@id`). `get_node_document_qname` resolves the
+        // attribute's NAMESPACE, so it returns "xml:id" for the former and "id"
+        // for the latter; SERIALIZE that qname. Ordering stays keyed on the
+        // local name, which is what the goldens encode (`xml:lang` files under
+        // "lang", so it precedes `role`), with `xml:id` forced last -- the
+        // previous code got that by appending it separately, which is also what
+        // rewrote every plain `id` into an invalid-NCName `xml:id`
+        // (witness arXiv 2508.17585).
+        let mut anodes_keys: Vec<(SymStr, &String)> = anodes
+          .keys()
+          .map(|key| {
+            let qname = node
+              .get_attribute_node(key)
+              .map(|a| model::get_node_document_qname(&a))
+              .unwrap_or_else(|| arena::pin(key));
+            (qname, key)
+          })
+          .collect();
+        // Rank: xmlns:* declarations first (matching Perl's output order), then
+        // the ordinary attributes by local name, then xml:id last.
+        let rank = |qname: SymStr, key: &String| -> u8 {
+          if key.starts_with("xmlns:") {
+            0
+          } else if arena::with(qname, |q| q == "xml:id") {
+            2
+          } else {
+            1
           }
+        };
+        anodes_keys.sort_by(|(a_sym, a_key), (b_sym, b_key)| {
+          rank(*a_sym, a_key)
+            .cmp(&rank(*b_sym, b_key))
+            .then_with(|| a_key.cmp(b_key))
         });
-        for key in anodes_keys {
-          // Plain "id" is duplicated by libxml2 when xml:id is set.
-          // Skip it for non-SVG elements (which use xml:id).
-          // SVG elements use plain "id" (not xml:id).
-          if key == "id" && !tag.starts_with("svg:") {
-            continue;
-          }
-          // For SVG elements that have plain "id", skip the xml:id duplicate
-          if key == "xml:id" && tag.starts_with("svg:") && anodes.contains_key("id") {
-            continue;
-          }
-          let key_sym = model::get_node_document_qname(&node.get_attribute_node(key).unwrap());
+        for (key_sym, key) in anodes_keys {
           // Reuse the value already in `anodes` instead of re-fetching it with
           // `get_property` — `get_attributes()` read each value from the
           // attribute node directly, so a by-name `xmlGetProp` re-scan (plus a
@@ -1529,12 +1545,6 @@ impl Document {
             write!(open_tag, " {key_str}=\"{val_serialized}\"")
           })
           .ok();
-        }
-        // HACK for xml:id for now, assuming last element.
-        // SVG elements use plain "id" (not xml:id) — skip xml:id conversion for them.
-        if anodes.contains_key("id") && !tag.starts_with("svg:") {
-          let val_serialized = serialize_attr(anodes.get("id").map(String::as_str).unwrap_or(""));
-          write!(open_tag, " xml:id=\"{val_serialized}\"").ok();
         }
 
         let noindent_children: bool = if heuristic {
@@ -2888,36 +2898,42 @@ impl Document {
     if value.is_empty() {
       return Ok(()); // skip if empty
     }
-    // Perl: setAttribute checks canHaveAttribute before setting.
+    // Normalise the key first, then run Perl's plain `setAttribute`
+    // (`Core/Document.pm:1370-1386`): schema-check, then the LITERAL `xml:id`
+    // test. The normalisation is needed because this port spells `xml:id` as a
+    // bare `id` throughout its property/attribute maps -- the math parser,
+    // `base_xmath`, alignment rows and `RefStepID`'s `#id` all do it, where
+    // Perl's constructors always write `xml:id` out in full -- so a bare `id`
+    // arriving here normally MEANS `xml:id`. The exception is that `id` is ALSO
+    // a real attribute in the model: `LaTeXML-bib.rnc:335,353` declare
+    // `attribute id { text }?` on `ltx:bib-identifier` and `ltx:bib-review`,
+    // carrying the ISSN/DOI/MR identifier itself. Letting the alias apply
+    // unconditionally rewrote those into invalid-NCName ids
+    // (`xml:id="0010-3640,1097-0312"`) -- witness arXiv 2508.17585.
+    let key = if key == "id" && !model::can_have_attribute(get_node_qname(node), arena::pin("id")) {
+      "xml:id"
+    } else {
+      key
+    };
     // Accept internal attributes (starting with _), namespaced (containing :), and model-allowed.
-    if !key.starts_with('_') && !key.contains(':') && key != "id" {
+    if !key.starts_with('_') && !key.contains(':') {
       let qname = get_node_qname(node);
       if !model::can_have_attribute(qname, arena::pin(key)) {
         return Ok(()); // silently skip attributes not allowed by schema
       }
     }
-    if key == "xml:id" || key == "id" {
-      // Perl: only matches 'xml:id' literally, but our constructors use "id" for
-      // xml:id. For SVG elements, keep plain "id" (SVG spec uses id, not xml:id).
-      let node_qname = get_node_qname(node);
-      let is_svg = arena::with(node_qname, |s| s.starts_with("svg:"));
-      if is_svg && key == "id" {
-        // SVG elements use plain id, not xml:id (matching Perl behavior)
-        node.set_attribute(key, value)?;
-      } else {
-        // LaTeXML elements: always use xml:id.
-        // record_id_with_node detects duplicates and returns a
-        // deduplicated id when a DIFFERENT node already claims the
-        // same id. Previously we discarded that return value and
-        // wrote the original `value`, which meant libxml2 saw two
-        // nodes with the same xml:id. The post-processing scan's
-        // libxml2 idHash lookups then ran O(n²) on any document
-        // with enough duplicates (see 1106.1389 / KNOWN_PERL_ERRORS
-        // #13: 14 duplicate-id sites from \addtocounter{equation}{-1}
-        // + \subequations inside a \newtheorem[equation] theorem).
-        let deduped = self.record_id_with_node(value, node);
-        node.set_attribute("xml:id", &deduped)?;
-      }
+    if key == "xml:id" {
+      // record_id_with_node detects duplicates and returns a
+      // deduplicated id when a DIFFERENT node already claims the
+      // same id. Previously we discarded that return value and
+      // wrote the original `value`, which meant libxml2 saw two
+      // nodes with the same xml:id. The post-processing scan's
+      // libxml2 idHash lookups then ran O(n²) on any document
+      // with enough duplicates (see 1106.1389 / KNOWN_PERL_ERRORS
+      // #13: 14 duplicate-id sites from \addtocounter{equation}{-1}
+      // + \subequations inside a \newtheorem[equation] theorem).
+      let deduped = self.record_id_with_node(value, node);
+      node.set_attribute("xml:id", &deduped)?;
     } else if !key.contains(':') {
       // No colon; no namespace (the common case!)
       // Note: Full model validation (can_have_attribute) is done in node_set_attribute.

--- a/latexml_engine/src/bibtex.rs
+++ b/latexml_engine/src/bibtex.rs
@@ -1474,8 +1474,16 @@ LoadDefinitions!({
         normalised.push(c);
       }
     }
-    // Perl L674: Digest(Tokenize($pages)) — tokenize, not explode.
-    whatsit.set_property("pages", Stored::Tokens(Tokenize!(normalised.as_str())));
+    // Perl L674: `Digest(Tokenize($pages))` — tokenize (so `\ndash` &co stay
+    // live control sequences), then DIGEST. The digest step is load-bearing:
+    // `#pages` is a content slot, and `prop_digested!` only renders
+    // `Stored::Digested`/`VecDigested` — a `Stored::Tokens` fell through to its
+    // catch-all and rendered as NOTHING, so every amsrefs `pages` field came
+    // out as an empty `<ltx:bib-part role="pages"/>`. Witness arXiv 2508.17585.
+    whatsit.set_property(
+      "pages",
+      Stored::Digested(digest(Tokenize!(normalised.as_str()))?),
+    );
   });
 
   // Standard BibTeX fields.
@@ -1772,18 +1780,23 @@ LoadDefinitions!({
     // `current_entry_field` etc.) see the right entry.
     set_current_entry(&key);
 
-    let mut out: Vec<Token> = Vec::new();
+    // Perl L134-166 assembles the entry as TeX *source lines* and hands
+    // the join to a fresh Mouth. That is load-bearing, not incidental:
+    // the field values come from the document, so they must be tokenized
+    // under live catcodes (`\MR{...}` / `\ndash` in an amsrefs entry are
+    // real control sequences), and tokenizing lazily from a Mouth is what
+    // lets the handlers' `Verbatim`/`Semiverbatim` parameter types set
+    // their catcodes *first* — which is what keeps `%`/`#`/`~` in a `url`
+    // value intact. Building a pre-tokenized stream with `Explode!`
+    // (catcode-12 OTHER throughout) did neither: `\MR{849427}` reached the
+    // XML as the literal characters `\MR{849427}`. Witness arXiv 2508.17585.
+    //
+    // Handler names carry `@`, which is catcode-OTHER under the standard
+    // table a Mouth reads with, so — exactly as Perl does — they are
+    // invoked through `\csname ...\endcsname` rather than written bare.
+    let mut lines: Vec<String> = Vec::new();
     // `\begin{bib@entry}{<type>}{<key>}`
-    out.push(T_CS!("\\begin"));
-    out.push(T_BEGIN!());
-    out.extend(Explode!("bib@entry"));
-    out.push(T_END!());
-    out.push(T_BEGIN!());
-    out.extend(Explode!(resolved_type.as_str()));
-    out.push(T_END!());
-    out.push(T_BEGIN!());
-    out.extend(Explode!(&key));
-    out.push(T_END!());
+    lines.push(format!("\\begin{{bib@entry}}{{{}}}{{{}}}", resolved_type, key));
 
     // Dispatch prepare macros. Perl L128-131: prepare for the
     // resolved type, then the orig type if different, then default.
@@ -1794,9 +1807,8 @@ LoadDefinitions!({
     ];
     for cs_name in &prepare_csnames {
       if cs_name.is_empty() { continue; }
-      let tok = T_CS!(cs_name.as_str());
-      if lookup_definition(&tok)?.is_some() {
-        out.push(tok);
+      if lookup_definition(&T_CS!(cs_name.as_str()))?.is_some() {
+        lines.push(format!("\\csname {}\\endcsname", &cs_name[1..]));
       }
     }
 
@@ -1811,29 +1823,19 @@ LoadDefinitions!({
       let mut handler: Option<&str> = None;
       for c in candidates.iter() {
         if c.is_empty() { continue; }
-        let tok = T_CS!(c.as_str());
-        if lookup_definition(&tok)?.is_some() {
+        if lookup_definition(&T_CS!(c.as_str()))?.is_some() {
           handler = Some(c.as_str());
           break;
         }
       }
       match handler {
         Some(h) => {
-          // `\csname <h>\endcsname{value}`
-          out.push(T_CS!(h));
-          out.push(T_BEGIN!());
-          out.extend(Explode!(value));
-          out.push(T_END!());
+          lines.push(format!("\\csname {}\\endcsname{{{}}}", &h[1..], value));
         },
         None => {
           // Fallback per Perl L157: `\bib@field@default@default{field}{value}`.
-          out.push(T_CS!("\\bib@field@default@default"));
-          out.push(T_BEGIN!());
-          out.extend(Explode!(field));
-          out.push(T_END!());
-          out.push(T_BEGIN!());
-          out.extend(Explode!(value));
-          out.push(T_END!());
+          lines.push(format!(
+            "\\csname bib@field@default@default\\endcsname{{{}}}{{{}}}", field, value));
         },
       }
     }
@@ -1846,19 +1848,20 @@ LoadDefinitions!({
     ];
     for cs_name in &complete_csnames {
       if cs_name.is_empty() { continue; }
-      let tok = T_CS!(cs_name.as_str());
-      if lookup_definition(&tok)?.is_some() {
-        out.push(tok);
+      if lookup_definition(&T_CS!(cs_name.as_str()))?.is_some() {
+        lines.push(format!("\\csname {}\\endcsname", &cs_name[1..]));
       }
     }
 
     // `\end{bib@entry}`
-    out.push(T_CS!("\\end"));
-    out.push(T_BEGIN!());
-    out.extend(Explode!("bib@entry"));
-    out.push(T_END!());
+    lines.push("\\end{bib@entry}".to_string());
 
-    Ok(Tokens::new(out))
+    // Release the entry borrow before handing control to the gullet.
+    drop(entry);
+    // Perl L165-166: `openMouth(Mouth->new($tex))` — autoclose (Perl passes
+    // no `$noautoclose`), so the mouth pops itself once drained.
+    open_mouth(Mouth::new(&lines.join("\n"), None)?, true);
+    Ok(Tokens!())
   });
 
   // `{bib@entry}` environment — Perl L185-190. Wraps an entry's

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -1121,6 +1121,24 @@ fn amsrefs_inline_bibliography_is_not_dropped() {
     !x.contains("<bibentry"),
     "an ltx:bibentry survived unconverted:\n{x}"
   );
+  // A `\bib` field value is TeX, not literal text: Perl `BibTeX.pool.ltxml`
+  // `\bibentry@create` (L134-166) hands the assembled entry to a fresh Mouth, so
+  // `\ndash`/`\MR{…}` tokenize as control sequences. Building a pre-tokenized
+  // catcode-12 stream instead leaked them verbatim (`661\ndash693` and the OT1
+  // rendering `Review “MR–849427˝`) and left `pages` empty. Witness 2508.17585.
+  assert!(
+    x.contains("661–693"),
+    "`pages={{661\\ndash 693}}` did not render as an en-dashed range — the field \
+     value never reached the handlers as live TeX:\n{x}"
+  );
+  // MakeBibliography must clone bib-review's CHILDREN (Perl `do_links`
+  // L655-667 `cloneNodes($node->childNodes)`), not collapse them to text, or
+  // the `\MR` MathSciNet link is dropped on the floor.
+  assert!(
+    x.contains("mathscinet-getitem?mr=849427"),
+    "the `review={{\\MR{{849427}}}}` MathSciNet link vanished — bib-review's \
+     children were flattened to plain text:\n{x}"
+  );
 }
 
 /// Loading `bibunits` — even without ever opening a `bibunit` environment —

--- a/latexml_oxide/tests/cluster_regressions/amsrefs_inline_bibliography.tex
+++ b/latexml_oxide/tests/cluster_regressions/amsrefs_inline_bibliography.tex
@@ -1,7 +1,7 @@
 \documentclass{article}
 \usepackage[lite,abbrev,msc-links,alphabetic]{amsrefs}
 \begin{document}
-Cited inline: \cite{Bei87} and \cite{Smith2020}.
+Cited inline: \cite{Bei87} and \cite{Smith2020} and \cite{Bartnik}.
 % amsrefs writes the bibliography INTO the document (no external .bib, and so
 % no @files for getBibliographies to resolve). Upstream collects entries only
 % from external bib documents and then deletes every //ltx:bibentry, dropping
@@ -19,6 +19,19 @@ Cited inline: \cite{Bei87} and \cite{Smith2020}.
    title={On Examples},
    journal={JMP},
    date={2020},
+}
+% Field values must reach the handlers as LIVE TeX (Perl re-tokenizes them
+% through a fresh Mouth), so `\ndash` and `\MR` are control sequences, not
+% literal characters; and MakeBibliography must clone the marked-up children
+% of ltx:bib-review rather than flattening them to text. Witness 2508.17585.
+\bib{Bartnik}{article}{
+   author={Bartnik, Robert},
+   title={The mass of an asymptotically flat manifold},
+   journal={Comm. Pure Appl. Math.},
+   date={1986},
+   pages={661\ndash 693},
+   url={https://doi.org/10.1002/cpa.3160390505},
+   review={\MR{849427}},
 }
 \end{biblist}
 \end{bibdiv}

--- a/latexml_oxide/tests/structure/amsrefs_basic.tex
+++ b/latexml_oxide/tests/structure/amsrefs_basic.tex
@@ -15,6 +15,18 @@
   publisher = {Pub},
   year = 1999
 }
+\bib{Bartnik}{article}{
+      author={Bartnik, Robert},
+       title={The mass of an asymptotically flat manifold},
+        date={1986},
+        ISSN={0010-3640,1097-0312},
+     journal={Comm. Pure Appl. Math.,},
+      volume={39},
+      number={5},
+       pages={661\ndash 693},
+         url={https://doi.org/10.1002/cpa.3160390505},
+      review={\MR{849427}},
+}
 \end{biblist}
 \end{bibdiv}
 \end{document}

--- a/latexml_oxide/tests/structure/amsrefs_basic.xml
+++ b/latexml_oxide/tests/structure/amsrefs_basic.xml
@@ -38,6 +38,34 @@
  publisher = {Pub},
       year = {1999}}</bib-data>
       </bibentry>
+      <bibentry key="Bartnik" type="article" xml:id="bib.bib3">
+        <bib-name role="author">
+          <surname>Bartnik</surname>
+          <givenname>Robert</givenname>
+        </bib-name>
+        <bib-title>The mass of an asymptotically flat manifold</bib-title>
+        <bib-date role="publication">1986</bib-date>
+        <bib-identifier id="0010-3640,1097-0312" scheme="issn">ISSN 0010-3640,1097-0312</bib-identifier>
+        <bib-related role="host" type="journal">
+          <bib-title>Comm. Pure Appl. Math.,</bib-title>
+        </bib-related>
+        <bib-part role="volume">39</bib-part>
+        <bib-part role="number">5</bib-part>
+        <bib-part role="pages">661–693</bib-part>
+        <bib-url href="https://doi.org/10.1002/cpa.3160390505">Link</bib-url>
+        <bib-review>Review <ref class="ltx_mathreviews" href="http://www.ams.org/mathscinet-getitem?mr=849427">MathReviews</ref></bib-review>
+        <bib-data role="self" type="BibTeX">@article{Bartnik,
+    author = {Bartnik, Robert},
+     title = {The mass of an asymptotically flat manifold},
+      date = {1986},
+      issn = {0010-3640,1097-0312},
+   journal = {Comm. Pure Appl. Math.,},
+    volume = {39},
+    number = {5},
+     pages = {661\ndash 693},
+       url = {https://doi.org/10.1002/cpa.3160390505},
+    review = {\MR{849427}}}</bib-data>
+      </bibentry>
     </biblist>
   </bibliography>
 </document>

--- a/latexml_package/src/package/amsrefs_sty.rs
+++ b/latexml_package/src/package/amsrefs_sty.rs
@@ -28,7 +28,14 @@ LoadDefinitions!({
     use latexml_engine::bibtex::{BibEntry, register_entry, parse_amsrefs_keyvals};
     let key = if args[0].is_some() { args[0].to_string() } else { String::new() };
     let entry_type = if args[1].is_some() { args[1].to_string() } else { String::new() };
-    let raw_kv = if args[2].is_some() { args[2].to_string() } else { String::new() };
+    // Perl L48: `UnTeX(shift(@rawpairs), 1)`. `untex()` — NOT `to_string()`:
+    // the tokenizer eats the space that terminates a control word, so a plain
+    // token→string round-trip renders `661\ndash 693` as `661\ndash693`, and
+    // that string is what the `<ltx:bib-data>` BibTeX dump reproduces verbatim.
+    // `untex` re-inserts the separator at the letter boundary.
+    let raw_kv = if args[2].is_some() {
+      args[2].clone().owned_tokens().unwrap_or_default().untex()
+    } else { String::new() };
     let mut entry = BibEntry::new(key.clone(), entry_type);
     for (field, value) in parse_amsrefs_keyvals(&raw_kv) {
       entry.add_raw_field(field, value);

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -2460,47 +2460,61 @@ fn format_links(doc: &PostDocument, nodes: &[Node]) -> Vec<NodeData> {
       (Some(h), _) => Some(force_absolute_url(h)),
       (None, _) => None,
     };
+    // Perl `MakeBibliography.pm:do_links` L655-667 uses
+    // `$doc->cloneNodes($node->childNodes)` as the child list in EVERY branch —
+    // it copies the marked-up children, it does not flatten them. Taking
+    // `get_content()` (a plain-text collapse) instead silently dropped any
+    // nested element: an amsrefs `review={\MR{849427}}` digests to
+    // `<ltx:bib-review>Review <ltx:ref class="ltx_mathreviews" href="…">
+    // MathReviews</ltx:ref></ltx:bib-review>`, and the flattening rendered a
+    // dead "Review MathReviews" with the MathSciNet link gone. Witness
+    // arXiv 2508.17585.
+    let children: Vec<NodeData> = node
+      .get_child_nodes()
+      .into_iter()
+      .map(NodeData::XmlNode)
+      .collect();
     match tag.as_str() {
       "ltx:bib-identifier" | "ltx:bib-review" => {
         if let Some(href) = href {
           links.push(NodeData::Element {
-            tag:        "ltx:ref".to_string(),
+            tag: "ltx:ref".to_string(),
             attributes: Some(HashMap::from_iter([
               ("href".to_string(), href),
               ("class".to_string(), format!("{} ltx_bib_external", scheme)),
             ])),
-            children:   vec![NodeData::Text(content_text)],
+            children,
           });
         } else {
           links.push(NodeData::Element {
-            tag:        "ltx:text".to_string(),
+            tag: "ltx:text".to_string(),
             attributes: Some(HashMap::from_iter([(
               "class".to_string(),
               format!("{} ltx_bib_external", scheme),
             )])),
-            children:   vec![NodeData::Text(content_text)],
+            children,
           });
         }
       },
       "ltx:bib-links" => {
         links.push(NodeData::Element {
-          tag:        "ltx:text".to_string(),
+          tag: "ltx:text".to_string(),
           attributes: Some(HashMap::from_iter([(
             "class".to_string(),
             "ltx_bib_external".to_string(),
           )])),
-          children:   vec![NodeData::Text(content_text)],
+          children,
         });
       },
       "ltx:bib-url" => {
         if let Some(href) = href {
           links.push(NodeData::Element {
-            tag:        "ltx:ref".to_string(),
+            tag: "ltx:ref".to_string(),
             attributes: Some(HashMap::from_iter([
               ("href".to_string(), href),
               ("class".to_string(), "ltx_bib_external".to_string()),
             ])),
-            children:   vec![NodeData::Text(content_text)],
+            children,
           });
         }
       },


### PR DESCRIPTION
**Diagnostic.** The reported symptom on [arXiv:2508.17585](https://arxiv.org/html/2508.17585v1) ("references are not loading") is the *Perl* defect already fixed here (KNOWN_PERL_ERRORS #49 / OXIDIZED_DESIGN #57) — same-host Perl still emits 0 bibitems, Rust 34 (pdflatex: 34). Verifying that surfaced four Rust-only divergences *inside* the entries, all rooted in `bibtex.rs` building the entry as a pre-tokenized `Explode!` stream (catcode-12 OTHER) where Perl `BibTeX.pool.ltxml:134-166` hands TeX *source* to a fresh `Mouth`: `\MR{849427}` arrived as literal characters, `pages` rendered empty, the ISSN became an invalid-NCName `xml:id`, and `MakeBibliography` flattened `bib-review` to text.

**Approach.** Port the Mouth (with `\csname …\endcsname` for the `@`-bearing handler names, as Perl does) — lazy tokenization is also what lets the handlers' `Verbatim`/`Semiverbatim` params keep `%`/`#`/`~` in a `url` value intact, which a plain `Tokenize!` swap would have broken. Digest `pages` (Perl L674 `Digest(Tokenize(…))`); normalise the `id` key once in `set_attribute` so a bare `id` still means `xml:id` except where the model declares a real one (`LaTeXML-bib.rnc:335,353`), then follow `Core/Document.pm:1370-1386` verbatim; clone `bib-review`'s children per `MakeBibliography.pm:655-667` `do_links`; and `untex()` the amsrefs keyval slot (Perl `UnTeX($v,1)`).

**Validation.** Red→green guards `amsrefs_basic_test` (structure pair, extended with the pages/ISSN/url/review band) and `amsrefs_inline_bibliography_is_not_dropped` (post layer, verified red independently). Full suite **1681 passed / 1 failed**, the one failure being `process_coalesces_only_matching_conversion_options` — confirmed pre-existing on this host by stashing the change. `clippy -D warnings`, `fmt`, and `cargo doc -D warnings` clean. Perl parity re-checked same-host, verbose: all 34 witness entries now match Perl's core XML, and the HTML carries 34 bibitems with 27 live MathSciNet links, 0 errors.

Not fixed (adjacent, pre-existing, recorded in `SYNC_STATUS.md`): `mrnumber` synthesizes no `<bib-identifier scheme="mr">` in Rust; Rust omits the trailing newline Perl writes inside `<bib-data>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)