### PR TITLE
fix(bibliography): break the self-referential \let that hangs multi-\datalist .bbl files

### DIFF
--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -54,7 +54,7 @@ session of their own. Re-verify a row before planning on it (rule 1).
 | **R1** | Upstream `brucemiller/LaTeXML#2852` — subfile `\documentclass` options | **OPEN upstream**, ours merged as #310 | minutes — chase review, no code | Open items |
 | **R2** | `--preload=<cls>` trips the LaTeX hook stack (`Extra \PopDefaultHookLabel`) | **OPEN**, re-verified 2026-07-25 (1 error with `--preload=article.cls`, 0 without) | small–medium, self-contained | Open items |
 | **R3** | `latexmlmath_oxide` empties a single-structure formula | **OPEN**, re-verified 2026-07-25 (`\frac{1}{2}`→`<mrow/>`; `\frac{a}{b}+c` fine) | small, narrow surface | Open items |
-| **R4** | biblatex `.bbl` `TokenLimit` loop (2605.17646) | real Fatal, pre-existing (bisected — not a PR regression) | medium, needs a dive | Open items |
+| **R4** | biblatex `.bbl` `TokenLimit` loop (2605.17646) | ✅ **FIXED 2026-07-25** — self-referential `\let` on `setupPseudoBibitem` re-arm; shared with Perl | — | Open items |
 | **R5** | Bibliography targets + MakeBibliography re-port | surveyed 2026-07-12; user directive 2026-07-04 | **family** — dedicated session | [`BIBLIOGRAPHY_WORKLIST.md`](parity/BIBLIOGRAPHY_WORKLIST.md) |
 | **R6** | `ltx_env_<name>` env-markup class | user-requested, PLANNED | medium code, **large golden churn** → own branch | Open items |
 | **R7** | Beyond-Perl performance levers BP-1…BP-6 | POST-RELEASE; internal order BP-2 → BP-3 → BP-1 | **family** | [`BEYOND_PERL_LEVERS.md`](performance/BEYOND_PERL_LEVERS.md) |
