### PR TITLE
fix(bibliography): a .bib field's specials are data — the two-treatment design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,12 @@
     a percent that stays literal (BibTeX has no comments, and `%` is routine in
     an encoded URL). Measured over a 30,079-document arXiv sample: 62 more
     documents convert cleanly, 44 fewer carry errors.
+  - **An ampersand in a reference is an ampersand** — "Taylor & Francis" in a
+    `.bib` publisher, journal or booktitle used to report an error and print
+    "Taylor Francis". A `.bib` field's content is data, so the character is kept.
+  - **A reference exported through HTML no longer shows `&amp;` for `&`** — a
+    doubly escaped ampersand (`\&amp;`) in a `.bib` title, journal or booktitle
+    is decoded back to the one character the author wrote.
   - **amsrefs `\bib` values digest as live TeX** — `\MR{…}` came out as literal
     characters and `pages` rendered empty.
   - **MathReview / ZentralBlatt links are synthesized** — `mrnumber`/`zblno`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,9 +74,12 @@
     a percent that stays literal (BibTeX has no comments, and `%` is routine in
     an encoded URL). Measured over a 30,079-document arXiv sample: 62 more
     documents convert cleanly, 44 fewer carry errors.
-  - **An ampersand in a reference is an ampersand** — "Taylor & Francis" in a
-    `.bib` publisher, journal or booktitle used to report an error and print
-    "Taylor Francis". A `.bib` field's content is data, so the character is kept.
+  - **A reference's `& % # _` are the characters the author typed** — "Taylor &
+    Francis" in a publisher used to report an error and print "Taylor Francis",
+    a gene id `AT1G01010_v2` came out as a subscript error, and a percent in an
+    encoded URL commented out the rest of the entry. A `.bib` field's content is
+    data, so all four are kept, while `\emph{…}`, `$x_1+x_2$` and accents in the
+    same field keep working.
   - **A reference exported through HTML no longer shows `&amp;` for `&`** — a
     doubly escaped ampersand (`\&amp;`) in a `.bib` title, journal or booktitle
     is decoded back to the one character the author wrote.

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -64,6 +64,7 @@ session of their own. Re-verify a row before planning on it (rule 1).
 
 ## Current status
 
+- **2026-07-26 (later still) — a bare `&` in a `.bib` field is data (OXIDIZED_DESIGN #74).**
 - **2026-07-26 — undefined CSes from packages with no binding: `silence.sty`,
   bundled `arxiv.sty`/`PRIMEarxiv.sty`.** Long-standing gaps, **not** a
   regression: Perl 0.8.8 has no binding for either and reproduces the identical
@@ -89,15 +90,17 @@ session of their own. Re-verify a row before planning on it (rule 1).
   `.bbl` under `plain` and `abbrvnat`; pdflatex stops with "Misplaced alignment
   tab character &" and prints "Taylor Francis"). **A `.bib` field's content is
   DATA** — authorized surpass-Perl and surpass-pdflatex, since LaTeXML reads
-  `.bib` directly and decides what reaches the tokenizer. Neutralized at the
-  same two seams #74 uses for `%`, and BOTH are required — the per-entry Mouth
-  (`Mouth::with_align_as_other`) and `mouth::tokenize_bib_literal` for handlers
-  that re-tokenize a stored raw field (`\bib@@title` recasing, name/date/pages
-  assembly, MR/Zbl). Measured: **2605.06249 3→0, 2605.03054 1→0, 2605.00462 1→0,
-  2605.08753 1→0, 2605.10409 1→0, 2605.01936 13→6, 2605.06624 4→3** (the
-  residuals are unrelated `undefined:` errors). `#` was checked and NOT included
-  — one bare `#` across all seven, in a JabRef `file` path already covered as an
-  unknown field. **Stacked on PR #405**: merge after it.
+  `.bib` directly and decides what reaches the tokenizer.
+  Landed inside the consolidated **OXIDIZED_DESIGN #74**, which covers `%`, `&`,
+  `#` and `_` under one two-treatment design — be `bibtex` (the per-entry Mouth
+  and `mouth::tokenize_bib_literal`, via `Mouth::with_bib_data_literals`), then
+  be `pdflatex` on the `.bbl` you just synthesized
+  (`bibtex.rs::escape_bib_data_specials`, at three seams: the entry line,
+  `\bib@@title` and `\bib@@pages`). `_` is in the escaper ONLY: a catcode is
+  fixed at tokenization and cannot tell whether it is inside `$…$`, and a
+  subscript in a title's math is legitimate TeX — putting `_` in the Mouth set
+  flattened every one of them. Measured across all sixteen witnesses of the
+  three clusters (`_`, `%`, `&`): **193 -> 0**.
   Also fixed, a different bug the neutralization does *not* reach: the doubly
   escaped `\&amp;` / `{\&}amp;` / `&amp;`, an HTML entity that survived into
   the `.bib` and printed as "&amp;" in Perl and pdflatex alike

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -81,6 +81,31 @@ session of their own. Re-verify a row before planning on it (rule 1).
   1→0, 4→1, 1→0, 1→0. Divergence #77. Guards `00_contrib::{silence_filters,
   arxiv_keywords, primearxiv_keywords}_test`, `106_arxiv_sty_defers_to_bundled`,
   `107_silence_keeps_diagnostics`.
+- **2026-07-26 (later still) — a bare `&` in a `.bib` field is data (OXIDIZED_DESIGN #75).**
+  Seven 2605 witnesses carried `Error:unexpected:&` from `publisher` / `journal`
+  / `booktitle` / `author` / `copyright` ("Taylor & Francis"). Not a Rust-only
+  defect: same-host `latexmlc` raised the identical per-`&` count on all six
+  re-measured witnesses, and bibtex 0.99d + pdflatex agree (the `&` reaches the
+  `.bbl` under `plain` and `abbrvnat`; pdflatex stops with "Misplaced alignment
+  tab character &" and prints "Taylor Francis"). **A `.bib` field's content is
+  DATA** — authorized surpass-Perl and surpass-pdflatex, since LaTeXML reads
+  `.bib` directly and decides what reaches the tokenizer. Neutralized at the
+  same two seams #74 uses for `%`, and BOTH are required — the per-entry Mouth
+  (`Mouth::with_align_as_other`) and `mouth::tokenize_bib_literal` for handlers
+  that re-tokenize a stored raw field (`\bib@@title` recasing, name/date/pages
+  assembly, MR/Zbl). Measured: **2605.06249 3→0, 2605.03054 1→0, 2605.00462 1→0,
+  2605.08753 1→0, 2605.10409 1→0, 2605.01936 13→6, 2605.06624 4→3** (the
+  residuals are unrelated `undefined:` errors). `#` was checked and NOT included
+  — one bare `#` across all seven, in a JabRef `file` path already covered as an
+  unknown field. **Stacked on PR #405**: merge after it.
+  Also fixed, a different bug the neutralization does *not* reach: the doubly
+  escaped `\&amp;` / `{\&}amp;` / `&amp;`, an HTML entity that survived into
+  the `.bib` and printed as "&amp;" in Perl and pdflatex alike
+  (`undouble_escaped_ampersand`). Guards
+  `bib_bare_ampersand_is_literal_data`, `bib_bare_ampersand_leaves_live_markup_alone`
+  (the `\emph` / inline-math / space-form-accent boundary) and
+  `bib_escaped_amp_entity_decodes_to_one_ampersand`. Detail in
+  [`BIBLIOGRAPHY_WORKLIST.md`](parity/BIBLIOGRAPHY_WORKLIST.md).
 
 - **2026-07-26 (later) — session: resilience mining, and a regression the sweep caught.**
   Mined the 2605+2606 fatals: `Timeout:PushbackLimit` (25), `TooManyErrors`

--- a/docs/parity/BIBLIOGRAPHY_WORKLIST.md
+++ b/docs/parity/BIBLIOGRAPHY_WORKLIST.md
@@ -150,6 +150,48 @@ most of them as an interim, but it imitates the mechanism rather than using it.
 The durable fix is this re-port: route field interpretation through the lazy
 Mouth.
 
