### PR TITLE
fix(contrib): silence.sty and the bundled arXiv styles no longer leave commands undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@
     `agujournal2019` end-matter, `blkarray` (recovering papers that hit
     OOM/timeout), `scrartcl` `\titlehead`, and frontmatter bindings for
     `fairmeta`, `selfevolagent` and `openmoss`.
+  - **`silence` and the bundled arXiv preprint styles no longer leave their
+    commands undefined** — `\WarningFilter` and friends stopped spilling their
+    filter text into the page, and `\keywords` renders again. The silence
+    binding also restores diagnostics the real package's `\ErrorsOff` was
+    swallowing.
   - **A deferred package-load miss no longer poisons a later raw load.**
   - **Perl `.ltxml` bindings are never read as TeX** — file resolution used to hand
     back the `.ltxml` (Perl source) and tokenize it, so raw-loading a package that

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -64,6 +64,24 @@ session of their own. Re-verify a row before planning on it (rule 1).
 
 ## Current status
 
+- **2026-07-26 — undefined CSes from packages with no binding: `silence.sty`,
+  bundled `arxiv.sty`/`PRIMEarxiv.sty`.** Long-standing gaps, **not** a
+  regression: Perl 0.8.8 has no binding for either and reproduces the identical
+  `undefined:\WarningFilter` / `undefined:\keywords` on the same witnesses
+  today. They surface only where the raw `.sty` is not read (bare mode; or a
+  bundled class whose `\RequirePackage{silence}` never reaches a raw load —
+  2504.08779). The four witnesses' current `no_problem → error` flip in
+  sandbox-arxiv-2605 is a *different* cause (`unexpected:&`, `undefined:\sqrtn`,
+  bibliography `malformed:ltx:bibitem`/`ltx:bibentry`). New contrib bindings,
+  two deliberately different shapes — silence unconditional (the raw file's
+  `\ErrorsOff` rebinding of `\PackageError`/`\GenericError` *suppresses* real
+  LaTeXML diagnostics: measured Perl 0 vs Rust 1 on a probe), the two bundled
+  arxiv styles gated on `INCLUDE_STYLES` so the paper's own file still wins in
+  ar5iv mode (all four witnesses byte-identical there, before vs after). Bare:
+  1→0, 4→1, 1→0, 1→0. Divergence #74. Guards `00_contrib::{silence_filters,
+  arxiv_keywords, primearxiv_keywords}_test`, `106_arxiv_sty_defers_to_bundled`,
+  `107_silence_keeps_diagnostics`.
+
 - **2026-07-26 (later) — session: resilience mining, and a regression the sweep caught.**
   Mined the 2605+2606 fatals: `Timeout:PushbackLimit` (25), `TooManyErrors`
   (`MaxLimit(100)` is Perl's own default — parity; `MaxLimit(500)` is our

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -78,7 +78,7 @@ session of their own. Re-verify a row before planning on it (rule 1).
   LaTeXML diagnostics: measured Perl 0 vs Rust 1 on a probe), the two bundled
   arxiv styles gated on `INCLUDE_STYLES` so the paper's own file still wins in
   ar5iv mode (all four witnesses byte-identical there, before vs after). Bare:
-  1→0, 4→1, 1→0, 1→0. Divergence #74. Guards `00_contrib::{silence_filters,
+  1→0, 4→1, 1→0, 1→0. Divergence #77. Guards `00_contrib::{silence_filters,
   arxiv_keywords, primearxiv_keywords}_test`, `106_arxiv_sty_defers_to_bundled`,
   `107_silence_keeps_diagnostics`.
 

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2337,6 +2337,74 @@ session that `MakeBibliography` drives during POST). Fixture
 in `title`, in `author`, in a `note`-routed `Annote`, plus the `\\` note — 6
 errors RED, 0 GREEN.
 
+### 77. `silence.sty` and the bundled `arxiv.sty` family get bindings Perl does not have
+
+**Perl behaviour.** Neither package has a `.ltxml` — not in
+`LaTeXML/lib/LaTeXML/Package/`, not in the installed 0.8.8 tree, not in
+ar5iv-bindings. `\keywords` exists in Perl only inside a *class* binding
+(`OmniBus.cls.ltxml`, `llncs.cls.ltxml`, `sv_support.sty.ltxml`, …), and these
+papers are `\documentclass{article}` + `\usepackage{arxiv}`, so none of them
+fires. Both packages are therefore undefined in any configuration that does not
+raw-load the `.sty`. Measured, same-host Perl 0.8.8, verbose, no `--includestyles`:
+2605.05327 `undefined:\WarningFilter`; 2605.06624 `undefined:\WarningFilter` +
+`\ActivateWarningFilters` + `\DeactivateWarningFilters`; 2605.02338 and 2605.10111
+`undefined:\keywords`. So these bindings are **new work, not a port**, and Rust
+ends up with fewer errors than Perl on all four.
+
+**Why the gap is worth closing rather than matching.** LaTeXML recovers an
+undefined CS as a **zero-argument** `<ltx:ERROR/>`, so the arguments do not
+vanish — they leak into the body as text. 2605.05327 renders the literal
+"Extended allocation already in use" (an `\WarningFilter` message) in the
+document, and 2605.02338 renders its keyword list as an unlabelled paragraph
+next to an `ltx_ERROR` span. Arity, not the body, is what the binding is for.
+
+**Two different shapes, because the two packages are different kinds of file.**
+
+*`silence.sty`* is a stable CTAN package (v1.5b, 2012) whose entire job is
+filtering LaTeX's *console* messages; it contributes no document content, so
+every public command is a no-op with silence's own arity
+(`\WarningFilter*[family]{package}Semiverbatim`, …). It is registered
+**unconditionally** — it pre-empts the raw `.sty` everywhere — because the raw
+file rebinds `\PackageError`/`\GenericError` (L581-599) and `\ErrorsOff` then
+drops messages that LaTeXML would have reported. Measured on a two-line probe
+(`\usepackage{silence}\ErrorsOff` + a package raising `\PackageError`): Perl
+`--includestyles` reports **0 errors**, Rust with this binding reports **1**.
+Pre-empting the raw file *restores* a suppressed diagnostic; it does not hide one.
+
+*`arxiv.sty`* (George Kour's arXiv-preprint style) and its `PRIMEarxiv.sty` fork
+are **bundled inside the paper**, so their contents vary and they carry real
+formatting — `\@maketitle`, `abstract`/`table` redefinitions, section shapes.
+Their bindings are therefore gated on `lookup_bool("INCLUDE_STYLES")` — the same
+predicate the raw-load path uses (`binding/content.rs` L776): when raw style
+loading is available the binding does nothing but hand control back to the
+paper's own file, and only in bare mode does it define arxiv.sty L10/L29-31/L33/
+L44-47 (`\keywords`, `\keywordname`, `\headeright`, `\undertitle`,
+`\shorttitle`, and the two `\RequirePackage`s a registered binding would
+otherwise skip past the dependency scan). `\keywords` is ported verbatim,
+including the local `\and` → `$\cdot$` rebinding and PRIMEarxiv's unbraced
+`\emph Keywords`, so bare mode renders exactly what the raw load renders.
+
+**Measured.** Bare mode, four witnesses: 2605.05327 **1 → 0**, 2605.06624
+**4 → 1** (the residual `unexpected:&` is an unrelated pre-existing cluster,
+present in the ar5iv baseline too), 2605.02338 **1 → 0**, 2605.10111 **1 → 0**.
+ar5iv mode (`--preload=ar5iv.sty`), before vs after: all four HTML outputs
+**byte-identical**, same error counts. A fifth witness, 2504.08779
+(`ascelike-new.cls`, whose `\RequirePackage{silence}` never reaches a raw load),
+carried `undefined:\WarningFilter` in the full-arXiv corpus report and now
+converts at 0 errors — registering the binding is what lets the class's
+dependency scan resolve `silence` at all.
+
+Corpus scale from the full-arXiv report: `\keywords` 428 tasks;
+`\WarningFilter` witnesses 2010.00969, 2101.00910, 2504.08779, 2508.11482,
+2509.17283, 2509.20705, 2509.20709, 2510.02612, 2512.12232, 2512.14031,
+2601.01344, 2602.11517.
+
+Guards: `00_contrib::silence_filters_test`, `00_contrib::arxiv_keywords_test`,
+`00_contrib::primearxiv_keywords_test` (bare mode, golden `.tex`+`.xml` pairs),
+`106_arxiv_sty_defers_to_bundled` (the `INCLUDE_STYLES` gate — a bundled
+`arxiv.sty` with a distinctive keyword label must still win),
+`107_silence_keeps_diagnostics` (the raw-load suppression above).
+
 ## Known Upstream Perl Issues (brief)
 
 These are behaviors in the original Perl LaTeXML that are bugs or limitations, not

--- a/latexml_contrib/src/arxiv_sty.rs
+++ b/latexml_contrib/src/arxiv_sty.rs
@@ -1,0 +1,70 @@
+//! arxiv.sty — the widely-bundled "arXiv preprint" style
+//! (George Kour, <https://github.com/kourgeorge/arxiv-style>), shipped
+//! *inside* the paper's own source rather than installed in texmf.
+//!
+//! No Perl LaTeXML binding exists (the file is not a CTAN package at all),
+//! so same-host Perl reports the same `Error:undefined:\keywords` whenever
+//! the raw .sty is not read. Witness 2605.02338: Perl and Rust both emit
+//! exactly one error, `undefined:\keywords`.
+//!
+//! **Why a binding when the file is right there on disk.** `\keywords` is
+//! only undefined in configurations that do NOT raw-load style files
+//! (`INCLUDE_STYLES` off — the bare default). Under `--includestyles` /
+//! the ar5iv profile the paper's own arxiv.sty loads and everything works;
+//! a binding that *replaced* that load would throw away the file's
+//! `\@maketitle`, its `abstract`/`table` environment redefinitions and its
+//! section formatting for no gain. So this binding is deliberately
+//! **configuration-aware**: when raw style loading is available it does
+//! nothing but hand control back to the real file; otherwise it supplies
+//! the small set of definitions a document actually calls by name. The
+//! gate is the same `lookup_bool("INCLUDE_STYLES")` the raw-load path
+//! itself uses (`latexml_core/src/binding/content.rs` L776).
+//!
+//! The bare-mode definitions are a verbatim port of arxiv.sty L10, L29-31,
+//! L33 and L44-47 — including `\and`'s local rebinding to `$\cdot$`, which
+//! is what separates the keyword list in the rendered output. Getting the
+//! ARITY right is the point: an undefined `\keywords` is recovered as a
+//! zero-argument `<ltx:ERROR/>` and its braced argument then leaks into
+//! the body as an unlabelled paragraph.
+//!
+//! Witnesses: 2605.02338 (`arxiv.sty` + `\keywords{a \and b \and c}`),
+//! 2605.10111 (the `PRIMEarxiv.sty` fork — see `primearxiv_sty.rs`).
+use latexml_package::prelude::*;
+
+/// arxiv.sty L44-47, verbatim. `\keywordname` differs between the upstream
+/// file and its PRIMEarxiv fork, so it is passed in. Kept as raw TeX (not
+/// a `DefMacro!` body) so that the space arxiv.sty's line break leaves at
+/// the end of `\and` survives exactly as the real file has it.
+pub(crate) fn define_keywords(keywordname: &str) -> Result<()> {
+  RawTeX!(&s!(r"\def\keywordname{{{}}}", keywordname));
+  RawTeX!(
+    r"\def\keywords#1{\par\addvspace\medskipamount{\rightskip=0pt plus1cm
+\def\and{\ifhmode\unskip\nobreak\fi\ $\cdot$
+}\noindent\keywordname\enspace\ignorespaces#1\par}}"
+  );
+  Ok(())
+}
+
+/// The shared bare-mode fallback for the arxiv.sty family: everything a
+/// document calls by name, and nothing that only affects page layout.
+pub(crate) fn define_bare_fallbacks(keywordname: &str) -> Result<()> {
+  // arxiv.sty L10 / L33. On the miss-handler path these two are picked up
+  // by the `\RequirePackage` dependency scan of the raw file; a registered
+  // binding bypasses that scan, so request them explicitly.
+  RequirePackage!("geometry");
+  RequirePackage!("fancyhdr");
+  // arxiv.sty L29-31.
+  RawTeX!(r"\newcommand{\headeright}{A Preprint}");
+  RawTeX!(r"\newcommand{\undertitle}{A Preprint}");
+  RawTeX!(r"\newcommand{\shorttitle}{\@title}");
+  define_keywords(keywordname)
+}
+
+LoadDefinitions!({
+  if lookup_bool("INCLUDE_STYLES") {
+    // Raw style loading is on: the paper's own arxiv.sty is authoritative.
+    InputDefinitions!("arxiv", noltxml => true, extension => Some(Cow::Borrowed("sty")));
+  } else {
+    define_bare_fallbacks(r"{\bfseries \emph{Keywords}}")?;
+  }
+});

--- a/latexml_contrib/src/lib.rs
+++ b/latexml_contrib/src/lib.rs
@@ -46,6 +46,7 @@ pub mod apacite_sty;
 pub mod apxproof_sty;
 pub mod ar5iv_sty;
 pub mod arxbj_cls;
+pub mod arxiv_sty;
 pub mod arydshln_sty;
 pub mod ascmac_sty;
 pub mod asme2ej_cls;
@@ -181,6 +182,7 @@ pub mod pb_diagram_sty;
 pub mod phyzzx_plus;
 pub mod phyzzx_tex;
 pub mod pinlabel_sty;
+pub mod primearxiv_sty;
 pub mod program_sty;
 pub mod pst_all_sty;
 pub mod pst_plot_sty;
@@ -401,6 +403,11 @@ pub const BINDINGS: &[(&str, &str, BindingLoader)] = &[
     aligned_overset_sty::load_definitions,
   ),
   ("arxbj", "cls", arxbj_cls::load_definitions),
+  // Paper-BUNDLED styles, so both bindings hand control straight back to the
+  // paper's own file whenever raw style loading is on; they only fill the
+  // frontmatter gap in bare mode. See arxiv_sty.rs for the rationale.
+  ("arxiv", "sty", arxiv_sty::load_definitions),
+  ("PRIMEarxiv", "sty", primearxiv_sty::load_definitions),
   ("arydshln", "sty", arydshln_sty::load_definitions),
   ("autofe", "sty", autofe_sty::load_definitions),
   ("changes", "sty", changes_sty::load_definitions),

--- a/latexml_contrib/src/lib.rs
+++ b/latexml_contrib/src/lib.rs
@@ -214,6 +214,7 @@ pub mod semantic_sty;
 pub mod siamart_cls;
 pub mod siamltex_cls;
 pub mod sigma_cls;
+pub mod silence_sty;
 pub mod smc_ieeeconf_cls;
 pub mod sn_jnl_cls;
 pub mod spie_cls;
@@ -547,6 +548,7 @@ pub const BINDINGS: &[(&str, &str, BindingLoader)] = &[
   ("siamltex", "cls", siamltex_cls::load_definitions),
   ("semantic", "sty", semantic_sty::load_definitions),
   ("sigma", "cls", sigma_cls::load_definitions),
+  ("silence", "sty", silence_sty::load_definitions),
   ("selfevolagent", "cls", selfevolagent_cls::load_definitions),
   ("smc_ieeeconf", "cls", smc_ieeeconf_cls::load_definitions),
   ("sn-jnl", "cls", sn_jnl_cls::load_definitions),

--- a/latexml_contrib/src/primearxiv_sty.rs
+++ b/latexml_contrib/src/primearxiv_sty.rs
@@ -1,0 +1,28 @@
+//! PRIMEarxiv.sty — a paper-bundled fork of `arxiv.sty` ("based on the
+//! Arxiv style of George Kour", its own first line). It differs from the
+//! upstream file only cosmetically: no `\headeright`/`\undertitle`/
+//! `\shorttitle`, a rule-less header, and `\keywordname` written
+//! `{\bfseries \emph Keywords}` — an unbraced `\emph` that italicises the
+//! single letter `K` (PRIMEarxiv.sty L39). That quirk is reproduced here
+//! rather than corrected: it is what the raw file renders under
+//! `--includestyles` (`<em>K</em><span class="ltx_font_bold">eywords</span>`).
+//!
+//! Same rationale, same configuration gate and same Perl-parity position
+//! as [`crate::arxiv_sty`] — see that module's header. Witness 2605.10111
+//! (`\keywords{...}` at templateArxiv.tex L54); same-host Perl reports the
+//! identical single `undefined:\keywords`.
+use latexml_package::prelude::*;
+
+LoadDefinitions!({
+  if lookup_bool("INCLUDE_STYLES") {
+    // Raw style loading is on: the paper's own PRIMEarxiv.sty is authoritative.
+    InputDefinitions!("PRIMEarxiv", noltxml => true, extension => Some(Cow::Borrowed("sty")));
+  } else {
+    // PRIMEarxiv.sty drops arxiv.sty's `\headeright` / `\undertitle` /
+    // `\shorttitle` (L27-32 of the upstream file), so only the keyword
+    // pair — plus the two `\RequirePackage` dependencies — is ported.
+    RequirePackage!("geometry");
+    RequirePackage!("fancyhdr");
+    crate::arxiv_sty::define_keywords(r"{\bfseries \emph Keywords}")?;
+  }
+});

--- a/latexml_contrib/src/silence_sty.rs
+++ b/latexml_contrib/src/silence_sty.rs
@@ -1,0 +1,92 @@
+//! silence.sty — "Selective filtering of warnings and error messages"
+//! (Paul Isambert, v1.5b 2012/07/02; TeX Live
+//! `texmf-dist/tex/latex/silence/silence.sty`).
+//!
+//! No Perl LaTeXML binding exists — neither upstream
+//! (`LaTeXML/lib/LaTeXML/Package/silence.sty.ltxml` is absent) nor in the
+//! installed 0.8.8 tree — so same-host Perl reports the same
+//! `Error:undefined:\WarningFilter` on the witnesses below. Perl only
+//! survives when `--includestyles` raw-loads the real .sty; with the raw
+//! load unavailable (bare mode, or a class whose `\RequirePackage{silence}`
+//! never runs) every silence command is undefined.
+//!
+//! The package exists solely to filter LaTeX's *console* warnings and
+//! errors. It contributes **no document content**, so every public command
+//! is a no-op here. What matters is the ARITY: an undefined `\WarningFilter`
+//! is recovered as a zero-argument `<ltx:ERROR/>`, which leaks its two
+//! braced arguments into the document as visible text (witness 2605.05327
+//! renders "Extended allocation already in use" in the body). Consuming the
+//! arguments is the whole point of the binding.
+//!
+//! Signatures follow silence.sty verbatim:
+//!   * `\SafeMode`, `\BoldMode`                         L71-72
+//!   * `\WarningsOn[list]`, `\WarningsOff*[list]`       L90-114
+//!   * `\WarningFilter*[family]{package}{message}`      L152-164
+//!   * `\ActivateWarningFilters[list]`,
+//!     `\DeactivateWarningFilters[list]`                L199-209
+//!   * `\ActivateFilters[list]`, `\DeactivateFilters[list]` L231-247
+//!   * `\ErrorsOn[list]`, `\ErrorsOff*[list]`           L495-519
+//!   * `\ErrorFilter*[family]{package}{message}`        L521-530
+//!   * `\ActivateErrorFilters[list]`,
+//!     `\DeactivateErrorFilters[list]`                  L567-577
+//!
+//! The message argument is read `Semiverbatim`: silence itself reads it
+//! under `\catcode`\\12` (L186, L554) precisely because filter patterns
+//! quote LaTeX messages containing control sequences and `#`.
+//!
+//! silence also wraps `\PackageWarning` / `\ClassWarning` / `\PackageError`
+//! / `\ClassError` / `\@latex@error` / `\GenericError` (L386-431, L433,
+//! L581-599) to route them through its filter bank. Those are deliberately
+//! NOT touched: LaTeXML's own definitions are what turn them into
+//! `Error:`/`Warning:` diagnostics, and re-pointing them at a filter
+//! silently downgrades real ones. That is not hypothetical — it is why this
+//! binding is registered UNCONDITIONALLY, where the paper-bundled
+//! `arxiv_sty.rs` sibling defers to the raw file under `INCLUDE_STYLES`.
+//! Measured: `\usepackage{silence}\ErrorsOff` followed by a package that
+//! raises `\PackageError` converts at **0 errors** under same-host Perl
+//! 0.8.8 `--includestyles` (which raw-loads silence.sty) and at **1** with
+//! this binding in front of it. Guard:
+//! `107_silence_keeps_diagnostics::silence_errorsoff_does_not_swallow_a_package_error`.
+//! The trade is that silence's own filter *state* is not modelled, which
+//! costs nothing: LaTeXML has no message bank to filter.
+//!
+//! Witnesses: 2605.05327 (`\RequirePackage{silence}` before
+//! `\documentclass`, aa.cls), 2605.06624 (`\usepackage{silence}` +
+//! `\WarningFilter[captions]{caption}{...}` + `\ActivateWarningFilters`),
+//! 2504.08779 / 2509.17283 / 2512.12232 (ascelike-new.cls, whose
+//! `\RequirePackage{silence}` never runs).
+use latexml_package::prelude::*;
+
+LoadDefinitions!({
+  // Options: debrief, immediate, safe, save, saveall, showwarnings,
+  // showerrors (L38-48). All select filter *reporting* behaviour, which
+  // has no analogue here.
+  DeclareOption!(None, {});
+  ProcessOptions!();
+
+  // L71-72
+  def_macro_noop("\\SafeMode")?;
+  def_macro_noop("\\BoldMode")?;
+
+  // L90-114. `\WarningsOff` takes an optional star OR an optional list;
+  // `\WarningsOn` only the list.
+  def_macro_noop("\\WarningsOn []")?;
+  def_macro_noop("\\WarningsOff OptionalMatch:* []")?;
+
+  // L152-164 / L521-530. `*` selects "safe" (`\makeatletter`) reading of
+  // the message; both modes gobble it here.
+  def_macro_noop("\\WarningFilter OptionalMatch:* [] {} Semiverbatim")?;
+  def_macro_noop("\\ErrorFilter OptionalMatch:* [] {} Semiverbatim")?;
+
+  // L199-209 / L231-247 / L567-577
+  def_macro_noop("\\ActivateWarningFilters []")?;
+  def_macro_noop("\\DeactivateWarningFilters []")?;
+  def_macro_noop("\\ActivateErrorFilters []")?;
+  def_macro_noop("\\DeactivateErrorFilters []")?;
+  def_macro_noop("\\ActivateFilters []")?;
+  def_macro_noop("\\DeactivateFilters []")?;
+
+  // L495-519
+  def_macro_noop("\\ErrorsOn []")?;
+  def_macro_noop("\\ErrorsOff OptionalMatch:* []")?;
+});

