### PR TITLE
fix(bibliography): a blank line in a .bib field no longer starts a new bibliography item

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2275,6 +2275,68 @@ this fixture, 203 on the witness) passed every bibliography guard silently.
 (percent in `abstract`, specials in `keywords`, and a third entry as the
 containment canary).
 
+### 75. A `.bib`-derived bibliography does not run the missing-`\bibitem` rescue
+
+**Perl behaviour.** `BibTeX.pool.ltxml:183` gives `{bibtex@bibliography}` the
+same `afterDigestBegin => beginBibliography` as a hand-written
+`{thebibliography}`. `beginBibliography` = `beginBibliography_clean` +
+`setupPseudoBibitem` (`latex_constructs.pool.ltxml` L4028-4047), and
+`setupPseudoBibitem` `\let`s **both** `\par` and `\\` to
+`\par@in@bibliography`, which emits a fresh `\save@bibitem{}` every time it
+fires. Its purpose is stated in its own comment: "Since SOME people seem to
+write bibliographies w/o `\bibitem`, just blank lines between apparent
+entries".
+
+That rescue cannot apply to a `.bib`-derived bibliography.
+`Pre::BibTeX::toTeX` (L110-122) generates the body mechanically — one
+`\ProcessBibTeXEntry{key}` per line between `\begin{bibtex@bibliography}` and
+`\end{bibtex@bibliography}` — so there is never a missing `\bibitem` to
+recover, and the only `\par`/`\\` that can reach the heuristic come from
+**inside a field value**. There the heuristic opens `<ltx:bibitem>` in the
+middle of `<ltx:surname>` / `<ltx:bib-title>` / `<ltx:bib-note>`; the model
+rejects it (`Error:malformed:ltx:bibitem`), it is inserted anyway, and it is
+never closed, so every later entry nests inside it.
+
+Note the diagnostic trap: the element named in the error is **not** the one
+that failed to close. `<ltx:surname>` is opened and closed exactly as its
+constructor says — it is merely the insertion context at the moment the
+spurious item is opened.
+
+**Rust behaviour.** `{bibtex@bibliography}` calls `begin_bibliography_clean`
+and skips `setup_pseudo_bibitem`. Nothing else in that environment needs the
+skipped bindings: `\newblock`→`\lx@bibnewblock` is already `Let` globally
+(`latex_constructs.pool.ltxml` L4133), `\bibitem`/`\item`/`\vskip` never occur
+in the generated body, and the trailing "risky" lookahead that unreads a `\par`
+is a no-op because the body starts with the executable `\ProcessBibTeXEntry`.
+`{thebibliography}` and the biblatex/amsrefs/revtex/OmniBus bibliographies keep
+the full `begin_bibliography` — the rescue still applies where it was meant to.
+
+**Why.** Same-host Perl 0.8.8 emits byte-identical malformed output on the same
+input (over the fixture `.bib`: the same 6 `malformed:ltx:bibitem` errors, one
+of them naming `<ltx:givenname>` where Rust names `<ltx:surname>` — a name-split
+nuance, same cluster), so pdflatex is the ground truth, and it disagrees with
+both engines:
+bibtex 0.99d compresses every white-space run in a field value to a single
+space, so a blank line **never reaches TeX at all**, and it copies `\\` through
+to the `.bbl`, where `thebibliography` renders it as a line break *inside* the
+item. Verified by running bibtex 0.99d over the fixture's `blankline` entry:
+the generated `.bbl` reads `Debarati Das and Michal Koucky.` and `A dynamic
+structure for one-dimensional top-k range reporting.` on single lines. Under
+neither reading does a field value start a new bibliography item.
+
+Measured, current binary: **2605.03313 7 -> 0**, **2605.03693 7 -> 1** (the
+residual is an unrelated text-mode `^`), **2605.11080 1 -> 0**. The final
+rendered HTML is **byte-identical** on all three — `MakeBibliography` rebuilds
+each cited entry from its fields, so the injected items never reached the page
+and the whole cost was diagnostic noise plus a malformed intermediate.
+
+Guard: `06_cluster_bibliography::bib_field_blank_line_does_not_inject_a_bibitem`
+(`convert_and_post_clean`, since the damage is done in the recursive `.bib`
+session that `MakeBibliography` drives during POST). Fixture
+`bib_field_blank_line.{bib,tex}` carries all three witness shapes: a blank line
+in `title`, in `author`, in a `note`-routed `Annote`, plus the `\\` note — 6
+errors RED, 0 GREEN.
+
 ## Known Upstream Perl Issues (brief)
 
 These are behaviors in the original Perl LaTeXML that are bugs or limitations, not

