### PR TITLE
fix: take arXiv 2605.17646 to zero errors (biblatex \missing, leading-relop comma list)

### DIFF
--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -372,6 +372,39 @@ never reads a real `.bbl` this way. Mechanism, minimal trigger and the
 upstream-candidate note: `KNOWN_PERL_ERRORS.md` #57. Guard
 `06_cluster_regressions::cluster_biblatex_two_datalists`.
 
+**Follow-up the same day — the witness is now error-free.** Two more gaps it
+surfaced, both landed:
+* **`\missing{key}` was undefined** (`Error:undefined:\missing`). It is biber's
+  marker for a cite-key absent from every `.bib` (TL `biblatex.sty` L8503
+  `\blx@bbl@missing`): upstream records the key and emits a **warning**,
+  typesetting nothing. Ported faithfully to `biblatex_sty.rs` — a no-op that
+  names the key (`Warning:missing_entry:biblatex`), which is the author's bug,
+  not ours (issue #92). Perl's binding leaves it commented out
+  (ar5iv-bindings L613), so every biber `.bbl` carrying one errors there.
+* **A leading relop + comma had NO parse.** `list_apply`'s fragment guard
+  rejected any item with an `absent` relop operand while
+  `formula relop formula_list` is deliberately gone (`KNOWN_PERL_ERRORS` #37),
+  so `$>50,000$` was `ltx_math_unparsed` though `$>x$`, `$a,b$` and
+  `$a>50,000$` all parsed. The guard now rejects a **comma** pair only when
+  BOTH items are fragments (mirroring the relaxation `formulae_apply` already
+  carried) and stays strict for `\quad`, where a fragment run is one broken-up
+  equation — the `\quad` half is load-bearing: relaxing it too made
+  `tests/math/sampler`'s `\displaystyle=f(x)+\phantom{g(x)}+h(x)` parse
+  *wrongly* rather than not at all. Guard
+  `06_cluster_regressions::cluster_leading_relop_comma_list`.
+
+Witness end state: **0 errors, 1 warning** (the actionable missing-entry), 0.96 s,
+and structurally identical to Perl — same counts for all 25 element classes
+sampled (312 `Math`, 58 `bibitem`, 336 `td`, 78 `ref`, …; sole delta 87 vs 88
+`para`). **Residual: 3 of 312 formulas unparsed where Perl has 0** —
+`f(\cdot)`, `S(\cdot)` (a bare operator inside a fence: Perl parses 7 of 8 such
+shapes, we parsed 0 of 8; `\langle\cdot,\cdot\rangle` is in that family too) and
+one `\mid`-conditional equation. Both are math-grammar structure work and so sit
+under the R8 "do not pick off in isolation" directive — see
+[`CONTENT_MATHML_GAPS.md`](math/CONTENT_MATHML_GAPS.md), which also now records
+the **thousands-separator** reading (`50,000` is one number; both engines read
+the comma as a list separator — locale-dependent, decide policy before coding).
+
 
 ### R6 — `ltx_env_<name>` env-markup class — PLANNED, needs its own branch (churns every test XML)
 **User-requested generic enhancement** (2026-06-27): tag environment wrapper markup

--- a/docs/math/CONTENT_MATHML_GAPS.md
+++ b/docs/math/CONTENT_MATHML_GAPS.md
@@ -135,6 +135,26 @@
   (apply) where Perl groups `(n to infinity)`. Same ARROW-as-applied-function
   family as `f(a,b)`.
 
+- **Thousands-separator comma read as a list separator — OPEN, shared with Perl
+  (user-raised 2026-07-25).** `$>50,000$` is ONE number, `50000`, written with a
+  thousands separator. Neither engine sees that: Perl builds
+  `>(absent, list(50,000))`, Rust `list@(absent>50, 000)` (the #37 reading). The
+  glyphs come out right, so it is invisible in a rendered page, but the grouping
+  is wrong in presentation MathML too —
+  `mrow(mrow(mphantom, >, mn 50), mo ",", mn 000)` where it should be
+  `mrow(mo >, mn "50,000")` — and the content arm is nonsense.
+  A conservative lexer-level merge would be `NUMBER , NUMBER` where the right
+  group is **exactly three digits** (chaining for `1,234,567`), done where the
+  math lexer assigns roles (`latexml_math_parser/src/util.rs`) so the grammar
+  never sees the comma.
+  **Why it is not a five-minute fix: the comma is locale-dependent.** In much of
+  Europe the comma is the DECIMAL separator, so `$3,14$` is 3.14 and `$50,000$`
+  is 50 — the exact opposite reading. A digit-count heuristic gets the
+  Anglo-American case right and silently corrupts the European one, and TeX
+  source carries no locale marker (`\usepackage[german]{babel}` is a document-level
+  hint at best; siunitx's `\num{50000}` is the only unambiguous form). Decide the
+  policy before coding. Witness: arXiv 2605.17646 (`population $ > 50,000$`).
+
 CAUTION: new VERTBAR/fence grammar rules can collide with package-built
 structures — always cross-check the affected fixture against Perl before
 assuming a regression (the norm rule "regressed" physics_test, but Perl matched

--- a/latexml_contrib/src/biblatex_sty.rs
+++ b/latexml_contrib/src/biblatex_sty.rs
@@ -1050,6 +1050,36 @@ LoadDefinitions!({
   // entries, each generating an undefined-CS error.
   DefMacro!("\\blx@bbl@keyalias{}{}", "", locked => true);
   Let!("\\keyalias", "\\blx@bbl@keyalias");
+
+  // biblatex `\missing{entrykey}` (TL biblatex.sty L8503-8515
+  // `\blx@bbl@missing`, aliased at L8857 `\let\missing\blx@bbl@missing`):
+  // biber writes one per cite-key it could NOT find in any `.bib`. Upstream
+  // records the key on `blx@miss@<refsection>` and emits a package WARNING
+  // ("The following entry could not be found in the database … Please verify
+  // the spelling and rerun") — it typesets NOTHING. (The bold marker a reader
+  // sees at the citation site is a different macro, `\abx@missing` L1368
+  // = `\mbox{\reset@font\bfseries#1}`, invoked from the `\cite` side.)
+  //
+  // So the faithful port is a no-op that warns. We don't keep the miss-list —
+  // nothing consumes it: our `\cite` resolves against the entries actually
+  // built from the `.bbl`, so an unfound key is already dangling by
+  // construction. Perl's binding leaves `\missing` commented out
+  // (ar5iv-bindings/biblatex.sty.ltxml L613), so every biber `.bbl` carrying
+  // one costs an `Error:undefined:\missing` there.
+  //
+  // Warning, not error: an unresolvable cite-key is the AUTHOR's bug (a
+  // stale `.bib`), reported by biblatex itself as a warning — not a gap in
+  // our engine. Naming the key makes it actionable (issue #92,
+  // "Rust-grade author errors"). Witness: arXiv 2605.17646, whose `.bbl`
+  // ends in `\missing{Cowen2021}` for a `\cite{Cowen2021}` with no entry.
+  DefMacro!("\\blx@bbl@missing{}", sub[(key)] {
+    Warn!("missing_entry", "biblatex",
+      format!("the entry '{}' could not be found in the database; \
+               \\cite of it will not resolve. Please verify the spelling \
+               and re-run biber.", key.to_string().trim()));
+    Ok(Tokens::default())
+  }, locked => true);
+  Let!("\\missing", "\\blx@bbl@missing");
   // Perl L122-125: \enddatalist / \endsortlist / \endlossort / \endrefsection
   // → biblatex_as_thebibliography rebuilder. Wraps the accumulated bibitems
   // emitted by repeated \endentry calls in `\thebibliography{count}…

--- a/latexml_math_parser/src/semantics.rs
+++ b/latexml_math_parser/src/semantics.rs
@@ -239,12 +239,41 @@ pub fn list_apply(
   if !is_quad && left_rel && right_rel {
     return Err("list_apply: both items relational in a comma list, use formulae_apply".into());
   }
-  // Rule 3: Reject when either item has `absent` as a relop operand.
-  // `absent` means equation fragment — fragments should be single formulas,
-  // not list items. If `absent` appears, the expression should be parsed
-  // as a single formula, not broken into a list.
-  if left.as_ref().is_some_and(has_absent_relop_operand) || has_absent_relop_operand(&right) {
-    return Err("list_apply: absent relop operand (should be single formula, not list)".into());
+  // Rule 3: an `absent` relop operand marks an equation FRAGMENT — a leading or
+  // trailing relop whose other operand lives on a different align line. How
+  // strictly a fragment disqualifies an item depends on the separator:
+  //
+  //  * `\quad` (WIDE_PUNCT): reject if EITHER item is a fragment. A
+  //    `\quad`-separated run of align continuations is one broken-up equation,
+  //    not a list, and admitting it produces actively WRONG trees — the pinned
+  //    `tests/math/sampler` case `\displaystyle=f(x)+\phantom{g(x)}+h(x)`
+  //    (`\phantom` lexes as WIDE_PUNCT) parses to
+  //    `fragments@(absent = limit-from@(f@(x), +), + h@(x))`, which mis-groups
+  //    the `+`. `ltx_math_unparsed` is the honest outcome there.
+  //  * comma: reject only when BOTH items are fragments. This mirrors the
+  //    relaxation `formulae_apply` already carries below ("the earlier strict
+  //    rule (reject if EITHER is a fragment) was correct only for inner
+  //    contexts … at the top level these pairings are well-formed and need to
+  //    survive pragmatic prune").
+  //
+  // The comma half matters because `list_apply` kept the strict form for both,
+  // and with the `formula relop formula_list` rule deliberately gone
+  // (KNOWN_PERL_ERRORS #37) a leading-relop item followed by a comma then had NO
+  // derivation at all: `$>50,000$` fell out as `ltx_math_unparsed` even though
+  // both halves parse alone (`>x` ✓, `a,b` ✓, `a>50,000` ✓). Pragmas prune; they
+  // must not empty the forest. With this split, `>50,000` reaches the #37 reading
+  // `list@(absent>50, 000)` — the same shape `a>50,000` already produced as
+  // `list@(a>50, 000)`. (Perl instead builds `>(absent, list(50,000))` via the
+  // rule #37 removed; ours is the intended divergence.) Witness: arXiv 2605.17646.
+  let left_fragment = left.as_ref().is_some_and(has_absent_relop_operand);
+  let right_fragment = has_absent_relop_operand(&right);
+  let fragment_reject = if is_quad {
+    left_fragment || right_fragment
+  } else {
+    left_fragment && right_fragment
+  };
+  if fragment_reject {
+    return Err("list_apply: fragment item (absent relop operand) in this list".into());
   }
   // Rule 4: Reject when an item is a BARE `conditional@(...)` Apply
   // — `|` (conditional / MODIFIEROP) binds LOOSER than `,` (list

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -730,6 +730,34 @@ fn cluster_biblatex_two_datalists() {
   );
 }
 
+/// A leading relop (implied `absent` left operand) followed by a comma had no
+/// derivation at all: `list_apply`'s fragment guard rejected any item carrying
+/// an `absent` relop operand, and `formula relop formula_list` is deliberately
+/// gone (KNOWN_PERL_ERRORS #37), so `$>50,000$` fell out as `ltx_math_unparsed`
+/// while every neighbouring shape parsed. The guard now only rejects a comma
+/// pair when BOTH items are fragments — matching the relaxation `formulae_apply`
+/// already carried — and stays strict for `\quad`, where a run of align
+/// fragments really is one broken-up equation (`tests/math/sampler`).
+/// Witness: arXiv 2605.17646.
+#[test]
+fn cluster_leading_relop_comma_list() {
+  let x = convert_to_xml("tests/cluster_regressions/leading_relop_comma_list.tex");
+  assert!(
+    !x.contains("ltx_math_unparsed"),
+    "every formula here must parse; got an unparsed one:\n{x}"
+  );
+  // The #37 reading: the comma splits at the statements level, and the leading
+  // relop keeps its `absent` operand — same shape `a>50,000` already produced.
+  assert!(
+    x.contains(r#"text="list@(absent &gt; 50, 000)""#),
+    "expected list@(absent > 50, 000) for the leading-relop comma list:\n{x}"
+  );
+  assert!(
+    x.contains(r#"text="list@(a &gt; 50, 000)""#),
+    "the binary-relop sibling must be unchanged:\n{x}"
+  );
+}
+
 /// biblatex author-year support (ar5iv-bindings PRs #20/#21 + repair
 /// 0911aec): style=apa documents with a biber .bbl get "Surname, Year"
 /// labels, one schema-valid role-tagged <ltx:tags> per bibitem, and the

--- a/latexml_oxide/tests/cluster_regressions/biblatex_two_datalists/twolists.bbl
+++ b/latexml_oxide/tests/cluster_regressions/biblatex_two_datalists/twolists.bbl
@@ -70,4 +70,5 @@
       \field{year}{2019}
     \endentry
   \enddatalist
+  \missing{Ghost2021}
 \endrefsection

--- a/latexml_oxide/tests/cluster_regressions/leading_relop_comma_list.tex
+++ b/latexml_oxide/tests/cluster_regressions/leading_relop_comma_list.tex
@@ -1,0 +1,29 @@
+% Regression: a LEADING relop (implied `absent` left operand) followed by a
+% comma used to have no derivation at all.
+%
+% `list_apply`'s fragment guard rejected any item carrying an `absent` relop
+% operand, and the `formula relop formula_list` rule is deliberately gone
+% (KNOWN_PERL_ERRORS #37), so `$>50,000$` fell out as ltx_math_unparsed even
+% though every neighbouring shape parses: `$>x$`, `$a,b$` and `$a>50,000$` all
+% worked. Pragmas prune the forest; they must not empty it.
+%
+% The `\quad` cases are the other side of the same guard and must STAY strict —
+% a `\quad`-separated run of align fragments is one broken-up equation, not a
+% list (see tests/math/sampler's `\displaystyle=f(x)+\phantom{g(x)}+h(x)`).
+%
+% NOTE `50,000` is really one number with a thousands separator; BOTH engines
+% read the comma as a list separator instead. Presentation is unaffected, the
+% content arm is not. Tracked in docs/math/CONTENT_MATHML_GAPS.md — do not
+% "fix" the expectation here without settling the locale question first
+% (a decimal comma means `$3,14$` is 3.14).
+%
+% Witness: arXiv 2605.17646, `population $ > 50,000$`.
+\documentclass{article}
+\begin{document}
+A: $ > 50,000$.
+B: $>x$.
+C: $a > 50,000$.
+D: $a, b$.
+E: $> a, b$.
+F: $>50000$.
+\end{document}


### PR DESCRIPTION
Follow-up to #379, which cleared this paper's Fatal. Two gaps it then surfaced — the witness is now **error-free**.

## 1. `\missing{key}` was undefined

`Error:undefined:\missing` was the paper's only remaining error. biber writes one per cite-key it could not find in any `.bib`. Upstream (TL `biblatex.sty` L8503 `\blx@bbl@missing`, aliased L8857) records the key and emits a **warning** — it typesets nothing. (The bold marker a reader sees at the *citation* site is a different macro, `\abx@missing` L1368.)

Ported faithfully: a no-op that names the key. **Warning, not error** — an unresolvable cite-key is the author's stale `.bib`, not a gap in our engine, and naming it makes it actionable (issue #92). Perl's binding leaves `\missing` commented out (`ar5iv-bindings/biblatex.sty.ltxml` L613), so every biber `.bbl` carrying one costs an undefined-CS error there.

## 2. A leading relop followed by a comma had NO derivation

`list_apply`'s fragment guard rejected any item carrying an `absent` relop operand, and `formula relop formula_list` is deliberately gone (`KNOWN_PERL_ERRORS` #37) — so `$>50,000$` fell out as `ltx_math_unparsed` even though every neighbouring shape parsed:

| input | before | after |
|---|---|---|
| `$>x$` | parsed | parsed |
| `$a,b$` | parsed | parsed |
| `$a>50,000$` | parsed | parsed |
| `$>50,000$` | **UNPARSED** | parsed |
| `$>a,b$` | **UNPARSED** | parsed |

Pragmas prune the forest; they must not empty it. The guard is now separator-dependent:

- **comma** — reject only when BOTH items are fragments, mirroring the relaxation `formulae_apply` already carried ("the earlier strict rule (reject if EITHER is a fragment) was correct only for inner contexts").
- **`\quad` (WIDE_PUNCT)** — stays strict. **This half is load-bearing:** relaxing it too made `tests/math/sampler`'s `\displaystyle=f(x)+\phantom{g(x)}+h(x)` (`\phantom` lexes as WIDE_PUNCT) parse *wrongly* as `fragments@(absent = limit-from@(f@(x), +), + h@(x))` rather than not at all. `ltx_math_unparsed` is the honest outcome for a broken-up align equation — caught by `sampler_test` going red on the first attempt.

`>50,000` now reaches the #37 reading `list@(absent>50, 000)` — the same shape `a>50,000` already produced.

## Deliberately NOT fixed here

`50,000` is really **one** number with a thousands separator, and both engines read the comma as a list separator (Perl: `>(absent, list(50,000))`). Presentation is unaffected; the content arm is not. A digit-count merge in the lexer would fix the Anglo-American case and silently corrupt the European one, where the comma is the **decimal** separator (`$3,14$` = 3.14). Recorded with the policy question in `docs/math/CONTENT_MATHML_GAPS.md`.

## Witness end state

**0 errors, 1 warning** (the actionable missing-entry), 0.96 s. Structurally identical to same-host Perl — same counts across all 25 element classes sampled:

| | Rust | Perl |
|---|---|---|
| `Math` | 312 | 312 |
| `bibitem` | 58 | 58 |
| `td` / `tr` | 336 / 65 | 336 / 65 |
| `ref` / `cite` | 78 / 30 | 78 / 30 |
| `figure` / `graphics` / `caption` | 6 / 4 / 15 | 6 / 4 / 15 |
| `para` | 87 | 88 |

**Residual: 3 of 312 formulas unparsed where Perl has 0** — `f(\cdot)`, `S(\cdot)` (a bare operator inside a fence: Perl parses 7 of 8 such shapes, we parse 0 of 8; `\langle\cdot,\cdot\rangle` is in the same family) and one `\mid`-conditional equation. Both are math-grammar *structure* work and so sit under the R8 "do not pick off in isolation" directive — not attempted here.

## Gates

- Suite **1687 passed / 92 targets / 0 ignored**; the single red is the known local-only vector-graphics artifact (green in CI).
- New guard `cluster_leading_relop_comma_list`; `cluster_biblatex_two_datalists` extended with a `\missing` entry.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo doc` rustdoc-warning-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)