### PR TITLE
fix(bibliography): a reviewer's accented name is a name, not an undefined macro

### DIFF
--- a/latexml_engine/src/bibtex.rs
+++ b/latexml_engine/src/bibtex.rs
@@ -2022,9 +2022,21 @@ LoadDefinitions!({
 
   // \bib@synthesize@mr — Perl L803-810. Emit \bib@@mr if either
   // mrnumber or mrreviewer is set, else nothing.
+  // `untex()`, NOT `to_string()`, on all four MR/Zbl fields. Perl's
+  // `currentBibEntryField` returns a plain STRING (`Pre/BibTeX/Entry.pm` L38:
+  // `$$self{fieldmap}{$key}`), so `Tokenize($mrnumber)` at L806-807 never had a
+  // Tokens round trip to get wrong. Our `current_entry_field` returns `Tokens`,
+  // so recovering Perl's string requires `untex()` — `to_string()` drops the
+  // space that terminates a control word and welds it to the following text.
+  // Witness 2605.11579 (`biblo.bib`), five reviewer names, one per shape:
+  // `MRREVIEWER = {Fran\c cois\ Digne}` -> `undefined:\ccois`;
+  // `{S. I. Gel\cprime fand}` -> `\cprimefand`; `{Sait Hal\i c\i o\u{g}lu}`
+  // -> `\ic` and `\io`; `{Dragomir \v{Z}. \Dbar okovi\'{c}}` -> `\Dbarokovi`.
+  // Third site of this defect after `\bib@@names` (PR #399) and dcolumn/overpic
+  // (PR #400). Guard: `06_cluster_bibliography::bib_mr_reviewer_accent_survives_reversion`.
   DefMacro!("\\bib@synthesize@mr", sub[_args] {
-    let mrnumber = current_entry_field("mrnumber").map(|t| t.to_string());
-    let mrreviewer = current_entry_field("mrreviewer").map(|t| t.to_string());
+    let mrnumber = current_entry_field("mrnumber").map(Tokens::untex);
+    let mrreviewer = current_entry_field("mrreviewer").map(Tokens::untex);
     if mrnumber.is_none() && mrreviewer.is_none() {
       return Ok(Tokens!());
     }
@@ -2076,8 +2088,8 @@ LoadDefinitions!({
   // \bib@synthesize@zbl — Perl L828-835. Same shape as mr but
   // unconditional `isreview` (no MR-style id stripping).
   DefMacro!("\\bib@synthesize@zbl", sub[_args] {
-    let zblno = current_entry_field("zblno").map(|t| t.to_string());
-    let zblreviewer = current_entry_field("zblreviewer").map(|t| t.to_string());
+    let zblno = current_entry_field("zblno").map(Tokens::untex);
+    let zblreviewer = current_entry_field("zblreviewer").map(Tokens::untex);
     if zblno.is_none() && zblreviewer.is_none() {
       return Ok(Tokens!());
     }

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -1134,3 +1134,39 @@ fn bib_field_percent_is_an_ordinary_character() {
      MakeBibliography could not read the entry:\n{x}"
   );
 }
+
+/// A space-form accent in a `MRREVIEWER` / `ZBLREVIEWER` field must survive the
+/// Tokens->string round trip.
+///
+/// `current_entry_field` returns `Tokens`; `to_string()` drops the space that
+/// terminates a control word, so `Fran\c cois` welded to `\ccois` — an undefined
+/// macro where a reviewer's name belongs. Perl cannot hit this: its
+/// `currentBibEntryField` returns a plain string (`Pre/BibTeX/Entry.pm` L38), so
+/// `Tokenize($mrreviewer)` has no round trip. GENUINE-RUST-ONLY; the fix is
+/// `untex()`, the same one PR #399 applied to `\bib@@names`.
+///
+/// Witness 2605.11579: 5 errors -> 1, and the survivor (`undefined:\Dbar`, a
+/// MathSciNet glyph macro LaTeXML genuinely lacks) is now an honest diagnostic
+/// rather than a fabricated one.
+#[test]
+fn bib_mr_reviewer_accent_survives_reversion() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_mr_reviewer_accent.tex");
+  // The welds this guards against, one per accent shape in the witness.
+  for weld in ["ccois", "cprimefand", "\\ic", "\\io"] {
+    assert!(
+      !x.contains(weld),
+      "MR reviewer: accent welded to the following text ({weld:?}):\n{x}"
+    );
+  }
+  // ... and the names must actually be there, in both the MR and Zbl paths.
+  assert!(
+    x.matches("Digne").count() >= 2,
+    "MR reviewer: the cedilla name is missing from one of the MR/Zbl paths:\n{x}"
+  );
+  for needle in ["fand", "lu"] {
+    assert!(
+      x.contains(needle),
+      "MR reviewer: {needle:?} lost from a reviewer name:\n{x}"
+    );
+  }
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_mr_reviewer_accent.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_mr_reviewer_accent.bib
@@ -1,0 +1,57 @@
+% MathSciNet exports carry `MRREVIEWER`, and reviewer names are where non-ASCII
+% lives. BibTeX's own convention writes an accent in SPACE form — `\c c`, `\i o`,
+% `\cprime f` — because TeX consumes the space that terminates a control word.
+% That space is therefore GONE by token-time, so any Tokens->string round trip
+% must re-emit it: `untex()` does, `to_string()` does not. Without it `\c c` and
+% the following `ois` weld into `\ccois`, a control sequence that exists in no
+% LaTeX, and the reviewer's name is replaced by an undefined-macro error.
+%
+% Perl cannot hit this: `currentBibEntryField` returns a plain STRING
+% (`Pre/BibTeX/Entry.pm` L38, `$$self{fieldmap}{$key}`), so `Tokenize($mrreviewer)`
+% at `BibTeX.pool.ltxml` L806-807 has no round trip to get wrong. Our
+% `current_entry_field` returns `Tokens`, so this is GENUINE-RUST-ONLY.
+%
+% Witness 2605.11579 (`biblo.bib`) — one entry here per shape it exhibited:
+%   Fran\c cois        -> \ccois        Gel\cprime fand -> \cprimefand
+%   Hal\i c\i o\u{g}lu -> \ic and \io   \Dbar okovi\'{c} -> \Dbarokovi
+% Third site of this defect, after `\bib@@names` (PR #399) and dcolumn/overpic
+% (PR #400).
+%
+% `zblreviewer` is here because the Zentralblatt path is the same code shape and
+% was fixed in the same commit; without an entry it would be untested.
+
+@article{cedillarev,
+  author      = {A. Author},
+  title       = {Cedilla in a reviewer name},
+  journal     = {J. Reviews},
+  year        = {2025},
+  mrnumber    = {MR1234567},
+  MRREVIEWER  = {Fran\c cois\ Digne}
+}
+
+@article{primerev,
+  author      = {B. Author},
+  title       = {Soft sign in a reviewer name},
+  journal     = {J. Reviews},
+  year        = {2025},
+  mrnumber    = {MR2345678},
+  MRREVIEWER  = {S. I. Gel\cprime fand}
+}
+
+@article{dotlessrev,
+  author      = {C. Author},
+  title       = {Two dotless i accents in one name},
+  journal     = {J. Reviews},
+  year        = {2025},
+  mrnumber    = {MR3456789},
+  MRREVIEWER  = {Sait Hal\i c\i o\u{g}lu}
+}
+
+@article{zblrev,
+  author        = {D. Author},
+  title         = {The Zentralblatt path shares the code shape},
+  journal       = {J. Reviews},
+  year          = {2025},
+  zblno         = {1234.56789},
+  ZBLREVIEWER   = {Fran\c cois\ Digne}
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_mr_reviewer_accent.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_mr_reviewer_accent.tex
@@ -1,0 +1,9 @@
+% Driver for `bib_mr_reviewer_accent.bib`. Every entry carries a space-form
+% accent in a reviewer field; all must render as names, not undefined macros.
+% See the `.bib` header.
+\documentclass{article}
+\begin{document}
+See \cite{cedillarev,primerev,dotlessrev,zblrev}.
+\bibliographystyle{plain}
+\bibliography{bib_mr_reviewer_accent}
+\end{document}


### PR DESCRIPTION
**Diagnostic.** The four MathSciNet/Zentralblatt synthesizers flatten `current_entry_field` (which returns `Tokens`) with `to_string()`. That drops the space terminating a control word, so a space-form accent welds to the following text: `MRREVIEWER = {Fran\c cois\ Digne}` → `undefined:\ccois`. Perl cannot hit this — its `currentBibEntryField` returns a plain string (`Pre/BibTeX/Entry.pm` L38), so `Tokenize($mrreviewer)` has no round trip. GENUINE-RUST-ONLY.

**Approach.** `untex()` on all four fields (`mrnumber`, `mrreviewer`, `zblno`, `zblreviewer`) — the faithful repair, identical to PR #399's for `\bib@@names`. No divergence entry: this restores Perl's behaviour rather than departing from it.

**Validation.** Witness 2605.11579: **5 errors → 1**, 36 bibitems unchanged; the survivor `undefined:\Dbar` is a MathSciNet glyph macro LaTeXML genuinely lacks, so it is now an honest diagnostic instead of a fabricated `\Dbarokovi`. Guard `06_cluster_bibliography::bib_mr_reviewer_accent_survives_reversion` covers all four accent shapes plus the Zbl path; RED verified by reverting (patch, not `git stash` — that stack is shared across worktrees). Full suite **1723 passed / 0 failed**; clippy `-D warnings` and fmt clean.

## Decisions & open questions

**Found by audit, not by symptom.** Deprecating an inherent `Tokens::to_string` (an inherent method shadows `ToString::to_string`, so every caller warns without breaking the build) enumerates the surface: **544** call sites, **18** reaching a TeX-source sink, **6** able to weld. These were 2 of the 6. The remaining 4 are `base_utilities.rs:834`, `physics_sty.rs` ×5 (one `meaning` attribute shape), `amsthm_sty.rs:27`, `xy_sty.rs:403` — all lower-risk single keywords, and all in scope for the `TeXString` type-guard work.

**Why not fix all 6 here.** The other four are outside the bibliography and better handled by the type guard that makes the class unrepresentable, rather than a fourth round of manual repair.

**`\Dbar` left undefined deliberately.** Defining MathSciNet glyph macros is a separate question from this defect, and silencing it here would hide a real gap.