### PR TITLE
fix: use the short author form for the author-year citation label

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -2413,3 +2413,49 @@ cause: an LF copy of the same file renders correctly, the CRLF original does not
 read. Guard
 `104_lstinputlisting_range_crlf::crlf_line_comment_style_does_not_bleed_past_its_line`.
 Candidate to upstream (not filed as of 2026-07-25).
+
+## 58. `do_names_short` is dead code — the author-year label carries every author
+
+`LaTeXML/lib/LaTeXML/Post/MakeBibliography.pm` defines exactly the helper the
+author-year citation label needs:
+
+```perl
+sub do_names_short {
+  my (@names) = @_;
+  if (@names > 2) {
+    return ($names[0]->childNodes, ' ', ['ltx:text', { class => 'ltx_bib_etal' }, 'et al.']); }
+  elsif (@names > 1) {
+    return ($names[0]->childNodes, ' and ', $names[1]->childNodes); }
+  elsif (@names) {
+    return ($names[0]->childNodes); } }
+```
+
+It is **never called** — `grep do_names_short` finds only the definition (L586).
+The `role="refnum"` `ltx_bib_author-year` label instead goes through
+`do_authors`→`do_names` (L505-517, L568-584), which emits **every** author and
+says "et al." only when the BibTeX field literally ends `and others`. The
+author-year branch then drops the entry's first block
+(`shift(@blockspecs); # Skip redundant 1st block!!`) on the grounds that the
+authors are already in the label.
+
+For a collaboration paper the result is a citation label thousands of characters
+long which IS the entry. Witness arXiv 2607.21432 (A&A, Simons Observatory):
+a **5104-character** label; 9 of its 19 entries exceed 120 characters. Reader
+report: [arXiv/html_feedback#6797](https://github.com/arXiv/html_feedback/issues/6797).
+Reproduce with any `.bib` entry of >2 authors that does not end `and others`,
+under an author-year citestyle (the bibliography must be built from the `.bib` —
+LaTeXML does not interpret `.bst`).
+
+That this is an oversight rather than a considered style is corroborated inside
+the same file: the `role="authors"` tag already truncates at `>2` (L433-437), so
+the full-list label contradicts its neighbour; and BibTeX itself disagrees —
+running the witness's `aa.bst` puts the SHORT form in `\bibitem[…]` (natbib's
+`Abitbol {et~al.}(2025)`) and prints the authors in the entry body, the long
+surname list being only natbib's optional `\citet*` form.
+
+**Fixed in Rust** by calling the short form for the label and keeping the first
+block, so the full author list survives in the body (max label on the witness
+5104 → 48 chars). Intentional divergence OXIDIZED_DESIGN #71, guard
+`cluster_bib_long_author_list_refnum`. Candidate to upstream — the fix upstream is
+to route the refnum through the already-present `do_names_short` and stop
+skipping the first block.

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2074,6 +2074,54 @@ renders correctly and the CRLF original does not.
 
 Guard: `104_lstinputlisting_range_crlf::crlf_line_comment_style_does_not_bleed_past_its_line`.
 
