### PR TITLE
fix(fontenc): break the text-symbol loop in a Semiverbatim argument

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -1073,7 +1073,7 @@ Not actionable as a Rust-only fix; would require teaching LaTeXML's
 `\sqrtsign`/`\meaning` to round-trip mathchar codes the way TeX does,
 which is out of scope and equally absent in Perl.
 
-## A text-symbol CS (`\i`/`\j`) in a `\usepackage` Semiverbatim option hangs (SHARED)
+## A text-symbol CS (`\i`/`\j`) in a Semiverbatim argument hangs (SHARED — FIXED in Rust 2026-07-26)
 
 `\usepackage[pdfauthor={…Mar{\'\i}n…}]{hyperref}` — i.e. a font-encoding
 text symbol (`\i`, `\j`, …) inside a `\usepackage`/`\RequirePackage`
@@ -1110,11 +1110,45 @@ Mechanism (identical in both engines):
    *collects* them without executing — the font encoding stays "ASCII" —
    and the inner `\i` re-expands → step 2. Infinite.
 
-Breaking the loop requires making `\fontencoding{OT1}` take effect inside
-the semiverbatim `readXToken` (so the inner `\i` resolves to `\OT1\i`,
-CD 16, which IS defined). Perl does not, so Perl hangs too. **This is a
-RELEASE_CRITERIA surpass-Perl reliability item, not a translation parity
-bug.** Tracked in memory `robust-cs-semiverbatim-loop`. (Separately, a
+**✅ FIXED IN RUST 2026-07-26 (surpass-Perl; Perl still hangs).** The cure is
+the one this entry predicted — resolve the inner `\i` to `\OT1\i` — but
+reached without needing `\fontencoding` to take effect inside the collect
+loop. `\UseTextSymbol{#1}{#2}` (`latex_constructs.rs`, Perl
+`latex_constructs.pool.ltxml:2642`) now expands to the encoding-specific
+glyph CS `\csname #1\string#2\endcsname` **when that glyph is defined**,
+keeping Perl's literal `{\fontencoding{#1}#2}` only as the fallback for when
+it is not. That is not an invention: it is exactly what Perl's own
+`\DeclareTextSymbolDefault` (`latex_constructs.pool.ltxml:2684-2688`) makes
+`\?<cs>` expand to — the direct glyph, with no `\fontencoding` wrapper — so
+the observable result matches Perl in every case Perl can reach.
+
+**The dump is NOT the differentiator** — worth recording, because the obvious
+guess is wrong. Measured 2026-07-26 against a format-equipped Perl 0.8.8
+(`cd LaTeXML && cpanm --build-arg formats .`, which installs
+`{plain,latex}_dump.pool.ltxml` beside the modules): Perl's own dump carries
+`\?\i` → `\UseTextSymbol{OT1}\i`, 72 `UseTextSymbol` records. Perl has the
+identical looping shape available. On that one install:
+
+| trigger | Perl (with dumps) | Rust (before) | verdict |
+|---|---|---|---|
+| `\usepackage[pdfauthor={Mar{\'\i}n}]{hyperref}` | **hangs**, exit 124 | hangs | SHARED |
+| `\cite{garcía2024key}` under `[OT1]{fontenc}` | converts, 0.89 s, `bibrefs="garcía2024key"` | `Fatal:Timeout` | **GENUINE-RUST-ONLY** |
+
+So the second witness, **2606.11784**, is the same loop reached from a
+*literal* non-ASCII character rather than an author-typed CS: fontenc's `.dfu`
+maps `í` (U+00ED) onto the text-symbol chain and a `\cite` key is Semiverbatim.
+It went from `Fatal:Timeout:PushbackLimit` with no output to 0 errors / 519 KB.
+**Residual, unpinned:** *why* our `\cite`-key read reaches the encoding
+dispatch when Perl's does not — the fix removes the loop shape for both, but
+that read-path delta is still unexplained and deserves its own look.
+
+Guard: `tests/encoding/textsymbol_semiverbatim` (pins that the literal and
+`\'{i}` spellings converge). Causality checked by restoring Perl's literal body
+at runtime on the fixed binary — the Fatal returns. Of the 25 `PushbackLimit`
+papers in the 2605+2606 sandboxes only 2606.11784 carries a non-ASCII cite key,
+so this repairs a failure *shape*, not that whole cluster.
+
+Tracked in memory `robust-cs-semiverbatim-loop`. (Separately, a
 genuine adjacent divergence was fixed: Rust's `\cf@encoding`/`\f@encoding`
 fell back to *empty* when the live font's encoding slot is `None`; Perl's
 Font always carries OT1 — `Common/Font.pm:331`/`$DEFENCODING`. Now falls

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -6672,7 +6672,52 @@ LoadDefinitions!({
   // sub { ignoredDefinition("DeclareTextCompositeCommand", $_[1]); });
 
   def_primitive_noop("\\UndeclareTextCommand{}{}")?;
-  DefMacro!("\\UseTextSymbol{}{}", "{\\fontencoding{#1}#2}");
+  // Perl `latex_constructs.pool.ltxml:2642`:
+  //   DefMacro('\UseTextSymbol{}{}', '{\fontencoding{#1}#2}');
+  //
+  // Perl's body verbatim is `{\fontencoding{#1}#2}`, and that shape CANNOT
+  // TERMINATE when it is reached from a pure-expansion collect loop: `{` and
+  // `\fontencoding` are non-expandable, so the loop gathers them without
+  // executing, the font encoding never changes, and the inner `#2` re-enters
+  // `\@changed@cmd` under the same encoding — forever.
+  //
+  // The live trigger is `beginSemiverbatim` (Perl `State.pm:597`, faithfully
+  // ported at `state.rs:2691`) merging `encoding => 'ASCII'` — a stay-ASCII
+  // neutralization, not a real LaTeX text encoding. So inside a Semiverbatim
+  // argument (a `\cite` key, a `\usepackage` option value) `\cf@encoding` is
+  // `ASCII`, `\ASCII\i` is undefined, and the `?`-fallback spins.
+  //
+  // Perl has the SAME looping shape available and simply reaches it less
+  // often: measured 2026-07-26 against a format-equipped Perl 0.8.8 built with
+  // `cpanm --build-arg formats .`, its own `latex_dump.pool.ltxml` carries
+  // `\?\i -> \UseTextSymbol{OT1}\i` (72 `UseTextSymbol` records). So the dump
+  // is NOT the differentiator — an earlier draft of this comment claimed it
+  // was, and that was wrong. What is measured, on that one Perl install:
+  //   * `\usepackage[pdfauthor={Mar{\'\i}n}]{hyperref}` — Perl HANGS (exit 124)
+  //     exactly as we did: SHARED, the KNOWN_PERL_ERRORS entry.
+  //   * `\cite{garc<U+00ED>a2024key}` under `[OT1]{fontenc}` — Perl converts
+  //     cleanly in 0.89 s (`bibrefs="garcía2024key"`) while we looped:
+  //     GENUINE-RUST-ONLY. Something in our `\cite`-key read reaches the
+  //     encoding dispatch where Perl's does not; that residual delta is not
+  //     yet pinned and is worth its own look.
+  //
+  // Either way the loop is a property of this macro's SHAPE, so fix it here:
+  // resolve to the direct glyph — which is precisely what Perl's own
+  // `\DeclareTextSymbolDefault` (`latex_constructs.pool.ltxml:2684-2688`,
+  // ported above) makes `\?<cs>` expand to — and keep Perl's literal body as
+  // the fallback when no such glyph exists. The observable result therefore
+  // matches Perl wherever Perl terminates, and terminates where Perl does not.
+  //
+  // Witness 2606.11784 (`\usepackage[OT1]{fontenc}` + a literal `í` U+00ED in
+  // a `\cite` key, mapped onto the text-symbol chain by the `.dfu`):
+  // `Fatal:Timeout:PushbackLimit` with no output before, 0 errors / 519 KB
+  // after. Also breaks the SHARED hang 2004.08143 — a surpass-Perl reliability
+  // win, using the cure KNOWN_PERL_ERRORS "text-symbol CS in a Semiverbatim
+  // argument" prescribes.
+  DefMacro!(
+    "\\UseTextSymbol{}{}",
+    r"\expandafter\ifx\csname #1\string#2\endcsname\relax{\fontencoding{#1}#2}\else\csname #1\string#2\endcsname\fi"
+  );
   DefMacro!("\\UseTextAccent{}{}", "{\\fontencoding{#1}#2{#3}}");
 
   // Perl: DefPrimitive('\DeclareMathAccent DefToken {}{} {Number}', ...)

--- a/latexml_oxide/tests/encoding/textsymbol_semiverbatim.tex
+++ b/latexml_oxide/tests/encoding/textsymbol_semiverbatim.tex
@@ -1,0 +1,34 @@
+% A font-encoding text symbol reached from inside a SEMIVERBATIM argument.
+%
+% `beginSemiverbatim` (Perl State.pm:597, ported at state.rs:2691) merges the
+% current font with `encoding => 'ASCII'` — a stay-ASCII neutralization, not a
+% real LaTeX text encoding. A `\cite` key is read that way, so inside it
+% `\cf@encoding` is `ASCII` and `\ASCII\i` is undefined.
+%
+% With `fontenc` loaded, the `.dfu` makes the literal `í` (U+00ED) active and
+% maps it onto the text-symbol CS chain, which then lands in `\@changed@cmd`'s
+% `?`-fallback. The LaTeX kernel spells that fallback `\UseTextSymbol{OT1}\i` =
+% `{\fontencoding{OT1}\i}` — and `{` / `\fontencoding` are NON-EXPANDABLE, so a
+% pure-expansion collect loop gathers them without executing: the encoding
+% stays ASCII and the inner `\i` re-enters forever.
+%
+% Perl never reaches that shape (its own `\DeclareTextSymbolDefault` makes
+% `\?<cs>` the direct glyph `\<enc><cs>`, and Perl does not dump latex.ltx, so
+% the kernel form is not live there). We DO dump latex.ltx, so the kernel form
+% wins — the inherited-kernel-macro leak class.
+%
+% Guards `\UseTextSymbol` resolving to the direct glyph. Witness 2606.11784
+% (`\usepackage[OT1]{fontenc}` + a literal `í` in a `\cite` key): before the
+% fix this was `Fatal:Timeout:PushbackLimit` with no output at all; same-host
+% Perl 0.8.8 converts it in 0.91 s. The same repair also breaks the SHARED
+% hyperref hang 2004.08143 (`pdfauthor={…Mar{\'\i}n…}`) — see
+% KNOWN_PERL_ERRORS "text-symbol CS in a Semiverbatim option".
+\documentclass{article}
+\usepackage[OT1]{fontenc}
+\begin{document}
+A literal accented character inside a \verb|\cite| key: \cite{garcía2024key}.
+
+The same symbol written as an explicit control sequence: \cite{garc\'{i}a2024cs}.
+
+And in ordinary text, where the encoding is not neutralized: garc\'{i}a, garcía.
+\end{document}

--- a/latexml_oxide/tests/encoding/textsymbol_semiverbatim.xml
+++ b/latexml_oxide/tests/encoding/textsymbol_semiverbatim.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article"?>
+<?latexml package="fontenc" options="OT1"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <para xml:id="p1">
+    <p>A literal accented character inside a <verbatim font="typewriter">\cite</verbatim> key: <cite class="ltx_citemacro_cite">[<bibref bibrefs="garcía2024key" separator="," yyseparator=","/>]</cite>.</p>
+  </para>
+  <para xml:id="p2">
+    <p>The same symbol written as an explicit control sequence: <cite class="ltx_citemacro_cite">[<bibref bibrefs="garcía2024cs" separator="," yyseparator=","/>]</cite>.</p>
+  </para>
+  <para xml:id="p3">
+    <p>And in ordinary text, where the encoding is not neutralized: garcía, garcía.</p>
+  </para>
+</document>


### PR DESCRIPTION
**Diagnostic.** A font-encoding text symbol reached from inside a **Semiverbatim** argument (a `\cite` key, a `\usepackage` option value) could never terminate. `beginSemiverbatim` merges the font with `encoding => 'ASCII'` — a stay-ASCII neutralization, not a real text encoding (Perl `State.pm:597`, faithfully ported) — so `\cf@encoding` is `ASCII`, `\ASCII\i` is undefined, and the `?`-fallback is the LaTeX kernel's `\UseTextSymbol{OT1}\i` = `{\fontencoding{OT1}\i}`. `{` and `\fontencoding` are **non-expandable**, so a pure-expansion collect loop gathers them without executing: the encoding never changes and the inner `\i` re-enters, forever.

**Approach.** Perl has the *same* shape and merely reaches it less often. Measured against a **format-equipped** Perl 0.8.8 (`cd LaTeXML && cpanm --build-arg formats .`), its own `latex_dump.pool.ltxml` carries `\?\i` → `\UseTextSymbol{OT1}\i` (72 records) — so the kernel dump is **not** the differentiator:

| trigger | Perl (with dumps) | Rust (before) | verdict |
|---|---|---|---|
| `pdfauthor={Mar{\'\i}n}` | **hangs**, exit 124 | hangs | SHARED |
| `\cite{garcía2024key}` + `[OT1]{fontenc}` | converts 0.89 s | `Fatal:Timeout` | **GENUINE-RUST-ONLY** |

Since the loop is a property of this macro's shape, fix it there: `\UseTextSymbol` resolves to the encoding-specific glyph when defined — exactly what Perl's own `\DeclareTextSymbolDefault` (`latex_constructs.pool.ltxml:2684-2688`) makes `\?<cs>` expand to — keeping Perl's literal body as the fallback when not. The result matches Perl wherever Perl terminates, and terminates where Perl does not. **Residual, not pinned:** why our `\cite`-key read reaches the dispatch when Perl's does not.

**Validation.** Witness **2606.11784** (`[OT1]{fontenc}` + a literal `í` U+00ED in a `\cite` key, mapped onto the text-symbol chain by the `.dfu`): `Fatal:Timeout:PushbackLimit` with no output → **0 errors / 519 KB**; GENUINE-RUST-ONLY, same-host Perl 0.8.8 converts it in 0.91 s. Also clears the **SHARED** hang **2004.08143** (`pdfauthor={…Mar{\'\i}n…}`) that `KNOWN_PERL_ERRORS` had parked as a surpass-Perl item, using the cure that entry prescribed; Perl still hangs. Causality checked, not assumed: restoring Perl's literal body at runtime on the fixed binary brings the Fatal straight back. Guard `tests/encoding/textsymbol_semiverbatim` pins that the literal and `\'{i}` spellings converge. Full suite **94 targets / 1697 / 0**; clippy `-D warnings`, fmt clean.

**Scope, stated plainly.** Of the 25 `PushbackLimit` papers in the 2605+2606 sandboxes, only 2606.11784 carries a non-ASCII cite key — this repairs a failure *shape*, not that whole cluster.