### PR TITLE
fix(bibtex): revive MR/Zbl synthesis and the date guard (dead `fields` store)

### DIFF
--- a/docs/archive/SYNC_SESSIONS_2026-07.md
+++ b/docs/archive/SYNC_SESSIONS_2026-07.md
@@ -1216,7 +1216,33 @@ Also `amsrefs_sty.rs` uses `untex()` (Perl `UnTeX($v,1)`) for the keyval slot:
 the tokenizer eats a control word's terminating space, so `to_string()` wrote
 `661\ndash693` into the `<bib-data>` BibTeX dump. Guards: `amsrefs_basic`
 (structure pair, extended with the pages/ISSN/url/review band) +
-`amsrefs_inline_bibliography_is_not_dropped` (post layer). **Not fixed** (adjacent,
-pre-existing, out of scope): a `mrnumber` field synthesizes no
-`<bib-identifier scheme="mr">` in Rust where Perl's `default@complete` does; and
-Rust omits the trailing newline Perl writes inside `<bib-data>`.
+`amsrefs_inline_bibliography_is_not_dropped` (post layer). Two adjacent gaps this
+surfaced were closed in the follow-up below.
+
+### `BibEntry::fields` is dead, so MR/Zbl synthesis never fired — ✅ LANDED 2026-07-25 (branch `fix-bibtex-mrnumber-synthesis`)
+
+Rust Error Fix; the closeout of the entry above. `current_entry_field`
+(Perl `currentBibEntryField`) read `BibEntry::fields`, but `add_field` is called
+**only** by `copy_crossref_fields` — outside a `crossref` that store is EMPTY, so
+every lookup returned `None` for fields that plainly exist. Two observable
+symptoms, one root:
+
+* `\bib@synthesize@mr` / `@zbl` (Perl L803-845) could never fire — a `mrnumber`
+  produced no `<ltx:bib-identifier scheme="mr">`, `mrreviewer` no
+  `<ltx:bib-review>`, `zblno` no ZentralBlatt link. Perl emits all three.
+* `\bib@field@default@year`'s "is `date` already set?" guard never fired, so an
+  entry carrying **both** emitted a duplicate `<ltx:bib-date>` (Perl emits one).
+
+Fix: `current_entry_field` falls back to the raw field (Perl's `getField`
+returns the field's STRING, and `Pre::BibTeX::Entry` is built with both lists
+populated — for amsrefs, `new(…, [@fields], [@fields])` passes the same list
+twice). `\bib@field@unknownasdata` now reads the raw field FIRST, since it
+reproduces source text verbatim and a Tokens round-trip eats a control word's
+terminating space. Also: `pretty_print` appends the trailing newline Perl's
+`Pre/BibTeX/Entry.pm:64` writes (`. "}\n"`) — the `<ltx:bib-data>` dump is now
+byte-identical to Perl, and the unwired `tests/daemon/formats/makebib.xml`
+reference fixture (copied from Perl) already had that shape. Guard: `55_bibtex.rs`
+`bibtex_mode_emits_bibentries`, extended with all four synthesis shapes
+(bare `mrnumber`; `mrnumber`+`mrreviewer`; `MR1380882 (96e:83024)` → id stripped,
+review implied; `zblno`) plus the one-`bib-date` assertion, all verified against
+same-host Perl.