+### 71. The author-year citation label is the SHORT author form, not every author
+
+**Perl behaviour.** `MakeBibliography.pm` builds the `role="refnum"`
+`ltx_bib_author-year` label from `do_authors`→`do_names` (L505-517, L568-584):
+**every** author, with "et al." only when the BibTeX field literally ends
+`and others`. It then drops the entry's first block — `shift(@blockspecs); # Skip
+redundant 1st block!!` — because the authors are already in the label.
+
+On a collaboration paper that label is the whole entry. Witness arXiv 2607.21432
+(A&A, Simons Observatory): a **5104-character** citation label, and 9 of its 19
+entries over 120 characters. Reported by a reader as
+[arXiv/html_feedback#6797](https://github.com/arXiv/html_feedback/issues/6797).
+Applies whenever the bibliography is built from a `.bib` (we do not interpret
+`.bst`), which is the default `BIB_CONFIG` order `['bib','bbl']`.
+
+**Rust behaviour.** The label is the short form — `Abitbol et al. (2025)`,
+`Jones and Brown (2019)`, `Berg (2018)` — and the first block is **kept**, so the
+full author list still appears in the entry body. Nothing is lost; the label
+becomes usable. Max label on the witness: 5104 → **48** characters.
+
+**Why — pdflatex is the ground truth for the shape.** Running the witness's own
+`aa.bst` through BibTeX emits
+
+```
+\bibitem[{Abitbol {et~al.}(2025)Abitbol, Abril-Cabezas, Adachi, …}]{Abitbol_2025}
+Abitbol, M., Abril-Cabezas, I., Adachi, S., {et~al.} 2025, JCAP, 2025, 034
+```
+
+natbib's **short** form (`Abitbol et al. (2025)`) is the citation label; the long
+surname list is only natbib's *optional* full-author form, used by `\citet*` and
+never printed in the bibliography; and the authors are shown in the entry BODY.
+That is exactly the shape adopted here.
+
+Two further signs the Perl behaviour is an oversight rather than a decision:
+`do_names_short` — the correct `>2 → "First et al."` helper — is **defined at
+`MakeBibliography.pm` L586 and never called**; and Perl's own `role="authors"`
+tag already truncates at `>2` (L433-437), so the full-list label contradicted its
+own neighbouring policy. See `KNOWN_PERL_ERRORS.md` #58.
+
+Beyond Perl's unused helper, a trailing BibTeX `others` is dropped and forces the
+"et al." form, so `Smith and others` reads "Smith et al." rather than
+"Smith and others" — keeping it consistent with `do_names`, which does handle
+`others`.
+
+**Witnesses**: arXiv 2607.21432 (arXiv/html_feedback#6797).
+**Guard**: `cluster_bib_long_author_list_refnum`.
+**Upstream**: to file against `brucemiller/LaTeXML` (dead `do_names_short`).
+
 ## Known Upstream Perl Issues (brief)
 
 These are behaviors in the original Perl LaTeXML that are bugs or limitations, not

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -865,6 +865,29 @@ fn cluster_bib_long_author_list_refnum() {
     x.contains("Abril-Cabezas") && x.contains("Agrawal"),
     "the full author list must survive in the entry body:\n{x}"
   );
+  // ...but the RENDERED first block must not re-print the year the label
+  // already carries. Perl dropped the whole block to avoid that redundancy; we
+  // keep it and drop only its year field, matching the shipped biblatex
+  // author-year rendering (`[Smith (2020)] John Smith “A study…”`).
+  //
+  // Scoped to the first <bibblock> on purpose: `2025` also legitimately occurs
+  // as the `<tags>` metadata year (CrossRef reads it, and the numeric style
+  // emits it too), in `key="Collab2025"`, and as this entry's journal VOLUME.
+  let first_block = {
+    let i = x.find("science goals and forecasts").expect("entry");
+    let start = x[..i].rfind("<bibitem").expect("bibitem start");
+    let b = start + x[start..].find("<bibblock").expect("first bibblock");
+    let e = b + x[b..].find("</bibblock>").expect("bibblock end");
+    &x[b..e]
+  };
+  assert!(
+    first_block.contains(r#"class="ltx_bib_author""#),
+    "the first block should carry the authors:\n{first_block}"
+  );
+  assert!(
+    !first_block.contains(r#"class="ltx_bib_year""#),
+    "the first block must not re-emit the year the label already carries:\n{first_block}"
+  );
 }
 
 /// biblatex author-year support (ar5iv-bindings PRs #20/#21 + repair

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -792,6 +792,81 @@ fn cluster_fenced_bare_operator() {
   );
 }
 
+/// arXiv/html_feedback#6797 — an author-year bibliography built from a `.bib`
+/// used the FULL author list as the entry's refnum LABEL (5104 characters on the
+/// witness, arXiv 2607.21432); and because the author-year branch also skipped
+/// the first block, the authors appeared ONLY there.
+///
+/// pdflatex is the ground truth for the shape: `aa.bst` over the witness emits
+/// `\bibitem[{Abitbol {et~al.}(2025)Abitbol, …all surnames…}]` — natbib's SHORT
+/// form is the citation label, the long list is only natbib's optional
+/// full-author form and is never printed — and shows the authors in the entry
+/// BODY. Perl is byte-identical to the old Rust (`do_names` truncates only for a
+/// literal BibTeX `and others`), so this is a deliberate divergence,
+/// OXIDIZED_DESIGN #71.
+#[test]
+fn cluster_bib_long_author_list_refnum() {
+  let x = convert_and_post("tests/cluster_regressions/bib_long_author_list.tex");
+  // The refnum tag of the <bibitem> that carries a given entry's title. NOTE
+  // the refnum is pushed LAST within <tags>, so it follows the title — scope to
+  // the enclosing bibitem rather than searching backwards from the title.
+  let refnum = |title: &str| -> String {
+    let i = x
+      .find(title)
+      .unwrap_or_else(|| panic!("no entry titled {title} in:\n{x}"));
+    let start = x[..i].rfind("<bibitem").unwrap_or(0);
+    let end = x[start..]
+      .find("</bibitem>")
+      .map(|e| start + e)
+      .unwrap_or(x.len());
+    let s = start
+      + x[start..end]
+        .find(r#"role="refnum""#)
+        .unwrap_or_else(|| panic!("no refnum in the bibitem for {title}:\n{x}"));
+    let open = x[s..].find('>').expect("tag open") + s + 1;
+    let close = x[open..].find("</tag>").expect("tag close") + open;
+    let (mut out, mut depth) = (String::new(), 0);
+    for c in x[open..close].chars() {
+      match c {
+        '<' => depth += 1,
+        '>' => depth -= 1,
+        _ if depth == 0 => out.push(c),
+        _ => {},
+      }
+    }
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+  };
+  // >2 authors: the label is natbib's short form, NOT the full list.
+  assert_eq!(
+    refnum("science goals and forecasts"),
+    "Abitbol et al. (2025)",
+    "long-author label:\n{x}"
+  );
+  // 2 and 1 author are unaffected by the short form.
+  assert_eq!(
+    refnum("On examples"),
+    "Jones and Brown (2019)",
+    "2-author:\n{x}"
+  );
+  assert_eq!(
+    refnum("A single-author paper"),
+    "Berg (2018)",
+    "1-author:\n{x}"
+  );
+  // A literal BibTeX `and others` already produced "et al." — still does.
+  assert_eq!(
+    refnum("An explicit BibTeX others entry"),
+    "Smith et al. (2020)",
+    "explicit others:\n{x}"
+  );
+  // The full author list must NOT be lost: with a short label the first block
+  // (the authors) is no longer redundant and must appear in the entry body.
+  assert!(
+    x.contains("Abril-Cabezas") && x.contains("Agrawal"),
+    "the full author list must survive in the entry body:\n{x}"
+  );
+}
+
 /// biblatex author-year support (ar5iv-bindings PRs #20/#21 + repair
 /// 0911aec): style=apa documents with a biber .bbl get "Surname, Year"
 /// labels, one schema-valid role-tagged <ltx:tags> per bibitem, and the

--- a/latexml_oxide/tests/cluster_regressions/bib_long_author_list.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_long_author_list.tex
@@ -1,0 +1,28 @@
+% arXiv/html_feedback#6797 — an author-year bibliography built from a `.bib`
+% (no `.bst` interpretation) used the FULL author list as the entry's refnum
+% LABEL. On a collaboration paper that is a 5104-character label, and because
+% the author-year branch also skipped the first block ("Skip redundant 1st
+% block!!"), the authors appeared ONLY there.
+%
+% pdflatex is the ground truth for the shape. Running `aa.bst` over the witness
+% (arXiv 2607.21432) emits
+%   \bibitem[{Abitbol {et~al.}(2025)Abitbol, Abril-Cabezas, …all surnames…}]{…}
+%   Abitbol, M., Abril-Cabezas, I., Adachi, S., {et~al.} 2025, JCAP, 2025, 034
+% i.e. natbib's SHORT form ("Abitbol et al. (2025)") is the citation label, the
+% long list is only natbib's optional full-author form and is never printed,
+% and the authors are shown in the entry BODY.
+%
+% Perl is byte-identical to the old Rust here (`do_names` truncates only for a
+% literal BibTeX "and others"), so this is a deliberate divergence —
+% OXIDIZED_DESIGN #71. Note Perl already carries the right helper,
+% `do_names_short`, defined at MakeBibliography.pm L586 and never called.
+\documentclass{article}
+\usepackage[authoryear]{natbib}
+\begin{document}
+See \citep{Collab2025}, \citep{Pair2019}, \citep{Solo2018} and \citep{Others2020}.
+% `aa` is not in the BIBSTYLES map (like the witness), so natbib's [authoryear]
+% option decides the citestyle. A mapped name such as `plainnat` would override
+% it back to `numbers` and the entry would never take the author-year branch.
+\bibliographystyle{aa}
+\bibliography{bib_long_author_list_refs}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/bib_long_author_list_refs.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_long_author_list_refs.bib
@@ -1,0 +1,29 @@
+@article{Collab2025,
+  author = {Abitbol, M. and Abril-Cabezas, I. and Adachi, S. and Ade, P. and Adler, A.E. and Agrawal, P.},
+  title = {The Simons Observatory: science goals and forecasts},
+  journal = {Journal of Cosmology and Astroparticle Physics},
+  year = {2025},
+  volume = {2025},
+  pages = {034}
+}
+
+@article{Pair2019,
+  author = {Jones, Alice and Brown, Bob},
+  title = {On examples},
+  journal = {Review of Examples},
+  year = {2019}
+}
+
+@article{Solo2018,
+  author = {Berg, Pieter},
+  title = {A single-author paper},
+  journal = {Dutch Journal},
+  year = {2018}
+}
+
+@article{Others2020,
+  author = {Smith, John and Doe, Jane and others},
+  title = {An explicit BibTeX others entry},
+  journal = {Journal of Testing},
+  year = {2020}
+}

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -752,6 +752,8 @@ impl MakeBibliography {
     }
 
     let mut skip_first_block = false;
+    // Author-year only: keep the first block but drop its (redundant) year field.
+    let mut drop_first_block_year = false;
     match effective_style {
       CitationStyle::Numbers => {
         tags.push(NodeData::Element {
@@ -811,6 +813,7 @@ impl MakeBibliography {
         // below is its port. Perl's own role="authors" tag likewise truncates at
         // >2 (L433-437), so the full-list label was internally inconsistent.
         skip_first_block = false;
+        drop_first_block_year = true;
         let suffix = entry.suffix.as_deref().unwrap_or("");
         let mut refnum_children: Vec<NodeData> = if let Some(ref bibentry) = entry.bibentry {
           let authors = PostDocument::findnodes_foreign("ltx:bib-name[@role='author']", bibentry);
@@ -876,7 +879,7 @@ impl MakeBibliography {
     }
 
     // --- Content blocks ---
-    let blocks = self.format_blocks(doc, entry, skip_first_block);
+    let blocks = self.format_blocks(doc, entry, skip_first_block, drop_first_block_year);
     children.extend(blocks);
 
     // --- Cited-by block ---
@@ -1201,6 +1204,7 @@ impl MakeBibliography {
     doc: &PostDocument,
     entry: &BibEntryData,
     skip_first: bool,
+    drop_first_year: bool,
   ) -> Vec<NodeData> {
     let format_type = entry.format_type();
     let block_specs = get_fmt_spec(format_type);
@@ -1213,6 +1217,16 @@ impl MakeBibliography {
 
       let mut items: Vec<NodeData> = Vec::new();
       for field_spec in block_spec {
+        // Author-year: the refnum label already reads "Author (Year)", so the
+        // first block repeating the year would print it twice in the one entry.
+        // Perl avoids that by dropping the whole block (and with it the author
+        // list); we keep the block and drop only the redundant field. Matches
+        // the biblatex author-year path already shipped here, whose entries
+        // render as `[Smith (2020)]  John Smith  “A study of things” …` —
+        // label carries the year, author block does not. See OXIDIZED_DESIGN #71.
+        if drop_first_year && i == 0 && field_spec.class == "year" {
+          continue;
+        }
         let (nodes_found, negated) = if let Some(ref bibentry) = entry.bibentry {
           let xpath = field_spec.xpath.trim_start_matches('!').trim();
           let negated = field_spec.xpath.starts_with('!');

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -786,18 +786,36 @@ impl MakeBibliography {
         });
       },
       CitationStyle::AuthorYear => {
-        // Author-year refnum — Perl MakeBibliography.pm else-branch (L505-517):
-        // the ltx_bib_author-year label is the FULL author list via
-        // do_authors→do_names (every author, initials-first do_name, ", "/" "
-        // separators with "and " before the last, "et al." only for a literal
-        // BibTeX "and others"), followed by " (year)". NOT the abbreviated
-        // inline "X et al." form — that is the separate role="authors" tag.
-        skip_first_block = true;
+        // Author-year refnum. Perl (MakeBibliography.pm else-branch L505-517)
+        // builds this label from `do_authors`→`do_names`, i.e. EVERY author,
+        // with "et al." only for a literal BibTeX "and others"; and it then
+        // drops the first block ("Skip redundant 1st block!!") because the
+        // authors are already in the label.
+        //
+        // We use the SHORT form instead — intentional divergence
+        // OXIDIZED_DESIGN #71. On a collaboration paper Perl's rule yields a
+        // 5104-character citation label (witness arXiv 2607.21432, reported as
+        // arXiv/html_feedback#6797) and, with the block skipped, that label is
+        // essentially the whole entry.
+        //
+        // pdflatex is the ground truth for the shape. `aa.bst` over the witness
+        // emits
+        //   \bibitem[{Abitbol {et~al.}(2025)Abitbol, Abril-Cabezas, …}]{…}
+        //   Abitbol, M., Abril-Cabezas, I., Adachi, S., {et~al.} 2025, JCAP …
+        // — natbib's SHORT form is the citation label, the long surname list is
+        // only natbib's optional full-author form (never printed), and the
+        // authors live in the entry BODY. So: short label, and keep the block.
+        //
+        // Perl already carries the right helper — `do_names_short`
+        // (MakeBibliography.pm L586) — defined and never called; `do_names_short`
+        // below is its port. Perl's own role="authors" tag likewise truncates at
+        // >2 (L433-437), so the full-list label was internally inconsistent.
+        skip_first_block = false;
         let suffix = entry.suffix.as_deref().unwrap_or("");
         let mut refnum_children: Vec<NodeData> = if let Some(ref bibentry) = entry.bibentry {
           let authors = PostDocument::findnodes_foreign("ltx:bib-name[@role='author']", bibentry);
           if !authors.is_empty() {
-            do_names(authors)
+            do_names_short(authors)
           } else {
             let editors = PostDocument::findnodes_foreign("ltx:bib-name[@role='editor']", bibentry);
             if !editors.is_empty() {
@@ -2633,6 +2651,63 @@ fn do_name_text(namenode: &Node) -> String {
     out.push_str(&surname.get_content());
   }
   out
+}
+
+/// The SHORT author form used for the author-year citation label: surnames
+/// only, `>2` collapsing to "First et al.".
+///
+/// Port of Perl's `do_names_short` (MakeBibliography.pm L586-593) — which is
+/// **defined there and never called**; Perl's author-year refnum uses the full
+/// `do_names` instead, producing labels thousands of characters long on
+/// collaboration papers. See OXIDIZED_DESIGN #71 for why we call it, and
+/// `cluster_bib_long_author_list_refnum` for the guard.
+///
+/// Beyond Perl's version: a trailing BibTeX `others` is dropped and forces the
+/// "et al." form, so `Smith and others` reads "Smith et al." rather than
+/// "Smith and others". Perl's unused helper has no `others` handling at all;
+/// `do_names` (its called sibling) does, so this keeps the two consistent.
+fn do_names_short(mut names: Vec<Node>) -> Vec<NodeData> {
+  let surname_text = |n: &Node| -> String {
+    PostDocument::findnodes_foreign("ltx:surname", n)
+      .into_iter()
+      .next()
+      .map(|s| s.get_content())
+      .unwrap_or_else(|| n.get_content())
+      .trim()
+      .to_string()
+  };
+  let mut etal = names
+    .last()
+    .map(|n| n.get_content().trim() == "others")
+    .unwrap_or(false);
+  if etal {
+    names.pop();
+  }
+  if names.len() > 2 {
+    etal = true;
+  }
+  let etal_span = || NodeData::Element {
+    tag:        "ltx:text".to_string(),
+    attributes: Some(HashMap::from_iter([(
+      "class".to_string(),
+      "ltx_bib_etal".to_string(),
+    )])),
+    children:   vec![NodeData::Text("et al.".to_string())],
+  };
+  match (names.len(), etal) {
+    (0, _) => Vec::new(),
+    (_, true) => vec![
+      NodeData::Text(surname_text(&names[0])),
+      NodeData::Text(" ".to_string()),
+      etal_span(),
+    ],
+    (1, false) => vec![NodeData::Text(surname_text(&names[0]))],
+    (_, false) => vec![
+      NodeData::Text(surname_text(&names[0])),
+      NodeData::Text(" and ".to_string()),
+      NodeData::Text(surname_text(&names[1])),
+    ],
+  }
 }
 
 /// Perl MakeBibliography `do_names` (L568-584) / `do_authors` (L595-597): the


### PR DESCRIPTION
**Diagnostic.** `MakeBibliography` built the `role="refnum"` author-year label from *every* author (`do_authors`→`do_names`; "et al." only for a literal BibTeX `and others`) and then dropped the entry's first block, so on a collaboration paper the label *is* the entry — 5104 characters on witness arXiv 2607.21432, with 9 of its 19 entries over 120.

**Approach.** pdflatex is the ground truth: the paper's own `aa.bst` puts natbib's **short** form in `\bibitem[…]` (`Abitbol et al. (2025)`) — the long surname list is only natbib's optional `\citet*` form, never printed — and shows the authors in the entry **body**. So: short label (a port of Perl's `do_names_short`, which is defined at `MakeBibliography.pm` L586 and **never called**), and keep the first block so the full list survives. Max label 5104 → 48 chars. Perl is byte-identical to the old behaviour, so this is an intentional divergence: **OXIDIZED_DESIGN #71**, upstream oversight recorded as **KNOWN_PERL_ERRORS #61**.

**Validation.** `cluster_bib_long_author_list_refnum` (red→green; covers >2 / 2 / 1 authors, explicit `and others`, and that the full list survives in the body); full suite **1696 passed / 94 targets / 0 failed** after merging current `main`; clippy `-D warnings`, fmt, rustdoc clean; **no golden churn**; Perl parity re-confirmed same-host both with and without a `.bbl`.

Closes arXiv/html_feedback#6797

---

**Rebased onto `main` 2026-07-26** (merge `59722a6ec5`). The conflicts were the two numbered-doc appends: the `KNOWN_PERL_ERRORS` entry is renumbered **#58 → #61** (main had since gained 58/59/60 from #380 and #383) and its cross-reference in `OXIDIZED_DESIGN_DIVERGENCES.md` was updated to match; the divergence stays **#71** (main's max is 70 after #384). The Rust files auto-merged, and the changes are independent of #383's: `do_names_short` feeds `format_author_nodes`, not the `field_content` path #383 touched.

Headline claim re-verified independently on witness 2607.21432 with the merged binary: **19 refnum labels, max 48 chars** ("The Pan-Experiment Galactic Science Group et al."), and the full **602-character** author list still present in the entry body — the pdflatex shape. The paper's one remaining error is `\corrauth` (aa.cls frontmatter), unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
