### PR TITLE
fix(bibliography): stop losing .bib field content in the References

### DIFF
--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -54,7 +54,7 @@ session of their own. Re-verify a row before planning on it (rule 1).
 | **R1** | Upstream `brucemiller/LaTeXML#2852` — subfile `\documentclass` options | **OPEN upstream**, ours merged as #310 | minutes — chase review, no code | Open items |
 | **R2** | `--preload=<cls>` trips the LaTeX hook stack (`Extra \PopDefaultHookLabel`) | **OPEN**, re-verified 2026-07-25 (1 error with `--preload=article.cls`, 0 without) | small–medium, self-contained | Open items |
 | **R4** | biblatex `.bbl` `TokenLimit` loop (2605.17646) | ✅ **FIXED 2026-07-25** — self-referential `\let` on `setupPseudoBibitem` re-arm; shared with Perl | — | Open items |
-| **R5** | Bibliography targets + MakeBibliography re-port | surveyed 2026-07-12; user directive 2026-07-04 | **family** — dedicated session | [`BIBLIOGRAPHY_WORKLIST.md`](parity/BIBLIOGRAPHY_WORKLIST.md) |
+| **R5** | Bibliography targets + MakeBibliography re-port | surveyed 2026-07-12; user directive 2026-07-04; **field-markup interim landed 2026-07-25** | **family** — dedicated session | [`BIBLIOGRAPHY_WORKLIST.md`](parity/BIBLIOGRAPHY_WORKLIST.md) |
 | **R6** | `ltx_env_<name>` env-markup class | user-requested, PLANNED | medium code, **large golden churn** → own branch | Open items |
 | **R7** | Beyond-Perl performance levers BP-1…BP-6 | POST-RELEASE; internal order BP-2 → BP-3 → BP-1 | **family** | [`BEYOND_PERL_LEVERS.md`](performance/BEYOND_PERL_LEVERS.md) |
 | **R8** | Content-MathML / math-parser gaps | **deferred by user directive 2026-06-20** | **family** — do not pick off in isolation | [`CONTENT_MATHML_GAPS.md`](math/CONTENT_MATHML_GAPS.md) |

--- a/docs/parity/BIBLIOGRAPHY_WORKLIST.md
+++ b/docs/parity/BIBLIOGRAPHY_WORKLIST.md
@@ -270,6 +270,65 @@ and one `url={\url{...}}` that **Perl renders equally broken**
 Guard: `06_cluster_regressions::bib_field_markup_survives_into_the_bibliography`
 (fixture carries a `\&` so a text-escaping regression cannot pass silently).
 
+THIRD INTERIM — fields that reached NO emit branch (landed 2026-07-25). Found by
+asking what else the reported family ("content missing from References") could
+cover. `convert_bib_file_to_xml` parsed every field but emitted only a subset,
+so eleven field kinds were **silently discarded** — most damagingly
+`howpublished = {\url{...}}`, which is how a `@misc` conventionally carries its
+URL. Same-host Perl emits all of them, so this was GENUINE-RUST-ONLY.
+
+The format specs ALREADY query the matching elements (`ltx:bib-organization`,
+`ltx:bib-place`, `ltx:bib-edition`, `ltx:bib-part[@role='series'|'part']`,
+`ltx:bib-status`, `ltx:bib-language`, `ltx:bib-type`, `ltx:bib-note`), so only
+the emitter was missing — mappings taken from `bibtex.rs` L1340-1573 (the port of
+`BibTeX.pool` `\bib@field@default@*`): `howpublished`→`bib-note[role=publication]`,
+`note`/`annote`→`bib-note[role=annotation]`,
+`institution`/`organization`/`school`→`bib-organization`, `address`→`bib-place`,
+`edition`→`bib-edition`, `series`/`part`→`bib-part[@role=…]`, `type`→`bib-type`,
+`status`→`bib-status`, `language`→`bib-language`.
+
+Deliberately still NOT emitted: `chapter`, `subtitle`, `translator`. Perl builds
+elements for them, but **no format spec queries** `ltx:bib-part[@role='chapter']`,
+`ltx:bib-subtitle` or `ltx:bib-name[@role='translator']`, so emitting them adds
+nodes that can never render (confirmed: Perl leaves `chapter={5}` unrendered
+too). The entry-type boilerplate Perl synthesizes in `\bib@entry@<type>@prepare`
+("Ph.D. Thesis", "Technical Report") is engine-side, not a `.bib` field, and
+arrives with item 1 below.
+
+`bib-type` is safe to emit here even though Perl's `getBibEntries` unions it with
+`bib-date`: the Rust port queries the two separately (make_bibliography.rs
+L1029/L1048), so a `type` field cannot displace the publication year.
+
+Measured: 7/7 probe fields now match same-host Perl on a per-entry fixture;
+across the nine 2607 witnesses this recovers **45 `bib-place` + 8 `bib-edition`
++ 1 `bib-type`** that were previously dropped, at **unchanged error counts**
+(the wider interpretation surfaces no new diagnostics on real input).
+Guard: the `BIGINSTITUTE`/`TECHMEMO`/`LECTURENOTES`/`SECONDED`/`BERLINPLACE`/
+`SOMEUNIVERSITY` + `howpub` assertions in
+`bib_field_markup_survives_into_the_bibliography`.
+
+#### Why this file is 3,735 lines, and why the interims did NOT refactor it
+
+User observation (2026-07-25): `make_bibliography.rs` builds XML by **string
+concatenation** instead of using libxml2 directly, and the file is large partly
+as a consequence. Measured: **3,735 lines vs Perl's 818** (4.6×), with 33
+`xml.push_str` / 31 `xml_escape` / 71 `format!` sites; the `.bib`→XML route
+alone is **573 lines** (`convert_bib_file_to_xml` 296, `interpret_tex_markup`
+105, plus the parse/escape helpers).
+
+The cost is concrete, not stylistic: the 2026-07-25 markup work had to add a
+serialize→string→reparse round-trip AND a namespace-prefix scanner purely
+because the target is a string rather than a node tree. With
+`PostDocument::add_nodes`/`NodeData` those two would not exist, and `xml_escape`
+would be unnecessary (libxml escapes on set).
+
+**Decision (user, 2026-07-25): do NOT refactor it to node-building as an
+intermediate step** — item 1 below already deletes the entire route, so a
+node-based rewrite of `convert_bib_file_to_xml` would be thrown away, while
+adding regression risk to a validated fix. Item 1 is the answer; it removes the
+string machinery *and* fixes the residual math gap and the entry-type
+boilerplate for free.
+
 FULL RE-PORT remaining (post-release):
 1. Replace `convert_bib_file_to_xml` with the recursive core conversion
    (`DigestionMode::BibTeX` + `PreBibTeX` + bibtex.rs already exist):

--- a/docs/parity/BIBLIOGRAPHY_WORKLIST.md
+++ b/docs/parity/BIBLIOGRAPHY_WORKLIST.md
@@ -202,6 +202,46 @@ absolute `https://doi.org/` hrefs (percent-encoded, Perl BibTeX.pool
 L750-756) and scheme-less bib URLs are forced absolute — normalized both at
 .bib conversion AND in `format_links` (covers .bbl-borne/pre-compiled XML).
 
