### PR TITLE
docs: retire the TL2026 dump-gate residual — re-confirmed 0/0 on main

### DIFF
--- a/.github/workflows/release-dumps.yml
+++ b/.github/workflows/release-dumps.yml
@@ -26,6 +26,19 @@
 #   fails that year (fail toward flagging, per CLAUDE.md "Canvas
 #   signal integrity").
 #
+# Reproducing a single year LOCALLY (e.g. to re-check the init gate
+# without dispatching all five legs): build the dumper in a container
+# whose base is OLDER than the TL image's, never on the dev host. Two
+# independent things break otherwise, both only at `docker run` time —
+# a 2026-07-25 host (glibc 2.43, libxml2.so.16) produced a binary the
+# `:2026` image cannot load at all (it has glibc 2.41 / libxml2.so.2),
+# which the gate reports as `exit=127 errors=0`, i.e. NOT as an init
+# failure. `rustlang/rust:nightly` (bookworm, glibc 2.36) works; add
+# `clang libclang-dev` to the apt set below, which GitHub's runner image
+# preinstalls but a bare image does not (bindgen/libmarpa-asf-sys needs
+# it). `KPATHSEA_NO_LINK=1` is what keeps the binary kpathsea-free on a
+# host that HAS libkpathsea-dev installed.
+#
 # Callable from release.yml (workflow_call) and testable standalone
 # (workflow_dispatch).
 

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -142,20 +142,6 @@ history now live in the dated session archives:
 (Upstream-sync catalog also at
 [`archive/UPSTREAM_SYNC_2767_to_2833_2026-06-26.md`](archive/UPSTREAM_SYNC_2767_to_2833_2026-06-26.md).)
 
-## Live residuals from the 2026-07-20 ar5iv sprint (merged as PR #323)
-
-Everything that sprint landed is in `docs/archive/SYNC_SESSIONS_2026-07.md`.
-Two scraps are still live:
-
-- **TL2026 dump gate may be closer than recorded** — the expl3 catcode gap is
-  closed (2112.11932 1003⇒0, 2110.10227 102⇒0, 2204.05282 86⇒0, 2110.12034 45⇒8;
-  2203.05327 411⇒0 via the `aligned_overset_sty.rs` contrib binding, guarded by
-  `102_aligned_overset_includestyles.rs`). **Re-run the init gate on a TL2026
-  host** before trusting the recorded blocker.
-- **ar5iv residuals — closed, do not re-mine.** All three resolve
-  parity-or-Rust-better, none Rust-only; detail in `AR5IV_DIAGNOSTICS.md` and
-  `docs/archive/SYNC_SESSIONS_2026-07.md`.
-
 ## Standing policies & method — read before changing behaviour
 
 ### Methodology & the cortex cross-join
@@ -484,6 +470,12 @@ drops stretch/shrink to bare pt.
   2410.10068, 2511.03798 (Perl also fails).
 - **Rust supersedes Perl**: `1207.6068`, `0909.3444`, + 40 more in
   `memory/project_rust_supersedes_perl.md`.
