### PR TITLE
feat(core): a TeXString type, so a flattened Tokens cannot reach the tokenizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,12 @@
   - **MathReview / ZentralBlatt links are synthesized** — `mrnumber`/`zblno`
     produced no link at all — and an entry carrying both `date` and `year` no
     longer emits a duplicate date.
+  - **An accent in a MathSciNet / Zentralblatt reviewer name survives** —
+    `MRREVIEWER = {Fran\c cois Digne}` came back as `\ccois`, an undefined
+    macro, because flattening a token list drops the space that terminates a
+    control word. That flattening had already cost author names and two column
+    types, so the tokenizing entry points now take a dedicated TeX-string type
+    and it no longer compiles anywhere in the tree.
   - **A biblatex `.bbl` carrying two `\datalist` blocks no longer hangs the
     conversion** on a self-referential `\let`.
   - **A biber `\missing{key}` is a named warning**, not an undefined-command error.

--- a/docs/parity/WISDOM.md
+++ b/docs/parity/WISDOM.md
@@ -2674,3 +2674,55 @@ wrong, not the code.
 Guards: `bibtex::tests::recase_title_handles_every_character_width_at_every_position`,
 `util::char_cursor::tests::*`. Related: [[#68]] above (the same "port a Perl
 loop, inherit an invariant Perl never had" family).
+
+## #71 A `Tokens` flattened with `Display` and re-tokenized WELDS control words — the tokenizing sinks take `TeXString`, so a bare `String` cannot reach them
+
+TeX **consumes** the space that terminates a control word, so it is gone as data
+by token time: `\v S` tokenizes to `[\v][S]`, and concatenating those token
+strings gives `\vS` — a control sequence that exists in no LaTeX. `untex()`
+re-emits the space; `Display`/`to_string()` deliberately does not.
+
+This is **not** a divergence. Perl is identical (`Core/Tokens.pm:61 toString`
+joins the token strings, `Core/Token.pm:306` returns a CS name with no trailing
+space) and its comment — which our port copies verbatim — already says the
+result is "NOT for creating valid TeX (use revert or UnTeX for that!)". Perl
+protects itself by author discipline alone. That failed three times here, each
+found by a user-visible failure years later: `\bib@@names` (PR #399),
+`dcolumn`/`overpic` (PR #400), and `\bib@synthesize@mr` (issue 410 —
+`MRREVIEWER = {Dragomir \v{Z}. \Dbar okovi\'{c}}` → `undefined:\Dbarokovi`;
+witness 2605.11579, 5 welds over 36 bibitems, Perl 0).
+
+**The rule.** All three mouth entry points — `mouth::tokenize`,
+`mouth::tokenize_internal`, `mouth::tokenize_bib_literal` — and therefore
+`Tokenize!`/`TokenizeInternal!`/`bib_tex_tokens` take `impl Into<TeXString>`
+(`latexml_core::tokens`). Its value, like `CharCursor`'s in [[#70]], is what it
+withholds — there is `From<&'static str>` and nothing else:
+
+| you have | you write |
+|---|---|
+| a TeX literal | nothing; `&'static str` converts implicitly (~125 sites untouched) |
+| a `Tokens` | `t.untex_string()` |
+| a `format!` of literal TeX around safe pieces | `TeXString::assembled(…)`, whose doc names the obligation |
+
+`s!(…)` returns `String` and `&some_var` is a short-lived borrow, so neither
+coerces: a welded flatten fails to compile (E0277) or fails the borrow check
+(E0521 "`'1` must outlive `'static`"). **Do not add `From<String>`.**
+
+**Not every flatten is a weld** — the audit matters. A string that becomes a CS
+*name* (`T_CS!(cs.to_string())`), an `ExplodeText!` char run, a `.parse()`, or a
+comparison cannot weld, and those keep `to_string()`. So does `Display for
+Tokens` itself: 500+ sites use it for keys and names, and making it TeX-correct
+would silently change all of them.
+
+**Method — census a call site family without breaking the build.** Replace/shadow
+the trait method with a *deprecated inherent* one (`impl Tokens { #[deprecated]
+pub fn to_string(&self) }`): an inherent method wins over `ToString`, so every
+call site warns while `format!("{t}")` stays silent. Collect the warnings
+workspace-wide, classify, then remove the shim. Measured 547 sites, of which 18
+reached a TeX-source sink and 6 could weld.
+
+Guards: `tokens::texstring_guard_tests` (compile-time — `String`/`&String` must
+NOT be `Into<TeXString>`, `&'static str` must be; plus a `compile_fail`
+doctest), `bib_name_space_form_accent_survives_reversion`,
+`bib_mr_reviewer_accent_survives_reversion`. Related: [[#70]] (the same
+"withhold the operation and the class disappears" shape).

--- a/latexml_codegen/src/tokenizeable.rs
+++ b/latexml_codegen/src/tokenizeable.rs
@@ -1,4 +1,7 @@
-use latexml_core::{mouth, tokens::Tokens};
+use latexml_core::{
+  mouth,
+  tokens::{TeXString, Tokens},
+};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::DeriveInput;
@@ -11,7 +14,10 @@ pub fn compile_expansion(input: DeriveInput) -> TokenStream {
   let compiled_expansion = if expansion.is_empty() {
     quote!(None)
   } else {
-    let performed_expansion = mouth::tokenize_internal(&expansion);
+    // `assembled` is exact here: this string IS the source literal, recovered
+    // from the derive attribute at compile time. It just cannot be typed
+    // `&'static str` because `syn` hands it back owned.
+    let performed_expansion = mouth::tokenize_internal(TeXString::assembled(expansion));
     if performed_expansion.is_empty() {
       quote!(None)
     } else {
@@ -47,7 +53,8 @@ pub fn compile_tokenize(input: DeriveInput) -> TokenStream {
   let tokenized = if literal.is_empty() {
     Tokens::default()
   } else {
-    mouth::tokenize(&literal)
+    // The source literal, recovered from the derive attribute — see above.
+    mouth::tokenize(TeXString::assembled(literal))
   };
   quote!(
     macro_rules! these_tokens {
@@ -63,7 +70,8 @@ pub fn compile_tokenize_internal(input: DeriveInput) -> TokenStream {
   let tokenized = if literal.is_empty() {
     Tokens::default()
   } else {
-    mouth::tokenize_internal(&literal)
+    // The source literal, recovered from the derive attribute — see above.
+    mouth::tokenize_internal(TeXString::assembled(literal))
   };
 
   quote!(

--- a/latexml_contrib/src/catchfile_sty.rs
+++ b/latexml_contrib/src/catchfile_sty.rs
@@ -27,7 +27,7 @@ LoadDefinitions!({
       .and_then(|disk| std::fs::read(&disk).ok())
       .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
       .unwrap_or_default();
-    let tokens = mouth::tokenize_internal(&body);
+    let tokens = mouth::tokenize_internal(TeXString::assembled(body));
     def_macro(target, None, tokens, None)?;
     Ok(())
   });

--- a/latexml_contrib/src/fontawesome5_sty.rs
+++ b/latexml_contrib/src/fontawesome5_sty.rs
@@ -18,7 +18,7 @@ use latexml_package::prelude::*;
 fn def_fa5_icon(suffix: &str, kebab: &str) -> Result<()> {
   let proto = format!("\\fa{suffix}[]");
   let (cs, params) = parse_prototype(&proto, true)?;
-  let body = mouth::tokenize_internal(&format!("\\faIcon[#1]{{{kebab}}}"));
+  let body = mouth::tokenize_internal(TeXString::assembled(format!("\\faIcon[#1]{{{kebab}}}")));
   def_macro(cs, params, ExpansionBody::Tokens(body), None)?;
   Ok(())
 }

--- a/latexml_contrib/src/fontawesome_sty.rs
+++ b/latexml_contrib/src/fontawesome_sty.rs
@@ -9,7 +9,9 @@ use latexml_package::prelude::*;
 fn def_fa4_icon(suffix: &str) -> Result<()> {
   let proto = format!("\\fa{suffix}");
   let (cs, params) = parse_prototype(&proto, true)?;
-  let body = mouth::tokenize_internal(&format!("\\faIconFromMacro{{fa{suffix}}}"));
+  let body = mouth::tokenize_internal(TeXString::assembled(format!(
+    "\\faIconFromMacro{{fa{suffix}}}"
+  )));
   def_macro(cs, params, ExpansionBody::Tokens(body), None)?;
   Ok(())
 }

--- a/latexml_contrib/src/script_bindings/engine.rs
+++ b/latexml_contrib/src/script_bindings/engine.rs
@@ -108,9 +108,14 @@ pub(super) fn make_engine() -> Engine {
   // `Tokens` is registered as an opaque pass-through handle (Tier-2): a script
   // produces it with Tokenize and hands it to Digest without inspecting it.
   engine.register_type_with_name::<Tokens>("Tokens");
-  engine.register_fn("Tokenize", |s: &str| -> Tokens { mouth::tokenize(s) });
+  // `assembled`: the argument is TeX the script author wrote — the runtime twin
+  // of a `Tokenize!("…")` literal. A script cannot hand us a flattened `Tokens`
+  // (Rhai `Tokens` is opaque and has no string conversion registered).
+  engine.register_fn("Tokenize", |s: &str| -> Tokens {
+    mouth::tokenize(TeXString::assembled(s.to_string()))
+  });
   engine.register_fn("TokenizeInternal", |s: &str| -> Tokens {
-    mouth::tokenize_internal(s)
+    mouth::tokenize_internal(TeXString::assembled(s.to_string()))
   });
   // `Digest` returns the digested handle (Perl returns the digested box), so a
   // script can `ToString(Digest(...))` — e.g. a default-option handler reading
@@ -245,7 +250,10 @@ pub(super) fn make_engine() -> Engine {
   engine.register_fn(
     "TeX",
     |text: &str| -> std::result::Result<(), Box<EvalAltResult>> {
-      latexml_core::stomach::digest(mouth::tokenize_internal(text)).map_err(rhai_err)?;
+      latexml_core::stomach::digest(mouth::tokenize_internal(TeXString::assembled(
+        text.to_string(),
+      )))
+      .map_err(rhai_err)?;
       Ok(())
     },
   );
@@ -267,7 +275,10 @@ pub(super) fn make_engine() -> Engine {
   engine.register_fn(
     "DigestText",
     |s: &str| -> std::result::Result<Digested, Box<EvalAltResult>> {
-      latexml_core::binding::content::digest_text(mouth::tokenize_internal(s)).map_err(rhai_err)
+      latexml_core::binding::content::digest_text(mouth::tokenize_internal(TeXString::assembled(
+        s.to_string(),
+      )))
+      .map_err(rhai_err)
     },
   );
   // ToString/ToAttribute/Revert on a Digested handle (Perl ToString/Revert).
@@ -875,9 +886,11 @@ pub(super) fn make_engine() -> Engine {
   engine.register_fn(
     "ReadUntil",
     |delim: &str| -> std::result::Result<String, Box<EvalAltResult>> {
-      latexml_core::gullet::read_until(&mouth::tokenize_internal(delim))
-        .map(|t| t.untex())
-        .map_err(rhai_err)
+      latexml_core::gullet::read_until(&mouth::tokenize_internal(TeXString::assembled(
+        delim.to_string(),
+      )))
+      .map(|t| t.untex())
+      .map_err(rhai_err)
     },
   );
   // ReadOptional: a bracketed [..] optional ("" when absent).

--- a/latexml_contrib/src/script_bindings/mod.rs
+++ b/latexml_contrib/src/script_bindings/mod.rs
@@ -65,7 +65,7 @@ use latexml_core::{
   mouth,
   state::Scope,
   token::{Catcode, Token},
-  tokens::Tokens,
+  tokens::{TeXString, Tokens},
   whatsit::Whatsit,
 };
 // `Error!` expands a `Fatal!`/`fatal!` arm (too-many-errors escalation); the

--- a/latexml_contrib/src/script_bindings/wire.rs
+++ b/latexml_contrib/src/script_bindings/wire.rs
@@ -57,7 +57,9 @@ pub(super) fn wire_macro(
       Ok(v) => v,
       Err(e) => return contain(&format!("macro {cs_name}"), e, Tokens::default()),
     };
-    Ok(mouth::tokenize_internal(&dynamic_to_string(ret)))
+    Ok(mouth::tokenize_internal(TeXString::assembled(
+      dynamic_to_string(ret),
+    )))
   });
 
   def_macro(cs, paramlist, ExpansionBody::Closure(closure), None)?;
@@ -73,7 +75,9 @@ pub(super) fn wire_macro_string(proto: &str, body: &str) -> Result<()> {
   def_macro(
     cs,
     paramlist,
-    ExpansionBody::Tokens(mouth::tokenize_internal(body)),
+    ExpansionBody::Tokens(mouth::tokenize_internal(TeXString::assembled(
+      body.to_string(),
+    ))),
     None,
   )?;
   Ok(())
@@ -87,7 +91,9 @@ pub(super) fn wire_macro_string_opts(proto: &str, body: &str, opts: Map) -> Resu
   def_macro(
     cs,
     paramlist,
-    ExpansionBody::Tokens(mouth::tokenize_internal(body)),
+    ExpansionBody::Tokens(mouth::tokenize_internal(TeXString::assembled(
+      body.to_string(),
+    ))),
     Some(expandable_options_from_map(opts)),
   )?;
   Ok(())
@@ -316,7 +322,7 @@ pub(super) fn apply_opts<B: BindingBuilder>(
         } else if key.as_str() == "reversion" {
           // String reversion (`reversion => "\\begin{x}#1\\end{x}"`, "" disables).
           builder = builder.reversion(Reversion::Tokens(mouth::tokenize_internal(
-            &dynamic_to_string(val),
+            TeXString::assembled(dynamic_to_string(val)),
           )));
         } else if key.as_str() == "font" && val.is_map() {
           // Partial-font directive (`font => { family => 'typewriter', … }`).
@@ -662,7 +668,9 @@ pub(super) fn wire_macro_opts(
     let dyn_args: Vec<Dynamic> = args.into_iter().map(arg_to_dynamic).collect();
     let ret: Dynamic = call_deferred_body(&engine, &ast, &body, dyn_args)
       .or_else(|e| contain(&format!("macro {cs_name}"), e, Dynamic::UNIT))?;
-    Ok(mouth::tokenize_internal(&dynamic_to_string(ret)))
+    Ok(mouth::tokenize_internal(TeXString::assembled(
+      dynamic_to_string(ret),
+    )))
   });
   def_macro(
     cs,
@@ -788,7 +796,9 @@ pub(super) fn wire_columntype(
     let dyn_args: Vec<Dynamic> = args.into_iter().map(arg_to_dynamic).collect();
     let ret: Dynamic = call_deferred_body(&engine, &ast, &body, dyn_args)
       .or_else(|e| contain(&format!("column type {cs_name}"), e, Dynamic::UNIT))?;
-    Ok(mouth::tokenize_internal(&dynamic_to_string(ret)))
+    Ok(mouth::tokenize_internal(TeXString::assembled(
+      dynamic_to_string(ret),
+    )))
   });
   def_macro(cs, paramlist, ExpansionBody::Closure(closure), None)?;
   Ok(())
@@ -875,7 +885,9 @@ pub(super) fn wire_option_string(opt: &str, body: &str) -> Result<()> {
   def_macro(
     latexml_core::T_CS!(format!("\\ds@{opt}")),
     None,
-    ExpansionBody::Tokens(mouth::tokenize_internal(body)),
+    ExpansionBody::Tokens(mouth::tokenize_internal(TeXString::assembled(
+      body.to_string(),
+    ))),
     None,
   )?;
   Ok(())
@@ -1013,7 +1025,9 @@ pub(super) fn reversion_trampoline(
         .collect();
       let ret = call_deferred_body(&engine, &ast, &fp, dyn_args)
         .or_else(|e| contain("reversion", e, Dynamic::UNIT))?;
-      Ok(mouth::tokenize_internal(&dynamic_to_string(ret)))
+      Ok(mouth::tokenize_internal(TeXString::assembled(
+        dynamic_to_string(ret),
+      )))
     },
   )
 }
@@ -1175,7 +1189,11 @@ fn parse_rewrite_options(kind: &str, opts: Map) -> latexml_core::rewrite::Rewrit
         }
       },
       "regexp" => o.regexp = Some(dynamic_to_string(val)),
-      "match" => o.on_match = Some(mouth::tokenize_internal(&dynamic_to_string(val))),
+      "match" => {
+        o.on_match = Some(mouth::tokenize_internal(TeXString::assembled(
+          dynamic_to_string(val),
+        )))
+      },
       "scope" => o.scope = scope_of(&dynamic_to_string(val)),
       _ => {},
     }

--- a/latexml_contrib/src/tabularray_sty.rs
+++ b/latexml_contrib/src/tabularray_sty.rs
@@ -335,7 +335,7 @@ LoadDefinitions!({
   DefMacro!("\\tblr []{}", sub[(_outer, inner)] {
     let inner_str = inner.to_string();
     let cols = translate_tblr_colspec(&inner_str).unwrap_or(inner_str);
-    Ok(Tokenize!(&format!("\\tabular{{{cols}}}")))
+    Ok(Tokenize!(TeXString::assembled(format!("\\tabular{{{cols}}}"))))
   });
   DefMacro!("\\endtblr", "\\endtabular");
   DefMacro!("\\booktabs", "\\tabular");

--- a/latexml_core/src/binding/content.rs
+++ b/latexml_core/src/binding/content.rs
@@ -28,7 +28,7 @@ use crate::{
   state::{let_i, *},
   stomach::*,
   token::*,
-  tokens::Tokens,
+  tokens::{TeXString, Tokens},
   util::pathname::{self, PathnameFindOptions},
 };
 
@@ -2973,7 +2973,7 @@ pub fn def_color(
   def_macro(
     T_CS!(s!("\\\\color@{name}")),
     None,
-    crate::mouth::tokenize_internal(&model_spec),
+    crate::mouth::tokenize_internal(TeXString::assembled(model_spec)),
     Some(ExpandableOptions {
       scope: effective_scope,
       ..Default::default()
@@ -3106,8 +3106,12 @@ pub fn build_invocation<T: Into<Token>>(token: T, args: Vec<Option<Tokens>>) -> 
 /// token, this reduces to `build_invocation` on that token. Otherwise the tokens are
 /// treated as an "anonymous macro" containing parameter markers like `#1`, and the
 /// arguments are substituted in.
-pub fn build_invocation_str(spec: &str, args: Vec<Option<Tokens>>) -> Result<Tokens> {
-  let tokens = crate::mouth::tokenize_internal(spec);
+pub fn build_invocation_str(
+  spec: impl Into<TeXString>,
+  args: Vec<Option<Tokens>>,
+) -> Result<Tokens> {
+  let spec = spec.into();
+  let tokens = crate::mouth::tokenize_internal(spec.clone());
   let mut list = tokens.unlist();
   if list.len() > 1 {
     // Treat as anonymous macro

--- a/latexml_core/src/binding/counter/dialect.rs
+++ b/latexml_core/src/binding/counter/dialect.rs
@@ -28,7 +28,7 @@ use crate::{
   state::*,
   stomach,
   token::*,
-  tokens::Tokens,
+  tokens::{TeXString, Tokens},
   whatsit::Whatsit,
 };
 
@@ -230,13 +230,13 @@ pub fn new_counter(ctr: &str, within: &str, options_opt: Option<NewCounterOption
           // semantics — `create_xmrefs`/`get_xmarg_id`). Witness
           // math0402448 (plain TeX + 3464 formulae): "Conversion failed:
           // 1 fatal error" with no Fatal: line in the log.
-          Ok(mouth::tokenize_internal(&s!(
+          Ok(mouth::tokenize_internal(TeXString::assembled(s!(
             "\\expandafter\\ifx\\csname the{}@ID\\endcsname\\lx@empty\\else\\csname the{}@ID\\endcsname.\\fi {}\\csname @{}@ID\\endcsname",
             idwithin,
             idwithin,
             prefix,
             ctr_string
-          )))
+          ))))
         }))),
         Some(ExpandableOptions {
           scope: Some(Scope::Global),
@@ -248,9 +248,9 @@ pub fn new_counter(ctr: &str, within: &str, options_opt: Option<NewCounterOption
         T_CS!(thectrid),
         None,
         Some(ExpansionBody::Closure(Rc::new(move |_args| {
-          Ok(mouth::tokenize_internal(&s!(
+          Ok(mouth::tokenize_internal(TeXString::assembled(s!(
             "{prefix}\\csname @{ctr_string}@ID\\endcsname",
-          )))
+          ))))
         }))),
         Some(ExpandableOptions {
           scope: Some(Scope::Global),
@@ -833,7 +833,7 @@ pub fn begin_itemize(
     def_macro(
       T_CS!(thectr),
       None,
-      mouth::tokenize_internal(&theexpansion),
+      mouth::tokenize_internal(TeXString::assembled(theexpansion)),
       None,
     )?;
 

--- a/latexml_core/src/binding/def/dialect.rs
+++ b/latexml_core/src/binding/def/dialect.rs
@@ -33,7 +33,7 @@ use crate::{
   stomach::*,
   tbox::Tbox,
   token::*,
-  tokens::Tokens,
+  tokens::{TeXString, Tokens},
   whatsit::Whatsit,
 };
 
@@ -475,7 +475,7 @@ pub fn def_math_dual(
   } else {
     cs
   };
-  let presentation_toks = mouth::tokenize_internal(&presentation);
+  let presentation_toks = mouth::tokenize_internal(TeXString::assembled(presentation.clone()));
 
   // Make the original CS expand into a DUAL invoking a presentation macro and content constructor
   let captured_role = options.role.clone();

--- a/latexml_core/src/binding/def/traits.rs
+++ b/latexml_core/src/binding/def/traits.rs
@@ -12,6 +12,7 @@ use crate::{
   list::List,
   state::{Scope, lookup_font},
   token::*,
+  tokens::TeXString,
   whatsit::Whatsit,
   *,
 };
@@ -78,7 +79,12 @@ impl IntoOption<Option<Reversion>> for &str {
       Some(Reversion::Tokens(Tokens!()))
     } else {
       Some(Reversion::Tokens(
-        mouth::tokenize_internal(self)
+        // `assembled`, not the literal `From<&'static str>`: this impl is on
+        // plain `&str`, so the lifetime is unknown here. See the note on
+        // `From<&str> for Reversion` in `definition.rs` — these `&str`
+        // conversion helpers are the residual way a `String` can still reach
+        // the tokenizer without saying so.
+        mouth::tokenize_internal(TeXString::assembled(self.to_string()))
           .pack_parameters()
           .ok()
           .unwrap(),

--- a/latexml_core/src/common/def_parser.rs
+++ b/latexml_core/src/common/def_parser.rs
@@ -10,7 +10,7 @@ use crate::{
   parameter::{Parameter, Parameters},
   pin,
   token::*,
-  tokens::Tokens,
+  tokens::{TeXString, Tokens},
 };
 
 static CSNAME_MACRO_RE: Lazy<Regex> =
@@ -59,9 +59,11 @@ pub fn parse_prototype(proto: &str, init_flag: bool) -> Result<(Token, Option<Pa
     SINGLE_CHAR_RE.replace(proto, "")
   } else if let Some(captures) = ACTIVE_CHAR_RE.captures(proto) {
     // Match an active char
-    cs = mouth::tokenize_internal(captures.get(1).map_or("", |m| m.as_str()))
-      .unlist()
-      .remove(0);
+    cs = mouth::tokenize_internal(TeXString::assembled(
+      captures.get(1).map_or("", |m| m.as_str()).to_string(),
+    ))
+    .unlist()
+    .remove(0);
     // also replace in proto
     ACTIVE_CHAR_RE.replace(proto, "")
   } else {
@@ -168,7 +170,9 @@ pub fn parse_parameters(
               let extra = if default_str.is_empty() {
                 vec![]
               } else {
-                vec![mouth::tokenize_internal(default_str)]
+                vec![mouth::tokenize_internal(TeXString::assembled(
+                  default_str.to_string(),
+                ))]
               };
               Parameter {
                 name: pin!("Optional"),
@@ -208,7 +212,11 @@ pub fn parse_parameters(
                   None | Some("") => Vec::new(),
                   Some(extra_str) => extra_str
                     .split('|')
-                    .map(|t| Tokens::new(mouth::tokenize_internal(t).unlist()))
+                    .map(|t| {
+                      Tokens::new(
+                        mouth::tokenize_internal(TeXString::assembled(t.to_string())).unlist(),
+                      )
+                    })
                     .collect(),
                 };
                 Parameter {

--- a/latexml_core/src/common/float.rs
+++ b/latexml_core/src/common/float.rs
@@ -7,7 +7,7 @@ use crate::{
   common::{error::Result, numeric_ops::NumericOps, object::Object},
   definition::register::RegisterType,
   mouth,
-  tokens::Tokens,
+  tokens::{TeXString, Tokens},
 };
 
 static TRAILING_ZEROS: Lazy<Regex> = Lazy::new(|| Regex::new(r"0+$").unwrap());
@@ -57,7 +57,7 @@ impl NumericOps for Float {
 }
 
 impl From<Float> for Tokens {
-  fn from(v: Float) -> Tokens { mouth::tokenize_internal(&v.to_string()) }
+  fn from(v: Float) -> Tokens { mouth::tokenize_internal(TeXString::assembled(v.to_string())) }
 }
 
 impl From<Float> for Option<Tokens> {

--- a/latexml_core/src/common/number.rs
+++ b/latexml_core/src/common/number.rs
@@ -7,7 +7,7 @@ use crate::{
   digested::Digested,
   mouth,
   token::Catcode,
-  tokens::Tokens,
+  tokens::{TeXString, Tokens},
 };
 
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
@@ -29,7 +29,7 @@ impl Number {
 }
 
 impl From<Number> for Tokens {
-  fn from(v: Number) -> Tokens { mouth::tokenize_internal(&v.0.to_string()) }
+  fn from(v: Number) -> Tokens { mouth::tokenize_internal(TeXString::assembled(v.0.to_string())) }
 }
 
 impl From<Number> for Option<Tokens> {

--- a/latexml_core/src/common/store.rs
+++ b/latexml_core/src/common/store.rs
@@ -39,7 +39,7 @@ use crate::{
   rewrite::Rewrite,
   state::StashTable,
   token::{Catcode, Token},
-  tokens::Tokens,
+  tokens::{TeXString, Tokens},
 };
 
 const STORED_TRUE: Stored = Stored::Bool(true);
@@ -1088,7 +1088,9 @@ impl<'a> From<&'a Stored> for Option<Glue> {
 impl From<Stored> for Option<Tokens> {
   fn from(value: Stored) -> Option<Tokens> {
     match value {
-      Stored::String(sym) => Some(mouth::tokenize_internal(&arena::to_string(sym))),
+      Stored::String(sym) => Some(mouth::tokenize_internal(TeXString::assembled(
+        arena::to_string(sym),
+      ))),
       Stored::Token(ts) => Some(Tokens::new(vec![ts])),
       Stored::Tokens(ts) => Some(ts),
       // Digested: revert to tokens (needed for \AtBeginDocument hooks that

--- a/latexml_core/src/definition.rs
+++ b/latexml_core/src/definition.rs
@@ -32,7 +32,7 @@ use crate::{
   parameter::Parameters,
   state::{Scope, expire_state_unlocked, local_state_unlocked},
   token::Token,
-  tokens::{NO_TOKENS, Tokens},
+  tokens::{NO_TOKENS, TeXString, Tokens},
   whatsit::Whatsit,
 };
 
@@ -132,9 +132,20 @@ impl PartialEq for Reversion {
   }
 }
 
+/// NOTE (`TeXString` guard): this and `From<&str> for ExpansionBody` below are
+/// the residual back doors into the tokenizer — a `String` reaches them as
+/// `s.as_str()` without ever naming its intent. They stay on plain `&str`
+/// because narrowing them to `&'static str` would reject the many legitimate
+/// runtime-built bodies. Anything that flattens `Tokens` must still go through
+/// [`Tokens::untex_string`](crate::tokens::Tokens::untex_string) before it gets
+/// here.
 impl From<&str> for Reversion {
   fn from(t: &str) -> Reversion {
-    Reversion::Tokens(mouth::tokenize_internal(t).pack_parameters().unwrap())
+    Reversion::Tokens(
+      mouth::tokenize_internal(TeXString::assembled(t.to_string()))
+        .pack_parameters()
+        .unwrap(),
+    )
   }
 }
 impl From<Tokens> for Reversion {
@@ -158,7 +169,9 @@ impl From<Tokens> for Option<ExpansionBody> {
 }
 
 impl From<&str> for ExpansionBody {
-  fn from(s: &str) -> ExpansionBody { mouth::tokenize_internal(s).into() }
+  fn from(s: &str) -> ExpansionBody {
+    mouth::tokenize_internal(TeXString::assembled(s.to_string())).into()
+  }
 }
 
 impl From<String> for ExpansionBody {

--- a/latexml_core/src/keyval.rs
+++ b/latexml_core/src/keyval.rs
@@ -16,7 +16,7 @@ use crate::{
   parameter::Parameter,
   state,
   token::{Catcode, Token},
-  tokens::Tokens,
+  tokens::{TeXString, Tokens},
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -97,9 +97,9 @@ pub fn disable_keyval(prefix: &str, keyset: &str, key: &str) -> Result<()> {
   // disable the key
   define_ordinary(
     &qname,
-    Some(ExpansionBody::Tokens(tokenize(&s!(
+    Some(ExpansionBody::Tokens(tokenize(TeXString::assembled(s!(
       "\\PackageWarning{{keyval}}{{`{key}' has been disabled. }}"
-    )))),
+    ))))),
   )
 }
 
@@ -257,14 +257,29 @@ pub fn define(options: KeyvalConfig) -> Result<()> {
   // store metadata for introspection (used by \xkvview)
   // only register when xkvview tracking is enabled
   if state::lookup_bool("XKVVIEW_TRACKING") {
+    // `assembled`: these four are bare identifiers (a key/keyset/prefix name),
+    // not markup — nothing to weld — but they arrive as borrowed `&str`.
+    let identifier = |s: &str| TeXString::assembled(s.to_string());
     keyval_set(
       &qname,
       "kind",
-      Stored::Tokens(tokenize(kind.unwrap_or("ordinary"))),
+      Stored::Tokens(tokenize(identifier(kind.unwrap_or("ordinary")))),
     );
-    keyval_set(&qname, "keyval_prefix", Stored::Tokens(tokenize(prefix)));
-    keyval_set(&qname, "keyset", Stored::Tokens(tokenize(keyset)));
-    keyval_set(&qname, "key_name", Stored::Tokens(tokenize(key)));
+    keyval_set(
+      &qname,
+      "keyval_prefix",
+      Stored::Tokens(tokenize(identifier(prefix))),
+    );
+    keyval_set(
+      &qname,
+      "keyset",
+      Stored::Tokens(tokenize(identifier(keyset))),
+    );
+    keyval_set(
+      &qname,
+      "key_name",
+      Stored::Tokens(tokenize(identifier(key))),
+    );
     register_keyval(&qname);
   }
   // set the type
@@ -301,7 +316,7 @@ pub fn define(options: KeyvalConfig) -> Result<()> {
   // set the default
   // Question: Why was $default converted ToString ???
   if let Some(default_str) = default {
-    let default_tks = tokenize(default_str);
+    let default_tks = tokenize(TeXString::assembled(default_str.to_string()));
     keyval_set(&qname, "default", Stored::Tokens(default_tks.clone()));
     def_macro(
       T_CS!(s!("\\{qname}@default")),

--- a/latexml_core/src/mouth.rs
+++ b/latexml_core/src/mouth.rs
@@ -18,7 +18,7 @@ use crate::{
   common::{error::*, locator::Locator, numeric_ops::NumericOps, object::Object},
   state::*,
   token::*,
-  tokens::{NO_TOKENS, Tokens},
+  tokens::{NO_TOKENS, TeXString, Tokens},
   util::pathname,
 };
 
@@ -1170,13 +1170,20 @@ impl Mouth {
 ///
 /// See [`tokenize_internal`] for the `.sty`-style table that treats `@` as a
 /// letter.
-pub fn tokenize(text: &str) -> Tokens {
+///
+/// The argument is an `impl Into<`[`TeXString`]`>`, not a `&str`: a string
+/// literal converts implicitly, but a `String` — the shape a control-word-welding
+/// `Tokens::to_string()` arrives in — must declare itself via
+/// [`Tokens::untex_string`] or [`TeXString::assembled`]. See the [`TeXString`]
+/// docs for why.
+pub fn tokenize(text: impl Into<TeXString>) -> Tokens {
+  let text = text.into();
   // special case! empty input is empty Tokens
   if text.is_empty() {
     return NO_TOKENS;
   }
   use_std_state();
-  let result = Mouth::new(text, None).unwrap().read_tokens();
+  let result = Mouth::new(text.as_str(), None).unwrap().read_tokens();
   use_main_state();
   result
 }
@@ -1194,13 +1201,18 @@ pub fn tokenize(text: &str) -> Tokens {
 /// This exists because the handlers that re-read a raw field — `\bib@@title`
 /// recasing, name splitting, date/pages assembly — build their tokens from the
 /// stored string and never pass through the per-entry mouth.
-pub fn tokenize_bib_literal(text: &str) -> Tokens {
+///
+/// Takes an `impl Into<`[`TeXString`]`>` for the same reason as [`tokenize`] —
+/// and it is the sink that most needs it: the bibliography is where the
+/// control-word weld has surfaced three times (PR #399, PR #400, issue 410).
+pub fn tokenize_bib_literal(text: impl Into<TeXString>) -> Tokens {
+  let text = text.into();
   // special case! empty input is empty Tokens
   if text.is_empty() {
     return NO_TOKENS;
   }
   use_std_state();
-  let result = Mouth::new(text, None)
+  let result = Mouth::new(text.as_str(), None)
     .unwrap()
     .with_bib_data_literals()
     .read_tokens();
@@ -1215,13 +1227,16 @@ pub fn tokenize_bib_literal(text: &str) -> Tokens {
 /// internal control sequences (`\@ifnextchar`, `\@currentlabel`, …) tokenize as
 /// single names. This is the right choice for a macro body a binding writes
 /// itself, and the wrong one for text that came from the document.
-pub fn tokenize_internal(text: &str) -> Tokens {
+///
+/// Takes an `impl Into<`[`TeXString`]`>` for the same reason as [`tokenize`].
+pub fn tokenize_internal(text: impl Into<TeXString>) -> Tokens {
+  let text = text.into();
   // special case! empty input is empty Tokens
   if text.is_empty() {
     return NO_TOKENS;
   }
   use_sty_state();
-  let result = Mouth::new(text, None).unwrap().read_tokens();
+  let result = Mouth::new(text.as_str(), None).unwrap().read_tokens();
   use_main_state();
   result
 }

--- a/latexml_core/src/state.rs
+++ b/latexml_core/src/state.rs
@@ -39,7 +39,7 @@ use crate::{
   document::{resource::Resource, tag::TagOptions},
   gullet, mouth, pin,
   token::{Catcode, Token},
-  tokens::Tokens,
+  tokens::{TeXString, Tokens},
   util::pathname,
 };
 
@@ -1714,12 +1714,18 @@ pub fn lookup_tokens(key: &str) -> Option<Tokens> {
     Some(Stored::Tokens(v)) => Some(v.clone()),
     Some(Stored::Token(v)) => Some(Tokens::new(vec![*v])),
     Some(Stored::String(sym)) => {
-      // Release the state borrow first, then pass the interned &str directly
-      // into tokenize_internal via the re-entrant arena — avoids materializing
-      // an owned String just to tokenize.
+      // Release the state borrow first, then read the interned string through
+      // the re-entrant arena. The copy is unavoidable: an arena `&str` is not
+      // `'static` (it dangles across a realloc — see WISDOM), and `TeXString`
+      // borrows only `'static`, so the value has to be owned to cross into the
+      // tokenizer. `Mouth::new` copies its input anyway.
       let sym = *sym;
       drop(state);
-      arena::with(sym, |astr| Some(mouth::tokenize_internal(astr)))
+      arena::with(sym, |astr| {
+        Some(mouth::tokenize_internal(TeXString::assembled(
+          astr.to_string(),
+        )))
+      })
     },
     Some(Stored::VecDequeStored(v)) => {
       // Reverting the queue to Tokens routes each String item through
@@ -1873,7 +1879,7 @@ pub fn lookup_dimension_cs(cs: &str, noerror: bool) -> Option<Dimension> {
   if obvious && let Ok(d) = Dimension::from_str(cs) {
     return Some(d);
   }
-  let tokens = mouth::tokenize_internal(cs);
+  let tokens = mouth::tokenize_internal(TeXString::assembled(cs.to_string()));
   let toks = tokens.unlist();
   if toks.len() == 1 {
     match lookup_definition(&toks[0]) {

--- a/latexml_core/src/tokens.rs
+++ b/latexml_core/src/tokens.rs
@@ -151,6 +151,102 @@ impl AsRef<Tokens> for Tokens {
   fn as_ref(&self) -> &Tokens { self }
 }
 
+/// A string of **TeX markup** — text that is safe to hand back to the tokenizer.
+///
+/// It is *not* a path and *not* an input `.tex` file (`source_directory`,
+/// `--source-map` and `docs/performance/SOURCE_PROVENANCE.md` own that sense of
+/// "source"); it is the character content a [`crate::mouth::Mouth`] will read.
+///
+/// # Why the type exists
+///
+/// Flattening [`struct@Tokens`] with [`Display`] **welds control words**. TeX consumes
+/// the space that terminates a control word, so `\v S` tokenizes to `[\v][S]`;
+/// re-emitting that with `Display` gives `\vS`, a control sequence that exists in
+/// no LaTeX. [`Tokens::untex`] re-emits the space, `Display` deliberately does
+/// not — this is faithful to Perl (`Core/Tokens.pm:61 toString` joins the token
+/// strings, and `Core/Token.pm:306` returns a CS name with no trailing space),
+/// whose own comment says the result is "NOT for creating valid TeX (use revert
+/// or UnTeX for that!)".
+///
+/// Perl relies on author discipline there. It has failed three times in this
+/// port — `\bib@@names` (PR #399), `dcolumn`/`overpic` (PR #400), and the
+/// MathSciNet review path (issue 410: `MRREVIEWER = {Fran\c cois\ Digne}` became
+/// `undefined:\ccois`) — each found by a user-visible failure years after the
+/// code was written. `TeXString` makes the mistake unrepresentable instead: the
+/// tokenizing sinks take `impl Into<TeXString>`, and a bare `String` has no way
+/// in.
+///
+/// # The three ways in
+///
+/// * `From<&'static str>` — a string *literal* in a binding is TeX its author
+///   typed by hand, so it converts implicitly and the ~125 literal call sites
+///   stay untouched. There is deliberately **no** `From<String>` and **no**
+///   `From<&str>`: those are exactly the shapes a welded `Tokens::to_string()`
+///   arrives in, and `s!(…)`/`format!(…)` returns the former.
+/// * [`Tokens::untex_string`] — the blessed path from `Tokens`.
+/// * [`TeXString::assembled`] — the explicit escape hatch, for a `format!` of
+///   literal TeX around already-safe pieces. It names the obligation it imposes.
+///
+/// ```
+/// # use latexml_core::tokens::TeXString;
+/// let s: TeXString = r"\relax".into(); // literal: implicit
+/// assert_eq!(s.as_str(), r"\relax");
+/// ```
+///
+/// A `String` cannot get in on its own — this is the guard, and it bites:
+///
+/// ```compile_fail
+/// # use latexml_core::tokens::TeXString;
+/// let welded: String = String::from(r"\vS");
+/// let _: TeXString = welded.into(); // no `From<String>`: does not compile
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub struct TeXString(Cow<'static, str>);
+
+impl TeXString {
+  /// Assert that an owned `String` is valid TeX markup.
+  ///
+  /// **The caller's obligation**: every interpolated fragment must be either
+  /// literal TeX written at the call site, or a fragment that came from
+  /// [`Tokens::untex_string`] / another `TeXString`. It must **not** be a bare
+  /// `Tokens::to_string()` — that is the welding bug this type exists to
+  /// prevent (`\v S` → `\vS`); use [`Tokens::untex_string`] for those.
+  ///
+  /// The typical honest use is a `format!` whose *shape* is literal TeX:
+  ///
+  /// ```
+  /// # use latexml_core::tokens::TeXString;
+  /// let counter = "section";
+  /// let tex = TeXString::assembled(format!(r"\the{counter}"));
+  /// assert_eq!(tex.as_str(), r"\thesection");
+  /// ```
+  pub fn assembled(tex: String) -> Self { TeXString(Cow::Owned(tex)) }
+
+  /// The TeX markup, borrowed.
+  pub fn as_str(&self) -> &str { &self.0 }
+
+  /// The TeX markup, owned (allocates only when this was built from a literal).
+  pub fn into_string(self) -> String { self.0.into_owned() }
+
+  /// Is there any markup at all?
+  pub fn is_empty(&self) -> bool { self.0.is_empty() }
+}
+
+impl From<&'static str> for TeXString {
+  /// A `&'static str` in a binding is a TeX literal its author typed by hand.
+  ///
+  /// Deliberately the *only* blanket string conversion — see the type docs.
+  fn from(tex: &'static str) -> Self { TeXString(Cow::Borrowed(tex)) }
+}
+
+impl Display for TeXString {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { f.write_str(&self.0) }
+}
+
+impl AsRef<str> for TeXString {
+  fn as_ref(&self) -> &str { &self.0 }
+}
+
 impl Tokens {
   /// Create a Tokens object from a `Vec` of individual `Token`
   pub fn new(tokens: Vec<Token>) -> Self { Tokens(tokens) }
@@ -526,6 +622,17 @@ impl Tokens {
     tex_string
   }
 
+  /// [`untex`](Tokens::untex), typed — the blessed way to get TeX markup out of
+  /// a `Tokens` and back into a tokenizing sink.
+  ///
+  /// Prefer this over `untex()` whenever the string is destined for
+  /// `Tokenize!` / `mouth::tokenize` / `mouth::tokenize_internal`: it is the
+  /// only [`struct@Tokens`]→[`TeXString`] conversion, so the sink's signature proves
+  /// the round trip cannot weld a control word (`\v S` stays `\v S`, not
+  /// `\vS`). `untex()` itself is unchanged for the callers that want a plain
+  /// `String` (a `tex=` attribute, a log message, a comparison).
+  pub fn untex_string(self) -> TeXString { TeXString::assembled(self.untex()) }
+
   /// Packs repeated CC_PARAM tokens into CC_ARG tokens for use as a macro body (and other token
   /// lists) Also unwraps \noexpand tokens, since that is also needed for macro bodies
   /// (but not strictly part of packing parameters)
@@ -880,7 +987,7 @@ mod untex_control_word_space_tests {
           .unwrap_or_default()
       };
       assert_eq!(
-        first(crate::mouth::tokenize(&toks.clone().untex())),
+        first(crate::mouth::tokenize(toks.clone().untex_string())),
         first(crate::mouth::tokenize(src)),
         "untex({src:?}) changed the leading control sequence on re-tokenization"
       );
@@ -898,6 +1005,86 @@ mod untex_control_word_space_tests {
       r"\vSpakov",
       "Display for Tokens is documented as NOT producing valid TeX; if this \
        changes, audit every to_string() caller before updating the expectation"
+    );
+  }
+}
+
+/// The guard itself: proof, at COMPILE time, that a welded `String` cannot reach
+/// a tokenizing sink.
+///
+/// This module contains no runtime assertions worth the name — its whole value is
+/// that it stops compiling if the property is lost. It is `#[cfg(test)]`, so it is
+/// checked whenever the test target is built (`cargo test --tests`, and so CI).
+#[cfg(test)]
+mod texstring_guard_tests {
+  use super::*;
+
+  /// Neither `String: Into<TeXString>` nor `&String: Into<TeXString>` may hold.
+  ///
+  /// Those are the shapes a control-word-welding `Tokens::to_string()` arrives in
+  /// (`s!(…)`/`format!(…)` gives the first, `&some_local` the second), so an
+  /// implicit conversion would silently reopen the bug this type exists to close
+  /// (`\bib@@names` PR #399, `dcolumn`/`overpic` PR #400, MathSciNet review path
+  /// issue 410).
+  ///
+  /// Mechanism (the `static_assertions::assert_not_impl_any!` trick, hand-rolled
+  /// to avoid the dependency): a helper trait with a blanket impl for everything
+  /// plus a second impl gated on `Into<TeXString>`. If BOTH apply the item path is
+  /// ambiguous and this fails to compile; if only the blanket one applies it
+  /// resolves. So "still compiles" == "the conversion does not exist".
+  ///
+  /// A `&str` whose lifetime is shorter than `'static` is rejected too, but not
+  /// by this assertion — an unconstrained `&'_ str` here infers to `&'static str`,
+  /// which is exactly the case that MUST convert. The compiler enforces that half
+  /// at the call site instead, as an E0521 "borrowed data escapes … `'1` must
+  /// outlive `'static`".
+  const _NO_IMPLICIT_STRING_CONVERSION: fn() = || {
+    trait AmbiguousIfConvertible<A> {
+      fn some_item() {}
+    }
+    impl<T> AmbiguousIfConvertible<()> for T {}
+    impl<T: Into<TeXString>> AmbiguousIfConvertible<u8> for T {}
+
+    let _ = <String as AmbiguousIfConvertible<_>>::some_item;
+    let _ = <&String as AmbiguousIfConvertible<_>>::some_item;
+  };
+
+  /// The other half: a `&'static str` — i.e. every TeX literal a binding types
+  /// out — must keep converting implicitly, or ~125 call sites would need
+  /// ceremony for nothing.
+  const _LITERALS_STILL_CONVERT: fn() = || {
+    fn sink(_: impl Into<TeXString>) {}
+    sink(r"\relax");
+    sink(TeXString::assembled(String::new()));
+  };
+
+  /// …while the three blessed ways in must all still work. Kept beside the
+  /// negative assertion so a "fix" that deletes the conversions to satisfy it is
+  /// caught here.
+  #[test]
+  fn the_three_blessed_constructors_reach_the_sink() {
+    // 1. a literal
+    assert_eq!(crate::mouth::tokenize(r"\relax").to_string(), r"\relax");
+    // 2. untex_string — the space that terminates `\v` survives the round trip
+    let welded = crate::mouth::tokenize(r"\v Spakov");
+    assert_eq!(
+      crate::mouth::tokenize(welded.clone().untex_string()).to_string(),
+      r"\vSpakov",
+      "re-tokenizing untex_string() output must give back the SAME tokens \
+       (whose Display is again the welded form) — i.e. \\v stayed \\v"
+    );
+    // …which is precisely what the welded string does NOT do:
+    let welded_again = crate::mouth::tokenize(TeXString::assembled(welded.to_string()));
+    assert_eq!(
+      welded_again.unlist().first().map(|t| t.to_string()),
+      Some(r"\vSpakov".to_string()),
+      "the welded path collapses \\v + Spakov into the single undefined CS \
+       \\vSpakov — the bug TeXString exists to make hard to write"
+    );
+    // 3. assembled
+    assert_eq!(
+      crate::mouth::tokenize(TeXString::assembled(format!(r"\the{}", "section"))).to_string(),
+      r"\thesection"
     );
   }
 }

--- a/latexml_engine/src/base_parameter_types.rs
+++ b/latexml_engine/src/base_parameter_types.rs
@@ -494,7 +494,7 @@ LoadDefinitions!({
       // workflow requiring multiple conversion calls, alongside a call to the
       // `makeidx` binary, which we don't do in latexml. This parameter type
       // emulates one important aspect implied by those steps.
-      Ok(mouth::tokenize_internal(&arg.untex()))
+      Ok(mouth::tokenize_internal(arg.untex_string()))
     },
     reversion => sub[arg, _inner, _extra] {
       let mut reverted = vec![T_BEGIN!()];

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -831,7 +831,13 @@ LoadDefinitions!({
   // author<->affiliation). Witness arXiv:2606.00313.
   DefMacro!("\\lx@add@thanks [] Semiverbatim", sub[(attr, content)] {
     if starts_with_affiliation_mark(&content) {
-      let retok = mouth::tokenize_internal(&content.to_string());
+      // `untex_string()`, NOT `to_string()`: flattening with `Display` welds a
+      // control word to whatever letter follows it (`\c c` → `\cc`), because the
+      // space that terminated the control word was eaten by the tokenizer and is
+      // not in the token list. `\thanks{...}` carries author names, so that is
+      // exactly the space-form-accent case that broke `\bib@@names` (PR #399) and
+      // the MathSciNet review path (issue 410). Witness arXiv:2606.00313.
+      let retok = mouth::tokenize_internal(content.clone().untex_string());
       let mut calls: Vec<Token> = Vec::new();
       for seg in split_before_affiliation_marks(retok) {
         if seg.unlist_ref().iter().all(|t| *t == T_SPACE!()) {
@@ -4216,7 +4222,7 @@ mod author_split_tests {
     // string interning.
     set_state(State::new(StateOptions::default()));
   }
-  fn tk(s: &str) -> Tokens { mouth::tokenize_internal(s) }
+  fn tk(s: &'static str) -> Tokens { mouth::tokenize_internal(s) }
 
   #[test]
   fn whole_line_cs_wrapper_detects_font_wrapper() {

--- a/latexml_engine/src/bibtex.rs
+++ b/latexml_engine/src/bibtex.rs
@@ -451,7 +451,12 @@ pub fn current_entry_field(name: &str) -> Option<Tokens> {
   if let Some(tokens) = entry.get_field(name) {
     return Some(tokens.clone());
   }
-  entry.get_raw_field(name).map(tokenize_bib_field)
+  // `assembled`: a *raw* field is the .bib source text verbatim, straight off
+  // the BibTeX lexer — never a flattened `Tokens`, so no control word can have
+  // been welded to what follows it.
+  entry
+    .get_raw_field(name)
+    .map(|raw| tokenize_bib_field(TeXString::assembled(raw.to_string())))
 }
 
 /// `Tokenize!` for a string that came out of the BibTeX lexer.
@@ -475,7 +480,7 @@ pub fn current_entry_field(name: &str) -> Option<Tokens> {
 /// `_` is NOT in this set: a catcode is fixed at tokenization, before anything
 /// knows whether it is inside `$…$`, and a subscript in a title's math is
 /// legitimate TeX. It is handled by treatment 2 ([`bib_tex_tokens`]) instead.
-fn tokenize_bib_field(text: &str) -> Tokens { mouth::tokenize_bib_literal(text) }
+fn tokenize_bib_field(text: impl Into<TeXString>) -> Tokens { mouth::tokenize_bib_literal(text) }
 
 /// Both treatments, for a raw `.bib` string that is about to become TeX tokens.
 ///
@@ -491,7 +496,22 @@ fn tokenize_bib_field(text: &str) -> Tokens { mouth::tokenize_bib_literal(text) 
 /// all three, plus the name-, date- and MR/Zbl-assembly sites that share that
 /// path". Escaping is idempotent, so a value already escaped upstream (a recased
 /// title) is unharmed by passing through again.
-fn bib_tex_tokens(text: &str) -> Tokens { tokenize_bib_field(&escape_bib_data_specials(text)) }
+///
+/// The `impl Into<TeXString>` is the guard, and this is the site that has needed
+/// it: a caller must hand over either a raw `.bib` string (`TeXString::assembled`
+/// — lexer output, never a flattened `Tokens`) or a reverted token list
+/// ([`Tokens::untex_string`]). A bare `Tokens::to_string()` no longer compiles
+/// here, which is what made `MRREVIEWER = {Fran\c cois\ Digne}` come back as
+/// `undefined:\ccois`. See [`latexml_core::tokens::TeXString`].
+fn bib_tex_tokens(text: impl Into<TeXString>) -> Tokens {
+  // `escape_bib_data_specials` is a TeX-preserving transform of TeX-valid input,
+  // so re-asserting `assembled` over its output carries the caller's assertion
+  // through rather than laundering a new one.
+  let text = text.into();
+  tokenize_bib_field(TeXString::assembled(escape_bib_data_specials(
+    text.as_str(),
+  )))
+}
 
 /// Collapse an HTML-escaped ampersand — `&amp;` — back to the single `&` the
 /// author wrote, in whichever of its three spellings a `.bib` export used.
@@ -1245,21 +1265,26 @@ LoadDefinitions!({
     let mut body: Vec<Token> = Vec::new();
     body.push(T_CS!("\\bib@@@names"));
     body.push(T_BEGIN!());
+    // `assembled`: every part below is a slice of `names_str`, which came out of
+    // `Tokens::untex` just above — already valid TeX, with the spaces that
+    // terminate control words restored. That is exactly the obligation
+    // `TeXString::assembled` names.
+    let part = |s: &str| TeXString::assembled(s.to_string());
     for name in &parsed.names {
       let mut name_tks: Vec<Token> = Vec::new();
       if !name.surname.is_empty() {
         let inv = Invocation!(T_CS!("\\bib@surname"),
-          vec![bib_tex_tokens(&name.surname)]);
+          vec![bib_tex_tokens(part(&name.surname))]);
         name_tks.extend(inv.unlist());
       }
       if !name.given.is_empty() {
         let inv = Invocation!(T_CS!("\\bib@given"),
-          vec![bib_tex_tokens(&name.given)]);
+          vec![bib_tex_tokens(part(&name.given))]);
         name_tks.extend(inv.unlist());
       }
       if !name.lineage.is_empty() {
         let inv = Invocation!(T_CS!("\\bib@lineage"),
-          vec![bib_tex_tokens(&name.lineage)]);
+          vec![bib_tex_tokens(part(&name.lineage))]);
         name_tks.extend(inv.unlist());
       }
       let inv = Invocation!(T_CS!("\\bib@@@name"),
@@ -1326,7 +1351,8 @@ LoadDefinitions!({
     // `tokenize_bib_field`, not `Tokenize!`: treatment 1 is the safety net under
     // the escaping above — anything the escaper deliberately left alone (a
     // `%` inside `\url{…}`) is still read as data rather than as a comment.
-    let recased_tokens = bib_tex_tokens(&recased);
+    // `assembled`: `recased` is a re-cased *raw* field, i.e. .bib source text.
+    let recased_tokens = bib_tex_tokens(TeXString::assembled(recased));
     let inv = Invocation!(T_CS!("\\bib@@field"),
       vec![tag_tokens, Tokens!(), recased_tokens]);
     Ok(inv)
@@ -1738,7 +1764,8 @@ LoadDefinitions!({
     let mut out_toks: Vec<Token> = Vec::new();
     out_toks.push(T_CS!("\\bib@field@default@date"));
     out_toks.push(T_BEGIN!());
-    out_toks.extend(bib_tex_tokens(&date).unlist());
+    // `assembled`: `date` is assembled here from digits and `-` separators.
+    out_toks.extend(bib_tex_tokens(TeXString::assembled(date)).unlist());
     out_toks.push(T_END!());
     Ok(Tokens::new(out_toks))
   });
@@ -1803,7 +1830,8 @@ LoadDefinitions!({
     // it escapes too, on the same rule (`escape_bib_data_specials`).
     whatsit.set_property(
       "pages",
-      Stored::Digested(digest(bib_tex_tokens(&normalised))?),
+      // `assembled`: `normalised` is the raw `pages` field, `-` runs collapsed.
+      Stored::Digested(digest(bib_tex_tokens(TeXString::assembled(normalised)))?),
     );
   });
 
@@ -2035,14 +2063,14 @@ LoadDefinitions!({
   // Third site of this defect after `\bib@@names` (PR #399) and dcolumn/overpic
   // (PR #400). Guard: `06_cluster_bibliography::bib_mr_reviewer_accent_survives_reversion`.
   DefMacro!("\\bib@synthesize@mr", sub[_args] {
-    let mrnumber = current_entry_field("mrnumber").map(Tokens::untex);
-    let mrreviewer = current_entry_field("mrreviewer").map(Tokens::untex);
+    let mrnumber = current_entry_field("mrnumber").map(Tokens::untex_string);
+    let mrreviewer = current_entry_field("mrreviewer").map(Tokens::untex_string);
     if mrnumber.is_none() && mrreviewer.is_none() {
       return Ok(Tokens!());
     }
-    let mr_tks = bib_tex_tokens(&mrnumber.unwrap_or_default());
+    let mr_tks = bib_tex_tokens(mrnumber.unwrap_or_default());
     let rev_tks = match mrreviewer {
-      Some(r) => bib_tex_tokens(&r),
+      Some(r) => bib_tex_tokens(r),
       None => Tokens!(),
     };
     let inv = Invocation!(T_CS!("\\bib@@mr"), vec![mr_tks, rev_tks]);
@@ -2088,14 +2116,14 @@ LoadDefinitions!({
   // \bib@synthesize@zbl — Perl L828-835. Same shape as mr but
   // unconditional `isreview` (no MR-style id stripping).
   DefMacro!("\\bib@synthesize@zbl", sub[_args] {
-    let zblno = current_entry_field("zblno").map(Tokens::untex);
-    let zblreviewer = current_entry_field("zblreviewer").map(Tokens::untex);
+    let zblno = current_entry_field("zblno").map(Tokens::untex_string);
+    let zblreviewer = current_entry_field("zblreviewer").map(Tokens::untex_string);
     if zblno.is_none() && zblreviewer.is_none() {
       return Ok(Tokens!());
     }
-    let zbl_tks = bib_tex_tokens(&zblno.unwrap_or_default());
+    let zbl_tks = bib_tex_tokens(zblno.unwrap_or_default());
     let rev_tks = match zblreviewer {
-      Some(r) => bib_tex_tokens(&r),
+      Some(r) => bib_tex_tokens(r),
       None => Tokens!(),
     };
     let inv = Invocation!(T_CS!("\\bib@@zbl"), vec![zbl_tks, rev_tks]);

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -669,7 +669,9 @@ fn after_digest_verbatim(starred: bool, whatsit: &mut Whatsit) -> Result<()> {
     if let Some((final_line, remaining)) = line.split_once(end) {
       line = final_line;
       unread_one(T_CR!());
-      unread(Tokenize!(remaining));
+      // `assembled`: `remaining` is a slice of the raw verbatim line — source
+      // text straight off the mouth, never a flattened `Tokens`.
+      unread(Tokenize!(TeXString::assembled(remaining.to_string())));
       exiting = true;
     }
     // The raw chars will still have to be decoded (but not space!!)
@@ -1300,7 +1302,9 @@ pub fn use_theorem_style(name: &str) {
             },
             // Values round-tripping through tokens — use internal cattable so
             // any `\lx@…` names re-tokenize as single CS (not `\lx`+`@…`).
-            _ => mouth::tokenize_internal(&val.to_string()),
+            // `assembled`: the `Stored::Tokens` case is taken by the arm above,
+            // so what reaches here is a scalar (string/number) rendering.
+            _ => mouth::tokenize_internal(TeXString::assembled(val.to_string())),
           };
           let _ = assign_register(&key, RegisterValue::Tokens(tokens), None, vec![]);
         } else {
@@ -1393,7 +1397,9 @@ pub fn define_new_theorem(
       DefMacro!(
         T_CS!(s!("\\the{counter}")),
         None,
-        Some(ExpansionBody::Tokens(mouth::tokenize_internal(&the_counter_body))),
+        Some(ExpansionBody::Tokens(mouth::tokenize_internal(
+          TeXString::assembled(the_counter_body)
+        ))),
         scope => Some(Scope::Global)
       );
     }
@@ -1531,7 +1537,9 @@ pub fn define_new_theorem(
     DefMacro!(
       format_cs_token,
       params,
-      Some(ExpansionBody::Tokens(mouth::tokenize_internal(&fmt_str))),
+      Some(ExpansionBody::Tokens(mouth::tokenize_internal(
+        TeXString::assembled(fmt_str)
+      ))),
       scope => Some(Scope::Global)
     );
   }
@@ -1669,7 +1677,7 @@ pub fn define_new_theorem(
       .map(|n| n.revert().map(|t| t.to_string()).unwrap_or_default())
       .unwrap_or_default();
     let digest_str = s!("\\the\\thm@bodyfont\\the\\thm@styling\\def\\lx@thistheorem{{{name_str}}}");
-    let digested = digest(mouth::tokenize_internal(&digest_str))?;
+    let digested = digest(mouth::tokenize_internal(TeXString::assembled(digest_str)))?;
     Ok(vec![digested])
   });
   options.after_digest_begin.push(after_digest_begin_closure);
@@ -1714,7 +1722,9 @@ pub fn define_new_theorem(
               T_BEGIN!(),
             ]);
             let mut full_toks = tag_tokens.unlist();
-            full_toks.extend(mouth::tokenize_internal(&thmset_for_tags).unlist());
+            full_toks.extend(
+              mouth::tokenize_internal(TeXString::assembled(thmset_for_tags.clone())).unlist(),
+            );
             full_toks.push(T_END!());
             full_toks.push(T_END!());
             let tags = digest(Tokens::new(full_toks))?;
@@ -6135,7 +6145,8 @@ LoadDefinitions!({
         other => other.to_string(),
       };
       let new_id_macro = format!("{}.\\@equation@ID", id_str);
-      def_macro(T_CS!("\\theequation@ID"), None, mouth::tokenize_internal(&new_id_macro), None)?;
+      def_macro(T_CS!("\\theequation@ID"), None,
+        mouth::tokenize_internal(TeXString::assembled(new_id_macro)), None)?;
     }
   });
   Tag!("ltx:equationgroup", auto_close => true);
@@ -7290,10 +7301,10 @@ LoadDefinitions!({
       let thectrid = s!("\\the{}@ID", ctr_str);
       let _ = def_macro(T_CS!(thectrid), None,
         Some(ExpansionBody::Closure(Rc::new(move |_args| {
-          Ok(mouth::tokenize_internal(&s!(
+          Ok(mouth::tokenize_internal(TeXString::assembled(s!(
             "\\expandafter\\ifx\\csname the{}@ID\\endcsname\\@empty\\else\\csname the{}@ID\\endcsname.\\fi {}\\csname @{}@ID\\endcsname",
             within_for_id, within_for_id, clean_prefix, ctr_for_id
-          )))
+          ))))
         }))),
         Some(NewDefault!(ExpandableOptions, scope => Some(Scope::Global))));
     }
@@ -7327,9 +7338,9 @@ LoadDefinitions!({
       let thectrid = s!("\\the{}@ID", ctr_str);
       let _ = def_macro(T_CS!(thectrid), None,
         Some(ExpansionBody::Closure(Rc::new(move |_args| {
-          Ok(mouth::tokenize_internal(&s!(
+          Ok(mouth::tokenize_internal(TeXString::assembled(s!(
             "{}\\csname @{}@ID\\endcsname", clean_prefix, ctr_for_id
-          )))
+          ))))
         }))),
         Some(NewDefault!(ExpandableOptions, scope => Some(Scope::Global))));
     }

--- a/latexml_engine/src/prelude.rs
+++ b/latexml_engine/src/prelude.rs
@@ -72,7 +72,7 @@ pub use latexml_core::{
   stomach::*,
   tbox::Tbox,
   token::*,
-  tokens::{NO_TOKENS, Tokens},
+  tokens::{NO_TOKENS, TeXString, Tokens},
   // `CharCursor` is preluded on purpose: it is the shared answer to the
   // byte-index scanners this port keeps inheriting from Perl's
   // character-oriented string ops (WISDOM #70), so it should be the thing

--- a/latexml_package/src/package/amsmath_sty.rs
+++ b/latexml_package/src/package/amsmath_sty.rs
@@ -1564,7 +1564,7 @@ LoadDefinitions!({
     let within_str = Expand!(within.unwrap().clone()).to_string();
     new_counter(&counter_str, &within_str, None)?;
     let the_body = s!("\\csname the{within_str}\\endcsname.{format_str}{{{counter_str}}}");
-    let expansion_tokens = mouth::tokenize(&the_body);
+    let expansion_tokens = mouth::tokenize(TeXString::assembled(the_body));
     def_macro(
       T_CS!(s!("\\the{counter_str}")),
       None,

--- a/latexml_package/src/package/amsthm_sty.rs
+++ b/latexml_package/src/package/amsthm_sty.rs
@@ -24,11 +24,15 @@ LoadDefinitions!({
 
   // activate a certain theorem style
   DefPrimitive!("\\theoremstyle{}", sub[(style_tok)] {
+    // `untex_string()` for the tokenizer, plain `to_string()` for the CS *name*
+    // below: only the former is re-read as TeX, and only it can weld a control
+    // word onto a following letter. See `TeXString`.
     let style = style_tok.to_string();
+    let style_tex = style_tok.untex_string();
     let style_cs = T_CS!(s!("\\th@{style}"));
     if is_defined(&s!("\\th@{style}")) {
       assign_register("\\thm@style",
-        RegisterValue::Tokens(mouth::tokenize(&style)),
+        RegisterValue::Tokens(mouth::tokenize(style_tex)),
         None, vec![])?;
       digest(Tokens::new(vec![style_cs]))?;
     } else {

--- a/latexml_package/src/package/cases_sty.rs
+++ b/latexml_package/src/package/cases_sty.rs
@@ -169,14 +169,14 @@ LoadDefinitions!({
     reset_counter(&T_OTHER!("equation"))?;
     // Redefine \theequation to parent_number + \alph{equation} (e.g. "3a", "3b")
     let new_theequation = format!("{}\\alph{{equation}}", eqnum_str);
-    def_macro(T_CS!("\\theequation"), None, mouth::tokenize_internal(&new_theequation), None)?;
+    def_macro(T_CS!("\\theequation"), None, mouth::tokenize_internal(TeXString::assembled(new_theequation)), None)?;
     // Redefine \theequation@ID for xml:id generation (e.g. "S0.E3.\@equation@ID")
     let id_str = eqn_props.iter().find_map(|(k, v)| {
       if with(*k, |ks| ks == "id") { Some(v.to_string()) } else { None }
     }).unwrap_or_default();
     if !id_str.is_empty() {
       let new_id_macro = format!("{}.\\@equation@ID", id_str);
-      def_macro(T_CS!("\\theequation@ID"), None, mouth::tokenize_internal(&new_id_macro), None)?;
+      def_macro(T_CS!("\\theequation@ID"), None, mouth::tokenize_internal(TeXString::assembled(new_id_macro)), None)?;
     }
   });
   DefPrimitive!("\\lx@numcases@subnumbering@end", sub[_args] {

--- a/latexml_package/src/package/cleveref_sty.rs
+++ b/latexml_package/src/package/cleveref_sty.rs
@@ -234,7 +234,7 @@ fn cref_multi(
       out.push(T_OTHER!("*"));
     }
     out.push(T_BEGIN!());
-    out.extend(mouth::tokenize_internal(show).unlist());
+    out.extend(mouth::tokenize_internal(TeXString::assembled(show.to_string())).unlist());
     out.push(T_END!());
     out.push(T_BEGIN!());
     out.extend(label.clone().unlist());

--- a/latexml_package/src/package/colordvi_sty.rs
+++ b/latexml_package/src/package/colordvi_sty.rs
@@ -51,7 +51,7 @@ LoadDefinitions!({
       name_str, name_str
     );
     for def_str in [&text_def, &name_def] {
-      let tokens = mouth::tokenize_internal(def_str);
+      let tokens = mouth::tokenize_internal(TeXString::assembled(def_str.clone()));
       do_expand(tokens)?;
     }
     Ok(Vec::new())

--- a/latexml_package/src/package/dcolumn_sty.rs
+++ b/latexml_package/src/package/dcolumn_sty.rs
@@ -95,7 +95,7 @@ LoadDefinitions!({
         "\\lx@hidden@bgroup\\lx@unactivate{{{}}}\\lx@wrap[role=PERIOD]{{{}}}\\lx@hidden@egroup",
         delim_str, todelim_str
       );
-      let expansion = mouth::tokenize_internal(&expansion_body);
+      let expansion = mouth::tokenize_internal(TeXString::assembled(expansion_body));
       def_macro(T_CS!(delim_str), None, expansion, None)?;
     }
     // Save and deactivate $

--- a/latexml_package/src/package/enumitem_sty.rs
+++ b/latexml_package/src/package/enumitem_sty.rs
@@ -36,7 +36,7 @@ fn begin_enum_itemize(
         .flatten()
         .is_none()
     {
-      let toks = mouth::tokenize_internal(first_key);
+      let toks = mouth::tokenize_internal(TeXString::assembled(first_key.to_string()));
       set_enumeration_style(Some(&toks), Some(level as i32))?;
     }
   }
@@ -248,7 +248,9 @@ fn merged_enumitem_keyvals(
             Stored::Tokens(t) => ArgWrap::Tokens(t),
             Stored::Number(n) => ArgWrap::Number(n),
             Stored::None => ArgWrap::None,
-            Stored::String(s) => ArgWrap::Tokens(with(s, mouth::tokenize_internal)),
+            Stored::String(s) => ArgWrap::Tokens(with(s, |t| {
+              mouth::tokenize_internal(TeXString::assembled(t.to_string()))
+            })),
             _ => ArgWrap::None,
           };
           hash.insert(key.clone(), aw);
@@ -272,7 +274,9 @@ fn argwrap_to_tokens(aw: &ArgWrap) -> Option<Tokens> {
   match aw {
     ArgWrap::Tokens(t) => Some(t.clone()),
     ArgWrap::None => None,
-    _ => Some(mouth::tokenize_internal(&aw.to_string())),
+    _ => Some(mouth::tokenize_internal(TeXString::assembled(
+      aw.to_string(),
+    ))),
   }
 }
 

--- a/latexml_package/src/package/expl3_sty.rs
+++ b/latexml_package/src/package/expl3_sty.rs
@@ -94,7 +94,7 @@ LoadDefinitions!({
     } else {
       cp_n
     };
-    Ok(Tokenize!(&format!("{{{}}}{{}}{{}}", result_cp)))
+    Ok(Tokenize!(TeXString::assembled(format!("{{{}}}{{}}{{}}", result_cp))))
   });
 
   // expl3 system-info constants normally bound by `\g__sys_everyjob_tl`

--- a/latexml_package/src/package/float_sty.rs
+++ b/latexml_package/src/package/float_sty.rs
@@ -57,7 +57,7 @@ LoadDefinitions!({
     let format_cs_tok = T_CS!(format_cs);
     let format_paramlist = parse_parameters("{}", &format_cs_tok, true)?;
     def_macro(format_cs_tok, format_paramlist,
-      mouth::tokenize_internal(&format_body), None)?;
+      mouth::tokenize_internal(TeXString::assembled(format_body)), None)?;
 
     define_float_environment(&ftype, &auxext, &within)?;
   });
@@ -91,7 +91,7 @@ pub fn define_float_environment(ftype: &str, auxext: &str, within: &str) -> Resu
     def_macro(
       T_CS!(the_cs),
       None,
-      mouth::tokenize_internal(&the_body),
+      mouth::tokenize_internal(TeXString::assembled(the_body)),
       None,
     )?;
   }

--- a/latexml_package/src/package/graphics_sty.rs
+++ b/latexml_package/src/package/graphics_sty.rs
@@ -236,7 +236,7 @@ LoadDefinitions!({
       let dim = read_dimension()?;
       // Return the raw sp value as tokens for lossless round-trip.
       // to_attribute() rounds to 1 decimal pt, losing precision in scale calculations.
-      Ok(Tokenize!(&dim.value_of().to_string()))
+      Ok(Tokenize!(TeXString::assembled(dim.value_of().to_string())))
     }
   }, optional => true);
 
@@ -297,7 +297,7 @@ LoadDefinitions!({
         .map(|d| Dimension(*d).to_string())
         .collect::<Vec<_>>()
         .join(" ");
-      Ok(Tokenize!(&joined))
+      Ok(Tokenize!(TeXString::assembled(joined)))
     }
   }, optional => true);
 

--- a/latexml_package/src/package/ifplatform_sty.rs
+++ b/latexml_package/src/package/ifplatform_sty.rs
@@ -41,7 +41,7 @@ LoadDefinitions!({
     ("\\unknownplatform", os.to_string())
   };
   def_macro(T_CS!("\\unknownplatform"), None,
-    Tokenize!(&unknown_name), None)?;
+    Tokenize!(TeXString::assembled(unknown_name)), None)?;
   let_i(&T_CS!("\\platformname"), &T_CS!(platform_cs), None);
 
   // Perl L63-66: one conditional per OS, returning the same-named sub.

--- a/latexml_package/src/package/inputenc_sty.rs
+++ b/latexml_package/src/package/inputenc_sty.rs
@@ -27,7 +27,7 @@ fn set_input_encoding(encoding: &str) -> Result<()> {
   // or more likely, treating the bytes as (misinterpreted?) utf8?
   // In latter case, perhaps it doesn't matter as long as we end up with the same bytes in/out???
   assign_value("INPUT_ENCODING", encoding.to_string(), None);
-  let encoding_tokenized = TokenizeInternal!(encoding);
+  let encoding_tokenized = TokenizeInternal!(TeXString::assembled(encoding.to_string()));
   def_macro(T_CS!("\\inputencodingname"), None, encoding_tokenized, None)
 }
 

--- a/latexml_package/src/package/iopart_support_sty.rs
+++ b/latexml_package/src/package/iopart_support_sty.rs
@@ -11,7 +11,7 @@ use crate::prelude::*;
 /// Per [[wisdom_data_drive_min_call_sites]]: 74 ≫ 5 threshold.
 fn def_iop_journal(cs: &str, name: &str) -> Result<()> {
   let (cs_tok, params) = parse_prototype(cs, true)?;
-  let body_toks = mouth::tokenize_internal(&format!("\\textit{{{name}}}"));
+  let body_toks = mouth::tokenize_internal(TeXString::assembled(format!("\\textit{{{name}}}")));
   def_macro(cs_tok, params, ExpansionBody::Tokens(body_toks), None)?;
   Ok(())
 }
@@ -116,7 +116,7 @@ LoadDefinitions!({
   DefPrimitive!("\\jl{}", sub[(n)] {
     let idx: usize = n.to_string().trim().parse().unwrap_or(0);
     if let Some(journal) = IOP_JOURNALS.get(idx) {
-      def_macro(T_CS!("\\journal"), None, Tokenize!(journal), None)?;
+      def_macro(T_CS!("\\journal"), None, Tokenize!(*journal), None)?;
     }
   });
 

--- a/latexml_package/src/package/jhep_cls.rs
+++ b/latexml_package/src/package/jhep_cls.rs
@@ -16,7 +16,7 @@ use crate::{
 fn def_jhep_journal(cs: &str, body: &str) -> Result<()> {
   let proto = format!("{cs}{{}}{{}}{{}}");
   let (cs_tok, params) = parse_prototype(&proto, true)?;
-  let body_toks = mouth::tokenize_internal(body);
+  let body_toks = mouth::tokenize_internal(TeXString::assembled(body.to_string()));
   def_macro(cs_tok, params, ExpansionBody::Tokens(body_toks), None)?;
   Ok(())
 }

--- a/latexml_package/src/package/listings_sty.rs
+++ b/latexml_package/src/package/listings_sty.rs
@@ -101,7 +101,7 @@ pub fn listings_read_raw_lines(environment: &str) -> String {
       }
       let rest = line[m.end()..].to_string();
       if !rest.is_empty() {
-        unread(Tokenize!(&rest));
+        unread(Tokenize!(TeXString::assembled(rest)));
         unread(Tokens::new(vec![T_CR!()]));
       }
       break;
@@ -144,7 +144,7 @@ fn read_balanced_group(tokens: &[Token], pos: &mut usize) -> Vec<Token> {
 
 /// Perl: TokenizeBalanced — tokenize a string with current catcodes, then balance groups.
 fn tokenize_balanced(text: &str) -> Vec<Token> {
-  let tokens = mouth::tokenize(text);
+  let tokens = mouth::tokenize(TeXString::assembled(text.to_string()));
   let mut toks: Vec<Token> = tokens.unlist();
   let mut level: i32 = 0;
   for t in &toks {
@@ -814,7 +814,7 @@ fn lst_add_delimiter(
     let style_is_markup =
       !style_re.is_match(style) && !style.is_empty() && style != "None" && style.contains('\\'); // TeX markup contains backslash
     let style_tokens = if style_is_markup {
-      mouth::tokenize_internal(style)
+      mouth::tokenize_internal(TeXString::assembled(style.to_string()))
     } else {
       Tokens!()
     };

--- a/latexml_package/src/package/mathtools_sty.rs
+++ b/latexml_package/src/package/mathtools_sty.rs
@@ -60,9 +60,16 @@ LoadDefinitions!({
   // Perl: DefPrimitive('\mathtoolsset RequiredKeyVals', sub { ... getPairs ... DefMacro })
   DefPrimitive!("\\mathtoolsset RequiredKeyVals:mt", sub[(kv)] {
     for (key, val) in kv.get_pairs() {
-      let val_str = if val.is_empty() { "\\@mt@true".to_string() } else { val.to_string() };
+      // `untex_string()` on the `Tokens` variant: this value is re-tokenized as
+      // TeX, so a flattened control word would weld onto the letter after it
+      // (`\\v S` -> `\\vS`). The other `ArgWrap` variants are scalar renderings.
+      let val_tex = match val {
+        _ if val.is_empty() => TeXString::from("\\@mt@true"),
+        ArgWrap::Tokens(t) => t.clone().untex_string(),
+        _ => TeXString::assembled(val.to_string()),
+      };
       let cs_name = s!("\\@mt@mathtoolsset@{}", key);
-      def_macro(T_CS!(&cs_name), None, Tokenize!(&val_str), None)?;
+      def_macro(T_CS!(&cs_name), None, Tokenize!(val_tex), None)?;
     }
   });
 

--- a/latexml_package/src/package/omnibus_cls.rs
+++ b/latexml_package/src/package/omnibus_cls.rs
@@ -451,7 +451,7 @@ LoadDefinitions!({
         require_package("amsthm", RequireOptions::default())?;
         let mut expanded = preload.clone();
         expanded.push_str(&beginenv_clone);
-        Ok(mouth::tokenize_internal(&expanded))
+        Ok(mouth::tokenize_internal(TeXString::assembled(expanded)))
       })), None)?;
   }
   // Perl L216-219: newtheorem aliases auto-load amsthm
@@ -626,7 +626,7 @@ LoadDefinitions!({
           } else {
             require_package(&name_str, RequireOptions::default())?;
           }
-          Ok(mouth::tokenize_internal(&trigger_str))
+          Ok(mouth::tokenize_internal(TeXString::assembled(trigger_str.clone())))
         })), None)?;
     }
   }

--- a/latexml_package/src/package/pgfmathcalc_code_tex.rs
+++ b/latexml_package/src/package/pgfmathcalc_code_tex.rs
@@ -20,7 +20,7 @@ LoadDefinitions!({
     bgroup();
     let result = pgfmath_code_tex::pgfmathparse_eval(&expr_str);
     egroup()?;
-    let result_tokens = mouth::tokenize_internal(&result);
+    let result_tokens = mouth::tokenize_internal(TeXString::assembled(result));
     def_macro(
       cs.unlist().into_iter().next().unwrap_or_else(|| T_CS!("\\pgfmathresult")),
       None,

--- a/latexml_package/src/package/pgfsys_latexml_def.rs
+++ b/latexml_package/src/package/pgfsys_latexml_def.rs
@@ -91,7 +91,7 @@ fn color_to_hex_tokens(r: f64, g: f64, b: f64) -> Vec<Token> {
   // Perl uses Explode() which creates catcode-12 (OTHER) tokens.
   // '#' as catcode OTHER, then hex digits as catcode OTHER.
   let mut tokens = vec![T_OTHER!("#")];
-  tokens.extend(mouth::tokenize_internal(&hex).unlist());
+  tokens.extend(mouth::tokenize_internal(TeXString::assembled(hex)).unlist());
   tokens
 }
 
@@ -672,7 +672,7 @@ LoadDefinitions!({
       dim_to_px(e),
       dim_to_px(f));
     let tok_str = format!("\\lxSVG@begingroup{{{}}}", transform);
-    mouth::tokenize_internal(&tok_str).unlist()
+    mouth::tokenize_internal(TeXString::assembled(tok_str)).unlist()
   });
 
   //===================================================================
@@ -705,10 +705,10 @@ LoadDefinitions!({
     let clip = lookup_int("pgf_clipnext") != 0;
     if clip {
       let clip_cmd = format!("\\lxSVG@clearpath\\lxSVG@clearclip\\pgfsysprotocol@literal{{\\lxSVG@drawpath@clipped{{{}}}{{{}}}}}", path, arg_str);
-      mouth::tokenize_internal(&clip_cmd).unlist()
+      mouth::tokenize_internal(TeXString::assembled(clip_cmd)).unlist()
     } else {
       let draw_cmd = format!("\\lxSVG@clearpath\\pgfsysprotocol@literal{{\\lxSVG@drawpath@unclipped{{{}}}{{{}}}}}", path, arg_str);
-      mouth::tokenize_internal(&draw_cmd).unlist()
+      mouth::tokenize_internal(TeXString::assembled(draw_cmd)).unlist()
     }
   });
 
@@ -820,7 +820,7 @@ LoadDefinitions!({
     let clip = lookup_int("pgf_clipnext") != 0;
     if clip {
       let clip_cmd = format!("\\lxSVG@clearpath\\lxSVG@clearclip\\pgfsysprotocol@literal{{\\lxSVG@discardpath@clipped{{{}}}}}", path);
-      mouth::tokenize_internal(&clip_cmd).unlist()
+      mouth::tokenize_internal(TeXString::assembled(clip_cmd)).unlist()
     } else {
       vec![]
     }
@@ -1616,7 +1616,7 @@ LoadDefinitions!({
 
       // Define \lxSVG@pos macro
       let pos_toks = mouth::tokenize_internal(
-        &format!("\\pgfpoint{{{x}}}{{{y}}}"));
+        TeXString::assembled(format!("\\pgfpoint{{{x}}}{{{y}}}")));
       let _ = def_macro(T_CS!("\\lxSVG@pos"), None, pos_toks, None);
 
       Ok(vec![Digested::default()])
@@ -1698,7 +1698,7 @@ LoadDefinitions!({
 
       // Define \lxSVG@pos macro
       let pos_toks = mouth::tokenize_internal(
-        &format!("\\pgfpoint{{{}}}{{{}}}", 2.0 * endpos, 2.0 * endpos));
+        TeXString::assembled(format!("\\pgfpoint{{{}}}{{{}}}", 2.0 * endpos, 2.0 * endpos)));
       let _ = def_macro(T_CS!("\\lxSVG@pos"), None, pos_toks, None);
 
       Ok(vec![Digested::default()])

--- a/latexml_package/src/package/physics_sty.rs
+++ b/latexml_package/src/package/physics_sty.rs
@@ -51,6 +51,15 @@ fn phys_rev_size(no_stretch: bool, size_tok: &Option<Token>) -> Vec<Token> {
   }
 }
 
+/// The TeX for one delimiter token, ready to re-tokenize.
+///
+/// `assembled` rather than `Tokens::untex_string` because a physics delimiter is
+/// a *single* `Token` — `(`, `|`, `\lbrace`. Flattening it cannot weld a control
+/// word onto a following letter, because there is nothing following it. (The
+/// `semantic` arguments in this file are full `Tokens` and do use
+/// `untex_string`.)
+fn phys_delim_tex(t: Token) -> TeXString { TeXString::assembled(t.to_string()) }
+
 /// Perl: phys_open — opening fence with sizing
 fn phys_open(no_stretch: bool, size_tok: &Option<Token>, delim: Tokens) -> Tokens {
   if delim.is_empty() {
@@ -227,9 +236,9 @@ LoadDefinitions!({
     let content = Tokens::new(vec![i_arg("1")]);
 
     // Presentation: open + arg + close
-    let open_tks = open.map(|t| Tokenize!(&t.to_string()))
+    let open_tks = open.map(|t| Tokenize!(phys_delim_tex(t)))
       .unwrap_or_else(|| Tokenize!("\\lbrace"));
-    let close_tks = close.map(|t| Tokenize!(&t.to_string()))
+    let close_tks = close.map(|t| Tokenize!(phys_delim_tex(t)))
       .unwrap_or_else(|| Tokenize!("\\rbrace"));
     let mut pres = Vec::new();
     pres.extend(phys_open(no_stretch, &size_tok, open_tks).unlist());
@@ -248,8 +257,8 @@ LoadDefinitions!({
   // Perl: \lx@physics@fenced — fenced stuff with optional semantics
   DefPrimitive!("\\lx@physics@fenced{}{}{}{}{}", sub[(cs, semantic, function, open, close)] {
     let cs_tks = cs;
-    let semantic_str = semantic.to_string();
-    let semantic_opt = if semantic_str.is_empty() { None } else { Some(semantic_str.as_str()) };
+    let semantic_tex = semantic.untex_string();
+    let semantic_opt = if semantic_tex.is_empty() { None } else { Some(semantic_tex) };
     let function_tks = function;
     let open_tks = open;
     let close_tks = close;
@@ -368,7 +377,7 @@ LoadDefinitions!({
     let reversion = Tokens::new(rev);
     let content = i_apply(&[],
       i_symbol(&[("meaning", Tokenize!("evaluated-at"))], None), content_args);
-    let open_tks = open.map(|t| Tokenize!(&t.to_string())).unwrap_or_else(|| Tokenize!("."));
+    let open_tks = open.map(|t| Tokenize!(phys_delim_tex(t))).unwrap_or_else(|| Tokenize!("."));
     let close_tks = close.map(|_| Tokenize!("|")).unwrap_or_else(|| Tokenize!("|"));
     let mut pres = Vec::new();
     pres.extend(
@@ -393,7 +402,7 @@ LoadDefinitions!({
   // Perl: \lx@physics@fencedII — 2-argument fenced
   DefPrimitive!("\\lx@physics@fencedII{}{}{}{}{}", sub[(cs, semantic, _function, open, close)] {
     let cs_tks = cs;
-    let semantic_str = semantic.to_string();
+    let semantic_tex = semantic.untex_string();
     let open_tks = open;
     let close_tks = close;
     let (no_stretch, size_tok) = phys_read_size()?;
@@ -411,7 +420,7 @@ LoadDefinitions!({
     let reversion = Tokens::new(rev);
 
     // Content: apply(symbol(meaning), arg1, arg2)
-    let content = i_apply(&[], i_symbol(&[("meaning", Tokenize!(&semantic_str))], None),
+    let content = i_apply(&[], i_symbol(&[("meaning", Tokenize!(semantic_tex.clone()))], None),
       vec![a1, a2]);
 
     // Presentation: open arg1 , arg2 close
@@ -471,9 +480,9 @@ LoadDefinitions!({
   // WISDOM #44 alignment reason as `\mqty`/`\lx@physics@operatorP`. Return the dual.
   DefMacro!("\\lx@physics@operator{}{}{}", sub[(cs, semantic, function)] {
     let cs_tks = cs;
-    let semantic_str = semantic.to_string();
+    let semantic_tex = semantic.untex_string();
     let function_tks = function;
-    let cfunc = i_symbol(&[("meaning", Tokenize!(&semantic_str))], None);
+    let cfunc = i_symbol(&[("meaning", Tokenize!(semantic_tex.clone()))], None);
     let (no_stretch, size_tok) = phys_read_size()?;
     let (arg, open, close) = phys_read_arg(false, physics_delimiters)?;
 
@@ -487,8 +496,8 @@ LoadDefinitions!({
       let reversion = Tokens::new(rev);
 
       let content = i_apply(&[], cfunc, vec![a1]);
-      let open_tks = open.map(|t| Tokenize!(&t.to_string())).unwrap_or_default();
-      let close_tks = close.map(|t| Tokenize!(&t.to_string())).unwrap_or_default();
+      let open_tks = open.map(|t| Tokenize!(phys_delim_tex(t))).unwrap_or_default();
+      let close_tks = close.map(|t| Tokenize!(phys_delim_tex(t))).unwrap_or_default();
       let mut pres = Vec::new();
       pres.extend(function_tks.unlist());
       pres.extend(phys_open(no_stretch, &size_tok, open_tks).unlist());
@@ -537,9 +546,9 @@ LoadDefinitions!({
   // of `gullet::unread`.
   DefMacro!("\\lx@physics@operatorP{}{}{}", sub[(cs, semantic, function)] {
     let cs_tks = cs;
-    let semantic_str = semantic.to_string();
+    let semantic_tex = semantic.untex_string();
     let function_tks = function;
-    let cfunc = i_symbol(&[("meaning", Tokenize!(&semantic_str))], None);
+    let cfunc = i_symbol(&[("meaning", Tokenize!(semantic_tex.clone()))], None);
     let pfunc = function_tks;
     let (no_stretch, size_tok) = phys_read_size()?;
     let power = read_optional(None)?;
@@ -589,8 +598,8 @@ LoadDefinitions!({
       let reversion = Tokens::new(rev);
       let content = i_apply(&[], content_op, vec![a1]);
 
-      let open_tks = open.map(|t| Tokenize!(&t.to_string())).unwrap_or_else(|| Tokenize!("("));
-      let close_tks = close.map(|t| Tokenize!(&t.to_string())).unwrap_or_else(|| Tokenize!(")"));
+      let open_tks = open.map(|t| Tokenize!(phys_delim_tex(t))).unwrap_or_else(|| Tokenize!("("));
+      let close_tks = close.map(|t| Tokenize!(phys_delim_tex(t))).unwrap_or_else(|| Tokenize!(")"));
       let mut pres = Vec::new();
       pres.extend(pres_func.unlist());
       pres.extend(phys_open(no_stretch, &size_tok, open_tks).unlist());
@@ -686,11 +695,11 @@ LoadDefinitions!({
   // Perl: \lx@physics@ReIm — Re/Im with optional braced arg
   DefPrimitive!("\\lx@physics@ReIm{}{}{}{}", sub[(cs, semantic, raw, function)] {
     let cs_tks = cs;
-    let semantic_str = semantic.to_string();
+    let semantic_tex = semantic.untex_string();
     let raw_tks = raw;
     let function_tks = function;
     let (no_stretch, size_tok) = phys_read_size()?;
-    let cfunc = i_symbol(&[("meaning", Tokenize!(&semantic_str))], None);
+    let cfunc = i_symbol(&[("meaning", Tokenize!(semantic_tex.clone()))], None);
     let arg = phys_read_arg_tex()?;
 
     if let Some(arg_tks) = arg {
@@ -790,9 +799,9 @@ LoadDefinitions!({
   // WISDOM #44 alignment reason as `\mqty`/`\lx@physics@operatorP`. Return the dual.
   DefMacro!("\\lx@physics@diff{}{}{}", sub[(cs, semantic, diff)] {
     let cs_tks = cs;
-    let semantic_str = semantic.to_string();
+    let semantic_tex = semantic.untex_string();
     let diff_tks = diff;
-    let cfunc = i_symbol(&[("meaning", Tokenize!(&semantic_str))], None);
+    let cfunc = i_symbol(&[("meaning", Tokenize!(semantic_tex.clone()))], None);
     let pfunc = i_wrap(Some(Tokenize!("role=DIFFOP")), diff_tks);
     let degree = read_optional(None)?;
     let (arg, open, close) = phys_read_arg(false, |s| {
@@ -826,17 +835,17 @@ LoadDefinitions!({
         content = i_apply(&[], cfunc, vec![a1, a2.clone()]);
         presentation = Tokens::new([
           i_superscript(&[("role", Tokenize!("DIFFOP"))], pfunc, a2).unlist(),
-          phys_open(false, &None, open.map(|t| Tokenize!(&t.to_string())).unwrap_or_default()).unlist(),
+          phys_open(false, &None, open.map(|t| Tokenize!(phys_delim_tex(t))).unwrap_or_default()).unlist(),
           vec![i_arg("1")],
-          phys_close(false, &None, close.map(|t| Tokenize!(&t.to_string())).unwrap_or_default()).unlist(),
+          phys_close(false, &None, close.map(|t| Tokenize!(phys_delim_tex(t))).unwrap_or_default()).unlist(),
         ].concat());
       } else {
         content = i_apply(&[], cfunc, vec![a1]);
         presentation = Tokens::new([
           pfunc.unlist(),
-          phys_open(false, &None, open.map(|t| Tokenize!(&t.to_string())).unwrap_or_default()).unlist(),
+          phys_open(false, &None, open.map(|t| Tokenize!(phys_delim_tex(t))).unwrap_or_default()).unlist(),
           vec![i_arg("1")],
-          phys_close(false, &None, close.map(|t| Tokenize!(&t.to_string())).unwrap_or_default()).unlist(),
+          phys_close(false, &None, close.map(|t| Tokenize!(phys_delim_tex(t))).unwrap_or_default()).unlist(),
         ].concat());
       }
 
@@ -873,9 +882,9 @@ LoadDefinitions!({
   // For partial: \pdv{f}{x}{y} (double derivative)
   DefPrimitive!("\\lx@physics@deriv{}{}{}", sub[(cs, semantic, diff)] {
     let cs_tks = cs;
-    let semantic_str = semantic.to_string();
+    let semantic_tex = semantic.untex_string();
     let diff_tks = diff;
-    let cfunc = i_symbol(&[("meaning", Tokenize!(&semantic_str))], None);
+    let cfunc = i_symbol(&[("meaning", Tokenize!(semantic_tex.clone()))], None);
     let pfunc = i_wrap(Some(Tokenize!("role=DIFFOP")), diff_tks);
 
     let inline = read_match(&[&Tokenize!("*")])?.is_some();
@@ -887,7 +896,7 @@ LoadDefinitions!({
 
     // For partial derivatives: try to read a 3rd {} arg (2nd var)
     let mut tmp3: Option<Tokens> = None;
-    if semantic_str.starts_with("partial")
+    if semantic_tex.as_str().starts_with("partial")
       && let Some(ref _t2) = tmp2
         && open.is_none() {
           // tmp2 was a {} arg, try for 3rd
@@ -1036,9 +1045,9 @@ LoadDefinitions!({
       pres_tks.push(T_END!());
       if has_expr && has_open {
         pres_tks.push(T_CS!("\\lx@ApplyFunction"));
-        pres_tks.extend(phys_open(false, &None, open.map(|t| Tokenize!(&t.to_string())).unwrap_or_default()).unlist());
+        pres_tks.extend(phys_open(false, &None, open.map(|t| Tokenize!(phys_delim_tex(t))).unwrap_or_default()).unlist());
         pres_tks.push(i_arg("1"));
-        pres_tks.extend(phys_close(false, &None, close.map(|t| Tokenize!(&t.to_string())).unwrap_or_default()).unlist());
+        pres_tks.extend(phys_close(false, &None, close.map(|t| Tokenize!(phys_delim_tex(t))).unwrap_or_default()).unlist());
       }
       let presentation = Tokens::new(pres_tks);
       // Perl passes (expr, var, degree) to I_dual unconditionally (physics.sty
@@ -1158,7 +1167,7 @@ LoadDefinitions!({
   // Perl: \innerproduct — ⟨arg1|arg2⟩
   DefPrimitive!("\\lx@physics@qm@product{}{}{}{}{}", sub[(cs, semantic, open, middle, close)] {
     let cs_tks = cs;
-    let semantic_str = semantic.to_string();
+    let semantic_tex = semantic.untex_string();
     let open_tks = open;
     let middle_tks = middle;
     let close_tks = close;
@@ -1177,7 +1186,7 @@ LoadDefinitions!({
     let reversion = Tokens::new(rev);
 
     let content = i_apply(&[],
-      i_symbol(&[("meaning", Tokenize!(&semantic_str))], None),
+      i_symbol(&[("meaning", Tokenize!(semantic_tex.clone()))], None),
       vec![a1, a2]);
     // Stretchy by default (Perl parity); `no_stretch` passed directly — see the
     // `\matrixelement` note. A prior `!no_stretch` made `\innerproduct`/`\outerproduct`
@@ -1448,8 +1457,8 @@ LoadDefinitions!({
   // `&`/`\\`. Return the dual instead of `gullet::unread`.
   DefMacro!("\\lx@physics@mat{}{}{}{}{}", sub[(cs, semantic, env, defopen, defclose)] {
     let cs_tks = cs;
-    let semantic_str = semantic.to_string();
-    let semantic_opt = if semantic_str.is_empty() { None } else { Some(semantic_str.as_str()) };
+    let semantic_tex = semantic.untex_string();
+    let semantic_opt = if semantic_tex.is_empty() { None } else { Some(semantic_tex) };
     let env_str = env.to_string();
     let defopen_tks = defopen;
     let defclose_tks = defclose;
@@ -1480,8 +1489,8 @@ LoadDefinitions!({
     };
 
     // Presentation: open + matrix + close (using default fences if no explicit ones)
-    let open_fence = open.map(|t| Tokenize!(&t.to_string())).unwrap_or(defopen_tks);
-    let close_fence = close.map(|t| Tokenize!(&t.to_string())).unwrap_or(defclose_tks);
+    let open_fence = open.map(|t| Tokenize!(phys_delim_tex(t))).unwrap_or(defopen_tks);
+    let close_fence = close.map(|t| Tokenize!(phys_delim_tex(t))).unwrap_or(defclose_tks);
     let mut pres = Vec::new();
     if !open_fence.is_empty() {
       pres.extend(phys_open(false, &None, open_fence).unlist());

--- a/latexml_package/src/package/pifont_sty.rs
+++ b/latexml_package/src/package/pifont_sty.rs
@@ -67,12 +67,12 @@ LoadDefinitions!({
     let postfix = roman_aux(level);
     // DefMacroI for \theenumX, \p@enumX, \labelenumX
     let the_body = s!("\\lx@Picountersymbol{{{font_str}}}{{enum{postfix}}}{{{base_str}}}");
-    let the_tokens = mouth::tokenize_internal(&the_body);
+    let the_tokens = mouth::tokenize_internal(TeXString::assembled(the_body));
     def_macro(T_CS!(s!("\\theenum{postfix}")), None, the_tokens, None)?;
     let empty_tokens = Tokens::new(vec![]);
     def_macro(T_CS!(s!("\\p@enum{postfix}")), None, empty_tokens, None)?;
     let label_body = s!("\\theenum{postfix}");
-    let label_tokens = mouth::tokenize_internal(&label_body);
+    let label_tokens = mouth::tokenize_internal(TeXString::assembled(label_body));
     def_macro(T_CS!(s!("\\labelenum{postfix}")), None, label_tokens, None)?;
     Ok(Tokens::new(vec![]))
   });

--- a/latexml_package/src/package/siunitx_sty.rs
+++ b/latexml_package/src/package/siunitx_sty.rs
@@ -150,7 +150,7 @@ fn six_get_tokens_sym(key: SymStr) -> Tokens {
     Some(Stored::Tokens(t)) => t,
     Some(Stored::String(s)) => {
       let txt = with(s, |t| t.to_string());
-      Tokenize!(&txt)
+      Tokenize!(TeXString::assembled(txt))
     },
     _ => Tokens::default(),
   }
@@ -1064,7 +1064,7 @@ fn six_format_simplenumber(number: &SixNumber) -> Tokens {
     tokens.extend(trailer);
 
     let meaning = six_number_string(number);
-    let meaning_toks = Tokenize!(&meaning);
+    let meaning_toks = Tokenize!(TeXString::assembled(meaning));
     let symbol = i_symbol(
       &[("role", Tokenize!("NUMBER")), ("meaning", meaning_toks)],
       None,
@@ -1679,10 +1679,10 @@ fn six_format_1unit(unit: &SixUnit) -> Tokens {
   // to be ASCII.
   let mut pres_inner = Vec::new();
   if let Some(pr) = &pre_resolved {
-    pres_inner.extend(mouth::tokenize(pr).unlist());
+    pres_inner.extend(mouth::tokenize(TeXString::assembled(pr.clone())).unlist());
   }
   if let Some(ut) = &u_resolved {
-    pres_inner.extend(mouth::tokenize(ut).unlist());
+    pres_inner.extend(mouth::tokenize(TeXString::assembled(ut.clone())).unlist());
   }
 
   // \lx@unit{name}{\mathrm{presentation}}
@@ -2057,9 +2057,9 @@ fn six_convert_units_from_tokens(tokens: &Tokens) -> Option<Vec<SixUnitDefn>> {
       {
         // Apply arg to the appropriate field
         if defn.unit_type == "postpower" || defn.unit_type == "prepower" {
-          defn.power = Some(Tokenize!(&arg));
+          defn.power = Some(Tokenize!(TeXString::assembled(arg.clone())));
         } else if defn.unit_type == "qualifier" {
-          defn.presentation = Tokenize!(&arg);
+          defn.presentation = Tokenize!(TeXString::assembled(arg.clone()));
         }
         defns.push(defn);
       }
@@ -2144,12 +2144,14 @@ fn decode_unit_defn_from_encoded_sym(
     Some(SixUnitDefn {
       name:         name.to_string(),
       unit_type:    parts[0].to_string(),
-      presentation: Tokenize!(parts.get(1).unwrap_or(&"")),
+      presentation: Tokenize!(TeXString::assembled(
+        parts.get(1).unwrap_or(&"").to_string()
+      )),
       power:        parts.get(2).and_then(|p| {
         if p.is_empty() {
           None
         } else {
-          Some(Tokenize!(p))
+          Some(Tokenize!(TeXString::assembled(p.to_string())))
         }
       }),
       base:         parts.get(3).and_then(|b| b.parse().ok()),
@@ -2218,7 +2220,7 @@ fn resolve_unit_presentation(pres: &Tokens) -> String {
           let pres = parts[1];
           // If the presentation itself contains backslashes, try to resolve recursively
           if pres.contains('\\') {
-            let sub = Tokenize!(pres);
+            let sub = Tokenize!(TeXString::assembled(pres.to_string()));
             let sub_resolved = resolve_unit_presentation(&sub);
             result.push_str(&sub_resolved);
           } else {
@@ -2456,7 +2458,7 @@ LoadDefinitions!({
     };
     if !pkg_opts.is_empty() {
       let setup = format!("\\sisetup{{{}}}", pkg_opts.join(","));
-      Digest!(Tokenize!(&setup))?;
+      Digest!(Tokenize!(TeXString::assembled(setup)))?;
     }
 
     // Perl siunitx.sty.ltxml L115-121: if version-1-compatibility OR
@@ -2849,7 +2851,7 @@ LoadDefinitions!({
     }
 
     let symbol = i_symbol(
-      &[("role", Tokenize!("NUMBER")), ("meaning", Tokenize!(&meaning))],
+      &[("role", Tokenize!("NUMBER")), ("meaning", Tokenize!(TeXString::assembled(meaning)))],
       None,
     );
     let dual = i_dual(&[], symbol, combined, vec![]).unwrap_or_default();

--- a/latexml_package/src/package/soul_sty.rs
+++ b/latexml_package/src/package/soul_sty.rs
@@ -64,7 +64,7 @@ LoadDefinitions!({
       let font_key = s!("soul_font_{cs_name}");
       if let Some(Stored::String(font_sym)) = lookup_value(&font_key) {
         let font_str = to_string(font_sym);
-        let toks = mouth::tokenize_internal(&font_str);
+        let toks = mouth::tokenize_internal(TeXString::assembled(font_str));
         digest(toks)?;
       }
     }

--- a/latexml_package/src/package/xcolor_sty.rs
+++ b/latexml_package/src/package/xcolor_sty.rs
@@ -1123,13 +1123,13 @@ LoadDefinitions!({
   DefMacro!("\\lshiftnum {}", sub[(num)] {
     let n: f64 = do_expand(num)?.to_string().parse().unwrap_or(0.0);
     let result = (10.0 * n) as i64;
-    Ok(mouth::tokenize_internal(&result.to_string()))
+    Ok(mouth::tokenize_internal(TeXString::assembled(result.to_string())))
   });
 
   DefMacro!("\\llshiftnum {}", sub[(num)] {
     let n: f64 = do_expand(num)?.to_string().parse().unwrap_or(0.0);
     let result = (100.0 * n) as i64;
-    Ok(mouth::tokenize_internal(&result.to_string()))
+    Ok(mouth::tokenize_internal(TeXString::assembled(result.to_string())))
   });
 
   // \lshiftset and \llshiftset: set register = 10*n or 100*n

--- a/latexml_package/src/package/xy_sty.rs
+++ b/latexml_package/src/package/xy_sty.rs
@@ -400,8 +400,14 @@ LoadDefinitions!({
   // Catch-all: DeclareOption(undef, ...)
   // Perl: DeclareOption(undef, '\edef\next{\noexpand\xyoption{\CurrentOption}}\next');
   DeclareOption!(None, {
-    let current_option = do_expand(T_CS!("\\CurrentOption"))?.to_string();
-    unread(Tokenize!(&s!("\\xyoption{{{}}}", current_option)));
+    // `untex_string()`, NOT `to_string()`: `\\CurrentOption` expands to `Tokens`,
+    // and flattening those with `Display` welds a control word onto the letter
+    // that follows it. See `TeXString`.
+    let current_option = do_expand(T_CS!("\\CurrentOption"))?.untex_string();
+    unread(Tokenize!(TeXString::assembled(s!(
+      "\\xyoption{{{}}}",
+      current_option.as_str()
+    ))));
   });
 
   //======================================================================

--- a/latexml_package/src/package/xylatexml_tex.rs
+++ b/latexml_package/src/package/xylatexml_tex.rs
@@ -449,8 +449,8 @@ LoadDefinitions!({
       2 => (-delta, 1.0),
       _ => (-1.0, -delta),
     };
-    def_macro(T_CS!("\\cosDirection"), None, Tokenize!(&s!("{:.6}", dx * norm)), None)?;
-    def_macro(T_CS!("\\sinDirection"), None, Tokenize!(&s!("{:.6}", dy * norm)), None)?;
+    def_macro(T_CS!("\\cosDirection"), None, Tokenize!(TeXString::assembled(s!("{:.6}", dx * norm))), None)?;
+    def_macro(T_CS!("\\sinDirection"), None, Tokenize!(TeXString::assembled(s!("{:.6}", dy * norm))), None)?;
   });
 
   // \lx@xy@move@to — position content at (x,y) in SVG (Perl L236-242)
@@ -1389,23 +1389,23 @@ LoadDefinitions!({
         let mut h_max = Dimension::default();
         for (i, h) in row_heights.iter().enumerate() {
           let name = s!("\\Hrow@{}", i + 1);
-          def_macro(T_CS!(&name), None, Tokenize!(&h.to_string()), global_opts(&name))?;
+          def_macro(T_CS!(&name), None, Tokenize!(TeXString::assembled(h.to_string())), global_opts(&name))?;
           h_max = h_max.larger(*h);
         }
         // Add fake last row (Perl L1077-1078)
         let last_idx = row_heights.len() + 1;
         let name = s!("\\Hrow@{}", last_idx);
         def_macro(T_CS!(&name), None, Tokenize!("0pt"), global_opts(&name))?;
-        def_macro(T_CS!("\\H@max"), None, Tokenize!(&h_max.to_string()), global_opts(""))?;
+        def_macro(T_CS!("\\H@max"), None, Tokenize!(TeXString::assembled(h_max.to_string())), global_opts(""))?;
         // Define \Wcol@1, \Wcol@2, ... and find \W@max
         let mut w_max = Dimension::default();
         for (j, w) in col_widths.iter().enumerate() {
           let name = s!("\\Wcol@{}", j + 1);
-          def_macro(T_CS!(&name), None, Tokenize!(&w.to_string()), global_opts(&name))?;
+          def_macro(T_CS!(&name), None, Tokenize!(TeXString::assembled(w.to_string())), global_opts(&name))?;
           w_max = w_max.larger(*w);
         }
-        def_macro(T_CS!("\\W@max"), None, Tokenize!(&w_max.to_string()), global_opts(""))?;
-        def_macro(T_CS!("\\HW@max"), None, Tokenize!(&h_max.larger(w_max).to_string()), global_opts(""))?;
+        def_macro(T_CS!("\\W@max"), None, Tokenize!(TeXString::assembled(w_max.to_string())), global_opts(""))?;
+        def_macro(T_CS!("\\HW@max"), None, Tokenize!(TeXString::assembled(h_max.larger(w_max).to_string())), global_opts(""))?;
         // Reset counters (Perl L1086-1088)
         assign_register("\\Col", RegisterValue::Number(Number::new(0)), Some(Scope::Global), Vec::new())?;
         assign_register("\\Row", RegisterValue::Number(Number::new(0)), Some(Scope::Global), Vec::new())?;


### PR DESCRIPTION
## Diagnostic.

Flattening `Tokens` with `Display` **welds control words**. TeX consumes the
space that terminates one, so `\v S` tokenizes to `[\v][S]` and `to_string()`
re-emits it as `\vS` — a control sequence that exists in no LaTeX. `untex()`
puts the space back; `Display` does not, and says so in its own doc comment.

This is **not a translation divergence**. Perl is identical (`Core/Tokens.pm:61
toString` joins the token strings; `Core/Token.pm:306` returns a CS name with no
trailing space) and its comment — which our port copies verbatim — already warns
"NOT for creating valid TeX (use revert or UnTeX for that!)". Perl protects
itself by author discipline alone.

That discipline has now failed **three** times here, each found by a
user-visible failure years after the code was written:

| site | PR / issue | symptom |
|---|---|---|
| `\bib@@names` | PR #399 | every space-form accent in an author name → undefined macro |
| `dcolumn` / `overpic` | PR #400 | same shape, different binding |
| `\bib@synthesize@mr` | issue 410 | `MRREVIEWER = {Fran\c cois\ Digne}` → `undefined:\ccois` |

Three is a pattern, so this closes the class with a type instead of fixing a
fourth site by hand.

## Approach.

`TeXString` (in `latexml_core::tokens`, beside `Tokens`) is a string of TeX
markup that is safe to re-tokenize. The whole trick is which conversions exist:

* **`From<&'static str>` — and deliberately no `From<String>`, no `From<&str>`.**
  A TeX literal in a binding is `&'static str`, so ~125 literal call sites keep
  compiling untouched. `s!(…)`/`format!(…)` returns `String` and `&some_var` is a
  short-lived borrow: neither coerces, so both must declare intent. A welded
  flatten now fails with E0277, or with E0521 "`'1` must outlive `'static`".
* **`Tokens::untex_string(self) -> TeXString`** — the blessed path. `untex()`
  itself is unchanged for callers that want a plain `String` (a `tex=` attribute,
  a log line, a comparison).
* **`TeXString::assembled(String)`** — the escape hatch, whose doc states the
  obligation it imposes: *every interpolated fragment is either literal TeX
  written at the call site, or came from `untex_string`.*

The sinks — `mouth::tokenize`, `mouth::tokenize_internal`, and therefore
`Tokenize!` / `TokenizeInternal!`, which expand to them — now take
`impl Into<TeXString>`. `build_invocation_str` (a thin `tokenize_internal`
wrapper behind `Invocation!`) propagates the type rather than laundering it.

**`Display for Tokens` is untouched.** It is the faithful translation of Perl
`toString`, and 500+ sites legitimately use it for keys, names and comparisons.
Nothing about the output changes, so this is an internal safety property, **not**
an `OXIDIZED_DESIGN` divergence — no divergence entry was added.

82 call sites had to declare intent. Each says which of the two it is, in one
line: the six that could genuinely weld now use `untex_string()`; the rest
declare `assembled` with the reason they cannot (a scalar rendering, an arena
string, a raw `.bib` field, a single delimiter `Token` with nothing after it).

## Validation.

**Audit, before → after.** Method: shadow the trait method with a *deprecated
inherent* `Tokens::to_string`, so every call site warns while `format!("{t}")`
stays silent; collect the warnings workspace-wide; remove the shim.

| | before (`main`) | after |
|---|---|---|
| `Tokens::to_string()` call sites, workspace-wide | 547 | 536 |
| …feeding a **tokenizing** sink, in production code | 6 | **0** |
| …feeding a tokenizing sink at all | 6 | 1 — the guard test's own negative demo |

(−15 converted, +4 added by the new guard test.) The remaining 536 are the
cannot-weld bucket the type deliberately leaves alone: the string becomes a CS
*name* (`T_CS!(cs.to_string())`), an `Explode`d char run, a `.parse()`, or a
comparison. They are unreachable from a sink by construction now — the signature
no longer accepts a `String`.

**Suite: 1711 → 1713 passing, 0 failed, 101 targets** (`cargo test --tests
--workspace`, both measured on this machine, `main` @ `b6ed9a1920` vs this
branch). Delta is exactly the two new tests; **no existing test changed
outcome**. `cargo +nightly clippy --workspace --all-targets -- -D warnings`,
`cargo +nightly fmt --all` and `cargo doc --workspace` are clean.

**Witness `2605.11579`** (`main.tex`, `--includestyles` — bare mode gives false
results, the paper's `.sty` files live in `preamble/`), same-host, 36 bibitems in
every run:

| | errors | undefined CSes |
|---|---|---|
| before (`main`) | 5 | `\ccois`, `\cprimefand`, `\ic`, `\io`, `\Dbarokovi` |
| after | **1** | `\Dbar` |
| Perl 0.8.8 | 80 | `\Dbar` |

Four of the five welds are gone outright. The fifth is *un-welded*:
`MRREVIEWER = {Dragomir \v{Z}. \Dbar okovi\'{c}}` now reads `\Dbar` + ` okovi…`
instead of `\Dbarokovi`, and `\Dbar` (MathSciNet's Đ) is defined nowhere in Perl
LaTeXML or TeX Live either — same-host Perl emits exactly the same one
`undefined:\Dbar`, so the residual is **parity**, not a leftover. Perl's own
`\bib@synthesize@mr` never had the bug: `currentBibEntryField` hands it a raw
string, where our `current_entry_field` returns `Tokens` — the weld was
introduced by the port.

**Guards.**
* `latexml_core::tokens::texstring_guard_tests` — compile-time. A hand-rolled
  `assert_not_impl_any!` asserts `String` and `&String` are **not**
  `Into<TeXString>`, and a companion asserts `&'static str` still **is**. If a
  future `impl From<String>` reopens the hole, the test target stops compiling
  (so `cargo test --tests`, and CI, catch it). Plus a `compile_fail` doctest on
  the type, for the human reader.
* `bib_mr_review_space_form_accent_survives_reversion` — behavioural, on the
  issue-410 path. Verified RED with the old flattening (`Fran\ccoisDigne`,
  `Error:undefined:\ccois`) and GREEN with `untex_string()` (`François Digne`).
* WISDOM #71 records the rule, the census method, and the three sites it cost.

## Decisions & open questions

1. **Full sink typing, not the bibliography-only landing.** The smaller option
   was to type only `bibtex.rs`'s sinks. I took the full one: the 82 sites were
   all mechanical, and the partial landing would have left `Tokenize!` accepting
   a welded `String` everywhere else — i.e. the fourth site could still be
   written, which is the entire point of the PR. *Alternative*: the narrow
   landing. *Settled by*: it is green with no output movement, so there is no
   cost to weigh against.

2. **The `&str`-taking conversion helpers stay a hole.** `From<&str> for
   Reversion`, `From<&str> for ExpansionBody` and `IntoOption<Option<Reversion>>
   for &str` are thin `tokenize_internal` wrappers; a `String` still reaches them
   via `s.as_str()` without saying so. *Chosen*: leave them on `&str`, call
   `assembled` inside, and comment the residual hole in `definition.rs`.
   *Alternative*: narrow them to `&'static str`, closing it. *What would settle
   it*: a count of legitimate runtime-built bodies flowing through them — I did
   not measure it, and narrowing is a wider blast radius than this PR should
   carry.

3. **Two families converted to `untex_string()` beyond the six.**
   `\lx@physics@*`'s `semantic` arguments (7 sites) and `\mathtoolsset`'s value
   (the `ArgWrap::Tokens` variant only) are `Tokens` flattened straight back into
   `Tokenize!` — the same bug class, reachable with an accented `meaning`/value.
   *Alternative*: `assembled`, byte-identical and zero-risk. *Chosen* because
   leaving a weld in place after seeing it seemed worse; the suite is unchanged
   either way.

4. **Physics *delimiters* use `assembled`, not `untex_string`.** `open`/`close`
   there are single `Token`s, so there is nothing following them to weld to.
   Routed through one named helper, `phys_delim_tex`, so the reasoning is written
   once instead of fifteen times. *Alternative*: `untex_string` anyway — also
   safe, and arguably more uniform. *Settles on*: taste.

5. **`tabularray`'s `tblr` colspec keeps `to_string()` for the translator.**
   `translate_tblr_colspec` consumes the flattened string; feeding it `untex`
   output would change the translator's *input*, i.e. behaviour. Only the
   surrounding `\tabular{…}` format is `assembled`. *What would settle it*: a
   colspec fixture containing a space-form control word — I could not construct a
   realistic one.

6. **`lookup_tokens` gives up one micro-optimization.** Its `Stored::String`
   branch deliberately passed the interned arena `&str` straight to
   `tokenize_internal` to avoid materializing a `String`. An arena `&str` is not
   `'static` (it dangles across a realloc), so it now copies. `Mouth::new` copies
   its input anyway, so the marginal cost is one malloc; the comment records the
   trade. *What would settle it*: a profile showing `lookup_tokens` is hot enough
   to care.

7. **The Rhai front-end asserts `assembled` on script-author strings.** A
   `Tokenize("…")` from a contributed binding is the runtime twin of a
   compile-time literal, and Rhai's `Tokens` is opaque with no string conversion
   registered — so a script cannot hand us a flattened `Tokens` today. If one is
   ever registered, that assertion becomes wrong.

8. **Branched off `main`, not #403.** PR #403 is still open and touches
   `bibtex.rs` heavily. Whichever lands second will need a small rebase; the
   overlap here is four lines in `\bib@synthesize@mr`/`@zbl` plus the
   `current_entry_field` raw-field arm.