@@ -76,10 +76,13 @@ session of their own. Re-verify a row before planning on it (rule 1).
   2606.13010 (arXiv/html_feedback#6624) now converts at 0 errors / 0 warnings /
   0 unparsed math. This file was compacted the same day — see the header.
 
-- `cargo test --tests`: **1684 passing / 91 targets, 0 failed, 0 ignored**
-  (2026-07-25, on `main` @ `0dda6ca833`, dev box with ImageMagick + ghostscript +
-  poppler installed, `mutool` absent). +6 against the 2026-07-24 count of 1678;
-  two of those are this session's `siunitx_v3_test` and `split_fence_test`.
+- `cargo test --tests`: **1684 passing / 91 targets, 0 ignored** (2026-07-25, on
+  `main` @ `35200b1598` + the R4 fix, dev box with ImageMagick + ghostscript +
+  poppler installed, `mutool` absent) — including this session's
+  `cluster_biblatex_two_datalists`. The one red,
+  `latexml_post::graphics::process_coalesces_only_matching_conversion_options`,
+  is the **known local-only artifact** (this laptop has the full vector
+  toolchain; green in CI) — not a regression, and unrelated to bibliographies.
   **Caveat that keeps mattering:** the two vector-SVG tests
   (`test_vector_svg_graphics_path`, `test_vector_svg_pathological_convert_case`)
   do NOT go red on a bare host — `svg_converter_available()`
@@ -357,17 +360,35 @@ output with Perl. Not a regression from that work — which is verified byte-ide
 Perl modulo whitespace on formulas that do convert.
 
 
-### R4 — biblatex `.bbl` TokenLimit loop, 2605.17646 (pre-existing, NOT a PR regression)
+### R4 — biblatex `.bbl` TokenLimit loop, 2605.17646 — ✅ FIXED 2026-07-25
 
-A biblatex (apa style) paper whose `.bbl` ends in `\missing{Cowen2021}` hits
-`Fatal:Timeout:TokenLimit` (999M tokens) during .bbl processing under the
-ar5iv profile. Bisect 2026-07-04: **9a679469e1 (run-230 binary) fatals
-identically** under equal local conditions (release, `LATEXML_TOKEN_LIMIT`
-=50M, `--preload=ar5iv.sty`) — run 230's "error" status for this paper was
-fleet nondeterminism, so the July PR branch did not introduce it. Repro:
-`scratchpad fatal5/17646src` (arXiv 2605.17646). Suspect area: biblatex
-runtime binding's refsection/datalist handling with `\missing`. Not a
-July-5 blocker; needs a dedicated session.
+Root cause was **not** `\missing{Cowen2021}` (the `.bbl`'s last line, and the
+entry's standing suspicion): deleting it leaves the Fatal untouched. It is a
+self-referential `\let` in the engine's pseudo-bibitem machinery —
+`setupPseudoBibitem` re-arming captures `\save@bibitem` ← `\restoring@bibitem`,
+whose body ends in `\bibitem`, so it expands forever. The re-arm happens because
+biblatex's apa style asks biber for **two sorting schemes**, so the `.bbl`
+carries two `\datalist` blocks (2 × 29 entries here) and each `\enddatalist`
+expands to a whole *bare-CS* `\thebibliography…\endthebibliography` — no group,
+so the first arming was still live when the second opened.
+
+Fixed in two symmetric halves: `setup_pseudo_bibitem` captures the originals
+once per arming (`\ifx\bibitem\restoring@bibitem` guard), and
+`\endthebibliography` now disarms — upstream has no teardown, relying on
+`\begin`/`\end` popping the group, which the bare-CS pair never opens. The
+missing teardown was separately costing a stray empty bibitem outside the
+biblist (`Error:malformed:ltx:bibitem`) from the blank line after
+`\printbibliography`.
+
+Witness now converts in ~1 s with **1 error** (`\missing`, undefined in both
+engines) and 58 bibitems / 2 bibliographies / 2 biblists — byte-for-byte the
+structure same-host Perl produces, which takes 33.7 s and reports **59 errors**.
+**The defect is shared with Perl** (`\thebibliography \endthebibliography
+\thebibliography \bibitem{b}` hangs Perl 0.8.8 >400 s); it stays latent upstream
+only because Perl's biblatex binding never defines `\printbibliography`, so Perl
+never reads a real `.bbl` this way. Mechanism, minimal trigger and the
+upstream-candidate note: `KNOWN_PERL_ERRORS.md` #57. Guard
+`06_cluster_regressions::cluster_biblatex_two_datalists`.
 
 
 ### R6 — `ltx_env_<name>` env-markup class — PLANNED, needs its own branch (churns every test XML)

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -75,8 +75,8 @@ session of their own. Re-verify a row before planning on it (rule 1).
   2606.13010 (arXiv/html_feedback#6624) now converts at 0 errors / 0 warnings /
   0 unparsed math. This file was compacted the same day — see the header.
 
-- `cargo test --tests`: **1684 passing / 91 targets, 0 ignored** (2026-07-25, on
-  `main` @ `35200b1598` + the R4 fix, dev box with ImageMagick + ghostscript +
+- `cargo test --tests`: **1686 passing / 92 targets, 0 ignored** (2026-07-25, on
+  `main` @ `3b04a8fb79` + the R4 fix, dev box with ImageMagick + ghostscript +
   poppler installed, `mutool` absent) — including this session's
   `cluster_biblatex_two_datalists`. The one red,
   `latexml_post::graphics::process_coalesces_only_matching_conversion_options`,

--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -2278,3 +2278,76 @@ arguments through the same `\@doimport` as `\import`/`\subimport`, and Perl's ow
 `06_cluster_regressions::includefrom_takes_directory_and_file`. Candidate to
 upstream (not filed as of 2026-07-23) — a two-character fix at
 `import.sty.ltxml` L45/L47.
+
+## 57. `setupPseudoBibitem` re-arming makes `\save@bibitem` a self-referential `\let` → infinite expansion
+
+`latex_constructs.pool.ltxml:setupPseudoBibitem` (L4028-4032) saves the real
+meanings before installing its "missing `\bibitem`" redirection:
+
+```perl
+Let('\save@bibitem', '\bibitem');
+Let('\save@par',     '\par');
+Let('\save@backbackslash', '\\\\');
+Let('\bibitem', '\restoring@bibitem');
+Let('\par',     '\par@in@bibliography');
+Let('\\\\',     '\par@in@bibliography');
+```
+
+The captures are unconditional. If it runs a second time while the redirection
+is still armed, all three save the *redirectors*: `\save@bibitem` becomes
+`\restoring@bibitem`, whose body is
+`\let\bibitem\save@bibitem\let\par\save@par\let\\\save@backbackslash\bibitem`
+(L4067) — it points `\bibitem` back at `\restoring@bibitem` and then calls it.
+That is an unconditional infinite expansion, not a slow document.
+
+`\thebibliography` / `\endthebibliography` are `DefConstructor`s, not an
+environment ("Should be an environment, but people seem to want to misuse it"),
+so a *bare-CS* pair opens no group and the arming survives it. Minimal trigger —
+hangs Perl 0.8.8 (>400 s on 8 lines; the same file converts in <2 s once the
+double-arm is broken):
+
+```latex
+\documentclass{article}
+\begin{document}
+\thebibliography{9}
+\endthebibliography
+\thebibliography{9}
+\bibitem{b} Author B.
+\endthebibliography
+\end{document}
+```
+
+The first bibliography must contain no `\bibitem` — one there fires
+`\restoring@bibitem`, which disarms and makes the second capture legitimate.
+`\ifx\save@bibitem\restoring@bibitem` after the second `\thebibliography` is
+true in **both** engines, so the latent defect is shared.
+
+It stays latent upstream because Perl's biblatex binding
+(`ar5iv-bindings/biblatex.sty.ltxml`) never defines `\printbibliography`, so
+Perl never reads a real `.bbl` through this path. Rust's binding does, and a
+biber `.bbl` reaches it routinely: biblatex's apa style requests two sorting
+schemes, so the `.bbl` carries **two `\datalist` blocks** with the same
+references, and each `\enddatalist` expands to a whole bare
+`\thebibliography…\endthebibliography` (`biblatex_sty.rs::bib_as_thebibliography`,
+mirroring Perl's `biblatex_as_thebibliography` L105-119).
+
+**Fixed in Rust**, in two symmetric halves:
+* `setup_pseudo_bibitem` guards the three captures on
+  `\ifx\bibitem\restoring@bibitem` — capture the originals once per arming.
+* `\endthebibliography` now *disarms* (the same three `\let`s
+  `\restoring@bibitem` performs, minus its trailing `\bibitem`). Upstream has no
+  teardown, relying on `\begin`/`\end{thebibliography}` popping the group; that
+  never covers the bare-CS pair, so the redirection outlived the bibliography
+  and the next `\par` — a blank line after `\printbibliography` — expanded to
+  `\par@in@bibliography` and deposited a stray empty `\save@bibitem{}` outside
+  the biblist (`Error:malformed:ltx:bibitem <ltx:bibitem> isn't allowed in
+  <ltx:p>`). Restoring is a no-op for the grouped shape and for a bare
+  `\thebibliography` with no closer.
+
+Witness arXiv 2605.17646 (biblatex apa, 2 × 29 entries, blank line after
+`\printbibliography`): `Fatal:Timeout:TokenLimit` at 1e9 tokens with no output →
+now converts with 1 error (`\missing{Cowen2021}`, undefined in both engines) and
+58 bibitems / 2 bibliographies / 2 biblists, matching same-host Perl exactly
+(Perl: 59 errors, 33.7 s). Guard
+`06_cluster_regressions::cluster_biblatex_two_datalists`. Candidate to upstream
+(not filed as of 2026-07-25).

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -2226,9 +2226,34 @@ pub fn before_digest_bibliography() -> Result<()> {
 // bibliographies with blank lines!
 // So, let's do some redirection!
 fn setup_pseudo_bibitem() -> Result<()> {
-  Let!("\\save@bibitem", "\\bibitem");
-  Let!("\\save@par", "\\par");
-  Let!("\\save@backbackslash", "\\\\");
+  // Capture the REAL meanings, but only once per arming. Perl
+  // (latex_constructs.pool.ltxml:setupPseudoBibitem L4028-4032) captures
+  // unconditionally; if this runs while the redirection below is still
+  // installed, all three saves capture the *redirectors* instead of the
+  // originals — `\save@bibitem` becomes `\restoring@bibitem`, whose body ends
+  // in `\bibitem`, which `\let\bibitem\save@bibitem` has just pointed back at
+  // `\restoring@bibitem`. That is an unconditional infinite expansion loop
+  // (`\let \bibitem \save@bibitem \let \par \save@par \let \\
+  // \save@backbackslash \bibitem` forever), not a slow document.
+  //
+  // Perl has the identical hole — `\thebibliography \endthebibliography
+  // \thebibliography \bibitem{b}` hangs Perl 0.8.8 too (>400 s on an 8-line
+  // file that converts in <2 s otherwise); see KNOWN_PERL_ERRORS #57. It stays
+  // latent upstream only because Perl's biblatex binding never defines
+  // `\printbibliography`, so Perl never reads a real `.bbl` this way.
+  //
+  // We do reach it: a biber `.bbl` carries one `\datalist` per sorting scheme
+  // (apa emits `nyt/apasortcite//…` *and* `nyt/global//…`), and every
+  // `\enddatalist` expands to a whole `\thebibliography…\endthebibliography`.
+  // Neither of those is an environment — no group — so the first arming is
+  // still in force when the second `\thebibliography` opens. Witness:
+  // arXiv 2605.17646 (`Fatal:Timeout:TokenLimit`, 1e9 tokens), guarded by
+  // `tests/cluster_regressions/biblatex_two_datalists`.
+  if !x_equals(&T_CS!("\\bibitem"), &T_CS!("\\restoring@bibitem")) {
+    Let!("\\save@bibitem", "\\bibitem");
+    Let!("\\save@par", "\\par");
+    Let!("\\save@backbackslash", "\\\\");
+  }
   Let!("\\bibitem", "\\restoring@bibitem");
   Let!("\\par", "\\par@in@bibliography");
   Let!("\\\\", "\\par@in@bibliography");
@@ -8312,7 +8337,39 @@ LoadDefinitions!({
   DefConstructor!("\\endthebibliography", sub[document,_whatsit,_props] {
     document.maybe_close_element("ltx:biblist")?;
     document.maybe_close_element("ltx:bibliography")?;
-  }, locked=>true);
+  },
+    // Disarm the `setupPseudoBibitem` redirection that `\thebibliography`
+    // installed — the same three `\let`s `\restoring@bibitem` performs, minus
+    // its trailing `\bibitem`. Perl (latex_constructs.pool.ltxml L4014-4017)
+    // has no teardown: it relies on `\begin`/`\end{thebibliography}` popping
+    // the group the `\let`s were made in. That covers hand-written
+    // bibliographies, but NOT the bare-CS `\thebibliography …
+    // \endthebibliography` pair that the biblatex `.bbl` rebuilder expands to
+    // (`biblatex_sty.rs::bib_as_thebibliography`), which opens no group. There
+    // the redirection outlived the bibliography, so the next `\par` — a blank
+    // line after `\printbibliography` — still expanded to
+    // `\par@in@bibliography` and deposited a stray empty `\save@bibitem{}`
+    // OUTSIDE the biblist (`Error:malformed:ltx:bibitem <ltx:bibitem> isn't
+    // allowed in <ltx:p>`, witness arXiv 2605.17646: 59 bibitems where Perl
+    // and the `.bbl` both say 58).
+    //
+    // Restoring here is a no-op for the grouped case (the `\let`s are undone
+    // again when the group pops) and for the bare `\thebibliography` with no
+    // closer at all (this never runs) — the two shapes Perl's comment at
+    // `\thebibliography` calls out. See KNOWN_PERL_ERRORS #57.
+    //
+    // Gated on still being armed, for the same reason `\restoring@bibitem`
+    // only runs once: a real `\bibitem` inside the bibliography has already
+    // restored all three, and an `\endthebibliography` reached with no arming
+    // at all would otherwise copy an UNDEFINED `\save@par` onto `\par`.
+    after_digest => sub[_whatsit] {
+      if x_equals(&T_CS!("\\bibitem"), &T_CS!("\\restoring@bibitem")) {
+        Let!("\\bibitem", "\\save@bibitem");
+        Let!("\\par", "\\save@par");
+        Let!("\\\\", "\\save@backbackslash");
+      }
+    },
+    locked=>true);
   Let!("\\saved@endthebibliography", "\\endthebibliography");
   // auto close the bibliography and contained biblist.
   Tag!("ltx:biblist",      auto_close => true);

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -662,6 +662,74 @@ fn convert_to_xml_contrib(source: &str) -> String {
     .unwrap_or_else(|| panic!("{source}: conversion produced no result"))
 }
 
+/// `convert_to_xml_contrib` with the strict signal-integrity gate that
+/// `convert_to_xml` applies to the core helpers: zero `Error:<class>:` markers
+/// and a non-fatal status. Use this for contrib regressions whose whole point
+/// is that the input stops erroring — tolerating an error there is exactly the
+/// false negative the project's log-parsing rule forbids.
+fn convert_to_xml_contrib_clean(source: &str) -> String {
+  latexml::util::test::init_test_rss_cap();
+  let _ = latexml_core::util::logger::init(log::LevelFilter::Warn);
+  let cfg = Config {
+    format: OutputFormat::HTML5,
+    extra_bindings_dispatch: Some(std::rc::Rc::new(latexml_contrib::dispatch)),
+    ..Config::default()
+  };
+  let mut c = Converter::from_config(cfg);
+  c.initialize_session().expect("initialize");
+  let r = c.convert(source.to_string());
+  let n_errors = latexml::util::test::error_count(&r.log);
+  assert_eq!(
+    n_errors, 0,
+    "{source}: expected 0 errors but log contained {n_errors} Error:<class>: markers (status_code={})",
+    r.status_code
+  );
+  assert!(
+    r.status_code <= 1,
+    "{source}: status_code {} (expected 0/1), status={:?}",
+    r.status_code,
+    r.status
+  );
+  r.result
+    .unwrap_or_else(|| panic!("{source}: conversion produced no result"))
+}
+
+/// A biber `.bbl` with more than one `\datalist` (biblatex's apa style asks for
+/// two sorting schemes, so the same references are emitted twice) used to hang
+/// the engine: each `\enddatalist` expands to a bare
+/// `\thebibliography…\endthebibliography`, neither of which opens a group, so
+/// the second one re-entered `setupPseudoBibitem` while the first arming was
+/// live and captured `\save@bibitem` ← `\restoring@bibitem` — a self-referential
+/// `\let` that expands forever (`Fatal:Timeout:TokenLimit`, 1e9 tokens).
+/// The blank line after `\printbibliography` covers the second half of the fix:
+/// `\endthebibliography` now disarms the redirection, so that `\par` no longer
+/// expands to `\par@in@bibliography` and deposits a stray empty bibitem outside
+/// the biblist. Witness: arXiv 2605.17646 (Perl converts it — its biblatex
+/// binding never defines `\printbibliography`, so upstream never reaches this —
+/// but Perl hangs identically on the bare-CS form; KNOWN_PERL_ERRORS #57).
+#[test]
+fn cluster_biblatex_two_datalists() {
+  let x =
+    convert_to_xml_contrib_clean("tests/cluster_regressions/biblatex_two_datalists/twolists.tex");
+  // One bibliography per \datalist, each holding its own biblist.
+  assert_eq!(
+    x.matches("<bibliography").count(),
+    2,
+    "expected one <bibliography> per \\datalist:\n{x}"
+  );
+  assert_eq!(
+    x.matches("<biblist>").count(),
+    2,
+    "expected one <biblist> per \\datalist:\n{x}"
+  );
+  // 2 entries × 2 datalists, and NOT a 5th stray from the trailing blank line.
+  assert_eq!(
+    x.matches("<bibitem").count(),
+    4,
+    "expected exactly 4 bibitems (2 entries x 2 datalists, no stray):\n{x}"
+  );
+}
+
 /// biblatex author-year support (ar5iv-bindings PRs #20/#21 + repair
 /// 0911aec): style=apa documents with a biber .bbl get "Surname, Year"
 /// labels, one schema-valid role-tagged <ltx:tags> per bibitem, and the

--- a/latexml_oxide/tests/cluster_regressions/biblatex_two_datalists/twolists.bbl
+++ b/latexml_oxide/tests/cluster_regressions/biblatex_two_datalists/twolists.bbl
@@ -1,0 +1,73 @@
+% $ biblatex auxiliary file $
+% $ biblatex bbl format version 3.2 $
+% Do not modify the above lines!
+\refsection{0}
+  \datalist[entry]{nyt/apasortcite//global/global/global}
+    \entry{smith2020}{article}{}
+      \name{author}{1}{}{%
+        {{un=0,uniquepart=base,hash=3f8a2b}{%
+           family={Smith},
+           familyi={S\bibinitperiod},
+           given={John},
+           giveni={J\bibinitperiod}}}%
+      }
+      \strng{namehash}{3f8a2b}
+      \field{sortinit}{S}
+      \field{labelnamesource}{author}
+      \field{labeltitlesource}{title}
+      \field{journaltitle}{Journal of Testing}
+      \field{title}{A study of things}
+      \field{year}{2020}
+    \endentry
+    \entry{jones2019}{article}{}
+      \name{author}{1}{}{%
+        {{un=0,uniquepart=base,hash=a1b2c3}{%
+           family={Jones},
+           familyi={J\bibinitperiod},
+           given={Alice},
+           giveni={A\bibinitperiod}}}%
+      }
+      \strng{namehash}{a1b2c3}
+      \field{sortinit}{J}
+      \field{labelnamesource}{author}
+      \field{labeltitlesource}{title}
+      \field{journaltitle}{Review of Examples}
+      \field{title}{On examples}
+      \field{year}{2019}
+    \endentry
+  \enddatalist
+  \datalist[entry]{nyt/global//global/global/global}
+    \entry{smith2020}{article}{}
+      \name{author}{1}{}{%
+        {{un=0,uniquepart=base,hash=3f8a2b}{%
+           family={Smith},
+           familyi={S\bibinitperiod},
+           given={John},
+           giveni={J\bibinitperiod}}}%
+      }
+      \strng{namehash}{3f8a2b}
+      \field{sortinit}{S}
+      \field{labelnamesource}{author}
+      \field{labeltitlesource}{title}
+      \field{journaltitle}{Journal of Testing}
+      \field{title}{A study of things}
+      \field{year}{2020}
+    \endentry
+    \entry{jones2019}{article}{}
+      \name{author}{1}{}{%
+        {{un=0,uniquepart=base,hash=a1b2c3}{%
+           family={Jones},
+           familyi={J\bibinitperiod},
+           given={Alice},
+           giveni={A\bibinitperiod}}}%
+      }
+      \strng{namehash}{a1b2c3}
+      \field{sortinit}{J}
+      \field{labelnamesource}{author}
+      \field{labeltitlesource}{title}
+      \field{journaltitle}{Review of Examples}
+      \field{title}{On examples}
+      \field{year}{2019}
+    \endentry
+  \enddatalist
+\endrefsection

--- a/latexml_oxide/tests/cluster_regressions/biblatex_two_datalists/twolists.tex
+++ b/latexml_oxide/tests/cluster_regressions/biblatex_two_datalists/twolists.tex
@@ -1,0 +1,21 @@
+% Regression: a biber .bbl that carries MORE THAN ONE \datalist block.
+% biblatex's apa style asks biber for two sorting schemes, so the .bbl holds
+% the same references twice (nyt/apasortcite//… and nyt/global//…). Every
+% \enddatalist expands to a whole \thebibliography…\endthebibliography, and
+% neither of those is an environment, so the second one re-entered
+% setupPseudoBibitem while the first one's \let-redirection was still armed:
+%   \save@bibitem -> \restoring@bibitem -> …\let\bibitem\save@bibitem…\bibitem
+% i.e. an unconditional infinite expansion (Fatal:Timeout:TokenLimit, 1e9
+% tokens). The BLANK LINE after \printbibliography below is load-bearing too:
+% with the redirection left armed past \endthebibliography, that \par expanded
+% to \par@in@bibliography and deposited a stray empty \save@bibitem{} outside
+% the biblist ("Error:malformed:ltx:bibitem <ltx:bibitem> isn't allowed in
+% <ltx:p>"). Witness: arXiv 2605.17646. See KNOWN_PERL_ERRORS #57.
+\documentclass{article}
+\usepackage[style=apa,backend=biber]{biblatex}
+\addbibresource{twolists.bib}
+\begin{document}
+Cited: \parencite{smith2020} and \parencite{jones2019}.
+\printbibliography
+
+\end{document}


### PR DESCRIPTION
Closes SYNC_STATUS **R4** — the biblatex `.bbl` `TokenLimit` loop (arXiv 2605.17646).

## The bug

`setupPseudoBibitem` unconditionally captures `\save@bibitem` ← `\bibitem` before installing its missing-`\bibitem` redirection. Run it while that redirection is still armed and all three saves capture the *redirectors*: `\save@bibitem` becomes `\restoring@bibitem`, whose body is `\let\bibitem\save@bibitem…\bibitem` — it points `\bibitem` back at itself and calls it. Unconditional infinite expansion, not a slow document.

It re-arms because biblatex's **apa style asks biber for two sorting schemes**, so the `.bbl` carries two `\datalist` blocks with the same references, and every `\enddatalist` expands to a whole *bare-CS* `\thebibliography … \endthebibliography` (`biblatex_sty.rs::bib_as_thebibliography`). Neither is an environment, so no group, so the first arming was still live when the second `\thebibliography` opened.

The entry's standing suspicion — the `.bbl`'s trailing `\missing{Cowen2021}` — was **wrong**; deleting that line leaves the Fatal untouched.

## The fix — two symmetric halves

- `setup_pseudo_bibitem` captures the originals **once per arming** (`\ifx\bibitem\restoring@bibitem` guard).
- `\endthebibliography` now **disarms**. Upstream has no teardown, relying on `\begin`/`\end{thebibliography}` popping the group the `\let`s were made in — which the bare-CS pair never opens. That leak separately cost a stray empty bibitem outside the biblist (`Error:malformed:ltx:bibitem`) from the blank line after `\printbibliography`. Gated on still being armed, so an `\endthebibliography` reached unarmed cannot copy an undefined `\save@par` onto `\par`.

## Classification: shared with Perl

`\thebibliography \endthebibliography \thebibliography \bibitem{b}` hangs Perl 0.8.8 **>400 s on an 8-line file** that otherwise converts in <2 s. `\ifx\save@bibitem\restoring@bibitem` is true in **both** engines after the second `\thebibliography`.

It stays latent upstream only because Perl's ar5iv biblatex binding never defines `\printbibliography`, so Perl never reads a real `.bbl` this way. Recorded as `KNOWN_PERL_ERRORS.md` **#57**, candidate to upstream.

## Verification

Witness arXiv 2605.17646, same host, ANSI-stripped, Perl run verbose (not `--quiet`):

| | before | after | same-host Perl |
|---|---|---|---|
| outcome | `Fatal:Timeout:TokenLimit` (1e9 tokens), no output | **1 error**, 0.86 s | 59 errors, 33.7 s |
| bibitems / bibliographies / biblists | — | **58 / 2 / 2** | 58 / 2 / 2 ✓ |

The one remaining error is `\missing`, undefined in both engines.

The three shapes the redirection exists to serve all still match Perl element-for-element:

| shape | Rust | Perl |
|---|---|---|
| bibliography with **no** `\bibitem` (blank-line entries) | 3 bibitems / 1 / 1 | 3 / 1 / 1 |
| bare `\thebibliography`, **no** closer | 2 / 1 / 1 | 2 / 1 / 1 |
| `\bibitem` **after** `\end{thebibliography}` | 2 / 2 / 2 | 2 / 2 / 2 |

Gates:
- `cargo test --tests --no-fail-fast`: **1684 passed, 1 failed** — the failure is `latexml_post::graphics::process_coalesces_only_matching_conversion_options`, the known local-only artifact (dev laptop has the full vector toolchain; green in CI), unrelated to bibliographies.
- New guard `cluster_biblatex_two_datalists` verified **red before / green after** (stashed the engine hunk → status_code 3, `Fatal:Timeout:TokenLimit`).
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo doc --workspace` rustdoc-warning-clean.

Blast radius is likely wider than one paper — any apa-style biblatex `.bbl` (two datalists) with a `\par` after `\printbibliography` hits this — but only the single witness was measured, so no fleet number is claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)