+SECOND INTERIM — field values keep their MARKUP (landed 2026-07-25). The
+2026-07-04 step digested field values but then **stringified** them, and a
+Whatsit stringifies to its *reversion*: `note = {\url{https://x}}` came back as
+its own TeX source, which `strip_braces` mashed into the dead literal
+`\urlhttps://x`; `\href{u}{text}` additionally **lost its link text** (the
+reversion keeps only the first argument). A second, independent flatten sat
+downstream in `apply_formatter`, which took `get_content()` of the field node and
+discarded element children — Perl's formatters are `do_any`-shaped and return
+`$doc->cloneNodes(@nodes)` (`MakeBibliography.pm` L525-531, L550-552). **Both had
+to be fixed; either one alone keeps the bug.** Same-host Perl renders all of
+`\url`/`\href`/`\emph`/math correctly, so this was GENUINE-RUST-ONLY.
+
+* `interpret_tex_markup` (make_bibliography.rs) digests into a scratch
+  `Document`, runs the new `Document::finalize_subtree` (font resolution +
+  `_font`/`_autoopened` bookkeeping-attribute removal — whole-document
+  `finalize()` *fails* on a fragment), and serializes the wrapper's children.
+* Applied to `title`/`journal`/`journaltitle`/`booktitle`/`publisher`/`note`;
+  every other field is untouched, and a wholly plain field still takes the
+  plain-text path, so the 99 % case is byte-identical.
+* Three fail-safe gates return `None` (→ escaped plain text) rather than splice
+  something unsound, because a bad fragment would break the XML parse and lose
+  the WHOLE bibliography: failed digest, **unparsed math**, and any prefixed
+  element name. The math gate is the one remaining sub-Perl case — the Marpa
+  pass lives in `latexml_math_parser`, which `latexml_post` does not depend on,
+  so a `<Math>` built here keeps unparsed `<XMath>` and would emit malformed
+  MathML (`x^2` → `msup` with an empty base). Falling back to the TeX source is
+  exactly today's behaviour for math; item 1 below fixes it properly.
+* One serialization note settled during review: a finalized LaTeXML document is
+  entirely in the LaTeXML namespace and serializes **unprefixed**, so the single
+  `xmlns` on the generated `<bibliography>` root covers the spliced fragment —
+  no second `xmlns:ltx` declaration is needed (an early draft added one).
+
+Witness 2607.00045 (sn-jnl, reported by email 2026-07-25): 44 of 78 rendered
+entries carry `note = {\url{...}}`. Raw-TeX tokens in the rendered bibliography
+**46 → 2**, live links **0 → 45**; the 2 residuals are the gated `$\psi$` title
+and one `url={\url{...}}` that **Perl renders equally broken**
+(`href="\urlhttps://arxiv.org/abs/quant-ph/0510095"`) — parity, not ours.
+Guard: `06_cluster_regressions::bib_field_markup_survives_into_the_bibliography`
+(fixture carries a `\&` so a text-escaping regression cannot pass silently).
+
 FULL RE-PORT remaining (post-release):
 1. Replace `convert_bib_file_to_xml` with the recursive core conversion
    (`DigestionMode::BibTeX` + `PreBibTeX` + bibtex.rs already exist):

--- a/docs/parity/BIBLIOGRAPHY_WORKLIST.md
+++ b/docs/parity/BIBLIOGRAPHY_WORKLIST.md
@@ -216,8 +216,14 @@ to be fixed; either one alone keeps the bug.** Same-host Perl renders all of
 
 * `interpret_tex_markup` (make_bibliography.rs) digests into a scratch
   `Document`, runs the new `Document::finalize_subtree` (font resolution +
-  `_font`/`_autoopened` bookkeeping-attribute removal — whole-document
-  `finalize()` *fails* on a fragment), and serializes the wrapper's children.
+  `_font`/`_autoopened` bookkeeping-attribute removal), and serializes the
+  scratch `ltx:text` wrapper's children. It must be the SUBTREE variant:
+  whole-document `finalize()` returns `Ok` but, recursing from the root,
+  legitimately UNWRAPS that redundant font-only `ltx:text` — measured, the
+  content survives at the root while the caller's handle is left detached and
+  childless (`wrapper_children 1 → 0`, `parent = None`), serializing to nothing.
+  (An earlier note here said `finalize()` "fails"; it does not — that was
+  inferred from the empty output rather than measured.)
 * Applied to `title`/`journal`/`journaltitle`/`booktitle`/`publisher`/`note`;
   every other field is untouched, and a wholly plain field still takes the
   plain-text path, so the 99 % case is byte-identical.

--- a/docs/parity/BIBLIOGRAPHY_WORKLIST.md
+++ b/docs/parity/BIBLIOGRAPHY_WORKLIST.md
@@ -221,10 +221,22 @@ to be fixed; either one alone keeps the bug.** Same-host Perl renders all of
 * Applied to `title`/`journal`/`journaltitle`/`booktitle`/`publisher`/`note`;
   every other field is untouched, and a wholly plain field still takes the
   plain-text path, so the 99 % case is byte-identical.
-* Three fail-safe gates return `None` (→ escaped plain text) rather than splice
+* Four fail-safe gates return `None` (→ escaped plain text) rather than splice
   something unsound, because a bad fragment would break the XML parse and lose
-  the WHOLE bibliography: failed digest, **unparsed math**, and any prefixed
-  element name. The math gate is the one remaining sub-Perl case — the Marpa
+  the WHOLE bibliography: failed digest, **escaped content**, **unparsed math**,
+  and any prefixed element name.
+* The **escaped-content** gate is the one that a first cut got WRONG, and it is
+  the most important: BLOCK-level content (`\begin{itemize}`, `\par`,
+  `\begin{quote}`, `\footnote`) CLOSES the `ltx:text` wrapper and continues as a
+  SIBLING, so serializing only the wrapper's children dropped everything past
+  that point — `note={before \begin{itemize}\item X\end{itemize} after}`
+  rendered as just `before`, **silently, with zero errors**, i.e. precisely the
+  fail-OPEN the design claims to prevent. The gate compares the scratch
+  document's whole text against the wrapper's and declines on any difference.
+  It compares TEXT, so block content carrying none (a lone floated image) is
+  still invisible to it; every realistic escape carries text. Guarded by the
+  `INSIDELIST`/`afterblock`/`AFTERPAR` entries in the fixture.
+* The math gate is the one remaining sub-Perl case — the Marpa
   pass lives in `latexml_math_parser`, which `latexml_post` does not depend on,
   so a `<Math>` built here keeps unparsed `<XMath>` and would emit malformed
   MathML (`x^2` → `msup` with an empty base). Falling back to the TeX source is

--- a/docs/parity/BIBLIOGRAPHY_WORKLIST.md
+++ b/docs/parity/BIBLIOGRAPHY_WORKLIST.md
@@ -229,6 +229,16 @@ to be fixed; either one alone keeps the bug.** Same-host Perl renders all of
   so a `<Math>` built here keeps unparsed `<XMath>` and would emit malformed
   MathML (`x^2` → `msup` with an empty base). Falling back to the TeX source is
   exactly today's behaviour for math; item 1 below fixes it properly.
