### PR TITLE
fix(bibliography): an ampersand in a .bib field is an ampersand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,12 @@
     a percent that stays literal (BibTeX has no comments, and `%` is routine in
     an encoded URL). Measured over a 30,079-document arXiv sample: 62 more
     documents convert cleanly, 44 fewer carry errors.
+  - **An ampersand in a reference is an ampersand** — "Taylor & Francis" in a
+    `.bib` publisher, journal or booktitle used to report an error and print
+    "Taylor Francis". A `.bib` field's content is data, so the character is kept.
+  - **A reference exported through HTML no longer shows `&amp;` for `&`** — a
+    doubly escaped ampersand (`\&amp;`) in a `.bib` title, journal or booktitle
+    is decoded back to the one character the author wrote.
   - **amsrefs `\bib` values digest as live TeX** — `\MR{…}` came out as literal
     characters and `pages` rendered empty.
   - **MathReview / ZentralBlatt links are synthesized** — `mrnumber`/`zblno`

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -64,6 +64,32 @@ session of their own. Re-verify a row before planning on it (rule 1).
 
 ## Current status
 
+- **2026-07-26 (later still) — a bare `&` in a `.bib` field is data (OXIDIZED_DESIGN #75).**
+  Seven 2605 witnesses carried `Error:unexpected:&` from `publisher` / `journal`
+  / `booktitle` / `author` / `copyright` ("Taylor & Francis"). Not a Rust-only
+  defect: same-host `latexmlc` raised the identical per-`&` count on all six
+  re-measured witnesses, and bibtex 0.99d + pdflatex agree (the `&` reaches the
+  `.bbl` under `plain` and `abbrvnat`; pdflatex stops with "Misplaced alignment
+  tab character &" and prints "Taylor Francis"). **A `.bib` field's content is
+  DATA** — authorized surpass-Perl and surpass-pdflatex, since LaTeXML reads
+  `.bib` directly and decides what reaches the tokenizer. Neutralized at the
+  same two seams #74 uses for `%`, and BOTH are required — the per-entry Mouth
+  (`Mouth::with_align_as_other`) and `mouth::tokenize_bib_literal` for handlers
+  that re-tokenize a stored raw field (`\bib@@title` recasing, name/date/pages
+  assembly, MR/Zbl). Measured: **2605.06249 3→0, 2605.03054 1→0, 2605.00462 1→0,
+  2605.08753 1→0, 2605.10409 1→0, 2605.01936 13→6, 2605.06624 4→3** (the
+  residuals are unrelated `undefined:` errors). `#` was checked and NOT included
+  — one bare `#` across all seven, in a JabRef `file` path already covered as an
+  unknown field. **Stacked on PR #405**: merge after it.
+  Also fixed, a different bug the neutralization does *not* reach: the doubly
+  escaped `\&amp;` / `{\&}amp;` / `&amp;`, an HTML entity that survived into
+  the `.bib` and printed as "&amp;" in Perl and pdflatex alike
+  (`undouble_escaped_ampersand`). Guards
+  `bib_bare_ampersand_is_literal_data`, `bib_bare_ampersand_leaves_live_markup_alone`
+  (the `\emph` / inline-math / space-form-accent boundary) and
+  `bib_escaped_amp_entity_decodes_to_one_ampersand`. Detail in
+  [`BIBLIOGRAPHY_WORKLIST.md`](parity/BIBLIOGRAPHY_WORKLIST.md).
+
 - **2026-07-26 (later) — session: resilience mining, and a regression the sweep caught.**
   Mined the 2605+2606 fatals: `Timeout:PushbackLimit` (25), `TooManyErrors`
   (`MaxLimit(100)` is Perl's own default — parity; `MaxLimit(500)` is our

--- a/docs/parity/BIBLIOGRAPHY_WORKLIST.md
+++ b/docs/parity/BIBLIOGRAPHY_WORKLIST.md
@@ -65,6 +65,48 @@ most of them as an interim, but it imitates the mechanism rather than using it.
 The durable fix is this re-port: route field interpretation through the lazy
 Mouth.
 
+**Maintainer policy, 2026-07-26 — a `.bib` field's content is DATA, not TeX.**
+A bare `%`, `&`, `_` is the literal character; "Taylor & Francis" renders with
+its ampersand. Authorized surpass-Perl *and* surpass-pdflatex: LaTeXML reads
+`.bib` directly, with no `.bst` and no `bibtex(1)`, so it decides what reaches
+the tokenizer. **The boundary is blast radius, not character:**
+
+* *Regime A, per-Mouth* — a character destructive in ANY field, with no Perl
+  per-field idiom to follow. `%` (#74, PR #405) and `&` (#75) are here.
+  `Mouth::with_percent_as_other()` / `with_align_as_other()`, deliberately NOT a
+  State catcode, so a `.sty` raw-loaded from inside a field handler — and the
+  document — keep TeX's meaning.
+* *Regime B, per-field parameter type* — harmful only in specific fields where
+  Perl already has the idiom. `_` (PR #403) is here: `eprint`/`preprint`/
+  `archive` get `Semiverbatim`, mirroring `doi`/`isbn`/`issn`/`lccn`/`pii`.
+
+**Both regime-A seams are required.** The value reaches a tokenizer by two
+independent routes: the per-entry Mouth, and the handlers that re-read the
+stored RAW field and tokenize it themselves (`\bib@@title` recasing,
+`current_entry_field`, name splitting, date/pages assembly, MR/Zbl). The
+companion for the second is `mouth::tokenize_bib_literal`, behind
+`bibtex.rs::tokenize_bib_field`. Fixing only the mouth made 2605.02131 *worse*
+(28 → 37 errors) — a title's value never passes through it.
+
+*The `&` third, measured.* Witnesses 2605.01936, 2605.06249, 2605.00462,
+2605.03054, 2605.06624, 2605.08753, 2605.10409. The `&` sits in `publisher` /
+`journal` / `booktitle` / `author` / `copyright` — all `Digested` in
+`BibTeX.pool.ltxml`, so **no parameter type was ever going to cover them and the
+eager-tokenization gap above was never this third's cause**. Before: Rust
+matched same-host `latexmlc` 1:1 on every re-measured witness, and pdflatex
+broke identically. After (#75): **3→0, 1→0, 1→0, 1→0, 1→0, 13→6, 4→3**; the two
+residuals are unrelated `undefined:` errors, no `unexpected:&` remains anywhere.
+`#` was checked and deliberately left alone — one bare `#` across all seven
+witnesses, in 2605.00462's JabRef `file` path, already covered as an unknown
+field.
+
+*A separate ampersand bug, also fixed as #75:* the doubly escaped `\&amp;` /
+`{\&}amp;` / `&amp;`, where an HTML entity survived into the `.bib`. Those raise
+no error at all — Perl and pdflatex both print "&amp;" — so the mouth-level
+change does not reach them; `undouble_escaped_ampersand` in `bibtex.rs` does.
+Guard `bib_escaped_amp_entity_decodes_to_one_ampersand`. The `^` third remains
+open.
+
 #### What the 2026-07-26 prototype measured (and the two claims it corrected)
 
 Before designing the re-port, the existing `--bibtex` route was probed directly

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2275,6 +2275,76 @@ this fixture, 203 on the witness) passed every bibliography guard silently.
 (percent in `abstract`, specials in `keywords`, and a third entry as the
 containment canary).
 
+### 74. A `%` inside a `.bib` field value is data, not a comment
+
+**Perl behaviour.** `Pre::BibTeX` is a real BibTeX-format parser: field values
+come out of `parseString`/`parseBalancedBraces` as raw strings, and `%` is
+significant **only** in the junk between entries (`skipJunk`, `BibTeX.pm` L335-343
+— its own comment reads "Although % officially starts comments, apparently BibTeX
+accepts anything until @"). Inside an entry there is no comment syntax, matching
+`bibtex.web`. `BibTeX.pool.ltxml` L134-166 (`\bibentry@create`) then re-serializes
+those values into TeX source — one `\csname bib@field@<t>@<f>\endcsname{<value>}`
+per line — and hands the join to `Mouth->new($tex)`. There `%` is catcode 14
+again, so it comments out the rest of its line, **the field's own closing brace
+included**. The entry's group never closes, `<ltx:bibentry>` is left open, and
+every following entry nests inside it: `<ltx:bibentry> isn't allowed in
+<ltx:bibentry>`, once per remaining entry. `\bib@@title` (L293-333) loses the
+value a second way — it re-reads the RAW field to re-case it and `Tokenize`s the
+result itself, and `Tokenize` uses the standard cattable, where `%` is again a
+comment; the truncated title leaves a `\href` mid-argument and the runaway eats
+the following `\csname`s (`Extra \endcsname`).
+
+**Rust behaviour.** The text BibTeX lexed is read with `%` as an ordinary
+character. Two seams, because the value reaches the tokenizer two ways:
+`Mouth::with_percent_as_other()` on the per-entry mouth
+(`\ProcessBibTeXEntry`, `bibtex.rs`), and `mouth::tokenize_percent_literal`
+behind `bibtex.rs::tokenize_bib_field` for the handlers that re-tokenize a
+stored raw field (title recasing, name splitting, date/pages assembly, MR/Zbl).
+It is a per-**Mouth** property rather than a `\catcode` assignment on purpose: a
+State catcode would be inherited by a `.sty` raw-load triggered from inside a
+field handler, where `%` must stay a comment. Only comment-ness is removed — a
+`%` given some other catcode keeps it, and `\%` is unaffected (a control symbol
+is formed from the following character whatever its catcode).
+
+**Why — measured against `bibtex` 0.99d + pdflatex, not against Perl.** The
+fixture's three entries were run through the real toolchain (TL2025,
+`plain.bst`, hyperref loaded), and it handles both fields cleanly:
+
+* `doi` — **`bibtex` drops it.** `plain.bst` does not declare `doi` in its
+  `ENTRY` list, so the generated `d.bbl` carries author/title/journal/year and
+  no trace of `%doi:`. pdflatex never sees the character. (Nor would it in the
+  witness: 2605.01196's entry sits in that file's own "UNUSED REFERENCES" block,
+  which `bibtex` never processes at all.)
+* `title` — **`bibtex` keeps the `%` verbatim** (its lexer has no comment rule
+  inside `{}`), writing `\href{https://…/20240723%20IPWG%20…DRAFT.pdf}{A linked
+  title…}` into the `.bbl` with the closing brace on that same line. pdflatex
+  **compiles it, rc=0**, and the PDF renders the linked title: real hyperref's
+  `\href` sets `` \catcode`\%=12 `` before reading its URL. So the ground-truth
+  engine reads a percent-encoded URL with `%` as an ordinary character — the
+  exact rule adopted here.
+
+LaTeXML's `HyperVerbatim` does the same catcode trick as hyperref, but far too
+late: the `%` is eaten during the *field* read, before `\href` is ever reached.
+Reading the `.bib` **directly** — which is what both LaTeXML engines do, and
+what no other consumer does — is what puts the value in front of a TeX tokenizer
+in the first place, so the reader has to use BibTeX's lexing rules for it. The
+damage under the old reading is also wildly disproportionate to the input: one
+stray character in one uncited reference costs the whole rest of the
+bibliography.
+
+This is `surpass-perl` on a shared bug, like #73 (its sibling: same "element
+opened and never closed" shape, same `%`-eats-the-closing-brace mechanism, but
+#73's three fields could be read `Verbatim` because nothing renders
+`ltx:bib-extract`, while `doi`/`title` are rendered and cannot be). Measured on
+the same host: **2605.01196 28 → 0 errors** (Perl `latexmlc` 29; output otherwise
+byte-identical, 83 bibitems before and after — the entire cost was diagnostics)
+and **2605.02131 28 → 0** (Perl 31; 20 bibitems unchanged, and the two
+percent-encoded `\href` titles now render, URLs intact).
+
+Guard: `06_cluster_bibliography::bib_field_percent_is_an_ordinary_character`
+(fixture `bib_field_percent.{tex,bib}` — one entry per seam plus a containment
+canary; the single-line `value...}` layout is load-bearing, as in #73).
+
 ## Known Upstream Perl Issues (brief)
 
 These are behaviors in the original Perl LaTeXML that are bugs or limitations, not

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2344,6 +2344,85 @@ percent-encoded `\href` titles now render, URLs intact).
 Guard: `06_cluster_bibliography::bib_field_percent_is_an_ordinary_character`
 (fixture `bib_field_percent.{tex,bib}` — one entry per seam plus a containment
 canary; the single-line `value...}` layout is load-bearing, as in #73).
+### 75. A bare `&` in a `.bib` field is data, and a `\&amp;` is one ampersand
+
+Two ampersand bugs in `.bib` field values, with different causes and different
+fixes. Both are settled against **pdflatex**, not against Perl.
+
+**(a) The bare `&`.** `publisher = {Taylor & Francis}` — seven arXiv/2605
+witnesses: 2605.01936 (7 occurrences), 2605.06249 (3), 2605.00462 / 2605.03054 /
+2605.06624 / 2605.08753 / 2605.10409 (1 each), in `publisher`, `journal`,
+`booktitle`, `author` and `copyright`. BibTeX's lexer has no alignment, so the
+`&` it hands back is a character in a name; TeX reads catcode 4, raises
+`Error:unexpected:&`, and **drops** it, so the entry printed "Taylor Francis".
+
+*What every other engine does, measured.* Same-host `latexmlc` raises the same
+one-error-per-`&` on all six re-measured witnesses (1/1, 3/3, 1/1, 1/1, 1/1,
+1/1). bibtex 0.99d + pdflatex agree: under `plain` and under natbib's
+`abbrvnat` the bare `&` is copied straight into the `.bbl`, pdflatex stops with
+`! Misplaced alignment tab character &`, and the PDF reads "Taylor Francis" /
+"Information Processing Management" / "Knowledge Discovery Data Mining". So
+this was never a Rust-only defect — Rust already beat Perl on the witnesses
+overall (2605.01936: 7 errors and a complete bibliography vs Perl's 101 plus a
+Fatal and none at all; 2605.00462: 1 vs 57).
+
+*Rust behaviour.* A `.bib` field's content is **data, not TeX**: the `&` is read
+as an ordinary character. Implemented at the per-entry Mouth beside the `%` of
+**#74** — `Mouth::with_align_as_other()`, plus `mouth::tokenize_bib_literal`
+for the handlers that re-tokenize a stored raw field (`\bib@@title` recasing,
+name splitting, date/pages assembly) and never pass through that mouth.
+
+*Why the mouth and not a parameter type.* `&` derails alignment in **any**
+field, and the fields carrying it here have no Perl `Semiverbatim` precedent to
+follow — unlike `doi`/`isbn`/`issn`/`lccn`/`pii`, whose per-field treatment
+`eprint` joins. Per-Mouth rather than a State catcode for #74's reason: a raw
+`.sty` opened from inside a field handler, and the document itself, must keep
+TeX's alignment tab. The rule belongs to the text BibTeX lexed.
+
+Authorized surpass-Perl **and** surpass-pdflatex: LaTeXML reads `.bib`
+directly, with no `.bst` and no `bibtex(1)` in the path, so it decides what
+reaches the tokenizer, and the real toolchain's breakage there is a property of
+that toolchain. `#` is deliberately **not** included: across all seven
+witnesses there is exactly one bare `#`, in 2605.00462's JabRef `file` path,
+and that field is already covered as an unknown field
+(`\bib@field@default@default Verbatim Verbatim`). No evidence, no change.
+
+**(b) The doubly escaped `\&amp;`.** A reference manager rendered the field to
+HTML (`&` → `&amp;`), then a second pass TeX-escaped that entity's own
+ampersand. Three spellings, all found by scanning 6000 arXiv/2605 sources:
+`\&amp;` (booktitle 2605.00833, 2605.01362; journal 2605.00922, 2605.01200,
+2605.01224; title 2605.01353 `{{A}}\&amp;{{AS}}`), `{\&}amp;` (title 2605.01224,
+"Reversible Template-based Shake {\&}amp; Bake Generation") and bare `&amp;`
+(publisher 2605.00859; journal 2605.01187).
+
+Not the same bug, and (a) does not fix it: that `&` is already **escaped**, so
+it raises no error at all — in Perl or in pdflatex, both of which print
+"Computer Engineering, &amp; Applied Computing". The damage is the stray `amp;`.
+`undouble_escaped_ampersand` (`bibtex.rs`) drops an `amp;` that directly follows
+an ampersand in any of its three spellings, at the entry-assembly seam and again
+in `\bib@@title`, which re-reads the RAW field for its case conversion (Perl
+L294) and so bypasses the first. Only `amp;` immediately after an ampersand is
+touched: "amplitude", and a lone `\&`, are untouched. Measured: witness
+2605.00833 renders "Computer Engineering, & Applied Computing" (was
+"&amp;"), 0 errors.
+
+*Why repair it rather than render it faithfully.* It is not a TeX construct
+that a reader might have meant — no author writes `\&amp;` intending the six
+characters — it is one file mixing two escaping conventions, and the entity is
+unambiguous. Rendering it faithfully means printing `&amp;` in a bibliography
+for every reader of the paper. pdflatex has no way to know better; reading the
+`.bib` directly, we do, which is the same position #73 argued from.
+
+**Boundary, verified rather than assumed.** The neutralization downgrades one
+catcode and nothing else: in the same entry that carries a bare `&`, `\emph`
+still produces markup, `$x_1+x_2$` still parses as math with `_` a subscript
+INSIDE math, and the space-form accents PR #399 recovered (`{\v S}pakov` →
+Špakov, `Gon{\c c}alves` → Gonçalves) still resolve.
+
+Guards: `06_cluster_bibliography::bib_bare_ampersand_is_literal_data`,
+`::bib_bare_ampersand_leaves_live_markup_alone` (the boundary entry) and
+`::bib_escaped_amp_entity_decodes_to_one_ampersand` (all three spellings, a `\&`
+control, and an "amp;"-as-ordinary-text near miss).
 
 ## Known Upstream Perl Issues (brief)
 

--- a/latexml_core/src/mouth.rs
+++ b/latexml_core/src/mouth.rs
@@ -83,6 +83,13 @@ pub struct Mouth {
   /// floor and cheaper than a per-read flag check.
   last_token_start:       (usize, usize),
   foodtype:               FoodType,
+  /// Read `%` as an ordinary character rather than a comment, for this
+  /// mouth only. Set by `with_percent_as_other()`; see that method for the
+  /// BibTeX rationale. Deliberately a per-Mouth field rather than a State
+  /// catcode assignment: a nested mouth (a `.sty` raw-load triggered from
+  /// inside the text) is a separate object and keeps `%` as a comment,
+  /// which a State-level assignment could not guarantee.
+  percent_is_other:       bool,
   saved_at_cc:            Option<Catcode>,
   saved_include_comments: Option<bool>,
   note_message:           Option<String>,
@@ -129,6 +136,7 @@ impl Default for Mouth {
       shortsource:            s!("String"),
       // handle : None,
       foodtype:               FoodType::File,
+      percent_is_other:       false,
       saved_at_cc:            None,
       saved_include_comments: None,
       buffer:                 VecDeque::new(),
@@ -283,6 +291,30 @@ impl Mouth {
     };
     mouth.open(text)?;
     Ok(mouth)
+  }
+
+  /// Read `%` as an ordinary character (catcode 12) instead of a comment,
+  /// for the whole life of this mouth.
+  ///
+  /// BibTeX's lexer has **no comment syntax inside an entry** — `%` is only
+  /// significant in the junk BETWEEN entries (`Pre::BibTeX::skipJunk`), so a
+  /// field value it hands back is a string in which `%` is an ordinary
+  /// character. When such a value is re-injected as TeX source (BibTeX.pool's
+  /// `\bibentry@create`), the default catcode 14 makes it comment out the rest
+  /// of its line — the field's own closing brace included — and the entry's
+  /// group never closes. Reading the injected text with `%` neutralized is what
+  /// preserves the value BibTeX actually parsed.
+  ///
+  /// A `\catcode` in the injected text cannot do this job: the catcode would
+  /// still be a State assignment, so a raw `.sty` opened from inside a field
+  /// handler would inherit it. Scoping to the Mouth keeps the rule attached to
+  /// the *text that BibTeX lexed*, which is exactly where it belongs.
+  ///
+  /// Only comment-ness is removed: a `%` that has been given some other catcode
+  /// (LETTER, say) keeps it.
+  pub fn with_percent_as_other(mut self) -> Self {
+    self.percent_is_other = true;
+    self
   }
 
   pub fn get_source(&self) -> &str { &self.source }
@@ -611,7 +643,7 @@ impl Mouth {
     self.colno += 1;
     if let Some(ch) = ch_opt {
       let mut ch = *ch;
-      let mut cc = lookup_catcode(ch).unwrap_or(Catcode::OTHER);
+      let mut cc = self.catcode_of(ch);
       // Possible convert ^^x
       // Perl: (cc == CC_SUPER) && (colno + 1 < nchars) && (ch == chars[colno])
       if cc == Catcode::SUPER
@@ -647,11 +679,22 @@ impl Mouth {
           self.splice(self.colno - 1..self.colno + 2, &[ch]);
           self.nchars -= 2;
         }
-        cc = lookup_catcode(ch).unwrap_or(Catcode::OTHER);
+        cc = self.catcode_of(ch);
       }
       Some((ch, cc))
     } else {
       None
+    }
+  }
+
+  /// The catcode this mouth reads `ch` with: the State's, except that a
+  /// `with_percent_as_other()` mouth downgrades a COMMENT `%` to OTHER.
+  fn catcode_of(&self, ch: char) -> Catcode {
+    let cc = lookup_catcode(ch).unwrap_or(Catcode::OTHER);
+    if self.percent_is_other && ch == '%' && cc == Catcode::COMMENT {
+      Catcode::OTHER
+    } else {
+      cc
     }
   }
 
@@ -1113,6 +1156,29 @@ pub fn tokenize(text: &str) -> Tokens {
   use_main_state();
   result
 }
+/// Tokenize a string under the standard catcode table, reading `%` as an
+/// ordinary character rather than a comment.
+///
+/// For text that came out of a lexer with no comment syntax of its own — a
+/// BibTeX field value, whose `%` is data (see
+/// [`Mouth::with_percent_as_other`]). Plain [`tokenize`] would let that `%`
+/// comment out the rest of the string, which for a `.bib` field means losing
+/// its closing brace and leaving whatever it opened unclosed
+/// (`OXIDIZED_DESIGN #74`).
+pub fn tokenize_percent_literal(text: &str) -> Tokens {
+  // special case! empty input is empty Tokens
+  if text.is_empty() {
+    return NO_TOKENS;
+  }
+  use_std_state();
+  let result = Mouth::new(text, None)
+    .unwrap()
+    .with_percent_as_other()
+    .read_tokens();
+  use_main_state();
+  result
+}
+
 /// Tokenize a string under the **style-file** catcode table — Perl
 /// `Package.pm:TokenizeInternal` L1026-1030.
 ///

--- a/latexml_core/src/mouth.rs
+++ b/latexml_core/src/mouth.rs
@@ -90,6 +90,10 @@ pub struct Mouth {
   /// inside the text) is a separate object and keeps `%` as a comment,
   /// which a State-level assignment could not guarantee.
   percent_is_other:       bool,
+  /// Read `&` as an ordinary character rather than an alignment tab, for this
+  /// mouth only. Set by `with_align_as_other()`; same per-Mouth scoping, and
+  /// for the same reason, as `percent_is_other` above.
+  align_is_other:         bool,
   saved_at_cc:            Option<Catcode>,
   saved_include_comments: Option<bool>,
   note_message:           Option<String>,
@@ -137,6 +141,7 @@ impl Default for Mouth {
       // handle : None,
       foodtype:               FoodType::File,
       percent_is_other:       false,
+      align_is_other:         false,
       saved_at_cc:            None,
       saved_include_comments: None,
       buffer:                 VecDeque::new(),
@@ -314,6 +319,29 @@ impl Mouth {
   /// (LETTER, say) keeps it.
   pub fn with_percent_as_other(mut self) -> Self {
     self.percent_is_other = true;
+    self
+  }
+
+  /// Read `&` as an ordinary character (catcode 12) instead of an alignment
+  /// tab, for the whole life of this mouth.
+  ///
+  /// The companion of [`Self::with_percent_as_other`], and the same argument:
+  /// BibTeX's lexer has no alignment either, so an `&` in a field value it
+  /// hands back is an ordinary character — a publisher's name ("Taylor &
+  /// Francis"), a journal's ("Infrared Physics & Technology"), a conference's
+  /// ("Knowledge Discovery & Data Mining"). Under TeX's catcode 4 each one is a
+  /// stray alignment tab, `Error:unexpected:&`, and the character is dropped
+  /// from the rendered entry.
+  ///
+  /// Per-Mouth rather than a State catcode for the same reason as `%`: a raw
+  /// `.sty` opened from inside a field handler must keep TeX's alignment tab,
+  /// and so must the DOCUMENT — this rule belongs to the text BibTeX lexed, not
+  /// to the session.
+  ///
+  /// Only alignment-ness is removed: an `&` that has been given some other
+  /// catcode keeps it.
+  pub fn with_align_as_other(mut self) -> Self {
+    self.align_is_other = true;
     self
   }
 
@@ -688,13 +716,14 @@ impl Mouth {
   }
 
   /// The catcode this mouth reads `ch` with: the State's, except that a
-  /// `with_percent_as_other()` mouth downgrades a COMMENT `%` to OTHER.
+  /// `with_percent_as_other()` mouth downgrades a COMMENT `%` to OTHER, and a
+  /// `with_align_as_other()` mouth downgrades an ALIGN `&` the same way.
   fn catcode_of(&self, ch: char) -> Catcode {
     let cc = lookup_catcode(ch).unwrap_or(Catcode::OTHER);
-    if self.percent_is_other && ch == '%' && cc == Catcode::COMMENT {
-      Catcode::OTHER
-    } else {
-      cc
+    match cc {
+      Catcode::COMMENT if self.percent_is_other && ch == '%' => Catcode::OTHER,
+      Catcode::ALIGN if self.align_is_other && ch == '&' => Catcode::OTHER,
+      _ => cc,
     }
   }
 
@@ -1156,16 +1185,17 @@ pub fn tokenize(text: &str) -> Tokens {
   use_main_state();
   result
 }
-/// Tokenize a string under the standard catcode table, reading `%` as an
-/// ordinary character rather than a comment.
+/// Tokenize a string under the standard catcode table, reading `%` and `&` as
+/// ordinary characters rather than a comment and an alignment tab.
 ///
-/// For text that came out of a lexer with no comment syntax of its own — a
-/// BibTeX field value, whose `%` is data (see
-/// [`Mouth::with_percent_as_other`]). Plain [`tokenize`] would let that `%`
-/// comment out the rest of the string, which for a `.bib` field means losing
+/// For text that came out of the BibTeX lexer, which has neither construct, so
+/// both characters are data (see [`Mouth::with_percent_as_other`] and
+/// [`Mouth::with_align_as_other`]). Plain [`tokenize`] would let that `%`
+/// comment out the rest of the string — which for a `.bib` field means losing
 /// its closing brace and leaving whatever it opened unclosed
-/// (`OXIDIZED_DESIGN #74`).
-pub fn tokenize_percent_literal(text: &str) -> Tokens {
+/// (`OXIDIZED_DESIGN #74`) — and would make an `&` in "Taylor & Francis" a
+/// stray alignment tab (`#75`).
+pub fn tokenize_bib_literal(text: &str) -> Tokens {
   // special case! empty input is empty Tokens
   if text.is_empty() {
     return NO_TOKENS;
@@ -1174,6 +1204,7 @@ pub fn tokenize_percent_literal(text: &str) -> Tokens {
   let result = Mouth::new(text, None)
     .unwrap()
     .with_percent_as_other()
+    .with_align_as_other()
     .read_tokens();
   use_main_state();
   result

--- a/latexml_engine/src/bibtex.rs
+++ b/latexml_engine/src/bibtex.rs
@@ -270,8 +270,25 @@ pub fn current_entry_field(name: &str) -> Option<Tokens> {
   if let Some(tokens) = entry.get_field(name) {
     return Some(tokens.clone());
   }
-  entry.get_raw_field(name).map(|raw| Tokenize!(raw))
+  entry.get_raw_field(name).map(tokenize_bib_field)
 }
+
+/// `Tokenize!` for a string that came out of the BibTeX lexer.
+///
+/// The standard catcode table, as Perl's `Tokenize` uses — except that `%` is
+/// an ordinary character. BibTeX has no comment syntax inside an entry
+/// (`Pre::BibTeX` only skips `%` in the junk BETWEEN entries), so a `%` in a
+/// field value is data; under catcode 14 it comments out the rest of the
+/// string and takes any brace still open with it, which leaves the field's
+/// element unclosed and swallows every following entry. Witness 2605.02131:
+/// a percent-encoded URL in a `title`'s `\href`, 24 `malformed:ltx:bibentry`.
+/// See `OXIDIZED_DESIGN #74`.
+///
+/// This is the same rule the per-entry Mouth applies (see `\ProcessBibTeXEntry`
+/// below); it has to be repeated here because the handlers that re-read a raw
+/// field — `\bib@@title` recasing, name splitting, date/pages assembly — build
+/// their tokens from the stored string and never go through that mouth.
+fn tokenize_bib_field(text: &str) -> Tokens { mouth::tokenize_percent_literal(text) }
 
 /// Perl: `currentBibEntryRawField('fieldname')` — get the *raw*
 /// source string of a field on the current entry.
@@ -983,17 +1000,17 @@ LoadDefinitions!({
       let mut name_tks: Vec<Token> = Vec::new();
       if !name.surname.is_empty() {
         let inv = Invocation!(T_CS!("\\bib@surname"),
-          vec![Tokenize!(name.surname.as_str())]);
+          vec![tokenize_bib_field(&name.surname)]);
         name_tks.extend(inv.unlist());
       }
       if !name.given.is_empty() {
         let inv = Invocation!(T_CS!("\\bib@given"),
-          vec![Tokenize!(name.given.as_str())]);
+          vec![tokenize_bib_field(&name.given)]);
         name_tks.extend(inv.unlist());
       }
       if !name.lineage.is_empty() {
         let inv = Invocation!(T_CS!("\\bib@lineage"),
-          vec![Tokenize!(name.lineage.as_str())]);
+          vec![tokenize_bib_field(&name.lineage)]);
         name_tks.extend(inv.unlist());
       }
       let inv = Invocation!(T_CS!("\\bib@@@name"),
@@ -1042,7 +1059,7 @@ LoadDefinitions!({
     // is the OptionalKeyVals arg (absent → no attributes).
     // Perl L333: Tokenize($recap) — catcode-aware, so TeX macros in
     // titles stay live (accents, math). Explode leaked them verbatim.
-    let recased_tokens = Tokenize!(recased.as_str());
+    let recased_tokens = tokenize_bib_field(&recased);
     let inv = Invocation!(T_CS!("\\bib@@field"),
       vec![tag_tokens, Tokens!(), recased_tokens]);
     Ok(inv)
@@ -1454,7 +1471,7 @@ LoadDefinitions!({
     let mut out_toks: Vec<Token> = Vec::new();
     out_toks.push(T_CS!("\\bib@field@default@date"));
     out_toks.push(T_BEGIN!());
-    out_toks.extend(Tokenize!(date.as_str()).unlist());
+    out_toks.extend(tokenize_bib_field(&date).unlist());
     out_toks.push(T_END!());
     Ok(Tokens::new(out_toks))
   });
@@ -1516,7 +1533,7 @@ LoadDefinitions!({
     // out as an empty `<ltx:bib-part role="pages"/>`. Witness arXiv 2508.17585.
     whatsit.set_property(
       "pages",
-      Stored::Digested(digest(Tokenize!(normalised.as_str()))?),
+      Stored::Digested(digest(tokenize_bib_field(&normalised))?),
     );
   });
 
@@ -1741,9 +1758,9 @@ LoadDefinitions!({
     if mrnumber.is_none() && mrreviewer.is_none() {
       return Ok(Tokens!());
     }
-    let mr_tks = Tokenize!(mrnumber.unwrap_or_default().as_str());
+    let mr_tks = tokenize_bib_field(&mrnumber.unwrap_or_default());
     let rev_tks = match mrreviewer {
-      Some(r) => Tokenize!(r.as_str()),
+      Some(r) => tokenize_bib_field(&r),
       None => Tokens!(),
     };
     let inv = Invocation!(T_CS!("\\bib@@mr"), vec![mr_tks, rev_tks]);
@@ -1794,9 +1811,9 @@ LoadDefinitions!({
     if zblno.is_none() && zblreviewer.is_none() {
       return Ok(Tokens!());
     }
-    let zbl_tks = Tokenize!(zblno.unwrap_or_default().as_str());
+    let zbl_tks = tokenize_bib_field(&zblno.unwrap_or_default());
     let rev_tks = match zblreviewer {
-      Some(r) => Tokenize!(r.as_str()),
+      Some(r) => tokenize_bib_field(&r),
       None => Tokens!(),
     };
     let inv = Invocation!(T_CS!("\\bib@@zbl"), vec![zbl_tks, rev_tks]);
@@ -1980,8 +1997,18 @@ LoadDefinitions!({
     // `\ProcessBibTeXEntry` and `\end{bibtex@bibliography}` too, so a 3-entry
     // `.bib` produced ONE entry and a single error where Perl produces all three
     // and four errors. Guard: `55_bibtex::runaway_field_costs_only_its_own_entry`.
+    //
+    // `%` is read as an ordinary character in this mouth (OXIDIZED_DESIGN #74).
+    // BibTeX has no comment syntax inside an entry, so the values `PreBibTeX`
+    // just handed us hold `%` literally; under TeX's catcode 14 each one
+    // comments out the rest of its line — the field's own closing `}` included —
+    // so the entry's group never closes, `ltx:bibentry` is left open, and every
+    // later entry nests inside it. Witnesses arXiv 2605.01196 (`doi={%doi:...}`)
+    // and 2605.02131 (a percent-encoded URL in a `title`'s `\href`): 28 errors
+    // each, and Perl breaks identically (29 / 31 on the same host).
+    // Guard: `06_cluster_bibliography::bib_field_percent_is_an_ordinary_character`.
     open_mouth_with(
-      Mouth::new(&lines.join("\n"), None)?,
+      Mouth::new(&lines.join("\n"), None)?.with_percent_as_other(),
       true,
       BalancedBoundary::Opaque,
     );

--- a/latexml_engine/src/bibtex.rs
+++ b/latexml_engine/src/bibtex.rs
@@ -275,20 +275,67 @@ pub fn current_entry_field(name: &str) -> Option<Tokens> {
 
 /// `Tokenize!` for a string that came out of the BibTeX lexer.
 ///
-/// The standard catcode table, as Perl's `Tokenize` uses — except that `%` is
-/// an ordinary character. BibTeX has no comment syntax inside an entry
-/// (`Pre::BibTeX` only skips `%` in the junk BETWEEN entries), so a `%` in a
-/// field value is data; under catcode 14 it comments out the rest of the
-/// string and takes any brace still open with it, which leaves the field's
-/// element unclosed and swallows every following entry. Witness 2605.02131:
-/// a percent-encoded URL in a `title`'s `\href`, 24 `malformed:ltx:bibentry`.
-/// See `OXIDIZED_DESIGN #74`.
+/// The standard catcode table, as Perl's `Tokenize` uses — except that `%` and
+/// `&` are ordinary characters. BibTeX has no comment syntax inside an entry
+/// (`Pre::BibTeX` only skips `%` in the junk BETWEEN entries) and no alignment
+/// either, so both are data; under catcode 14 a `%` comments out the rest of
+/// the string and takes any brace still open with it, and under catcode 4 an
+/// `&` is a stray alignment tab. Witnesses 2605.02131 (a percent-encoded URL in
+/// a `title`'s `\href`, 24 `malformed:ltx:bibentry`) and 2605.01936
+/// (`publisher = {Taylor & Francis}` and six more, 7 `unexpected:&`).
+/// See `OXIDIZED_DESIGN #74` and `#75`.
 ///
 /// This is the same rule the per-entry Mouth applies (see `\ProcessBibTeXEntry`
 /// below); it has to be repeated here because the handlers that re-read a raw
 /// field — `\bib@@title` recasing, name splitting, date/pages assembly — build
 /// their tokens from the stored string and never go through that mouth.
-fn tokenize_bib_field(text: &str) -> Tokens { mouth::tokenize_percent_literal(text) }
+fn tokenize_bib_field(text: &str) -> Tokens { mouth::tokenize_bib_literal(text) }
+
+/// Collapse an HTML-escaped ampersand — `&amp;` — back to the single `&` the
+/// author wrote, in whichever of its three spellings a `.bib` export used.
+///
+/// This is a DOUBLE escape, not a TeX construct: a reference manager rendered
+/// the field to HTML (`&` -> `&amp;`), then a second pass TeX-escaped the
+/// ampersand of that entity, so the file carries `\&amp;` / `{\&}amp;` /
+/// `&amp;` where the source said `&`. TeX has no idea: `\&` produces the glyph
+/// and `amp;` is four more ordinary characters, so the entry renders
+/// "Computer Engineering, &amp; Applied Computing". pdflatex prints exactly the
+/// same thing — this is not a parity gap in either direction, it is an input
+/// corruption that only the `.bib` reader is positioned to undo, and we read
+/// `.bib` directly (see OXIDIZED_DESIGN #73's framing of that position).
+///
+/// Distinct from a BARE `&`, which is catcode 4 and is neutralized at the mouth
+/// (`tokenize_bib_field` above, `#75`). Decoding here deliberately yields a
+/// plain `&` and lets that mechanism give it its catcode, rather than escaping
+/// it to `\&` behind the mechanism's back.
+///
+/// Measured over 6000 arXiv/2605 sources: `\&amp;` in `booktitle` (2605.00833,
+/// 2605.01362), in `journal` (2605.00922, 2605.01200, 2605.01224), in `title`
+/// (2605.01353 `{{A}}\&amp;{{AS}}`); `{\&}amp;` in `title` (2605.01224 "Shake
+/// {\&}amp; Bake"); bare `&amp;` in `publisher` (2605.00859 "European
+/// Association of Geoscientists &amp; Engineers") and `journal` (2605.01187).
+///
+/// Only `amp;` DIRECTLY after an ampersand is touched, so a field that merely
+/// contains the letters "amp" is untouched, and a lone `&` is left exactly as
+/// it was.
+fn undouble_escaped_ampersand(value: &str) -> String {
+  if !value.contains("amp;") {
+    return value.to_string();
+  }
+  let mut out = String::with_capacity(value.len());
+  let mut rest = value;
+  while let Some(i) = rest.find("amp;") {
+    let (head, tail) = rest.split_at(i);
+    out.push_str(head);
+    // `{\&}` first: its last character is `}`, not `&`.
+    if !(head.ends_with("{\\&}") || head.ends_with('&')) {
+      out.push_str("amp;");
+    }
+    rest = &tail["amp;".len()..];
+  }
+  out.push_str(rest);
+  out
+}
 
 /// Perl: `currentBibEntryRawField('fieldname')` — get the *raw*
 /// source string of a field on the current entry.
@@ -1053,7 +1100,11 @@ LoadDefinitions!({
       })
       .unwrap_or_else(|| "capitalize1".to_string());
     let mode = TitleCaseMode::parse(&mode_str);
-    let raw = current_entry_raw_field(&field_name).unwrap_or_default();
+    // Re-read the RAW field rather than the passed argument (Perl L294), which
+    // is why the decode in `\bibentry@create` does not reach this path and has
+    // to be repeated here — witness 2605.01353, a `title` reading
+    // `{{A}}\&amp;{{AS}}`. See `undouble_escaped_ampersand`.
+    let raw = undouble_escaped_ampersand(&current_entry_raw_field(&field_name).unwrap_or_default());
     let recased = recase_title(&raw, mode);
     // Emit `\bib@@field{tag}{}{<recased>}`. The empty `{}` slot
     // is the OptionalKeyVals arg (absent → no attributes).
@@ -1955,6 +2006,7 @@ LoadDefinitions!({
           break;
         }
       }
+      let value = &undouble_escaped_ampersand(value);
       match handler {
         Some(h) => {
           lines.push(format!("\\csname {}\\endcsname{{{}}}", &h[1..], value));
@@ -2007,8 +2059,21 @@ LoadDefinitions!({
     // and 2605.02131 (a percent-encoded URL in a `title`'s `\href`): 28 errors
     // each, and Perl breaks identically (29 / 31 on the same host).
     // Guard: `06_cluster_bibliography::bib_field_percent_is_an_ordinary_character`.
+    //
+    // `&` likewise (OXIDIZED_DESIGN #75) — BibTeX has no alignment either, so
+    // an `&` in a value it handed us is a character in a publisher's or a
+    // journal's name. Under catcode 4 it is a stray alignment tab:
+    // `Error:unexpected:&`, and the `&` is dropped from the entry, so "Taylor &
+    // Francis" printed as "Taylor Francis". Witnesses arXiv 2605.01936 (7),
+    // 2605.06249 (3), 2605.00462 / 2605.03054 / 2605.06624 / 2605.08753 /
+    // 2605.10409 (1 each). Same-host Perl and bibtex+pdflatex both break the
+    // same way — the decision that a field's content is DATA is what overrides
+    // them, and it is ours to make because we read the `.bib` directly.
+    // Guard: `06_cluster_bibliography::bib_bare_ampersand_is_literal_data`.
     open_mouth_with(
-      Mouth::new(&lines.join("\n"), None)?.with_percent_as_other(),
+      Mouth::new(&lines.join("\n"), None)?
+        .with_percent_as_other()
+        .with_align_as_other(),
       true,
       BalancedBoundary::Opaque,
     );

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -644,6 +644,138 @@ fn bib_abstract_percent_does_not_sink_the_entry() {
     "abstract percent: abstract prose leaked into the rendered entry:\n{x}"
   );
 }
+/// `\&amp;` in a `.bib` field is a doubly escaped ampersand, and renders as one.
+///
+/// A reference manager rendered the field to HTML (`&` -> `&amp;`) and a second
+/// pass TeX-escaped that entity's own ampersand, so the file carries four
+/// characters the author never wrote. TeX has no way to know: `\&` is the glyph,
+/// `amp;` is ordinary text, and the entry reads "Computer Engineering, &amp;
+/// Applied Computing". pdflatex prints exactly the same, so this is neither a
+/// Perl gap nor a pdflatex gap — it is corrupt input, and reading `.bib`
+/// directly is what puts us in a position to undo it. OXIDIZED_DESIGN #75.
+///
+/// All three spellings are real; found by scanning 6000 arXiv/2605 sources.
+/// `titleentity` is the one that needs its own decode: `\bib@@title` re-reads
+/// the raw field for case conversion instead of using the argument it was
+/// handed, so it bypasses the decode done while assembling the entry.
+///
+/// RED before the fix: `&amp;amp;` for the first three entries.
+#[test]
+fn bib_escaped_amp_entity_decodes_to_one_ampersand() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_escaped_amp_entity.tex");
+  // The XML escape of a literal `&` is `&amp;`, so the doubled entity shows up
+  // as `&amp;amp;`. Assert on that serialized form directly — unescaping first
+  // would make the two cases indistinguishable.
+  assert!(
+    !x.contains("&amp;amp;"),
+    "escaped amp entity: a doubled `&amp;` survived into the bibliography:\n{x}"
+  );
+  // Not merely absent — decoded. Each entry keeps ONE ampersand, with the text
+  // on both sides intact (a decode that ate the neighbouring word would also
+  // satisfy the assertion above).
+  for needle in [
+    "Computer Engineering, &amp; Applied Computing",
+    "the A&amp;AS all-sky survey",
+    "shake &amp; bake generation",
+    // Control: an ordinary `\&` was already right and must stay right.
+    "Crime &amp; Delinquency",
+  ] {
+    assert!(
+      x.contains(needle),
+      "escaped amp entity: expected {needle:?} in the bibliography:\n{x}"
+    );
+  }
+  // Near miss: "amp;" that is NOT preceded by an ampersand is ordinary text.
+  assert!(
+    x.contains("amp; token and amplitude modulation"),
+    "escaped amp entity: a literal `amp;` unrelated to an ampersand was eaten:\n{x}"
+  );
+}
+/// A bare `&` in a `.bib` field is the literal character, not an alignment tab.
+///
+/// `publisher = {Taylor & Francis}` is real: seven arXiv/2605 papers ship it
+/// (per-witness provenance in the fixture header). BibTeX's lexer has no
+/// alignment, so the `&` it hands back is a character in a publisher's or a
+/// journal's name — but TeX reads catcode 4, raises `Error:unexpected:&`, and
+/// DROPS the character, so the entry printed "Taylor Francis".
+///
+/// Deliberately ahead of every other engine, which is why the before-numbers
+/// matter: same-host `latexmlc` raised the same one-error-per-`&` (2605.03054
+/// 1/1, 2605.06249 3/3, 2605.00462 1/1, 2605.06624 1/1, 2605.08753 1/1,
+/// 2605.10409 1/1), and bibtex 0.99d + pdflatex agree — under `plain` and
+/// `abbrvnat` the bare `&` reaches the `.bbl`, pdflatex stops with "Misplaced
+/// alignment tab character &" and prints "Taylor Francis". Reading `.bib`
+/// directly is what lets us decide otherwise. OXIDIZED_DESIGN #75.
+///
+/// Neutralized at the per-entry Mouth beside the `%` of #74 — regime A, because
+/// `&` derails alignment in ANY field and these fields have no Perl
+/// Semiverbatim precedent to follow.
+///
+/// RED before the fix: 5 post-stage errors, and "Taylor Francis".
+#[test]
+fn bib_bare_ampersand_is_literal_data() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_bare_ampersand.tex");
+  // The ampersand is KEPT, with the text on both sides of it — a neutralization
+  // that swallowed the rest of the field would still be error-free.
+  for needle in [
+    "Taylor &amp; Francis",
+    "Information Processing &amp; Management",
+    "Knowledge Discovery &amp; Data Mining",
+  ] {
+    assert!(
+      x.contains(needle),
+      "bare ampersand: expected the literal {needle:?} in the bibliography:\n{x}"
+    );
+  }
+  // Containment: every entry still renders, including the one after the run of
+  // bad fields. The sibling `%` bug (#73) took the whole bibliography down.
+  for needle in ["Author", "Builder", "Coder", "Crespi", "Draper", "Ericsson"] {
+    assert!(
+      x.contains(needle),
+      "bare ampersand: {needle:?} was lost from the bibliography:\n{x}"
+    );
+  }
+  assert!(
+    x.contains("The entry after the stray ampersands"),
+    "bare ampersand: the trailing entry's title was lost:\n{x}"
+  );
+}
+/// Making `&` ordinary must not flatten the live TeX beside it.
+///
+/// The boundary the mouth-level neutralization has to hold: it downgrades ONE
+/// catcode, so everything else in the same field keeps working. `\emph` still
+/// marks up, `$x_1+x_2$` still parses as math with `_` a subscript INSIDE math
+/// (the neutralization is not a blanket verbatim), and the space-form accents
+/// PR #399 recovered still resolve — all in the entry that also carries a bare
+/// `&`, so a regression cannot hide behind a separate clean fixture.
+#[test]
+fn bib_bare_ampersand_leaves_live_markup_alone() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_bare_ampersand.tex");
+  // Lower-cased by `\bib@@title`'s `capitalize1` recasing, exactly as Perl
+  // recases it — the point here is the `&`, which survives.
+  assert!(
+    x.contains("ampere &amp; ohm"),
+    "markup boundary: the ampersand in the boundary entry was lost:\n{x}"
+  );
+  assert!(
+    x.contains(">emphasized</emph>"),
+    "markup boundary: \\emph stopped producing markup:\n{x}"
+  );
+  // `_` keeps its subscript meaning INSIDE math — the neutralization downgrades
+  // one catcode in the `.bib` text, it is not a blanket verbatim. The parsed
+  // form is a subscript application, not the literal characters.
+  assert!(
+    x.contains(r#"role="SUBSCRIPTOP""#),
+    "markup boundary: inline math stopped parsing (`_` must still subscript \
+     inside math):\n{x}"
+  );
+  for needle in ["\u{160}pakov", "Gon\u{e7}alves"] {
+    assert!(
+      x.contains(needle),
+      "markup boundary: space-form accent {needle:?} regressed (PR #399):\n{x}"
+    );
+  }
+}
 /// A space-form accent in an author name must survive reversion.
 ///
 /// `{\v S}pakov` / `Gon{\c c}alves` / `\" Ozturk` are ordinary BibTeX — the

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -695,3 +695,78 @@ fn bib_name_space_form_accent_survives_reversion() {
     );
   }
 }
+/// A `%` inside a `.bib` field value is data, not a comment.
+///
+/// BibTeX's lexer has no comment syntax inside an entry — `Pre::BibTeX` only
+/// skips `%` in the junk BETWEEN entries — so the value it stores keeps its
+/// `%`. LaTeXML then re-injects that value as TeX source, where catcode 14
+/// makes it comment out the rest of its line, closing brace included: the
+/// entry's group never closes and every later entry nests inside the unclosed
+/// element (`<ltx:bibentry> isn't allowed in <ltx:bibentry>`).
+///
+/// Two paths, one per entry in the fixture: `doi` goes through the per-entry
+/// Mouth `\ProcessBibTeXEntry` opens, `title` does NOT — `\bib@@title` re-reads
+/// the raw field and tokenizes it itself. Fixing only the mouth left the
+/// `title` half broken (it went 28 → 37 errors on the witness, surfacing an
+/// `Extra \endcsname` once the value was no longer truncated), so both call
+/// sites read `%` as OTHER. OXIDIZED_DESIGN #74.
+///
+/// RED before the fix: witnesses 2605.01196 (`doi={%doi:10.1017/jfm.2016.420}`)
+/// and 2605.02131 (percent-encoded URL in a `title`'s `\href`) at **28 errors
+/// each**; same-host `latexmlc` 29 / 31 on the same inputs, so this is a shared
+/// bug and a surpass-Perl fix, not a Rust-only defect. Both are 0 after.
+/// `convert_and_post_clean`, not `convert_and_post`: the bibliography is built
+/// in POST, and a text-presence assertion still finds text INSIDE an unclosed
+/// element — the plain helper passes on a structurally broken document.
+#[test]
+fn bib_field_percent_is_an_ordinary_character() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_field_percent.tex");
+  // Containment: three entries, three bibitems. Before the fix the runaway
+  // swallowed its followers into its own unclosed <ltx:bibentry>.
+  assert_eq!(
+    x.matches("<bibitem").count(),
+    4,
+    "percent field: expected four bibitems, one per entry:\n{x}"
+  );
+  assert!(
+    x.contains("The entry after the runaway"),
+    "percent field: the canary entry after the runaway is missing:\n{x}"
+  );
+  // The `%` is DATA: it must survive into the output, not be dropped along
+  // with everything after it on its line.
+  // (the doi becomes an href, so its own `%`/`:` are URL-escaped there —
+  // `%25doi%3A` IS the surviving `%doi:`.)
+  assert!(
+    x.contains("dx.doi.org/%25doi%3A10.1017/jfm.2016.420"),
+    "percent field: the doi value was truncated at its percent sign:\n{x}"
+  );
+  assert!(
+    x.contains("https://cdn.example.org/20240723%20IPWG%20Item%2004b%20DRAFT.pdf"),
+    "percent field: the percent-encoded URL lost its escapes:\n{x}"
+  );
+  assert!(
+    x.contains("A linked title behind a percent-encoded URL"),
+    "percent field: the linked title did not render:\n{x}"
+  );
+  // Neutralizing `%` must not flatten the field: markup, math and accents in
+  // the SAME field still have to work (the boundary PR #399 established).
+  assert!(
+    x.contains("Yield rose <emph") && x.contains(">sharply</emph>"),
+    "percent field: \\emph in a percent-bearing title lost its markup:\n{x}"
+  );
+  assert!(
+    x.contains("tex=\"x_{1}+x_{2}\"") && x.contains("<XMApp>"),
+    "percent field: inline math in a percent-bearing title did not parse:\n{x}"
+  );
+  assert!(
+    x.contains("Špakov"),
+    "percent field: the space-form accent in the same entry stopped \
+     composing:\n{x}"
+  );
+  // No entry may nest inside another, and no element may be left open.
+  assert!(
+    !x.contains("<bibentry"),
+    "percent field: a raw <bibentry> survived post-processing — \
+     MakeBibliography could not read the entry:\n{x}"
+  );
+}

--- a/latexml_oxide/tests/55_bibtex.rs
+++ b/latexml_oxide/tests/55_bibtex.rs
@@ -114,32 +114,31 @@ fn bibtex_mode_emits_bibentries() {
   );
 }
 
-/// A runaway field must cost only its own entry — not the rest of the `.bib`.
+/// A `%` in a field is data, and a real runaway costs only its own entry.
 ///
-/// A bare `%` in a BibTeX field is literal data (BibTeX has no comment syntax
-/// inside an entry) but TeX source when `\ProcessBibTeXEntry` replays the entry
-/// through a Mouth, so it comments out the closing brace and the argument read
-/// runs away. Both engines mis-read the field — that is parity, and real
-/// bibtex+pdflatex break on it too, so it is deliberately NOT corrected here.
+/// **The `%` half.** A bare `%` in a BibTeX field is literal data — BibTeX has
+/// no comment syntax inside an entry — but it used to become TeX source when
+/// `\ProcessBibTeXEntry` replays the entry through a Mouth, so catcode 14 ate
+/// the closing brace and the argument read ran away. That is now corrected on
+/// both seams (OXIDIZED_DESIGN #74): the entry Mouth reads `%` as OTHER, and so
+/// does `\bib@@title`, which never touches that Mouth — it re-reads the RAW
+/// field to re-case it and tokenizes the result itself. Hence the fixture's two
+/// `%` entries, one per seam. Perl still truncates both (`Fifty`, `plain`), so
+/// these assertions are deliberately BEYOND same-host Perl; see #74 for why
+/// pdflatex, not Perl, is the ground truth for a directly-read `.bib`.
 ///
-/// What was Rust-only was the blast radius, and it had two independent causes —
-/// hence the two runaway entries in the fixture, which fail by different routes:
-///
-/// * **`{}`-read argument** (`\bib@@title`). `read_balanced` used to treat every
-///   autoclose literal mouth as a token-level continuation of its parent
-///   (`gullet.rs`, the xint `\scantokens` divergence), so the runaway crossed out
-///   of the entry mouth and swallowed every following `\ProcessBibTeXEntry` AND
-///   `\end{bibtex@bibliography}`. The entry mouth now declares itself
-///   `BalancedBoundary::Opaque`, which is what Perl's readBalanced (`Gullet.pm`
-///   L465-472, current mouth only) does for every mouth.
-/// * **`Digested` argument** (`\bib@@field`). The group opened by `{` is never
-///   closed, so the argument digestion runs to EOF; `readDigested` then `pop`s
-///   the last box to strip the closing brace, but `digest_next_body` was pushing
-///   Perl's EOF trailer box (`Stomach.pm` L130) only for a body that had read no
-///   token at all, so the `pop` ate real content — every following entry.
-///
-/// Ground truth for the assertions is same-host Perl on the same fixture: all
-/// four keys present, and the runaway title truncated at the `%` to "Fifty".
+/// **The blast-radius half.** `runawaymath`'s unescaped `$` still runs away —
+/// it opens math that never closes, so the `Digested` argument (`\bib@@field`,
+/// BibTeX.pool L230) digests to EOF. `readDigested` then `pop`s the last box to
+/// strip the closing brace, and `digest_next_body` must have pushed Perl's EOF
+/// trailer box (`Stomach.pm` L130) or that `pop` eats real content — every
+/// following entry. The gullet-level twin of that guarantee is the entry
+/// mouth's `BalancedBoundary::Opaque` (Perl's readBalanced reads the current
+/// mouth only, `Gullet.pm` L465-472); with `%` retired as a trigger, no `.bib`
+/// input reachable through `Pre::BibTeX` produces a token-level unbalanced read
+/// any more — the parser balances braces character-wise before we ever see the
+/// value — so that boundary is now an invariant this fixture states rather than
+/// one it can provoke.
 #[test]
 fn runaway_field_costs_only_its_own_entry() {
   // `init` is process-global and the sibling test in this target may have won
@@ -161,11 +160,17 @@ fn runaway_field_costs_only_its_own_entry() {
   };
   let s = doc.to_string();
 
-  for key in ["before", "runawaytitle", "runawaynote", "after"] {
+  for key in [
+    "before",
+    "runawaytitle",
+    "runawaynote",
+    "runawaymath",
+    "after",
+  ] {
     assert!(
       s.contains(&format!("key=\"{key}\"")),
       "entry '{key}' was lost — a runaway field must not take other entries \
-       with it (same-host Perl keeps all four). Got:\n{s}"
+       with it. Got:\n{s}"
     );
   }
   // The entries that carry no runaway must be intact, not merely present.
@@ -174,10 +179,17 @@ fn runaway_field_costs_only_its_own_entry() {
     "the entry FOLLOWING the runaway lost its title, so the runaway is still \
      consuming past its own mouth. Got:\n{s}"
   );
-  // And the damaged entry is damaged exactly as far as Perl's is: the title is
-  // truncated at the `%`, the rest of that line gone.
+  // The `%` is data: both seams must keep the whole value, not stop at it.
+  // `\bib@@title` re-tokenizes the raw field itself …
   assert!(
-    s.contains("<bib-title>Fifty</bib-title>"),
-    "expected the runaway title truncated at the `%` (same as Perl), got:\n{s}"
+    s.contains("<bib-title>Fifty % of the time</bib-title>"),
+    "the title was truncated at its `%` — a `%` in a .bib field is data, not a \
+     comment (OXIDIZED_DESIGN #74). Got:\n{s}"
+  );
+  // … while the note comes straight off the entry Mouth.
+  assert!(
+    s.contains("plain % comment"),
+    "the note was truncated at its `%` — the entry Mouth must read `%` as an \
+     ordinary character (OXIDIZED_DESIGN #74). Got:\n{s}"
   );
 }

--- a/latexml_oxide/tests/bibtex/runaway_field.bib
+++ b/latexml_oxide/tests/bibtex/runaway_field.bib
@@ -1,39 +1,60 @@
-% A `.bib` whose fields contain a bare `%`.
+% A `.bib` whose fields break the TeX replay of their own entry.
 %
-% BibTeX has NO comment syntax inside an entry, so this is literal data — but
-% `\ProcessBibTeXEntry` hands the entry to a Mouth as TeX SOURCE (Perl
-% `BibTeX.pool.ltxml` L165-166), where `%` is catcode 14 and comments out the
-% rest of the line, closing brace included. Both engines therefore mis-read the
-% field, and so does real bibtex+pdflatex — that part is parity and is
-% deliberately not corrected.
+% Two things are asserted over this file, in `55_bibtex.rs`:
 %
-% What is NOT parity is the blast radius. The point of this fixture is that the
-% damage stays inside the entry that caused it: `before` and `after` must
-% survive, whichever field the runaway sits in.
+% 1. A `%` in a field value is DATA. BibTeX has no comment syntax inside an
+%    entry, so `Pre::BibTeX` hands the `%` through; `\ProcessBibTeXEntry` then
+%    replays the entry as TeX SOURCE (Perl `BibTeX.pool.ltxml` L165-166), where
+%    catcode 14 used to comment out the rest of the line — closing brace and
+%    all. That is corrected: the entry Mouth (and the handlers that re-tokenize
+%    a stored raw field, like `\bib@@title`) read `%` as an ordinary character.
+%    OXIDIZED_DESIGN #74; `runawaytitle` and `runawaynote` are its two seams.
+%    Perl still mis-reads both, so their titles/notes come out truncated there.
+%
+% 2. A runaway that IS still a runaway must cost only its own entry. `$5` — an
+%    unescaped dollar in a `note`, one of the most common `.bib` malformations —
+%    opens math that never closes, so the argument digestion runs to EOF. That
+%    is the `Digested`-argument mechanism (`\bib@@field`, BibTeX.pool L230):
+%    `readDigested` `pop`s the last box to drop the closing brace, and
+%    `digest_next_body` has to have pushed Perl's EOF trailer box
+%    (`Stomach.pm` L130) or the `pop` eats real content — every following entry.
+%    The entry mouth is also `BalancedBoundary::Opaque`, as Perl's readBalanced
+%    is for every mouth (`Gullet.pm` L465-472), so a gullet-level runaway cannot
+%    cross out of the entry either.
+%
+% `before` and `after` are the containment canaries: they must survive whichever
+% field the runaway sits in.
 @misc{before,
   author = {Able, Ann},
   title  = {Entry Before The Runaway},
   year   = {2023}
 }
 
-% Runaway inside a `{}`-read macro argument (`\bib@@title`, BibTeX.pool L293).
-% Fixed by the entry mouth being opaque to a balanced read.
+% `%` in a `{}`-read macro argument (`\bib@@title`, BibTeX.pool L293) — which
+% never reaches the entry Mouth: `\bib@@title` re-reads the RAW field to re-case
+% it and tokenizes the result itself.
 @misc{runawaytitle,
   author = {Poe, Percy},
   title  = {Fifty % of the time},
   year   = {2024}
 }
 
-% Runaway inside a `Digested` argument (`\bib@@field`, BibTeX.pool L230) — a
-% different mechanism: the group opened by `{` is never closed, so the argument
-% digestion runs to EOF and `readDigested`'s `pop` (which is meant to drop the
-% closing-brace box) ate real content instead, for want of the EOF trailer box
-% Perl pushes at `Stomach.pm` L130.
+% `%` in a `Digested` argument (`\bib@@field`, BibTeX.pool L230) — this one does
+% come off the entry Mouth.
 @misc{runawaynote,
   author = {Quill, Quinn},
   title  = {Has A Runaway Note},
   year   = {2024},
   note   = {plain % comment}
+}
+
+% A live runaway: the unescaped `$` opens math and swallows the rest of the
+% entry. Its damage must not reach `after`.
+@misc{runawaymath,
+  author = {Rho, Rita},
+  title  = {Has An Unescaped Dollar},
+  year   = {2024},
+  note   = {costs $5 each}
 }
 
 @misc{after,

--- a/latexml_oxide/tests/cluster_regressions/bib_bare_ampersand.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_bare_ampersand.bib
@@ -1,0 +1,97 @@
+% A bare `&` in a `.bib` field, verbatim as seven arXiv/2605 papers ship it.
+% `&` is catcode 4, so digesting the field reads it as an alignment tab.
+% Every line below is copied from a witness, not invented:
+%
+%   publisher  {Taylor & Francis}                       2605.03054, 2605.01936,
+%                                                       2605.06249 (x2)
+%   journal    {Information Processing & Management}    2605.01936
+%   journal    {Infrared Physics & Technology}          2605.08753
+%   booktitle  {... Knowledge Discovery & Data Mining}  2605.00462
+%   author     {Giovanni P. Crespi,
+%               Daishi Kuroiwa & Matteo Rocca}          2605.06624
+%   copyright  {Copyright {\copyright}2009
+%               Lippincott Williams & Wilkins}          2605.01936 L2838
+%   publisher  {... John Wiley & Sons Ltd.}             2605.10409
+%
+% A `.bib` field's content is DATA, not TeX: the `&` is the literal character
+% BibTeX handed back, so "Taylor & Francis" renders with its ampersand. Read at
+% the per-entry Mouth, beside the `%` of #74 — regime A, because `&` derails
+% alignment in ANY field and the fields carrying it here (publisher, journal,
+% booktitle) have no Perl Semiverbatim precedent to follow.
+%
+% What every engine did BEFORE, measured, because this is deliberately ahead of
+% all of them: one `Error:unexpected:&` per bare `&` in Rust and in same-host
+% `latexmlc` alike (2605.03054 1/1, 2605.06249 3/3, 2605.00462 1/1, 2605.06624
+% 1/1, 2605.08753 1/1, 2605.10409 1/1), and bibtex 0.99d + pdflatex agree —
+% under `plain` and `abbrvnat` the bare `&` is copied into the `.bbl`, pdflatex
+% stops with "Misplaced alignment tab character &", drops the character and
+% prints "Taylor Francis". So this is not a defect fix: LaTeXML reads `.bib`
+% directly, with no `.bst` and no bibtex(1), so it decides what reaches the
+% tokenizer. OXIDIZED_DESIGN #75.
+%
+% `#` is NOT neutralized with it. Checked across all seven witnesses: one bare
+% `#` in total, in 2605.00462's JabRef `file` path, and that field is already
+% covered (unknown field -> `\bib@field@default@default Verbatim Verbatim`).
+% No evidence, no change.
+%
+% `markupboundary` is the entry that keeps the neutralization honest: making a
+% character ordinary must not flatten the live TeX around it. `\emph` must
+% still mark up, `$x_1+x_2$` must still parse as math with `_` a subscript
+% INSIDE math, and the space-form accents PR #399 recovered must still resolve.
+%
+% `ampsurvivor` is the containment canary: a stray `&` must cost its own field
+% and nothing else. Under the sibling `%` bug (#73) an entry like these took the
+% WHOLE bibliography down, so "the entries after the bad one still render" is a
+% live assertion, not decoration.
+
+@book{amppublisher,
+  author = {Alice Author},
+  title = {A book from a two-name press},
+  publisher = {Taylor & Francis},
+  address = {Abingdon},
+  year = {2009}
+}
+
+@article{ampjournal,
+  author = {Bob Builder},
+  title = {A paper in a two-name journal},
+  journal = {Information Processing & Management},
+  volume = {12},
+  year = {2010}
+}
+
+@inproceedings{ampbooktitle,
+  author = {Carol Coder},
+  title = {A talk at a two-name conference},
+  booktitle = {Proceedings of the 26th ACM SIGKDD International Conference on Knowledge Discovery & Data Mining},
+  year = {2011}
+}
+
+@article{ampauthor,
+  author = {Giovanni P. Crespi, Daishi Kuroiwa & Matteo Rocca},
+  title = {A paper whose author list uses an ampersand},
+  journal = {J. Bibliographies},
+  year = {2012}
+}
+
+@book{ampcopyright,
+  author = {Dan Draper},
+  title = {A book with a copyright line},
+  publisher = {Lippincott},
+  copyright = {Copyright {\copyright}2009 Lippincott Williams & Wilkins},
+  year = {2009}
+}
+
+@article{ampsurvivor,
+  author = {Eve Ericsson},
+  title = {The entry after the stray ampersands},
+  journal = {J. Bibliographies},
+  year = {2013}
+}
+
+@article{markupboundary,
+  author = {{\v S}pakov, Oleg and Gon{\c c}alves, Ana},
+  title = {An \emph{emphasized} word, math $x_1+x_2$, and Ampere \& Ohm},
+  journal = {J. Bibliographies},
+  year = {2022}
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_bare_ampersand.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_bare_ampersand.tex
@@ -1,0 +1,10 @@
+% Driver for `bib_bare_ampersand.bib`: the five field kinds that carry a bare
+% `&` across the seven 2605 witnesses, plus a containment canary and a live-markup
+% boundary entry. See the `.bib`
+% header for the per-witness provenance and the policy.
+\documentclass{article}
+\begin{document}
+See \cite{amppublisher,ampjournal,ampbooktitle,ampauthor,ampcopyright,ampsurvivor,markupboundary}.
+\bibliographystyle{plain}
+\bibliography{bib_bare_ampersand}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/bib_escaped_amp_entity.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_escaped_amp_entity.bib
@@ -1,0 +1,61 @@
+% `\&amp;` — an HTML-escaped ampersand that was then TeX-escaped a second time.
+% A reference manager rendered the field to HTML (`&` -> `&amp;`), a second pass
+% escaped that entity's own `&`, and the `.bib` ended up carrying four extra
+% characters the author never wrote. TeX cannot tell: `\&` is the glyph and
+% `amp;` is ordinary text, so the entry renders "Computer Engineering, &amp;
+% Applied Computing". pdflatex prints the same — this is neither a Perl gap nor
+% a pdflatex gap, it is corrupt input that only the `.bib` reader can undo.
+% OXIDIZED_DESIGN #75.
+%
+% All three spellings are real, found by scanning 6000 arXiv/2605 sources:
+%
+%   \&amp;    booktitle 2605.00833, 2605.01362; journal 2605.00922, 2605.01200,
+%             2605.01224; title 2605.01353 (`{{A}}\&amp;{{AS}}`)
+%   {\&}amp;  title 2605.01224 ("Reversible Template-based Shake {\&}amp; Bake")
+%   &amp;     publisher 2605.00859 ("European Association of Geoscientists
+%             &amp; Engineers"); journal 2605.01187
+%
+% The `title` cases are NOT redundant with the others: `\bib@@title` re-reads the
+% raw field for its case conversion (Perl L294) instead of using the argument it
+% was handed, so it bypasses the decode done while assembling the entry and needs
+% its own. `titleentity` is the case that proves it.
+%
+% `plainescaped` is the control: an ordinary `\&` must keep rendering as one
+% ampersand and must not lose a following word that happens to start with "amp".
+% `ampersandword` is the near-miss guard — "amp;" not preceded by an ampersand is
+% ordinary text and must survive untouched.
+
+@inproceedings{bookentity,
+  author = {Alice Author},
+  title = {A talk at a doubly-escaped conference},
+  booktitle = {2023 Congress in Computer Science, Computer Engineering, \&amp; Applied Computing},
+  year = {2023}
+}
+
+@article{titleentity,
+  author = {Bob Builder},
+  title = {Commentary on the {{A}}\&amp;{{AS}} all-sky survey},
+  journal = {J. Bibliographies},
+  year = {2019}
+}
+
+@article{bracedentity,
+  author = {Carol Coder},
+  title = {Reversible template-based shake {\&}amp; bake generation},
+  journal = {J. Bibliographies},
+  year = {2021}
+}
+
+@article{plainescaped,
+  author = {Dan Draper},
+  title = {A control entry},
+  journal = {Crime \& Delinquency},
+  year = {2019}
+}
+
+@article{ampersandword,
+  author = {Eve Ericsson},
+  title = {On the amp; token and amplitude modulation},
+  journal = {J. Bibliographies},
+  year = {2022}
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_escaped_amp_entity.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_escaped_amp_entity.tex
@@ -1,0 +1,9 @@
+% Driver for `bib_escaped_amp_entity.bib`: the three spellings of a doubly
+% escaped `&amp;`, plus a control and a near-miss. See the `.bib` header and
+% OXIDIZED_DESIGN #75.
+\documentclass{article}
+\begin{document}
+See \cite{bookentity,titleentity,bracedentity,plainescaped,ampersandword}.
+\bibliographystyle{plain}
+\bibliography{bib_escaped_amp_entity}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/bib_field_percent.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_field_percent.bib
@@ -1,0 +1,76 @@
+% A `%` inside a BibTeX field value is DATA, not a comment.
+%
+% BibTeX's lexer has no comment syntax inside an entry — `%` is only significant
+% in the junk BETWEEN entries — so `Pre::BibTeX` hands the value back with the
+% `%` in it. LaTeXML then re-injects that value as TeX source, where catcode 14
+% makes it comment out the rest of its LINE. The field's own closing brace goes
+% with it, the entry's group never closes, and every following entry nests
+% inside the unclosed element: `<ltx:bibentry> isn't allowed in <ltx:bibentry>`,
+% over and over. See OXIDIZED_DESIGN #74.
+%
+% The single-line layout is load-bearing, exactly as in `bib_abstract_percent.bib`:
+% the closing `}` must sit at the END of the line that carries the `%`. Wrap the
+% value across lines and the `%` only eats to its own line end, the brace on the
+% next line still closes the group, and the fixture stops reproducing. Do not
+% reflow these entries.
+%
+% Two DISTINCT code paths reach the tokenizer, and each needs its own entry:
+%
+%   `percentdoi`  — `doi` is dispatched through the per-entry Mouth that
+%                   `\ProcessBibTeXEntry` opens over the generated
+%                   `\csname bib@field@default@doi\endcsname{<value>}` line.
+%                   Copied from witness arXiv 2605.01196 `references.bib` L1984
+%                   (`doi={%doi:10.1017/jfm.2016.420},` — an author's own note to
+%                   self, left in an UNCITED entry). 28 errors, and the paper's
+%                   rendered output was otherwise byte-identical: the whole cost
+%                   was diagnostics for a reference nobody cites.
+%
+%   `percenthref` — `title` never reaches that Mouth. `\bib@@title` re-reads the
+%                   RAW field to re-case it and tokenizes the result itself, so
+%                   the mouth-level rule has to be repeated at that call. Copied
+%                   from witness arXiv 2605.02131 `IAS_GFM_References.bib` L104
+%                   (a percent-ENCODED URL in an `\href`). 28 errors; the two
+%                   linked titles were lost.
+%
+% pdflatex is the ground truth for both. `bibtex` keeps the `%` (its lexer has
+% no comment rule inside `{}`), and neither of these fields is in plain.bst's
+% ENTRY list, so `bibtex(1)` drops them when writing the `.bbl` and pdflatex
+% never sees them. Reading the `.bib` directly is what puts them in front of a
+% TeX tokenizer, so the reader has to use BibTeX's rules, not TeX's.
+%
+% `survivor` is the containment canary: before the fix it was swallowed into the
+% preceding entry's unclosed `<ltx:bibentry>`.
+
+@article{percentdoi,
+   author={Gagnon, D. A. and Arratia, P. E.},
+   year={2016},
+   journal={J. Fluid Mech.},
+   title={A doi field carrying a bare percent sign},
+   doi={%doi:10.1017/jfm.2016.420},
+}
+
+@techreport{percenthref,
+  author       = {{Midcontinent Independent System Operator}},
+  title        = {\href{https://cdn.example.org/20240723%20IPWG%20Item%2004b%20DRAFT.pdf}{A linked title behind a percent-encoded URL}},
+  institution  = {MISO},
+  year         = {2024},
+}
+
+% The boundary: neutralizing `%` must not flatten the field into plain text.
+% Markup, math and accents in the SAME field as the `%` all have to keep working
+% — `\emph` must still produce an element, `$x_1+x_2$` must still parse as math,
+% and `{\v S}` must still compose (PR #399; `bib_accent_space_form.bib` guards
+% the accent path on its own).
+@article{percentwithmarkup,
+   author = {{\v S}pakov, Oleg},
+   title = {Yield rose \emph{sharply} by 50% when $x_1+x_2$ held},
+   journal = {J. Bibliographies},
+   year = {2025}
+}
+
+@article{survivor,
+   author = {Bo Lindqvist},
+   title = {The entry after the runaway},
+   journal = {J. Bibliographies},
+   year = {2025}
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_field_percent.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_field_percent.tex
@@ -1,0 +1,14 @@
+% Driver for `bib_field_percent.bib`: a `%` inside a `.bib` field value must be
+% an ordinary character, not a TeX comment. See the `.bib` header and
+% OXIDIZED_DESIGN #74.
+%
+% `hyperref` is loaded because witness 2605.02131 loads it — the point of the
+% `percenthref` entry is a percent-encoded URL reaching a DEFINED `\href`, not
+% an undefined-macro diagnostic.
+\documentclass{article}
+\usepackage{hyperref}
+\begin{document}
+See \cite{percentdoi,percenthref,percentwithmarkup,survivor}.
+\bibliographystyle{plain}
+\bibliography{bib_field_percent}
+\end{document}


### PR DESCRIPTION
> **Stacked on #405** — the first commit here is that PR's. Merge #405 first;
> this rebases onto it and its diff then reduces to the `&` half.

**Diagnostic.** Seven arXiv/2605 papers report `Error:unexpected:&` at
`Anonymous String` — the recursive BibTeX session. The `&` is real `.bib`
content: `publisher = {Taylor & Francis}`, `journal = {Infrared Physics &
Technology}`, `booktitle = {… Knowledge Discovery & Data Mining}`, `author = {…
Daishi Kuroiwa & Matteo Rocca}`, `copyright = {… Lippincott Williams &
Wilkins}`. BibTeX's lexer has no alignment, so that `&` is a character in a
name; TeX reads catcode 4, errors, and **drops** it — the entry printed "Taylor
Francis". This is *not* a Rust-only defect: same-host `latexmlc` raised the
identical per-`&` count on all six re-measured witnesses (1/1, 3/3, 1/1, 1/1,
1/1, 1/1), and `bibtex` 0.99d + pdflatex agree — under `plain` and under
natbib's `abbrvnat` the bare `&` is copied into the `.bbl` and pdflatex stops
with `! Misplaced alignment tab character &`, printing "Taylor Francis". Rust
already beat Perl on these overall (2605.01936: 13 errors and a complete
bibliography vs Perl's 101 + a Fatal + none at all).

A second, unrelated ampersand bug turned up in the same sweep: `\&amp;` — an
HTML entity that survived into the `.bib` and was TeX-escaped a second time.
That one raises no error anywhere (Perl and pdflatex both print "&amp;"), so the
catcode work does not reach it.

**Approach.** A `.bib` field's content is **data, not TeX** (maintainer policy)
— authorized surpass-Perl and surpass-pdflatex, because LaTeXML reads `.bib`
directly, with no `.bst` and no `bibtex(1)`, and so decides what reaches the
tokenizer. `&` is regime A, beside #405's `%`: it derails alignment in *any*
field, and these fields have no Perl `Semiverbatim` precedent to follow (unlike
`doi`/`isbn`/… which `eprint` joins in #403). Both of #405's seams are extended,
and both are needed — the per-entry Mouth (`Mouth::with_align_as_other`) and
`mouth::tokenize_bib_literal` for the handlers that re-tokenize a stored raw
field and never pass through it (`\bib@@title` recasing, name/date/pages
assembly, MR/Zbl). Per-Mouth, not a State catcode, so a `.sty` raw-loaded from
inside a field handler — and the document — keep TeX's alignment tab.
`undouble_escaped_ampersand` handles the `\&amp;` family separately, at the
entry-assembly seam and again in `\bib@@title`. `OXIDIZED_DESIGN #75`.

**Validation.** Per-witness `Error:` totals, debug profile with dumps, baseline
= #405 tip:

| witness | before | after | `unexpected:&` |
|---|---|---|---|
| 2605.06249 | 3 | **0** | 3 → 0 |
| 2605.03054 | 1 | **0** | 1 → 0 |
| 2605.00462 | 1 | **0** | 1 → 0 |
| 2605.08753 | 1 | **0** | 1 → 0 |
| 2605.10409 | 1 | **0** | 1 → 0 |
| 2605.01936 | 13 | **6** | 7 → 0 |
| 2605.06624 | 4 | **3** | 1 → 0 |

No `unexpected:&` remains on any of the seven; the two residuals are unrelated
`undefined:` errors. #405's own canaries are unaffected (2605.02131 and
2605.01196: 0 errors both before and after this change). Entity witness
2605.00833 renders "Computer Engineering, & Applied Computing" (was `&amp;`),
0 errors.

Guards, each RED-verified by reverting the relevant hunk (`git diff` +
`git checkout`, never `git stash` — that stack is shared across worktrees on
this box and it swapped two agents' trees today):
`06_cluster_bibliography::bib_bare_ampersand_is_literal_data` (5 post-stage
errors → 0, and "Taylor & Francis" instead of "Taylor Francis"),
`::bib_bare_ampersand_leaves_live_markup_alone`, and
`::bib_escaped_amp_entity_decodes_to_one_ampersand` (`&amp;amp;` → `&amp;`).
All three gate the POST stage with `convert_and_post_clean`. Clippy and fmt
clean; full suite green apart from the known
`latexml_post graphics::tests::process_coalesces_only_matching_conversion_options`
(issue 401, fails on clean main on this host).

## Decisions & open questions

1. **Where to neutralize `&` — per-Mouth (regime A) vs per-field `Semiverbatim`
   (regime B).** Chose regime A, per the blast-radius rule: `&` is destructive
   in any field, and `publisher`/`journal`/`booktitle` have no Perl per-field
   idiom to mirror. Regime B would have meant inventing `Semiverbatim` for five
   ordinary rendered fields, which also suppresses `~ $ ^ _ '` in them — far
   more than the evidence supports. *What would settle it:* a witness needing
   `&` literal but something else in the SPECIALS set live.
2. **Both seams, or just the mouth.** Both. The `%` agent measured 2605.02131
   getting *worse* (28 → 37) with the mouth alone, because `\bib@@title` re-reads
   the raw field. Confirmed directly here: with only the mouth covered, `\&amp;`
   in a `title` stayed broken while the same shape in a `booktitle` was fixed.
3. **`#` deliberately not included.** Checked rather than assumed: exactly one
   bare `#` across all seven witnesses, in 2605.00462's JabRef `file` path, and
   that field is already covered (unknown field → `Verbatim Verbatim`).
   *Settles it:* a witness with a bare `#` in a rendered field.
4. **`\&amp;` — repair, or render faithfully?** Chose repair. pdflatex is the
   named tiebreaker and pdflatex prints `&amp;`, but it has no way to know
   better; reading the `.bib` we can see one file mixing two escaping
   conventions, and the entity is unambiguous — no author writes `\&amp;`
   meaning six characters. The alternative ("garbage in, garbage out") is
   defensible; it just means every reader of that paper sees `&amp;`. Scoped
   tightly: only `amp;` DIRECTLY after an ampersand, so "amplitude" and a lone
   `\&` are untouched, with a near-miss case in the fixture.
5. **Known cost of `&`-as-data.** A `.bib` field containing a real `tabular`
   would no longer align. Judged acceptable — no such witness in the 6000-source
   scan — but it is the honest price of regime A.
6. **A `copyright`-specific fix was implemented, then withdrawn.** Before the
   policy call, `copyright` was the one field in the cluster with a #73-style
   argument (no `.bst` emits it; no `FMT_SPEC` queries
   `ltx:bib-date[@role='copyright']`), and reading it `Verbatim` took 2605.01936
   7 → 6. Dropped once `&` became data everywhere — it would be a second
   overlapping mechanism in a file four agents are editing. *Reopen if:* a
   non-`&` special in `copyright` shows up in a sweep.
7. **`latexml_core/src/mouth.rs` is shared machinery.** The change is additive —
   one `bool`, one builder method, one arm in `catcode_of` — and inert unless a
   caller opts in; the only opt-in is the BibTeX path. Flagged because it is not
   my own binding.
8. **Renamed #405's `mouth::tokenize_percent_literal` → `tokenize_bib_literal`**
   (one call site). It now neutralizes `%` *and* `&`, so the old name would
   mislead. Trivial to revert if #405's author prefers the original name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
