### PR TITLE
fix(listings): convert the requested snippet, not a broken one

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -2278,3 +2278,66 @@ arguments through the same `\@doimport` as `\import`/`\subimport`, and Perl's ow
 `06_cluster_regressions::includefrom_takes_directory_and_file`. Candidate to
 upstream (not filed as of 2026-07-23) — a two-character fix at
 `import.sty.ltxml` L45/L47.
+
+## 57. A listing's trailing-empty-line trim discards the braces that close it
+
+`listings.sty.ltxml` L1330 trims trailing blank lines by slicing the generated token
+vector:
+
+```perl
+@LaTeXML::lsttokens = @LaTeXML::lsttokens[0 .. $LaTeXML::emptyfrom - 1] if $LaTeXML::emptyfrom;
+```
+
+`$emptyfrom` is a token index, not a structural boundary. Any delimited class still
+open there (string, comment, styled span) has its closing `}` in the discarded tail,
+so the listing body is emitted with unclosed groups and `\@@listings@block` reads its
+arguments past the end of the document.
+
+Trigger: `lastline=N` on a file with **more** than N lines — the line-skipping loop
+consumes the rest without closing what the last rendered line left open.
+
+```latex
+\documentclass{article}\usepackage{listings}
+\begin{document}
+\lstinputlisting[lastline=3]{four_line_file.py}
+Text after the listing.
+\end{document}
+```
+
+Perl: `Error:expected:{} Missing argument {} for Core::Definition::Constructor
+[\@@listings@block {}{}{}]`, ×7 on the witness. **Both engines lose the snippet.**
+
+**Fixed in Rust** (OXIDIZED_DESIGN #68): truncate as Perl does, then re-close whatever
+the cut left open — the discarded region is by construction only empty-line markup.
+Witness arXiv 2412.04705 (arXiv/html_feedback#6735): 22 errors → **0**, while
+same-host Perl still reports 15. Guard
+`104_lstinputlisting_range_crlf::lastline_shorter_than_file_does_not_swallow_the_document`.
+Candidate to upstream (not filed as of 2026-07-25).
+
+## 58. A CRLF listing source makes line-comment styling bleed down the file
+
+`listingsReadRawFile` slurps the file verbatim, but every end-of-line test in the
+listings processor is written against `\n` (the `__NEWLINE__` comment-close test, the
+blank-line test in `lstProcessStartLine`, the line-skipping loops). A `\r` before the
+`\n` defeats them all, so a line comment never terminates and its style bleeds over
+every following line. The `ltx_lst_comment` class wrapper *does* close — only the
+font/colour group leaks — so the bug is invisible if you inspect classes rather than
+`font`/`color`.
+
+```latex
+\lstdefinestyle{s}{morecomment=[l]{\#},commentstyle=\itshape}
+\lstinputlisting[style=s]{crlf_file.py}   % every line comes out italic
+```
+
+TeX never sees the CR (its file reader strips the terminator and appends
+`\endlinechar`), so this is a slurp that skips what the engine does.
+
+Ground truth on arXiv 2412.04705 (CRLF Python sources): pdflatex renders only the `#`
+line in comment green — 9 green vs 69 black glyph groups on the page — while both
+LaTeXML engines paint the whole snippet green and slanted. Pre-fix A/B confirms the
+cause: an LF copy of the same file renders correctly, the CRLF original does not.
+
+**Fixed in Rust** (OXIDIZED_DESIGN #69): normalize `\r\n` and lone `\r` to `\n` on
+read. Guard
+`104_lstinputlisting_range_crlf::crlf_line_comment_style_does_not_bleed_past_its_line`.
+Candidate to upstream (not filed as of 2026-07-25).

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2011,6 +2011,69 @@ end-to-end `30_script_bindings::script_binding_macro_and_constructor_convert`
 (`\rhfragment` parses two siblings, edits them while detached, inserts both, and
 asserts `data-top="detached"` plus a blanket `!contains("_lxfragment")`).
 
+### 68. Trimming a listing's trailing empty lines re-closes what the trim cut open
+
+Perl `listings.sty.ltxml` L1330 drops trailing blank lines by slicing the generated
+token vector:
+
+```perl
+@LaTeXML::lsttokens = @LaTeXML::lsttokens[0 .. $LaTeXML::emptyfrom - 1] if $LaTeXML::emptyfrom;
+```
+
+`$emptyfrom` is where the run of trailing empty lines began — but it is an index into
+a token stream, not a structural boundary. When a delimited class (a string, a
+comment, a styled span) is still **open** at that point, its closing `}` tokens live
+in the discarded tail. The slice throws them away and the listing body is emitted with
+unclosed groups; `\@@listings@block` then reads its arguments past the end of the
+listing and off the end of the **document**.
+
+`lastline=N` on a file with more than N lines is the everyday way to reach it: the
+skip loop consumes the remaining lines without closing what the last rendered line
+left open. Measured discarded tail on the witness below —
+
+```
+["\@lst@startline", "{", "}", "}", "}", "}", "\@lst@endline"]
+```
+
+— three of those `}` close groups opened *before* the cut, leaving the body at brace
+depth 3.
+
+**Both engines lose the snippet**, with different diagnostics: Perl reports
+`Missing argument {} for \@@listings@block {}{}{}`, we reported
+`Gullet->readBalanced ran out of input in an unbalanced state` plus a cascade of
+`Attempt to end mode internal_vertical` and malformed-sectioning errors as the
+mode-switch frame was never unwound.
+
+Rust truncates as Perl does, then re-closes whatever the cut left open. The discarded
+region is by construction only empty-line markup (it starts at a line with
+`colnum == 0`), so nothing visible is lost by closing there.
+
+Witness: arXiv 2412.04705 (arXiv/html_feedback#6735) — 22 errors → **0**, where
+same-host Perl still reports 15. Guard:
+`104_lstinputlisting_range_crlf::lastline_shorter_than_file_does_not_swallow_the_document`.
+
+### 69. A listing source file's CRLF line endings are normalized on read
+
+`listingsReadRawFile` slurps the file verbatim in Perl. Every end-of-line test in the
+listings processor is then written against `\n` — the `__NEWLINE__` close test for
+line comments, the blank-line test in `lstProcessStartLine`, the line-skipping loops —
+and a `\r` sitting before the `\n` defeats all of them. A line comment therefore never
+terminates, and its **style** bleeds over every following line. (The
+`ltx_lst_comment` class wrapper does close; it is the font/colour group that leaks, so
+the defect is invisible if you inspect classes rather than `font`/`color`.)
+
+TeX never sees the CR — its file reader strips the line terminator and appends
+`\endlinechar` — so normalizing `\r\n` and lone `\r` to `\n` at ingestion is what
+matches the engine we emulate, not a special case.
+
+Ground truth, arXiv 2412.04705 (arXiv/html_feedback#6735), whose Python sources are
+CRLF: pdflatex renders only the `#` line in comment green (measured on the rendered
+page: 9 green vs 69 black glyph groups), while both LaTeXML engines painted the whole
+snippet green and slanted. Verified by A/B — pre-fix, an LF copy of the same file
+renders correctly and the CRLF original does not.
+
+Guard: `104_lstinputlisting_range_crlf::crlf_line_comment_style_does_not_bleed_past_its_line`.
+
 ## Known Upstream Perl Issues (brief)
 
 These are behaviors in the original Perl LaTeXML that are bugs or limitations, not

--- a/latexml_oxide/tests/104_lstinputlisting_range_crlf.rs
+++ b/latexml_oxide/tests/104_lstinputlisting_range_crlf.rs
@@ -1,0 +1,154 @@
+//! Regression tests: `\lstinputlisting` over an externally-read source file —
+//! a truncating line range, and CRLF line terminators.
+//!
+//! Witness: arXiv 2412.04705 (arXiv/html_feedback#6735, "Wrong code snippet in
+//! html display"), whose `\inputpython` wraps
+//! `\lstinputlisting[firstline=32,lastline=35,...]` over CRLF Python sources.
+//! Both defects are shared with Perl LaTeXML; see OXIDIZED_DESIGN #68 / #69 and
+//! `KNOWN_PERL_ERRORS.md`.
+//!
+//! 1. **Truncating range** (`listings_sty.rs` "Remove trailing empty lines").
+//!    `lastline=N` on a file with MORE than N lines cut the generated token
+//!    vector at `emptyfrom`, discarding `}` tokens that closed groups opened
+//!    BEFORE the cut — measured discarded tail on the witness:
+//!    `["\@lst@startline", "{", "}", "}", "}", "}", "\@lst@endline"]`, three of
+//!    them closers. The listing body was emitted with unclosed groups, so
+//!    `\@@listings@block` read its arguments off the end of the DOCUMENT and
+//!    everything after the listing was swallowed.
+//!
+//! 2. **CRLF** (`listings_read_raw_file`). Every end-of-line test in the
+//!    listings processor is written against `\n`; a `\r` before it defeats them,
+//!    so a line comment never terminates and its STYLE (not its class — the
+//!    `ltx_lst_comment` wrapper does close) bleeds over every following line.
+//!    pdflatex on the witness renders only the `#` line in comment green
+//!    (9 green vs 69 black glyph groups); both LaTeXML engines painted the whole
+//!    snippet green.
+//!
+//! Binary-driven (fresh process) so the listing file is read from disk.
+
+use std::{path::Path, process::Command};
+
+/// CRLF on purpose — this is half of what is under test.
+const DATA_PY: &str = "# a comment line\r\nvalue = 1\r\nother = 2\r\nlast = 3\r\n";
+
+fn convert(tex: &str, data: &str) -> (String, String) {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+
+  let workdir = tempfile::tempdir().expect("create tempdir");
+  std::fs::write(workdir.path().join("data.py"), data).expect("write data.py");
+  std::fs::write(workdir.path().join("t.tex"), tex).expect("write t.tex");
+
+  let output = Command::new(bin)
+    .args(["t.tex", "--dest", "t.xml", "--nocomments"])
+    .current_dir(workdir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+
+  let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+  assert!(
+    output.status.success(),
+    "binary exited {:?}\nstderr:\n{stderr}",
+    output.status.code(),
+  );
+  let xml = std::fs::read_to_string(workdir.path().join("t.xml")).expect("read t.xml");
+  (xml, stderr)
+}
+
+/// Collect the text of each `<listingline>`, in order.
+fn listing_lines(xml: &str) -> Vec<String> {
+  let mut out = Vec::new();
+  for chunk in xml.split("<listingline").skip(1) {
+    let Some(end) = chunk.find("</listingline>") else {
+      continue;
+    };
+    out.push(chunk[..end].to_string());
+  }
+  out
+}
+
+fn strip_tags(fragment: &str) -> String {
+  let mut text = String::new();
+  let mut in_tag = false;
+  for ch in fragment.chars() {
+    match ch {
+      '<' => in_tag = true,
+      '>' => in_tag = false,
+      c if !in_tag => text.push(c),
+      _ => {},
+    }
+  }
+  text
+}
+
+#[test]
+fn lastline_shorter_than_file_does_not_swallow_the_document() {
+  // `lastline=3` over a 4-line file: the truncation path is exercised.
+  let tex = "\\documentclass{article}\n\
+    \\usepackage{listings}\n\
+    \\begin{document}\n\
+    \\lstinputlisting[lastline=3]{data.py}\n\
+    Text after the listing.\n\
+    \\end{document}\n";
+  let (xml, stderr) = convert(tex, DATA_PY);
+
+  assert!(
+    !stderr.contains("Error:") && !stderr.contains("Fatal:"),
+    "truncating lastline should convert cleanly, stderr had:\n{stderr}",
+  );
+  // The document continues after the listing — the unbalanced body used to make
+  // `\@@listings@block` read its arguments to EOF, losing everything after it.
+  assert!(
+    xml.contains("Text after the listing"),
+    "content after the listing was swallowed:\n{xml}",
+  );
+  let lines = listing_lines(&xml);
+  assert_eq!(
+    lines.len(),
+    3,
+    "expected exactly lines 1..3 of the file, got {}:\n{xml}",
+    lines.len()
+  );
+  assert!(
+    strip_tags(&lines[2]).contains("other = 2"),
+    "third listing line should be the file's line 3:\n{}",
+    strip_tags(&lines[2])
+  );
+  assert!(
+    !xml.contains("last = 3"),
+    "line 4 is past lastline=3 and must not appear:\n{xml}",
+  );
+}
+
+#[test]
+fn crlf_line_comment_style_does_not_bleed_past_its_line() {
+  // `\r\n` terminators: only the `#` line is a comment. The class wrapper always
+  // closed correctly; it is the STYLE that used to leak, so assert on `font`.
+  let tex = "\\documentclass{article}\n\
+    \\usepackage{listings}\n\
+    \\lstdefinestyle{s}{morecomment=[l]{\\#},commentstyle=\\itshape}\n\
+    \\begin{document}\n\
+    \\lstinputlisting[style=s]{data.py}\n\
+    \\end{document}\n";
+  let (xml, stderr) = convert(tex, DATA_PY);
+
+  assert!(
+    !stderr.contains("Error:") && !stderr.contains("Fatal:"),
+    "CRLF listing should convert cleanly, stderr had:\n{stderr}",
+  );
+  let lines = listing_lines(&xml);
+  assert_eq!(lines.len(), 4, "expected all 4 file lines:\n{xml}");
+
+  assert!(
+    lines[0].contains("font=\"italic\""),
+    "the comment line should carry the commentstyle:\n{}",
+    lines[0]
+  );
+  for (i, line) in lines.iter().enumerate().skip(1) {
+    assert!(
+      !line.contains("font=\"italic\""),
+      "line {} is code, but the comment style bled into it:\n{line}",
+      i + 1
+    );
+  }
+}

--- a/latexml_package/src/package/listings_sty.rs
+++ b/latexml_package/src/package/listings_sty.rs
@@ -261,7 +261,28 @@ fn listings_read_raw_file(file: &str) -> Option<String> {
       ..Default::default()
     }),
   ) {
-    std::fs::read_to_string(&path).ok()
+    // Normalize line terminators to bare LF.
+    //
+    // DIVERGENCE (OXIDIZED_DESIGN #69) — Perl slurps the file verbatim, so a
+    // CRLF (or classic-Mac CR) source keeps its `\r`, and every downstream
+    // end-of-line test in the listings processor is written against `\n`: the
+    // `__NEWLINE__` close test for line comments, the blank-line test in
+    // `lst_process_start_line`, the line-skipping loops. A `\r` sitting before
+    // the `\n` defeats all of them, so a line comment never terminates and its
+    // style bleeds over every following line.
+    //
+    // TeX itself never sees the CR — its file reader strips the line
+    // terminator and appends `\endlinechar` — so normalizing here is what
+    // matches the engine we emulate, not a special case.
+    //
+    // Ground truth, arXiv 2412.04705 (arXiv/html_feedback#6735), whose Python
+    // sources are CRLF: pdflatex renders only the `#` line in comment green
+    // (measured: 9 green vs 69 black glyph groups), while BOTH LaTeXML engines
+    // paint the whole snippet green — Perl identically, so this is a shared
+    // upstream bug we are fixing rather than a Rust regression.
+    std::fs::read_to_string(&path)
+      .ok()
+      .map(|text| text.replace("\r\n", "\n").replace('\r', "\n"))
   } else {
     log::warn!("Can't read listings file '{}'", filename);
     None
@@ -1255,9 +1276,45 @@ fn lst_process(mode: &str, text: &str) -> Tokens {
     assign_value(&key, Stored::Int(ctx.linenum), Some(Scope::Global));
   }
 
-  // Remove trailing empty lines
+  // Remove trailing empty lines.
+  // Perl listings.sty.ltxml:1330 does the bare truncation:
+  //   @lsttokens = @lsttokens[0 .. $emptyfrom - 1] if $emptyfrom;
+  //
+  // DIVERGENCE (OXIDIZED_DESIGN #68) — that truncation is UNBALANCED, in Perl
+  // too. `$emptyfrom` is the index of the first trailing empty line's
+  // `\@lst@startline`, but a delimited class left open by the last *content*
+  // line (a string/comment the listing was cut off inside — exactly what
+  // `lastline=N` on a longer file does) has its closing `}` tokens sitting in
+  // that discarded tail. Dropping them emits a listing body with unclosed
+  // groups; `\@@listings@block` then reads its arguments off the end of the
+  // DOCUMENT. Perl reports that as "Missing argument {} for \@@listings@block",
+  // we reported it as "readBalanced ran out of input" plus a cascade of
+  // mode/sectioning errors — both engines lose the snippet.
+  // Witness: arXiv 2412.04705 (arXiv/html_feedback#6735), whose
+  // `\lstinputlisting[firstline=32,lastline=35]` over CRLF Python sources hit
+  // this 7×. Measured discarded tail there:
+  //   ["\@lst@startline", "{", "}", "}", "}", "}", "\@lst@endline"]
+  // — three of those `}` close groups opened BEFORE the cut.
+  //
+  // So: truncate as Perl does, then re-close whatever the cut left open. The
+  // discarded region is by construction only empty-line markup (it starts at a
+  // line with colnum == 0), so nothing visible is lost by closing here.
   if let Some(from) = ctx.emptyfrom {
     ctx.lsttokens.truncate(from);
+    let mut depth: i64 = 0;
+    for token in &ctx.lsttokens {
+      match token.get_catcode() {
+        Catcode::BEGIN => depth += 1,
+        Catcode::END => depth -= 1,
+        _ => {},
+      }
+    }
+    // `depth` still counts the opening T_BEGIN this function seeded
+    // `lsttokens` with; the T_END pushed below is its partner. Any depth
+    // beyond that is a group whose closer was truncated away.
+    for _ in 1..depth {
+      ctx.lsttokens.push(T_END!());
+    }
   }
 
   ctx.lsttokens.push(T_END!());

--- a/latexml_package/src/package/listings_sty.rs
+++ b/latexml_package/src/package/listings_sty.rs
@@ -280,9 +280,13 @@ fn listings_read_raw_file(file: &str) -> Option<String> {
     // (measured: 9 green vs 69 black glyph groups), while BOTH LaTeXML engines
     // paint the whole snippet green — Perl identically, so this is a shared
     // upstream bug we are fixing rather than a Rust regression.
-    std::fs::read_to_string(&path)
-      .ok()
-      .map(|text| text.replace("\r\n", "\n").replace('\r', "\n"))
+    std::fs::read_to_string(&path).ok().map(|text| {
+      if text.contains('\r') {
+        text.replace("\r\n", "\n").replace('\r', "\n")
+      } else {
+        text
+      }
+    })
   } else {
     log::warn!("Can't read listings file '{}'", filename);
     None
@@ -1299,7 +1303,12 @@ fn lst_process(mode: &str, text: &str) -> Tokens {
   // So: truncate as Perl does, then re-close whatever the cut left open. The
   // discarded region is by construction only empty-line markup (it starts at a
   // line with colnum == 0), so nothing visible is lost by closing here.
-  if let Some(from) = ctx.emptyfrom {
+  // `from > 0` mirrors Perl's `if $LaTeXML::emptyfrom` truthiness guard, which
+  // skips index 0. It cannot be reached today (`lsttokens` is seeded with the
+  // opening T_BEGIN, so the `linestart` that feeds `emptyfrom` is always >= 1),
+  // but truncating to 0 would drop that T_BEGIN and leave the lone T_END pushed
+  // below — the very imbalance this block exists to prevent.
+  if let Some(from) = ctx.emptyfrom.filter(|from| *from > 0) {
     ctx.lsttokens.truncate(from);
     let mut depth: i64 = 0;
     for token in &ctx.lsttokens {


### PR DESCRIPTION
**Diagnostic.** `\lstinputlisting` lost its snippet two ways, both shared with Perl. (1) Trailing-empty-line trimming slices the generated token vector at `emptyfrom` — a *token* index, not a structural boundary — so a class still open there has its closing `}` in the discarded tail. `lastline=N` on a file with more than N lines hits it every time, leaving the body at brace depth 3, and `\@@listings@block` then reads its arguments off the end of the **document**, swallowing everything after the listing. (2) CRLF sources were slurped verbatim while every end-of-line test is written against `\n`, so a line comment never terminated and its style bled down the file.

**Approach.** Truncate as Perl does, then re-close what the cut left open (the discarded region is by construction only empty-line markup). Normalize `\r\n`/`\r` on read — TeX never sees the CR. pdflatex is the oracle for (2): on the witness it renders only the `#` line in comment green (9 green vs 69 black glyph groups) where both LaTeXML engines painted the whole snippet green. Documented as OXIDIZED_DESIGN #68/#69 and KNOWN_PERL_ERRORS #57/#58, both candidates to upstream.

**Validation.** Witness arXiv 2412.04705 (arXiv/html_feedback#6735): **22 errors → 0**, status error → warning, while same-host Perl still reports 15. Re-swept all 39 locally-available html_feedback-reported papers: that paper improved, **zero regressions**. Guards `104_lstinputlisting_range_crlf` (2 tests, verified RED first: 6 errors + swallowed document; all lines italic). Suite **1688/0 across 93 targets**; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)