+* **Digest each field exactly once.** The markup path runs BEFORE
+  `interpret_tex_text` and suppresses it on success — both digest the same
+  value, and digesting twice re-reports every error the field raises (measured:
+  a `_` in a note counted its `unexpected:_` **twice**, silently inflating the
+  document's error count, which is the canvas pass/fail signal) and re-runs any
+  side effect the macros have. Undefined macros hide this: the first digest
+  defines them as `<ltx:ERROR/>`, so they are self-healing on a second pass —
+  a guard fixture must use a non-self-healing error, and must contain a
+  backslash or both paths short-circuit and the test goes vacuously green.
+  Guard: `105_bib_field_digest_once`.
 * One serialization note settled during review: a finalized LaTeXML document is
   entirely in the LaTeXML namespace and serializes **unprefixed**, so the single
   `xmlns` on the generated `<bibliography>` root covers the spliced fragment —

--- a/docs/parity/BIBLIOGRAPHY_WORKLIST.md
+++ b/docs/parity/BIBLIOGRAPHY_WORKLIST.md
@@ -299,6 +299,16 @@ arrives with item 1 below.
 `bib-date`: the Rust port queries the two separately (make_bibliography.rs
 L1029/L1048), so a `type` field cannot displace the publication year.
 
+One visible consequence of emitting `type`, checked and accepted: real BibTeX
+treats it as an **override** of the entry-type label, while LaTeXML renders both,
+so `type = {Technical Report}` on a `@techreport` now reads "Technical Report
+Technical Report SIDL-WP-1999-0120". Verified byte-identical in same-host Perl —
+this is **parity**, KNOWN_PERL_ERRORS #60, and suppressing it would be a
+surpass-Perl divergence. It was previously hidden by dropping the field
+entirely, which also lost genuinely distinct types (`type = {Technical Memo}`) —
+a strictly worse trade. Only 1 `type` field exists across the nine witness
+`.bib` files.
+
 Measured: 7/7 probe fields now match same-host Perl on a per-entry fixture;
 across the nine 2607 witnesses this recovers **45 `bib-place` + 8 `bib-edition`
 + 1 `bib-type`** that were previously dropped, at **unchanged error counts**

--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -2413,3 +2413,38 @@ cause: an LF copy of the same file renders correctly, the CRLF original does not
 read. Guard
 `104_lstinputlisting_range_crlf::crlf_line_comment_style_does_not_bleed_past_its_line`.
 Candidate to upstream (not filed as of 2026-07-25).
+
+## 60. A BibTeX `type` field is APPENDED to the entry-type label instead of replacing it
+
+Real BibTeX treats `type` as an **override**: in `@techreport`/`@phdthesis`/
+`@mastersthesis`/`@inbook`, `type = {...}` replaces the default label
+("Technical report", "PhD thesis", "chapter"). `plain.bst` implements this as
+`format.tr.number`: `type empty$ { "Technical report" } { type } if$`.
+
+LaTeXML renders both. The value lands in `ltx:bib-type` (`BibTeX.pool.ltxml`
+L1544 `\bib@field@default@type`), while the format spec independently carries an
+unconditional `"Technical Report "` prestring in front of
+`ltx:bib-part[@role='number']` — so the two concatenate.
+
+```bibtex
+@techreport{pr, author={Page, L.}, title={PageRank}, year={1998},
+  institution={Stanford}, type={Technical Report}, number={SIDL-WP-1999-0120} }
+```
+
+Both engines render, byte-identically:
+
+```
+Technical Report Technical Report SIDL-WP-1999-0120 , Stanford
+```
+
+where real BibTeX prints the label once. Witness arXiv 2607.00052 (the PageRank
+entry in `main.bib`); it is the ONLY `type` field across the nine 2607 witness
+`.bib` files, so the practical blast radius is small.
+
+**PARITY — not fixed.** Rust only started showing it on 2026-07-25, when the
+`.bib` emitter stopped dropping the `type` field altogether (previously the
+duplication was hidden by losing the field, which also lost genuinely distinct
+types like `type = {Technical Memo}` — a strictly worse trade). Suppressing the
+prestring when `ltx:bib-type` is present would make Rust emit less than Perl on
+the same input, i.e. a surpass-Perl divergence needing explicit authorization.
+Candidate to upstream (not filed as of 2026-07-25).

--- a/latexml_core/src/document.rs
+++ b/latexml_core/src/document.rs
@@ -297,11 +297,19 @@ impl Document {
   /// against ancestors and strip the `_font`/`_autoopened`/… bookkeeping
   /// attributes, without the document-level passes (idstore rebuild, XMDual
   /// pruning, RDFa/namespace declarations) that only make sense for a complete
-  /// document — on a scratch fragment those either no-op or fail, taking the
-  /// whole finalization down with them.
+  /// document.
   ///
   /// Used by `latexml_post::make_bibliography` to render a `.bib` field value
-  /// into an XML fragment through the real engine.
+  /// into an XML fragment through the real engine: it absorbs into a scratch
+  /// `ltx:text` wrapper and serializes that wrapper's children.
+  ///
+  /// Whole-document [`finalize`](Self::finalize) cannot serve that caller —
+  /// **not** because it errors (it returns `Ok`), but because running
+  /// `finalize_rec` from the ROOT legitimately UNWRAPS a redundant font-only
+  /// `ltx:text`: measured on such a scratch document, the content survives at
+  /// the root while the caller's wrapper handle is left detached and childless
+  /// (`wrapper_children 1 -> 0`, `parent = None`), so it serializes to nothing.
+  /// Starting the recursion AT the wrapper keeps it addressable.
   pub fn finalize_subtree(&mut self, node: &mut Node) -> Result<()> {
     self.set_local_font(Rc::new(Font::text_default()));
     let result = self.finalize_rec(node);

--- a/latexml_core/src/document.rs
+++ b/latexml_core/src/document.rs
@@ -293,6 +293,22 @@ impl Document {
     Ok(())
   }
 
+  /// [`finalize`](Self::finalize) restricted to one subtree: resolve fonts
+  /// against ancestors and strip the `_font`/`_autoopened`/… bookkeeping
+  /// attributes, without the document-level passes (idstore rebuild, XMDual
+  /// pruning, RDFa/namespace declarations) that only make sense for a complete
+  /// document — on a scratch fragment those either no-op or fail, taking the
+  /// whole finalization down with them.
+  ///
+  /// Used by `latexml_post::make_bibliography` to render a `.bib` field value
+  /// into an XML fragment through the real engine.
+  pub fn finalize_subtree(&mut self, node: &mut Node) -> Result<()> {
+    self.set_local_font(Rc::new(Font::text_default()));
+    let result = self.finalize_rec(node);
+    self.expire_local_font();
+    result
+  }
+
   /// Apply registered document namespace declarations to the root element.
   /// Perl's RegisterDocumentNamespace stores prefix→URI mappings in the model.
   /// These must appear as xmlns:prefix="URI" on the root element during serialization.

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -1321,6 +1321,69 @@ fn non_utf8_bib_file_still_yields_a_bibliography() {
   );
 }
 
+/// Witness arXiv 2607.00045 (sn-jnl): 44 of its 78 rendered entries carry
+/// `note = {\url{...}}`, and every one of them rendered as the dead literal text
+/// `\urlhttps://…` instead of a link.
+///
+/// Two independent flatten-to-text steps had to be fixed, and EITHER of them
+/// alone keeps the bug alive:
+///
+/// 1. `convert_bib_file_to_xml` stringified the digested field
+///    (`interpret_tex_text`), and a Whatsit stringifies to its REVERSION — so
+///    `\url{…}` came back as its own TeX source, which `strip_braces` then
+///    mashed into `\urlhttps://…`. `\href{u}{text}` was worse: the reversion
+///    drops the second argument, so the link TEXT was lost outright.
+/// 2. `apply_formatter` then took `get_content()` of the field node, discarding
+///    any element children. Perl's formatters are `do_any`-shaped and return
+///    `$doc->cloneNodes(@nodes)` (`MakeBibliography.pm` L525-531, L550-552), so
+///    the markup reaches the bibitem.
+///
+/// Same-host Perl renders all three of these correctly, so this was
+/// GENUINE-RUST-ONLY, not a parity gap.
+#[test]
+fn bib_field_markup_survives_into_the_bibliography() {
+  let x = convert_and_post("tests/cluster_regressions/bib_field_markup.tex");
+  assert!(
+    x.contains("<bibitem"),
+    "bib markup: no bibliography at all:\n{x}"
+  );
+  // The whole point: no TeX source may leak into the rendered entries.
+  for leak in ["\\urlhttps", "\\url{", "\\href", "\\emph"] {
+    assert!(
+      !x.contains(leak),
+      "bib markup: {leak:?} leaked as literal text into the bibliography:\n{x}"
+    );
+  }
+  // `\url` becomes a real link carrying the URL as its own text.
+  assert!(
+    x.contains("href=\"https://example.org/a\""),
+    "bib markup: \\url in a note did not become a link:\n{x}"
+  );
+  // `\href`'s SECOND argument is the link text — the reversion path lost it.
+  assert!(
+    x.contains("href=\"https://example.org/b\"") && x.contains("the link text"),
+    "bib markup: \\href lost its href or its link text:\n{x}"
+  );
+  // Markup inside a title survives as markup, not as flattened text.
+  assert!(
+    x.contains("<emph") && x.contains("emphasis"),
+    "bib markup: the emphasized title lost its markup:\n{x}"
+  );
+  // The fragment is spliced as SERIALIZED XML, so an unescaped `&` in a text
+  // node would make the generated bibliography unparseable and drop every
+  // entry — the other three entries above are the canary for that.
+  assert!(
+    x.contains("an ampersand"),
+    "bib markup: `\\&` in a marked-up title broke the field:\n{x}"
+  );
+  // A wholly plain field keeps taking the plain-text path unchanged, so the
+  // fix cannot silently restructure the 99% case.
+  assert!(
+    x.contains("Wholly Plain Title") && x.contains("Plain Publisher"),
+    "bib markup: a plain field was damaged by the markup path:\n{x}"
+  );
+}
+
 /// Witness 2605.11619: `\end{lstlisting}` preceded by content on the same line
 /// (`</body></html> \end{lstlisting}`). Perl anchors the terminator regex at the
 /// line start (listings.sty.ltxml L316), so the reader ran to EOF and swallowed

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -1382,6 +1382,18 @@ fn bib_field_markup_survives_into_the_bibliography() {
     x.contains("Wholly Plain Title") && x.contains("Plain Publisher"),
     "bib markup: a plain field was damaged by the markup path:\n{x}"
   );
+  // Block-level content closes the `ltx:text` wrapper and continues as a
+  // sibling. Serializing only the wrapper's children dropped everything past
+  // that point — silently, with zero errors. The content must survive (the
+  // fallback renders it as flattened text, which is the pre-existing
+  // behaviour); losing it is the regression being guarded.
+  for needle in ["INSIDELIST", "afterblock", "AFTERPAR"] {
+    assert!(
+      x.contains(needle),
+      "bib markup: {needle:?} was silently dropped — block content escaped the \
+       wrapper and the fragment was spliced anyway:\n{x}"
+    );
+  }
 }
 
 /// Witness 2605.11619: `\end{lstlisting}` preceded by content on the same line

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -1394,6 +1394,29 @@ fn bib_field_markup_survives_into_the_bibliography() {
        wrapper and the fragment was spliced anyway:\n{x}"
     );
   }
