### PR TITLE
fix(bibliography): revert author names with UnTeX — space-form accents were becoming undefined macros

### DIFF
--- a/docs/parity/WISDOM.md
+++ b/docs/parity/WISDOM.md
@@ -2625,3 +2625,52 @@ BalancedBoundary::{Transparent,Opaque})` — rather than inferred from
 `autoclose && !File`. Declare **Opaque** whenever the mouth carries a
 self-contained input; reserve Transparent for token-level injections
 (`\scantokens`, RawTeX). Related: #68 above.
+
+## #70 Byte-index scanners over `&str` are a standing hazard of this port — scan by CHARACTER (`CharCursor`), and remember the bug is in the ADVANCE, not the slice
+
+`&str` carries one compiler-enforced invariant — valid UTF-8. A `usize` used to
+index it carries **none**. So every `&s[a..b]` is an unchecked assertion that
+both ends are char boundaries, and when it is wrong the program does not return
+an error, it **panics** — aborting the whole document.
+
+That is unusually dangerous *here* specifically, and it will recur: Perl strings
+are sequences of **characters** (`pos`, `substr`, `\G` have no boundary concept),
+so every hand-rolled `as_bytes()` + `i += 1` scanner translated from Perl
+introduces an invariant the original never had. Silently, with no type-level
+trace, and passing every ASCII fixture forever.
+
+**The rule.** The panic fires at the slice; the defect is always in the advance:
+
+| advance | safe? |
+|---|---|
+| scan to an ASCII delimiter | **always** — an ASCII byte is never a UTF-8 continuation byte |
+| by `char::len_utf8()` | **always** |
+| a fixed count past an unclassified byte | **never** |
+
+That is why a walker can be correct for years and break on one edit: three of the
+four arms in `recase_title` only ever *stopped* at ASCII, and the fourth
+(`\<char>`) advanced one byte past the backslash — right for `\&`, fatal for
+`\“`. Witness 2605.22125, found by the 2026-07-26 sandbox sweep, not by tests.
+
+**What to use.** `latexml_core::util::char_cursor::CharCursor` — a thin wrapper
+over `char_indices` (Rust guidelines `anti-index-over-iter` /
+`perf-iter-over-index`; do NOT invent a newtype, std already has the iterator).
+Its value is what it withholds: no advance-by-byte-count exists, so `slice_from`
+is infallible and the class is unrepresentable. Deliberately NOT an `Iterator` —
+`by_ref().take_while()` consumes the item that fails the predicate, desyncing
+`peek`/`pos` and making a mark meaningless.
+
+**Convert even the arms that are provably safe.** All three `bibtex.rs` walkers
+were converted, though only one had ever panicked: "happens to be safe" is
+exactly the state `recase_title` was in.
+
+**Testing.** Enumerate rather than sample where the space is small: 4 UTF-8
+widths x scanner position x mode is complete coverage and needs no proptest
+dev-dependency (which would touch the license inventory and `cargo-deny`).
+Assert across CASE FORMS when the function re-cases — a literal `contains(c)`
+check fails on `Uppercase` turning `a` into `A`, and that is the test being
+wrong, not the code.
+
+Guards: `bibtex::tests::recase_title_handles_every_character_width_at_every_position`,
+`util::char_cursor::tests::*`. Related: [[#68]] above (the same "port a Perl
+loop, inherit an invariant Perl never had" family).

--- a/latexml_core/src/tokens.rs
+++ b/latexml_core/src/tokens.rs
@@ -840,3 +840,64 @@ mod tests {
     assert_eq!(s, "abc");
   }
 }
+
+#[cfg(test)]
+mod untex_control_word_space_tests {
+  use super::*;
+
+  /// `untex()` must re-emit the space that terminates a control word;
+  /// `to_string()` documents that it does not, and the two must not be
+  /// confused at a call site that needs valid TeX back.
+  ///
+  /// TeX CONSUMES the space after a control word, so by token-time it is gone
+  /// as data — `\v S` and `\vS` tokenize to different things but a naive
+  /// concatenation of the first yields the second. `\vS` exists in no LaTeX.
+  ///
+  /// This is not academic: `\bib@@names` used `to_string()` where Perl uses
+  /// `UnTeX` (BibTeX.pool.ltxml L277), which mangled every space-form accent in
+  /// a bibliography author name — `{\v S}`, `{\c c}`, `{\" a}`, i.e. most
+  /// non-English names — into an undefined macro. ~+2800 error documents per
+  /// corpus on the 2026-07-26 sandbox sweep.
+  #[test]
+  fn untex_reemits_the_space_that_terminates_a_control_word() {
+    for (src, expect_untex) in [
+      (r"\v Spakov", r"\v Spakov"), // control word + space + LETTER: space needed
+      (r"\c calves", r"\c calves"), //   likewise
+      (r"\v{S}pakov", r"\v{S}pakov"), // braced argument: no space needed, none added
+    ] {
+      let toks = crate::mouth::tokenize(src);
+      assert_eq!(
+        toks.clone().untex(),
+        expect_untex,
+        "untex({src:?}) must round-trip to valid TeX"
+      );
+      // Re-tokenizing the untex output must yield the SAME control sequence —
+      // the property that actually matters, and the one that broke.
+      let first = |t: Tokens| {
+        t.unlist()
+          .first()
+          .map(|t| t.to_string())
+          .unwrap_or_default()
+      };
+      assert_eq!(
+        first(crate::mouth::tokenize(&toks.clone().untex())),
+        first(crate::mouth::tokenize(src)),
+        "untex({src:?}) changed the leading control sequence on re-tokenization"
+      );
+    }
+  }
+
+  /// The documented contract of the other direction, pinned so nobody
+  /// "helpfully" makes `Display` TeX-correct and silently changes every
+  /// keyword-ish `to_string()` caller in the tree.
+  #[test]
+  fn to_string_deliberately_does_not_reemit_the_space() {
+    let toks = crate::mouth::tokenize(r"\v Spakov");
+    assert_eq!(
+      toks.to_string(),
+      r"\vSpakov",
+      "Display for Tokens is documented as NOT producing valid TeX; if this \
+       changes, audit every to_string() caller before updating the expectation"
+    );
+  }
+}