--- a/latexml_engine/src/bibtex.rs
+++ b/latexml_engine/src/bibtex.rs
@@ -115,7 +115,7 @@ impl BibEntry {
   pub fn pretty_print(&self) -> String {
     let mut out = format!("@{}{{{}", self.entry_type, self.key);
     if self.raw_fields.is_empty() {
-      out.push('}');
+      out.push_str("}\n");
       return out;
     }
     for (k, v) in &self.raw_fields {
@@ -127,7 +127,9 @@ impl BibEntry {
       // Match Perl's source reconstruction: each field on its own line,
       // the name right-justified so the `=` aligns — `max(1, 10 - len)`
       // leading spaces (≥1 space even for names ≥10 chars). The entry's
-      // closing `}` follows the last value directly (no newline before it).
+      // closing `}` follows the last value directly (no newline before it),
+      // and the whole entry ends with one — Perl `Pre/BibTeX/Entry.pm:60-64`
+      // joins the lines and appends `"}\n"`.
       let lead = 10usize.saturating_sub(k.len()).max(1);
       out.push_str(",\n");
       out.push_str(&" ".repeat(lead));
@@ -136,7 +138,7 @@ impl BibEntry {
       out.push_str(v);
       out.push('}');
     }
-    out.push('}');
+    out.push_str("}\n");
     out
   }
 }
@@ -223,9 +225,30 @@ pub fn lookup_entry(key: &str) -> Option<Rc<RefCell<BibEntry>>> {
 }
 
 /// Perl: `currentBibEntryField('fieldname')` — get the *processed*
-/// token value of a field on the current entry.
+/// value of a field on the current entry.
+///
+/// Falls back to the raw source field, and that fallback is what makes this
+/// function work at all: Perl's `Pre::BibTeX::Entry` is built with BOTH lists
+/// populated (for amsrefs, `new(…, [@fields], [@fields])` passes the *same*
+/// list twice), whereas here [`BibEntry::add_field`] is only ever called by
+/// [`copy_crossref_fields`] — so outside a `crossref` the `fields` store is
+/// EMPTY and an unguarded `get_field` returned `None` for every field that
+/// exists. That silently disabled every caller which asks Perl's question:
+/// `\bib@synthesize@mr`/`@zbl` never emitted a MathReview/ZentralBlatt link,
+/// and `\bib@field@default@year`'s "is `date` already set?" guard never fired,
+/// so an entry with both emitted a duplicate `<ltx:bib-date>`.
+///
+/// Perl's `getField` yields the field's STRING; callers that need the source
+/// text verbatim (e.g. `\bib@field@unknownasdata`) should therefore prefer
+/// [`current_entry_raw_field`] — tokenizing here is lossy in one direction, in
+/// that a control word's terminating space is consumed (`\ndash 693`).
 pub fn current_entry_field(name: &str) -> Option<Tokens> {
-  current_entry()?.borrow().get_field(name).cloned()
+  let entry = current_entry()?;
+  let entry = entry.borrow();
+  if let Some(tokens) = entry.get_field(name) {
+    return Some(tokens.clone());
+  }
+  entry.get_raw_field(name).map(|raw| Tokenize!(raw))
 }
 
 /// Perl: `currentBibEntryRawField('fieldname')` — get the *raw*
@@ -1052,17 +1075,19 @@ LoadDefinitions!({
   // body is already built — the previous code set the property too late, so
   // every unknown bib field came out as an EMPTY `<ltx:bib-data role=.../>`,
   // dropping its value entirely; Perl emits the value). `args[0]` is the field
-  // name (#1). Prefer the DIGESTED field tokens (Perl `currentBibEntryField`),
-  // falling back to the raw source exploded char-by-char.
+  // name (#1).
   properties => sub[args] {
     let field = args[0].as_ref().map(|a| a.to_string()).unwrap_or_default();
-    // Prefer the DIGESTED field (Perl `currentBibEntryField`), falling back to
-    // the raw source — but as a STRING, not Tokens: the constructor's `#prop`
+    // The value goes out as a STRING, not Tokens: the constructor's `#prop`
     // content-insertion handles `Stored::String` and silently drops
     // `Stored::Tokens` (the old `after_digest` + `Stored::Tokens(...)` produced
     // an EMPTY `<ltx:bib-data role=.../>`, dropping every unknown field's value).
-    let s = current_entry_field(&field).map(|t| t.to_string())
-      .or_else(|| current_entry_raw_field(&field))
+    // Read the RAW field first: this element reproduces the field's source text,
+    // and a Tokens round-trip eats the space that terminates a control word
+    // (`\ndash 693` -> `\ndash693`). Perl reads `currentBibEntryField`, but
+    // there that IS the string.
+    let s = current_entry_raw_field(&field)
+      .or_else(|| current_entry_field(&field).map(|t| t.to_string()))
       .unwrap_or_default();
     Ok(stored_map!("rawdata" => Stored::String(pin(&s))))
   });
@@ -2282,7 +2307,9 @@ mod tests {
   #[test]
   fn pretty_print_no_fields_is_empty_braced() {
     let e = BibEntry::new("Solo", "misc");
-    assert_eq!(e.pretty_print(), "@misc{Solo}");
+    // Trailing newline included — Perl `Pre/BibTeX/Entry.pm:64` appends `"}\n"`
+    // on every entry, fields or not.
+    assert_eq!(e.pretty_print(), "@misc{Solo}\n");
   }
 
   #[test]
@@ -2294,10 +2321,11 @@ mod tests {
     let out = e.pretty_print();
     // Order matches insertion order (Vec<(String,String)>). Field names are
     // right-justified to width 10 so the `=` aligns (Perl source-reconstruction
-    // shape): author→4sp, title→5sp, year→6sp; entry `}` follows the last value.
+    // shape): author→4sp, title→5sp, year→6sp; entry `}` follows the last value,
+    // and the whole thing ends with a newline (Perl `Entry.pm:64` `. "}\n"`).
     assert_eq!(
       out,
-      "@article{Smith2020,\n    author = {John Smith},\n     title = {On Examples},\n      year = {2020}}"
+      "@article{Smith2020,\n    author = {John Smith},\n     title = {On Examples},\n      year = {2020}}\n"
     );
   }
 

--- a/latexml_oxide/tests/55_bibtex.rs
+++ b/latexml_oxide/tests/55_bibtex.rs
@@ -70,4 +70,41 @@ fn bibtex_mode_emits_bibentries() {
     "expected unknown bib field value to be emitted (not dropped), got:\n{}",
     s
   );
+
+  // `\bib@entry@default@complete` runs `\bib@synthesize@mr\bib@synthesize@zbl`
+  // (Perl `BibTeX.pool.ltxml:210-211`, `:803-845`), turning the non-standard
+  // mrnumber/mrreviewer/zblno fields into MathReview/ZentralBlatt links. Both
+  // synthesizers read `currentBibEntryField`, which in Perl returns the field's
+  // STRING; the Rust `BibEntry::fields` (Tokens) store it consulted is only ever
+  // populated by crossref-copy, so every lookup returned None and NEITHER
+  // synthesizer could fire. Expected shapes verified against same-host Perl.
+  for needle in [
+    // mrnumber alone -> a plain identifier, no review.
+    "<bib-identifier href=\"https://www.ams.org/mathscinet-getitem?mr=849427\" \
+     id=\"849427\" scheme=\"mr\">MathReview Entry</bib-identifier>",
+    // mrnumber + mrreviewer -> a review naming the reviewer.
+    "<bib-review href=\"https://www.ams.org/mathscinet-getitem?mr=2124018\" \
+     id=\"2124018\" scheme=\"mr\">MathReview (C. Three)</bib-review>",
+    // `MR1380882 (96e:83024)` -> review, `MR` prefix and note stripped from the id.
+    "<bib-review href=\"https://www.ams.org/mathscinet-getitem?mr=1380882\" \
+     id=\"1380882\" scheme=\"mr\">MathReview</bib-review>",
+    // zblno -> ZentralBlatt review.
+    "<bib-review href=\"https://zbmath.org/0674.53077\" id=\"0674.53077\" \
+     scheme=\"zbl\">ZentralBlatt</bib-review>",
+  ] {
+    assert!(
+      s.contains(needle),
+      "MR/Zbl synthesis missing:\n  expected: {needle}\ngot:\n{s}"
+    );
+  }
+
+  // Same root, different symptom: the `date`-already-set guard in
+  // `\bib@field@default@year` also read the dead `fields` store, so an entry
+  // carrying BOTH emitted a SECOND <ltx:bib-date> from the year. Perl emits one.
+  let dates = s.matches("<bib-date").count();
+  assert_eq!(
+    dates, 4,
+    "expected exactly one <ltx:bib-date> per entry (4 entries, and DateAndYear1986 \
+     must not emit a second one from its `year`), got {dates}:\n{s}"
+  );
 }

--- a/latexml_oxide/tests/bibtex/sample.bib
+++ b/latexml_oxide/tests/bibtex/sample.bib
@@ -8,11 +8,36 @@
   journal = tcs,
   year    = 2020,
   zzcustomfield = {unknown-field marker value},
+  mrnumber = {849427},
 }
 
 @book{Doe1999,
   author    = {Jane Doe},
   title     = {A Book of Things},
   publisher = {Acme Press},
-  year      = 1999
+  year      = 1999,
+  mrnumber  = {2124018},
+  mrreviewer = {C. Three},
+}
+
+% `\bib@entry@default@complete` synthesizes MathReview/ZentralBlatt links from
+% the non-standard mrnumber/mrreviewer/zblno fields. A parenthesised note on the
+% mrnumber means "there IS a review" even with no named reviewer, and the `MR`
+% prefix + note are stripped from the id.
+@article{Review1990,
+  author   = {D. Four},
+  title    = {Parenthesised note},
+  year     = 1990,
+  mrnumber = {MR1380882 (96e:83024)},
+  zblno    = {0674.53077},
+}
+
+% An explicit `date` wins: the `year` field must NOT also emit a second
+% <ltx:bib-date> (Perl `\bib@field@default@year` returns early on
+% `currentBibEntryField('date')`).
+@article{DateAndYear1986,
+  author = {E. Five},
+  title  = {Date beats year},
+  date   = {1986-05},
+  year   = {1999},
 }

--- a/latexml_oxide/tests/structure/amsrefs_basic.xml
+++ b/latexml_oxide/tests/structure/amsrefs_basic.xml
@@ -22,7 +22,8 @@
     author = {John Smith},
      title = {On Examples},
    journal = {JMP},
-      year = {2020}}</bib-data>
+      year = {2020}}
+</bib-data>
       </bibentry>
       <bibentry key="Doe1999" type="book" xml:id="bib.bib2">
         <bib-name role="author">