+  // Fields that reached NO emit branch at all, so their content never appeared
+  // in the References. Perl emits every one of them and the format specs
+  // already query the matching `ltx:bib-*` elements — only the emitter was
+  // missing. `howpublished` is the important one: it is how a @misc carries its
+  // URL, and that URL was simply gone.
+  for needle in [
+    "BIGINSTITUTE",
+    "TECHMEMO",
+    "LECTURENOTES",
+    "SECONDED",
+    "BERLINPLACE",
+    "SOMEUNIVERSITY",
+  ] {
+    assert!(
+      x.contains(needle),
+      "bib fields: {needle:?} never reached the bibliography — its field is \
+       parsed but emitted by no branch:\n{x}"
+    );
+  }
+  assert!(
+    x.contains("href=\"https://example.org/howpub\""),
+    "bib fields: a @misc lost the URL its `howpublished` carries:\n{x}"
+  );
 }
 
 /// Witness 2605.11619: `\end{lstlisting}` preceded by content on the same line

--- a/latexml_oxide/tests/105_bib_field_digest_once.rs
+++ b/latexml_oxide/tests/105_bib_field_digest_once.rs
@@ -1,0 +1,95 @@
+//! Regression test: a bibliography field value is digested EXACTLY ONCE.
+//!
+//! `convert_bib_file_to_xml` has two digesting paths — `interpret_tex_markup`
+//! (XML fragment, so `\url`/`\href`/font switches survive) and
+//! `interpret_tex_text` (plain string). They digest the SAME value, so running
+//! both on one field re-reports every error that field raises and re-runs any
+//! side effect its macros have. The markup path therefore runs first and
+//! suppresses the text path on success.
+//!
+//! This is guarded by counting `Error:` lines rather than by inspecting the XML,
+//! because the duplicate is invisible in the output — the rendered entry looked
+//! perfectly fine while the document's error count silently doubled. Error
+//! counts are the canvas pass/fail signal, so inflating them is a real defect.
+//!
+//! Binary-driven: the count has to come from the conversion log.
+
+use std::{path::Path, process::Command};
+
+/// Two properties this fixture must have, both learned the hard way:
+///
+/// * `_` outside math raises `unexpected:_` on EVERY digest — unlike an
+///   undefined macro, which is defined as `<ltx:ERROR/>` on first sight and is
+///   therefore silently self-healing on a second pass. An undefined-macro
+///   fixture would pass even with the bug present.
+/// * The value must contain a BACKSLASH. Both interpret paths short-circuit on
+///   a value with no `\`, `~` or `$`, so `note={a _ b}` never digests at all and
+///   the test goes vacuously green (observed: "digested 0 times"). `\textbf` is
+///   the carrier here because it needs no package.
+const BIB: &str = r"@article{a1, author={Doe, J.}, title={T}, year={2020},
+  note={a _ \textbf{b}} }
+@article{a2, author={Roe, R.}, title={T2}, year={2021},
+  note={x ^ \textbf{y}} }
+";
+
+const TEX: &str = r"\documentclass{article}
+\begin{document}
+See \cite{a1,a2}.
+\bibliographystyle{plain}
+\bibliography{refs}
+\end{document}
+";
+
+#[test]
+fn bib_field_errors_are_reported_once_not_once_per_digest() {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+
+  let workdir = tempfile::tempdir().expect("create tempdir");
+  std::fs::write(workdir.path().join("refs.bib"), BIB).expect("write refs.bib");
+  std::fs::write(workdir.path().join("t.tex"), TEX).expect("write t.tex");
+
+  let output = Command::new(bin)
+    .args([
+      "t.tex",
+      "--dest",
+      "t.html",
+      "--format=html5",
+      "--nocomments",
+    ])
+    .current_dir(workdir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+  // ANSI-strip before counting: a naive grep over coloured output matches zero
+  // and would make this test vacuously green.
+  let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+
+  for needle in [
+    "Script _ can only appear in math mode",
+    "Script ^ can only appear in math mode",
+  ] {
+    let n = stderr.matches(needle).count();
+    assert_eq!(
+      n, 1,
+      "the field was digested {n} times, not once — bibliography errors are \
+       being multiplied into the document's error count.\nstderr:\n{stderr}"
+    );
+  }
+}
+
+fn strip_ansi(s: &str) -> String {
+  let mut out = String::with_capacity(s.len());
+  let mut chars = s.chars().peekable();
+  while let Some(c) = chars.next() {
+    if c == '\u{1b}' && chars.peek() == Some(&'[') {
+      for c in chars.by_ref() {
+        if c.is_ascii_alphabetic() {
+          break;
+        }
+      }
+    } else {
+      out.push(c);
+    }
+  }
+  out
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_field_markup.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_field_markup.bib
@@ -1,0 +1,32 @@
+@article{urlnote2020,
+  author  = {Doe, Jane},
+  title   = {A Plain Title},
+  journal = {Journal of Things},
+  year    = {2020},
+  note    = {\url{https://example.org/a}}
+}
+
+@article{hrefnote2021,
+  author = {Roe, Richard},
+  title  = {Another Title},
+  year   = {2021},
+  note   = {\href{https://example.org/b}{the link text}}
+}
+
+% The `\&` matters: the markup path splices SERIALIZED XML into the generated
+% bibliography, so a text node that failed to escape `&` would make the whole
+% document unparseable and drop every entry.
+@article{emphtitle2022,
+  author = {Poe, Paula},
+  title  = {A Title with \emph{emphasis} \& an ampersand},
+  year   = {2022}
+}
+
+% `@book` on purpose: `publisher` is only rendered by the book-shaped format
+% specs, so an `@article` here would make the plain-field assertion vacuous.
+@book{plaintitle2023,
+  author    = {Moe, Mark},
+  title     = {Wholly Plain Title},
+  publisher = {Plain Publisher},
+  year      = {2023}
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_field_markup.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_field_markup.bib
@@ -22,6 +22,44 @@
   year   = {2022}
 }
 
+% These fields were emitted by NO branch at all, so their content vanished from
+% the References — `howpublished = {\url{...}}` is the conventional way to give
+% a @misc its URL, and that URL was simply gone. Perl emits every one of them
+% (BibTeX.pool `\bib@field@default@*`), and the format specs already query the
+% corresponding `ltx:bib-*` elements, so only the emitter was missing.
+@misc{howpub2026,
+  author       = {Xoe, Xena},
+  title        = {A Web Thing},
+  year         = {2026},
+  howpublished = {\url{https://example.org/howpub}}
+}
+
+@techreport{report2026,
+  author      = {Yoe, Yuri},
+  title       = {A Report},
+  year        = {2026},
+  institution = {BIGINSTITUTE},
+  type        = {TECHMEMO},
+  number      = {TR-7}
+}
+
+@book{book2026,
+  author    = {Zoe, Zack},
+  title     = {A Book},
+  year      = {2026},
+  publisher = {Pub},
+  series    = {LECTURENOTES},
+  edition   = {SECONDED},
+  address   = {BERLINPLACE}
+}
+
+@phdthesis{thesis2026,
+  author = {Qoe, Quinn},
+  title  = {A Thesis},
+  year   = {2026},
+  school = {SOMEUNIVERSITY}
+}
+
 % Block-level content CLOSES the `ltx:text` wrapper the markup path builds and
 % continues as a sibling. Serializing only that wrapper's children therefore
 % dropped everything from `\begin{itemize}` onward — silently, with zero errors.

--- a/latexml_oxide/tests/cluster_regressions/bib_field_markup.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_field_markup.bib
@@ -22,6 +22,25 @@
   year   = {2022}
 }
 
+% Block-level content CLOSES the `ltx:text` wrapper the markup path builds and
+% continues as a sibling. Serializing only that wrapper's children therefore
+% dropped everything from `\begin{itemize}` onward — silently, with zero errors.
+% The escape guard declines such a fragment so the plain-text digest keeps it
+% all; these entries are the canary.
+@article{blocklist2024,
+  author = {Voe, Vera},
+  title  = {T Blocklist},
+  year   = {2024},
+  note   = {beforeblock \begin{itemize}\item INSIDELIST\end{itemize} afterblock}
+}
+
+@article{blockpar2025,
+  author = {Woe, Walt},
+  title  = {T Blockpar},
+  year   = {2025},
+  note   = {beforepar \par AFTERPAR \textbf{tail}}
+}
+
 % `@book` on purpose: `publisher` is only rendered by the book-shaped format
 % specs, so an `@article` here would make the plain-field assertion vacuous.
 @book{plaintitle2023,

--- a/latexml_oxide/tests/cluster_regressions/bib_field_markup.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_field_markup.tex
@@ -1,7 +1,7 @@
 \documentclass{article}
 \usepackage{hyperref}
 \begin{document}
-See \cite{urlnote2020,hrefnote2021,emphtitle2022,plaintitle2023}.
+See \cite{urlnote2020,hrefnote2021,emphtitle2022,plaintitle2023,blocklist2024,blockpar2025}.
 \bibliographystyle{plain}
 \bibliography{bib_field_markup}
 \end{document}

--- a/latexml_oxide/tests/cluster_regressions/bib_field_markup.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_field_markup.tex
@@ -1,0 +1,7 @@
+\documentclass{article}
+\usepackage{hyperref}
+\begin{document}
+See \cite{urlnote2020,hrefnote2021,emphtitle2022,plaintitle2023}.
+\bibliographystyle{plain}
+\bibliography{bib_field_markup}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/bib_field_markup.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_field_markup.tex
@@ -2,6 +2,7 @@
 \usepackage{hyperref}
 \begin{document}
 See \cite{urlnote2020,hrefnote2021,emphtitle2022,plaintitle2023,blocklist2024,blockpar2025}.
+And \cite{howpub2026,report2026,book2026,thesis2026}.
 \bibliographystyle{plain}
 \bibliography{bib_field_markup}
 \end{document}

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -2273,15 +2273,43 @@ fn get_fmt_spec(format_type: &str) -> Vec<Vec<FieldSpec>> {
 // ======================================================================
 // Formatting helpers
 
+/// The renderable content of one bibliography field node.
+///
+/// Perl's field formatters are all `do_any`-shaped — they receive
+/// `$doc->cloneNodes(@nodes)` and return the CLONED NODES (`MakeBibliography.pm`
+/// L525-531, L550-552), so an `ltx:ref`/`ltx:emph`/`ltx:Math` inside a field
+/// reaches the bibitem intact. Taking `get_content()` here instead threw all of
+/// that away and kept only the text, which is how `note = {\url{...}}` rendered
+/// as dead text even once the field XML carried a proper link.
+///
+/// Fields whose content is plain text — the overwhelming majority — keep
+/// returning a single `Text` node, so their output is byte-identical to before;
+/// only a field that actually holds markup takes the cloning path. (Perl clones
+/// the field element itself and lets the XSLT render it transparently; we clone
+/// its CHILDREN, which yields the same HTML without changing our flatter
+/// intermediate shape.)
+fn field_content(node: &Node) -> Vec<NodeData> {
+  let mut children = Vec::new();
+  let mut child = node.get_first_child();
+  let mut has_element = false;
+  while let Some(n) = child {
+    has_element |= n.get_type() == Some(libxml::tree::NodeType::ElementNode);
+    child = n.get_next_sibling();
+    children.push(n);
+  }
+  if has_element {
+    children.into_iter().map(NodeData::XmlNode).collect()
+  } else {
+    vec![NodeData::Text(node.get_content())]
+  }
+}
+
 /// Apply a formatter function to the given nodes.
 ///
 /// Port of the various `do_*` functions.
 fn apply_formatter(doc: &PostDocument, formatter: Formatter, nodes: &[Node]) -> Vec<NodeData> {
   match formatter {
-    Formatter::Any => nodes
-      .iter()
-      .map(|n| NodeData::Text(n.get_content()))
-      .collect(),
+    Formatter::Any => nodes.iter().flat_map(field_content).collect(),
     Formatter::Authors => format_author_nodes(doc, nodes),
     Formatter::EditorsA => {
       let mut result = format_author_nodes(doc, nodes);
@@ -2312,34 +2340,21 @@ fn apply_formatter(doc: &PostDocument, formatter: Formatter, nodes: &[Node]) -> 
       result
     },
     Formatter::Type => {
-      let content: Vec<NodeData> = nodes
-        .iter()
-        .map(|n| NodeData::Text(n.get_content()))
-        .collect();
       let mut result = vec![NodeData::Text("(".to_string())];
-      result.extend(content);
+      result.extend(nodes.iter().flat_map(field_content));
       result.push(NodeData::Text(")".to_string()));
       result
     },
-    Formatter::Title => nodes
-      .iter()
-      .map(|n| NodeData::Text(n.get_content()))
-      .collect(),
-    Formatter::ThesisType => nodes
-      .iter()
-      .map(|n| NodeData::Text(n.get_content()))
-      .collect(),
+    Formatter::Title => nodes.iter().flat_map(field_content).collect(),
+    Formatter::ThesisType => nodes.iter().flat_map(field_content).collect(),
     Formatter::Edition => {
-      let mut result: Vec<NodeData> = nodes
-        .iter()
-        .map(|n| NodeData::Text(n.get_content()))
-        .collect();
+      let mut result: Vec<NodeData> = nodes.iter().flat_map(field_content).collect();
       result.push(NodeData::Text(" edition".to_string()));
       result
     },
     Formatter::Pages => {
       let mut result = vec![NodeData::Text("pp.\u{00A0}".to_string())]; // Non-breaking space
-      result.extend(nodes.iter().map(|n| NodeData::Text(n.get_content())));
+      result.extend(nodes.iter().flat_map(field_content));
       result
     },
     Formatter::CrossRef => {
@@ -2958,22 +2973,7 @@ fn interpret_tex_text(s: &str) -> String {
   match interpreted {
     Ok(Ok(text)) => text,
     _ => {
-      let n = BIB_INTERPRET_FAILURES.with(|c| {
-        let n = c.get() + 1;
-        c.set(n);
-        n
-      });
-      if n == MAX_BIB_INTERPRET_FAILURES + 1 {
-        Warn!(
-          "bibliography",
-          "interpret",
-          format!(
-            "Disabling TeX interpretation of bibliography fields after {} failures; \
-             remaining fields pass through raw.",
-            MAX_BIB_INTERPRET_FAILURES
-          )
-        );
-      }
+      bump_bib_interpret_failures();
       s.to_string()
     },
   }
@@ -3154,6 +3154,10 @@ fn convert_bib_file_to_xml(bib_path: &str) -> Result<PostDocument, String> {
       // full rendering-field coverage is an open parity task (SYNC_STATUS,
       // "bibliography field-interpretation parity"). url/doi/eprint render but
       // are verbatim identifiers; isbn/issn are plain digits.
+
+      // The RAW field text, before `interpret_tex_text` flattens it — the markup
+      // path below has to re-digest from source, not from the stringified form.
+      let orig_value: &str = value;
       let interpreted;
       let value = match field.as_str() {
         "author" | "editor" | "title" | "year" | "journal" | "journaltitle" | "booktitle"
@@ -3164,6 +3168,18 @@ fn convert_bib_file_to_xml(bib_path: &str) -> Result<PostDocument, String> {
         _ => value,
       };
       let clean = strip_braces(value);
+      // Markup-bearing fields: prefer the digested XML fragment, so links and
+      // font switches survive; fall back to the escaped plain text (which is
+      // also what `interpret_tex_markup` asks for on math — see its math gate).
+      // `raw` is the already-escaped text, so each arm reads as one substitution.
+      let markup = |raw: &str| -> String {
+        match field.as_str() {
+          "title" | "journal" | "journaltitle" | "booktitle" | "publisher" | "note" => {
+            interpret_tex_markup(orig_value).unwrap_or_else(|| raw.to_string())
+          },
+          _ => raw.to_string(),
+        }
+      };
       match field.as_str() {
         "author" => {
           let authors = parse_bib_authors(value);
@@ -3202,7 +3218,7 @@ fn convert_bib_file_to_xml(bib_path: &str) -> Result<PostDocument, String> {
         "title" => {
           xml.push_str(&format!(
             "    <bib-title>{}</bib-title>\n",
-            xml_escape(&clean)
+            markup(&xml_escape(&clean))
           ));
         },
         "year" => {
@@ -3214,13 +3230,13 @@ fn convert_bib_file_to_xml(bib_path: &str) -> Result<PostDocument, String> {
         "journal" | "journaltitle" => {
           xml.push_str(&format!(
             "    <bib-related type=\"journal\"><bib-title>{}</bib-title></bib-related>\n",
-            xml_escape(&clean)
+            markup(&xml_escape(&clean))
           ));
         },
         "booktitle" => {
           xml.push_str(&format!(
             "    <bib-related type=\"book\"><bib-title>{}</bib-title></bib-related>\n",
-            xml_escape(&clean)
+            markup(&xml_escape(&clean))
           ));
         },
         "volume" => {
@@ -3278,13 +3294,13 @@ fn convert_bib_file_to_xml(bib_path: &str) -> Result<PostDocument, String> {
         "publisher" => {
           xml.push_str(&format!(
             "    <bib-publisher>{}</bib-publisher>\n",
-            xml_escape(&clean)
+            markup(&xml_escape(&clean))
           ));
         },
         "note" => {
           xml.push_str(&format!(
             "    <bib-note>{}</bib-note>\n",
-            xml_escape(&clean)
+            markup(&xml_escape(&clean))
           ));
         },
         // Remaining fields: skip or log
@@ -3301,6 +3317,131 @@ fn convert_bib_file_to_xml(bib_path: &str) -> Result<PostDocument, String> {
     source_directory: Some(".".to_string()),
     ..PostDocumentOptions::default()
   })
+}
+
+/// Interpret a BibTeX field value into an XML **fragment**, so that constructs
+/// which digest into *elements* survive instead of collapsing to their TeX
+/// source.
+///
+/// [`interpret_tex_text`] stringifies the digested boxes, and a Whatsit
+/// stringifies to its REVERSION — so `\url{https://x}` came back as the literal
+/// `\url{https://x}`, which [`strip_braces`] then mashed into `\urlhttps://x`.
+/// `\href{u}{text}` was worse: the reversion kept only the first argument, so
+/// the link text was *lost*. Perl has neither problem, because its
+/// `convertBibliography` (`MakeBibliography.pm` L180-215) runs the `.bib`
+/// through a real BibTeX.pool session whose `\bib@@field` is a DefConstructor
+/// absorbing digested boxes into the XML (`BibTeX.pool.ltxml` L693-694 for
+/// `note`). This helper closes that gap for the fields where markup carries
+/// meaning, without re-porting the whole `.bib`→XML route (tracked separately
+/// in `docs/parity/BIBLIOGRAPHY_WORKLIST.md`).
+///
+/// Witness arXiv 2607.00045 (sn-jnl): 44 of 78 entries carry
+/// `note = {\url{...}}` and every one of them rendered as dead literal text.
+///
+/// Returns `None` whenever the fragment cannot be trusted — a failed digest,
+/// unparsed math, or a namespace prefix the generated `<bibliography>` root does
+/// not declare (see the three gates below) — so the caller falls back to escaped
+/// plain text. That direction is the safe one: splicing a fragment we cannot
+/// vouch for would break the XML parse and lose the WHOLE bibliography.
+fn interpret_tex_markup(s: &str) -> Option<String> {
+  use latexml_core::document::Document;
+  if !s.contains('\\') && !s.contains('~') && !s.contains('$') {
+    return None; // plain text: nothing markup-bearing to preserve
+  }
+  if BIB_INTERPRET_FAILURES.with(|c| c.get()) > MAX_BIB_INTERPRET_FAILURES {
+    return None;
+  }
+  // Same diagnostic policy as `interpret_tex_text`: report at native severity,
+  // but never let a broken field take the document down with it.
+  let prev = latexml_core::common::error::set_demote_fatals(true);
+  let built = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    let digested = latexml_core::stomach::digest(latexml_core::mouth::tokenize(s)).ok()?;
+    let mut doc = Document::new();
+    // `ltx:text` is the model's generic inline container, so any inline content
+    // a field can hold is placeable inside it; we serialize its CHILDREN, so the
+    // wrapper itself (and anything `find_insertion_point` opened above it) never
+    // reaches the output.
+    let mut wrapper = doc.open_element("ltx:text", None, None).ok()?;
+    doc.absorb(&digested, None).ok()?;
+    // The subtree half of what the main conversion applies before handing its
+    // DOM out: resolve each node's font against its ancestors into a real
+    // `font=` attribute and drop the `_font`/`_autoopened`/… bookkeeping
+    // attributes. Without it the fragment carries engine-internal attributes
+    // into the bibliography, and `\emph` loses the very styling it exists for.
+    // (Whole-document `finalize()` is wrong here and *fails* on a scratch
+    // fragment — see `Document::finalize_subtree`.)
+    doc.finalize_subtree(&mut wrapper).ok()?;
+    let mut fragment = String::new();
+    let mut child = wrapper.get_first_child();
+    while let Some(node) = child {
+      fragment.push_str(&doc.serialize_aux(&node, 0, true, false));
+      child = node.get_next_sibling();
+    }
+    Some(fragment)
+  }));
+  latexml_core::common::error::set_demote_fatals(prev);
+
+  let fragment = match built {
+    Ok(Some(fragment)) => fragment,
+    _ => {
+      bump_bib_interpret_failures();
+      return None;
+    },
+  };
+  if fragment.trim().is_empty() {
+    return None;
+  }
+  // Math gate. The Marpa parse pass lives in `latexml_math_parser`, which runs
+  // over the main document in `core_interface::convert_document` — this crate
+  // does not (and should not) depend on it, so a `<Math>` built here keeps its
+  // UNPARSED `<XMath>` and converts to malformed MathML (`x^2` came out as an
+  // `msup` with an empty base). Falling back to the escaped TeX source is the
+  // honest option: it is exactly today's behaviour for math, whereas splicing
+  // the fragment would be a regression. Perl gets this right because its
+  // recursive BibTeX session is a full conversion, math parse included — so
+  // this is the one piece of the gap that waits for the full `.bib`-through-the-
+  // engine re-port (`docs/parity/BIBLIOGRAPHY_WORKLIST.md`).
+  if fragment.contains("<XMath") {
+    return None;
+  }
+  // Namespace gate. A finalized LaTeXML document lives entirely in the LaTeXML
+  // namespace and serializes UNPREFIXED, so the single `xmlns` on the generated
+  // `<bibliography>` root covers every element spliced in here. A *prefixed*
+  // element would therefore be something from outside that namespace, with no
+  // declaration to bind it — and an undeclared prefix makes `new_from_string`
+  // reject the document, losing the WHOLE bibliography. Decline the fragment
+  // instead; the caller falls back to escaped plain text.
+  for (idx, _) in fragment.match_indices('<') {
+    let rest = &fragment[idx + 1..];
+    let rest = rest.strip_prefix('/').unwrap_or(rest);
+    let name: String = rest
+      .chars()
+      .take_while(|c| c.is_ascii_alphanumeric() || *c == ':' || *c == '_' || *c == '-')
+      .collect();
+    if name.contains(':') {
+      return None;
+    }
+  }
+  Some(fragment)
+}
+
+fn bump_bib_interpret_failures() {
+  let n = BIB_INTERPRET_FAILURES.with(|c| {
+    let n = c.get() + 1;
+    c.set(n);
+    n
+  });
+  if n == MAX_BIB_INTERPRET_FAILURES + 1 {
+    Warn!(
+      "bibliography",
+      "interpret",
+      format!(
+        "Disabling TeX interpretation of bibliography fields after {} failures; \
+         remaining fields pass through raw.",
+        MAX_BIB_INTERPRET_FAILURES
+      )
+    );
+  }
 }
 
 /// Escape special XML characters.

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -3155,31 +3155,36 @@ fn convert_bib_file_to_xml(bib_path: &str) -> Result<PostDocument, String> {
       // "bibliography field-interpretation parity"). url/doi/eprint render but
       // are verbatim identifiers; isbn/issn are plain digits.
 
-      // The RAW field text, before `interpret_tex_text` flattens it — the markup
-      // path below has to re-digest from source, not from the stringified form.
-      let orig_value: &str = value;
-      let interpreted;
-      let value = match field.as_str() {
-        "author" | "editor" | "title" | "year" | "journal" | "journaltitle" | "booktitle"
-        | "volume" | "number" | "issue" | "pages" | "publisher" | "note" => {
-          interpreted = interpret_tex_text(value);
-          &interpreted
+      // Markup-bearing fields are tried FIRST, from the raw field text, so that
+      // links and font switches survive. This must run BEFORE `interpret_tex_text`
+      // and suppress it on success: both digest the same value, and digesting
+      // twice re-reports every error the field raises (measured: a `_` in a note
+      // counted its `unexpected:_` twice) and re-runs any side effect its macros
+      // have. Only the fallback path pays for the text digest — which is also
+      // what `interpret_tex_markup` asks for on math (see its math gate).
+      let fragment = match field.as_str() {
+        "title" | "journal" | "journaltitle" | "booktitle" | "publisher" | "note" => {
+          interpret_tex_markup(value)
         },
-        _ => value,
+        _ => None,
       };
-      let clean = strip_braces(value);
-      // Markup-bearing fields: prefer the digested XML fragment, so links and
-      // font switches survive; fall back to the escaped plain text (which is
-      // also what `interpret_tex_markup` asks for on math — see its math gate).
-      // `raw` is the already-escaped text, so each arm reads as one substitution.
-      let markup = |raw: &str| -> String {
+      let interpreted;
+      let value = if fragment.is_some() {
+        value
+      } else {
         match field.as_str() {
-          "title" | "journal" | "journaltitle" | "booktitle" | "publisher" | "note" => {
-            interpret_tex_markup(orig_value).unwrap_or_else(|| raw.to_string())
+          "author" | "editor" | "title" | "year" | "journal" | "journaltitle" | "booktitle"
+          | "volume" | "number" | "issue" | "pages" | "publisher" | "note" => {
+            interpreted = interpret_tex_text(value);
+            &interpreted
           },
-          _ => raw.to_string(),
+          _ => value,
         }
       };
+      let clean = strip_braces(value);
+      // `raw` is the already-escaped plain text, used only when there is no
+      // fragment — so each field arm below reads as a single substitution.
+      let markup = |raw: &str| -> String { fragment.clone().unwrap_or_else(|| raw.to_string()) };
       match field.as_str() {
         "author" => {
           let authors = parse_bib_authors(value);

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -3373,8 +3373,10 @@ fn interpret_tex_markup(s: &str) -> Option<String> {
     // `font=` attribute and drop the `_font`/`_autoopened`/… bookkeeping
     // attributes. Without it the fragment carries engine-internal attributes
     // into the bibliography, and `\emph` loses the very styling it exists for.
-    // (Whole-document `finalize()` is wrong here and *fails* on a scratch
-    // fragment — see `Document::finalize_subtree`.)
+    // It must be the SUBTREE variant: whole-document `finalize()` returns `Ok`
+    // but unwraps this redundant font-only `ltx:text`, leaving `wrapper`
+    // detached and childless so the fragment serializes to nothing — see
+    // `Document::finalize_subtree`.
     doc.finalize_subtree(&mut wrapper).ok()?;
     // Fail-safe: BLOCK-level content (a list, `\par`, a quote, a footnote)
     // CLOSES `ltx:text` and continues as a sibling, so serializing only the

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -3162,10 +3162,15 @@ fn convert_bib_file_to_xml(bib_path: &str) -> Result<PostDocument, String> {
       // counted its `unexpected:_` twice) and re-runs any side effect its macros
       // have. Only the fallback path pays for the text digest — which is also
       // what `interpret_tex_markup` asks for on math (see its math gate).
+      // Every field emitted as element CONTENT takes the markup path. Excluded
+      // are the ones whose text is parsed further or used as an attribute:
+      // author/editor (name splitting), year (4-digit extraction), volume/
+      // number/issue/pages (numeric, and `pages` rewrites `--`), and
+      // doi/url/isbn/issn (verbatim identifiers, some of them hrefs).
       let fragment = match field.as_str() {
-        "title" | "journal" | "journaltitle" | "booktitle" | "publisher" | "note" => {
-          interpret_tex_markup(value)
-        },
+        "title" | "journal" | "journaltitle" | "booktitle" | "publisher" | "note" | "annote"
+        | "howpublished" | "institution" | "organization" | "school" | "address" | "edition"
+        | "series" | "part" | "type" | "status" | "language" => interpret_tex_markup(value),
         _ => None,
       };
       let interpreted;
@@ -3174,7 +3179,9 @@ fn convert_bib_file_to_xml(bib_path: &str) -> Result<PostDocument, String> {
       } else {
         match field.as_str() {
           "author" | "editor" | "title" | "year" | "journal" | "journaltitle" | "booktitle"
-          | "volume" | "number" | "issue" | "pages" | "publisher" | "note" => {
+          | "volume" | "number" | "issue" | "pages" | "publisher" | "note" | "annote"
+          | "howpublished" | "institution" | "organization" | "school" | "address" | "edition"
+          | "series" | "part" | "type" | "status" | "language" => {
             interpreted = interpret_tex_text(value);
             &interpreted
           },
@@ -3302,13 +3309,88 @@ fn convert_bib_file_to_xml(bib_path: &str) -> Result<PostDocument, String> {
             markup(&xml_escape(&clean))
           ));
         },
-        "note" => {
+        // Perl `\bib@field@default@note` is `\bib@@field{ltx:bib-note}
+        // [role=annotation]` (BibTeX.pool L693-694); `annote` is the same
+        // element (L680-681) and `howpublished` the same element with
+        // `role=publication` (L641-642). All three render under the META_BLOCK's
+        // unqualified `ltx:bib-note`.
+        "note" | "annote" => {
           xml.push_str(&format!(
-            "    <bib-note>{}</bib-note>\n",
+            "    <bib-note role=\"annotation\">{}</bib-note>\n",
             markup(&xml_escape(&clean))
           ));
         },
-        // Remaining fields: skip or log
+        // `howpublished = {\url{...}}` is THE conventional way to give a
+        // `@misc` its URL, and dropping the field lost that URL outright.
+        "howpublished" => {
+          xml.push_str(&format!(
+            "    <bib-note role=\"publication\">{}</bib-note>\n",
+            markup(&xml_escape(&clean))
+          ));
+        },
+        // Perl maps all three of institution/organization/school onto
+        // `ltx:bib-organization` (BibTeX.pool L646-660 → bibtex.rs L1369-1379).
+        "institution" | "organization" | "school" => {
+          xml.push_str(&format!(
+            "    <bib-organization>{}</bib-organization>\n",
+            markup(&xml_escape(&clean))
+          ));
+        },
+        "address" => {
+          xml.push_str(&format!(
+            "    <bib-place>{}</bib-place>\n",
+            markup(&xml_escape(&clean))
+          ));
+        },
+        "edition" => {
+          xml.push_str(&format!(
+            "    <bib-edition>{}</bib-edition>\n",
+            markup(&xml_escape(&clean))
+          ));
+        },
+        "series" => {
+          xml.push_str(&format!(
+            "    <bib-part role=\"series\">{}</bib-part>\n",
+            markup(&xml_escape(&clean))
+          ));
+        },
+        "part" => {
+          xml.push_str(&format!(
+            "    <bib-part role=\"part\">{}</bib-part>\n",
+            markup(&xml_escape(&clean))
+          ));
+        },
+        // The `type` FIELD (e.g. "Technical Memo"). Safe to emit: `bib-type` is
+        // queried on its own here, NOT unioned with `bib-date`, so it cannot
+        // displace the publication year the way Perl's combined XPath could.
+        "type" => {
+          xml.push_str(&format!(
+            "    <bib-type>{}</bib-type>\n",
+            markup(&xml_escape(&clean))
+          ));
+        },
+        "status" => {
+          xml.push_str(&format!(
+            "    <bib-status>{}</bib-status>\n",
+            markup(&xml_escape(&clean))
+          ));
+        },
+        "language" => {
+          xml.push_str(&format!(
+            "    <bib-language>{}</bib-language>\n",
+            markup(&xml_escape(&clean))
+          ));
+        },
+        // Everything else is deliberately not emitted. Perl's BibTeX.pool does
+        // build elements for `chapter`, `subtitle` and `translator`, but NO
+        // format spec queries `ltx:bib-part[@role='chapter']`,
+        // `ltx:bib-subtitle` or `ltx:bib-name[@role='translator']`, so emitting
+        // them would add nodes that can never render — dead weight rather than
+        // fidelity. (Perl leaves them unrendered too; verified on a fixture
+        // carrying `chapter={5}`.) The entry-type boilerplate Perl synthesizes
+        // in `\bib@entry@<type>@prepare` ("Ph.D. Thesis", "Technical Report")
+        // is engine-side, not a `.bib` field, and arrives with the full
+        // `.bib`-through-the-engine re-port.
         _ => {},
       }
     }

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -3376,6 +3376,28 @@ fn interpret_tex_markup(s: &str) -> Option<String> {
     // (Whole-document `finalize()` is wrong here and *fails* on a scratch
     // fragment — see `Document::finalize_subtree`.)
     doc.finalize_subtree(&mut wrapper).ok()?;
+    // Fail-safe: BLOCK-level content (a list, `\par`, a quote, a footnote)
+    // CLOSES `ltx:text` and continues as a sibling, so serializing only the
+    // wrapper's children would silently drop everything from that point on.
+    // Measured before this guard: `note={before \begin{itemize}\item X
+    // \end{itemize} after}` rendered as just "before" — with zero errors, i.e.
+    // exactly the fail-OPEN this function is supposed to avoid. Whenever any
+    // text escaped the wrapper, decline and let the caller fall back to the
+    // plain-text digest, which keeps the whole value.
+    //
+    // Compares TEXT, so it cannot see block content carrying none (a lone
+    // floated image in a note). Every realistic escape — list, `\par`, quote,
+    // footnote — carries text, and the check is cheap; tightening it further is
+    // only worth it once the full `.bib`-through-the-engine re-port makes block
+    // content in a field renderable at all instead of merely lossless.
+    let escaped = doc
+      .get_document()
+      .get_root_element()
+      .map(|root| squash_ws(&root.get_content()) != squash_ws(&wrapper.get_content()))
+      .unwrap_or(true);
+    if escaped {
+      return None;
+    }
     let mut fragment = String::new();
     let mut child = wrapper.get_first_child();
     while let Some(node) = child {
@@ -3429,6 +3451,10 @@ fn interpret_tex_markup(s: &str) -> Option<String> {
   }
   Some(fragment)
 }
+
+/// All non-whitespace characters, for comparing two renderings of the same
+/// content without tripping over the builder's incidental whitespace.
+fn squash_ws(s: &str) -> String { s.split_whitespace().collect() }
 
 fn bump_bib_interpret_failures() {
   let n = BIB_INTERPRET_FAILURES.with(|c| {


### PR DESCRIPTION
Reported by email (2026-07-25) as "references not showing up". Triaging the 11 witness papers found latexml-oxide already clean on 4 of the 5 reported clusters, and turned up **two GENUINE-RUST-ONLY content losses** in the bibliography, both confirmed against same-host Perl.

**Diagnostic.**
1. Field values were digested and then **stringified** — and a Whatsit stringifies to its *reversion*, so `note = {\url{https://x}}` rendered as the dead literal `\urlhttps://x` and `\href{u}{text}` lost its link text outright. A second, independent flatten sat downstream in `apply_formatter`, which took `get_content()` of the field node and discarded element children. Either one alone keeps the bug alive.
2. Eleven field kinds reached **no emit branch at all** and were silently discarded: `howpublished`, `institution`, `organization`, `school`, `address`, `edition`, `series`, `part`, `type`, `status`, `language`. `howpublished = {\url{...}}` is how a `@misc` conventionally carries its URL, so that URL was simply gone.

**Approach.** `interpret_tex_markup` digests into a scratch `Document` and serializes an XML fragment; `field_content` clones a field's children when it holds markup — Perl's formatters are `do_any`-shaped and return `$doc->cloneNodes(@nodes)` (`MakeBibliography.pm` L525-531/L550-552) — and keeps the single-`Text` path otherwise, so plain fields stay byte-identical. The missing emissions follow `bibtex.rs` L1340-1573 (the port of `BibTeX.pool` `\bib@field@default@*`); every element added was already queried by the format specs, so only the emitter was missing. New `Document::finalize_subtree`: whole-document `finalize()` returns `Ok` but, recursing from the root, unwraps the scratch font-only `ltx:text`, leaving the caller's handle detached and childless. Four fail-safe gates decline a fragment rather than splice something unsound — failed digest, **escaped block content**, unparsed math, any prefixed element name.

**Validation.** Guards `bib_field_markup_survives_into_the_bibliography` and `105_bib_field_digest_once`, both verified genuinely RED by disabling each fix in turn. Full suite **1693/0** across 94 targets; `clippy --workspace --all-targets -D warnings` clean; CI green on Linux, macOS, lint and miri. Witness 2607.00045: raw-TeX tokens **46 → 2**, live links **0 → 45**. Across the nine witnesses, **45 `bib-place` + 8 `bib-edition` + 1 `bib-type`** recovered at **unchanged error counts**; 0.39 s / 267 MB (Perl: 10.5 s).

**Known limits, stated rather than papered over.**
- Math in a bib field still falls back to TeX source — the Marpa pass lives in `latexml_math_parser`, which `latexml_post` does not depend on. Worse than Perl, and gated so it cannot emit malformed MathML.
- Block content in a field is lossless but flattened; the escaped-content gate compares text, so block content carrying none is invisible to it.
- `chapter`/`subtitle`/`translator` stay unemitted: no format spec queries them, and Perl leaves them unrendered too (verified).
- Entry-type boilerplate ("Ph.D. Thesis") is engine-side, not a `.bib` field.
- Two residuals are **parity**, not regressions: `url={\url{...}}` (Perl emits the identical broken `href`) and the BibTeX `type`-label duplication, recorded as KNOWN_PERL_ERRORS #60.

Detail — including why the file's string building was not refactored (worklist item 1 deletes the whole 573-line route, which also clears the math gap and the entry-type boilerplate) — in `docs/parity/BIBLIOGRAPHY_WORKLIST.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