--- a/latexml_engine/src/bibtex.rs
+++ b/latexml_engine/src/bibtex.rs
@@ -2008,10 +2008,26 @@ LoadDefinitions!({
   // `{bibtex@bibliography}` environment — Perl
   // `BibTeX.pool.ltxml:175-183`. The outer wrapper for the entries
   // emitted by `Pre::BibTeX::toTeX`. Delegates the heavy lifting
-  // (id allocation, title resolution, bibstyle/citestyle lookup,
-  // pseudo-bibitem fixup) to `before_digest_bibliography` /
-  // `begin_bibliography` in `latex_constructs.rs`, which already
-  // port the Perl helpers used by `\thebibliography`.
+  // (id allocation, title resolution, bibstyle/citestyle lookup) to
+  // `before_digest_bibliography` / `begin_bibliography_clean` in
+  // `latex_constructs.rs`, which already port the Perl helpers used by
+  // `\thebibliography`.
+  //
+  // OXIDIZED_DESIGN #75: `begin_bibliography_clean`, NOT
+  // `begin_bibliography` — the `setupPseudoBibitem` half is deliberately
+  // skipped here. Perl `BibTeX.pool.ltxml:183` calls the full
+  // `beginBibliography`, which `\let`s `\par` AND `\\` to
+  // `\par@in@bibliography`, a heuristic that starts a fresh
+  // `\save@bibitem{}` whenever it fires. That rescue exists for
+  // HAND-WRITTEN `thebibliography` lists whose author separated entries
+  // with blank lines instead of `\bibitem`. This body is machine-generated
+  // — one `\ProcessBibTeXEntry{key}` per line, never a missing `\bibitem`
+  // — so the heuristic can only misfire, and it does: a blank line or a
+  // `\\` inside a `.bib` FIELD VALUE injects a spurious `<ltx:bibitem>`
+  // mid-field, which the model rejects and which is then never closed, so
+  // every later entry nests inside the dangling `<ltx:surname>` /
+  // `<ltx:bib-title>` / `<ltx:bib-note>`.
+  // Witnesses: 2605.03313 (7 errors), 2605.03693 (7), 2605.11080 (1).
   DefEnvironment!("{bibtex@bibliography}",
   "<ltx:bibliography xml:id='#id' \
      bibstyle='#bibstyle' citestyle='#citestyle' sort='#sort'>\
@@ -2022,7 +2038,7 @@ LoadDefinitions!({
     crate::latex_constructs::before_digest_bibliography()?;
   },
   after_digest_begin => sub[whatsit] {
-    crate::latex_constructs::begin_bibliography(whatsit)?;
+    crate::latex_constructs::begin_bibliography_clean(whatsit)?;
   });
 });
 

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -695,3 +695,104 @@ fn bib_name_space_form_accent_survives_reversion() {
     );
   }
 }