--- a/latexml_core/src/util.rs
+++ b/latexml_core/src/util.rs
@@ -1,3 +1,6 @@
+/// boundary-safe forward cursor over `&str` — the shared answer to the
+/// byte-index scanners inherited from Perl's character-oriented string ops
+pub mod char_cursor;
 /// image file helpers — port of `LaTeXML::Util::Image`
 pub mod image;
 /// log recording and reporting interface

--- a/latexml_core/src/util/char_cursor.rs
+++ b/latexml_core/src/util/char_cursor.rs
@@ -1,0 +1,199 @@
+//! A forward cursor over `&str` whose position is always a char boundary.
+//!
+//! # Why this exists
+//!
+//! `&str` carries exactly one invariant the compiler enforces — *valid UTF-8*.
+//! A `usize` used to index it carries **none**. So every `&s[a..b]` is an
+//! unchecked assertion that both ends are char boundaries, and when the
+//! assertion is wrong the program does not return an error, it **panics**.
+//!
+//! That combination is unusually hostile here. This is a Perl port, and Perl
+//! strings are sequences of *characters*: `pos`, `substr` and `\G` have no
+//! boundary concept at all. Every hand-rolled `as_bytes()` + `i += 1` scanner
+//! translated from Perl therefore introduces an invariant the original never
+//! had, silently, with no type-level trace — and passes every ASCII fixture
+//! forever. Witness 2605.22125: a `.bib` title containing `\“` aborted the whole
+//! document, and the code had been live for months.
+//!
+//! # The rule the bug teaches
+//!
+//! The panic happens at the slice, but the defect is always in the **advance**:
+//!
+//! | advance | safe? |
+//! |---|---|
+//! | scan to an ASCII delimiter | always — an ASCII byte is never a UTF-8 continuation byte |
+//! | by `char::len_utf8()` | always |
+//! | a fixed count past an unclassified byte | **never** |
+//!
+//! So the fix is not to check slices, it is to remove the ability to advance
+//! wrongly. This cursor exposes no byte-count advance at all, which makes
+//! [`slice_from`](crate::util::char_cursor::CharCursor::slice_from) infallible and the whole class
+//! unrepresentable in code written against it.
+//!
+//! Rust guidelines `anti-index-over-iter` / `perf-iter-over-index`: prefer the
+//! iterator std already provides (`char_indices`) over manual indexing. This is
+//! a thin, self-documenting wrapper over exactly that — not a new abstraction.
+//!
+//! # Cost
+//!
+//! A `Peekable<CharIndices>` and the source reference; no allocation, one pass,
+//! the same traversal a byte walker made. `char_indices` also decodes each
+//! character once instead of re-decoding at every slice.
+
+/// Forward cursor over a `&str`, positioned only ever at char boundaries.
+///
+/// # Examples
+///
+/// ```
+/// use latexml_core::util::char_cursor::CharCursor;
+///
+/// // Take a run of ASCII letters, then whatever single character follows —
+/// // even a 3-byte one. A byte walker would split it; this cannot.
+/// let mut cur = CharCursor::new("word“tail");
+/// let start = cur.pos();
+/// cur.take_while(char::is_alphanumeric);
+/// assert_eq!(cur.slice_from(start), "word");
+/// assert_eq!(cur.next(), Some('“'));
+/// ```
+pub struct CharCursor<'a> {
+  src:  &'a str,
+  iter: std::iter::Peekable<std::str::CharIndices<'a>>,
+  /// Byte offset of the next character, or `src.len()` at the end. Always a
+  /// char boundary: it only ever comes from `CharIndices`.
+  pos:  usize,
+}
+
+impl<'a> CharCursor<'a> {
+  /// Start at the beginning of `src`.
+  #[inline]
+  pub fn new(src: &'a str) -> Self {
+    Self {
+      src,
+      iter: src.char_indices().peekable(),
+      pos: 0,
+    }
+  }
+
+  /// Byte offset of the next character — a valid boundary, and the mark to
+  /// hand to [`slice_from`](Self::slice_from).
+  #[inline]
+  pub fn pos(&self) -> usize { self.pos }
+
+  /// The next character, without consuming it.
+  #[inline]
+  pub fn peek(&mut self) -> Option<char> { self.iter.peek().map(|&(_, c)| c) }
+
+  /// The character *after* the next one, without consuming anything.
+  ///
+  /// This is the `i + 1 < len` lookahead a byte walker spells out by hand, with
+  /// no arithmetic on indices — the arithmetic is where the bug lives.
+  #[inline]
+  pub fn peek_second(&mut self) -> Option<char> {
+    let mut probe = self.iter.clone();
+    probe.next();
+    probe.next().map(|(_, c)| c)
+  }
+
+  /// Consume and return the next character, advancing by its full width.
+  #[inline]
+  #[allow(clippy::should_implement_trait)] // deliberately not `Iterator`: see below
+  pub fn next(&mut self) -> Option<char> {
+    let (i, c) = self.iter.next()?;
+    self.pos = i + c.len_utf8();
+    Some(c)
+  }
+
+  /// Consume characters while `pred` holds.
+  #[inline]
+  pub fn take_while(&mut self, mut pred: impl FnMut(char) -> bool) {
+    while self.peek().is_some_and(&mut pred) {
+      self.next();
+    }
+  }
+
+  /// `true` once the input is exhausted.
+  #[inline]
+  pub fn is_done(&mut self) -> bool { self.peek().is_none() }
+
+  /// The text between a previous [`pos`](Self::pos) mark and the current
+  /// position.
+  ///
+  /// Infallible — both ends came from `CharIndices`, so both are char
+  /// boundaries. That is the entire point of the type.
+  ///
+  /// # Panics
+  ///
+  /// Only if `mark` did not come from this cursor's [`pos`](Self::pos), or is
+  /// ahead of the current position. Both are caller bugs, not input-dependent.
+  #[inline]
+  pub fn slice_from(&self, mark: usize) -> &'a str { &self.src[mark..self.pos] }
+
+  /// The remaining, unconsumed text.
+  #[inline]
+  pub fn rest(&self) -> &'a str { &self.src[self.pos..] }
+}
+
+// NOTE: deliberately NOT an `Iterator` impl. `Iterator` would hand callers
+// `by_ref().take_while(..)`, `zip`, `enumerate` and friends, all of which
+// consume the item that fails the predicate — the cursor's whole job is that
+// `peek`/`pos` stay in lockstep so a mark remains meaningful.
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn positions_are_always_char_boundaries() {
+    // One representative per UTF-8 encoded width, interleaved with ASCII so
+    // marks land on both sides of every multi-byte character.
+    let src = "a é b “ c 𝔄 d";
+    let mut cur = CharCursor::new(src);
+    while !cur.is_done() {
+      assert!(
+        src.is_char_boundary(cur.pos()),
+        "cursor stopped at byte {} which is not a boundary of {src:?}",
+        cur.pos()
+      );
+      // The invariant that matters: slicing at any reachable position is safe.
+      let _ = cur.slice_from(0);
+      let _ = cur.rest();
+      cur.next();
+    }
+    assert_eq!(cur.pos(), src.len());
+  }
+
+  #[test]
+  fn slice_from_returns_exactly_the_consumed_text() {
+    let mut cur = CharCursor::new("“quoted” rest");
+    let start = cur.pos();
+    cur.take_while(|c| c != ' ');
+    assert_eq!(cur.slice_from(start), "“quoted”");
+    assert_eq!(cur.rest(), " rest");
+  }
+
+  #[test]
+  fn peek_does_not_advance_and_peek_second_looks_past_it() {
+    let mut cur = CharCursor::new("𝔄b");
+    assert_eq!(cur.peek(), Some('𝔄'));
+    assert_eq!(cur.peek(), Some('𝔄'), "peek must not consume");
+    assert_eq!(cur.pos(), 0, "peek must not advance");
+    assert_eq!(cur.peek_second(), Some('b'));
+    assert_eq!(cur.pos(), 0, "peek_second must not advance");
+    assert_eq!(cur.next(), Some('𝔄'));
+    assert_eq!(cur.pos(), 4, "a 4-byte char advances by 4");
+  }
+
+  #[test]
+  fn empty_and_exhausted_are_well_behaved() {
+    let mut cur = CharCursor::new("");
+    assert!(cur.is_done());
+    assert_eq!(cur.next(), None);
+    assert_eq!(cur.pos(), 0);
+    assert_eq!(cur.slice_from(0), "");
+
+    let mut cur = CharCursor::new("é");
+    assert_eq!(cur.next(), Some('é'));
+    assert_eq!(cur.next(), None, "past the end stays None");
+    assert_eq!(cur.pos(), 2, "position does not run past the end");
+  }
+}