--- a/latexml_oxide/tests/106_arxiv_sty_defers_to_bundled.rs
+++ b/latexml_oxide/tests/106_arxiv_sty_defers_to_bundled.rs
@@ -1,0 +1,69 @@
+//! Guard for the configuration gate in `latexml_contrib/src/arxiv_sty.rs`.
+//!
+//! `arxiv.sty` is BUNDLED with the paper, so its contents vary: the binding
+//! exists only to supply `\keywords` & friends in configurations that do not
+//! raw-load style files. Whenever raw loading IS available (`--includestyles`
+//! / the ar5iv profile) the binding must hand control straight back to the
+//! paper's own file — otherwise every arxiv.sty paper silently loses that
+//! file's `\@maketitle`, `abstract`/`table` redefinitions and section
+//! formatting. Witnesses 2605.02338 and 2605.10111 convert byte-identically
+//! before and after the binding under `--preload=ar5iv.sty` because of this.
+//!
+//! The bundled fixture below names its keyword label `Bundled-keywords`,
+//! which the Rust fallback never emits (it says `Keywords`, arxiv.sty L44).
+//! So the assertion distinguishes "raw file won" from "binding shadowed it".
+//! `tests/contrib/arxiv_keywords.{tex,xml}` covers the complementary bare
+//! case, where the binding is the only source of `\keywords`.
+
+use std::{path::Path, process::Command};
+
+const TEX: &str = "\\documentclass{article}\n\
+  \\usepackage{arxiv}\n\
+  \\begin{document}\n\
+  \\keywords{alpha \\and beta}\n\
+  \\end{document}\n";
+
+/// A stand-in for the paper-bundled file: only the `\keywords` pair, with a
+/// label the binding's own fallback cannot produce.
+const STY: &str = "\\NeedsTeXFormat{LaTeX2e}\n\
+  \\ProcessOptions\\relax\n\
+  \\def\\keywordname{{\\bfseries Bundled-keywords}}\n\
+  \\def\\keywords#1{\\par\\noindent\\keywordname\\enspace\\ignorespaces#1\\par}\n";
+
+#[test]
+fn arxiv_binding_defers_to_the_bundled_sty_under_includestyles() {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+
+  let workdir = tempfile::tempdir().expect("create tempdir");
+  std::fs::write(workdir.path().join("a.tex"), TEX).expect("write a.tex");
+  std::fs::write(workdir.path().join("arxiv.sty"), STY).expect("write arxiv.sty");
+
+  let output = Command::new(bin)
+    .arg("a.tex")
+    .arg("--dest")
+    .arg("a.xml")
+    .arg("--nocomments")
+    .arg("--includestyles")
+    .current_dir(workdir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+
+  let stderr = String::from_utf8_lossy(&output.stderr);
+  assert!(
+    output.status.success(),
+    "binary exited {:?}\nstderr:\n{stderr}",
+    output.status.code(),
+  );
+  assert!(
+    !stderr.contains("Error:") && !stderr.contains("Fatal:"),
+    "arxiv.sty + \\keywords should be error-clean, stderr had errors:\n{stderr}",
+  );
+
+  let xml = std::fs::read_to_string(workdir.path().join("a.xml")).expect("read a.xml");
+  assert!(
+    xml.contains("Bundled-keywords"),
+    "the paper's own arxiv.sty must still define \\keywords under \
+     --includestyles; the binding shadowed it:\n{xml}",
+  );
+}

--- a/latexml_oxide/tests/107_silence_keeps_diagnostics.rs
+++ b/latexml_oxide/tests/107_silence_keeps_diagnostics.rs
@@ -1,0 +1,57 @@
+//! `silence.sty` must never cost us a real diagnostic
+//! (`latexml_contrib/src/silence_sty.rs`).
+//!
+//! Unlike the `arxiv.sty` sibling, the silence binding is deliberately NOT
+//! gated on `INCLUDE_STYLES`: it pre-empts the raw `.sty` in every
+//! configuration. The reason is measurable. The real silence.sty rebinds
+//! `\PackageError` / `\ClassError` / `\@latex@error` / `\GenericError`
+//! (silence.sty L582-599) so that `\ErrorsOff` drops messages before they
+//! are printed — and under LaTeXML those are the very definitions that turn
+//! a package's error into an `Error:` line. Measured on the fixture below,
+//! same-host Perl 0.8.8 with `--includestyles` reports **0 errors**; without
+//! `\usepackage{silence}` the same document reports **1**. The raw load
+//! silently downgrades a genuine diagnostic.
+//!
+//! The binding models only what silence contributes to the *document*
+//! (nothing) and leaves the error/warning definitions alone, so the
+//! diagnostic survives. This test pins that: the run must still report the
+//! `boompkg` error even with silence loaded and `\ErrorsOff` in force.
+
+use std::{path::Path, process::Command};
+
+const TEX: &str = "\\documentclass{article}\n\
+  \\usepackage{silence}\n\
+  \\ErrorsOff\n\
+  \\usepackage{boompkg}\n\
+  \\begin{document}\n\
+  x\n\
+  \\end{document}\n";
+
+const STY: &str = "\\ProvidesPackage{boompkg}\n\
+  \\PackageError{boompkg}{Deliberate boom}{}\n";
+
+#[test]
+fn silence_errorsoff_does_not_swallow_a_package_error() {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+
+  let workdir = tempfile::tempdir().expect("create tempdir");
+  std::fs::write(workdir.path().join("a.tex"), TEX).expect("write a.tex");
+  std::fs::write(workdir.path().join("boompkg.sty"), STY).expect("write boompkg.sty");
+
+  let output = Command::new(bin)
+    .arg("a.tex")
+    .arg("--dest")
+    .arg("a.xml")
+    .arg("--nocomments")
+    .arg("--includestyles")
+    .current_dir(workdir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+
+  let stderr = String::from_utf8_lossy(&output.stderr);
+  assert!(
+    stderr.contains("Deliberate boom"),
+    "silence + \\ErrorsOff must not suppress the boompkg error:\n{stderr}",
+  );
+}

--- a/latexml_oxide/tests/contrib/arxiv_keywords.tex
+++ b/latexml_oxide/tests/contrib/arxiv_keywords.tex
@@ -1,0 +1,5 @@
+\documentclass{article}
+\usepackage{arxiv}
+\begin{document}
+\keywords{Joint model \and Prostate cancer \and npde}
+\end{document}

--- a/latexml_oxide/tests/contrib/arxiv_keywords.xml
+++ b/latexml_oxide/tests/contrib/arxiv_keywords.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article"?>
+<?latexml package="arxiv"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <para class="ltx_noindent" xml:id="p1">
+    <p><emph font="bold italic">Keywords</emph> Joint model  <Math mode="inline" tex="\cdot" text="cdot" xml:id="p1.m1">
+        <XMath>
+          <XMTok name="cdot" role="MULOP">⋅</XMTok>
+        </XMath>
+      </Math>
+Prostate cancer  <Math mode="inline" tex="\cdot" text="cdot" xml:id="p1.m2">
+        <XMath>
+          <XMTok name="cdot" role="MULOP">⋅</XMTok>
+        </XMath>
+      </Math>
+npde</p>
+  </para>
+</document>

--- a/latexml_oxide/tests/contrib/primearxiv_keywords.tex
+++ b/latexml_oxide/tests/contrib/primearxiv_keywords.tex
@@ -1,0 +1,5 @@
+\documentclass{article}
+\usepackage{PRIMEarxiv}
+\begin{document}
+\keywords{Stroke rehabilitation, motor imagery}
+\end{document}

--- a/latexml_oxide/tests/contrib/primearxiv_keywords.xml
+++ b/latexml_oxide/tests/contrib/primearxiv_keywords.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article"?>
+<?latexml package="PRIMEarxiv"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <para class="ltx_noindent" xml:id="p1">
+    <p><emph font="bold italic">K</emph><text font="bold">eywords</text> Stroke rehabilitation, motor imagery</p>
+  </para>
+</document>

--- a/latexml_oxide/tests/contrib/silence_filters.tex
+++ b/latexml_oxide/tests/contrib/silence_filters.tex
@@ -1,0 +1,9 @@
+\documentclass{article}
+\usepackage{silence}
+\WarningFilter{etex}{Extended allocation already in use}
+\WarningFilter[captions]{caption}{Unknown document class (or package)}
+\ActivateWarningFilters[captions]
+\begin{document}
+\DeactivateWarningFilters[captions]
+Body text.
+\end{document}

--- a/latexml_oxide/tests/contrib/silence_filters.tex
+++ b/latexml_oxide/tests/contrib/silence_filters.tex
@@ -1,9 +1,18 @@
 \documentclass{article}
-\usepackage{silence}
+\usepackage[debrief]{silence}
 \WarningFilter{etex}{Extended allocation already in use}
 \WarningFilter[captions]{caption}{Unknown document class (or package)}
+\WarningFilter{latex}{Reference `\thref' on page \thepage\space undefined}
+\WarningFilter*[fam]{hyperref}{Token not allowed in a PDF string (Unicode)}
+\ErrorFilter{amsmath}{\begin{split} won't work here}
+\WarningsOff[latex,hyperref]
+\ErrorsOff*
 \ActivateWarningFilters[captions]
+\ActivateFilters
 \begin{document}
 \DeactivateWarningFilters[captions]
+\DeactivateFilters[fam]
+\WarningsOn
+\ErrorsOn[latex]
 Body text.
 \end{document}

--- a/latexml_oxide/tests/contrib/silence_filters.xml
+++ b/latexml_oxide/tests/contrib/silence_filters.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article"?>
+<?latexml package="silence"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <para xml:id="p1">
+    <p>Body text.</p>
+  </para>
+</document>

--- a/latexml_oxide/tests/contrib/silence_filters.xml
+++ b/latexml_oxide/tests/contrib/silence_filters.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?latexml class="article"?>
-<?latexml package="silence"?>
+<?latexml package="silence" options="debrief"?>
 <?latexml RelaxNGSchema="LaTeXML"?>
 <document xmlns="http://dlmf.nist.gov/LaTeXML">
   <resource src="LaTeXML.css" type="text/css"/>


### PR DESCRIPTION
**Diagnostic.** Two packages with no binding anywhere leave their commands undefined whenever the raw `.sty` is not read (bare mode; or a bundled class whose `\RequirePackage` never reaches a raw load). LaTeXML recovers an undefined CS as a **zero-argument** `<ltx:ERROR/>`, so the arguments do not vanish — they land in the page: 2605.05327 renders the literal `\WarningFilter` message "Extended allocation already in use" as body text, and 2605.02338/2605.10111 render their keyword list as an unlabelled paragraph next to an `ltx_ERROR` span.

**These are long-standing gaps, not a recent regression.** Perl LaTeXML 0.8.8 has no `silence.sty.ltxml` and no `arxiv.sty.ltxml` (checked the vendored tree, the installed tree, and ar5iv-bindings), and same-host Perl reproduces the identical errors on all four witnesses *today*. They are also **not** what flipped these four papers `no_problem → error` in sandbox-arxiv-2605 — that run uses the ar5iv profile, where the raw `.sty` still loads; its current errors are `unexpected:&` (05327, 06624), `undefined:\sqrtn` (06624), and bibliography `malformed:ltx:bibitem` / `ltx:bibentry` (02338, 10111), all outside this cluster. The cluster is real at corpus scale in the **full-arXiv** report: `\keywords` 428 tasks, and a `\WarningFilter` bucket including 2010.00969, 2101.00910, 2504.08779, 2508.11482, 2509.17283, 2510.02612, 2512.12232, 2601.01344, 2602.11517.

**Approach.** Three new `latexml_contrib` bindings, in two deliberately different shapes.

*`silence.sty`* — a stable CTAN package (v1.5b) that filters LaTeX's *console* messages and contributes no document content, so every public command is a no-op carrying silence's own arity (L71-72, L90-114, L152-164, L199-209, L231-247, L495-530, L567-577); the message argument is `Semiverbatim`, mirroring the ``\catcode`\\12`` the real file reads it under. Registered **unconditionally**: the raw file rebinds `\PackageError`/`\GenericError` (L581-599), and `\ErrorsOff` then drops messages LaTeXML would have reported. Measured on the `107` fixture — a package raising `\PackageError` behind `\usepackage{silence}\ErrorsOff` — Perl `--includestyles` reports **0** errors and Rust with this binding reports **1**. Pre-empting the raw file *restores* a suppressed diagnostic.

*`arxiv.sty` / `PRIMEarxiv.sty`* — bundled inside the paper, so contents vary and they carry real formatting (`\@maketitle`, `abstract`/`table` redefinitions, section shapes). Both are gated on `lookup_bool("INCLUDE_STYLES")`, the same predicate the raw-load path uses (`binding/content.rs` L776): when raw loading is on the binding hands control straight back to the paper's own file; only in bare mode does it define arxiv.sty L10/L29-31/L33/L44-47. `\keywords` is ported verbatim — including the local `\and` → `$\cdot$` rebinding and PRIMEarxiv's unbraced `\emph Keywords` — so bare mode renders exactly what the raw load renders. No global `\keywords`.

Recorded as `OXIDIZED_DESIGN_DIVERGENCES.md` **#74** (Rust ends up with fewer errors than same-host Perl), plus a `SYNC_STATUS` entry and a CHANGELOG bullet.

**Validation.** Guards, all red-verified by reverting the change and confirming the failure is the issue's own symptom (`undefined:\WarningFilter` / `\ActivateWarningFilters` / `\DeactivateWarningFilters` / `\keywords`, and the swallowed `\PackageError`):

- `00_contrib::silence_filters_test`, `00_contrib::arxiv_keywords_test`, `00_contrib::primearxiv_keywords_test` — bare-mode `.tex`+`.xml` golden pairs, hand-checked against the intended rendering rather than blessed blind.
- `106_arxiv_sty_defers_to_bundled::arxiv_binding_defers_to_the_bundled_sty_under_includestyles` — a bundled `arxiv.sty` with a distinctive keyword label must still win under `--includestyles`; pins the gate.
- `107_silence_keeps_diagnostics::silence_errorsoff_does_not_swallow_a_package_error` — pins the diagnostic the raw load drops.

Per-witness error counts (ANSI-stripped `^(Error|Fatal):`, verbose):

| witness | Perl 0.8.8, bare | Rust bare, before → after | Rust `--preload=ar5iv.sty`, before → after |
|---|---|---|---|
| 2605.05327 | 2 (`\WarningFilter`, `\nolinenumbers`) | **1 → 0** | 0 → 0, HTML byte-identical |
| 2605.06624 | 3 (all silence) | **4 → 1** | 1 → 1, HTML byte-identical |
| 2605.02338 | 1 (`\keywords`) | **1 → 0** | 0 → 0, HTML byte-identical |
| 2605.10111 | 1 (`\keywords`) | **1 → 0** | 0 → 0, HTML byte-identical |

The residual 1 on 2605.06624 is `unexpected:&`, an unrelated pre-existing cluster present in the ar5iv baseline and in cortex — deliberately not touched. A fifth witness, **2504.08779** (`ascelike-new.cls`, whose `\RequirePackage{silence}` never reaches a raw load), carried `undefined:\WarningFilter` in the full-arXiv report and now converts at **0 errors**: registering the binding is what lets the class's dependency scan resolve `silence` at all.

`cargo test --tests --no-fail-fast -- --test-threads=4`: **101 targets, 1709 passed, 1 failed** — the single expected pre-existing `latexml_post graphics::tests::process_coalesces_only_matching_conversion_options` (issue 401). `cargo +nightly clippy --workspace --all-targets -- -D warnings`, `cargo +nightly fmt --all` and `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` all clean.

## Decisions & open questions

**1. Writing bindings Perl does not have.** Perl LaTeXML has **no** `silence.sty.ltxml` and **no** `arxiv.sty.ltxml`, and defines `\keywords` only inside class bindings (`OmniBus.cls.ltxml`, `llncs.cls.ltxml`, `sv_support.sty.ltxml`) that these `\documentclass{article}` papers never load. So this is new work, justified on its own merits, not a port. The merit: the recovered zero-argument `<ltx:ERROR/>` spills author content into the page, which is worse than the error itself, and both packages' document-level semantics are small and fully knowable from their sources. *Alternative:* match Perl and leave both undefined. *What would settle it:* a decision on whether bare-mode conversion should aim to match Perl's error set or the paper's intended rendering.

**2. No stub silences anything the author meant to see.** silence renders nothing by construction — it manipulates message banks and wraps `\PackageWarning`/`\PackageError`; its no-ops are a complete model of its *document* effect. `\keywords` does render, and is rendered — proven by the byte-identical ar5iv comparison, where the raw file and the binding produce the same HTML.

**3. `\keywords` is per-package, never global.** Two package bindings (`arxiv`, `PRIMEarxiv`), no kernel- or OmniBus-level definition, so a genuinely missing class binding elsewhere in the corpus still reports itself. *Alternative:* a global `\keywords` would clear all 428 full-arXiv tasks at once. *What would settle it:* a breakdown of the remaining 428 by providing class — if they concentrate in a handful of journal classes, per-class bindings remain right; if they are a long tail of author `\providecommand`s, a fallback becomes arguable.

**4. The `INCLUDE_STYLES` gate is a new pattern in this tree** (no other binding branches on it). Chosen as the conservative option: a bundled `arxiv.sty` varies per paper and does far more than `\keywords`, so shadowing its raw load would silently regress every ar5iv-mode paper that bundles one. *Alternatives:* (a) unconditional replacement — simpler, matches every other contrib binding, but loses the file's `\@maketitle`/`abstract`/section work; (b) unconditional force-raw-load (the `apxproof_sty.rs` shape) — makes bare mode identical to ar5iv, but starts raw-loading arbitrary paper-bundled content in bare mode, which is exactly what bare mode exists to avoid. *What would settle it:* a corpus A/B over papers bundling `arxiv.sty`, comparing (a) against the gate on error count and frontmatter shape.

**5. silence is deliberately NOT gated, unlike its two siblings in the same PR.** The asymmetry is intentional and evidence-backed (the Perl-0 / Rust-1 measurement above): keeping the raw load would preserve a mechanism that suppresses real diagnostics, which the project's first non-negotiable forbids. *Alternative:* gate it for symmetry, leaving ar5iv-mode behaviour literally untouched. *What would settle it:* a corpus A/B on error counts for silence-using papers in ar5iv mode — if the gate loses errors relative to the binding, the binding is confirmed.

**6. Scope held to the cluster.** 2605.06624's `unexpected:&`, 2605.06624's `undefined:\sqrtn`, and the bibliography `malformed:*` errors on 2605.02338 / 2605.10111 are left untouched; the four papers' current cortex `error` status is driven by those, not by this cluster, so this PR does not by itself return them to `no_problem`.


**7. No fallback behind the gate.** Under `INCLUDE_STYLES` the binding defers to the raw file and stops there — if that raw load were to fail partway, `\keywords` would still be undefined. I have no witness for that, `arxiv.sty`/`PRIMEarxiv.sty` are in no texmf tree (`kpsewhich` misses both), and a `\providecommand`-shaped fallback after the raw load is unverified machinery, so it is deliberately left out. *What would settle it:* a corpus scan for `\usepackage{arxiv}` papers that still report `undefined:\keywords` after this lands.

**Merge mechanics (for whoever lands this alongside the sibling PRs):** the three shared docs are the only likely conflict points — `OXIDIZED_DESIGN_DIVERGENCES.md` (this PR claims **#74**; a sibling adding an entry will collide on the number), the top of `SYNC_STATUS.md` "Current status", and one CHANGELOG bullet. The code side (`latexml_contrib/src/{silence,arxiv,primearxiv}_sty.rs`, three registration rows, six test files) touches nothing a sibling would.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