+- **2026-07-20 ar5iv sprint (PR #323) residuals — do not re-mine.** Its three
+  ar5iv leftovers all resolve parity-or-Rust-better, none Rust-only
+  (`AR5IV_DIAGNOSTICS.md`); its TL2026 dump-gate scrap closed 2026-07-23 and
+  was re-confirmed on `main` 2026-07-25 (0 errors on both inits inside
+  `ghcr.io/tkw1536/texlive-docker:2026`; 2026 is in the release window). Both
+  in `archive/SYNC_SESSIONS_2026-07.md`.
 - **BibTeX**: `BibTeX.pool.ltxml` ported (Phases 1–8; remaining B1–B6 polish in
   `BIBTEX_PORT_PLAN.md`). `--nobibtex` is opt-out, not default.
 

--- a/docs/archive/SYNC_SESSIONS_2026-07.md
+++ b/docs/archive/SYNC_SESSIONS_2026-07.md
@@ -677,17 +677,34 @@ const version, read dynamically → no version-bump churn; + explicit-param over
 > under the verbatim gate (`LATEXML_INIT_DEBUG=1`, ANSI-strip, `grep -acE
 > '^(Error|Fatal):'`):
 >
-> | init | 2026-07-12 | 2026-07-23 |
-> |---|---|---|
-> | `--init=plain.tex` | exit 0, 0 errors | exit 0, **0 errors** |
-> | `--init=latex.ltx` | exit 0, **137 errors** | exit 0, **0 errors** |
+> | init | 2026-07-12 | 2026-07-23 | 2026-07-25 |
+> |---|---|---|---|
+> | `--init=plain.tex` | exit 0, 0 errors | exit 0, **0 errors** | exit 0, **0 errors** |
+> | `--init=latex.ltx` | exit 0, **137 errors** | exit 0, **0 errors** | exit 0, **0 errors** |
+>
+> The 07-25 column re-confirms the gate on `main` @ `b36c6cd21c` — 22 commits
+> later — by the same method: 934 plain entries, **24,199** latex entries
+> (24,221 lines), i.e. the 07-23 dump unchanged. The host's own TL2025 tree
+> gates 0/0 on the same binary. **The stale "re-run the init gate before
+> trusting the recorded blocker" residual in `SYNC_STATUS.md` is retired by
+> this.**
+>
+> **Reproducing one year locally costs two false starts** — both surface only at
+> `docker run`, and the first reads as a *clean* gate. Build the dumper in a
+> container OLDER than the TL image, never on the dev host: a 2026-07-25 host
+> (glibc 2.43, `libxml2.so.16`) yields a binary `:2026` (glibc 2.41,
+> `libxml2.so.2`) cannot load, which the gate reports as `exit=127 errors=0` —
+> **zero errors, because nothing ran.** `rustlang/rust:nightly` (bookworm, glibc
+> 2.36) works, plus `clang libclang-dev`, which GitHub's runner preinstalls but
+> a bare image does not (bindgen/`libmarpa-asf-sys`). `KPATHSEA_NO_LINK=1` is
+> what keeps the binary kpathsea-free on a host that HAS libkpathsea-dev.
 >
 > The **likely** closers (not bisected — the 0/0 result is measured, the
 > attribution is inferred) are the two expl3 fixes that landed **2026-07-20**,
 > after the measurement below: force `\ExplSyntaxOff` when `_` is still LETTER
 > (`latex_constructs.rs`) and the global `:`/`_`/`~` restore (`expl3_sty.rs`).
 > They are the same pair credited with closing
-> [`EXPL3_CATCODE_GAP_2026-06-08.md`](parity/diagnostics/EXPL3_CATCODE_GAP_2026-06-08.md),
+> [`EXPL3_CATCODE_GAP_2026-06-08.md`](../parity/diagnostics/EXPL3_CATCODE_GAP_2026-06-08.md),
 > and all three error families listed below are now gone (the 90 ×
 > `unexpected:_` was the bulk). Dump is sound, not degenerate: **24,221** latex entries vs
 > 2025's 21,997 — the delta IS TL2026's expanded l3 `text-case` module — and

--- a/docs/release/WINDOWS_COMPATIBILITY_PLAN.md
+++ b/docs/release/WINDOWS_COMPATIBILITY_PLAN.md
@@ -15,7 +15,9 @@ Linux/macOS assets. No MinGW/GNU bring-up phase.
 > test-suite green does NOT imply TL2026 release-readiness, because
 > `--init=latex.ltx` on TL2026 emitted 137 expl3-catcode errors and 2026 was
 > out of the release dump window. Both halves are now closed — the init is
-> **0 errors** and **2026 is IN the window** (2022–2026). See `SYNC_STATUS.md`
+> **0 errors** and **2026 is IN the window** (2022–2026); re-confirmed on `main`
+> 2026-07-25. See
+> [`archive/SYNC_SESSIONS_2026-07.md`](../archive/SYNC_SESSIONS_2026-07.md)
 > ("TL2026 `latex.ltx` dump init … ✅ CLOSED 2026-07-23").
 
 ## Toolchain & native deps (reproduce the build from here)
@@ -186,8 +188,9 @@ cold run for a fair Linux-vs-Windows benchmark.
   2026-07-20 closed it; re-measured inside the real
   `ghcr.io/tkw1536/texlive-docker:2026` under the verbatim release gate:
   `plain.tex` and `latex.ltx` both exit 0 with **0 errors**. 2026 is now in the
-  window (`SYNC_STATUS.md`: "TL2026 `latex.ltx` dump init … ✅ CLOSED
-  2026-07-23").
+  window; re-confirmed on `main` 2026-07-25
+  ([`archive/SYNC_SESSIONS_2026-07.md`](../archive/SYNC_SESSIONS_2026-07.md):
+  "TL2026 `latex.ltx` dump init … ✅ CLOSED 2026-07-23").
 - [ ] **Fast TeX-ecosystem CI install** (DEFERRED). The cold
   `setup-texlive-action` download (~1–2 GB) is the slowest CI step. Target: a
   pinned, content-hash-keyed minimal texmf snapshot (fast + deterministic +


### PR DESCRIPTION
**Diagnostic.** `SYNC_STATUS.md` still carried "re-run the init gate on a TL2026 host before trusting the recorded blocker" — but that blocker closed 2026-07-23, and 2026 has been in the release dump window since (`release-dumps.yml` matrix + all five `release.yml` legs span 2022–2026; CI run 30032528819 green on the 2026 leg). Yesterday's compaction moved the closure record to the archive, leaving two cross-references dangling.

**Approach.** Re-ran the gate verbatim on `main` @ `b36c6cd21c`, 22 commits later, inside the real `ghcr.io/tkw1536/texlive-docker:2026`: `plain.tex` and `latex.ltx` both **exit 0 with 0 errors** (934 / 24,199 entries — the 07-23 dump unchanged). Retired the residual, kept the "do not re-mine" marker under Permanent ignores, repointed the two references, and recorded what a local single-year reproduction needs.

**Validation.** Measurement is the deliverable; docs-only otherwise. Worth flagging: a dumper built on a modern host (glibc 2.43 / `libxml2.so.16`) cannot load in the `:2026` image (glibc 2.41 / `libxml2.so.2`), and the gate scores that as `exit=127 errors=0` — **zero errors because nothing ran**. Build the dumper on an older base; the workflow header now says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)