+/// A blank line or a `\\` inside a `.bib` FIELD VALUE must not start a new
+/// bibliography item.
+///
+/// `{bibtex@bibliography}` inherited Perl's `setupPseudoBibitem`
+/// (`latex_constructs.pool.ltxml` L4028-4047), which `\let`s BOTH `\par` and
+/// `\\` to `\par@in@bibliography` — a heuristic that emits a fresh
+/// `\save@bibitem{}` whenever it fires. It rescues HAND-WRITTEN
+/// `thebibliography` lists whose author used blank lines instead of
+/// `\bibitem`; a `.bib`-derived bibliography is machine-generated
+/// (`Pre::BibTeX::toTeX` writes one `\ProcessBibTeXEntry{key}` per line) and
+/// has no missing `\bibitem` to rescue, so it can only misfire. It did:
+/// `<ltx:bibitem>` was opened inside `<ltx:surname>` / `<ltx:bib-title>` /
+/// `<ltx:bib-note>`, which the model rejects, and it never closed — every
+/// later entry then nested inside the dangling element.
+///
+/// Note the diagnostic trap: the element in the error message is NOT unclosed
+/// at fault. `<ltx:surname>` is opened and closed exactly as its constructor
+/// says; it is merely the insertion context when the spurious item is opened.
+///
+/// Same-host Perl 0.8.8 over this very `.bib` emits the same 6
+/// `malformed:ltx:bibitem` errors (it names `<ltx:givenname>` where Rust names
+/// `<ltx:surname>` — a name-split nuance, same cluster), so pdflatex is the
+/// ground truth: bibtex 0.99d compresses white-space runs in a field value to a
+/// single space (the blank line never reaches TeX) and copies `\\` through,
+/// where `thebibliography` renders it as a line break inside the item.
+/// OXIDIZED_DESIGN #75.
+///
+/// RED before the fix on exactly this fixture: 6 post-stage
+/// `malformed:ltx:bibitem` errors — 2 in `<ltx:surname>`, 2 in
+/// `<ltx:bib-note>`, 1 in `<ltx:bib-title>`, 1 cascading into the injected
+/// item's own `<ltx:bibblock>`. Witnesses 2605.03313 7 -> 0,
+/// 2605.03693 7 -> 1 (residual is an unrelated text-mode `^`),
+/// 2605.11080 1 -> 0; final rendered HTML byte-identical on all three.
+#[test]
+fn bib_field_blank_line_does_not_inject_a_bibitem() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_field_blank_line.tex");
+  assert!(
+    x.contains("<bibitem"),
+    "blank line: no bibliography at all:\n{x}"
+  );
+  // Every entry must arrive, including the canary AFTER the injected item.
+  for needle in ["Tao", "Santos", "Girolami", "Fixture"] {
+    assert!(
+      x.contains(needle),
+      "blank line: {needle:?} was lost to an injected bibliography item:\n{x}"
+    );
+  }
+  assert!(
+    x.contains("The entry after the injected item"),
+    "blank line: the containment canary's title was lost:\n{x}"
+  );
+  // The blank line inside `title` is whitespace, so the title must read as ONE
+  // phrase; before the fix everything past it moved into an injected item.
+  assert!(
+    x.contains("top-k range reporting"),
+    "blank line: the title was split at the blank line:\n{x}"
+  );
+  // The blank lines inside `author` must not damage the name split either:
+  // `MacDonald` is the SECOND name, the one that followed a blank line.
+  assert!(
+    x.contains("MacDonald"),
+    "blank line: a name following a blank line was lost:\n{x}"
+  );
+  // Both `\\`-separated URLs of the 2605.11080 note must survive in one entry.
+  for url in ["pages.jh.edu/eberti2/ringdown", "grit/files/ringdown"] {
+    assert!(
+      x.contains(url),
+      "blank line: {url:?} was lost — `\\\\` started a new item:\n{x}"
+    );
+  }
+  // Resilience half: an EMPTY name part is the other way an `<ltx:surname>`
+  // could be left open, since `insert_element(tag, [], attrs)` opens and leaves
+  // open on empty content (Perl `insertElement($tag, undef, ...)`). It cannot
+  // happen through this path — `\bib@@names` skips an empty part outright — and
+  // these five entries pin that. Each one's title must arrive, which it cannot
+  // if a preceding entry left an element open.
+  for title in [
+    "Wholly empty author",
+    "Surname then nothing",
+    "Nothing then given",
+    "A trailing and",
+    "Two ands in a row",
+  ] {
+    assert!(
+      x.contains(title),
+      "blank line: {title:?} lost — an empty name part left an element open:\n{x}"
+    );
+  }
+  // The parts that DO exist are still split correctly around the empty ones.
+  // `, John` is deliberately absent from this list: a givenname-only author
+  // renders as nothing at all, which is a MakeBibliography formatting nuance
+  // shared with Perl (bibtex's `{f.}` would print "J."), not this cluster. Its
+  // ENTRY still arrives — asserted by title above — which is what containment
+  // means here.
+  for name in ["Smith", "Brown", "Green"] {
+    assert!(
+      x.contains(name),
+      "blank line: {name:?} lost — an empty sibling part ate a real one:\n{x}"
+    );
+  }
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_field_blank_line.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_field_blank_line.bib
@@ -1,0 +1,132 @@
+% A `.bib` field value that contains a BLANK LINE, or a `\\`, must not start a
+% new bibliography item.
+%
+% `{bibtex@bibliography}` used to run Perl's `setupPseudoBibitem`
+% (`latex_constructs.pool.ltxml` L4028-4047), which `\let`s BOTH `\par` and `\\`
+% to `\par@in@bibliography` — a heuristic that emits a fresh `\save@bibitem{}`
+% whenever it fires. It exists to rescue HAND-WRITTEN `thebibliography` lists
+% whose author separated entries with blank lines instead of `\bibitem`. A
+% `.bib`-derived bibliography is machine-generated (one `\ProcessBibTeXEntry`
+% per line), so it has no missing `\bibitem` to rescue and the heuristic can
+% only misfire — a blank line or a `\\` inside a FIELD VALUE injected an
+% `<ltx:bibitem>` in the middle of `<ltx:surname>` / `<ltx:bib-title>` /
+% `<ltx:bib-note>`, which the model rejects. See OXIDIZED_DESIGN #75.
+%
+% The blank lines and the `\\` are load-bearing. Reflowing any field onto one
+% line removes the `\par` and the fixture stops reproducing. Do not tidy them.
+%
+% Ground truth is bibtex(1), not Perl — same-host Perl 0.8.8 emits exactly the
+% same malformed errors on this file. bibtex 0.99d compresses every white-space
+% run in a field value to a single space, so the blank line never reaches TeX
+% at all, and it copies `\\` through verbatim, where `thebibliography` renders
+% it as a line break inside the item. Verified by running bibtex 0.99d over the
+% `blankline`-shaped entry: the generated `.bbl` reads
+% `Debarati Das and Michal Koucky.` / `A dynamic structure for one-dimensional
+% top-k range reporting.` on single lines.
+%
+% Witnesses, all from arXiv 2605:
+%   `t14b` / `smo15`  — 2605.03313 `ref.bib` (7 errors: 5 blank-line entries)
+%   `Girolami05`      — 2605.03693 `Bibliography-MM-MC.bib` (7 errors, one entry)
+%   `BertiRingdown`   — 2605.11080 `reference.bib` (1 error, the `\\` in a note)
+% `survivor` is the containment canary: before the fix the injected item stayed
+% open, so every later entry nested inside the dangling element.
+%
+% `booktitle`/`journal` are spelled out here; the 2605.03313 original used
+% `@string` abbreviations (`pods`, `kdd`) that are beside the point.
+
+@inproceedings{t14b,
+	title        = {
+		A dynamic {I/O}-efficient structure for one-dimensional top-k range
+
+		reporting
+	},
+	author       = {Yufei Tao},
+	year         = 2014,
+	booktitle    = {Principles of Database Systems},
+	pages        = {256--265}
+}
+
+@article{smo15,
+	title        = {Search Result Diversification},
+	author       = {
+		Rodrygo L. T. Santos and
+
+		Craig MacDonald and
+
+		Iadh Ounis
+	},
+	year         = 2015,
+	journal      = {Found. Trends Inf. Retr.},
+	volume       = 9,
+	number       = 1,
+	pages        = {1--90}
+}
+
+@article{Girolami05,
+	Annote = {Builds a mixed-membership model where the basis profiles are markov chains of varying order.
+Uses two types of estimation: Variational approximation, and maximum a posteriori.
+
+Compares models on perplexity, defined as the exponential of the negative-normalized log-likelihood.
+
+For all the data sets, the mixed-membership model offers better results.},
+	Author = {Mark Girolami and Ata Kaban},
+	Journal = {Data Mining and Knowledge Discovery},
+	Pages = {175-196},
+	Title = {Sequential Activity Profiling: Latent Dirichlet Allocation of Markov Chains},
+	Volume = {10},
+	Year = {2005}
+}
+
+@misc{BertiRingdown,
+    note = {\url{https://pages.jh.edu/eberti2/ringdown} \\
+    \url{https://centra.tecnico.ulisboa.pt/network/grit/files/ringdown}}
+}
+
+% An EMPTY name part is the other way an `<ltx:surname>` could in principle be
+% left open — `insert_element(tag, [], attrs)` opens an element and leaves it
+% open on empty content, mirroring Perl `insertElement($tag, undef, ...)`. These
+% five entries pin that it cannot happen here: `\bib@@names` never invokes
+% `\bib@surname`/`\bib@given`/`\bib@lineage` for an empty part (Perl
+% `BibTeX.pool.ltxml` L912-914 `$surname ? Invocation(...) : ()`, ported as
+% `if !name.surname.is_empty()`), and the name-part constructors are a paired
+% `<tag>#1</tag>` that lowers to OpenElement+Absorb+CloseElement — closed even
+% with empty content. Measured: 0 errors, and the elements that ARE emitted are
+% all closed. Keep them; they are what makes the guard a resilience test rather
+% than a single-trigger one.
+@article{emptyauthor,
+	title        = {Wholly empty author},
+	author       = {},
+	year         = 2020
+}
+
+@article{trailingcomma,
+	title        = {Surname then nothing},
+	author       = {Smith, },
+	year         = 2021
+}
+
+@article{leadingcomma,
+	title        = {Nothing then given},
+	author       = {, John},
+	year         = 2022
+}
+
+@article{trailingand,
+	title        = {A trailing and},
+	author       = {Alice Brown and },
+	year         = 2023
+}
+
+@article{doubleand,
+	title        = {Two ands in a row},
+	author       = {Alice Brown and and Bob Green},
+	year         = 2024
+}
+
+@article{survivor,
+	title        = {The entry after the injected item},
+	author       = {Jane Q. Fixture},
+	year         = 2026,
+	journal      = {Journal of Containment},
+	pages        = {1--2}
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_field_blank_line.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_field_blank_line.tex
@@ -1,0 +1,11 @@
+% Driver for `bib_field_blank_line.bib`: a blank line (`\par`) or a `\\` inside
+% a `.bib` field value must not inject a bibliography item mid-field. Every
+% entry must reach the rendered bibliography; `survivor` is the containment
+% canary. See the `.bib` header and OXIDIZED_DESIGN #75.
+\documentclass{article}
+\begin{document}
+See \cite{t14b,smo15,Girolami05,BertiRingdown,survivor}.
+Empty name parts: \cite{emptyauthor,trailingcomma,leadingcomma,trailingand,doubleand}.
+\bibliographystyle{plain}
+\bibliography{bib_field_blank_line}
+\end{document}


### PR DESCRIPTION
**Diagnostic.** The cluster is not an unclosed name element. `<ltx:surname>` is
opened *and* closed exactly as its constructor says; it is merely the insertion
context at the moment a spurious `<ltx:bibitem>` is opened inside it. The
injector is `setupPseudoBibitem` (`latex_constructs.pool.ltxml` L4028-4047),
which `\let`s **both** `\par` and `\\` to `\par@in@bibliography` — a heuristic
that emits a fresh `\save@bibitem{}` whenever it fires. Perl
`BibTeX.pool.ltxml:183` arms it for `{bibtex@bibliography}` as well as for
`{thebibliography}`, but a `.bib`-derived bibliography is machine-generated
(`Pre::BibTeX::toTeX` writes one `\ProcessBibTeXEntry{key}` per line), so it has
no missing `\bibitem` to rescue and the only `\par`/`\\` that can reach the
heuristic come from **inside a field value**. Bisecting the three witnesses'
`.bib` files gives exactly two triggers: a **blank line** in a field
(2605.03313 — 5 entries; 2605.03693 — one `Annote`) and a **`\\`** in a `note`
(2605.11080). The injected item is rejected by the model, inserted anyway, and
never closed, so everything after it nests inside the dangling element.

**Approach.** `{bibtex@bibliography}` now calls `begin_bibliography_clean` —
Perl's own decomposition, already ported — instead of `begin_bibliography`,
skipping only the `setup_pseudo_bibitem` half. `{thebibliography}` and the
biblatex / amsrefs / revtex / OmniBus bibliographies keep the full
`begin_bibliography`, so the rescue still applies where it was meant to. Nothing
else in the environment needs the skipped bindings: `\newblock` → `\lx@bibnewblock`
is already `Let` globally (L4133), `\bibitem`/`\item`/`\vskip` never occur in the
generated body, and the trailing lookahead that unreads a `\par` is a no-op
because the body starts with the executable `\ProcessBibTeXEntry`. One call
swapped; no shared primitive touched. `OXIDIZED_DESIGN #75`.

Ground truth is **bibtex(1)**, not Perl: same-host Perl 0.8.8 produces
byte-identical malformed output on the same input. `bibtex 0.99d` compresses
every white-space run in a field value to a single space — the blank line never
reaches TeX — and copies `\\` through to the `.bbl`, where `thebibliography`
renders it as a line break *inside* the item. Verified by running bibtex 0.99d
over the fixture's blank-line entry: the `.bbl` reads
`Debarati Das and Michal Koucky.` and `A dynamic structure for one-dimensional
top-k range reporting.` on single lines. Under neither reading does a field
value start a new bibliography item.

**Validation.** Guard
`06_cluster_bibliography::bib_field_blank_line_does_not_inject_a_bibitem`
(`convert_and_post_clean`, since the damage happens in the recursive `.bib`
session `MakeBibliography` drives during POST). RED verified by reverting the
one-line change: **6** `malformed:ltx:bibitem` errors (2 `<ltx:surname>`, 2
`<ltx:bib-note>`, 1 `<ltx:bib-title>`, 1 cascading `<ltx:bibblock>`); GREEN 0.
Same-host Perl over the same fixture `.bib`: the **same 6** (it names
`<ltx:givenname>` where Rust names `<ltx:surname>` — a name-split nuance, same
cluster).

| witness | before | after |
|---|---|---|
| 2605.03313 | 7 | **0** |
| 2605.03693 | 7 | **1** (unrelated text-mode `^`, present before) |
| 2605.11080 | 1 | **0** |

The final rendered HTML is **byte-identical** on all three — `MakeBibliography`
rebuilds each cited entry from its fields, so the injected items never reached
the page and the whole cost was diagnostic noise plus a malformed intermediate.
`bib_field_markup` also drops from 2 errors to 1 (its pre-existing
`ltx:itemize`-in-`bib-note` is untouched). Full suite: **1705 passed, 1 failed**
— `latexml_post graphics::tests::process_coalesces_only_matching_conversion_options`,
the documented pre-existing failure (issue #401). `clippy --workspace
--all-targets -D warnings` clean, `fmt --check` clean. The
`bib_name_space_form_accent_survives_reversion` guard (PR #399) was run
specifically and passes: no name-splitting code was touched.

## Decisions & open questions

**1. Root cause is NOT `insert_element`'s open-and-leave-open-on-empty content.**
*Chosen:* leave the shared primitive alone. *Evidence:* the emitted XML shows
`<ltx:surname>` correctly closed around the injected item, and the name-part
constructors are a paired `<tag>#1</tag>` that lowers to
OpenElement+Absorb+CloseElement — closed even on empty content. Independently,
`\bib@@names` never invokes `\bib@surname`/`\bib@given`/`\bib@lineage` for an
empty part at all (Perl `BibTeX.pool.ltxml` L912-914
`$surname ? Invocation(...) : ()`, ported as `if !name.surname.is_empty()`).
Measured directly: `author = {}`, `{Smith, }`, `{, John}`, `{Alice Brown and }`,
`{Alice Brown and and Bob Green}` all convert with **0 errors** and no dangling
element. Those five entries are now in the fixture as a permanent resilience
canary, so the property is pinned even though it was never violated. *What
would settle a change to the primitive:* a case where a bibliography emitter
reaches `insert_element` with an empty content vector — I found none in this
path, and `bib_add_to_container` is the only bibliography caller.

**2. Divergence vs. faithful port.** *Chosen:* diverge, and document it
(`OXIDIZED_DESIGN #75`). *Alternative:* keep `begin_bibliography` for exact
Perl parity and accept the errors. *Why not:* the non-negotiable is that an
error-count reduction needs positive proof Perl or pdflatex agrees. Perl does
not — it emits the same 6 errors — so the justification rests entirely on
pdflatex/bibtex(1), and that evidence is direct (the generated `.bbl` above).
This is `surpass-perl` on a shared bug, in the same shape as #73.

**3. Scope: I did not implement BibTeX's white-space compression.**
*Chosen:* the conservative, localized fix. *Alternative considered:* compress
white-space runs in `.bib` field values at scan time in `pre_bibtex.rs`, which
is what bibtex(1) actually does and would remove the `\par` at the source
(defense in depth, and it would also repair the name split in point 4). *Why
not:* it changes stored field text for **every** paper — including the
`<ltx:bib-data role="self">` recap, which currently preserves raw newlines — so
it is a broad behavioural change with golden churn, and the cluster is already
at 0 without it. *What would settle it:* a corpus measurement of `bib-data`
diffs across a 2605 sweep, plus a decision on whether the recap is contractually
raw. Flagging rather than doing it also keeps me clear of the sibling agent who
owns the `.bib` reading path.

**4. Known residual, not fixed: `starts_lowercase` diverges from Perl.**
`bibtex.rs::starts_lowercase` strips a leading `\` before testing for a
lowercase letter; its doc-comment claims this "matches Perl behaviour", which is
**factually wrong** — Perl's test is `$word !~ /^[a-z]/`, and `\` is not in
`[a-z]`, so Perl classifies `\par`/`\von` as *given*, Rust as *surname*. Visible
only on the garbage input this PR is about: for `author = {Debarati Das and\n\nMichal Koucky}`
Perl yields `surname=Koucky, given=\par Michal` while Rust yields
`surname=\par Michal Koucky`. *Chosen:* leave it — it is a name-splitting change,
exactly what could regress the #399 space-form-accent guard, and it is outside
this cluster. *Not obviously wrong, either:* real BibTeX looks *inside* accent
control sequences when deciding von-ness, so Rust's peek may be closer to
bibtex than Perl's regex. *What would settle it:* bibtex 0.99d's classification
of `\'Etienne`, `\textsc{de la}` and `\v son` in the von position.

**5. `2605.11080`'s `\\` trigger and the sibling catcode work.** The `\\` case
is structural, not catcode, and is fixed here. If the sibling's `.bib`-content-is-
data mechanism lands first it does not overlap: it changes how `%`/`_`/`&`/`#`
are read, not how `\par`/`\\` are bound.

## Note for the maintainer

While verifying RED I used `git stash`, which is **repository-global and shared
across the sibling agent worktrees**. My `stash pop` retrieved
`worktree-agent-ac3adc4a017e453fd`'s WIP (the percent-in-`.bib`-field work)
instead of my own, and my own stash was then popped into a sibling worktree. I
restored the other agent's commit intact to the stash stack
(`git stash store 34cc9fc…`, listed with a descriptive message) and reverted its
content out of my tree; nothing was lost. Worth a standing rule that agents
sharing a repo use patch files, not `git stash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