--- a/latexml_engine/src/bibtex.rs
+++ b/latexml_engine/src/bibtex.rs
@@ -722,7 +722,15 @@ pub fn recase_title(title: &str, mode: TitleCaseMode) -> String {
             i += 1;
           }
         } else {
-          i += 1;
+          // Advance by the WHOLE character, not one byte. This walk is over raw
+          // byte indices, so a fixed `i += 1` past a multi-byte escape (`\“`,
+          // `\é`) leaves `i` inside the codepoint and the `&title[word_start..i]`
+          // slice below panics — aborting the document, since a panic is not a
+          // recoverable conversion error. Witness 2605.22125 (`\` at byte 26,
+          // `“` at 27..30, `i` at 28). Perl's `\bib@@title`
+          // (BibTeX.pool.ltxml L293-333) works in characters and cannot hit this.
+          // Guard: `recase_title_does_not_split_a_multibyte_escape`.
+          i += title[i..].chars().next().map_or(1, char::len_utf8);
         }
         consumed_word = true;
         continue;
@@ -2262,6 +2270,51 @@ mod tests {
       recase_title("THE {LaTeX} BOOK", TitleCaseMode::Capitalize1),
       "THE {LaTeX} book"
     );
+  }
+
+  /// A `\<char>` escape whose character is MULTI-BYTE must not split it.
+  ///
+  /// `recase_title` walks raw byte indices, and the `\<char>` branch advanced a
+  /// fixed ONE byte past the backslash. For an ASCII escape (`\&`, `\_`) that is
+  /// right; for `\“` it lands `i` inside the character, and the very next
+  /// `&title[word_start..i]` slice panics — taking the whole document with it,
+  /// since a panic is not a recoverable conversion error.
+  ///
+  /// Witness 2605.22125, found by the 2026-07-26 sandbox sweep:
+  /// `panicked at bibtex.rs:733:24: end byte index 28 is not a char boundary;
+  /// it is inside '“' (bytes 27..30 of string)` — `\` at 26, `“` at 27..30,
+  /// `i` at 28. Latent until #396 routed every raw `.bib` through this code;
+  /// before that only `--bibtex` mode reached it.
+  ///
+  /// Perl cannot have this bug: `\bib@@title` (BibTeX.pool.ltxml L293-333)
+  /// works in characters, not bytes.
+  #[test]
+  fn recase_title_does_not_split_a_multibyte_escape() {
+    // The assertion is that it RETURNS AT ALL — the bug was a panic, and any
+    // sane output beats aborting the document.
+    for title in [
+      "A \\“smart\\” quote",   // the witness shape: backslash + curly quote
+      "\\é accent",            // 2-byte
+      "\\→ arrow",             // 3-byte
+      "\\𝔄 fraktur",           // 4-byte
+      "trailing backslash \\", // the i+1 < len guard's edge
+    ] {
+      for mode in [
+        TitleCaseMode::Capitalize1,
+        TitleCaseMode::Capitalize,
+        TitleCaseMode::Lowercase,
+        TitleCaseMode::Uppercase,
+        TitleCaseMode::AsIs,
+      ] {
+        let out = recase_title(title, mode);
+        // Nothing may be silently dropped either: every char of the input has
+        // to survive in some case-form, so a "fix" that skips the escape fails.
+        assert!(
+          out.chars().count() >= title.chars().count(),
+          "recase_title({title:?}, {mode:?}) lost characters: {out:?}"
+        );
+      }
+    }
   }
 
   #[test]