+**Maintainer policy, 2026-07-26 — a `.bib` field's content is DATA, not TeX.**
+A bare `%`, `&`, `_` is the literal character; "Taylor & Francis" renders with
+its ampersand. Authorized surpass-Perl *and* surpass-pdflatex: LaTeXML reads
+`.bib` directly, with no `.bst` and no `bibtex(1)`, so it decides what reaches
+the tokenizer. **The boundary is blast radius, not character:**
+
+* *Regime A, per-Mouth* — a character destructive in ANY field, with no Perl
+  per-field idiom to follow. `%` (#74, PR #405) and `&` (#75) are here.
+  `Mouth::with_percent_as_other()` / `with_align_as_other()`, deliberately NOT a
+  State catcode, so a `.sty` raw-loaded from inside a field handler — and the
+  document — keep TeX's meaning.
+* *Regime B, per-field parameter type* — harmful only in specific fields where
+  Perl already has the idiom. `_` (PR #403) is here: `eprint`/`preprint`/
+  `archive` get `Semiverbatim`, mirroring `doi`/`isbn`/`issn`/`lccn`/`pii`.
+
+**Both regime-A seams are required.** The value reaches a tokenizer by two
+independent routes: the per-entry Mouth, and the handlers that re-read the
+stored RAW field and tokenize it themselves (`\bib@@title` recasing,
+`current_entry_field`, name splitting, date/pages assembly, MR/Zbl). The
+companion for the second is `mouth::tokenize_bib_literal`, behind
+`bibtex.rs::tokenize_bib_field`. Fixing only the mouth made 2605.02131 *worse*
+(28 → 37 errors) — a title's value never passes through it.
+
+*The `&` third, measured.* Witnesses 2605.01936, 2605.06249, 2605.00462,
+2605.03054, 2605.06624, 2605.08753, 2605.10409. The `&` sits in `publisher` /
+`journal` / `booktitle` / `author` / `copyright` — all `Digested` in
+`BibTeX.pool.ltxml`, so **no parameter type was ever going to cover them and the
+eager-tokenization gap above was never this third's cause**. Before: Rust
+matched same-host `latexmlc` 1:1 on every re-measured witness, and pdflatex
+broke identically. After (#75): **3→0, 1→0, 1→0, 1→0, 1→0, 13→6, 4→3**; the two
+residuals are unrelated `undefined:` errors, no `unexpected:&` remains anywhere.
+`#` was checked and deliberately left alone — one bare `#` across all seven
+witnesses, in 2605.00462's JabRef `file` path, already covered as an unknown
+field.
+
+*A separate ampersand bug, also fixed as #75:* the doubly escaped `\&amp;` /
+`{\&}amp;` / `&amp;`, where an HTML entity survived into the `.bib`. Those raise
+no error at all — Perl and pdflatex both print "&amp;" — so the mouth-level
+change does not reach them; `undouble_escaped_ampersand` in `bibtex.rs` does.
+Guard `bib_escaped_amp_entity_decodes_to_one_ampersand`. The `^` third remains
+open.
+
 #### What the 2026-07-26 prototype measured (and the two claims it corrected)
 
 Before designing the re-port, the existing `--bibtex` route was probed directly

--- a/docs/parity/BIBLIOGRAPHY_WORKLIST.md
+++ b/docs/parity/BIBLIOGRAPHY_WORKLIST.md
@@ -90,6 +90,17 @@ name-, date- and MR/Zbl-assembly sites that share that path.
 State catcode is inherited by a `.sty` raw-load triggered from inside a field
 handler, where `%` must still be a comment.
 
+**Correction to the table above, measured while implementing it: `_` belongs to
+treatment 2 ONLY.** The row is right that a `_` in a field is data, but wrong
+that treatment 1 is where that gets expressed. A catcode is decided at
+tokenization, before anything knows whether the character is inside `$…$`, and
+a subscript in a title's math (`title = {Bounds on $x_1+x_2$}`) is legitimate
+TeX that must keep working. Putting `_` in `Mouth::with_bib_data_literals`
+silently flattened every subscript in a bibliography title — caught by the
+existing `bib_bare_ampersand_leaves_live_markup_alone`, which asserts
+`role="SUBSCRIPTOP"`. Only the escaper can be math-aware, so treatment 1 covers
+`% & #` and treatment 2 covers all four. Landed that way in OXIDIZED_DESIGN #74.
+
 ### Why the re-port is the real fix: eager tokenization defeats parameter types (measured 2026-07-26)
 
 The 2026-07-26 sandbox rerun quantified what the simplified parser costs. In
@@ -110,6 +121,28 @@ The first two are fixed (#391: `BBL_STANDARD_FALLBACKS`, `BibCatcodeScope`).
 The third is **not**, and must not be fixed by widening the catcode phase:
 `$a_b$` and `$x^2$` in a title are legitimate, so neutralizing `_`/`^`
 file-wide would trade one regression for another.
+
+**LANDED 2026-07-27 on the `.bib` POOL route, exactly as consequence 2 above
+prescribes** — an escape at the A→B boundary, not catcode suppression.
+`escape_bib_data_specials` (`bibtex.rs`) emits `%`→`\%`, `&`→`\&`, `#`→`\#`,
+`_`→`\_`; `\emph{…}`, `$x_1+x_2$` and `{\v S}pakov` pass through untouched.
+The mechanism, its four hazards (math, idempotency, raw-read fields, nested
+`\url` data regions) and — the part that was NOT obvious — the **three** seams
+it had to cover are in OXIDIZED_DESIGN #74: the entry line in
+`\ProcessBibTeXEntry` plus `\bib@@title` and `\bib@@pages`, both of which
+re-read the RAW field instead of using the value the entry line passed them, so
+escaping only the entry line silently missed every `title`. Guard
+`06_cluster_bibliography::bib_field_specials_are_data_not_tex` plus six
+`escape_bib_data_specials` unit tests. Seven witnesses, TOTAL document errors,
+`--release` before→after: 2605.06926 8→0, 2605.01936 13→0, 2605.04604 2→0,
+2605.08986 2→0, 2605.11300 1→0, 2605.05898 1→0, 2605.06249 3→0. **30 → 0** —
+every one converts clean.
+
+Two corrections this work turned up: those witnesses raise their errors in the
+**pool route's own Mouth**, so the 61 above are not all
+`make_bibliography.rs`'s eager digest as this section assumes; and
+`volume`/`language`, previously read as genuine parity to leave erroring, are
+covered by the DATA-regime policy like everything else.
 
 Perl does not need any of these patches, and the reason is structural.
 `BibTeX.pool.ltxml` declares a parameter type per field — `url` **Verbatim**
@@ -157,8 +190,8 @@ its ampersand. Authorized surpass-Perl *and* surpass-pdflatex: LaTeXML reads
 the tokenizer. **The boundary is blast radius, not character:**
 
 * *Regime A, per-Mouth* — a character destructive in ANY field, with no Perl
-  per-field idiom to follow. `%` (#74, PR #405) and `&` (#75) are here.
-  `Mouth::with_percent_as_other()` / `with_align_as_other()`, deliberately NOT a
+  per-field idiom to follow. `%`, `&`, `#` and `_` are all here (#74).
+  `Mouth::with_bib_data_literals()`, deliberately NOT a
   State catcode, so a `.sty` raw-loaded from inside a field handler — and the
   document — keep TeX's meaning.
 * *Regime B, per-field parameter type* — harmful only in specific fields where
@@ -179,13 +212,13 @@ companion for the second is `mouth::tokenize_bib_literal`, behind
 `BibTeX.pool.ltxml`, so **no parameter type was ever going to cover them and the
 eager-tokenization gap above was never this third's cause**. Before: Rust
 matched same-host `latexmlc` 1:1 on every re-measured witness, and pdflatex
-broke identically. After (#75): **3→0, 1→0, 1→0, 1→0, 1→0, 13→6, 4→3**; the two
+broke identically. After: **3→0, 1→0, 1→0, 1→0, 1→0, 13→6, 4→3**; the two
 residuals are unrelated `undefined:` errors, no `unexpected:&` remains anywhere.
 `#` was checked and deliberately left alone — one bare `#` across all seven
 witnesses, in 2605.00462's JabRef `file` path, already covered as an unknown
 field.
 
-*A separate ampersand bug, also fixed as #75:* the doubly escaped `\&amp;` /
+*A separate ampersand bug, also fixed under #74:* the doubly escaped `\&amp;` /
 `{\&}amp;` / `&amp;`, where an HTML entity survived into the `.bib`. Those raise
 no error at all — Perl and pdflatex both print "&amp;" — so the mouth-level
 change does not reach them; `undouble_escaped_ampersand` in `bibtex.rs` does.

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2275,6 +2275,76 @@ this fixture, 203 on the witness) passed every bibliography guard silently.
 (percent in `abstract`, specials in `keywords`, and a third entry as the
 containment canary).
 
+### 74. A `%` inside a `.bib` field value is data, not a comment
+
+**Perl behaviour.** `Pre::BibTeX` is a real BibTeX-format parser: field values
+come out of `parseString`/`parseBalancedBraces` as raw strings, and `%` is
+significant **only** in the junk between entries (`skipJunk`, `BibTeX.pm` L335-343
+— its own comment reads "Although % officially starts comments, apparently BibTeX
+accepts anything until @"). Inside an entry there is no comment syntax, matching
+`bibtex.web`. `BibTeX.pool.ltxml` L134-166 (`\bibentry@create`) then re-serializes
+those values into TeX source — one `\csname bib@field@<t>@<f>\endcsname{<value>}`
+per line — and hands the join to `Mouth->new($tex)`. There `%` is catcode 14
+again, so it comments out the rest of its line, **the field's own closing brace
+included**. The entry's group never closes, `<ltx:bibentry>` is left open, and
+every following entry nests inside it: `<ltx:bibentry> isn't allowed in
+<ltx:bibentry>`, once per remaining entry. `\bib@@title` (L293-333) loses the
+value a second way — it re-reads the RAW field to re-case it and `Tokenize`s the
+result itself, and `Tokenize` uses the standard cattable, where `%` is again a
+comment; the truncated title leaves a `\href` mid-argument and the runaway eats
+the following `\csname`s (`Extra \endcsname`).
+
+**Rust behaviour.** The text BibTeX lexed is read with `%` as an ordinary
+character. Two seams, because the value reaches the tokenizer two ways:
+`Mouth::with_percent_as_other()` on the per-entry mouth
+(`\ProcessBibTeXEntry`, `bibtex.rs`), and `mouth::tokenize_percent_literal`
+behind `bibtex.rs::tokenize_bib_field` for the handlers that re-tokenize a
+stored raw field (title recasing, name splitting, date/pages assembly, MR/Zbl).
+It is a per-**Mouth** property rather than a `\catcode` assignment on purpose: a
+State catcode would be inherited by a `.sty` raw-load triggered from inside a
+field handler, where `%` must stay a comment. Only comment-ness is removed — a
+`%` given some other catcode keeps it, and `\%` is unaffected (a control symbol
+is formed from the following character whatever its catcode).
+
+**Why — measured against `bibtex` 0.99d + pdflatex, not against Perl.** The
+fixture's three entries were run through the real toolchain (TL2025,
+`plain.bst`, hyperref loaded), and it handles both fields cleanly:
+
+* `doi` — **`bibtex` drops it.** `plain.bst` does not declare `doi` in its
+  `ENTRY` list, so the generated `d.bbl` carries author/title/journal/year and
+  no trace of `%doi:`. pdflatex never sees the character. (Nor would it in the
+  witness: 2605.01196's entry sits in that file's own "UNUSED REFERENCES" block,
+  which `bibtex` never processes at all.)
+* `title` — **`bibtex` keeps the `%` verbatim** (its lexer has no comment rule
+  inside `{}`), writing `\href{https://…/20240723%20IPWG%20…DRAFT.pdf}{A linked
+  title…}` into the `.bbl` with the closing brace on that same line. pdflatex
+  **compiles it, rc=0**, and the PDF renders the linked title: real hyperref's
+  `\href` sets `` \catcode`\%=12 `` before reading its URL. So the ground-truth
+  engine reads a percent-encoded URL with `%` as an ordinary character — the
+  exact rule adopted here.
+
+LaTeXML's `HyperVerbatim` does the same catcode trick as hyperref, but far too
+late: the `%` is eaten during the *field* read, before `\href` is ever reached.
+Reading the `.bib` **directly** — which is what both LaTeXML engines do, and
+what no other consumer does — is what puts the value in front of a TeX tokenizer
+in the first place, so the reader has to use BibTeX's lexing rules for it. The
+damage under the old reading is also wildly disproportionate to the input: one
+stray character in one uncited reference costs the whole rest of the
+bibliography.
+
+This is `surpass-perl` on a shared bug, like #73 (its sibling: same "element
+opened and never closed" shape, same `%`-eats-the-closing-brace mechanism, but
+#73's three fields could be read `Verbatim` because nothing renders
+`ltx:bib-extract`, while `doi`/`title` are rendered and cannot be). Measured on
+the same host: **2605.01196 28 → 0 errors** (Perl `latexmlc` 29; output otherwise
+byte-identical, 83 bibitems before and after — the entire cost was diagnostics)
+and **2605.02131 28 → 0** (Perl 31; 20 bibitems unchanged, and the two
+percent-encoded `\href` titles now render, URLs intact).
+
+Guard: `06_cluster_bibliography::bib_field_percent_is_an_ordinary_character`
+(fixture `bib_field_percent.{tex,bib}` — one entry per seam plus a containment
+canary; the single-line `value...}` layout is load-bearing, as in #73).
+
 ### 75. A `.bib`-derived bibliography does not run the missing-`\bibitem` rescue
 
 **Perl behaviour.** `BibTeX.pool.ltxml:183` gives `{bibtex@bibliography}` the

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2357,6 +2357,85 @@ fields no parameter type was protecting.
 Guard: `06_cluster_bibliography::bib_field_percent_is_an_ordinary_character`
 (fixture `bib_field_percent.{tex,bib}` — one entry per seam plus a containment
 canary; the single-line `value...}` layout is load-bearing, as in #73).
+### 75. A bare `&` in a `.bib` field is data, and a `\&amp;` is one ampersand
+
+Two ampersand bugs in `.bib` field values, with different causes and different
+fixes. Both are settled against **pdflatex**, not against Perl.
+
+**(a) The bare `&`.** `publisher = {Taylor & Francis}` — seven arXiv/2605
+witnesses: 2605.01936 (7 occurrences), 2605.06249 (3), 2605.00462 / 2605.03054 /
+2605.06624 / 2605.08753 / 2605.10409 (1 each), in `publisher`, `journal`,
+`booktitle`, `author` and `copyright`. BibTeX's lexer has no alignment, so the
+`&` it hands back is a character in a name; TeX reads catcode 4, raises
+`Error:unexpected:&`, and **drops** it, so the entry printed "Taylor Francis".
+
+*What every other engine does, measured.* Same-host `latexmlc` raises the same
+one-error-per-`&` on all six re-measured witnesses (1/1, 3/3, 1/1, 1/1, 1/1,
+1/1). bibtex 0.99d + pdflatex agree: under `plain` and under natbib's
+`abbrvnat` the bare `&` is copied straight into the `.bbl`, pdflatex stops with
+`! Misplaced alignment tab character &`, and the PDF reads "Taylor Francis" /
+"Information Processing Management" / "Knowledge Discovery Data Mining". So
+this was never a Rust-only defect — Rust already beat Perl on the witnesses
+overall (2605.01936: 7 errors and a complete bibliography vs Perl's 101 plus a
+Fatal and none at all; 2605.00462: 1 vs 57).
+
+*Rust behaviour.* A `.bib` field's content is **data, not TeX**: the `&` is read
+as an ordinary character. Implemented at the per-entry Mouth beside the `%` of
+**#74** — `Mouth::with_align_as_other()`, plus `mouth::tokenize_bib_literal`
+for the handlers that re-tokenize a stored raw field (`\bib@@title` recasing,
+name splitting, date/pages assembly) and never pass through that mouth.
+
+*Why the mouth and not a parameter type.* `&` derails alignment in **any**
+field, and the fields carrying it here have no Perl `Semiverbatim` precedent to
+follow — unlike `doi`/`isbn`/`issn`/`lccn`/`pii`, whose per-field treatment
+`eprint` joins. Per-Mouth rather than a State catcode for #74's reason: a raw
+`.sty` opened from inside a field handler, and the document itself, must keep
+TeX's alignment tab. The rule belongs to the text BibTeX lexed.
+
+Authorized surpass-Perl **and** surpass-pdflatex: LaTeXML reads `.bib`
+directly, with no `.bst` and no `bibtex(1)` in the path, so it decides what
+reaches the tokenizer, and the real toolchain's breakage there is a property of
+that toolchain. `#` is deliberately **not** included: across all seven
+witnesses there is exactly one bare `#`, in 2605.00462's JabRef `file` path,
+and that field is already covered as an unknown field
+(`\bib@field@default@default Verbatim Verbatim`). No evidence, no change.
+
+**(b) The doubly escaped `\&amp;`.** A reference manager rendered the field to
+HTML (`&` → `&amp;`), then a second pass TeX-escaped that entity's own
+ampersand. Three spellings, all found by scanning 6000 arXiv/2605 sources:
+`\&amp;` (booktitle 2605.00833, 2605.01362; journal 2605.00922, 2605.01200,
+2605.01224; title 2605.01353 `{{A}}\&amp;{{AS}}`), `{\&}amp;` (title 2605.01224,
+"Reversible Template-based Shake {\&}amp; Bake Generation") and bare `&amp;`
+(publisher 2605.00859; journal 2605.01187).
+
+Not the same bug, and (a) does not fix it: that `&` is already **escaped**, so
+it raises no error at all — in Perl or in pdflatex, both of which print
+"Computer Engineering, &amp; Applied Computing". The damage is the stray `amp;`.
+`undouble_escaped_ampersand` (`bibtex.rs`) drops an `amp;` that directly follows
+an ampersand in any of its three spellings, at the entry-assembly seam and again
+in `\bib@@title`, which re-reads the RAW field for its case conversion (Perl
+L294) and so bypasses the first. Only `amp;` immediately after an ampersand is
+touched: "amplitude", and a lone `\&`, are untouched. Measured: witness
+2605.00833 renders "Computer Engineering, & Applied Computing" (was
+"&amp;"), 0 errors.
+
+*Why repair it rather than render it faithfully.* It is not a TeX construct
+that a reader might have meant — no author writes `\&amp;` intending the six
+characters — it is one file mixing two escaping conventions, and the entity is
+unambiguous. Rendering it faithfully means printing `&amp;` in a bibliography
+for every reader of the paper. pdflatex has no way to know better; reading the
+`.bib` directly, we do, which is the same position #73 argued from.
+
+**Boundary, verified rather than assumed.** The neutralization downgrades one
+catcode and nothing else: in the same entry that carries a bare `&`, `\emph`
+still produces markup, `$x_1+x_2$` still parses as math with `_` a subscript
+INSIDE math, and the space-form accents PR #399 recovered (`{\v S}pakov` →
+Špakov, `Gon{\c c}alves` → Gonçalves) still resolve.
+
+Guards: `06_cluster_bibliography::bib_bare_ampersand_is_literal_data`,
+`::bib_bare_ampersand_leaves_live_markup_alone` (the boundary entry) and
+`::bib_escaped_amp_entity_decodes_to_one_ampersand` (all three spellings, a `\&`
+control, and an "amp;"-as-ordinary-text near miss).
 
 ### 75. A `.bib`-derived bibliography does not run the missing-`\bibitem` rescue
 

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2275,167 +2275,160 @@ this fixture, 203 on the witness) passed every bibliography guard silently.
 (percent in `abstract`, specials in `keywords`, and a third entry as the
 containment canary).
 
-### 74. A `%` inside a `.bib` field value is data, not a comment
+### 74. A `.bib` field's content is DATA — `% & # _` are literal, not catcodes
 
-**Perl behaviour.** `Pre::BibTeX` is a real BibTeX-format parser: field values
-come out of `parseString`/`parseBalancedBraces` as raw strings, and `%` is
-significant **only** in the junk between entries (`skipJunk`, `BibTeX.pm` L335-343
-— its own comment reads "Although % officially starts comments, apparently BibTeX
-accepts anything until @"). Inside an entry there is no comment syntax, matching
-`bibtex.web`. `BibTeX.pool.ltxml` L134-166 (`\bibentry@create`) then re-serializes
-those values into TeX source — one `\csname bib@field@<t>@<f>\endcsname{<value>}`
-per line — and hands the join to `Mouth->new($tex)`. There `%` is catcode 14
-again, so it comments out the rest of its line, **the field's own closing brace
-included**. The entry's group never closes, `<ltx:bibentry>` is left open, and
-every following entry nests inside it: `<ltx:bibentry> isn't allowed in
-<ltx:bibentry>`, once per remaining entry. `\bib@@title` (L293-333) loses the
-value a second way — it re-reads the RAW field to re-case it and `Tokenize`s the
-result itself, and `Tokenize` uses the standard cattable, where `%` is again a
-comment; the truncated title leaves a `\href` mid-argument and the runaway eats
-the following `\csname`s (`Extra \endcsname`).
+Supersedes the separate `%`-only and `&`-only entries this consolidates
+(PRs #405 and #409); `_` was a third instance of the same defect.
 
-**Rust behaviour.** The text BibTeX lexed is read with `%` as an ordinary
-character. Two seams, because the value reaches the tokenizer two ways:
-`Mouth::with_percent_as_other()` on the per-entry mouth
-(`\ProcessBibTeXEntry`, `bibtex.rs`), and `mouth::tokenize_percent_literal`
-behind `bibtex.rs::tokenize_bib_field` for the handlers that re-tokenize a
-stored raw field (title recasing, name splitting, date/pages assembly, MR/Zbl).
-It is a per-**Mouth** property rather than a `\catcode` assignment on purpose: a
-State catcode would be inherited by a `.sty` raw-load triggered from inside a
-field handler, where `%` must stay a comment. Only comment-ness is removed — a
-`%` given some other catcode keeps it, and `\%` is unaffected (a control symbol
-is formed from the following character whatever its catcode).
+**The two regimes, and the two treatments that restore them.** The real
+toolchain is `pdflatex → bibtex → pdflatex`, and it treats these characters
+differently at two distinct points. We collapse both into one pass over live
+core state, so we have to perform both, in order — the frame is
+[`BIBLIOGRAPHY_WORKLIST.md` → "two regimes collapsed into one pass"](BIBLIOGRAPHY_WORKLIST.md).
 
-**Why — measured against `bibtex` 0.99d + pdflatex, not against Perl.** The
-fixture's three entries were run through the real toolchain (TL2025,
-`plain.bst`, hyperref loaded), and it handles both fields cleanly:
+**Treatment 1 — reading the `.bib` (be `bibtex`).** A field's bytes are inert
+data. BibTeX's lexer interprets only braces and the entry/field delimiters: `%`
+is not a comment (it is significant only in the junk BETWEEN entries,
+`Pre::BibTeX::skipJunk`), `&` is not an alignment tab, `#` is not a parameter.
+So the read path neutralizes those three **without altering the text** — the
+stored value keeps its exact bytes. `Mouth::with_bib_data_literals()` is a
+per-Mouth property, applied to the per-entry mouth in `\ProcessBibTeXEntry` and,
+via `mouth::tokenize_bib_literal` / `bibtex.rs::tokenize_bib_field`, to the
+handlers that re-read a raw field instead. Deliberately NOT a State catcode
+assignment: a raw `.sty` opened from inside a field handler — and the document
+itself — must keep TeX's meanings, so the rule belongs to the *text BibTeX
+lexed*, not to the session.
 
-* `doi` — **`bibtex` drops it.** `plain.bst` does not declare `doi` in its
-  `ENTRY` list, so the generated `d.bbl` carries author/title/journal/year and
-  no trace of `%doi:`. pdflatex never sees the character. (Nor would it in the
-  witness: 2605.01196's entry sits in that file's own "UNUSED REFERENCES" block,
-  which `bibtex` never processes at all.)
-* `title` — **`bibtex` keeps the `%` verbatim** (its lexer has no comment rule
-  inside `{}`), writing `\href{https://…/20240723%20IPWG%20…DRAFT.pdf}{A linked
-  title…}` into the `.bbl` with the closing brace on that same line. pdflatex
-  **compiles it, rc=0**, and the PDF renders the linked title: real hyperref's
-  `\href` sets `` \catcode`\%=12 `` before reading its URL. So the ground-truth
-  engine reads a percent-encoded URL with `%` as an ordinary character — the
-  exact rule adopted here.
+**Treatment 2 — synthesizing the `.bbl` and digesting it (be `pdflatex` pass 2).**
+Now the content must be valid TeX. We are the ones writing the `.bbl` and we
+know the author meant the literal character, so we escape at that boundary:
+`%`→`\%`, `&`→`\&`, `#`→`\#`, `_`→`\_`.
+`bibtex.rs::escape_bib_data_specials`. Escaping here rather than suppressing
+catcodes during digestion is what keeps the TeX regime intact **by
+construction**: `\emph{…}`, `{\v S}pakov` and `$x_1+x_2$` are already valid TeX
+and simply pass through.
 
-LaTeXML's `HyperVerbatim` does the same catcode trick as hyperref, but far too
-late: the `%` is eaten during the *field* read, before `\href` is ever reached.
-Reading the `.bib` **directly** — which is what both LaTeXML engines do, and
-what no other consumer does — is what puts the value in front of a TeX tokenizer
-in the first place, so the reader has to use BibTeX's lexing rules for it. The
-damage under the old reading is also wildly disproportionate to the input: one
-stray character in one uncited reference costs the whole rest of the
-bibliography.
+**Why `_` is in treatment 2 only.** A catcode is decided at tokenization, before
+anything knows whether it is inside `$…$` — and a subscript in a title's math
+(`title = {Bounds on $x_1+x_2$}`) is legitimate TeX that must keep working.
+Measured: adding `_` to treatment 1 silently flattened every subscript in a
+bibliography title. Only the escaper can be math-aware, so `_` lives there
+alone. The other three have no legitimate TeX meaning inside a `.bib` field,
+in math or out.
 
-This is `surpass-perl` on a shared bug, like #73 (its sibling: same "element
-opened and never closed" shape, same `%`-eats-the-closing-brace mechanism, but
-#73's three fields could be read `Verbatim` because nothing renders
-`ltx:bib-extract`, while `doi`/`title` are rendered and cannot be). Measured on
-the same host: **2605.01196 28 → 0 errors** (Perl `latexmlc` 29; output otherwise
-byte-identical, 83 bibitems before and after — the entire cost was diagnostics),
-**2605.02131 28 → 0** (Perl 31; 20 bibitems unchanged, and the two
-percent-encoded `\href` titles now render, URLs intact), and **2605.00879
-103 → 5** (`note = {https://doi.org/10.1145%2F3292500.3330925}`; the residual 5
-are other clusters — `unexpected:_`, `\mathsemicolon`).
+**The exclusion list is principled, not ad hoc.** A handler that consumes the
+field's characters *itself*, under its own catcode regime — `url`'s Verbatim
+href, `doi`'s Semiverbatim id — is still operating in **treatment 1, on data**,
+so it must receive the *unescaped* value. `bib_field_source` reads that
+declaration back off the `Definition` (Perl declares it per field,
+`BibTeX.pool.ltxml` L740 and L684/L750-783) rather than keeping a second copy of
+the list. **Trap:** only `Semiverbatim` sets the `semiverbatim` *descriptor*
+field; `Verbatim` calls `begin_semiverbatim(Some(&['%','\\']))` inside its reader
+closure and leaves the descriptor empty, so a descriptor-only test silently
+misses `url` — measured, it planted a literal `\%` in a href. The check must
+also test `Parameter::name`.
 
-**How much of the corpus this is.** Over the first 1200 papers of
-sandbox-arxiv-2605, 178 ship a `.bib` with a `%` somewhere in a field value; 66
-of those have an *unescaped* `%` in a field other than the three #73 already
-reads `Verbatim`. Of the 15 whose field is one that is neither `Semiverbatim`
-nor `Verbatim` (`doi`, `note`, `journal`, `howpublished`, `adsurl`), two were
-broken and are now clean — 2605.00879 (103 → 5) and 2605.01196 (28 → 0) — and
-the other 13 were already fine, because `url` (#72) and unknown fields
-(`\bib@field@default@default Verbatim Verbatim`) had their catcodes protected by
-their parameter type. That is exactly the population this closes: the rendered
-fields no parameter type was protecting.
+**Treatment 2 covers three seams, not one.** Two handlers re-read the RAW field
+instead of using the value the entry line passed them, so escaping only the
+entry line silently missed them — `title` most of all:
 
-Guard: `06_cluster_bibliography::bib_field_percent_is_an_ordinary_character`
-(fixture `bib_field_percent.{tex,bib}` — one entry per seam plus a containment
-canary; the single-line `value...}` layout is load-bearing, as in #73).
-### 75. A bare `&` in a `.bib` field is data, and a `\&amp;` is one ampersand
+* `\ProcessBibTeXEntry`'s synthesized entry line (Perl L147-157);
+* `\bib@@title` (Perl L293-333), which re-reads the raw field to recase it — the
+  value it is handed lands in Perl's vestigial `ignoretitle` slot and is dropped;
+* `\bib@@pages` (Perl L670-674), which re-reads the raw field to normalize `-`.
 
-Two ampersand bugs in `.bib` field values, with different causes and different
-fixes. Both are settled against **pdflatex**, not against Perl.
+Escaping runs **before** `recase_title`: that pass splits on words and treats a
+`\…` escape as part of its word, so raw `AT&T` would recase to `AT&t` (three
+words) while raw `AT\&T` recases to `AT&T` (one). Every real `.bib` mixes both
+spellings and they must render identically.
 
-**(a) The bare `&`.** `publisher = {Taylor & Francis}` — seven arXiv/2605
-witnesses: 2605.01936 (7 occurrences), 2605.06249 (3), 2605.00462 / 2605.03054 /
-2605.06624 / 2605.08753 / 2605.10409 (1 each), in `publisher`, `journal`,
-`booktitle`, `author` and `copyright`. BibTeX's lexer has no alignment, so the
-`&` it hands back is a character in a name; TeX reads catcode 4, raises
-`Error:unexpected:&`, and **drops** it, so the entry printed "Taylor Francis".
+**Idempotency.** Most real `.bib` files already write `\&`, `\%`, `\_`. In the
+escaper a backslash consumes the next character as a pair and neither is
+re-examined, so `\&` stays `\&`. The tricky `\\&` falls out of the same rule:
+`\\` is consumed as one pair, leaving a genuinely bare `&` that IS escaped.
 
-*What every other engine does, measured.* Same-host `latexmlc` raises the same
-one-error-per-`&` on all six re-measured witnesses (1/1, 3/3, 1/1, 1/1, 1/1,
-1/1). bibtex 0.99d + pdflatex agree: under `plain` and under natbib's
-`abbrvnat` the bare `&` is copied straight into the `.bbl`, pdflatex stops with
-`! Misplaced alignment tab character &`, and the PDF reads "Taylor Francis" /
-"Information Processing Management" / "Knowledge Discovery Data Mining". So
-this was never a Rust-only defect — Rust already beat Perl on the witnesses
-overall (2605.01936: 7 errors and a complete bibliography vs Perl's 101 plus a
-Fatal and none at all; 2605.00462: 1 vs 57).
+**A nested data region.** url.sty reads `\url`/`\nolinkurl`/`\path`'s argument
+verbatim, so `howpublished = {\url{http://x.org/a%20b}}` must keep its `%20`.
+Those control words' single next group is copied through untouched
+(`VERBATIM_ARG_COMMANDS`); `\href`'s *second* argument is prose and is still
+escaped.
 
-*Rust behaviour.* A `.bib` field's content is **data, not TeX**: the `&` is read
-as an ordinary character. Implemented at the per-entry Mouth beside the `%` of
-**#74** — `Mouth::with_align_as_other()`, plus `mouth::tokenize_bib_literal`
-for the handlers that re-tokenize a stored raw field (`\bib@@title` recasing,
-name splitting, date/pages assembly) and never pass through that mouth.
+**A separate input corruption, fixed alongside: `\&amp;`.** A reference manager
+rendered the field to HTML (`&` → `&amp;`), then a second pass TeX-escaped the
+ampersand of that entity, so the file carries `\&amp;` / `{\&}amp;` / `&amp;`
+where the source said `&`. TeX has no idea — `\&` produces the glyph and `amp;`
+is four more ordinary characters — so the entry renders "Computer Engineering,
+&amp; Applied Computing", and pdflatex prints exactly the same. Not a parity gap
+in either direction: an input corruption only the `.bib` reader is positioned to
+undo. `undouble_escaped_ampersand` decodes it to a plain `&` and lets the two
+treatments give it its meaning. Witnesses: `\&amp;` in `booktitle` (2605.00833,
+2605.01362), `journal` (2605.00922, 2605.01200, 2605.01224), `title`
+(2605.01353); `{\&}amp;` in `title` (2605.01224); bare `&amp;` in `publisher`
+(2605.00859) and `journal` (2605.01187).
 
-*Why the mouth and not a parameter type.* `&` derails alignment in **any**
-field, and the fields carrying it here have no Perl `Semiverbatim` precedent to
-follow — unlike `doi`/`isbn`/`issn`/`lccn`/`pii`, whose per-field treatment
-`eprint` joins. Per-Mouth rather than a State catcode for #74's reason: a raw
-`.sty` opened from inside a field handler, and the document itself, must keep
-TeX's alignment tab. The rule belongs to the text BibTeX lexed.
+**Why this is authorized surpass-Perl AND surpass-pdflatex.** User decision,
+2026-07-27. LaTeXML reads `.bib` **directly**, with no `.bst` and no `bibtex(1)`
+in the loop, so it is the component deciding what reaches the tokenizer. That
+the real toolchain also breaks on these characters is a property of that
+toolchain, not a semantic we are obliged to reproduce: the author's intent for
+`AT&T` in a bibliography field is plainly the two letters, an ampersand and a T.
+This supersedes the "genuine parity, pdflatex breaks on it too" reading that #73
+applied to a `title`, and it covers `volume = {27 suppl_4}` and
+`language = {en_US}`, which a narrower earlier version of this fix left erroring.
 
-Authorized surpass-Perl **and** surpass-pdflatex: LaTeXML reads `.bib`
-directly, with no `.bst` and no `bibtex(1)` in the path, so it decides what
-reaches the tokenizer, and the real toolchain's breakage there is a property of
-that toolchain. `#` is deliberately **not** included: across all seven
-witnesses there is exactly one bare `#`, in 2605.00462's JabRef `file` path,
-and that field is already covered as an unknown field
-(`\bib@field@default@default Verbatim Verbatim`). No evidence, no change.
+**Guards.** `06_cluster_bibliography::bib_field_specials_are_data_not_tex` (one
+ten-entry fixture, because the risk is precisely that fixing one case breaks
+another: the four specials bare, the same four already escaped rendering an
+IDENTICAL string, `$x_1+x_2$` keeping its `SUBSCRIPTOP`, `\emph` still markup,
+`{\v S}pakov` still reverting, `%20` inside `\url{…}` intact, and `url`/`doi`
+values with no backslash); `::bib_field_percent_is_an_ordinary_character`;
+`::bib_bare_ampersand_is_literal_data`;
+`::bib_bare_ampersand_leaves_live_markup_alone`;
+`::bib_escaped_amp_entity_decodes_to_one_ampersand`;
+`55_bibtex::runaway_field_costs_only_its_own_entry`; and six
+`escape_bib_data_specials` unit tests in `bibtex.rs`, which isolate the `\\&`
+hazard that cannot live end-to-end (see below).
 
-**(b) The doubly escaped `\&amp;`.** A reference manager rendered the field to
-HTML (`&` → `&amp;`), then a second pass TeX-escaped that entity's own
-ampersand. Three spellings, all found by scanning 6000 arXiv/2605 sources:
-`\&amp;` (booktitle 2605.00833, 2605.01362; journal 2605.00922, 2605.01200,
-2605.01224; title 2605.01353 `{{A}}\&amp;{{AS}}`), `{\&}amp;` (title 2605.01224,
-"Reversible Template-based Shake {\&}amp; Bake Generation") and bare `&amp;`
-(publisher 2605.00859; journal 2605.01187).
+**Measured**, `--release` before/after on the same host, TOTAL document errors:
 
-Not the same bug, and (a) does not fix it: that `&` is already **escaped**, so
-it raises no error at all — in Perl or in pdflatex, both of which print
-"Computer Engineering, &amp; Applied Computing". The damage is the stray `amp;`.
-`undouble_escaped_ampersand` (`bibtex.rs`) drops an `amp;` that directly follows
-an ampersand in any of its three spellings, at the entry-assembly seam and again
-in `\bib@@title`, which re-reads the RAW field for its case conversion (Perl
-L294) and so bypasses the first. Only `amp;` immediately after an ampersand is
-touched: "amplitude", and a lone `\&`, are untouched. Measured: witness
-2605.00833 renders "Computer Engineering, & Applied Computing" (was
-"&amp;"), 0 errors.
+| cluster | witness | before | after |
+|---|---|---|---|
+| `_` | 2605.06926 | 8 | **0** |
+| `_` | 2605.01936 | 13 | **0** |
+| `_` | 2605.04604 | 2 | **0** |
+| `_` | 2605.08986 | 2 | **0** |
+| `_` | 2605.05898 | 1 | **0** |
+| `_` | 2605.11300 | 1 | **0** |
+| `%` | 2605.01196 | 28 | **0** |
+| `%` | 2605.02131 | 28 | **0** |
+| `%` | 2605.00879 | 103 | **1** |
+| `&` | 2605.06249 | 3 | **0** |
+| `&` | 2605.03054 | 1 | **0** |
+| `&` | 2605.00462 | 1 | **0** |
+| `&` | 2605.08753 | 1 | **0** |
+| `&` | 2605.10409 | 1 | **0** |
+| `&` | 2605.00833 | 0 | **0** |
 
-*Why repair it rather than render it faithfully.* It is not a TeX construct
-that a reader might have meant — no author writes `\&amp;` intending the six
-characters — it is one file mixing two escaping conventions, and the entity is
-unambiguous. Rendering it faithfully means printing `&amp;` in a bibliography
-for every reader of the paper. pdflatex has no way to know better; reading the
-`.bib` directly, we do, which is the same position #73 argued from.
+**193 → 0.** Two residuals are unrelated to this cluster and were unchanged by
+it: 2605.00879's remaining error is `undefined:\mathsemicolon`, and 2605.11579
+(listed for the `_` cluster) has 5 errors before AND after with zero
+`unexpected:_` in either — its apparent three were an artifact of measuring in
+the DEGRADED no-dump mode a fresh worktree starts in. Run
+`tools/make_formats.sh` before believing any error count. 2605.00833 is a
+RENDERING witness, not an error-count one: its `\&amp;` printed as "&amp;" and
+now prints "&".
 
-**Boundary, verified rather than assumed.** The neutralization downgrades one
-catcode and nothing else: in the same entry that carries a bare `&`, `\emph`
-still produces markup, `$x_1+x_2$` still parses as math with `_` a subscript
-INSIDE math, and the space-form accents PR #399 recovered (`{\v S}pakov` →
-Špakov, `Gon{\c c}alves` → Gonçalves) still resolve.
-
-Guards: `06_cluster_bibliography::bib_bare_ampersand_is_literal_data`,
-`::bib_bare_ampersand_leaves_live_markup_alone` (the boundary entry) and
-`::bib_escaped_amp_entity_decodes_to_one_ampersand` (all three spellings, a `\&`
-control, and an "amp;"-as-ordinary-text near miss).
+**Known not covered.** A literal `\\` in a title makes
+`\bib@field@default@title` open a nested `<ltx:bibitem>`
+(`malformed:ltx:bibitem <ltx:bibitem> isn't allowed in <ltx:bib-title>`) with no
+special character anywhere in the entry — a pre-existing behaviour of `\\` in a
+bibliography, independent of this work, and the reason the `\\&` hazard is
+pinned by a unit test rather than end-to-end. `^` is deliberately outside the
+set: it is not in the authorized four, and outside math in a `.bib` field it is
+essentially always a typo (it also remains the live probe in
+`105_bib_field_digest_once`). An `&` inside a `.bib` field's `$\begin{array}…$`
+would lose its alignment meaning — treatment 1 is catcode-level and cannot be
+math-aware; no witness exhibits one.
 
 ### 75. A `.bib`-derived bibliography does not run the missing-`\bibitem` rescue
 

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2337,9 +2337,22 @@ opened and never closed" shape, same `%`-eats-the-closing-brace mechanism, but
 #73's three fields could be read `Verbatim` because nothing renders
 `ltx:bib-extract`, while `doi`/`title` are rendered and cannot be). Measured on
 the same host: **2605.01196 28 → 0 errors** (Perl `latexmlc` 29; output otherwise
-byte-identical, 83 bibitems before and after — the entire cost was diagnostics)
-and **2605.02131 28 → 0** (Perl 31; 20 bibitems unchanged, and the two
-percent-encoded `\href` titles now render, URLs intact).
+byte-identical, 83 bibitems before and after — the entire cost was diagnostics),
+**2605.02131 28 → 0** (Perl 31; 20 bibitems unchanged, and the two
+percent-encoded `\href` titles now render, URLs intact), and **2605.00879
+103 → 5** (`note = {https://doi.org/10.1145%2F3292500.3330925}`; the residual 5
+are other clusters — `unexpected:_`, `\mathsemicolon`).
+
+**How much of the corpus this is.** Over the first 1200 papers of
+sandbox-arxiv-2605, 178 ship a `.bib` with a `%` somewhere in a field value; 66
+of those have an *unescaped* `%` in a field other than the three #73 already
+reads `Verbatim`. Of the 15 whose field is one that is neither `Semiverbatim`
+nor `Verbatim` (`doi`, `note`, `journal`, `howpublished`, `adsurl`), two were
+broken and are now clean — 2605.00879 (103 → 5) and 2605.01196 (28 → 0) — and
+the other 13 were already fine, because `url` (#72) and unknown fields
+(`\bib@field@default@default Verbatim Verbatim`) had their catcodes protected by
+their parameter type. That is exactly the population this closes: the rendered
+fields no parameter type was protecting.
 
 Guard: `06_cluster_bibliography::bib_field_percent_is_an_ordinary_character`
 (fixture `bib_field_percent.{tex,bib}` — one entry per seam plus a containment

--- a/latexml_core/src/mouth.rs
+++ b/latexml_core/src/mouth.rs
@@ -83,6 +83,13 @@ pub struct Mouth {
   /// floor and cheaper than a per-read flag check.
   last_token_start:       (usize, usize),
   foodtype:               FoodType,
+  /// Read `%` as an ordinary character rather than a comment, for this
+  /// mouth only. Set by `with_percent_as_other()`; see that method for the
+  /// BibTeX rationale. Deliberately a per-Mouth field rather than a State
+  /// catcode assignment: a nested mouth (a `.sty` raw-load triggered from
+  /// inside the text) is a separate object and keeps `%` as a comment,
+  /// which a State-level assignment could not guarantee.
+  percent_is_other:       bool,
   saved_at_cc:            Option<Catcode>,
   saved_include_comments: Option<bool>,
   note_message:           Option<String>,
@@ -129,6 +136,7 @@ impl Default for Mouth {
       shortsource:            s!("String"),
       // handle : None,
       foodtype:               FoodType::File,
+      percent_is_other:       false,
       saved_at_cc:            None,
       saved_include_comments: None,
       buffer:                 VecDeque::new(),
@@ -283,6 +291,30 @@ impl Mouth {
     };
     mouth.open(text)?;
     Ok(mouth)
+  }
+
+  /// Read `%` as an ordinary character (catcode 12) instead of a comment,
+  /// for the whole life of this mouth.
+  ///
+  /// BibTeX's lexer has **no comment syntax inside an entry** — `%` is only
+  /// significant in the junk BETWEEN entries (`Pre::BibTeX::skipJunk`), so a
+  /// field value it hands back is a string in which `%` is an ordinary
+  /// character. When such a value is re-injected as TeX source (BibTeX.pool's
+  /// `\bibentry@create`), the default catcode 14 makes it comment out the rest
+  /// of its line — the field's own closing brace included — and the entry's
+  /// group never closes. Reading the injected text with `%` neutralized is what
+  /// preserves the value BibTeX actually parsed.
+  ///
+  /// A `\catcode` in the injected text cannot do this job: the catcode would
+  /// still be a State assignment, so a raw `.sty` opened from inside a field
+  /// handler would inherit it. Scoping to the Mouth keeps the rule attached to
+  /// the *text that BibTeX lexed*, which is exactly where it belongs.
+  ///
+  /// Only comment-ness is removed: a `%` that has been given some other catcode
+  /// (LETTER, say) keeps it.
+  pub fn with_percent_as_other(mut self) -> Self {
+    self.percent_is_other = true;
+    self
   }
 
   pub fn get_source(&self) -> &str { &self.source }
@@ -611,7 +643,7 @@ impl Mouth {
     self.colno += 1;
     if let Some(ch) = ch_opt {
       let mut ch = *ch;
-      let mut cc = lookup_catcode(ch).unwrap_or(Catcode::OTHER);
+      let mut cc = self.catcode_of(ch);
       // Possible convert ^^x
       // Perl: (cc == CC_SUPER) && (colno + 1 < nchars) && (ch == chars[colno])
       if cc == Catcode::SUPER
@@ -647,11 +679,22 @@ impl Mouth {
           self.splice(self.colno - 1..self.colno + 2, &[ch]);
           self.nchars -= 2;
         }
-        cc = lookup_catcode(ch).unwrap_or(Catcode::OTHER);
+        cc = self.catcode_of(ch);
       }
       Some((ch, cc))
     } else {
       None
+    }
+  }
+
+  /// The catcode this mouth reads `ch` with: the State's, except that a
+  /// `with_percent_as_other()` mouth downgrades a COMMENT `%` to OTHER.
+  fn catcode_of(&self, ch: char) -> Catcode {
+    let cc = lookup_catcode(ch).unwrap_or(Catcode::OTHER);
+    if self.percent_is_other && ch == '%' && cc == Catcode::COMMENT {
+      Catcode::OTHER
+    } else {
+      cc
     }
   }
 
@@ -1113,6 +1156,29 @@ pub fn tokenize(text: &str) -> Tokens {
   use_main_state();
   result
 }
+/// Tokenize a string under the standard catcode table, reading `%` as an
+/// ordinary character rather than a comment.
+///
+/// For text that came out of a lexer with no comment syntax of its own — a
+/// BibTeX field value, whose `%` is data (see
+/// [`Mouth::with_percent_as_other`]). Plain [`tokenize`] would let that `%`
+/// comment out the rest of the string, which for a `.bib` field means losing
+/// its closing brace and leaving whatever it opened unclosed
+/// (`OXIDIZED_DESIGN #74`).
+pub fn tokenize_percent_literal(text: &str) -> Tokens {
+  // special case! empty input is empty Tokens
+  if text.is_empty() {
+    return NO_TOKENS;
+  }
+  use_std_state();
+  let result = Mouth::new(text, None)
+    .unwrap()
+    .with_percent_as_other()
+    .read_tokens();
+  use_main_state();
+  result
+}
+
 /// Tokenize a string under the **style-file** catcode table — Perl
 /// `Package.pm:TokenizeInternal` L1026-1030.
 ///

--- a/latexml_core/src/mouth.rs
+++ b/latexml_core/src/mouth.rs
@@ -83,17 +83,14 @@ pub struct Mouth {
   /// floor and cheaper than a per-read flag check.
   last_token_start:       (usize, usize),
   foodtype:               FoodType,
-  /// Read `%` as an ordinary character rather than a comment, for this
-  /// mouth only. Set by `with_percent_as_other()`; see that method for the
-  /// BibTeX rationale. Deliberately a per-Mouth field rather than a State
-  /// catcode assignment: a nested mouth (a `.sty` raw-load triggered from
-  /// inside the text) is a separate object and keeps `%` as a comment,
-  /// which a State-level assignment could not guarantee.
-  percent_is_other:       bool,
-  /// Read `&` as an ordinary character rather than an alignment tab, for this
-  /// mouth only. Set by `with_align_as_other()`; same per-Mouth scoping, and
-  /// for the same reason, as `percent_is_other` above.
-  align_is_other:         bool,
+  /// Read `% & #` as ordinary characters — not comment, alignment tab,
+  /// parameter — for this mouth only. Set by `with_bib_data_literals()`; see
+  /// that method for the BibTeX rationale, and for why `_` is NOT here.
+  /// Deliberately a per-Mouth field rather than a State catcode assignment: a
+  /// nested mouth (a `.sty` raw-load triggered from inside the text) is a
+  /// separate object and keeps TeX's meanings, which a State-level assignment
+  /// could not guarantee.
+  bib_data_literals:      bool,
   saved_at_cc:            Option<Catcode>,
   saved_include_comments: Option<bool>,
   note_message:           Option<String>,
@@ -140,8 +137,7 @@ impl Default for Mouth {
       shortsource:            s!("String"),
       // handle : None,
       foodtype:               FoodType::File,
-      percent_is_other:       false,
-      align_is_other:         false,
+      bib_data_literals:      false,
       saved_at_cc:            None,
       saved_include_comments: None,
       buffer:                 VecDeque::new(),
@@ -298,50 +294,46 @@ impl Mouth {
     Ok(mouth)
   }
 
-  /// Read `%` as an ordinary character (catcode 12) instead of a comment,
-  /// for the whole life of this mouth.
+  /// Read `% & #` as ordinary characters (catcode 12) instead of comment,
+  /// alignment tab and parameter, for the whole life of this mouth.
   ///
-  /// BibTeX's lexer has **no comment syntax inside an entry** — `%` is only
-  /// significant in the junk BETWEEN entries (`Pre::BibTeX::skipJunk`), so a
-  /// field value it hands back is a string in which `%` is an ordinary
-  /// character. When such a value is re-injected as TeX source (BibTeX.pool's
-  /// `\bibentry@create`), the default catcode 14 makes it comment out the rest
-  /// of its line — the field's own closing brace included — and the entry's
-  /// group never closes. Reading the injected text with `%` neutralized is what
-  /// preserves the value BibTeX actually parsed.
+  /// **Treatment 1 of two** (see `OXIDIZED_DESIGN #74`): this is "be `bibtex`".
+  /// BibTeX's lexer interprets only braces and the entry/field delimiters — it
+  /// has no comment syntax inside an entry (`%` is significant only in the junk
+  /// BETWEEN entries, `Pre::BibTeX::skipJunk`), no alignment and no parameters.
+  /// So a field value it hands back is a string in which all three are ordinary
+  /// characters: a percent-encoded URL, a publisher's name ("Taylor &
+  /// Francis"), an issue number.
   ///
-  /// A `\catcode` in the injected text cannot do this job: the catcode would
-  /// still be a State assignment, so a raw `.sty` opened from inside a field
-  /// handler would inherit it. Scoping to the Mouth keeps the rule attached to
-  /// the *text that BibTeX lexed*, which is exactly where it belongs.
+  /// Re-injected as TeX source (BibTeX.pool's `\bibentry@create`) under the
+  /// default catcodes, each misfires: `%` (14) comments out the rest of its
+  /// line — the field's own closing brace included — so the entry's group never
+  /// closes; `&` (4) is a stray alignment tab and is dropped; `#` (6) reaches
+  /// the Stomach as a parameter token. Reading the injected text with all three
+  /// neutralized preserves the value BibTeX actually parsed, **without altering
+  /// a byte of it**.
   ///
-  /// Only comment-ness is removed: a `%` that has been given some other catcode
-  /// (LETTER, say) keeps it.
-  pub fn with_percent_as_other(mut self) -> Self {
-    self.percent_is_other = true;
-    self
-  }
-
-  /// Read `&` as an ordinary character (catcode 12) instead of an alignment
-  /// tab, for the whole life of this mouth.
+  /// **`_` is deliberately NOT in this set**, and the reason is the boundary
+  /// between the two treatments. A catcode is decided at tokenization, before
+  /// anything knows whether it is inside `$…$` — and a subscript in a `.bib`
+  /// title's math (`title = {Bounds on $x_1+x_2$}`) is *legitimate TeX* that
+  /// must keep working. `_` therefore belongs to treatment 2
+  /// (`bibtex.rs::escape_bib_data_specials`), which walks the value and skips
+  /// math spans. Measured: putting `_` here silently flattened every
+  /// subscript in a bibliography title. The other three have no legitimate
+  /// meaning inside a `.bib` field, in math or out.
   ///
-  /// The companion of [`Self::with_percent_as_other`], and the same argument:
-  /// BibTeX's lexer has no alignment either, so an `&` in a field value it
-  /// hands back is an ordinary character — a publisher's name ("Taylor &
-  /// Francis"), a journal's ("Infrared Physics & Technology"), a conference's
-  /// ("Knowledge Discovery & Data Mining"). Under TeX's catcode 4 each one is a
-  /// stray alignment tab, `Error:unexpected:&`, and the character is dropped
-  /// from the rendered entry.
+  /// A `\catcode` in the injected text cannot do this job either: the catcode
+  /// would still be a State assignment, so a raw `.sty` opened from inside a
+  /// field handler would inherit it — and so would the document. Scoping to the
+  /// Mouth keeps the rule attached to the *text that BibTeX lexed*, which is
+  /// exactly where it belongs.
   ///
-  /// Per-Mouth rather than a State catcode for the same reason as `%`: a raw
-  /// `.sty` opened from inside a field handler must keep TeX's alignment tab,
-  /// and so must the DOCUMENT — this rule belongs to the text BibTeX lexed, not
-  /// to the session.
-  ///
-  /// Only alignment-ness is removed: an `&` that has been given some other
-  /// catcode keeps it.
-  pub fn with_align_as_other(mut self) -> Self {
-    self.align_is_other = true;
+  /// Only the TeX-special meaning is removed: a character that has been given
+  /// some other catcode (LETTER, say) keeps it. And `\%`, `\&`, `\#` still
+  /// work, because the backslash is untouched.
+  pub fn with_bib_data_literals(mut self) -> Self {
+    self.bib_data_literals = true;
     self
   }
 
@@ -716,13 +708,16 @@ impl Mouth {
   }
 
   /// The catcode this mouth reads `ch` with: the State's, except that a
-  /// `with_percent_as_other()` mouth downgrades a COMMENT `%` to OTHER, and a
-  /// `with_align_as_other()` mouth downgrades an ALIGN `&` the same way.
+  /// [`Self::with_bib_data_literals`] mouth downgrades the four BibTeX-data
+  /// characters to OTHER when — and only when — they still carry their TeX
+  /// meaning.
   fn catcode_of(&self, ch: char) -> Catcode {
     let cc = lookup_catcode(ch).unwrap_or(Catcode::OTHER);
-    match cc {
-      Catcode::COMMENT if self.percent_is_other && ch == '%' => Catcode::OTHER,
-      Catcode::ALIGN if self.align_is_other && ch == '&' => Catcode::OTHER,
+    if !self.bib_data_literals {
+      return cc;
+    }
+    match (cc, ch) {
+      (Catcode::COMMENT, '%') | (Catcode::ALIGN, '&') | (Catcode::PARAM, '#') => Catcode::OTHER,
       _ => cc,
     }
   }
@@ -1185,16 +1180,20 @@ pub fn tokenize(text: &str) -> Tokens {
   use_main_state();
   result
 }
-/// Tokenize a string under the standard catcode table, reading `%` and `&` as
-/// ordinary characters rather than a comment and an alignment tab.
+/// Tokenize a string under the standard catcode table, reading `% & #` as
+/// ordinary characters rather than comment, alignment tab and parameter.
 ///
-/// For text that came out of the BibTeX lexer, which has neither construct, so
-/// both characters are data (see [`Mouth::with_percent_as_other`] and
-/// [`Mouth::with_align_as_other`]). Plain [`tokenize`] would let that `%`
-/// comment out the rest of the string — which for a `.bib` field means losing
-/// its closing brace and leaving whatever it opened unclosed
-/// (`OXIDIZED_DESIGN #74`) — and would make an `&` in "Taylor & Francis" a
-/// stray alignment tab (`#75`).
+/// For text that came out of the BibTeX lexer, which has none of those
+/// constructs, so all three are data — treatment 1 of `OXIDIZED_DESIGN #74`,
+/// see [`Mouth::with_bib_data_literals`] (including why `_` is not in the set).
+/// Plain [`tokenize`] would let a `%` comment out the rest of the string, which
+/// for a `.bib` field means losing its closing brace and leaving whatever it
+/// opened unclosed, and would make the `&` in "Taylor & Francis" a stray
+/// alignment tab.
+///
+/// This exists because the handlers that re-read a raw field — `\bib@@title`
+/// recasing, name splitting, date/pages assembly — build their tokens from the
+/// stored string and never pass through the per-entry mouth.
 pub fn tokenize_bib_literal(text: &str) -> Tokens {
   // special case! empty input is empty Tokens
   if text.is_empty() {
@@ -1203,8 +1202,7 @@ pub fn tokenize_bib_literal(text: &str) -> Tokens {
   use_std_state();
   let result = Mouth::new(text, None)
     .unwrap()
-    .with_percent_as_other()
-    .with_align_as_other()
+    .with_bib_data_literals()
     .read_tokens();
   use_main_state();
   result

--- a/latexml_core/src/mouth.rs
+++ b/latexml_core/src/mouth.rs
@@ -90,6 +90,10 @@ pub struct Mouth {
   /// inside the text) is a separate object and keeps `%` as a comment,
   /// which a State-level assignment could not guarantee.
   percent_is_other:       bool,
+  /// Read `&` as an ordinary character rather than an alignment tab, for this
+  /// mouth only. Set by `with_align_as_other()`; same per-Mouth scoping, and
+  /// for the same reason, as `percent_is_other` above.
+  align_is_other:         bool,
   saved_at_cc:            Option<Catcode>,
   saved_include_comments: Option<bool>,
   note_message:           Option<String>,
@@ -137,6 +141,7 @@ impl Default for Mouth {
       // handle : None,
       foodtype:               FoodType::File,
       percent_is_other:       false,
+      align_is_other:         false,
       saved_at_cc:            None,
       saved_include_comments: None,
       buffer:                 VecDeque::new(),
@@ -314,6 +319,29 @@ impl Mouth {
   /// (LETTER, say) keeps it.
   pub fn with_percent_as_other(mut self) -> Self {
     self.percent_is_other = true;
+    self
+  }
+
+  /// Read `&` as an ordinary character (catcode 12) instead of an alignment
+  /// tab, for the whole life of this mouth.
+  ///
+  /// The companion of [`Self::with_percent_as_other`], and the same argument:
+  /// BibTeX's lexer has no alignment either, so an `&` in a field value it
+  /// hands back is an ordinary character — a publisher's name ("Taylor &
+  /// Francis"), a journal's ("Infrared Physics & Technology"), a conference's
+  /// ("Knowledge Discovery & Data Mining"). Under TeX's catcode 4 each one is a
+  /// stray alignment tab, `Error:unexpected:&`, and the character is dropped
+  /// from the rendered entry.
+  ///
+  /// Per-Mouth rather than a State catcode for the same reason as `%`: a raw
+  /// `.sty` opened from inside a field handler must keep TeX's alignment tab,
+  /// and so must the DOCUMENT — this rule belongs to the text BibTeX lexed, not
+  /// to the session.
+  ///
+  /// Only alignment-ness is removed: an `&` that has been given some other
+  /// catcode keeps it.
+  pub fn with_align_as_other(mut self) -> Self {
+    self.align_is_other = true;
     self
   }
 
@@ -688,13 +716,14 @@ impl Mouth {
   }
 
   /// The catcode this mouth reads `ch` with: the State's, except that a
-  /// `with_percent_as_other()` mouth downgrades a COMMENT `%` to OTHER.
+  /// `with_percent_as_other()` mouth downgrades a COMMENT `%` to OTHER, and a
+  /// `with_align_as_other()` mouth downgrades an ALIGN `&` the same way.
   fn catcode_of(&self, ch: char) -> Catcode {
     let cc = lookup_catcode(ch).unwrap_or(Catcode::OTHER);
-    if self.percent_is_other && ch == '%' && cc == Catcode::COMMENT {
-      Catcode::OTHER
-    } else {
-      cc
+    match cc {
+      Catcode::COMMENT if self.percent_is_other && ch == '%' => Catcode::OTHER,
+      Catcode::ALIGN if self.align_is_other && ch == '&' => Catcode::OTHER,
+      _ => cc,
     }
   }
 
@@ -1156,16 +1185,17 @@ pub fn tokenize(text: &str) -> Tokens {
   use_main_state();
   result
 }
-/// Tokenize a string under the standard catcode table, reading `%` as an
-/// ordinary character rather than a comment.
+/// Tokenize a string under the standard catcode table, reading `%` and `&` as
+/// ordinary characters rather than a comment and an alignment tab.
 ///
-/// For text that came out of a lexer with no comment syntax of its own — a
-/// BibTeX field value, whose `%` is data (see
-/// [`Mouth::with_percent_as_other`]). Plain [`tokenize`] would let that `%`
-/// comment out the rest of the string, which for a `.bib` field means losing
+/// For text that came out of the BibTeX lexer, which has neither construct, so
+/// both characters are data (see [`Mouth::with_percent_as_other`] and
+/// [`Mouth::with_align_as_other`]). Plain [`tokenize`] would let that `%`
+/// comment out the rest of the string — which for a `.bib` field means losing
 /// its closing brace and leaving whatever it opened unclosed
-/// (`OXIDIZED_DESIGN #74`).
-pub fn tokenize_percent_literal(text: &str) -> Tokens {
+/// (`OXIDIZED_DESIGN #74`) — and would make an `&` in "Taylor & Francis" a
+/// stray alignment tab (`#75`).
+pub fn tokenize_bib_literal(text: &str) -> Tokens {
   // special case! empty input is empty Tokens
   if text.is_empty() {
     return NO_TOKENS;
@@ -1174,6 +1204,7 @@ pub fn tokenize_percent_literal(text: &str) -> Tokens {
   let result = Mouth::new(text, None)
     .unwrap()
     .with_percent_as_other()
+    .with_align_as_other()
     .read_tokens();
   use_main_state();
   result

--- a/latexml_engine/src/bibtex.rs
+++ b/latexml_engine/src/bibtex.rs
@@ -2005,7 +2005,8 @@ LoadDefinitions!({
     // so the entry's group never closes, `ltx:bibentry` is left open, and every
     // later entry nests inside it. Witnesses arXiv 2605.01196 (`doi={%doi:...}`)
     // and 2605.02131 (a percent-encoded URL in a `title`'s `\href`): 28 errors
-    // each, and Perl breaks identically (29 / 31 on the same host).
+    // each, and Perl breaks identically (29 / 31 on the same host); 2605.00879
+    // (`note = {https://doi.org/10.1145%2F...}`): 103 errors.
     // Guard: `06_cluster_bibliography::bib_field_percent_is_an_ordinary_character`.
     open_mouth_with(
       Mouth::new(&lines.join("\n"), None)?.with_percent_as_other(),

--- a/latexml_engine/src/bibtex.rs
+++ b/latexml_engine/src/bibtex.rs
@@ -275,20 +275,67 @@ pub fn current_entry_field(name: &str) -> Option<Tokens> {
 
 /// `Tokenize!` for a string that came out of the BibTeX lexer.
 ///
-/// The standard catcode table, as Perl's `Tokenize` uses — except that `%` is
-/// an ordinary character. BibTeX has no comment syntax inside an entry
-/// (`Pre::BibTeX` only skips `%` in the junk BETWEEN entries), so a `%` in a
-/// field value is data; under catcode 14 it comments out the rest of the
-/// string and takes any brace still open with it, which leaves the field's
-/// element unclosed and swallows every following entry. Witness 2605.02131:
-/// a percent-encoded URL in a `title`'s `\href`, 24 `malformed:ltx:bibentry`.
-/// See `OXIDIZED_DESIGN #74`.
+/// The standard catcode table, as Perl's `Tokenize` uses — except that `%` and
+/// `&` are ordinary characters. BibTeX has no comment syntax inside an entry
+/// (`Pre::BibTeX` only skips `%` in the junk BETWEEN entries) and no alignment
+/// either, so both are data; under catcode 14 a `%` comments out the rest of
+/// the string and takes any brace still open with it, and under catcode 4 an
+/// `&` is a stray alignment tab. Witnesses 2605.02131 (a percent-encoded URL in
+/// a `title`'s `\href`, 24 `malformed:ltx:bibentry`) and 2605.01936
+/// (`publisher = {Taylor & Francis}` and six more, 7 `unexpected:&`).
+/// See `OXIDIZED_DESIGN #74` and `#75`.
 ///
 /// This is the same rule the per-entry Mouth applies (see `\ProcessBibTeXEntry`
 /// below); it has to be repeated here because the handlers that re-read a raw
 /// field — `\bib@@title` recasing, name splitting, date/pages assembly — build
 /// their tokens from the stored string and never go through that mouth.
-fn tokenize_bib_field(text: &str) -> Tokens { mouth::tokenize_percent_literal(text) }
+fn tokenize_bib_field(text: &str) -> Tokens { mouth::tokenize_bib_literal(text) }
+
+/// Collapse an HTML-escaped ampersand — `&amp;` — back to the single `&` the
+/// author wrote, in whichever of its three spellings a `.bib` export used.
+///
+/// This is a DOUBLE escape, not a TeX construct: a reference manager rendered
+/// the field to HTML (`&` -> `&amp;`), then a second pass TeX-escaped the
+/// ampersand of that entity, so the file carries `\&amp;` / `{\&}amp;` /
+/// `&amp;` where the source said `&`. TeX has no idea: `\&` produces the glyph
+/// and `amp;` is four more ordinary characters, so the entry renders
+/// "Computer Engineering, &amp; Applied Computing". pdflatex prints exactly the
+/// same thing — this is not a parity gap in either direction, it is an input
+/// corruption that only the `.bib` reader is positioned to undo, and we read
+/// `.bib` directly (see OXIDIZED_DESIGN #73's framing of that position).
+///
+/// Distinct from a BARE `&`, which is catcode 4 and is neutralized at the mouth
+/// (`tokenize_bib_field` above, `#75`). Decoding here deliberately yields a
+/// plain `&` and lets that mechanism give it its catcode, rather than escaping
+/// it to `\&` behind the mechanism's back.
+///
+/// Measured over 6000 arXiv/2605 sources: `\&amp;` in `booktitle` (2605.00833,
+/// 2605.01362), in `journal` (2605.00922, 2605.01200, 2605.01224), in `title`
+/// (2605.01353 `{{A}}\&amp;{{AS}}`); `{\&}amp;` in `title` (2605.01224 "Shake
+/// {\&}amp; Bake"); bare `&amp;` in `publisher` (2605.00859 "European
+/// Association of Geoscientists &amp; Engineers") and `journal` (2605.01187).
+///
+/// Only `amp;` DIRECTLY after an ampersand is touched, so a field that merely
+/// contains the letters "amp" is untouched, and a lone `&` is left exactly as
+/// it was.
+fn undouble_escaped_ampersand(value: &str) -> String {
+  if !value.contains("amp;") {
+    return value.to_string();
+  }
+  let mut out = String::with_capacity(value.len());
+  let mut rest = value;
+  while let Some(i) = rest.find("amp;") {
+    let (head, tail) = rest.split_at(i);
+    out.push_str(head);
+    // `{\&}` first: its last character is `}`, not `&`.
+    if !(head.ends_with("{\\&}") || head.ends_with('&')) {
+      out.push_str("amp;");
+    }
+    rest = &tail["amp;".len()..];
+  }
+  out.push_str(rest);
+  out
+}
 
 /// Perl: `currentBibEntryRawField('fieldname')` — get the *raw*
 /// source string of a field on the current entry.
@@ -1053,7 +1100,11 @@ LoadDefinitions!({
       })
       .unwrap_or_else(|| "capitalize1".to_string());
     let mode = TitleCaseMode::parse(&mode_str);
-    let raw = current_entry_raw_field(&field_name).unwrap_or_default();
+    // Re-read the RAW field rather than the passed argument (Perl L294), which
+    // is why the decode in `\bibentry@create` does not reach this path and has
+    // to be repeated here — witness 2605.01353, a `title` reading
+    // `{{A}}\&amp;{{AS}}`. See `undouble_escaped_ampersand`.
+    let raw = undouble_escaped_ampersand(&current_entry_raw_field(&field_name).unwrap_or_default());
     let recased = recase_title(&raw, mode);
     // Emit `\bib@@field{tag}{}{<recased>}`. The empty `{}` slot
     // is the OptionalKeyVals arg (absent → no attributes).
@@ -1955,6 +2006,7 @@ LoadDefinitions!({
           break;
         }
       }
+      let value = &undouble_escaped_ampersand(value);
       match handler {
         Some(h) => {
           lines.push(format!("\\csname {}\\endcsname{{{}}}", &h[1..], value));
@@ -2008,8 +2060,21 @@ LoadDefinitions!({
     // each, and Perl breaks identically (29 / 31 on the same host); 2605.00879
     // (`note = {https://doi.org/10.1145%2F...}`): 103 errors.
     // Guard: `06_cluster_bibliography::bib_field_percent_is_an_ordinary_character`.
+    //
+    // `&` likewise (OXIDIZED_DESIGN #75) — BibTeX has no alignment either, so
+    // an `&` in a value it handed us is a character in a publisher's or a
+    // journal's name. Under catcode 4 it is a stray alignment tab:
+    // `Error:unexpected:&`, and the `&` is dropped from the entry, so "Taylor &
+    // Francis" printed as "Taylor Francis". Witnesses arXiv 2605.01936 (7),
+    // 2605.06249 (3), 2605.00462 / 2605.03054 / 2605.06624 / 2605.08753 /
+    // 2605.10409 (1 each). Same-host Perl and bibtex+pdflatex both break the
+    // same way — the decision that a field's content is DATA is what overrides
+    // them, and it is ours to make because we read the `.bib` directly.
+    // Guard: `06_cluster_bibliography::bib_bare_ampersand_is_literal_data`.
     open_mouth_with(
-      Mouth::new(&lines.join("\n"), None)?.with_percent_as_other(),
+      Mouth::new(&lines.join("\n"), None)?
+        .with_percent_as_other()
+        .with_align_as_other(),
       true,
       BalancedBoundary::Opaque,
     );

--- a/latexml_engine/src/bibtex.rs
+++ b/latexml_engine/src/bibtex.rs
@@ -263,6 +263,187 @@ fn bib_extract_text(field: &str) -> String {
     .unwrap_or_default()
 }
 
+/// The four TeX specials that a `.bib` field can only have meant literally.
+///
+/// Not `~` (a tie is plausible in a name) and not `^` (it only ever shows up in
+/// math here) — this is the maintainer-authorized set, no wider.
+const BIB_DATA_SPECIALS: [char; 4] = ['_', '&', '#', '%'];
+
+/// The `.bib`-data -> TeX-source boundary: escape the specials a `.bst` would
+/// have escaped, so the synthesized entry line is valid TeX.
+///
+/// Real BibTeX has TWO regimes and latexml-oxide collapses them into one pass.
+/// In the DATA regime (`.bib` read by `bibtex(1)`) a field's bytes are data:
+/// `%` is not a comment, `&` is not an alignment tab, `_` is not a subscript,
+/// `#` is not a parameter. Only in the TeX regime (the `.bbl` read by
+/// `pdflatex`) do those catcodes exist — and what lands in the `.bbl` is
+/// whatever the `.bst` chose to write. We read `.bib` directly, with no `.bst`
+/// in the loop, so we are the component that decides what reaches the
+/// tokenizer, and the author's intent for a bare `&` in `AT&T` is plainly the
+/// character. Escaping here — emitting what a careful `.bst` author would have
+/// written — is "be bibtex first, then be pdflatex on the `.bbl` you just
+/// synthesized". OXIDIZED_DESIGN #74.
+///
+/// Escaping at the boundary rather than neutralizing catcodes during digestion
+/// is what keeps the TeX regime intact **by construction**: `\emph{…}`,
+/// `{\v S}pakov` and `$x_1+x_2$` are already valid TeX and simply pass through.
+/// Two hazards, both guarded by
+/// `06_cluster_bibliography::bib_field_specials_are_data_not_tex`:
+///
+/// * **Math.** `_` inside `$…$` is a real subscript, so math spans are skipped.
+///   `$`/`$$` toggle; `\(`/`\[` open and `\)`/`\]` close.
+/// * **Idempotency.** Most `.bib` files already write `\&`, `\%`, `\_`. A
+///   backslash therefore consumes the next character as a pair and neither is
+///   re-examined, so `\&` stays `\&`. The tricky case falls out of the same
+///   rule: in `\\&` the `\\` is consumed as one pair, leaving a genuinely bare
+///   `&` that IS escaped.
+fn escape_bib_data_specials(value: &str) -> String {
+  let mut out = String::with_capacity(value.len() + 8);
+  let mut chars = value.chars().peekable();
+  let mut in_math = false;
+  while let Some(c) = chars.next() {
+    match c {
+      '\\' => {
+        out.push('\\');
+        match chars.peek() {
+          // A control WORD. Copy it whole (the terminating space is emitted by
+          // the next iteration, so `\ndash 693` keeps its space), then — if it
+          // reads its own argument verbatim — copy that argument untouched too.
+          Some(n) if n.is_alphabetic() => {
+            let mut word = String::new();
+            while let Some(&n) = chars.peek() {
+              if !n.is_alphabetic() {
+                break;
+              }
+              word.push(n);
+              chars.next();
+            }
+            out.push_str(&word);
+            if VERBATIM_ARG_COMMANDS.contains(&word.as_str()) {
+              copy_balanced_group(&mut chars, &mut out);
+            }
+          },
+          // A control SYMBOL. Copy the pair. This one arm is the whole of the
+          // idempotency rule (`\&` stays `\&`) AND of "leave `\` alone" — and
+          // it is what makes the tricky `\\&` case fall out for free: `\\` is
+          // consumed here as one pair, leaving a genuinely bare `&` to escape.
+          Some(_) => {
+            let n = chars.next().unwrap_or('\\');
+            out.push(n);
+            match n {
+              '(' | '[' => in_math = true,
+              ')' | ']' => in_math = false,
+              _ => {},
+            }
+          },
+          None => {},
+        }
+      },
+      '$' => {
+        out.push('$');
+        // `$$` is one display delimiter, not two toggles.
+        if chars.peek() == Some(&'$') {
+          chars.next();
+          out.push('$');
+        }
+        in_math = !in_math;
+      },
+      _ if !in_math && BIB_DATA_SPECIALS.contains(&c) => {
+        out.push('\\');
+        out.push(c);
+      },
+      _ => out.push(c),
+    }
+  }
+  out
+}
+
+/// Control words that read their own next argument as DATA, so the escaper must
+/// leave that argument alone.
+///
+/// url.sty's `\url`/`\nolinkurl`/`\path` take a Verbatim argument and `\href`
+/// takes a Semiverbatim URL — a percent-encoded `%20` inside one is not a
+/// comment and must not become `\%`, which would land a literal backslash in
+/// the href. `howpublished = {\url{http://x.org/a%20b}}` is the measured case
+/// (`docs/parity/BIBLIOGRAPHY_WORKLIST.md` records it as a working probe, and
+/// blind escaping regressed it). Only ONE group is skipped, so `\href`'s second
+/// argument — real prose — is still escaped.
+const VERBATIM_ARG_COMMANDS: [&str; 5] = ["url", "nolinkurl", "path", "href", "doi"];
+
+/// Copy one balanced `{...}` group through untouched, leading spaces included.
+/// A no-op when the next non-space character is not `{`.
+fn copy_balanced_group(chars: &mut std::iter::Peekable<std::str::Chars>, out: &mut String) {
+  let mut pending = String::new();
+  while let Some(&c) = chars.peek() {
+    if c == ' ' {
+      pending.push(c);
+      chars.next();
+    } else {
+      break;
+    }
+  }
+  if chars.peek() != Some(&'{') {
+    out.push_str(&pending);
+    return;
+  }
+  out.push_str(&pending);
+  out.push('{');
+  chars.next();
+  let mut depth = 1usize;
+  for c in chars.by_ref() {
+    out.push(c);
+    match c {
+      '{' => depth += 1,
+      '}' => {
+        depth -= 1;
+        if depth == 0 {
+          break;
+        }
+      },
+      _ => {},
+    }
+  }
+}
+
+/// The field value to write into the synthesized entry line for `handler`.
+///
+/// A handler that declares a `Verbatim`/`Semiverbatim` first parameter reads the
+/// field's characters itself, under its own catcode table, and hands them on as
+/// a string — a `url` href, a `doi` id. Escaping those would put a literal
+/// backslash in the value, so they are passed through raw. Perl declares
+/// exactly which fields those are (`BibTeX.pool.ltxml` L740 `url` **Verbatim**,
+/// L684/L750-783 `crossref`/`doi`/`isbn`/`issn`/`lccn`/`pii` **Semiverbatim**),
+/// and this reads that declaration back off the definition instead of keeping a
+/// second copy of the list that could drift from it.
+fn bib_field_source(value: &str, handler: &Rc<dyn Definition>) -> String {
+  let reads_raw = handler
+    .get_parameters()
+    .and_then(|params| params.get_parameters().first().map(|p| reads_field_raw(p)))
+    .unwrap_or(false);
+  if reads_raw {
+    value.to_string()
+  } else {
+    escape_bib_data_specials(value)
+  }
+}
+
+/// Whether `p` consumes its argument's characters as data rather than as TeX.
+///
+/// Both halves are needed, and the asymmetry is a trap worth naming: only
+/// `Semiverbatim` sets the `semiverbatim` DESCRIPTOR field; `Verbatim` calls
+/// `begin_semiverbatim(Some(&['%', '\\']))` inside its reader closure instead
+/// and leaves the descriptor empty (`base_parameter_types.rs`). Testing the
+/// descriptor alone therefore silently misses `url` — measured, it put a
+/// literal `\%` in a `url` href. `Parameter::name` is the declared type name
+/// (it is explicitly preserved when a descriptor is merged in), so it is the
+/// reliable half for `Verbatim`.
+fn reads_field_raw(p: &Parameter) -> bool {
+  p.semiverbatim.is_some()
+    || with(p.name, |name| {
+      matches!(name, "Verbatim" | "Semiverbatim" | "OptionalSemiverbatim")
+    })
+}
+
 /// that a control word's terminating space is consumed (`\ndash 693`).
 pub fn current_entry_field(name: &str) -> Option<Tokens> {
   let entry = current_entry()?;
@@ -275,21 +456,42 @@ pub fn current_entry_field(name: &str) -> Option<Tokens> {
 
 /// `Tokenize!` for a string that came out of the BibTeX lexer.
 ///
-/// The standard catcode table, as Perl's `Tokenize` uses — except that `%` and
-/// `&` are ordinary characters. BibTeX has no comment syntax inside an entry
-/// (`Pre::BibTeX` only skips `%` in the junk BETWEEN entries) and no alignment
-/// either, so both are data; under catcode 14 a `%` comments out the rest of
-/// the string and takes any brace still open with it, and under catcode 4 an
-/// `&` is a stray alignment tab. Witnesses 2605.02131 (a percent-encoded URL in
-/// a `title`'s `\href`, 24 `malformed:ltx:bibentry`) and 2605.01936
+/// The standard catcode table, as Perl's `Tokenize` uses — except that `%`, `&`
+/// and `#` are ordinary characters. BibTeX has no comment syntax inside an entry
+/// (`Pre::BibTeX` only skips `%` in the junk BETWEEN entries), no alignment and
+/// no parameters, so all three are data; under catcode 14 a `%` comments out the
+/// rest of the string and takes any brace still open with it, under catcode 4 an
+/// `&` is a stray alignment tab, and under catcode 6 a `#` reaches the Stomach as
+/// a parameter. Witnesses 2605.02131 (a percent-encoded URL in a `title`'s
+/// `\href`, 24 `malformed:ltx:bibentry`) and 2605.01936
 /// (`publisher = {Taylor & Francis}` and six more, 7 `unexpected:&`).
-/// See `OXIDIZED_DESIGN #74` and `#75`.
 ///
-/// This is the same rule the per-entry Mouth applies (see `\ProcessBibTeXEntry`
-/// below); it has to be repeated here because the handlers that re-read a raw
-/// field — `\bib@@title` recasing, name splitting, date/pages assembly — build
-/// their tokens from the stored string and never go through that mouth.
+/// **Treatment 1 of `OXIDIZED_DESIGN #74`** — the same rule the per-entry Mouth
+/// applies (see `\ProcessBibTeXEntry` below); it has to be repeated here because
+/// the handlers that re-read a raw field — `\bib@@title` recasing, name
+/// splitting, date/pages/MR/Zbl assembly — build their tokens from the stored
+/// string and never go through that mouth.
+///
+/// `_` is NOT in this set: a catcode is fixed at tokenization, before anything
+/// knows whether it is inside `$…$`, and a subscript in a title's math is
+/// legitimate TeX. It is handled by treatment 2 ([`bib_tex_tokens`]) instead.
 fn tokenize_bib_field(text: &str) -> Tokens { mouth::tokenize_bib_literal(text) }
+
+/// Both treatments, for a raw `.bib` string that is about to become TeX tokens.
+///
+/// Treatment 2 (`escape_bib_data_specials`) makes the data valid TeX — it is the
+/// only one of the two that can be math-aware, so it is what covers `_`; then
+/// treatment 1 ([`tokenize_bib_field`]) reads the result with `% & #` still inert,
+/// covering whatever the escaper deliberately left alone (the inside of a
+/// `\url{…}`).
+///
+/// Every site that re-reads a RAW field and hands it to the tokenizer uses this:
+/// `\bib@@title`, `\bib@@pages`, name splitting, date assembly, MR/Zbl. They are
+/// listed explicitly in `BIBLIOGRAPHY_WORKLIST.md` — "any change here must cover
+/// all three, plus the name-, date- and MR/Zbl-assembly sites that share that
+/// path". Escaping is idempotent, so a value already escaped upstream (a recased
+/// title) is unharmed by passing through again.
+fn bib_tex_tokens(text: &str) -> Tokens { tokenize_bib_field(&escape_bib_data_specials(text)) }
 
 /// Collapse an HTML-escaped ampersand — `&amp;` — back to the single `&` the
 /// author wrote, in whichever of its three spellings a `.bib` export used.
@@ -1047,17 +1249,17 @@ LoadDefinitions!({
       let mut name_tks: Vec<Token> = Vec::new();
       if !name.surname.is_empty() {
         let inv = Invocation!(T_CS!("\\bib@surname"),
-          vec![tokenize_bib_field(&name.surname)]);
+          vec![bib_tex_tokens(&name.surname)]);
         name_tks.extend(inv.unlist());
       }
       if !name.given.is_empty() {
         let inv = Invocation!(T_CS!("\\bib@given"),
-          vec![tokenize_bib_field(&name.given)]);
+          vec![bib_tex_tokens(&name.given)]);
         name_tks.extend(inv.unlist());
       }
       if !name.lineage.is_empty() {
         let inv = Invocation!(T_CS!("\\bib@lineage"),
-          vec![tokenize_bib_field(&name.lineage)]);
+          vec![bib_tex_tokens(&name.lineage)]);
         name_tks.extend(inv.unlist());
       }
       let inv = Invocation!(T_CS!("\\bib@@@name"),
@@ -1100,17 +1302,31 @@ LoadDefinitions!({
       })
       .unwrap_or_else(|| "capitalize1".to_string());
     let mode = TitleCaseMode::parse(&mode_str);
-    // Re-read the RAW field rather than the passed argument (Perl L294), which
-    // is why the decode in `\bibentry@create` does not reach this path and has
-    // to be repeated here — witness 2605.01353, a `title` reading
-    // `{{A}}\&amp;{{AS}}`. See `undouble_escaped_ampersand`.
-    let raw = undouble_escaped_ampersand(&current_entry_raw_field(&field_name).unwrap_or_default());
+    // Both treatments, in the order the real toolchain applies them, because
+    // `\bib@@title` re-reads the RAW field rather than the argument the entry
+    // line passed it (Perl L294 — that slot is the vestigial `ignoretitle`), so
+    // neither the decode nor the escaping in `\ProcessBibTeXEntry` reaches a
+    // title. Witnesses: 2605.01353, a `title` reading `{{A}}\&amp;{{AS}}`
+    // (decode); `title = {AT&T dataset AT1G01010_v2}` (escape).
+    //
+    // Escaping runs BEFORE `recase_title`, not after: `recase_title` splits on
+    // words and treats a `\…` escape as part of its word, so raw `AT&T` recases
+    // to `AT&t` (three words) while raw `AT\&T` recases to `AT&T` (one). Every
+    // real `.bib` mixes both spellings and they must render the same string, so
+    // the data becomes TeX first and the casing pass sees one consistent input.
+    // Guard case: `barespecials` vs `preescaped` in `bib_field_specials.bib`.
+    let raw = escape_bib_data_specials(&undouble_escaped_ampersand(
+      &current_entry_raw_field(&field_name).unwrap_or_default(),
+    ));
     let recased = recase_title(&raw, mode);
     // Emit `\bib@@field{tag}{}{<recased>}`. The empty `{}` slot
     // is the OptionalKeyVals arg (absent → no attributes).
     // Perl L333: Tokenize($recap) — catcode-aware, so TeX macros in
     // titles stay live (accents, math). Explode leaked them verbatim.
-    let recased_tokens = tokenize_bib_field(&recased);
+    // `tokenize_bib_field`, not `Tokenize!`: treatment 1 is the safety net under
+    // the escaping above — anything the escaper deliberately left alone (a
+    // `%` inside `\url{…}`) is still read as data rather than as a comment.
+    let recased_tokens = bib_tex_tokens(&recased);
     let inv = Invocation!(T_CS!("\\bib@@field"),
       vec![tag_tokens, Tokens!(), recased_tokens]);
     Ok(inv)
@@ -1522,7 +1738,7 @@ LoadDefinitions!({
     let mut out_toks: Vec<Token> = Vec::new();
     out_toks.push(T_CS!("\\bib@field@default@date"));
     out_toks.push(T_BEGIN!());
-    out_toks.extend(tokenize_bib_field(&date).unlist());
+    out_toks.extend(bib_tex_tokens(&date).unlist());
     out_toks.push(T_END!());
     Ok(Tokens::new(out_toks))
   });
@@ -1582,9 +1798,12 @@ LoadDefinitions!({
     // `Stored::Digested`/`VecDigested` — a `Stored::Tokens` fell through to its
     // catch-all and rendered as NOTHING, so every amsrefs `pages` field came
     // out as an empty `<ltx:bib-part role="pages"/>`. Witness arXiv 2508.17585.
+    // Third and last door from `.bib` data into the TeX regime — `\bib@@pages`
+    // also re-reads the raw field rather than using the entry line's value, so
+    // it escapes too, on the same rule (`escape_bib_data_specials`).
     whatsit.set_property(
       "pages",
-      Stored::Digested(digest(tokenize_bib_field(&normalised))?),
+      Stored::Digested(digest(bib_tex_tokens(&normalised))?),
     );
   });
 
@@ -1809,9 +2028,9 @@ LoadDefinitions!({
     if mrnumber.is_none() && mrreviewer.is_none() {
       return Ok(Tokens!());
     }
-    let mr_tks = tokenize_bib_field(&mrnumber.unwrap_or_default());
+    let mr_tks = bib_tex_tokens(&mrnumber.unwrap_or_default());
     let rev_tks = match mrreviewer {
-      Some(r) => tokenize_bib_field(&r),
+      Some(r) => bib_tex_tokens(&r),
       None => Tokens!(),
     };
     let inv = Invocation!(T_CS!("\\bib@@mr"), vec![mr_tks, rev_tks]);
@@ -1862,9 +2081,9 @@ LoadDefinitions!({
     if zblno.is_none() && zblreviewer.is_none() {
       return Ok(Tokens!());
     }
-    let zbl_tks = tokenize_bib_field(&zblno.unwrap_or_default());
+    let zbl_tks = bib_tex_tokens(&zblno.unwrap_or_default());
     let rev_tks = match zblreviewer {
-      Some(r) => tokenize_bib_field(&r),
+      Some(r) => bib_tex_tokens(&r),
       None => Tokens!(),
     };
     let inv = Invocation!(T_CS!("\\bib@@zbl"), vec![zbl_tks, rev_tks]);
@@ -1998,21 +2217,24 @@ LoadDefinitions!({
         if origtype != resolved_type { format!("\\bib@field@{}@{}", origtype, field) } else { String::new() },
         format!("\\bib@field@default@{}", field),
       ];
-      let mut handler: Option<&str> = None;
+      let mut handler: Option<(&str, Rc<dyn Definition>)> = None;
       for c in candidates.iter() {
         if c.is_empty() { continue; }
-        if lookup_definition(&T_CS!(c.as_str()))?.is_some() {
-          handler = Some(c.as_str());
+        if let Some(def) = lookup_definition(&T_CS!(c.as_str()))? {
+          handler = Some((c.as_str(), def));
           break;
         }
       }
       let value = &undouble_escaped_ampersand(value);
       match handler {
-        Some(h) => {
-          lines.push(format!("\\csname {}\\endcsname{{{}}}", &h[1..], value));
+        Some((h, def)) => {
+          let v = bib_field_source(value, &def);
+          lines.push(format!("\\csname {}\\endcsname{{{}}}", &h[1..], v));
         },
         None => {
           // Fallback per Perl L157: `\bib@field@default@default{field}{value}`.
+          // Both of its slots are `Verbatim`, so the value is passed raw — the
+          // same rule `bib_field_source` applies, reached without a lookup.
           lines.push(format!(
             "\\csname bib@field@default@default\\endcsname{{{}}}{{{}}}", field, value));
         },
@@ -2050,31 +2272,37 @@ LoadDefinitions!({
     // `.bib` produced ONE entry and a single error where Perl produces all three
     // and four errors. Guard: `55_bibtex::runaway_field_costs_only_its_own_entry`.
     //
-    // `%` is read as an ordinary character in this mouth (OXIDIZED_DESIGN #74).
-    // BibTeX has no comment syntax inside an entry, so the values `PreBibTeX`
-    // just handed us hold `%` literally; under TeX's catcode 14 each one
-    // comments out the rest of its line — the field's own closing `}` included —
-    // so the entry's group never closes, `ltx:bibentry` is left open, and every
-    // later entry nests inside it. Witnesses arXiv 2605.01196 (`doi={%doi:...}`)
-    // and 2605.02131 (a percent-encoded URL in a `title`'s `\href`): 28 errors
-    // each, and Perl breaks identically (29 / 31 on the same host); 2605.00879
-    // (`note = {https://doi.org/10.1145%2F...}`): 103 errors.
-    // Guard: `06_cluster_bibliography::bib_field_percent_is_an_ordinary_character`.
+    // `% & # _` are read as ordinary characters in this mouth — treatment 1 of
+    // OXIDIZED_DESIGN #74, "be `bibtex`". BibTeX's lexer has no comment syntax
+    // inside an entry, no alignment, no parameters and no subscripts, so the
+    // values `PreBibTeX` just handed us hold all four literally. Under TeX's
+    // catcodes each misfires: `%` (14) comments out the rest of its line — the
+    // field's own closing `}` included — so the entry's group never closes and
+    // every later entry nests inside it; `&` (4) is a stray alignment tab and
+    // is dropped, so "Taylor & Francis" printed as "Taylor Francis"; `#` (6)
+    // reaches the Stomach as a parameter; `_` (8) is a subscript outside math.
     //
-    // `&` likewise (OXIDIZED_DESIGN #75) — BibTeX has no alignment either, so
-    // an `&` in a value it handed us is a character in a publisher's or a
-    // journal's name. Under catcode 4 it is a stray alignment tab:
-    // `Error:unexpected:&`, and the `&` is dropped from the entry, so "Taylor &
-    // Francis" printed as "Taylor Francis". Witnesses arXiv 2605.01936 (7),
-    // 2605.06249 (3), 2605.00462 / 2605.03054 / 2605.06624 / 2605.08753 /
-    // 2605.10409 (1 each). Same-host Perl and bibtex+pdflatex both break the
-    // same way — the decision that a field's content is DATA is what overrides
-    // them, and it is ours to make because we read the `.bib` directly.
-    // Guard: `06_cluster_bibliography::bib_bare_ampersand_is_literal_data`.
+    // Witnesses — `%`: 2605.01196 (`doi={%doi:...}`) and 2605.02131 (a
+    // percent-encoded URL in a `title`'s `\href`), 28 errors each with Perl
+    // breaking identically (29 / 31 same-host), 2605.00879 (103).
+    // `&`: 2605.01936 (7), 2605.06249 (3), 2605.00462 / 2605.03054 /
+    // 2605.06624 / 2605.08753 / 2605.10409 (1 each).
+    // `_`: 2605.06926 (8), 2605.01936 (6), 2605.04604 / 2605.08986 (2 each),
+    // 2605.11300 / 2605.05898 (1 each).
+    // Same-host Perl and bibtex+pdflatex break the same way on all three — the
+    // decision that a field's content is DATA is what overrides them, and it is
+    // ours to make because we read the `.bib` directly.
+    //
+    // Treatment 2 (`escape_bib_data_specials`, applied to the values written
+    // into `lines` above) makes the synthesized `.bbl` valid TeX in the first
+    // place; this mouth is the safety net under it, covering the values that
+    // deliberately go through unescaped — a `url` href, a `doi` id, the inside
+    // of a `\url{…}`.
+    //
+    // Guards: `06_cluster_bibliography::bib_field_percent_is_an_ordinary_character`,
+    // `::bib_bare_ampersand_is_literal_data`, `::bib_field_specials_are_data_not_tex`.
     open_mouth_with(
-      Mouth::new(&lines.join("\n"), None)?
-        .with_percent_as_other()
-        .with_align_as_other(),
+      Mouth::new(&lines.join("\n"), None)?.with_bib_data_literals(),
       true,
       BalancedBoundary::Opaque,
     );
@@ -2394,6 +2622,89 @@ mod tests {
     attrs.insert("role".to_string(), "host".to_string());
     let xpath = bib_container_xpath("ltx:bib-related", &attrs);
     assert_eq!(xpath, "ltx:bib-related[@role='host' and @type='book']");
+  }
+
+  // --- escape_bib_data_specials (the `.bib`-data -> TeX-source boundary) ---
+
+  #[test]
+  fn escape_specials_bare_are_escaped() {
+    assert_eq!(
+      escape_bib_data_specials("AT&T AT1G01010_v2 95% #3"),
+      r"AT\&T AT1G01010\_v2 95\% \#3"
+    );
+  }
+
+  /// Idempotency. Most real `.bib` files already write `\&`, `\%`, `\_` — a
+  /// blind escaper would turn `\&` into `\\&`, i.e. a line break followed by an
+  /// ampersand. Escaping twice must equal escaping once.
+  #[test]
+  fn escape_specials_is_idempotent() {
+    let once = escape_bib_data_specials("AT&T at 95% with x_1");
+    assert_eq!(escape_bib_data_specials(&once), once);
+    assert_eq!(
+      escape_bib_data_specials(r"AT\&T at 95\% with x\_1"),
+      r"AT\&T at 95\% with x\_1"
+    );
+  }
+
+  /// The tricky case the idempotency rule has to get right: in `\\&` the `\\`
+  /// is a genuine line break, so the `&` after it is BARE and must be escaped —
+  /// the second backslash is not an escape character, it is escaped itself.
+  #[test]
+  fn escape_specials_double_backslash_then_bare_special() {
+    assert_eq!(
+      escape_bib_data_specials(r"break \\& more"),
+      r"break \\\& more"
+    );
+    assert_eq!(escape_bib_data_specials(r"break \\_x"), r"break \\\_x");
+  }
+
+  /// Math is the other hazard: `_` inside `$…$` is a real subscript and must
+  /// stay catcode 8, while the same character outside is data.
+  #[test]
+  fn escape_specials_skips_math() {
+    assert_eq!(
+      escape_bib_data_specials("Bounds on $x_1+x_2$ for AT1G_v2"),
+      r"Bounds on $x_1+x_2$ for AT1G\_v2"
+    );
+    assert_eq!(
+      escape_bib_data_specials("display $$a_1$$ then b_2"),
+      r"display $$a_1$$ then b\_2"
+    );
+    assert_eq!(
+      escape_bib_data_specials(r"open \(x_1\) then y_2"),
+      r"open \(x_1\) then y\_2"
+    );
+  }
+
+  /// Markup passes through by construction — the escaper never touches `\`,
+  /// `{` or `}`, so control words and their braces are untouched, and a
+  /// space-form accent keeps the space that terminates its control word.
+  #[test]
+  fn escape_specials_leaves_markup_and_accents_alone() {
+    assert_eq!(
+      escape_bib_data_specials(r"\emph{Drosophila} genetics"),
+      r"\emph{Drosophila} genetics"
+    );
+    assert_eq!(escape_bib_data_specials(r"{\v S}pakov"), r"{\v S}pakov");
+    assert_eq!(escape_bib_data_specials(r"\ndash 693"), r"\ndash 693");
+    // …but a special INSIDE an ordinary command's argument is still data.
+    assert_eq!(escape_bib_data_specials(r"\emph{AT&T}"), r"\emph{AT\&T}");
+  }
+
+  /// url.sty reads `\url`'s argument verbatim, so it is a nested DATA region
+  /// and a percent-encoded `%20` inside it must NOT become `\%20`.
+  /// `\href`'s SECOND argument is prose and is still escaped.
+  #[test]
+  fn escape_specials_skips_a_verbatim_argument() {
+    assert_eq!(
+      escape_bib_data_specials(r"\url{http://x.org/a%20b?c=1&d=2}"),
+      r"\url{http://x.org/a%20b?c=1&d=2}"
+    );
+    assert_eq!(
+      escape_bib_data_specials(r"\href{http://x.org/a%20b}{AT&T}"),
+      r"\href{http://x.org/a%20b}{AT\&T}"
+    );
   }
 
   // --- recase_title (Perl `\bib@@title` body) ---

--- a/latexml_engine/src/bibtex.rs
+++ b/latexml_engine/src/bibtex.rs
@@ -270,8 +270,25 @@ pub fn current_entry_field(name: &str) -> Option<Tokens> {
   if let Some(tokens) = entry.get_field(name) {
     return Some(tokens.clone());
   }
-  entry.get_raw_field(name).map(|raw| Tokenize!(raw))
+  entry.get_raw_field(name).map(tokenize_bib_field)
 }
+
+/// `Tokenize!` for a string that came out of the BibTeX lexer.
+///
+/// The standard catcode table, as Perl's `Tokenize` uses — except that `%` is
+/// an ordinary character. BibTeX has no comment syntax inside an entry
+/// (`Pre::BibTeX` only skips `%` in the junk BETWEEN entries), so a `%` in a
+/// field value is data; under catcode 14 it comments out the rest of the
+/// string and takes any brace still open with it, which leaves the field's
+/// element unclosed and swallows every following entry. Witness 2605.02131:
+/// a percent-encoded URL in a `title`'s `\href`, 24 `malformed:ltx:bibentry`.
+/// See `OXIDIZED_DESIGN #74`.
+///
+/// This is the same rule the per-entry Mouth applies (see `\ProcessBibTeXEntry`
+/// below); it has to be repeated here because the handlers that re-read a raw
+/// field — `\bib@@title` recasing, name splitting, date/pages assembly — build
+/// their tokens from the stored string and never go through that mouth.
+fn tokenize_bib_field(text: &str) -> Tokens { mouth::tokenize_percent_literal(text) }
 
 /// Perl: `currentBibEntryRawField('fieldname')` — get the *raw*
 /// source string of a field on the current entry.
@@ -983,17 +1000,17 @@ LoadDefinitions!({
       let mut name_tks: Vec<Token> = Vec::new();
       if !name.surname.is_empty() {
         let inv = Invocation!(T_CS!("\\bib@surname"),
-          vec![Tokenize!(name.surname.as_str())]);
+          vec![tokenize_bib_field(&name.surname)]);
         name_tks.extend(inv.unlist());
       }
       if !name.given.is_empty() {
         let inv = Invocation!(T_CS!("\\bib@given"),
-          vec![Tokenize!(name.given.as_str())]);
+          vec![tokenize_bib_field(&name.given)]);
         name_tks.extend(inv.unlist());
       }
       if !name.lineage.is_empty() {
         let inv = Invocation!(T_CS!("\\bib@lineage"),
-          vec![Tokenize!(name.lineage.as_str())]);
+          vec![tokenize_bib_field(&name.lineage)]);
         name_tks.extend(inv.unlist());
       }
       let inv = Invocation!(T_CS!("\\bib@@@name"),
@@ -1042,7 +1059,7 @@ LoadDefinitions!({
     // is the OptionalKeyVals arg (absent → no attributes).
     // Perl L333: Tokenize($recap) — catcode-aware, so TeX macros in
     // titles stay live (accents, math). Explode leaked them verbatim.
-    let recased_tokens = Tokenize!(recased.as_str());
+    let recased_tokens = tokenize_bib_field(&recased);
     let inv = Invocation!(T_CS!("\\bib@@field"),
       vec![tag_tokens, Tokens!(), recased_tokens]);
     Ok(inv)
@@ -1454,7 +1471,7 @@ LoadDefinitions!({
     let mut out_toks: Vec<Token> = Vec::new();
     out_toks.push(T_CS!("\\bib@field@default@date"));
     out_toks.push(T_BEGIN!());
-    out_toks.extend(Tokenize!(date.as_str()).unlist());
+    out_toks.extend(tokenize_bib_field(&date).unlist());
     out_toks.push(T_END!());
     Ok(Tokens::new(out_toks))
   });
@@ -1516,7 +1533,7 @@ LoadDefinitions!({
     // out as an empty `<ltx:bib-part role="pages"/>`. Witness arXiv 2508.17585.
     whatsit.set_property(
       "pages",
-      Stored::Digested(digest(Tokenize!(normalised.as_str()))?),
+      Stored::Digested(digest(tokenize_bib_field(&normalised))?),
     );
   });
 
@@ -1741,9 +1758,9 @@ LoadDefinitions!({
     if mrnumber.is_none() && mrreviewer.is_none() {
       return Ok(Tokens!());
     }
-    let mr_tks = Tokenize!(mrnumber.unwrap_or_default().as_str());
+    let mr_tks = tokenize_bib_field(&mrnumber.unwrap_or_default());
     let rev_tks = match mrreviewer {
-      Some(r) => Tokenize!(r.as_str()),
+      Some(r) => tokenize_bib_field(&r),
       None => Tokens!(),
     };
     let inv = Invocation!(T_CS!("\\bib@@mr"), vec![mr_tks, rev_tks]);
@@ -1794,9 +1811,9 @@ LoadDefinitions!({
     if zblno.is_none() && zblreviewer.is_none() {
       return Ok(Tokens!());
     }
-    let zbl_tks = Tokenize!(zblno.unwrap_or_default().as_str());
+    let zbl_tks = tokenize_bib_field(&zblno.unwrap_or_default());
     let rev_tks = match zblreviewer {
-      Some(r) => Tokenize!(r.as_str()),
+      Some(r) => tokenize_bib_field(&r),
       None => Tokens!(),
     };
     let inv = Invocation!(T_CS!("\\bib@@zbl"), vec![zbl_tks, rev_tks]);
@@ -1980,8 +1997,18 @@ LoadDefinitions!({
     // `\ProcessBibTeXEntry` and `\end{bibtex@bibliography}` too, so a 3-entry
     // `.bib` produced ONE entry and a single error where Perl produces all three
     // and four errors. Guard: `55_bibtex::runaway_field_costs_only_its_own_entry`.
+    //
+    // `%` is read as an ordinary character in this mouth (OXIDIZED_DESIGN #74).
+    // BibTeX has no comment syntax inside an entry, so the values `PreBibTeX`
+    // just handed us hold `%` literally; under TeX's catcode 14 each one
+    // comments out the rest of its line — the field's own closing `}` included —
+    // so the entry's group never closes, `ltx:bibentry` is left open, and every
+    // later entry nests inside it. Witnesses arXiv 2605.01196 (`doi={%doi:...}`)
+    // and 2605.02131 (a percent-encoded URL in a `title`'s `\href`): 28 errors
+    // each, and Perl breaks identically (29 / 31 on the same host).
+    // Guard: `06_cluster_bibliography::bib_field_percent_is_an_ordinary_character`.
     open_mouth_with(
-      Mouth::new(&lines.join("\n"), None)?,
+      Mouth::new(&lines.join("\n"), None)?.with_percent_as_other(),
       true,
       BalancedBoundary::Opaque,
     );

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -644,6 +644,138 @@ fn bib_abstract_percent_does_not_sink_the_entry() {
     "abstract percent: abstract prose leaked into the rendered entry:\n{x}"
   );
 }
+/// `\&amp;` in a `.bib` field is a doubly escaped ampersand, and renders as one.
+///
+/// A reference manager rendered the field to HTML (`&` -> `&amp;`) and a second
+/// pass TeX-escaped that entity's own ampersand, so the file carries four
+/// characters the author never wrote. TeX has no way to know: `\&` is the glyph,
+/// `amp;` is ordinary text, and the entry reads "Computer Engineering, &amp;
+/// Applied Computing". pdflatex prints exactly the same, so this is neither a
+/// Perl gap nor a pdflatex gap — it is corrupt input, and reading `.bib`
+/// directly is what puts us in a position to undo it. OXIDIZED_DESIGN #75.
+///
+/// All three spellings are real; found by scanning 6000 arXiv/2605 sources.
+/// `titleentity` is the one that needs its own decode: `\bib@@title` re-reads
+/// the raw field for case conversion instead of using the argument it was
+/// handed, so it bypasses the decode done while assembling the entry.
+///
+/// RED before the fix: `&amp;amp;` for the first three entries.
+#[test]
+fn bib_escaped_amp_entity_decodes_to_one_ampersand() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_escaped_amp_entity.tex");
+  // The XML escape of a literal `&` is `&amp;`, so the doubled entity shows up
+  // as `&amp;amp;`. Assert on that serialized form directly — unescaping first
+  // would make the two cases indistinguishable.
+  assert!(
+    !x.contains("&amp;amp;"),
+    "escaped amp entity: a doubled `&amp;` survived into the bibliography:\n{x}"
+  );
+  // Not merely absent — decoded. Each entry keeps ONE ampersand, with the text
+  // on both sides intact (a decode that ate the neighbouring word would also
+  // satisfy the assertion above).
+  for needle in [
+    "Computer Engineering, &amp; Applied Computing",
+    "the A&amp;AS all-sky survey",
+    "shake &amp; bake generation",
+    // Control: an ordinary `\&` was already right and must stay right.
+    "Crime &amp; Delinquency",
+  ] {
+    assert!(
+      x.contains(needle),
+      "escaped amp entity: expected {needle:?} in the bibliography:\n{x}"
+    );
+  }
+  // Near miss: "amp;" that is NOT preceded by an ampersand is ordinary text.
+  assert!(
+    x.contains("amp; token and amplitude modulation"),
+    "escaped amp entity: a literal `amp;` unrelated to an ampersand was eaten:\n{x}"
+  );
+}
+/// A bare `&` in a `.bib` field is the literal character, not an alignment tab.
+///
+/// `publisher = {Taylor & Francis}` is real: seven arXiv/2605 papers ship it
+/// (per-witness provenance in the fixture header). BibTeX's lexer has no
+/// alignment, so the `&` it hands back is a character in a publisher's or a
+/// journal's name — but TeX reads catcode 4, raises `Error:unexpected:&`, and
+/// DROPS the character, so the entry printed "Taylor Francis".
+///
+/// Deliberately ahead of every other engine, which is why the before-numbers
+/// matter: same-host `latexmlc` raised the same one-error-per-`&` (2605.03054
+/// 1/1, 2605.06249 3/3, 2605.00462 1/1, 2605.06624 1/1, 2605.08753 1/1,
+/// 2605.10409 1/1), and bibtex 0.99d + pdflatex agree — under `plain` and
+/// `abbrvnat` the bare `&` reaches the `.bbl`, pdflatex stops with "Misplaced
+/// alignment tab character &" and prints "Taylor Francis". Reading `.bib`
+/// directly is what lets us decide otherwise. OXIDIZED_DESIGN #75.
+///
+/// Neutralized at the per-entry Mouth beside the `%` of #74 — regime A, because
+/// `&` derails alignment in ANY field and these fields have no Perl
+/// Semiverbatim precedent to follow.
+///
+/// RED before the fix: 5 post-stage errors, and "Taylor Francis".
+#[test]
+fn bib_bare_ampersand_is_literal_data() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_bare_ampersand.tex");
+  // The ampersand is KEPT, with the text on both sides of it — a neutralization
+  // that swallowed the rest of the field would still be error-free.
+  for needle in [
+    "Taylor &amp; Francis",
+    "Information Processing &amp; Management",
+    "Knowledge Discovery &amp; Data Mining",
+  ] {
+    assert!(
+      x.contains(needle),
+      "bare ampersand: expected the literal {needle:?} in the bibliography:\n{x}"
+    );
+  }
+  // Containment: every entry still renders, including the one after the run of
+  // bad fields. The sibling `%` bug (#73) took the whole bibliography down.
+  for needle in ["Author", "Builder", "Coder", "Crespi", "Draper", "Ericsson"] {
+    assert!(
+      x.contains(needle),
+      "bare ampersand: {needle:?} was lost from the bibliography:\n{x}"
+    );
+  }
+  assert!(
+    x.contains("The entry after the stray ampersands"),
+    "bare ampersand: the trailing entry's title was lost:\n{x}"
+  );
+}
+/// Making `&` ordinary must not flatten the live TeX beside it.
+///
+/// The boundary the mouth-level neutralization has to hold: it downgrades ONE
+/// catcode, so everything else in the same field keeps working. `\emph` still
+/// marks up, `$x_1+x_2$` still parses as math with `_` a subscript INSIDE math
+/// (the neutralization is not a blanket verbatim), and the space-form accents
+/// PR #399 recovered still resolve — all in the entry that also carries a bare
+/// `&`, so a regression cannot hide behind a separate clean fixture.
+#[test]
+fn bib_bare_ampersand_leaves_live_markup_alone() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_bare_ampersand.tex");
+  // Lower-cased by `\bib@@title`'s `capitalize1` recasing, exactly as Perl
+  // recases it — the point here is the `&`, which survives.
+  assert!(
+    x.contains("ampere &amp; ohm"),
+    "markup boundary: the ampersand in the boundary entry was lost:\n{x}"
+  );
+  assert!(
+    x.contains(">emphasized</emph>"),
+    "markup boundary: \\emph stopped producing markup:\n{x}"
+  );
+  // `_` keeps its subscript meaning INSIDE math — the neutralization downgrades
+  // one catcode in the `.bib` text, it is not a blanket verbatim. The parsed
+  // form is a subscript application, not the literal characters.
+  assert!(
+    x.contains(r#"role="SUBSCRIPTOP""#),
+    "markup boundary: inline math stopped parsing (`_` must still subscript \
+     inside math):\n{x}"
+  );
+  for needle in ["\u{160}pakov", "Gon\u{e7}alves"] {
+    assert!(
+      x.contains(needle),
+      "markup boundary: space-form accent {needle:?} regressed (PR #399):\n{x}"
+    );
+  }
+}
 /// A space-form accent in an author name must survive reversion.
 ///
 /// `{\v S}pakov` / `Gon{\c c}alves` / `\" Ozturk` are ordinary BibTeX — the

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -652,7 +652,7 @@ fn bib_abstract_percent_does_not_sink_the_entry() {
 /// `amp;` is ordinary text, and the entry reads "Computer Engineering, &amp;
 /// Applied Computing". pdflatex prints exactly the same, so this is neither a
 /// Perl gap nor a pdflatex gap — it is corrupt input, and reading `.bib`
-/// directly is what puts us in a position to undo it. OXIDIZED_DESIGN #75.
+/// directly is what puts us in a position to undo it. OXIDIZED_DESIGN #74.
 ///
 /// All three spellings are real; found by scanning 6000 arXiv/2605 sources.
 /// `titleentity` is the one that needs its own decode: `\bib@@title` re-reads
@@ -705,7 +705,7 @@ fn bib_escaped_amp_entity_decodes_to_one_ampersand() {
 /// 2605.10409 1/1), and bibtex 0.99d + pdflatex agree — under `plain` and
 /// `abbrvnat` the bare `&` reaches the `.bbl`, pdflatex stops with "Misplaced
 /// alignment tab character &" and prints "Taylor Francis". Reading `.bib`
-/// directly is what lets us decide otherwise. OXIDIZED_DESIGN #75.
+/// directly is what lets us decide otherwise. OXIDIZED_DESIGN #74.
 ///
 /// Neutralized at the per-entry Mouth beside the `%` of #74 — regime A, because
 /// `&` derails alignment in ANY field and these fields have no Perl
@@ -775,6 +775,136 @@ fn bib_bare_ampersand_leaves_live_markup_alone() {
       "markup boundary: space-form accent {needle:?} regressed (PR #399):\n{x}"
     );
   }
+}
+/// A `.bib` field's content is DATA, not TeX: a bare `_`, `&`, `#` or `%` is
+/// the literal character. `AT&T` renders "AT&T"; `AT1G01010_v2` renders
+/// "AT1G01010_v2". Witnesses: 2605.06926 (8 `unexpected:_`, four `eprint` PDF
+/// URLs), 2605.01936, 2605.04604, 2605.08986, 2605.11300, and the `&` half in
+/// 2605.01936 / 2605.06249 (`publisher = {Taylor & Francis}`).
+///
+/// Authorized surpass-Perl AND surpass-pdflatex (OXIDIZED_DESIGN #74): real
+/// BibTeX has a DATA regime and a TeX regime, and we collapse them because we
+/// read `.bib` directly with no `.bst` in the loop. That `bibtex(1)` +
+/// `pdflatex` also break on these characters is a property of that toolchain,
+/// not a semantic we are obliged to reproduce.
+///
+/// ONE fixture for all of it, because the whole risk is that fixing one case
+/// breaks another. This asserts, together: the four specials bare render
+/// literally; already-escaped `\&`/`\%`/`\_`/`\#` render IDENTICALLY and are not
+/// double-escaped; `$x_1+x_2$` still parses as math with a real `<msub>`;
+/// `\emph` still produces markup; a space-form accent still reverts (PR #399);
+/// and `%20` inside `\url{…}` is untouched, since url.sty reads that argument
+/// verbatim. The `\\&` hazard is pinned separately, by the
+/// `escape_bib_data_specials` unit tests in `latexml_engine/src/bibtex.rs` —
+/// see the fixture header for why it cannot live end-to-end.
+#[test]
+fn bib_field_specials_are_data_not_tex() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_field_specials.tex");
+  assert!(
+    x.contains("<bibitem"),
+    "bib specials: no bibliography at all:\n{x}"
+  );
+  // All ten entries arrive — `Gilakjani` is the containment canary.
+  for needle in [
+    "Okonkwo",
+    "Lindqvist",
+    "Chen",
+    "Park",
+    "Diallo",
+    "Bergstr",
+    "Raghavan",
+    "Osman",
+    "Gilakjani",
+  ] {
+    assert!(
+      x.contains(needle),
+      "bib specials: {needle:?} was swallowed:\n{x}"
+    );
+  }
+  // The rendered `<text class="ltx_bib_title">` of the entry with a given key.
+  let title_of = |key: &str| -> String {
+    let i = x
+      .find(&format!("key=\"{key}\""))
+      .unwrap_or_else(|| panic!("bib specials: no entry keyed {key:?} in:\n{x}"));
+    let block = &x[i..];
+    let s = block
+      .find("class=\"ltx_bib_title\">")
+      .expect("a rendered bib-title")
+      + "class=\"ltx_bib_title\">".len();
+    let e = block[s..].find("</text>").expect("bib-title close") + s;
+    block[s..e].to_string()
+  };
+  // 1. The four specials, bare, are literal text. `&` is XML-escaped on the way
+  //    out, which is the correct rendering of the character. `recase_title`
+  //    lowercases (capitalize1, Perl parity), hence `at1g01010`.
+  let bare = "AT&amp;T dataset at1g01010_v2 at 95% with #3 replicates";
+  assert_eq!(
+    title_of("barespecials"),
+    bare,
+    "bib specials: bare `& _ % #` did not render literally:\n{x}"
+  );
+  // 2. Idempotency: the entry that already wrote `\&`/`\_`/`\%`/`\#` renders
+  //    the SAME string. Had the escaper double-escaped, `\&` would have become
+  //    `\\&` — a line break followed by an ampersand.
+  assert_eq!(
+    title_of("preescaped"),
+    title_of("barespecials"),
+    "bib specials: the pre-escaped title must render identically to the bare \
+     one:\n{x}"
+  );
+  assert!(
+    !x.contains(r"\&") && !x.contains(r"\_") && !x.contains(r"\%"),
+    "bib specials: an escaping backslash leaked into the output:\n{x}"
+  );
+  // 3. Math survives WITH its subscript, and 4. markup survives.
+  //    `convert_and_post_clean` stops at the post-processed `ltx` XML with
+  //    `pmml: false`, so the subscript shows as XMath's SUBSCRIPTOP rather than
+  //    an `<m:msub>`.
+  assert!(
+    x.contains(r#"role="SUBSCRIPTOP""#),
+    "bib specials: `$x_1+x_2$` in a title lost its subscript:\n{x}"
+  );
+  assert!(
+    x.contains("<emph font=\"italic\">Drosophila</emph>"),
+    "bib specials: `\\emph` in a title stopped producing markup:\n{x}"
+  );
+  // 5. Space-form accents still revert (PR #399).
+  assert!(
+    x.contains("Špakov") && x.contains("Gonçalves"),
+    "bib specials: a space-form accent stopped reverting:\n{x}"
+  );
+  // 6. A percent-encoded URL inside `\url{…}` is a nested DATA region.
+  assert!(
+    x.contains("http://example.org/a%20b"),
+    "bib specials: `%20` inside `\\url{{…}}` was escaped into the href:\n{x}"
+  );
+  // And a Verbatim/Semiverbatim-read FIELD is passed through raw, so neither
+  // the `url` href nor the `doi` id picks up a backslash.
+  assert!(
+    x.contains("https://example.org/a%20b?x=1&amp;y=2_3"),
+    "bib specials: the `url` field was escaped:\n{x}"
+  );
+  assert!(
+    x.contains("10.1007/3-540-44886-1%5F25"),
+    "bib specials: the `doi` id lost its percent-encoding:\n{x}"
+  );
+  // 7. The original cluster: both spellings of the AIP `eprint` URL land as a
+  //    plain `_`.
+  for needle in ["18931574/1876_1_online.pdf", "15540793/184110_1_online.pdf"] {
+    assert!(
+      x.contains(needle),
+      "bib specials: {needle:?} did not reach the rendered links:\n{x}"
+    );
+  }
+  // 8. The `&` half of the cluster.
+  assert!(
+    x.contains("Taylor &amp; Francis"),
+    "bib specials: a bare `&` in `publisher` did not render:\n{x}"
+  );
+  assert!(
+    x.contains("IEEE Communications Surveys &amp; Tutorials"),
+    "bib specials: a bare `&` in `journal` did not render:\n{x}"
+  );
 }
 /// A space-form accent in an author name must survive reversion.
 ///

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -795,4 +795,79 @@ fn bib_field_blank_line_does_not_inject_a_bibitem() {
       "blank line: {name:?} lost — an empty sibling part ate a real one:\n{x}"
     );
   }
+
+/// A `%` inside a `.bib` field value is data, not a comment.
+///
+/// BibTeX's lexer has no comment syntax inside an entry — `Pre::BibTeX` only
+/// skips `%` in the junk BETWEEN entries — so the value it stores keeps its
+/// `%`. LaTeXML then re-injects that value as TeX source, where catcode 14
+/// makes it comment out the rest of its line, closing brace included: the
+/// entry's group never closes and every later entry nests inside the unclosed
+/// element (`<ltx:bibentry> isn't allowed in <ltx:bibentry>`).
+///
+/// Two paths, one per entry in the fixture: `doi` goes through the per-entry
+/// Mouth `\ProcessBibTeXEntry` opens, `title` does NOT — `\bib@@title` re-reads
+/// the raw field and tokenizes it itself. Fixing only the mouth left the
+/// `title` half broken (it went 28 → 37 errors on the witness, surfacing an
+/// `Extra \endcsname` once the value was no longer truncated), so both call
+/// sites read `%` as OTHER. OXIDIZED_DESIGN #74.
+///
+/// RED before the fix: witnesses 2605.01196 (`doi={%doi:10.1017/jfm.2016.420}`)
+/// and 2605.02131 (percent-encoded URL in a `title`'s `\href`) at **28 errors
+/// each**; same-host `latexmlc` 29 / 31 on the same inputs, so this is a shared
+/// bug and a surpass-Perl fix, not a Rust-only defect. Both are 0 after.
+/// `convert_and_post_clean`, not `convert_and_post`: the bibliography is built
+/// in POST, and a text-presence assertion still finds text INSIDE an unclosed
+/// element — the plain helper passes on a structurally broken document.
+#[test]
+fn bib_field_percent_is_an_ordinary_character() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_field_percent.tex");
+  // Containment: three entries, three bibitems. Before the fix the runaway
+  // swallowed its followers into its own unclosed <ltx:bibentry>.
+  assert_eq!(
+    x.matches("<bibitem").count(),
+    4,
+    "percent field: expected four bibitems, one per entry:\n{x}"
+  );
+  assert!(
+    x.contains("The entry after the runaway"),
+    "percent field: the canary entry after the runaway is missing:\n{x}"
+  );
+  // The `%` is DATA: it must survive into the output, not be dropped along
+  // with everything after it on its line.
+  // (the doi becomes an href, so its own `%`/`:` are URL-escaped there —
+  // `%25doi%3A` IS the surviving `%doi:`.)
+  assert!(
+    x.contains("dx.doi.org/%25doi%3A10.1017/jfm.2016.420"),
+    "percent field: the doi value was truncated at its percent sign:\n{x}"
+  );
+  assert!(
+    x.contains("https://cdn.example.org/20240723%20IPWG%20Item%2004b%20DRAFT.pdf"),
+    "percent field: the percent-encoded URL lost its escapes:\n{x}"
+  );
+  assert!(
+    x.contains("A linked title behind a percent-encoded URL"),
+    "percent field: the linked title did not render:\n{x}"
+  );
+  // Neutralizing `%` must not flatten the field: markup, math and accents in
+  // the SAME field still have to work (the boundary PR #399 established).
+  assert!(
+    x.contains("Yield rose <emph") && x.contains(">sharply</emph>"),
+    "percent field: \\emph in a percent-bearing title lost its markup:\n{x}"
+  );
+  assert!(
+    x.contains("tex=\"x_{1}+x_{2}\"") && x.contains("<XMApp>"),
+    "percent field: inline math in a percent-bearing title did not parse:\n{x}"
+  );
+  assert!(
+    x.contains("Špakov"),
+    "percent field: the space-form accent in the same entry stopped \
+     composing:\n{x}"
+  );
+  // No entry may nest inside another, and no element may be left open.
+  assert!(
+    !x.contains("<bibentry"),
+    "percent field: a raw <bibentry> survived post-processing — \
+     MakeBibliography could not read the entry:\n{x}"
+  );
 }

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -795,6 +795,7 @@ fn bib_field_blank_line_does_not_inject_a_bibitem() {
       "blank line: {name:?} lost — an empty sibling part ate a real one:\n{x}"
     );
   }
+}
 
 /// A `%` inside a `.bib` field value is data, not a comment.
 ///
@@ -822,7 +823,7 @@ fn bib_field_blank_line_does_not_inject_a_bibitem() {
 #[test]
 fn bib_field_percent_is_an_ordinary_character() {
   let x = convert_and_post_clean("tests/cluster_regressions/bib_field_percent.tex");
-  // Containment: three entries, three bibitems. Before the fix the runaway
+  // Containment: four entries, four bibitems. Before the fix the runaway
   // swallowed its followers into its own unclosed <ltx:bibentry>.
   assert_eq!(
     x.matches("<bibitem").count(),

--- a/latexml_oxide/tests/105_bib_field_digest_once.rs
+++ b/latexml_oxide/tests/105_bib_field_digest_once.rs
@@ -18,14 +18,21 @@ use std::{path::Path, process::Command};
 
 /// Two properties this fixture must have, both learned the hard way:
 ///
-/// * `_` outside math raises `unexpected:_` on EVERY digest — unlike an
+/// * `^` outside math raises `unexpected:^` on EVERY digest — unlike an
 ///   undefined macro, which is defined as `<ltx:ERROR/>` on first sight and is
 ///   therefore silently self-healing on a second pass. An undefined-macro
 ///   fixture would pass even with the bug present.
 /// * The value must contain a BACKSLASH. Both interpret paths short-circuit on
-///   a value with no `\`, `~` or `$`, so `note={a _ b}` never digests at all and
+///   a value with no `\`, `~` or `$`, so `note={a ^ b}` never digests at all and
 ///   the test goes vacuously green (observed: "digested 0 times"). `\textbf` is
 ///   the carrier here because it needs no package.
+///
+/// `_` used to be the other probe, and no longer can be: OXIDIZED_DESIGN #74
+/// escapes `_ & # %` in a `.bib` field as DATA, so `note={a _ …}` now renders a
+/// literal underscore and raises nothing at all. The `a1` entry stays in the
+/// fixture as the standing check that escaping did not disturb the once-only
+/// property — it must contribute ZERO errors — while `a2`'s `^` (outside the
+/// escaped set) remains the live probe.
 const BIB: &str = r"@article{a1, author={Doe, J.}, title={T}, year={2020},
   note={a _ \textbf{b}} }
 @article{a2, author={Roe, R.}, title={T2}, year={2021},
@@ -64,17 +71,23 @@ fn bib_field_errors_are_reported_once_not_once_per_digest() {
   // and would make this test vacuously green.
   let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
 
-  for needle in [
-    "Script _ can only appear in math mode",
-    "Script ^ can only appear in math mode",
-  ] {
-    let n = stderr.matches(needle).count();
-    assert_eq!(
-      n, 1,
-      "the field was digested {n} times, not once — bibliography errors are \
-       being multiplied into the document's error count.\nstderr:\n{stderr}"
-    );
-  }
+  let needle = "Script ^ can only appear in math mode";
+  let n = stderr.matches(needle).count();
+  assert_eq!(
+    n, 1,
+    "the field was digested {n} times, not once — bibliography errors are \
+     being multiplied into the document's error count.\nstderr:\n{stderr}"
+  );
+  // `_` is DATA in a `.bib` field (OXIDIZED_DESIGN #74), so `a1` must raise
+  // nothing. Asserted rather than dropped: if the escaping ever regresses, this
+  // catches it here too, and once-per-digest would show up as a count of 2.
+  let n = stderr
+    .matches("Script _ can only appear in math mode")
+    .count();
+  assert_eq!(
+    n, 0,
+    "a `_` in a bib field is data and must raise nothing, got {n}.\nstderr:\n{stderr}"
+  );
 }
 
 fn strip_ansi(s: &str) -> String {

--- a/latexml_oxide/tests/55_bibtex.rs
+++ b/latexml_oxide/tests/55_bibtex.rs
@@ -114,32 +114,31 @@ fn bibtex_mode_emits_bibentries() {
   );
 }
 
-/// A runaway field must cost only its own entry — not the rest of the `.bib`.
+/// A `%` in a field is data, and a real runaway costs only its own entry.
 ///
-/// A bare `%` in a BibTeX field is literal data (BibTeX has no comment syntax
-/// inside an entry) but TeX source when `\ProcessBibTeXEntry` replays the entry
-/// through a Mouth, so it comments out the closing brace and the argument read
-/// runs away. Both engines mis-read the field — that is parity, and real
-/// bibtex+pdflatex break on it too, so it is deliberately NOT corrected here.
+/// **The `%` half.** A bare `%` in a BibTeX field is literal data — BibTeX has
+/// no comment syntax inside an entry — but it used to become TeX source when
+/// `\ProcessBibTeXEntry` replays the entry through a Mouth, so catcode 14 ate
+/// the closing brace and the argument read ran away. That is now corrected on
+/// both seams (OXIDIZED_DESIGN #74): the entry Mouth reads `%` as OTHER, and so
+/// does `\bib@@title`, which never touches that Mouth — it re-reads the RAW
+/// field to re-case it and tokenizes the result itself. Hence the fixture's two
+/// `%` entries, one per seam. Perl still truncates both (`Fifty`, `plain`), so
+/// these assertions are deliberately BEYOND same-host Perl; see #74 for why
+/// pdflatex, not Perl, is the ground truth for a directly-read `.bib`.
 ///
-/// What was Rust-only was the blast radius, and it had two independent causes —
-/// hence the two runaway entries in the fixture, which fail by different routes:
-///
-/// * **`{}`-read argument** (`\bib@@title`). `read_balanced` used to treat every
-///   autoclose literal mouth as a token-level continuation of its parent
-///   (`gullet.rs`, the xint `\scantokens` divergence), so the runaway crossed out
-///   of the entry mouth and swallowed every following `\ProcessBibTeXEntry` AND
-///   `\end{bibtex@bibliography}`. The entry mouth now declares itself
-///   `BalancedBoundary::Opaque`, which is what Perl's readBalanced (`Gullet.pm`
-///   L465-472, current mouth only) does for every mouth.
-/// * **`Digested` argument** (`\bib@@field`). The group opened by `{` is never
-///   closed, so the argument digestion runs to EOF; `readDigested` then `pop`s
-///   the last box to strip the closing brace, but `digest_next_body` was pushing
-///   Perl's EOF trailer box (`Stomach.pm` L130) only for a body that had read no
-///   token at all, so the `pop` ate real content — every following entry.
-///
-/// Ground truth for the assertions is same-host Perl on the same fixture: all
-/// four keys present, and the runaway title truncated at the `%` to "Fifty".
+/// **The blast-radius half.** `runawaymath`'s unescaped `$` still runs away —
+/// it opens math that never closes, so the `Digested` argument (`\bib@@field`,
+/// BibTeX.pool L230) digests to EOF. `readDigested` then `pop`s the last box to
+/// strip the closing brace, and `digest_next_body` must have pushed Perl's EOF
+/// trailer box (`Stomach.pm` L130) or that `pop` eats real content — every
+/// following entry. The gullet-level twin of that guarantee is the entry
+/// mouth's `BalancedBoundary::Opaque` (Perl's readBalanced reads the current
+/// mouth only, `Gullet.pm` L465-472); with `%` retired as a trigger, no `.bib`
+/// input reachable through `Pre::BibTeX` produces a token-level unbalanced read
+/// any more — the parser balances braces character-wise before we ever see the
+/// value — so that boundary is now an invariant this fixture states rather than
+/// one it can provoke.
 #[test]
 fn runaway_field_costs_only_its_own_entry() {
   // `init` is process-global and the sibling test in this target may have won
@@ -161,11 +160,17 @@ fn runaway_field_costs_only_its_own_entry() {
   };
   let s = doc.to_string();
 
-  for key in ["before", "runawaytitle", "runawaynote", "after"] {
+  for key in [
+    "before",
+    "runawaytitle",
+    "runawaynote",
+    "runawaymath",
+    "after",
+  ] {
     assert!(
       s.contains(&format!("key=\"{key}\"")),
       "entry '{key}' was lost — a runaway field must not take other entries \
-       with it (same-host Perl keeps all four). Got:\n{s}"
+       with it. Got:\n{s}"
     );
   }
   // The entries that carry no runaway must be intact, not merely present.
@@ -174,10 +179,17 @@ fn runaway_field_costs_only_its_own_entry() {
     "the entry FOLLOWING the runaway lost its title, so the runaway is still \
      consuming past its own mouth. Got:\n{s}"
   );
-  // And the damaged entry is damaged exactly as far as Perl's is: the title is
-  // truncated at the `%`, the rest of that line gone.
+  // The `%` is data: both seams must keep the whole value, not stop at it.
+  // `\bib@@title` re-tokenizes the raw field itself …
   assert!(
-    s.contains("<bib-title>Fifty</bib-title>"),
-    "expected the runaway title truncated at the `%` (same as Perl), got:\n{s}"
+    s.contains("<bib-title>Fifty % of the time</bib-title>"),
+    "the title was truncated at its `%` — a `%` in a .bib field is data, not a \
+     comment (OXIDIZED_DESIGN #74). Got:\n{s}"
+  );
+  // … while the note comes straight off the entry Mouth.
+  assert!(
+    s.contains("plain % comment"),
+    "the note was truncated at its `%` — the entry Mouth must read `%` as an \
+     ordinary character (OXIDIZED_DESIGN #74). Got:\n{s}"
   );
 }

--- a/latexml_oxide/tests/bibtex/runaway_field.bib
+++ b/latexml_oxide/tests/bibtex/runaway_field.bib
@@ -1,39 +1,60 @@
-% A `.bib` whose fields contain a bare `%`.
+% A `.bib` whose fields break the TeX replay of their own entry.
 %
-% BibTeX has NO comment syntax inside an entry, so this is literal data — but
-% `\ProcessBibTeXEntry` hands the entry to a Mouth as TeX SOURCE (Perl
-% `BibTeX.pool.ltxml` L165-166), where `%` is catcode 14 and comments out the
-% rest of the line, closing brace included. Both engines therefore mis-read the
-% field, and so does real bibtex+pdflatex — that part is parity and is
-% deliberately not corrected.
+% Two things are asserted over this file, in `55_bibtex.rs`:
 %
-% What is NOT parity is the blast radius. The point of this fixture is that the
-% damage stays inside the entry that caused it: `before` and `after` must
-% survive, whichever field the runaway sits in.
+% 1. A `%` in a field value is DATA. BibTeX has no comment syntax inside an
+%    entry, so `Pre::BibTeX` hands the `%` through; `\ProcessBibTeXEntry` then
+%    replays the entry as TeX SOURCE (Perl `BibTeX.pool.ltxml` L165-166), where
+%    catcode 14 used to comment out the rest of the line — closing brace and
+%    all. That is corrected: the entry Mouth (and the handlers that re-tokenize
+%    a stored raw field, like `\bib@@title`) read `%` as an ordinary character.
+%    OXIDIZED_DESIGN #74; `runawaytitle` and `runawaynote` are its two seams.
+%    Perl still mis-reads both, so their titles/notes come out truncated there.
+%
+% 2. A runaway that IS still a runaway must cost only its own entry. `$5` — an
+%    unescaped dollar in a `note`, one of the most common `.bib` malformations —
+%    opens math that never closes, so the argument digestion runs to EOF. That
+%    is the `Digested`-argument mechanism (`\bib@@field`, BibTeX.pool L230):
+%    `readDigested` `pop`s the last box to drop the closing brace, and
+%    `digest_next_body` has to have pushed Perl's EOF trailer box
+%    (`Stomach.pm` L130) or the `pop` eats real content — every following entry.
+%    The entry mouth is also `BalancedBoundary::Opaque`, as Perl's readBalanced
+%    is for every mouth (`Gullet.pm` L465-472), so a gullet-level runaway cannot
+%    cross out of the entry either.
+%
+% `before` and `after` are the containment canaries: they must survive whichever
+% field the runaway sits in.
 @misc{before,
   author = {Able, Ann},
   title  = {Entry Before The Runaway},
   year   = {2023}
 }
 
-% Runaway inside a `{}`-read macro argument (`\bib@@title`, BibTeX.pool L293).
-% Fixed by the entry mouth being opaque to a balanced read.
+% `%` in a `{}`-read macro argument (`\bib@@title`, BibTeX.pool L293) — which
+% never reaches the entry Mouth: `\bib@@title` re-reads the RAW field to re-case
+% it and tokenizes the result itself.
 @misc{runawaytitle,
   author = {Poe, Percy},
   title  = {Fifty % of the time},
   year   = {2024}
 }
 
-% Runaway inside a `Digested` argument (`\bib@@field`, BibTeX.pool L230) — a
-% different mechanism: the group opened by `{` is never closed, so the argument
-% digestion runs to EOF and `readDigested`'s `pop` (which is meant to drop the
-% closing-brace box) ate real content instead, for want of the EOF trailer box
-% Perl pushes at `Stomach.pm` L130.
+% `%` in a `Digested` argument (`\bib@@field`, BibTeX.pool L230) — this one does
+% come off the entry Mouth.
 @misc{runawaynote,
   author = {Quill, Quinn},
   title  = {Has A Runaway Note},
   year   = {2024},
   note   = {plain % comment}
+}
+
+% A live runaway: the unescaped `$` opens math and swallows the rest of the
+% entry. Its damage must not reach `after`.
+@misc{runawaymath,
+  author = {Rho, Rita},
+  title  = {Has An Unescaped Dollar},
+  year   = {2024},
+  note   = {costs $5 each}
 }
 
 @misc{after,

--- a/latexml_oxide/tests/cluster_regressions/bib_bare_ampersand.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_bare_ampersand.bib
@@ -27,7 +27,7 @@
 % stops with "Misplaced alignment tab character &", drops the character and
 % prints "Taylor Francis". So this is not a defect fix: LaTeXML reads `.bib`
 % directly, with no `.bst` and no bibtex(1), so it decides what reaches the
-% tokenizer. OXIDIZED_DESIGN #75.
+% tokenizer. OXIDIZED_DESIGN #74.
 %
 % `#` is NOT neutralized with it. Checked across all seven witnesses: one bare
 % `#` in total, in 2605.00462's JabRef `file` path, and that field is already

--- a/latexml_oxide/tests/cluster_regressions/bib_bare_ampersand.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_bare_ampersand.bib
@@ -1,0 +1,97 @@
+% A bare `&` in a `.bib` field, verbatim as seven arXiv/2605 papers ship it.
+% `&` is catcode 4, so digesting the field reads it as an alignment tab.
+% Every line below is copied from a witness, not invented:
+%
+%   publisher  {Taylor & Francis}                       2605.03054, 2605.01936,
+%                                                       2605.06249 (x2)
+%   journal    {Information Processing & Management}    2605.01936
+%   journal    {Infrared Physics & Technology}          2605.08753
+%   booktitle  {... Knowledge Discovery & Data Mining}  2605.00462
+%   author     {Giovanni P. Crespi,
+%               Daishi Kuroiwa & Matteo Rocca}          2605.06624
+%   copyright  {Copyright {\copyright}2009
+%               Lippincott Williams & Wilkins}          2605.01936 L2838
+%   publisher  {... John Wiley & Sons Ltd.}             2605.10409
+%
+% A `.bib` field's content is DATA, not TeX: the `&` is the literal character
+% BibTeX handed back, so "Taylor & Francis" renders with its ampersand. Read at
+% the per-entry Mouth, beside the `%` of #74 — regime A, because `&` derails
+% alignment in ANY field and the fields carrying it here (publisher, journal,
+% booktitle) have no Perl Semiverbatim precedent to follow.
+%
+% What every engine did BEFORE, measured, because this is deliberately ahead of
+% all of them: one `Error:unexpected:&` per bare `&` in Rust and in same-host
+% `latexmlc` alike (2605.03054 1/1, 2605.06249 3/3, 2605.00462 1/1, 2605.06624
+% 1/1, 2605.08753 1/1, 2605.10409 1/1), and bibtex 0.99d + pdflatex agree —
+% under `plain` and `abbrvnat` the bare `&` is copied into the `.bbl`, pdflatex
+% stops with "Misplaced alignment tab character &", drops the character and
+% prints "Taylor Francis". So this is not a defect fix: LaTeXML reads `.bib`
+% directly, with no `.bst` and no bibtex(1), so it decides what reaches the
+% tokenizer. OXIDIZED_DESIGN #75.
+%
+% `#` is NOT neutralized with it. Checked across all seven witnesses: one bare
+% `#` in total, in 2605.00462's JabRef `file` path, and that field is already
+% covered (unknown field -> `\bib@field@default@default Verbatim Verbatim`).
+% No evidence, no change.
+%
+% `markupboundary` is the entry that keeps the neutralization honest: making a
+% character ordinary must not flatten the live TeX around it. `\emph` must
+% still mark up, `$x_1+x_2$` must still parse as math with `_` a subscript
+% INSIDE math, and the space-form accents PR #399 recovered must still resolve.
+%
+% `ampsurvivor` is the containment canary: a stray `&` must cost its own field
+% and nothing else. Under the sibling `%` bug (#73) an entry like these took the
+% WHOLE bibliography down, so "the entries after the bad one still render" is a
+% live assertion, not decoration.
+
+@book{amppublisher,
+  author = {Alice Author},
+  title = {A book from a two-name press},
+  publisher = {Taylor & Francis},
+  address = {Abingdon},
+  year = {2009}
+}
+
+@article{ampjournal,
+  author = {Bob Builder},
+  title = {A paper in a two-name journal},
+  journal = {Information Processing & Management},
+  volume = {12},
+  year = {2010}
+}
+
+@inproceedings{ampbooktitle,
+  author = {Carol Coder},
+  title = {A talk at a two-name conference},
+  booktitle = {Proceedings of the 26th ACM SIGKDD International Conference on Knowledge Discovery & Data Mining},
+  year = {2011}
+}
+
+@article{ampauthor,
+  author = {Giovanni P. Crespi, Daishi Kuroiwa & Matteo Rocca},
+  title = {A paper whose author list uses an ampersand},
+  journal = {J. Bibliographies},
+  year = {2012}
+}
+
+@book{ampcopyright,
+  author = {Dan Draper},
+  title = {A book with a copyright line},
+  publisher = {Lippincott},
+  copyright = {Copyright {\copyright}2009 Lippincott Williams & Wilkins},
+  year = {2009}
+}
+
+@article{ampsurvivor,
+  author = {Eve Ericsson},
+  title = {The entry after the stray ampersands},
+  journal = {J. Bibliographies},
+  year = {2013}
+}
+
+@article{markupboundary,
+  author = {{\v S}pakov, Oleg and Gon{\c c}alves, Ana},
+  title = {An \emph{emphasized} word, math $x_1+x_2$, and Ampere \& Ohm},
+  journal = {J. Bibliographies},
+  year = {2022}
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_bare_ampersand.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_bare_ampersand.tex
@@ -1,0 +1,10 @@
+% Driver for `bib_bare_ampersand.bib`: the five field kinds that carry a bare
+% `&` across the seven 2605 witnesses, plus a containment canary and a live-markup
+% boundary entry. See the `.bib`
+% header for the per-witness provenance and the policy.
+\documentclass{article}
+\begin{document}
+See \cite{amppublisher,ampjournal,ampbooktitle,ampauthor,ampcopyright,ampsurvivor,markupboundary}.
+\bibliographystyle{plain}
+\bibliography{bib_bare_ampersand}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/bib_escaped_amp_entity.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_escaped_amp_entity.bib
@@ -5,7 +5,7 @@
 % `amp;` is ordinary text, so the entry renders "Computer Engineering, &amp;
 % Applied Computing". pdflatex prints the same — this is neither a Perl gap nor
 % a pdflatex gap, it is corrupt input that only the `.bib` reader can undo.
-% OXIDIZED_DESIGN #75.
+% OXIDIZED_DESIGN #74.
 %
 % All three spellings are real, found by scanning 6000 arXiv/2605 sources:
 %

--- a/latexml_oxide/tests/cluster_regressions/bib_escaped_amp_entity.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_escaped_amp_entity.bib
@@ -1,0 +1,61 @@
+% `\&amp;` — an HTML-escaped ampersand that was then TeX-escaped a second time.
+% A reference manager rendered the field to HTML (`&` -> `&amp;`), a second pass
+% escaped that entity's own `&`, and the `.bib` ended up carrying four extra
+% characters the author never wrote. TeX cannot tell: `\&` is the glyph and
+% `amp;` is ordinary text, so the entry renders "Computer Engineering, &amp;
+% Applied Computing". pdflatex prints the same — this is neither a Perl gap nor
+% a pdflatex gap, it is corrupt input that only the `.bib` reader can undo.
+% OXIDIZED_DESIGN #75.
+%
+% All three spellings are real, found by scanning 6000 arXiv/2605 sources:
+%
+%   \&amp;    booktitle 2605.00833, 2605.01362; journal 2605.00922, 2605.01200,
+%             2605.01224; title 2605.01353 (`{{A}}\&amp;{{AS}}`)
+%   {\&}amp;  title 2605.01224 ("Reversible Template-based Shake {\&}amp; Bake")
+%   &amp;     publisher 2605.00859 ("European Association of Geoscientists
+%             &amp; Engineers"); journal 2605.01187
+%
+% The `title` cases are NOT redundant with the others: `\bib@@title` re-reads the
+% raw field for its case conversion (Perl L294) instead of using the argument it
+% was handed, so it bypasses the decode done while assembling the entry and needs
+% its own. `titleentity` is the case that proves it.
+%
+% `plainescaped` is the control: an ordinary `\&` must keep rendering as one
+% ampersand and must not lose a following word that happens to start with "amp".
+% `ampersandword` is the near-miss guard — "amp;" not preceded by an ampersand is
+% ordinary text and must survive untouched.
+
+@inproceedings{bookentity,
+  author = {Alice Author},
+  title = {A talk at a doubly-escaped conference},
+  booktitle = {2023 Congress in Computer Science, Computer Engineering, \&amp; Applied Computing},
+  year = {2023}
+}
+
+@article{titleentity,
+  author = {Bob Builder},
+  title = {Commentary on the {{A}}\&amp;{{AS}} all-sky survey},
+  journal = {J. Bibliographies},
+  year = {2019}
+}
+
+@article{bracedentity,
+  author = {Carol Coder},
+  title = {Reversible template-based shake {\&}amp; bake generation},
+  journal = {J. Bibliographies},
+  year = {2021}
+}
+
+@article{plainescaped,
+  author = {Dan Draper},
+  title = {A control entry},
+  journal = {Crime \& Delinquency},
+  year = {2019}
+}
+
+@article{ampersandword,
+  author = {Eve Ericsson},
+  title = {On the amp; token and amplitude modulation},
+  journal = {J. Bibliographies},
+  year = {2022}
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_escaped_amp_entity.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_escaped_amp_entity.tex
@@ -1,6 +1,6 @@
 % Driver for `bib_escaped_amp_entity.bib`: the three spellings of a doubly
 % escaped `&amp;`, plus a control and a near-miss. See the `.bib` header and
-% OXIDIZED_DESIGN #75.
+% OXIDIZED_DESIGN #74.
 \documentclass{article}
 \begin{document}
 See \cite{bookentity,titleentity,bracedentity,plainescaped,ampersandword}.

--- a/latexml_oxide/tests/cluster_regressions/bib_escaped_amp_entity.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_escaped_amp_entity.tex
@@ -1,0 +1,9 @@
+% Driver for `bib_escaped_amp_entity.bib`: the three spellings of a doubly
+% escaped `&amp;`, plus a control and a near-miss. See the `.bib` header and
+% OXIDIZED_DESIGN #75.
+\documentclass{article}
+\begin{document}
+See \cite{bookentity,titleentity,bracedentity,plainescaped,ampersandword}.
+\bibliographystyle{plain}
+\bibliography{bib_escaped_amp_entity}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/bib_field_percent.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_field_percent.bib
@@ -1,0 +1,76 @@
+% A `%` inside a BibTeX field value is DATA, not a comment.
+%
+% BibTeX's lexer has no comment syntax inside an entry — `%` is only significant
+% in the junk BETWEEN entries — so `Pre::BibTeX` hands the value back with the
+% `%` in it. LaTeXML then re-injects that value as TeX source, where catcode 14
+% makes it comment out the rest of its LINE. The field's own closing brace goes
+% with it, the entry's group never closes, and every following entry nests
+% inside the unclosed element: `<ltx:bibentry> isn't allowed in <ltx:bibentry>`,
+% over and over. See OXIDIZED_DESIGN #74.
+%
+% The single-line layout is load-bearing, exactly as in `bib_abstract_percent.bib`:
+% the closing `}` must sit at the END of the line that carries the `%`. Wrap the
+% value across lines and the `%` only eats to its own line end, the brace on the
+% next line still closes the group, and the fixture stops reproducing. Do not
+% reflow these entries.
+%
+% Two DISTINCT code paths reach the tokenizer, and each needs its own entry:
+%
+%   `percentdoi`  — `doi` is dispatched through the per-entry Mouth that
+%                   `\ProcessBibTeXEntry` opens over the generated
+%                   `\csname bib@field@default@doi\endcsname{<value>}` line.
+%                   Copied from witness arXiv 2605.01196 `references.bib` L1984
+%                   (`doi={%doi:10.1017/jfm.2016.420},` — an author's own note to
+%                   self, left in an UNCITED entry). 28 errors, and the paper's
+%                   rendered output was otherwise byte-identical: the whole cost
+%                   was diagnostics for a reference nobody cites.
+%
+%   `percenthref` — `title` never reaches that Mouth. `\bib@@title` re-reads the
+%                   RAW field to re-case it and tokenizes the result itself, so
+%                   the mouth-level rule has to be repeated at that call. Copied
+%                   from witness arXiv 2605.02131 `IAS_GFM_References.bib` L104
+%                   (a percent-ENCODED URL in an `\href`). 28 errors; the two
+%                   linked titles were lost.
+%
+% pdflatex is the ground truth for both. `bibtex` keeps the `%` (its lexer has
+% no comment rule inside `{}`), and neither of these fields is in plain.bst's
+% ENTRY list, so `bibtex(1)` drops them when writing the `.bbl` and pdflatex
+% never sees them. Reading the `.bib` directly is what puts them in front of a
+% TeX tokenizer, so the reader has to use BibTeX's rules, not TeX's.
+%
+% `survivor` is the containment canary: before the fix it was swallowed into the
+% preceding entry's unclosed `<ltx:bibentry>`.
+
+@article{percentdoi,
+   author={Gagnon, D. A. and Arratia, P. E.},
+   year={2016},
+   journal={J. Fluid Mech.},
+   title={A doi field carrying a bare percent sign},
+   doi={%doi:10.1017/jfm.2016.420},
+}
+
+@techreport{percenthref,
+  author       = {{Midcontinent Independent System Operator}},
+  title        = {\href{https://cdn.example.org/20240723%20IPWG%20Item%2004b%20DRAFT.pdf}{A linked title behind a percent-encoded URL}},
+  institution  = {MISO},
+  year         = {2024},
+}
+
+% The boundary: neutralizing `%` must not flatten the field into plain text.
+% Markup, math and accents in the SAME field as the `%` all have to keep working
+% — `\emph` must still produce an element, `$x_1+x_2$` must still parse as math,
+% and `{\v S}` must still compose (PR #399; `bib_accent_space_form.bib` guards
+% the accent path on its own).
+@article{percentwithmarkup,
+   author = {{\v S}pakov, Oleg},
+   title = {Yield rose \emph{sharply} by 50% when $x_1+x_2$ held},
+   journal = {J. Bibliographies},
+   year = {2025}
+}
+
+@article{survivor,
+   author = {Bo Lindqvist},
+   title = {The entry after the runaway},
+   journal = {J. Bibliographies},
+   year = {2025}
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_field_percent.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_field_percent.tex
@@ -1,0 +1,14 @@
+% Driver for `bib_field_percent.bib`: a `%` inside a `.bib` field value must be
+% an ordinary character, not a TeX comment. See the `.bib` header and
+% OXIDIZED_DESIGN #74.
+%
+% `hyperref` is loaded because witness 2605.02131 loads it — the point of the
+% `percenthref` entry is a percent-encoded URL reaching a DEFINED `\href`, not
+% an undefined-macro diagnostic.
+\documentclass{article}
+\usepackage{hyperref}
+\begin{document}
+See \cite{percentdoi,percenthref,percentwithmarkup,survivor}.
+\bibliographystyle{plain}
+\bibliography{bib_field_percent}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/bib_field_specials.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_field_specials.bib
@@ -1,0 +1,115 @@
+% A `.bib` field's content is DATA, not TeX. Real BibTeX has two regimes and
+% latexml-oxide collapses them into one pass: in the DATA regime (`.bib` read by
+% `bibtex(1)`) `%` is not a comment, `&` is not an alignment tab, `_` is not a
+% subscript and `#` is not a parameter; only the `.bbl` that a `.bst` writes is
+% ever TeX. We read `.bib` directly, so we synthesize that `.bbl` ourselves and
+% must escape the four specials on the way. OXIDIZED_DESIGN #74.
+%
+% ONE fixture, because the whole risk is that fixing one case breaks another —
+% the escaper has to be simultaneously literal, idempotent, math-aware and
+% markup-preserving, and a fixture that split those apart would let a
+% regression through. Every entry below is a distinct hazard:
+%
+%   aipexport      bare `_` in an `eprint` PDF URL, verbatim from witness
+%                  2605.06926 `bibliography.bib` L145
+%   aipescaped     the SAME URL shape written `\_` (L1457 of the same file) —
+%                  the publisher's own export uses both spellings, which is why
+%                  escaping must be IDEMPOTENT and must not neutralize `\`
+%   taylorfrancis  bare `&` in `publisher`, verbatim from witnesses 2605.01936
+%                  `references.bib` L1570 and 2605.06249 `CV.bib` L715/763
+%   surveystut     bare `&` in `journal`, from 2605.06249 `CV.bib` L1775
+%   barespecials   all four specials bare in one rendered `title`
+%   preescaped     all four already escaped — must render IDENTICALLY to
+%                  `barespecials`, never `\\&`
+%   mathmarkup     `$x_1+x_2$` must stay math WITH A SUBSCRIPT, and `\emph`
+%                  must stay markup: the escaper skips math spans and never
+%                  touches `\`, so both are correct by construction
+%   accent         a space-form accent (PR #399) must still revert
+%   urlencoded     `%20` inside `\url{...}` must NOT become `\%20` — url.sty
+%                  reads that argument verbatim, so it is a nested DATA region.
+%                  `docs/parity/BIBLIOGRAPHY_WORKLIST.md` records this as a
+%                  working probe; blind escaping regressed it.
+%   survivor       the containment canary
+%
+% NOT covered here, deliberately: a literal `\\` in a title. It makes
+% `\bib@field@default@title` open a nested `<ltx:bibitem>`
+% (`malformed:ltx:bibitem <ltx:bibitem> isn't allowed in <ltx:bib-title>`) with
+% NO special character anywhere in the entry, so it is a pre-existing behaviour
+% of `\\` in a bibliography and not this cluster. The `\\&` hazard it would have
+% covered — where the second backslash must NOT be read as escaping the `&` —
+% is pinned instead by the `escape_bib_data_specials` unit tests in
+% `latexml_engine/src/bibtex.rs`, which isolate it exactly.
+
+@article{aipexport,
+    author = {Ada Okonkwo},
+    title = {An eprint field carrying a raw PDF URL},
+    journal = {J. Chem. Phys.},
+    year = {1981},
+    eprint = {https://pubs.aip.org/aip/jcp/article-pdf/75/4/1876/18931574/1876_1_online.pdf},
+}
+
+@article{aipescaped,
+    author = {Bo Lindqvist},
+    title = {An eprint field whose underscores are escaped},
+    journal = {J. Chem. Phys.},
+    year = {2018},
+    eprint = {https://pubs.aip.org/aip/jcp/article-pdf/doi/10.1063/1.5019805/15540793/184110\_1\_online.pdf},
+}
+
+@book{taylorfrancis,
+    author = {Wei Chen},
+    title = {A publisher name with a bare ampersand},
+    publisher = {Taylor & Francis},
+    year = {2024},
+}
+
+@article{surveystut,
+    author = {Jae-Hyun Park},
+    title = {A journal name with a bare ampersand},
+    journal = {IEEE Communications Surveys & Tutorials},
+    year = {2023},
+}
+
+@article{barespecials,
+    author = {Amara Diallo},
+    title = {AT&T dataset AT1G01010_v2 at 95% with #3 replicates},
+    journal = {J. Bibliographies},
+    year = {2025},
+}
+
+@article{preescaped,
+    author = {Nils Bergstr{\"o}m},
+    title = {AT\&T dataset AT1G01010\_v2 at 95\% with \#3 replicates},
+    journal = {J. Bibliographies},
+    year = {2025},
+}
+
+@article{mathmarkup,
+    author = {Priya Raghavan},
+    title = {Bounds on $x_1+x_2$ in \emph{Drosophila} genetics},
+    journal = {J. Bibliographies},
+    year = {2025},
+}
+
+@article{accent,
+    author = {{\v S}pakov, O. and Gon{\c c}alves, A.},
+    title = {A space-form accent must still revert},
+    journal = {J. Bibliographies},
+    year = {2025},
+}
+
+@misc{urlencoded,
+    author = {Hussein Al Osman},
+    title = {A percent-encoded URL inside a rendered field},
+    year = {2025},
+    howpublished = {\url{http://example.org/a%20b}},
+    url = {https://example.org/a%20b?x=1&y=2_3},
+    doi = {10.1007/3-540-44886-1_25},
+}
+
+@article{survivor,
+    author = {Sareh Gilakjani},
+    title = {The entry after the specials},
+    journal = {J. Bibliographies},
+    year = {2025}
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_field_specials.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_field_specials.tex
@@ -1,0 +1,14 @@
+% Driver for `bib_field_specials.bib`. Ten entries, each a distinct hazard for
+% the `.bib`-data -> TeX-source escaping boundary; all ten must reach the
+% rendered bibliography with zero POST errors. See the `.bib` header and
+% OXIDIZED_DESIGN #74.
+%
+% `url` is loaded because the `urlencoded` entry's `howpublished` calls `\url`,
+% and it is url.sty's own Verbatim parameter that keeps `%20` intact.
+\documentclass{article}
+\usepackage{url}
+\begin{document}
+See \cite{aipexport,aipescaped,taylorfrancis,surveystut,barespecials,preescaped,mathmarkup,accent,urlencoded,survivor}.
+\bibliographystyle{plain}
+\bibliography{bib_field_specials}
+\end{document}


### PR DESCRIPTION
Supersedes **#405** (`%`) and **#409** (`&`), which are absorbed here with their
commits, fixtures and guards intact. Rebased onto current `main` (post-#404, #406,
#408).

**Diagnostic.** `% & # _` in a `.bib` field are the characters the author typed,
but they were reaching the TeX tokenizer with live catcodes: `%` (14) commented
out the field's closing brace and took the rest of the entry with it, `&` (4)
was a stray alignment tab and was dropped ("Taylor Francis"), `#` (6) reached
the Stomach as a parameter, `_` (8) was a subscript outside math. Three
separately-reported clusters, one defect.

**Approach — mirror the real dynamic's two treatments.**
`pdflatex → bibtex → pdflatex` treats these characters differently at two
points, and we collapse both into one pass. Restored in order:

1. **Be `bibtex`.** A field's bytes are inert data — bibtex interprets only
   braces and the entry/field delimiters. The read path neutralizes `% & #`
   **without altering the text**: #405's per-Mouth opt-in, generalized from
   percent-only to `Mouth::with_bib_data_literals()`, plus
   `mouth::tokenize_bib_literal` for the handlers that re-read a raw field.
   Per-Mouth and not a State catcode, so a `.sty` raw-loaded from a field
   handler — and the document — keep TeX's meanings.
2. **Be `pdflatex` on the `.bbl` we just synthesized.** Now it must be valid
   TeX, and we know the author meant the literal character, so we escape at that
   boundary: `bibtex.rs::escape_bib_data_specials`, math spans skipped and
   idempotent, at **three** seams — the entry line in `\ProcessBibTeXEntry` plus
   `\bib@@title` and `\bib@@pages`, which re-read the RAW field rather than the
   value they were handed, so escaping only the entry line missed every title.

**`_` is in treatment 2 only.** A catcode is fixed at tokenization and cannot
tell whether it is inside `$…$`, and a subscript in a title's math is legitimate
TeX. Measured: putting `_` in the Mouth set silently flattened every subscript
in a bibliography title. Only the escaper can be math-aware.

**The exclusion list is the same insight, not an ad-hoc list.** A handler that
consumes the field's characters *itself*, under its own catcode regime — `url`'s
Verbatim href, `doi`'s id — is still operating in treatment 1, on data, so it
receives the value **unescaped**. `bib_field_source` reads that declaration off
the `Definition`. Consolidated as `OXIDIZED_DESIGN #74`, superseding #405's
percent-only and #409's ampersand-only entries; #409's
`undouble_escaped_ampersand` is kept as the separate input corruption it is.

**Validation.** Suite **1721 passed / 1 failed** (101 targets after #404) — the pre-existing
`latexml_post graphics::tests::process_coalesces_only_matching_conversion_options`
(issue 401). `clippy --workspace --all-targets -D warnings` and `fmt --check`
clean. All inherited canaries pass, including
`bib_name_space_form_accent_survives_reversion` (PR #399),
`bib_field_percent_is_an_ordinary_character`,
`bib_bare_ampersand_is_literal_data`,
`bib_bare_ampersand_leaves_live_markup_alone`,
`bib_escaped_amp_entity_decodes_to_one_ampersand` and
`55_bibtex::runaway_field_costs_only_its_own_entry`.

New: `bib_field_specials_are_data_not_tex` over a ten-entry fixture proving
together — the four specials bare render literally; the already-escaped entry
renders an **identical** title (no `\\&`); `$x_1+x_2$` keeps its `SUBSCRIPTOP`;
`\emph` still produces markup; `{\v S}pakov`/`Gon{\c c}alves` still revert;
`%20` inside `\url{…}` survives; `url`/`doi` pick up no backslash. Plus six
`escape_bib_data_specials` unit tests isolating the `\\&` hazard.

**All sixteen witnesses, all three clusters**, `--release` before/after on the
same host, TOTAL document errors:

| cluster | witness | before | after |
|---|---|---|---|
| `_` | 2605.06926 | 8 | **0** |
| `_` | 2605.01936 | 13 | **0** |
| `_` | 2605.04604 | 2 | **0** |
| `_` | 2605.08986 | 2 | **0** |
| `_` | 2605.05898 | 1 | **0** |
| `_` | 2605.11300 | 1 | **0** |
| `_` | 2605.11579 | 5 | 5 † |
| `%` | 2605.01196 | 28 | **0** |
| `%` | 2605.02131 | 28 | **0** |
| `%` | 2605.00879 | 103 | **1** ‡ |
| `&` | 2605.06249 | 3 | **0** |
| `&` | 2605.03054 | 1 | **0** |
| `&` | 2605.00462 | 1 | **0** |
| `&` | 2605.08753 | 1 | **0** |
| `&` | 2605.10409 | 1 | **0** |
| `&` | 2605.00833 | 0 | **0** § |

**193 → 0.** No number is worse than the separate PRs achieved, and two are
better: **2605.01936 13 → 0** where #409 alone reached 6 (its `_` half is now
fixed too), and **2605.06624 4 → 0** where #409 measured 3.

† 2605.11579 has **zero** `unexpected:_` before AND after — it never belonged to
the `_` cluster. Its apparent three were an artifact of measuring in the
DEGRADED no-dump mode a fresh worktree starts in.
‡ the residual is `undefined:\mathsemicolon`, unrelated and unchanged.
§ a RENDERING witness, not an error-count one: its `\&amp;` printed "&amp;" and
now prints "&" (`bib_escaped_amp_entity_decodes_to_one_ampersand`).

## Decisions & open questions

**1. What I dropped from the three branches.** From my own earlier work: the
`eprint`/`preprint`/`archive` **`Semiverbatim` change is gone**, and its
divergence entry with it — treatments 1+2 handle those fields, so it no longer
earned its place, and the bindings are back to Perl's exact shape. Its fixture
entries survive inside `bib_field_specials.bib`, and its guard was folded into
the consolidated one. From #405/#409: nothing dropped; `with_percent_as_other` /
`with_align_as_other` were merged into one `with_bib_data_literals`, and their
two divergence entries into #74.

**2. Doing BOTH treatments is belt-and-braces, deliberately.** For a value that
goes through the entry line they overlap — the escaper makes it valid TeX and
the Mouth would also have neutralized it. I kept both because they cover
different populations: the Mouth catches what the escaper deliberately leaves
alone (a `url` href, a `doi` id, the inside of `\url{…}`), and the escaper
covers `_`, which the Mouth cannot. **Alternative:** treatment 2 only, with a
math-aware pre-pass everywhere. **What would settle it:** whether any value
reaches a tokenizer by a fourth route neither covers.

**3. `^` is deliberately outside the set.** So `x_1` in a note now renders
literally while `x^1` still raises `unexpected:^`. That asymmetry is real. It is
not in the authorized four, outside math it is essentially always a typo, and it
is the live probe in `105_bib_field_digest_once` (whose `_` probe this work
retired — that test now asserts `_` contributes zero and keeps `^` as the
once-only probe). **What would settle it:** a corpus count of `^` outside math
in `.bib` fields.

**4. An `&` inside a field's `$\begin{array}…$` would lose its alignment.**
Treatment 1 is catcode-level and cannot be math-aware, and `&` is in treatment 1
because #409 measured and shipped it there. No witness exhibits one. **What
would settle it:** moving `&` to treatment 2 as well, which the escaper's
math-span skip would handle — deferred rather than done, because it would
re-open a measured, guarded decision on no evidence.

**5. Escaping runs BEFORE `recase_title`.** That pass splits on words and treats
a `\…` escape as part of its word, so raw `AT&T` would recase to `AT&t` while
`AT\&T` recases to `AT&T`; escaping last made the two spellings render
*differently*, which is the invariant the guard exists to protect. Visible
casing change for bare-`&` titles versus pre-fix (which was an error, not a
rendering). **What would settle it:** what `bibtex(1)`'s `change.case$` does to
`AT&T` — reasoned from `plain.bst`, not executed.

**6. Two previously-green guards changed behaviour, deliberately.**
`55_bibtex::runaway_field_costs_only_its_own_entry` (inherited from #405) now
expects the `%`-bearing title WHOLE where it expected Perl's truncation;
`105_bib_field_digest_once` swapped its probe as in (3). Flagging both rather
than letting them read as incidental edits.

**6b. One correction to the landed #408 doc, and the sites it named.** #408's
table puts `_` in **treatment 1**. Measured, that is wrong: a catcode is decided
at tokenization, before anything knows whether the character is inside `$…$`,
and putting `_` in `Mouth::with_bib_data_literals` silently flattened every
subscript in a bibliography title — caught by #409's own
`bib_bare_ampersand_leaves_live_markup_alone`, which asserts `role="SUBSCRIPTOP"`.
So treatment 1 covers `% & #` and treatment 2 covers all four. The table row is
corrected in place in `BIBLIOGRAPHY_WORKLIST.md` with the measurement and the
guard name. Separately, #408 says any change "must cover all three [seams], plus
the name-, date- and MR/Zbl-assembly sites that share that path" — those sites
had treatment 1 only, so treatment 2 now reaches them too, through one
`bib_tex_tokens` helper (escape, then tokenize-as-data). Escaping is idempotent,
so the title and pages sites that already escaped upstream are unaffected.

**7. Divergence numbering.** One consolidated `#74`; `#75` stays #406's;
`#76` retired with the `Semiverbatim` change. Please re-check at merge — the
numbers moved three times while this was in flight.

**8. Process note.** `git stash` is shared across worktrees and cost two
cross-agent collisions during this work (a sibling's stashed `bibtex.rs` landed
in my tree and mine in theirs; both recovered). Use `git diff > patch` +
`git checkout --` instead. Separately, a fresh worktree has no
`resources/dumps/`, so its first suite run reports ~6 unrelated failures from
DEGRADED raw-load mode and its first error counts are inflated — run
`tools/make_formats.sh` before believing any measurement.
