### PR TITLE
fix(bibliography): one runaway .bib field no longer empties the whole bibliography

### DIFF
--- a/latexml_core/src/gullet.rs
+++ b/latexml_core/src/gullet.rs
@@ -92,10 +92,35 @@ static COLUMN_ENDS: Lazy<[(Token, &'static str, bool); 6]> = Lazy::new(|| {
   ]
 });
 
+/// What a balanced read ([`read_balanced`]) does when it exhausts a mouth before
+/// the braces balance.
+///
+/// Perl has no such distinction: `Gullet.pm` L465-472 reads `$$self{mouth}
+/// ->readToken()` — the *current* mouth only — and `last`s at the boundary, so
+/// every Perl mouth is [`Opaque`](BalancedBoundary::Opaque). Rust crosses the
+/// boundary for token-level injections, which is a deliberate surpass-Perl
+/// divergence (xint, see [`read_balanced`]) and must stay narrow: crossing from a
+/// mouth that is *its own input* lets one runaway argument swallow everything
+/// after it.
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+pub enum BalancedBoundary {
+  /// The mouth is a token-level continuation of the enclosing stream
+  /// (`\scantokens`, RawTeX): its `}` may legitimately live in the parent, so a
+  /// balanced read drains it and resumes there.
+  Transparent,
+  /// The mouth is a self-contained input. A balanced read stops at its end, as
+  /// Perl always does — an unbalanced argument loses the rest of *this* mouth
+  /// and nothing more.
+  Opaque,
+}
+
 #[derive(PartialEq, Debug)]
 pub struct MouthRuntime {
   pub autoclose: bool,
   pub mouth:     Mouth,
+  /// See [`BalancedBoundary`]. Only consulted when `autoclose` is set and the
+  /// mouth is not a file.
+  pub boundary:  BalancedBoundary,
   /// Pushback LIFO stack: the "next to read" token is at `pushback.last()`.
   /// Invariant: reading pops from the back; `unread_one` pushes to the back;
   /// `unread_vec` iterates its input in reverse and pushes each — so the
@@ -384,6 +409,14 @@ pub fn unread_vec(tokens: Vec<Token>) {
 // Exception: if $toplevel=1, readXToken will step to next source
 // Note that a Tokens can act as a Mouth.
 pub fn open_mouth(mouth: Mouth, autoclose: bool) {
+  open_mouth_with(mouth, autoclose, BalancedBoundary::Transparent);
+}
+
+/// [`open_mouth`], choosing how a balanced read treats the new mouth's end.
+///
+/// Pass [`BalancedBoundary::Opaque`] whenever the mouth carries a self-contained
+/// input rather than a continuation of the current line — see the type's docs.
+pub fn open_mouth_with(mouth: Mouth, autoclose: bool, boundary: BalancedBoundary) {
   let mut gullet = gullet_mut!();
   if let Some(runtime) = gullet.runtime.take() {
     gullet.mouthstack.push_front(runtime);
@@ -391,6 +424,7 @@ pub fn open_mouth(mouth: Mouth, autoclose: bool) {
   gullet.runtime = Some(MouthRuntime {
     mouth,
     autoclose,
+    boundary,
     pushback: Vec::with_capacity(128),
   });
 }
@@ -1242,13 +1276,26 @@ pub fn read_balanced(
       // Perl — not silently absorb the parent document into the argument
       // (PR_READINESS should-fix 9). Only string/literal injections
       // (\scantokens, RawTeX) are transparent to a balanced read.
+      //
+      // The `boundary` check narrows it further, because "literal mouth" is not
+      // by itself evidence of a continuation: `\ProcessBibTeXEntry` also hands
+      // an entry to `Mouth::new` (bibtex.rs, Perl BibTeX.pool L165-166), and
+      // there one runaway field — a bare `%` in a title is enough — used to
+      // swallow every following entry AND `\end{bibtex@bibliography}`, emptying
+      // the whole bibliography while reporting a single error. Perl keeps all
+      // the other entries. Such a mouth declares itself
+      // [`BalancedBoundary::Opaque`].
       None => {
         let cross = {
           let gullet = gullet!();
           gullet
             .runtime
             .as_ref()
-            .map(|r| r.autoclose && r.mouth.foodtype() != crate::mouth::FoodType::File)
+            .map(|r| {
+              r.autoclose
+                && r.boundary == BalancedBoundary::Transparent
+                && r.mouth.foodtype() != crate::mouth::FoodType::File
+            })
             .unwrap_or(false)
             && !gullet.mouthstack.is_empty()
         };
@@ -2978,6 +3025,7 @@ pub fn flush() {
     mouth:     Mouth::default(),
     pushback:  Vec::with_capacity(128),
     autoclose: true,
+    boundary:  BalancedBoundary::Transparent,
   });
   g.mouthstack = VecDeque::new();
 }

--- a/latexml_core/src/stomach.rs
+++ b/latexml_core/src/stomach.rs
@@ -1354,7 +1354,12 @@ pub fn digest_next_body(terminal_opt: Option<Token>) -> Result<Vec<Digested>> {
   let start_location = { gullet::get_locator() };
 
   let init_depth = { stomach!().boxing.len() };
-  let mut found_token = false;
+  // Did the loop end because the INPUT RAN OUT (as opposed to reaching the
+  // terminal or closing the initial mode)? Perl `Stomach.pm` L130 keys the
+  // trailer box on `unless $token`, and `$token` is undef exactly when the
+  // `while (defined($token = ...))` condition failed — i.e. on EOF, whether or
+  // not tokens were read before it. See the trailer push below.
+  let mut ran_out = true;
   let mut found_terminal = false;
   new_local_box_list();
   let alignment_opt = lookup_alignment();
@@ -1368,8 +1373,6 @@ pub fn digest_next_body(terminal_opt: Option<Token>) -> Result<Vec<Digested>> {
   } {
     // Check conversion timeout
     check_timeout()?;
-    // done if we run out of tokens
-    found_token = true;
     // first, check for alignment case
     // Perl #2775: only fire at the original alignment nesting level,
     // not inside deeper boxing groups (e.g. \vbox inside a tabular cell).
@@ -1392,9 +1395,11 @@ pub fn digest_next_body(terminal_opt: Option<Token>) -> Result<Vec<Digested>> {
       && &token == terminal
     {
       found_terminal = true;
+      ran_out = false;
       break;
     }
     if init_depth > stomach!().boxing.len() {
+      ran_out = false;
       break;
     }
   }
@@ -1409,10 +1414,21 @@ pub fn digest_next_body(terminal_opt: Option<Token>) -> Result<Vec<Digested>> {
     );
     Warn!("expected", terminal, message);
   }
-  // and add a Dummy `trailer' if none explicit.
-  if !found_token {
+  // and add a Dummy `trailer' if none explicit — Perl `Stomach.pm` L130,
+  // `push(@LaTeXML::LIST, Box()) unless $token;`.
+  //
+  // This was mistranslated as "if we never read ANY token", which is a strictly
+  // narrower condition: it agrees with Perl only on a body that was empty from
+  // the start. The case it missed is a body that read content and THEN hit EOF —
+  // and that is the case the trailer exists for. `readDigested`
+  // (`Base_ParameterTypes.pool.ltxml` L374, ported in `base_parameter_types.rs`)
+  // does `push(@list, digestNextBody()); pop(@list);` to strip the closing `}`
+  // box; with no trailer pushed, that `pop` silently ate a box of REAL CONTENT.
+  // Concretely: one runaway `.bib` field swallowed the rest of the entry into
+  // its own argument, and the `pop` then removed the boxes carrying every
+  // following entry — an empty bibliography where Perl renders all of them.
+  if ran_out {
     push_box_list(Digested::from(Tbox::default()));
-    // info!(target:"digest_next_body","no_token");
   }
   Ok(expire_local_box_list())
 }

--- a/latexml_engine/src/bibtex.rs
+++ b/latexml_engine/src/bibtex.rs
@@ -1885,7 +1885,21 @@ LoadDefinitions!({
     drop(entry);
     // Perl L165-166: `openMouth(Mouth->new($tex))` — autoclose (Perl passes
     // no `$noautoclose`), so the mouth pops itself once drained.
-    open_mouth(Mouth::new(&lines.join("\n"), None)?, true);
+    //
+    // OPAQUE to a balanced read, which is what Perl's readBalanced is for every
+    // mouth (Gullet.pm L465-472 reads the current mouth only). This entry is a
+    // self-contained input, not a continuation of the enclosing wrapper, so an
+    // unbalanced field must cost only the rest of THIS entry. Left transparent,
+    // one runaway argument — a bare `%` in a title is enough, since BibTeX has
+    // no comment syntax inside an entry but TeX does — consumed every following
+    // `\ProcessBibTeXEntry` and `\end{bibtex@bibliography}` too, so a 3-entry
+    // `.bib` produced ONE entry and a single error where Perl produces all three
+    // and four errors. Guard: `55_bibtex::runaway_field_costs_only_its_own_entry`.
+    open_mouth_with(
+      Mouth::new(&lines.join("\n"), None)?,
+      true,
+      BalancedBoundary::Opaque,
+    );
     Ok(Tokens!())
   });
 

--- a/latexml_oxide/tests/55_bibtex.rs
+++ b/latexml_oxide/tests/55_bibtex.rs
@@ -108,3 +108,64 @@ fn bibtex_mode_emits_bibentries() {
      must not emit a second one from its `year`), got {dates}:\n{s}"
   );
 }
+
+/// A runaway field must cost only its own entry — not the rest of the `.bib`.
+///
+/// A bare `%` in a BibTeX field is literal data (BibTeX has no comment syntax
+/// inside an entry) but TeX source when `\ProcessBibTeXEntry` replays the entry
+/// through a Mouth, so it comments out the closing brace and the argument read
+/// runs away. Both engines mis-read the field — that is parity, and real
+/// bibtex+pdflatex break on it too, so it is deliberately NOT corrected here.
+///
+/// What was Rust-only was the blast radius. `read_balanced` used to treat every
+/// autoclose literal mouth as a token-level continuation of its parent
+/// (`gullet.rs`, the xint `\scantokens` divergence), so the runaway crossed out
+/// of the entry mouth and swallowed every following `\ProcessBibTeXEntry` AND
+/// `\end{bibtex@bibliography}`: a 3-entry `.bib` produced ONE entry and a single
+/// error, where same-host Perl produces all three. The entry mouth now declares
+/// itself `BalancedBoundary::Opaque`, which is what Perl's readBalanced
+/// (`Gullet.pm` L465-472, current mouth only) does for every mouth.
+///
+/// Ground truth for the assertions is same-host Perl on the same fixture: all
+/// three keys present, and the runaway title truncated at the `%` to "Fifty".
+#[test]
+fn runaway_field_costs_only_its_own_entry() {
+  // `init` is process-global and the sibling test in this target may have won
+  // the race; either outcome is fine here.
+  let _ = latexml_core::util::logger::init(log::LevelFilter::Warn);
+  let opts = Config {
+    format: OutputFormat::XML,
+    mode: Some(DigestionMode::BibTeX),
+    ..Config::default()
+  };
+  let mut converter = Converter::from_config(opts);
+  converter.initialize_session().expect("can initialize");
+  let resp = converter.convert("tests/bibtex/runaway_field.bib".to_string());
+  let Some(doc) = resp.result.as_ref() else {
+    panic!(
+      "BibTeX conversion produced no document. status={} ({})",
+      resp.status_code, resp.status
+    );
+  };
+  let s = doc.to_string();
+
+  for key in ["before", "runawaytitle", "after"] {
+    assert!(
+      s.contains(&format!("key=\"{key}\"")),
+      "entry '{key}' was lost — a runaway field must not take other entries \
+       with it (same-host Perl keeps all three). Got:\n{s}"
+    );
+  }
+  // The entries that carry no runaway must be intact, not merely present.
+  assert!(
+    s.contains("Entry after the runaway"),
+    "the entry FOLLOWING the runaway lost its title, so the runaway is still \
+     consuming past its own mouth. Got:\n{s}"
+  );
+  // And the damaged entry is damaged exactly as far as Perl's is: the title is
+  // truncated at the `%`, the rest of that line gone.
+  assert!(
+    s.contains("<bib-title>Fifty</bib-title>"),
+    "expected the runaway title truncated at the `%` (same as Perl), got:\n{s}"
+  );
+}

--- a/latexml_oxide/tests/55_bibtex.rs
+++ b/latexml_oxide/tests/55_bibtex.rs
@@ -117,17 +117,24 @@ fn bibtex_mode_emits_bibentries() {
 /// runs away. Both engines mis-read the field — that is parity, and real
 /// bibtex+pdflatex break on it too, so it is deliberately NOT corrected here.
 ///
-/// What was Rust-only was the blast radius. `read_balanced` used to treat every
-/// autoclose literal mouth as a token-level continuation of its parent
-/// (`gullet.rs`, the xint `\scantokens` divergence), so the runaway crossed out
-/// of the entry mouth and swallowed every following `\ProcessBibTeXEntry` AND
-/// `\end{bibtex@bibliography}`: a 3-entry `.bib` produced ONE entry and a single
-/// error, where same-host Perl produces all three. The entry mouth now declares
-/// itself `BalancedBoundary::Opaque`, which is what Perl's readBalanced
-/// (`Gullet.pm` L465-472, current mouth only) does for every mouth.
+/// What was Rust-only was the blast radius, and it had two independent causes —
+/// hence the two runaway entries in the fixture, which fail by different routes:
+///
+/// * **`{}`-read argument** (`\bib@@title`). `read_balanced` used to treat every
+///   autoclose literal mouth as a token-level continuation of its parent
+///   (`gullet.rs`, the xint `\scantokens` divergence), so the runaway crossed out
+///   of the entry mouth and swallowed every following `\ProcessBibTeXEntry` AND
+///   `\end{bibtex@bibliography}`. The entry mouth now declares itself
+///   `BalancedBoundary::Opaque`, which is what Perl's readBalanced (`Gullet.pm`
+///   L465-472, current mouth only) does for every mouth.
+/// * **`Digested` argument** (`\bib@@field`). The group opened by `{` is never
+///   closed, so the argument digestion runs to EOF; `readDigested` then `pop`s
+///   the last box to strip the closing brace, but `digest_next_body` was pushing
+///   Perl's EOF trailer box (`Stomach.pm` L130) only for a body that had read no
+///   token at all, so the `pop` ate real content — every following entry.
 ///
 /// Ground truth for the assertions is same-host Perl on the same fixture: all
-/// three keys present, and the runaway title truncated at the `%` to "Fifty".
+/// four keys present, and the runaway title truncated at the `%` to "Fifty".
 #[test]
 fn runaway_field_costs_only_its_own_entry() {
   // `init` is process-global and the sibling test in this target may have won
@@ -149,11 +156,11 @@ fn runaway_field_costs_only_its_own_entry() {
   };
   let s = doc.to_string();
 
-  for key in ["before", "runawaytitle", "after"] {
+  for key in ["before", "runawaytitle", "runawaynote", "after"] {
     assert!(
       s.contains(&format!("key=\"{key}\"")),
       "entry '{key}' was lost — a runaway field must not take other entries \
-       with it (same-host Perl keeps all three). Got:\n{s}"
+       with it (same-host Perl keeps all four). Got:\n{s}"
     );
   }
   // The entries that carry no runaway must be intact, not merely present.

--- a/latexml_oxide/tests/bibtex/runaway_field.bib
+++ b/latexml_oxide/tests/bibtex/runaway_field.bib
@@ -1,0 +1,28 @@
+% A `.bib` whose middle entry contains a bare `%` in a field.
+%
+% BibTeX has NO comment syntax inside an entry, so this is literal data — but
+% `\ProcessBibTeXEntry` hands the entry to a Mouth as TeX SOURCE (Perl
+% `BibTeX.pool.ltxml` L165-166), where `%` is catcode 14 and comments out the
+% rest of the line, closing brace included. Both engines therefore mis-read the
+% field, and so does real bibtex+pdflatex — that part is parity and is
+% deliberately not corrected.
+%
+% What is NOT parity is the blast radius, which is what this fixture pins:
+% `before` and `after` must survive the entry that ran away.
+@misc{before,
+  author = {Able, Ann},
+  title  = {Entry Before The Runaway},
+  year   = {2023}
+}
+
+@misc{runawaytitle,
+  author = {Poe, Percy},
+  title  = {Fifty % of the time},
+  year   = {2024}
+}
+
+@misc{after,
+  author = {Zed, Zoe},
+  title  = {Entry After The Runaway},
+  year   = {2025}
+}

--- a/latexml_oxide/tests/bibtex/runaway_field.bib
+++ b/latexml_oxide/tests/bibtex/runaway_field.bib
@@ -1,4 +1,4 @@
-% A `.bib` whose middle entry contains a bare `%` in a field.
+% A `.bib` whose fields contain a bare `%`.
 %
 % BibTeX has NO comment syntax inside an entry, so this is literal data — but
 % `\ProcessBibTeXEntry` hands the entry to a Mouth as TeX SOURCE (Perl
@@ -7,18 +7,33 @@
 % field, and so does real bibtex+pdflatex — that part is parity and is
 % deliberately not corrected.
 %
-% What is NOT parity is the blast radius, which is what this fixture pins:
-% `before` and `after` must survive the entry that ran away.
+% What is NOT parity is the blast radius. The point of this fixture is that the
+% damage stays inside the entry that caused it: `before` and `after` must
+% survive, whichever field the runaway sits in.
 @misc{before,
   author = {Able, Ann},
   title  = {Entry Before The Runaway},
   year   = {2023}
 }
 
+% Runaway inside a `{}`-read macro argument (`\bib@@title`, BibTeX.pool L293).
+% Fixed by the entry mouth being opaque to a balanced read.
 @misc{runawaytitle,
   author = {Poe, Percy},
   title  = {Fifty % of the time},
   year   = {2024}
+}
+
+% Runaway inside a `Digested` argument (`\bib@@field`, BibTeX.pool L230) — a
+% different mechanism: the group opened by `{` is never closed, so the argument
+% digestion runs to EOF and `readDigested`'s `pop` (which is meant to drop the
+% closing-brace box) ate real content instead, for want of the EOF trailer box
+% Perl pushes at `Stomach.pm` L130.
+@misc{runawaynote,
+  author = {Quill, Quinn},
+  title  = {Has A Runaway Note},
+  year   = {2024},
+  note   = {plain % comment}
 }
 
 @misc{after,


### PR DESCRIPTION
**Diagnostic.** A bare `%` in a BibTeX field is literal data (BibTeX has no comment syntax inside an entry) but TeX source once `\ProcessBibTeXEntry` replays the entry through a Mouth, so the argument read runs away. Mis-reading the field is parity — real `bibtex`+pdflatex break on it too. The blast radius was not: Rust emptied the entire bibliography where same-host Perl renders every entry, **and reported fewer errors while doing it**. Two independent causes, found while prototyping the R5 MakeBibliography re-port.

**Approach.** (1) `read_balanced` crossed out of the entry mouth into the wrapper, swallowing every following `\ProcessBibTeXEntry` and `\end{bibtex@bibliography}` — a surpass-Perl divergence added for xint's `\scantokens`. `open_mouth_with` now takes an explicit `BalancedBoundary`; the bib entry mouth is `Opaque`, matching Perl (`Gullet.pm` L465-472 reads the current mouth only), and nothing else changes. (2) `digest_next_body` pushed Perl's EOF trailer box (`Stomach.pm` L130, `push(@LaTeXML::LIST, Box()) unless $token`) only when the body had read *no token at all* — strictly narrower than Perl's "the read returned undef" — so `readDigested`'s `pop`, meant to strip the closing-brace box, ate real content instead.

**Validation.** Guard `55_bibtex::runaway_field_costs_only_its_own_entry` covers both routes; ground truth is same-host Perl on the same fixture. Across eight probe shapes Rust now matches Perl's entry count exactly (1/1, 2/2, 3/3) and truncates the damaged field exactly as far as Perl does. Full suite 1699 passing / 0 failed across 94 targets; clippy `-D warnings` clean; fmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)