### PR TITLE
fix(bibliography): a percent in a .bib field is data, not a comment

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2275,6 +2275,76 @@ this fixture, 203 on the witness) passed every bibliography guard silently.
 (percent in `abstract`, specials in `keywords`, and a third entry as the
 containment canary).
 
+### 74. A `%` inside a `.bib` field value is data, not a comment
+
+**Perl behaviour.** `Pre::BibTeX` is a real BibTeX-format parser: field values
+come out of `parseString`/`parseBalancedBraces` as raw strings, and `%` is
+significant **only** in the junk between entries (`skipJunk`, `BibTeX.pm` L335-343
+— its own comment reads "Although % officially starts comments, apparently BibTeX
+accepts anything until @"). Inside an entry there is no comment syntax, matching
+`bibtex.web`. `BibTeX.pool.ltxml` L134-166 (`\bibentry@create`) then re-serializes
+those values into TeX source — one `\csname bib@field@<t>@<f>\endcsname{<value>}`
+per line — and hands the join to `Mouth->new($tex)`. There `%` is catcode 14
+again, so it comments out the rest of its line, **the field's own closing brace
+included**. The entry's group never closes, `<ltx:bibentry>` is left open, and
+every following entry nests inside it: `<ltx:bibentry> isn't allowed in
+<ltx:bibentry>`, once per remaining entry. `\bib@@title` (L293-333) loses the
+value a second way — it re-reads the RAW field to re-case it and `Tokenize`s the
+result itself, and `Tokenize` uses the standard cattable, where `%` is again a
+comment; the truncated title leaves a `\href` mid-argument and the runaway eats
+the following `\csname`s (`Extra \endcsname`).
+
+**Rust behaviour.** The text BibTeX lexed is read with `%` as an ordinary
+character. Two seams, because the value reaches the tokenizer two ways:
+`Mouth::with_percent_as_other()` on the per-entry mouth
+(`\ProcessBibTeXEntry`, `bibtex.rs`), and `mouth::tokenize_percent_literal`
+behind `bibtex.rs::tokenize_bib_field` for the handlers that re-tokenize a
+stored raw field (title recasing, name splitting, date/pages assembly, MR/Zbl).
+It is a per-**Mouth** property rather than a `\catcode` assignment on purpose: a
+State catcode would be inherited by a `.sty` raw-load triggered from inside a
+field handler, where `%` must stay a comment. Only comment-ness is removed — a
+`%` given some other catcode keeps it, and `\%` is unaffected (a control symbol
+is formed from the following character whatever its catcode).
+
+**Why — measured against `bibtex` 0.99d + pdflatex, not against Perl.** The
+fixture's three entries were run through the real toolchain (TL2025,
+`plain.bst`, hyperref loaded), and it handles both fields cleanly:
+
+* `doi` — **`bibtex` drops it.** `plain.bst` does not declare `doi` in its
+  `ENTRY` list, so the generated `d.bbl` carries author/title/journal/year and
+  no trace of `%doi:`. pdflatex never sees the character. (Nor would it in the
+  witness: 2605.01196's entry sits in that file's own "UNUSED REFERENCES" block,
+  which `bibtex` never processes at all.)
+* `title` — **`bibtex` keeps the `%` verbatim** (its lexer has no comment rule
+  inside `{}`), writing `\href{https://…/20240723%20IPWG%20…DRAFT.pdf}{A linked
+  title…}` into the `.bbl` with the closing brace on that same line. pdflatex
+  **compiles it, rc=0**, and the PDF renders the linked title: real hyperref's
+  `\href` sets `` \catcode`\%=12 `` before reading its URL. So the ground-truth
+  engine reads a percent-encoded URL with `%` as an ordinary character — the
+  exact rule adopted here.
+
+LaTeXML's `HyperVerbatim` does the same catcode trick as hyperref, but far too
+late: the `%` is eaten during the *field* read, before `\href` is ever reached.
+Reading the `.bib` **directly** — which is what both LaTeXML engines do, and
+what no other consumer does — is what puts the value in front of a TeX tokenizer
+in the first place, so the reader has to use BibTeX's lexing rules for it. The
+damage under the old reading is also wildly disproportionate to the input: one
+stray character in one uncited reference costs the whole rest of the
+bibliography.
+
+This is `surpass-perl` on a shared bug, like #73 (its sibling: same "element
+opened and never closed" shape, same `%`-eats-the-closing-brace mechanism, but
+#73's three fields could be read `Verbatim` because nothing renders
+`ltx:bib-extract`, while `doi`/`title` are rendered and cannot be). Measured on
+the same host: **2605.01196 28 → 0 errors** (Perl `latexmlc` 29; output otherwise
+byte-identical, 83 bibitems before and after — the entire cost was diagnostics)
+and **2605.02131 28 → 0** (Perl 31; 20 bibitems unchanged, and the two
+percent-encoded `\href` titles now render, URLs intact).
+
+Guard: `06_cluster_bibliography::bib_field_percent_is_an_ordinary_character`
+(fixture `bib_field_percent.{tex,bib}` — one entry per seam plus a containment
+canary; the single-line `value...}` layout is load-bearing, as in #73).
+
 ### 75. A `.bib`-derived bibliography does not run the missing-`\bibitem` rescue
 
 **Perl behaviour.** `BibTeX.pool.ltxml:183` gives `{bibtex@bibliography}` the

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2337,9 +2337,22 @@ opened and never closed" shape, same `%`-eats-the-closing-brace mechanism, but
 #73's three fields could be read `Verbatim` because nothing renders
 `ltx:bib-extract`, while `doi`/`title` are rendered and cannot be). Measured on
 the same host: **2605.01196 28 → 0 errors** (Perl `latexmlc` 29; output otherwise
-byte-identical, 83 bibitems before and after — the entire cost was diagnostics)
-and **2605.02131 28 → 0** (Perl 31; 20 bibitems unchanged, and the two
-percent-encoded `\href` titles now render, URLs intact).
+byte-identical, 83 bibitems before and after — the entire cost was diagnostics),
+**2605.02131 28 → 0** (Perl 31; 20 bibitems unchanged, and the two
+percent-encoded `\href` titles now render, URLs intact), and **2605.00879
+103 → 5** (`note = {https://doi.org/10.1145%2F3292500.3330925}`; the residual 5
+are other clusters — `unexpected:_`, `\mathsemicolon`).
+
+**How much of the corpus this is.** Over the first 1200 papers of
+sandbox-arxiv-2605, 178 ship a `.bib` with a `%` somewhere in a field value; 66
+of those have an *unescaped* `%` in a field other than the three #73 already
+reads `Verbatim`. Of the 15 whose field is one that is neither `Semiverbatim`
+nor `Verbatim` (`doi`, `note`, `journal`, `howpublished`, `adsurl`), two were
+broken and are now clean — 2605.00879 (103 → 5) and 2605.01196 (28 → 0) — and
+the other 13 were already fine, because `url` (#72) and unknown fields
+(`\bib@field@default@default Verbatim Verbatim`) had their catcodes protected by
+their parameter type. That is exactly the population this closes: the rendered
+fields no parameter type was protecting.
 
 Guard: `06_cluster_bibliography::bib_field_percent_is_an_ordinary_character`
 (fixture `bib_field_percent.{tex,bib}` — one entry per seam plus a containment

--- a/latexml_core/src/mouth.rs
+++ b/latexml_core/src/mouth.rs
@@ -83,6 +83,13 @@ pub struct Mouth {
   /// floor and cheaper than a per-read flag check.
   last_token_start:       (usize, usize),
   foodtype:               FoodType,
+  /// Read `%` as an ordinary character rather than a comment, for this
+  /// mouth only. Set by `with_percent_as_other()`; see that method for the
+  /// BibTeX rationale. Deliberately a per-Mouth field rather than a State
+  /// catcode assignment: a nested mouth (a `.sty` raw-load triggered from
+  /// inside the text) is a separate object and keeps `%` as a comment,
+  /// which a State-level assignment could not guarantee.
+  percent_is_other:       bool,
   saved_at_cc:            Option<Catcode>,
   saved_include_comments: Option<bool>,
   note_message:           Option<String>,
@@ -129,6 +136,7 @@ impl Default for Mouth {
       shortsource:            s!("String"),
       // handle : None,
       foodtype:               FoodType::File,
+      percent_is_other:       false,
       saved_at_cc:            None,
       saved_include_comments: None,
       buffer:                 VecDeque::new(),
@@ -283,6 +291,30 @@ impl Mouth {
     };
     mouth.open(text)?;
     Ok(mouth)
+  }
+
+  /// Read `%` as an ordinary character (catcode 12) instead of a comment,
+  /// for the whole life of this mouth.
+  ///
+  /// BibTeX's lexer has **no comment syntax inside an entry** — `%` is only
+  /// significant in the junk BETWEEN entries (`Pre::BibTeX::skipJunk`), so a
+  /// field value it hands back is a string in which `%` is an ordinary
+  /// character. When such a value is re-injected as TeX source (BibTeX.pool's
+  /// `\bibentry@create`), the default catcode 14 makes it comment out the rest
+  /// of its line — the field's own closing brace included — and the entry's
+  /// group never closes. Reading the injected text with `%` neutralized is what
+  /// preserves the value BibTeX actually parsed.
+  ///
+  /// A `\catcode` in the injected text cannot do this job: the catcode would
+  /// still be a State assignment, so a raw `.sty` opened from inside a field
+  /// handler would inherit it. Scoping to the Mouth keeps the rule attached to
+  /// the *text that BibTeX lexed*, which is exactly where it belongs.
+  ///
+  /// Only comment-ness is removed: a `%` that has been given some other catcode
+  /// (LETTER, say) keeps it.
+  pub fn with_percent_as_other(mut self) -> Self {
+    self.percent_is_other = true;
+    self
   }
 
   pub fn get_source(&self) -> &str { &self.source }
@@ -611,7 +643,7 @@ impl Mouth {
     self.colno += 1;
     if let Some(ch) = ch_opt {
       let mut ch = *ch;
-      let mut cc = lookup_catcode(ch).unwrap_or(Catcode::OTHER);
+      let mut cc = self.catcode_of(ch);
       // Possible convert ^^x
       // Perl: (cc == CC_SUPER) && (colno + 1 < nchars) && (ch == chars[colno])
       if cc == Catcode::SUPER
@@ -647,11 +679,22 @@ impl Mouth {
           self.splice(self.colno - 1..self.colno + 2, &[ch]);
           self.nchars -= 2;
         }
-        cc = lookup_catcode(ch).unwrap_or(Catcode::OTHER);
+        cc = self.catcode_of(ch);
       }
       Some((ch, cc))
     } else {
       None
+    }
+  }
+
+  /// The catcode this mouth reads `ch` with: the State's, except that a
+  /// `with_percent_as_other()` mouth downgrades a COMMENT `%` to OTHER.
+  fn catcode_of(&self, ch: char) -> Catcode {
+    let cc = lookup_catcode(ch).unwrap_or(Catcode::OTHER);
+    if self.percent_is_other && ch == '%' && cc == Catcode::COMMENT {
+      Catcode::OTHER
+    } else {
+      cc
     }
   }
 
@@ -1113,6 +1156,29 @@ pub fn tokenize(text: &str) -> Tokens {
   use_main_state();
   result
 }
+/// Tokenize a string under the standard catcode table, reading `%` as an
+/// ordinary character rather than a comment.
+///
+/// For text that came out of a lexer with no comment syntax of its own — a
+/// BibTeX field value, whose `%` is data (see
+/// [`Mouth::with_percent_as_other`]). Plain [`tokenize`] would let that `%`
+/// comment out the rest of the string, which for a `.bib` field means losing
+/// its closing brace and leaving whatever it opened unclosed
+/// (`OXIDIZED_DESIGN #74`).
+pub fn tokenize_percent_literal(text: &str) -> Tokens {
+  // special case! empty input is empty Tokens
+  if text.is_empty() {
+    return NO_TOKENS;
+  }
+  use_std_state();
+  let result = Mouth::new(text, None)
+    .unwrap()
+    .with_percent_as_other()
+    .read_tokens();
+  use_main_state();
+  result
+}
+
 /// Tokenize a string under the **style-file** catcode table — Perl
 /// `Package.pm:TokenizeInternal` L1026-1030.
 ///

--- a/latexml_engine/src/bibtex.rs
+++ b/latexml_engine/src/bibtex.rs
@@ -2005,7 +2005,8 @@ LoadDefinitions!({
     // so the entry's group never closes, `ltx:bibentry` is left open, and every
     // later entry nests inside it. Witnesses arXiv 2605.01196 (`doi={%doi:...}`)
     // and 2605.02131 (a percent-encoded URL in a `title`'s `\href`): 28 errors
-    // each, and Perl breaks identically (29 / 31 on the same host).
+    // each, and Perl breaks identically (29 / 31 on the same host); 2605.00879
+    // (`note = {https://doi.org/10.1145%2F...}`): 103 errors.
     // Guard: `06_cluster_bibliography::bib_field_percent_is_an_ordinary_character`.
     open_mouth_with(
       Mouth::new(&lines.join("\n"), None)?.with_percent_as_other(),

--- a/latexml_engine/src/bibtex.rs
+++ b/latexml_engine/src/bibtex.rs
@@ -270,8 +270,25 @@ pub fn current_entry_field(name: &str) -> Option<Tokens> {
   if let Some(tokens) = entry.get_field(name) {
     return Some(tokens.clone());
   }
-  entry.get_raw_field(name).map(|raw| Tokenize!(raw))
+  entry.get_raw_field(name).map(tokenize_bib_field)
 }
+
+/// `Tokenize!` for a string that came out of the BibTeX lexer.
+///
+/// The standard catcode table, as Perl's `Tokenize` uses — except that `%` is
+/// an ordinary character. BibTeX has no comment syntax inside an entry
+/// (`Pre::BibTeX` only skips `%` in the junk BETWEEN entries), so a `%` in a
+/// field value is data; under catcode 14 it comments out the rest of the
+/// string and takes any brace still open with it, which leaves the field's
+/// element unclosed and swallows every following entry. Witness 2605.02131:
+/// a percent-encoded URL in a `title`'s `\href`, 24 `malformed:ltx:bibentry`.
+/// See `OXIDIZED_DESIGN #74`.
+///
+/// This is the same rule the per-entry Mouth applies (see `\ProcessBibTeXEntry`
+/// below); it has to be repeated here because the handlers that re-read a raw
+/// field — `\bib@@title` recasing, name splitting, date/pages assembly — build
+/// their tokens from the stored string and never go through that mouth.
+fn tokenize_bib_field(text: &str) -> Tokens { mouth::tokenize_percent_literal(text) }
 
 /// Perl: `currentBibEntryRawField('fieldname')` — get the *raw*
 /// source string of a field on the current entry.
@@ -983,17 +1000,17 @@ LoadDefinitions!({
       let mut name_tks: Vec<Token> = Vec::new();
       if !name.surname.is_empty() {
         let inv = Invocation!(T_CS!("\\bib@surname"),
-          vec![Tokenize!(name.surname.as_str())]);
+          vec![tokenize_bib_field(&name.surname)]);
         name_tks.extend(inv.unlist());
       }
       if !name.given.is_empty() {
         let inv = Invocation!(T_CS!("\\bib@given"),
-          vec![Tokenize!(name.given.as_str())]);
+          vec![tokenize_bib_field(&name.given)]);
         name_tks.extend(inv.unlist());
       }
       if !name.lineage.is_empty() {
         let inv = Invocation!(T_CS!("\\bib@lineage"),
-          vec![Tokenize!(name.lineage.as_str())]);
+          vec![tokenize_bib_field(&name.lineage)]);
         name_tks.extend(inv.unlist());
       }
       let inv = Invocation!(T_CS!("\\bib@@@name"),
@@ -1042,7 +1059,7 @@ LoadDefinitions!({
     // is the OptionalKeyVals arg (absent → no attributes).
     // Perl L333: Tokenize($recap) — catcode-aware, so TeX macros in
     // titles stay live (accents, math). Explode leaked them verbatim.
-    let recased_tokens = Tokenize!(recased.as_str());
+    let recased_tokens = tokenize_bib_field(&recased);
     let inv = Invocation!(T_CS!("\\bib@@field"),
       vec![tag_tokens, Tokens!(), recased_tokens]);
     Ok(inv)
@@ -1454,7 +1471,7 @@ LoadDefinitions!({
     let mut out_toks: Vec<Token> = Vec::new();
     out_toks.push(T_CS!("\\bib@field@default@date"));
     out_toks.push(T_BEGIN!());
-    out_toks.extend(Tokenize!(date.as_str()).unlist());
+    out_toks.extend(tokenize_bib_field(&date).unlist());
     out_toks.push(T_END!());
     Ok(Tokens::new(out_toks))
   });
@@ -1516,7 +1533,7 @@ LoadDefinitions!({
     // out as an empty `<ltx:bib-part role="pages"/>`. Witness arXiv 2508.17585.
     whatsit.set_property(
       "pages",
-      Stored::Digested(digest(Tokenize!(normalised.as_str()))?),
+      Stored::Digested(digest(tokenize_bib_field(&normalised))?),
     );
   });
 
@@ -1741,9 +1758,9 @@ LoadDefinitions!({
     if mrnumber.is_none() && mrreviewer.is_none() {
       return Ok(Tokens!());
     }
-    let mr_tks = Tokenize!(mrnumber.unwrap_or_default().as_str());
+    let mr_tks = tokenize_bib_field(&mrnumber.unwrap_or_default());
     let rev_tks = match mrreviewer {
-      Some(r) => Tokenize!(r.as_str()),
+      Some(r) => tokenize_bib_field(&r),
       None => Tokens!(),
     };
     let inv = Invocation!(T_CS!("\\bib@@mr"), vec![mr_tks, rev_tks]);
@@ -1794,9 +1811,9 @@ LoadDefinitions!({
     if zblno.is_none() && zblreviewer.is_none() {
       return Ok(Tokens!());
     }
-    let zbl_tks = Tokenize!(zblno.unwrap_or_default().as_str());
+    let zbl_tks = tokenize_bib_field(&zblno.unwrap_or_default());
     let rev_tks = match zblreviewer {
-      Some(r) => Tokenize!(r.as_str()),
+      Some(r) => tokenize_bib_field(&r),
       None => Tokens!(),
     };
     let inv = Invocation!(T_CS!("\\bib@@zbl"), vec![zbl_tks, rev_tks]);
@@ -1980,8 +1997,18 @@ LoadDefinitions!({
     // `\ProcessBibTeXEntry` and `\end{bibtex@bibliography}` too, so a 3-entry
     // `.bib` produced ONE entry and a single error where Perl produces all three
     // and four errors. Guard: `55_bibtex::runaway_field_costs_only_its_own_entry`.
+    //
+    // `%` is read as an ordinary character in this mouth (OXIDIZED_DESIGN #74).
+    // BibTeX has no comment syntax inside an entry, so the values `PreBibTeX`
+    // just handed us hold `%` literally; under TeX's catcode 14 each one
+    // comments out the rest of its line — the field's own closing `}` included —
+    // so the entry's group never closes, `ltx:bibentry` is left open, and every
+    // later entry nests inside it. Witnesses arXiv 2605.01196 (`doi={%doi:...}`)
+    // and 2605.02131 (a percent-encoded URL in a `title`'s `\href`): 28 errors
+    // each, and Perl breaks identically (29 / 31 on the same host).
+    // Guard: `06_cluster_bibliography::bib_field_percent_is_an_ordinary_character`.
     open_mouth_with(
-      Mouth::new(&lines.join("\n"), None)?,
+      Mouth::new(&lines.join("\n"), None)?.with_percent_as_other(),
       true,
       BalancedBoundary::Opaque,
     );

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -795,4 +795,79 @@ fn bib_field_blank_line_does_not_inject_a_bibitem() {
       "blank line: {name:?} lost — an empty sibling part ate a real one:\n{x}"
     );
   }
+
+/// A `%` inside a `.bib` field value is data, not a comment.
+///
+/// BibTeX's lexer has no comment syntax inside an entry — `Pre::BibTeX` only
+/// skips `%` in the junk BETWEEN entries — so the value it stores keeps its
+/// `%`. LaTeXML then re-injects that value as TeX source, where catcode 14
+/// makes it comment out the rest of its line, closing brace included: the
+/// entry's group never closes and every later entry nests inside the unclosed
+/// element (`<ltx:bibentry> isn't allowed in <ltx:bibentry>`).
+///
+/// Two paths, one per entry in the fixture: `doi` goes through the per-entry
+/// Mouth `\ProcessBibTeXEntry` opens, `title` does NOT — `\bib@@title` re-reads
+/// the raw field and tokenizes it itself. Fixing only the mouth left the
+/// `title` half broken (it went 28 → 37 errors on the witness, surfacing an
+/// `Extra \endcsname` once the value was no longer truncated), so both call
+/// sites read `%` as OTHER. OXIDIZED_DESIGN #74.
+///
+/// RED before the fix: witnesses 2605.01196 (`doi={%doi:10.1017/jfm.2016.420}`)
+/// and 2605.02131 (percent-encoded URL in a `title`'s `\href`) at **28 errors
+/// each**; same-host `latexmlc` 29 / 31 on the same inputs, so this is a shared
+/// bug and a surpass-Perl fix, not a Rust-only defect. Both are 0 after.
+/// `convert_and_post_clean`, not `convert_and_post`: the bibliography is built
+/// in POST, and a text-presence assertion still finds text INSIDE an unclosed
+/// element — the plain helper passes on a structurally broken document.
+#[test]
+fn bib_field_percent_is_an_ordinary_character() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_field_percent.tex");
+  // Containment: three entries, three bibitems. Before the fix the runaway
+  // swallowed its followers into its own unclosed <ltx:bibentry>.
+  assert_eq!(
+    x.matches("<bibitem").count(),
+    4,
+    "percent field: expected four bibitems, one per entry:\n{x}"
+  );
+  assert!(
+    x.contains("The entry after the runaway"),
+    "percent field: the canary entry after the runaway is missing:\n{x}"
+  );
+  // The `%` is DATA: it must survive into the output, not be dropped along
+  // with everything after it on its line.
+  // (the doi becomes an href, so its own `%`/`:` are URL-escaped there —
+  // `%25doi%3A` IS the surviving `%doi:`.)
+  assert!(
+    x.contains("dx.doi.org/%25doi%3A10.1017/jfm.2016.420"),
+    "percent field: the doi value was truncated at its percent sign:\n{x}"
+  );
+  assert!(
+    x.contains("https://cdn.example.org/20240723%20IPWG%20Item%2004b%20DRAFT.pdf"),
+    "percent field: the percent-encoded URL lost its escapes:\n{x}"
+  );
+  assert!(
+    x.contains("A linked title behind a percent-encoded URL"),
+    "percent field: the linked title did not render:\n{x}"
+  );
+  // Neutralizing `%` must not flatten the field: markup, math and accents in
+  // the SAME field still have to work (the boundary PR #399 established).
+  assert!(
+    x.contains("Yield rose <emph") && x.contains(">sharply</emph>"),
+    "percent field: \\emph in a percent-bearing title lost its markup:\n{x}"
+  );
+  assert!(
+    x.contains("tex=\"x_{1}+x_{2}\"") && x.contains("<XMApp>"),
+    "percent field: inline math in a percent-bearing title did not parse:\n{x}"
+  );
+  assert!(
+    x.contains("Špakov"),
+    "percent field: the space-form accent in the same entry stopped \
+     composing:\n{x}"
+  );
+  // No entry may nest inside another, and no element may be left open.
+  assert!(
+    !x.contains("<bibentry"),
+    "percent field: a raw <bibentry> survived post-processing — \
+     MakeBibliography could not read the entry:\n{x}"
+  );
 }

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -795,6 +795,7 @@ fn bib_field_blank_line_does_not_inject_a_bibitem() {
       "blank line: {name:?} lost — an empty sibling part ate a real one:\n{x}"
     );
   }
+}
 
 /// A `%` inside a `.bib` field value is data, not a comment.
 ///
@@ -822,7 +823,7 @@ fn bib_field_blank_line_does_not_inject_a_bibitem() {
 #[test]
 fn bib_field_percent_is_an_ordinary_character() {
   let x = convert_and_post_clean("tests/cluster_regressions/bib_field_percent.tex");
-  // Containment: three entries, three bibitems. Before the fix the runaway
+  // Containment: four entries, four bibitems. Before the fix the runaway
   // swallowed its followers into its own unclosed <ltx:bibentry>.
   assert_eq!(
     x.matches("<bibitem").count(),

--- a/latexml_oxide/tests/55_bibtex.rs
+++ b/latexml_oxide/tests/55_bibtex.rs
@@ -114,32 +114,31 @@ fn bibtex_mode_emits_bibentries() {
   );
 }
 
-/// A runaway field must cost only its own entry — not the rest of the `.bib`.
+/// A `%` in a field is data, and a real runaway costs only its own entry.
 ///
-/// A bare `%` in a BibTeX field is literal data (BibTeX has no comment syntax
-/// inside an entry) but TeX source when `\ProcessBibTeXEntry` replays the entry
-/// through a Mouth, so it comments out the closing brace and the argument read
-/// runs away. Both engines mis-read the field — that is parity, and real
-/// bibtex+pdflatex break on it too, so it is deliberately NOT corrected here.
+/// **The `%` half.** A bare `%` in a BibTeX field is literal data — BibTeX has
+/// no comment syntax inside an entry — but it used to become TeX source when
+/// `\ProcessBibTeXEntry` replays the entry through a Mouth, so catcode 14 ate
+/// the closing brace and the argument read ran away. That is now corrected on
+/// both seams (OXIDIZED_DESIGN #74): the entry Mouth reads `%` as OTHER, and so
+/// does `\bib@@title`, which never touches that Mouth — it re-reads the RAW
+/// field to re-case it and tokenizes the result itself. Hence the fixture's two
+/// `%` entries, one per seam. Perl still truncates both (`Fifty`, `plain`), so
+/// these assertions are deliberately BEYOND same-host Perl; see #74 for why
+/// pdflatex, not Perl, is the ground truth for a directly-read `.bib`.
 ///
-/// What was Rust-only was the blast radius, and it had two independent causes —
-/// hence the two runaway entries in the fixture, which fail by different routes:
-///
-/// * **`{}`-read argument** (`\bib@@title`). `read_balanced` used to treat every
-///   autoclose literal mouth as a token-level continuation of its parent
-///   (`gullet.rs`, the xint `\scantokens` divergence), so the runaway crossed out
-///   of the entry mouth and swallowed every following `\ProcessBibTeXEntry` AND
-///   `\end{bibtex@bibliography}`. The entry mouth now declares itself
-///   `BalancedBoundary::Opaque`, which is what Perl's readBalanced (`Gullet.pm`
-///   L465-472, current mouth only) does for every mouth.
-/// * **`Digested` argument** (`\bib@@field`). The group opened by `{` is never
-///   closed, so the argument digestion runs to EOF; `readDigested` then `pop`s
-///   the last box to strip the closing brace, but `digest_next_body` was pushing
-///   Perl's EOF trailer box (`Stomach.pm` L130) only for a body that had read no
-///   token at all, so the `pop` ate real content — every following entry.
-///
-/// Ground truth for the assertions is same-host Perl on the same fixture: all
-/// four keys present, and the runaway title truncated at the `%` to "Fifty".
+/// **The blast-radius half.** `runawaymath`'s unescaped `$` still runs away —
+/// it opens math that never closes, so the `Digested` argument (`\bib@@field`,
+/// BibTeX.pool L230) digests to EOF. `readDigested` then `pop`s the last box to
+/// strip the closing brace, and `digest_next_body` must have pushed Perl's EOF
+/// trailer box (`Stomach.pm` L130) or that `pop` eats real content — every
+/// following entry. The gullet-level twin of that guarantee is the entry
+/// mouth's `BalancedBoundary::Opaque` (Perl's readBalanced reads the current
+/// mouth only, `Gullet.pm` L465-472); with `%` retired as a trigger, no `.bib`
+/// input reachable through `Pre::BibTeX` produces a token-level unbalanced read
+/// any more — the parser balances braces character-wise before we ever see the
+/// value — so that boundary is now an invariant this fixture states rather than
+/// one it can provoke.
 #[test]
 fn runaway_field_costs_only_its_own_entry() {
   // `init` is process-global and the sibling test in this target may have won
@@ -161,11 +160,17 @@ fn runaway_field_costs_only_its_own_entry() {
   };
   let s = doc.to_string();
 
-  for key in ["before", "runawaytitle", "runawaynote", "after"] {
+  for key in [
+    "before",
+    "runawaytitle",
+    "runawaynote",
+    "runawaymath",
+    "after",
+  ] {
     assert!(
       s.contains(&format!("key=\"{key}\"")),
       "entry '{key}' was lost — a runaway field must not take other entries \
-       with it (same-host Perl keeps all four). Got:\n{s}"
+       with it. Got:\n{s}"
     );
   }
   // The entries that carry no runaway must be intact, not merely present.
@@ -174,10 +179,17 @@ fn runaway_field_costs_only_its_own_entry() {
     "the entry FOLLOWING the runaway lost its title, so the runaway is still \
      consuming past its own mouth. Got:\n{s}"
   );
-  // And the damaged entry is damaged exactly as far as Perl's is: the title is
-  // truncated at the `%`, the rest of that line gone.
+  // The `%` is data: both seams must keep the whole value, not stop at it.
+  // `\bib@@title` re-tokenizes the raw field itself …
   assert!(
-    s.contains("<bib-title>Fifty</bib-title>"),
-    "expected the runaway title truncated at the `%` (same as Perl), got:\n{s}"
+    s.contains("<bib-title>Fifty % of the time</bib-title>"),
+    "the title was truncated at its `%` — a `%` in a .bib field is data, not a \
+     comment (OXIDIZED_DESIGN #74). Got:\n{s}"
+  );
+  // … while the note comes straight off the entry Mouth.
+  assert!(
+    s.contains("plain % comment"),
+    "the note was truncated at its `%` — the entry Mouth must read `%` as an \
+     ordinary character (OXIDIZED_DESIGN #74). Got:\n{s}"
   );
 }

--- a/latexml_oxide/tests/bibtex/runaway_field.bib
+++ b/latexml_oxide/tests/bibtex/runaway_field.bib
@@ -1,39 +1,60 @@
-% A `.bib` whose fields contain a bare `%`.
+% A `.bib` whose fields break the TeX replay of their own entry.
 %
-% BibTeX has NO comment syntax inside an entry, so this is literal data — but
-% `\ProcessBibTeXEntry` hands the entry to a Mouth as TeX SOURCE (Perl
-% `BibTeX.pool.ltxml` L165-166), where `%` is catcode 14 and comments out the
-% rest of the line, closing brace included. Both engines therefore mis-read the
-% field, and so does real bibtex+pdflatex — that part is parity and is
-% deliberately not corrected.
+% Two things are asserted over this file, in `55_bibtex.rs`:
 %
-% What is NOT parity is the blast radius. The point of this fixture is that the
-% damage stays inside the entry that caused it: `before` and `after` must
-% survive, whichever field the runaway sits in.
+% 1. A `%` in a field value is DATA. BibTeX has no comment syntax inside an
+%    entry, so `Pre::BibTeX` hands the `%` through; `\ProcessBibTeXEntry` then
+%    replays the entry as TeX SOURCE (Perl `BibTeX.pool.ltxml` L165-166), where
+%    catcode 14 used to comment out the rest of the line — closing brace and
+%    all. That is corrected: the entry Mouth (and the handlers that re-tokenize
+%    a stored raw field, like `\bib@@title`) read `%` as an ordinary character.
+%    OXIDIZED_DESIGN #74; `runawaytitle` and `runawaynote` are its two seams.
+%    Perl still mis-reads both, so their titles/notes come out truncated there.
+%
+% 2. A runaway that IS still a runaway must cost only its own entry. `$5` — an
+%    unescaped dollar in a `note`, one of the most common `.bib` malformations —
+%    opens math that never closes, so the argument digestion runs to EOF. That
+%    is the `Digested`-argument mechanism (`\bib@@field`, BibTeX.pool L230):
+%    `readDigested` `pop`s the last box to drop the closing brace, and
+%    `digest_next_body` has to have pushed Perl's EOF trailer box
+%    (`Stomach.pm` L130) or the `pop` eats real content — every following entry.
+%    The entry mouth is also `BalancedBoundary::Opaque`, as Perl's readBalanced
+%    is for every mouth (`Gullet.pm` L465-472), so a gullet-level runaway cannot
+%    cross out of the entry either.
+%
+% `before` and `after` are the containment canaries: they must survive whichever
+% field the runaway sits in.
 @misc{before,
   author = {Able, Ann},
   title  = {Entry Before The Runaway},
   year   = {2023}
 }
 
-% Runaway inside a `{}`-read macro argument (`\bib@@title`, BibTeX.pool L293).
-% Fixed by the entry mouth being opaque to a balanced read.
+% `%` in a `{}`-read macro argument (`\bib@@title`, BibTeX.pool L293) — which
+% never reaches the entry Mouth: `\bib@@title` re-reads the RAW field to re-case
+% it and tokenizes the result itself.
 @misc{runawaytitle,
   author = {Poe, Percy},
   title  = {Fifty % of the time},
   year   = {2024}
 }
 
-% Runaway inside a `Digested` argument (`\bib@@field`, BibTeX.pool L230) — a
-% different mechanism: the group opened by `{` is never closed, so the argument
-% digestion runs to EOF and `readDigested`'s `pop` (which is meant to drop the
-% closing-brace box) ate real content instead, for want of the EOF trailer box
-% Perl pushes at `Stomach.pm` L130.
+% `%` in a `Digested` argument (`\bib@@field`, BibTeX.pool L230) — this one does
+% come off the entry Mouth.
 @misc{runawaynote,
   author = {Quill, Quinn},
   title  = {Has A Runaway Note},
   year   = {2024},
   note   = {plain % comment}
+}
+
+% A live runaway: the unescaped `$` opens math and swallows the rest of the
+% entry. Its damage must not reach `after`.
+@misc{runawaymath,
+  author = {Rho, Rita},
+  title  = {Has An Unescaped Dollar},
+  year   = {2024},
+  note   = {costs $5 each}
 }
 
 @misc{after,

--- a/latexml_oxide/tests/cluster_regressions/bib_field_percent.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_field_percent.bib
@@ -1,0 +1,76 @@
+% A `%` inside a BibTeX field value is DATA, not a comment.
+%
+% BibTeX's lexer has no comment syntax inside an entry — `%` is only significant
+% in the junk BETWEEN entries — so `Pre::BibTeX` hands the value back with the
+% `%` in it. LaTeXML then re-injects that value as TeX source, where catcode 14
+% makes it comment out the rest of its LINE. The field's own closing brace goes
+% with it, the entry's group never closes, and every following entry nests
+% inside the unclosed element: `<ltx:bibentry> isn't allowed in <ltx:bibentry>`,
+% over and over. See OXIDIZED_DESIGN #74.
+%
+% The single-line layout is load-bearing, exactly as in `bib_abstract_percent.bib`:
+% the closing `}` must sit at the END of the line that carries the `%`. Wrap the
+% value across lines and the `%` only eats to its own line end, the brace on the
+% next line still closes the group, and the fixture stops reproducing. Do not
+% reflow these entries.
+%
+% Two DISTINCT code paths reach the tokenizer, and each needs its own entry:
+%
+%   `percentdoi`  — `doi` is dispatched through the per-entry Mouth that
+%                   `\ProcessBibTeXEntry` opens over the generated
+%                   `\csname bib@field@default@doi\endcsname{<value>}` line.
+%                   Copied from witness arXiv 2605.01196 `references.bib` L1984
+%                   (`doi={%doi:10.1017/jfm.2016.420},` — an author's own note to
+%                   self, left in an UNCITED entry). 28 errors, and the paper's
+%                   rendered output was otherwise byte-identical: the whole cost
+%                   was diagnostics for a reference nobody cites.
+%
+%   `percenthref` — `title` never reaches that Mouth. `\bib@@title` re-reads the
+%                   RAW field to re-case it and tokenizes the result itself, so
+%                   the mouth-level rule has to be repeated at that call. Copied
+%                   from witness arXiv 2605.02131 `IAS_GFM_References.bib` L104
+%                   (a percent-ENCODED URL in an `\href`). 28 errors; the two
+%                   linked titles were lost.
+%
+% pdflatex is the ground truth for both. `bibtex` keeps the `%` (its lexer has
+% no comment rule inside `{}`), and neither of these fields is in plain.bst's
+% ENTRY list, so `bibtex(1)` drops them when writing the `.bbl` and pdflatex
+% never sees them. Reading the `.bib` directly is what puts them in front of a
+% TeX tokenizer, so the reader has to use BibTeX's rules, not TeX's.
+%
+% `survivor` is the containment canary: before the fix it was swallowed into the
+% preceding entry's unclosed `<ltx:bibentry>`.
+
+@article{percentdoi,
+   author={Gagnon, D. A. and Arratia, P. E.},
+   year={2016},
+   journal={J. Fluid Mech.},
+   title={A doi field carrying a bare percent sign},
+   doi={%doi:10.1017/jfm.2016.420},
+}
+
+@techreport{percenthref,
+  author       = {{Midcontinent Independent System Operator}},
+  title        = {\href{https://cdn.example.org/20240723%20IPWG%20Item%2004b%20DRAFT.pdf}{A linked title behind a percent-encoded URL}},
+  institution  = {MISO},
+  year         = {2024},
+}
+
+% The boundary: neutralizing `%` must not flatten the field into plain text.
+% Markup, math and accents in the SAME field as the `%` all have to keep working
+% — `\emph` must still produce an element, `$x_1+x_2$` must still parse as math,
+% and `{\v S}` must still compose (PR #399; `bib_accent_space_form.bib` guards
+% the accent path on its own).
+@article{percentwithmarkup,
+   author = {{\v S}pakov, Oleg},
+   title = {Yield rose \emph{sharply} by 50% when $x_1+x_2$ held},
+   journal = {J. Bibliographies},
+   year = {2025}
+}
+
+@article{survivor,
+   author = {Bo Lindqvist},
+   title = {The entry after the runaway},
+   journal = {J. Bibliographies},
+   year = {2025}
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_field_percent.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_field_percent.tex
@@ -1,0 +1,14 @@
+% Driver for `bib_field_percent.bib`: a `%` inside a `.bib` field value must be
+% an ordinary character, not a TeX comment. See the `.bib` header and
+% OXIDIZED_DESIGN #74.
+%
+% `hyperref` is loaded because witness 2605.02131 loads it — the point of the
+% `percenthref` entry is a percent-encoded URL reaching a DEFINED `\href`, not
+% an undefined-macro diagnostic.
+\documentclass{article}
+\usepackage{hyperref}
+\begin{document}
+See \cite{percentdoi,percenthref,percentwithmarkup,survivor}.
+\bibliographystyle{plain}
+\bibliography{bib_field_percent}
+\end{document}


### PR DESCRIPTION
**Diagnostic.** Both witnesses are one root cause: a `%` inside a `.bib` field
value. `Pre::BibTeX` is a faithful BibTeX parser — `%` is significant only in
the junk BETWEEN entries (`skipJunk`), so the stored value keeps it — but
`\bibentry@create` re-injects that value as TeX source, one
`\csname bib@field@…\endcsname{<value>}` per line, where catcode 14 comments
out the rest of the line **including the field's own closing brace**. The entry
group never closes, the element it opened is left dangling, and every later
entry nests inside it. That is the `malformed:ltx:bibentry` half; the
`expected:}` and `unexpected:\end{bibtex@bibliography}` are the same event seen
at the gullet. The "Currently in …" breadcrumb names the dangling element
differently per witness — `<ltx:bibentry>` for `2605.01196`
(`doi={%doi:10.1017/jfm.2016.420}`, an author's note-to-self in an *uncited*
entry) and `<ltx:bib-title>` for `2605.02131` (a percent-encoded URL in a
`title`'s `\href`) — because the two fields reach the tokenizer by different
routes. One-step bisect confirmed it: neutralize that single character in the
`.bib` and both go 28 → 0.

**Approach.** Read the text BibTeX lexed with `%` as an ordinary character, at
both seams:

* `Mouth::with_percent_as_other()` on the per-entry mouth. A **per-Mouth**
  property, not a `\catcode` assignment — a State catcode would be inherited by
  a `.sty` raw-load triggered from inside a field handler, where `%` must stay a
  comment. Opt-in, default off; every existing mouth is untouched.
* `mouth::tokenize_percent_literal` behind `bibtex.rs::tokenize_bib_field`, for
  the handlers that re-tokenize a stored **raw** field and never touch that
  mouth: `\bib@@title` recasing, name splitting, date/pages assembly, MR/Zbl.

Ground truth is `bibtex` 0.99d + pdflatex, run on the fixture: bibtex **drops**
`doi` (not in `plain.bst`'s `ENTRY` list, so pdflatex never sees `%doi:`) and
**keeps** the `%` verbatim in a `title`, where pdflatex compiles it **cleanly**
because real hyperref's `\href` sets `` \catcode`\%=12 `` before reading its
URL. Perl LaTeXML breaks on both — so this is surpass-Perl on a shared bug,
recorded as `OXIDIZED_DESIGN #74` (sibling of #73, same "opened and never
closed" shape).

**Validation.** Guard
`06_cluster_bibliography::bib_field_percent_is_an_ordinary_character`
(`convert_and_post_clean` — the bibliography is built in POST, and a
text-presence assertion still finds text inside an unclosed element). RED
verified by reverting the two source files: 7 errors, the exact cluster
signature including both breadcrumb shapes. The fixture carries one entry per
seam, a containment canary, and an entry holding `\emph`, inline math and a
space-form accent **alongside** the `%`, so the neutralization cannot quietly
flatten a field.

| witness | before | after | same-host Perl `latexmlc` |
|---|---|---|---|
| `2605.01196` | 28 | **0** | 29 |
| `2605.02131` | 28 | **0** | 31 |
| `2605.00879` (found by the sweep below) | 103 | **5** | — |

`2605.01196` output is otherwise byte-identical (83 bibitems before and after —
the entire cost was diagnostics for a reference nobody cites). `2605.02131`
keeps its 20 bibitems and now renders the two `\href` titles, URLs intact.
`2605.00879` is `note = {https://doi.org/10.1145%2F3292500.3330925}`; its
residual 5 belong to other clusters (`unexpected:_` ×3, `\mathsemicolon`, and
one `ltx:bibitem` in `<ltx:bib-title>`) — i.e. the two sibling agents' clusters,
cleanly separated from this one.

**Corpus reach.** Over the first 1200 papers of sandbox-arxiv-2605, 178 ship a
`.bib` with a `%` somewhere in a field value; 66 have an *unescaped* `%` in a
field other than the three #73 already reads `Verbatim`. Of the 15 whose field
is one that is neither `Semiverbatim` nor `Verbatim` (`doi`, `note`, `journal`,
`howpublished`, `adsurl`), **two were broken and are now clean** (the two rows
above) and the other 13 were already fine — `url` (#72) and unknown fields
(`\bib@field@default@default Verbatim Verbatim`) had their catcodes protected by
their parameter type. So this closes exactly the population no parameter type
was covering: the *rendered* fields.

Suite `1705 passed / 1 failed`, the one failure being the pre-existing
`latexml_post graphics::tests::process_coalesces_only_matching_conversion_options`
(issue 401, red on clean `main` on this host). `clippy -D warnings` and
`fmt --all` clean.

## Decisions & open questions

1. **This overlaps the shared `.bib` specials mechanism — probably drop mine.**
   The maintainer note says a sibling agent owns neutralizing `_ & # %` in the
   `.bib` reading path, and that a `%`-eats-the-closing-brace cause belongs to
   that mechanism. My cluster turned out to be **entirely** that cause: there is
   no separate structural half here. The `malformed:ltx:bibentry` errors are
   strictly downstream — killing the one `%` takes them to zero with no residue,
   so there is no "element opened on empty content" defect of the #73 kind to
   fix independently. I had already implemented and validated this before the
   note arrived; I am shipping it rather than stalling, but **if the sibling's
   mechanism lands first, close this in favour of it** and keep only the fixture
   + guard, which should pass unchanged under either implementation.
   *Handover intel the sibling will need:* neutralizing at the reading path
   **alone is not sufficient**. `\bib@@title` bypasses the entry mouth
   completely — it re-reads the RAW stored field to re-case it and tokenizes the
   result itself under the standard cattable. Fixing only the mouth took witness
   `2605.02131` from 28 to **37** errors (an `Extra \endcsname` surfaced once the
   value stopped being truncated). Any shared mechanism must cover
   `bibtex.rs::current_entry_field` / `\bib@@title` / the name-, date-, pages-
   and MR/Zbl-assembly call sites, not just the `.bib` read.
   *Evidence that would settle it:* whether the sibling's neutralization is
   applied to the stored value or to the tokenizer — if the former, both seams
   are covered and mine is redundant.

2. **Touching shared machinery: `latexml_core::mouth`.** `get_next_char` is on
   the hot path for every mouth in the workspace. The conservative shape was
   chosen: one `bool` field defaulting to `false`, one builder, and the catcode
   lookup factored into a `catcode_of` helper that is a pure passthrough unless
   the flag is set — so behaviour is bit-identical for every existing caller,
   and only comment-ness is removed (a `%` given some other catcode keeps it;
   `\%` is unaffected, since a control symbol is formed from the following
   character whatever its catcode). *Alternative considered and rejected:*
   injecting `` \catcode`\%=12 `` into the generated entry TeX — simpler and
   needs no core change, but it is a State assignment, so a raw `.sty` loaded
   from inside a field handler would inherit it and lose its own comments.
   *Evidence that would settle it:* if the sibling's mechanism works purely on
   the stored string, the core change can be dropped entirely.

3. **Did NOT read `doi`/`title` verbatim the way #73 read
   `abstract`/`keywords`/`contents`.** #73 could afford `Verbatim` because
   nothing renders `ltx:bib-extract`; `doi` and `title` are rendered, so
   verbatim would destroy their markup — and the boundary requires `\emph`,
   math and accents to keep working. Fixing the *reading* of `%` instead
   preserves everything. This is why the fixture asserts markup/math/accent
   survival in a percent-bearing field.

4. **Realigned a pre-existing guard whose premise I invalidated.**
   `55_bibtex::runaway_field_costs_only_its_own_entry` explicitly asserted the
   `%` truncation as parity ("deliberately NOT corrected"). It now asserts the
   values survive whole. Its containment half needed a live runaway, so the
   fixture gains an entry with an unescaped `$5` in a `note` (a common `.bib`
   malformation) which still digests to EOF. Measured and stated honestly in the
   test doc: with `%` retired as a trigger, **no `.bib` input reachable through
   `Pre::BibTeX` produces a token-level unbalanced read any more** (the parser
   balances braces character-wise before we see the value), so the entry mouth's
   `BalancedBoundary::Opaque` is now an invariant the fixture states rather than
   one it can provoke — I verified this by flipping it to `Transparent` and
   getting identical output. Flagging it rather than deleting the boundary.

5. **No CHANGELOG entry.** The existing 0.7.5 bibliography bullet already says
   "a percent that stays literal (BibTeX has no comments, and `%` is routine in
   an encoded URL)" from the #72 work, and the sibling's shared-mechanism PR is
   the natural owner of the user-facing line for `_ & # %` as a family. Skipped
   to avoid a duplicate bullet and a near-certain conflict. Say the word and I
   will add one.

6. **Scope held to the cluster.** Left unfixed: `\href` is *undefined* in the
   recursive bib session when the article loads neither `hyperref` nor a package
   providing it, so a `.bib` `title` using `\href` raises
   `Error:undefined:\href` (with the `%` fixed, that is now the only remaining
   error on such a document). That is divergence #72's territory — #72 loads
   `url.sty` when `\url` is undefined and could plausibly do the same for
   `\href` — and neither witness needs it (both have `\href` defined). Not
   touched.