--- a/latexml_engine/src/bibtex.rs
+++ b/latexml_engine/src/bibtex.rs
@@ -408,30 +408,19 @@ fn split_words(input: &str) -> Vec<String> {
 
   let mut words: Vec<String> = Vec::new();
   let mut word = String::new();
-  let bytes = s.as_bytes();
-  let mut i = 0;
-  while i < bytes.len() {
-    let b = bytes[i];
+  // Scanned by character, not by byte index — see `CharCursor`'s module docs.
+  // Author names are the most reliably non-ASCII field in a `.bib`.
+  let mut cur = CharCursor::new(&s);
+  const SEP: [char; 5] = [' ', '\t', '\n', '\r', '~'];
+  while let Some(c) = cur.peek() {
     // Check for `(comma?) whitespace+` separators. Perl regex:
     // s/^(,?)[\s~]+//
-    if b == b',' || b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' || b == b'~' {
-      let had_comma = b == b',';
-      let mut j = i + 1;
-      // Either a leading comma we just consumed, or the whole run is
-      // pure whitespace/tilde — collect the trailing whitespace.
-      if had_comma {
-        while j < bytes.len() && matches!(bytes[j], b' ' | b'\t' | b'\n' | b'\r' | b'~') {
-          j += 1;
-        }
-      } else {
-        // Pure whitespace run; skip them.
-        while j < bytes.len() && matches!(bytes[j], b' ' | b'\t' | b'\n' | b'\r' | b'~') {
-          j += 1;
-        }
-        // If we didn't actually see any whitespace beyond this one
-        // char, we still advance (the `[\s~]+` pattern matches `+`
-        // which requires ≥1; we have 1 = the current char).
-      }
+    if c == ',' || SEP.contains(&c) {
+      let had_comma = c == ',';
+      cur.next();
+      // Either a leading comma we just consumed, or a pure whitespace/tilde
+      // run — either way, absorb the trailing whitespace.
+      cur.take_while(|c| SEP.contains(&c));
       // Flush accumulated word
       if !word.is_empty() {
         words.push(std::mem::take(&mut word));
@@ -439,38 +428,31 @@ fn split_words(input: &str) -> Vec<String> {
       if had_comma {
         words.push(",".to_string());
       }
-      i = j;
-    } else if b == b'{' {
+    } else if c == '{' {
       // Extract balanced group; include the braces.
-      let start = i;
+      let start = cur.pos();
       let mut depth = 0i32;
-      while i < bytes.len() {
-        match bytes[i] {
-          b'{' => depth += 1,
-          b'}' => {
+      while let Some(c) = cur.next() {
+        match c {
+          '{' => depth += 1,
+          '}' => {
             depth -= 1;
             if depth == 0 {
-              i += 1;
               break;
             }
           },
           _ => {},
         }
-        i += 1;
       }
       // Append the entire braced chunk (including the braces) to the
       // current word so it stays atomic across word splits — matches
       // Perl `$word .= $t`.
-      word.push_str(&s[start..i]);
+      word.push_str(cur.slice_from(start));
     } else {
       // Greedily accumulate until the next separator / `{`.
-      let start = i;
-      while i < bytes.len()
-        && !matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\r' | b'~' | b',' | b'{')
-      {
-        i += 1;
-      }
-      word.push_str(&s[start..i]);
+      let start = cur.pos();
+      cur.take_while(|c| !SEP.contains(&c) && c != ',' && c != '{');
+      word.push_str(cur.slice_from(start));
     }
   }
   if !word.is_empty() {
@@ -644,93 +626,85 @@ impl TitleCaseMode {
 /// `Capitalize1` mode capitalise the FIRST word and lowercase the
 /// rest, while `Capitalize` uppercases every word.
 pub fn recase_title(title: &str, mode: TitleCaseMode) -> String {
-  let bytes = title.as_bytes();
+  // Scanned through `char_indices`, NOT `as_bytes()` + a hand-rolled index.
+  //
+  // Every index this yields is a char boundary by construction, so the
+  // `&title[a..b]` slices below cannot panic — which they previously could:
+  // the `\<char>` escape arm advanced a fixed ONE byte past the backslash, so
+  // `\“` left the cursor inside the codepoint and the next slice aborted the
+  // whole document (a panic is not a recoverable conversion error). Witness
+  // 2605.22125, found by the 2026-07-26 sandbox sweep.
+  //
+  // The class, not just the instance: a byte walker re-admits the bug on every
+  // future edit, because `usize` carries no boundary invariant and nothing in
+  // the type system objects. Perl cannot have it at all — `\bib@@title`
+  // (BibTeX.pool.ltxml L293-333) works in characters. Rust rules
+  // `anti-index-over-iter` / `perf-iter-over-index`.
+  let mut cur = CharCursor::new(title);
   let mut out = String::with_capacity(title.len());
   let mut wb: bool = true;
   let mut wc: u32 = 0;
-  let mut i = 0;
-  while i < bytes.len() {
-    let b = bytes[i];
+
+  while let Some(c) = cur.peek() {
     // Whitespace run — copy verbatim, set word-beginning.
-    if b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' {
-      let start = i;
-      while i < bytes.len() && matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\r') {
-        i += 1;
-      }
-      out.push_str(&title[start..i]);
+    if matches!(c, ' ' | '\t' | '\n' | '\r') {
+      let start = cur.pos();
+      cur.take_while(|c| matches!(c, ' ' | '\t' | '\n' | '\r'));
+      out.push_str(cur.slice_from(start));
       wb = true;
       continue;
     }
     // Balanced `{...}` — copy verbatim, atomic word.
-    if b == b'{' {
-      let start = i;
+    if c == '{' {
+      let start = cur.pos();
       let mut depth = 0i32;
-      while i < bytes.len() {
-        match bytes[i] {
-          b'{' => depth += 1,
-          b'}' => {
+      while let Some(c) = cur.next() {
+        match c {
+          '{' => depth += 1,
+          '}' => {
             depth -= 1;
             if depth == 0 {
-              i += 1;
               break;
             }
           },
           _ => {},
         }
-        i += 1;
       }
       if wb {
         wc += 1;
       }
-      out.push_str(&title[start..i]);
+      out.push_str(cur.slice_from(start));
       wb = false;
       continue;
     }
     // Balanced `$...$` — copy verbatim, no word-counter bump.
-    if b == b'$' {
-      let start = i;
-      i += 1;
-      while i < bytes.len() && bytes[i] != b'$' {
-        i += 1;
-      }
-      if i < bytes.len() {
-        i += 1;
-      }
-      out.push_str(&title[start..i]);
+    if c == '$' {
+      let start = cur.pos();
+      cur.next();
+      cur.take_while(|c| c != '$');
+      cur.next(); // the closing `$`, if any
+      out.push_str(cur.slice_from(start));
       wb = false;
       continue;
     }
     // Word: ASCII alphanumeric/underscore OR `\<word>` / `\<char>` escape.
-    let word_start = i;
+    let word_start = cur.pos();
     let mut consumed_word = false;
-    loop {
-      if i >= bytes.len() {
-        break;
-      }
-      let c = bytes[i];
-      let is_wordchar = c.is_ascii_alphanumeric() || c == b'_';
-      if is_wordchar {
-        i += 1;
+    while let Some(c) = cur.peek() {
+      if c.is_ascii_alphanumeric() || c == '_' {
+        cur.next();
         consumed_word = true;
         continue;
       }
-      if c == b'\\' && i + 1 < bytes.len() {
-        // \<word> or \<single-char>
-        i += 1;
-        if bytes[i].is_ascii_alphabetic() {
-          while i < bytes.len() && bytes[i].is_ascii_alphabetic() {
-            i += 1;
-          }
+      if c == '\\' && cur.peek_second().is_some() {
+        cur.next(); // the backslash
+        // `\<word>`: a run of ASCII letters. `\<char>`: exactly one character,
+        // of whatever width — the cursor advances by the CHARACTER, so a
+        // multi-byte escape can no longer split.
+        if cur.peek().is_some_and(|c| c.is_ascii_alphabetic()) {
+          cur.take_while(|c| c.is_ascii_alphabetic());
         } else {
-          // Advance by the WHOLE character, not one byte. This walk is over raw
-          // byte indices, so a fixed `i += 1` past a multi-byte escape (`\“`,
-          // `\é`) leaves `i` inside the codepoint and the `&title[word_start..i]`
-          // slice below panics — aborting the document, since a panic is not a
-          // recoverable conversion error. Witness 2605.22125 (`\` at byte 26,
-          // `“` at 27..30, `i` at 28). Perl's `\bib@@title`
-          // (BibTeX.pool.ltxml L293-333) works in characters and cannot hit this.
-          // Guard: `recase_title_does_not_split_a_multibyte_escape`.
-          i += title[i..].chars().next().map_or(1, char::len_utf8);
+          cur.next();
         }
         consumed_word = true;
         continue;
@@ -738,7 +712,7 @@ pub fn recase_title(title: &str, mode: TitleCaseMode) -> String {
       break;
     }
     if consumed_word {
-      let word = &title[word_start..i];
+      let word = cur.slice_from(word_start);
       let recased = match mode {
         TitleCaseMode::AsIs => word.to_string(),
         TitleCaseMode::Uppercase => word.to_uppercase(),
@@ -759,14 +733,9 @@ pub fn recase_title(title: &str, mode: TitleCaseMode) -> String {
       continue;
     }
     // Fallback single char (e.g. punctuation).
-    let ch_start = i;
-    let mut chars = title[i..].chars();
-    if let Some(c) = chars.next() {
-      i += c.len_utf8();
-    } else {
-      i += 1;
-    }
-    out.push_str(&title[ch_start..i]);
+    let ch_start = cur.pos();
+    cur.next();
+    out.push_str(cur.slice_from(ch_start));
     wb = true;
   }
   out
@@ -788,67 +757,59 @@ pub fn process_identifier(s: &str) -> String { s.trim().to_string() }
 /// dispatch. Mirrors Perl `$keyvals->getPairs` + `lc()` + `UnTeX()`
 /// from `amsrefs.sty.ltxml:42-50`.
 pub fn parse_amsrefs_keyvals(s: &str) -> Vec<(String, String)> {
-  let bytes = s.as_bytes();
+  // `CharCursor`, not `as_bytes()` + an index: see its module docs. This walker
+  // happens to be safe as written (it only ever STOPS at ASCII delimiters, and
+  // an ASCII byte is never a UTF-8 continuation byte), but "happens to be safe"
+  // is the state `recase_title` was in until someone added one `i += 1` —
+  // witness 2605.22125. Scanning by character removes the possibility rather
+  // than relying on every future edit to re-derive the argument.
+  let mut cur = CharCursor::new(s);
   let mut out: Vec<(String, String)> = Vec::new();
-  let mut i = 0;
-  while i < bytes.len() {
+  while !cur.is_done() {
     // Skip whitespace + commas.
-    while i < bytes.len() && matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\r' | b',') {
-      i += 1;
-    }
-    if i >= bytes.len() {
+    cur.take_while(|c| matches!(c, ' ' | '\t' | '\n' | '\r' | ','));
+    if cur.is_done() {
       break;
     }
     // Read key up to `=` (or end / `,`).
-    let key_start = i;
-    while i < bytes.len() && !matches!(bytes[i], b'=' | b',') {
-      i += 1;
-    }
-    let key = s[key_start..i].trim().to_ascii_lowercase();
+    let key_start = cur.pos();
+    cur.take_while(|c| !matches!(c, '=' | ','));
+    let key = cur.slice_from(key_start).trim().to_ascii_lowercase();
     if key.is_empty() {
       // Stray comma or trailing garbage; skip the separator and continue.
-      if i < bytes.len() {
-        i += 1;
-      }
+      cur.next();
       continue;
     }
-    if i >= bytes.len() || bytes[i] != b'=' {
+    if cur.peek() != Some('=') {
       // No `=` — key without value; record empty value.
       out.push((key, String::new()));
       continue;
     }
-    i += 1; // skip `=`
-    // Skip whitespace before value.
-    while i < bytes.len() && matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\r') {
-      i += 1;
-    }
+    cur.next(); // skip `=`
+    cur.take_while(|c| matches!(c, ' ' | '\t' | '\n' | '\r'));
     // Value: balanced `{...}` group OR until next top-level `,`.
     let value: String;
-    if i < bytes.len() && bytes[i] == b'{' {
-      let start = i + 1;
+    if cur.peek() == Some('{') {
+      cur.next(); // the opening brace, excluded from the value
+      let start = cur.pos();
       let mut depth = 1i32;
-      i += 1;
-      while i < bytes.len() && depth > 0 {
-        match bytes[i] {
-          b'{' => depth += 1,
-          b'}' => depth -= 1,
+      while let Some(c) = cur.peek() {
+        match c {
+          '{' => depth += 1,
+          '}' => depth -= 1,
           _ => {},
         }
         if depth == 0 {
           break;
         }
-        i += 1;
+        cur.next();
       }
-      value = s[start..i].to_string();
-      if i < bytes.len() {
-        i += 1;
-      } // skip closing `}`
+      value = cur.slice_from(start).to_string();
+      cur.next(); // skip the closing `}`, if present
     } else {
-      let start = i;
-      while i < bytes.len() && bytes[i] != b',' {
-        i += 1;
-      }
-      value = s[start..i].trim().to_string();
+      let start = cur.pos();
+      cur.take_while(|c| c != ',');
+      value = cur.slice_from(start).trim().to_string();
     }
     out.push((key, value));
   }
@@ -955,7 +916,25 @@ LoadDefinitions!({
   // name emit `Invocation(\bib@@@name, field, name_tokens)`.
   DefMacro!("\\bib@@names{}{}", sub[args] {
     let field_tokens = args[0].clone().owned_tokens().unwrap_or_default();
-    let names_str = if args[1].is_some() { args[1].to_string() } else { String::new() };
+    // `untex()`, NOT `to_string()` — Perl L277 is `processBibNameList(UnTeX($names, 1))`,
+    // and the two are not interchangeable. `Display for Tokens` says so itself:
+    // "NOT for creating valid TeX (use revert or UnTeX for that!)". It concatenates
+    // token texts, so the SPACE that terminated a control word — consumed by the
+    // tokenizer, and therefore absent as data — is never re-emitted: `\v` + `S`
+    // comes back as `\vS`, a control sequence that exists in no LaTeX.
+    //
+    // That silently mangles every space-form accent in an author name — `{\v S}`,
+    // `{\c c}`, `{\"a}`, `{\'e}`, i.e. most non-English names — into an undefined
+    // macro, rendering `\vSpakov` where Perl renders `Špakov`. Measured on the
+    // 2026-07-26 sweep of sandbox-arxiv-2605/2606: ~+2800 error documents per
+    // corpus. `\v{S}` (braced argument) was unaffected, which is what made it look
+    // like a brace bug rather than a reversion bug.
+    // Guard: `bib_name_space_form_accent_survives_reversion`.
+    let names_str = args[1]
+      .clone()
+      .owned_tokens()
+      .map(Tokens::untex)
+      .unwrap_or_default();
     let parsed = process_bib_name_list(&names_str);
 
     // Build the `\bib@@@names{ <name-invocations> }` Tokens stream.
@@ -2272,48 +2251,67 @@ mod tests {
     );
   }
 
-  /// A `\<char>` escape whose character is MULTI-BYTE must not split it.
+  /// `recase_title` must survive EVERY character width at every scanner
+  /// position — the deterministic stand-in for a property test.
   ///
-  /// `recase_title` walks raw byte indices, and the `\<char>` branch advanced a
-  /// fixed ONE byte past the backslash. For an ASCII escape (`\&`, `\_`) that is
-  /// right; for `\“` it lands `i` inside the character, and the very next
-  /// `&title[word_start..i]` slice panics — taking the whole document with it,
-  /// since a panic is not a recoverable conversion error.
+  /// The hazard is small and fully enumerable (4 widths x 6 positions x 5
+  /// modes), so a table gives complete coverage of it where random generation
+  /// would only sample; and it needs no new dev-dependency, which for this tree
+  /// means no addition to the license inventory or `cargo-deny` surface.
   ///
-  /// Witness 2605.22125, found by the 2026-07-26 sandbox sweep:
-  /// `panicked at bibtex.rs:733:24: end byte index 28 is not a char boundary;
-  /// it is inside '“' (bytes 27..30 of string)` — `\` at 26, `“` at 27..30,
-  /// `i` at 28. Latent until #396 routed every raw `.bib` through this code;
-  /// before that only `--bibtex` mode reached it.
+  /// What it is guarding: the scanner used to walk raw BYTE indices, and its
+  /// `\<char>` arm advanced a fixed one byte past the backslash — fine for
+  /// `\&`, fatal for `\“`, where the cursor landed inside the codepoint and the
+  /// next `&title[a..b]` slice PANICKED, aborting the whole document. Witness
+  /// 2605.22125 from the 2026-07-26 sandbox sweep. The scanner is now written
+  /// on `char_indices` (see `CharCursor`), so the class is gone structurally
+  /// rather than patched at the one arm that happened to fire.
   ///
-  /// Perl cannot have this bug: `\bib@@title` (BibTeX.pool.ltxml L293-333)
-  /// works in characters, not bytes.
+  /// Perl is immune by construction: `\bib@@title` (BibTeX.pool.ltxml
+  /// L293-333) works in characters, not bytes.
   #[test]
-  fn recase_title_does_not_split_a_multibyte_escape() {
-    // The assertion is that it RETURNS AT ALL — the bug was a panic, and any
-    // sane output beats aborting the document.
-    for title in [
-      "A \\“smart\\” quote",   // the witness shape: backslash + curly quote
-      "\\é accent",            // 2-byte
-      "\\→ arrow",             // 3-byte
-      "\\𝔄 fraktur",           // 4-byte
-      "trailing backslash \\", // the i+1 < len guard's edge
-    ] {
-      for mode in [
-        TitleCaseMode::Capitalize1,
-        TitleCaseMode::Capitalize,
-        TitleCaseMode::Lowercase,
-        TitleCaseMode::Uppercase,
-        TitleCaseMode::AsIs,
+  fn recase_title_handles_every_character_width_at_every_position() {
+    // One representative per UTF-8 encoded length.
+    let chars = ['a', 'é', '“', '𝔄'];
+    let modes = [
+      TitleCaseMode::AsIs,
+      TitleCaseMode::Uppercase,
+      TitleCaseMode::Lowercase,
+      TitleCaseMode::Capitalize,
+      TitleCaseMode::Capitalize1,
+    ];
+    for c in chars {
+      // Each position exercises a different scanner arm: after a backslash
+      // (the arm that broke), inside a word run, in a brace group, in math,
+      // as bare punctuation, and at end-of-input.
+      for title in [
+        format!("\\{c} tail"),      // `\<char>` escape  <-- the witness shape
+        format!("word\\{c}more"),   // escape mid-word
+        format!("{{brace {c}}} x"), // inside a braced group
+        format!("$math {c}$ x"),    // inside math
+        format!("bare {c} text"),   // standalone
+        format!("trailing \\{c}"),  // escape at end of input
       ] {
-        let out = recase_title(title, mode);
-        // Nothing may be silently dropped either: every char of the input has
-        // to survive in some case-form, so a "fix" that skips the escape fails.
-        assert!(
-          out.chars().count() >= title.chars().count(),
-          "recase_title({title:?}, {mode:?}) lost characters: {out:?}"
-        );
+        for mode in modes {
+          // Returning at all is the primary assertion: the bug was a panic.
+          let out = recase_title(&title, mode);
+          // And nothing may be dropped — a "fix" that skips the escape would
+          // pass a panic-only check while silently eating the author's text.
+          // Checked across case forms, since re-casing is the function's JOB:
+          // `Uppercase` turns `a` into `A`, which is not a loss.
+          let survives = out.contains(c)
+            || c.to_lowercase().all(|lc| out.contains(lc))
+            || c.to_uppercase().all(|uc| out.contains(uc));
+          assert!(
+            survives,
+            "recase_title({title:?}, {mode:?}) lost {c:?}: {out:?}"
+          );
+        }
       }
+    }
+    // A lone trailing backslash: the `peek_second` guard's edge.
+    for mode in modes {
+      assert_eq!(recase_title("x \\", mode).matches('\\').count(), 1);
     }
   }
 

--- a/latexml_engine/src/prelude.rs
+++ b/latexml_engine/src/prelude.rs
@@ -8,7 +8,9 @@ pub use std::{borrow::Cow, collections::VecDeque, rc::Rc, str::FromStr, sync::Ar
 // Re-export the public API available in latexml_core
 pub use latexml_core::binding::content::*;
 pub use latexml_core::{
-  BoxOps, Core, TexMode,
+  BoxOps,
+  Core,
+  TexMode,
   alignment::{
     Alignment, AlignmentConfig,
     cell::Cell,
@@ -71,7 +73,11 @@ pub use latexml_core::{
   tbox::Tbox,
   token::*,
   tokens::{NO_TOKENS, Tokens},
-  util::{pathname, radix},
+  // `CharCursor` is preluded on purpose: it is the shared answer to the
+  // byte-index scanners this port keeps inheriting from Perl's
+  // character-oriented string ops (WISDOM #70), so it should be the thing
+  // a binding author reaches for without having to know the path.
+  util::{char_cursor::CharCursor, pathname, radix},
   whatsit::Whatsit,
   *,
 };

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -2148,3 +2148,55 @@ fn includefrom_takes_directory_and_file() {
     "\\subincludefrom{{dir}}{{file}} silently dropped the included file:\n{xml}"
   );
 }
+
+/// A space-form accent in an author name must survive reversion.
+///
+/// `{\v S}pakov` / `Gon{\c c}alves` / `\" Ozturk` are ordinary BibTeX — the
+/// accent command separated from its argument by a space rather than braced.
+/// The space is what TERMINATES the control word, and the tokenizer consumes
+/// it, so by token-time it is gone as data. Reverting tokens back to a string
+/// therefore has to re-emit it: `UnTeX` does, plain concatenation does not.
+///
+/// `\bib@@names` reverted with `to_string()` where Perl uses
+/// `UnTeX($names, 1)` (`BibTeX.pool.ltxml` L277) — and `Display for Tokens`
+/// says outright that it is "NOT for creating valid TeX (use revert or UnTeX
+/// for that!)". So `\v` and `S` were welded into `\vS`, a control sequence that
+/// exists in no LaTeX: `Error:undefined:\vS`, rendered as literal `\vSpakov`.
+///
+/// RED before the fix, on exactly this content: 2 errors
+/// (`undefined:\vS`, `undefined:\cc`) and `O. \vSpakov and A. Gon\ccalves`.
+/// Same-host `latexmlc`: 0 errors, `O. Špakov and A. Gonçalves` —
+/// GENUINE-RUST-ONLY. Found by the 2026-07-26 sweep of sandbox-arxiv-2605/2606,
+/// where it cost ~+2800 error documents per corpus; the guard suite was green
+/// throughout, because every bibliography fixture was ASCII.
+#[test]
+fn bib_name_space_form_accent_survives_reversion() {
+  let x = convert_and_post("tests/cluster_regressions/bib_accent_space_form.tex");
+  assert!(
+    x.contains("<bibitem"),
+    "accent fixture: no bibliography at all:\n{x}"
+  );
+  // The accents must have COMPOSED, not merely survived as source.
+  for (name, ch) in [
+    ("Špakov", 'Š'),    // {\v S} — space form, braced group
+    ("Gonçalves", 'ç'), // {\c c} — space form, braced group
+    ("Özturk", 'Ö'),    // \" O   — space form, no braces at all
+    ("Švec", 'Š'),      // \v{S}  — braced argument, never broken
+    ("Grégoire", 'é'),  // {\'e}  — braced argument, never broken
+  ] {
+    assert!(
+      x.contains(name),
+      "accent fixture: {name:?} (composing {ch:?}) is missing — the accent \
+       command did not apply:\n{x}"
+    );
+  }
+  // And no welded control sequence may leak. These are the exact shapes the
+  // bug produced; each is a CS that exists in no LaTeX.
+  for welded in ["\\vS", "\\cc", "\\\"O", "\\vSpakov", "\\ccalves"] {
+    assert!(
+      !x.contains(welded),
+      "accent fixture: {welded:?} leaked — a control word was welded to its \
+       argument, so reversion dropped the terminating space:\n{x}"
+    );
+  }
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_accent_space_form.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_accent_space_form.bib
@@ -1,0 +1,54 @@
+% Author names carrying SPACE-FORM accents — `{\v S}`, `{\c c}`, `{\" a}` —
+% where the accent command is separated from its argument by a space rather
+% than braced (`\v{S}`). Both spellings are ordinary BibTeX; the space form is
+% what BibTeX's own documentation uses, and it dominates real `.bib` files
+% exported by reference managers.
+%
+% Why this fixture exists: the space that terminates a control word is CONSUMED
+% by the tokenizer, so it is gone as data by token-time. Reverting tokens to a
+% string therefore has to re-emit it — `UnTeX` does, plain concatenation does
+% not. `\bib@@names` reverted with `to_string()` instead of `untex()`, so `\v`
+% and `S` were welded into `\vS`, a control sequence that exists in no LaTeX:
+% every such name became `undefined:\vS` and rendered as literal `\vSpakov`.
+%
+% Measured cost on the 2026-07-26 sandbox sweep, which is how it was found:
+% ~+2800 error documents in sandbox-arxiv-2605 and again in 2606 — most
+% non-English author names in either corpus. Same-host `latexmlc` renders all
+% of these correctly, so this was GENUINE-RUST-ONLY.
+%
+% The braced forms are here deliberately: they were never broken, and pinning
+% them stops a "fix" that repairs the space form by mangling the braced one.
+@article{caron,
+  author  = {{\v S}pakov, Oleg},
+  title   = {Caron, space form},
+  journal = {J. Accents},
+  year    = {2025}
+}
+
+@article{cedilla,
+  author  = {Gon{\c c}alves, Ana},
+  title   = {Cedilla, space form},
+  journal = {J. Accents},
+  year    = {2025}
+}
+
+@article{umlautbare,
+  author  = {\" Ozturk, Mehmet},
+  title   = {Umlaut, space form without braces},
+  journal = {J. Accents},
+  year    = {2025}
+}
+
+@article{bracedarg,
+  author  = {\v{S}vec, Jan},
+  title   = {Caron, braced argument},
+  journal = {J. Accents},
+  year    = {2025}
+}
+
+@article{acute,
+  author  = {Gr{\'e}goire, Ren{\'e}},
+  title   = {Acute, braced argument},
+  journal = {J. Accents},
+  year    = {2025}
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_accent_space_form.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_accent_space_form.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+\begin{document}
+See \cite{caron,cedilla,umlautbare,bracedarg,acute}.
+\bibliographystyle{plain}
+\bibliography{bib_accent_space_form}
+\end{document}


### PR DESCRIPTION
**Diagnostic.** `\bib@@names` reverted its argument with `to_string()` where Perl uses `UnTeX($names, 1)` (`BibTeX.pool.ltxml` L277). TeX *consumes* the space terminating a control word, so reversion must re-emit it; concatenation does not, and `\v` + `S` came back as `\vS` — a control sequence in no LaTeX. Every space-form accent in an author name (`{\v S}`, `{\c c}`, `{\" a}` — most non-English names) became an undefined macro rendering as `\vSpakov` where Perl renders `Špakov`. `Display for Tokens` documents this: *"NOT for creating valid TeX (use revert or UnTeX for that!)"*.

**Measured.** 2026-07-26 sandbox sweep, the two corpora moving in near-identical proportion — 2605 error 4666→7498 / fatal 248→560; 2606 error 4917→7545 / fatal 229→513. Also fixes a prior panic in the same file (`\<char>` escape over a multi-byte character split a codepoint; witness 2605.22125) and removes the class behind it by scanning with a new `CharCursor` over `char_indices` rather than raw byte indices.

**Validation.** `bib_name_space_form_accent_survives_reversion` — verified red by reverting the fix, not asserted from memory; three space-form and two braced-argument accents, the latter pinning that the fix doesn't break what already worked. Plus `untex_control_word_space_tests` (both directions, including a pin on `Display`'s non-TeX contract), `recase_title_handles_every_character_width_at_every_position` (4 widths × 6 positions × 5 modes), `util::char_cursor::tests`. Audited the other 37 Perl `UnTeX(` sites against their Rust counterparts — the `tex=` family, TeX_FileIO, etoolbox, amsrefs and the `[Default:…]` specs all correctly use `untex()`; this was the only mismatch. Suite 1704/0 across 94 targets; clippy `-D warnings` clean. Same-host `latexmlc` agrees on the reproducer (0 errors, `O. Špakov and A. Gonçalves`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)