@@ -36,7 +37,8 @@
     author = {Jane Doe},
      title = {A Book},
  publisher = {Pub},
-      year = {1999}}</bib-data>
+      year = {1999}}
+</bib-data>
       </bibentry>
       <bibentry key="Bartnik" type="article" xml:id="bib.bib3">
         <bib-name role="author">
@@ -64,7 +66,8 @@
     number = {5},
      pages = {661\ndash 693},
        url = {https://doi.org/10.1002/cpa.3160390505},
-    review = {\MR{849427}}}</bib-data>
+    review = {\MR{849427}}}
+</bib-data>
       </bibentry>
     </biblist>
   </bibliography>


### PR DESCRIPTION
**Diagnostic.** `current_entry_field` (Perl `currentBibEntryField`) reads `BibEntry::fields`, but `add_field` is called **only** by `copy_crossref_fields` — outside a `crossref` that store is empty, so every lookup returned `None` for fields that plainly exist. Two symptoms, one root: `\bib@synthesize@mr`/`@zbl` (`BibTeX.pool.ltxml:803-845`) could never fire, so `mrnumber`/`mrreviewer`/`zblno` produced no MathReview or ZentralBlatt link at all; and `\bib@field@default@year`'s "is `date` already set?" guard never fired, so an entry carrying both emitted a duplicate `<ltx:bib-date>`.

**Approach.** Fall back to the raw field — Perl's `getField` returns the field's *string*, and `Pre::BibTeX::Entry` is constructed with both lists populated (for amsrefs, `new(…, [@fields], [@fields])` passes the same list twice). `\bib@field@unknownasdata` now reads raw *first*, since it reproduces source text verbatim and a Tokens round-trip eats a control word's terminating space. Separately, `pretty_print` appends the trailing newline Perl's `Pre/BibTeX/Entry.pm:64` writes (`. "}\n"`), making the `<ltx:bib-data>` dump byte-identical to Perl.

**Validation.** Red→green guard `bibtex_mode_emits_bibentries`, extended with all four synthesis shapes (bare `mrnumber`; `mrnumber`+`mrreviewer`; `MR1380882 (96e:83024)` → id stripped and review implied; `zblno`) plus a one-`bib-date`-per-entry assertion — every expected string taken from same-host Perl output. Full suite **1683 passed / 1 failed**, that one being `process_coalesces_only_matching_conversion_options`, confirmed pre-existing on this host. clippy `-D warnings` and fmt clean.

Follow-up to #374, which surfaced both gaps. The unwired `tests/daemon/formats/makebib.xml` reference fixture (copied from Perl) already carried the newline shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)