### PR TITLE
A .bib field's ^ is data; mathscinet.sty gets a real binding

### DIFF
--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -64,6 +64,37 @@ session of their own. Re-verify a row before planning on it (rule 1).
 
 ## Current status
 
+- **2026-07-27 — a `.bib` field's `^` is data too, and `mathscinet.sty` gets a
+  binding.** Two changes, one PR. (a) `^` joins `_` in treatment 2 of
+  **OXIDIZED_DESIGN #74** — verified symmetric with `_` rather than assumed
+  (both are TeX scripting characters, both inert to `bibtex(1)`, both raise
+  "Script … can only appear in math mode" outside math; `note = {q _ r ^ s}`
+  now renders literally, zero errors). It needs its OWN escaper arm, because
+  `\^` is the circumflex **accent** — the generic `\` + character arm would
+  render `^o` as "ô", a wrong glyph rather than a diagnostic — so
+  `BIB_DATA_CARET` emits `\textasciicircum{}`. Knock-on:
+  `105_bib_field_digest_once` lost its last non-self-healing probe and moved to
+  `\hline` (→ `\noalign`, a context error).
+  (b) **`mathscinet.sty`** (AMS, v1.05, in the amsrefs bundle) is now bound at
+  `latexml_package/src/package/mathscinet_sty.rs` — Perl has `amsrefs.sty.ltxml`
+  but no `mathscinet.sty.ltxml`, so Rust-only, though ported from the real
+  `.sty` (mappings from its T1 branches: `\Dbar`→`\DJ`, `\dbar`→`\dj`,
+  `\cprime`→`\tprime`, `\polhk`→`\k`). **Nothing auto-loads it**, and that is
+  the decision: witness 2605.11579 never loads the package and uses
+  `\bibliographystyle{alpha}`, whose `.bst` has zero `Dbar`, so its
+  `undefined:\Dbar` is **PARITY** with the author's own pdflatex build — it
+  stays at 1 error / 36 bibitems, now explained. `\Dbar` is package-only for a
+  second measured reason: 4 of 4,000 arXiv-2605 papers define it with
+  `\newcommand`, which an always-on definition silently shadows (LaTeXML keeps
+  the OLD meaning, no diagnostic). The `\cprime` family keeps an always-on stub
+  — a `.bib` carries `Gel\cprime fand` with no `\usepackage` — but moved out of
+  `latex_constructs.rs` (Perl-parity file) into `latex_constructs_rust_only.rs`
+  §5 with its witnesses 2508.13753 / 2508.20226 / 2509.07628, all three of which
+  load the package by name, refuting the old `cyracc.def` justification.
+  Divergence **#78**. Guards `bib_mathscinet_package_supplies_its_transliteration_glyphs`,
+  `bib_mathscinet_macro_yields_to_the_authors_own_definition`,
+  `escape_specials_caret_is_textasciicircum_not_an_accent`.
+
 - **2026-07-26 (later still) — a bare `&` in a `.bib` field is data (OXIDIZED_DESIGN #74).**
 - **2026-07-26 — undefined CSes from packages with no binding: `silence.sty`,
   bundled `arxiv.sty`/`PRIMEarxiv.sty`.** Long-standing gaps, **not** a

--- a/docs/parity/BIBLIOGRAPHY_WORKLIST.md
+++ b/docs/parity/BIBLIOGRAPHY_WORKLIST.md
@@ -69,7 +69,7 @@ collapsing the pipeline collapsed both handlings into one.
 
 | | treatment | what it does | mechanism |
 |---|---|---|---|
-| **1** | reading the `.bib` — *be `bibtex`* | field bytes are inert data: `%` is not a comment, `&` not an alignment tab, `#` not a parameter, `_` not a subscript. Only braces and the entry/field delimiters are structural. **The text is not altered** — the stored value keeps its exact bytes. | a per-Mouth opt-in property on the entry mouth, plus a companion (`tokenize_bib_literal`) for handlers that re-read the raw field |
+| **1** | reading the `.bib` — *be `bibtex`* | field bytes are inert data: `%` is not a comment, `&` not an alignment tab, `#` not a parameter, `_` not a subscript, `^` not a superscript. Only braces and the entry/field delimiters are structural. **The text is not altered** — the stored value keeps its exact bytes. | a per-Mouth opt-in property on the entry mouth, plus a companion (`tokenize_bib_literal`) for handlers that re-read the raw field |
 | **2** | synthesizing the `.bbl` and digesting it — *be `pdflatex` pass 2* | the content must now be valid TeX, and we are the ones writing the `.bbl`, so we escape what the author plainly meant literally | `escape_bib_data_specials` at the data→TeX boundary: math spans skipped, idempotent |
 
 **The corollary that makes the exclusion list principled.** A handler that
@@ -90,16 +90,26 @@ name-, date- and MR/Zbl-assembly sites that share that path.
 State catcode is inherited by a `.sty` raw-load triggered from inside a field
 handler, where `%` must still be a comment.
 
-**Correction to the table above, measured while implementing it: `_` belongs to
-treatment 2 ONLY.** The row is right that a `_` in a field is data, but wrong
-that treatment 1 is where that gets expressed. A catcode is decided at
+**Correction to the table above, measured while implementing it: `_` and `^`
+belong to treatment 2 ONLY.** The row is right that a `_` in a field is data,
+but wrong that treatment 1 is where that gets expressed. A catcode is decided at
 tokenization, before anything knows whether the character is inside `$…$`, and
 a subscript in a title's math (`title = {Bounds on $x_1+x_2$}`) is legitimate
 TeX that must keep working. Putting `_` in `Mouth::with_bib_data_literals`
 silently flattened every subscript in a bibliography title — caught by the
 existing `bib_bare_ampersand_leaves_live_markup_alone`, which asserts
 `role="SUBSCRIPTOP"`. Only the escaper can be math-aware, so treatment 1 covers
-`% & #` and treatment 2 covers all four. Landed that way in OXIDIZED_DESIGN #74.
+`% & #` and treatment 2 covers all five. Landed that way in OXIDIZED_DESIGN #74.
+
+**`^` is treatment-2-only for exactly the same reason as `_`, and joined it
+2026-07-27.** The two are twins in this flow: both are TeX scripting characters,
+both are plain data to `bibtex(1)`, both raise "Script … can only appear in math
+mode" outside math — verified end-to-end rather than assumed (`note = {q _ r ^ s}`
+renders `q _ r ^ s`, zero errors). The one asymmetry is the escape spelling, and
+it is a silent trap: `\_` is the underscore command but `\^` is the circumflex
+**accent**, so the generic `\` + character arm would render `^o` as "ô". `^` gets
+its own arm emitting `\textasciicircum{}`, braces included. This is what closed
+"the `^` third remains open" below.
 
 ### Why the re-port is the real fix: eager tokenization defeats parameter types (measured 2026-07-26)
 
@@ -118,14 +128,16 @@ Three sub-causes, and they are NOT three bugs — they are one architectural gap
 | `unexpected:_` / `&` / `^`, `misdefined:#` | 61 | TeX specials that are literal inside a URL |
 
 The first two are fixed (#391: `BBL_STANDARD_FALLBACKS`, `BibCatcodeScope`).
-The third is **not**, and must not be fixed by widening the catcode phase:
-`$a_b$` and `$x^2$` in a title are legitimate, so neutralizing `_`/`^`
-file-wide would trade one regression for another.
+The third is fixed too (below), but NOT by widening the catcode phase, and that
+constraint is why: `$a_b$` and `$x^2$` in a title are legitimate, so
+neutralizing `_`/`^` file-wide would trade one regression for another. Only the
+math-aware escaper can carry a scripting character.
 
 **LANDED 2026-07-27 on the `.bib` POOL route, exactly as consequence 2 above
 prescribes** — an escape at the A→B boundary, not catcode suppression.
 `escape_bib_data_specials` (`bibtex.rs`) emits `%`→`\%`, `&`→`\&`, `#`→`\#`,
-`_`→`\_`; `\emph{…}`, `$x_1+x_2$` and `{\v S}pakov` pass through untouched.
+`_`→`\_`, `^`→`\textasciicircum{}`; `\emph{…}`, `$x^2+y_1$` and `{\v S}pakov`
+pass through untouched.
 The mechanism, its four hazards (math, idempotency, raw-read fields, nested
 `\url` data regions) and — the part that was NOT obvious — the **three** seams
 it had to cover are in OXIDIZED_DESIGN #74: the entry line in
@@ -222,8 +234,9 @@ field.
 `{\&}amp;` / `&amp;`, where an HTML entity survived into the `.bib`. Those raise
 no error at all — Perl and pdflatex both print "&amp;" — so the mouth-level
 change does not reach them; `undouble_escaped_ampersand` in `bibtex.rs` does.
-Guard `bib_escaped_amp_entity_decodes_to_one_ampersand`. The `^` third remains
-open.
+Guard `bib_escaped_amp_entity_decodes_to_one_ampersand`. **The `^` third is
+CLOSED** (2026-07-27) — the same treatment-2 escape as `_`, with its own arm
+because `\^` is the circumflex accent; see the two-treatments section above.
 
 #### What the 2026-07-26 prototype measured (and the two claims it corrected)
 

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2584,6 +2584,92 @@ Guards: `00_contrib::silence_filters_test`, `00_contrib::arxiv_keywords_test`,
 `arxiv.sty` with a distinctive keyword label must still win),
 `107_silence_keeps_diagnostics` (the raw-load suppression above).
 
+### 78. `mathscinet.sty` gets a binding — and nothing loads it for you
+
+`mathscinet.sty` is a real package: AMS, v1.05 (2002/04/17), LPPL, shipped in TeX
+Live inside the **amsrefs** bundle
+(`texmf-dist/tex/latex/amsrefs/mathscinet.sty`). It holds the vocabulary
+[MathSciNet](https://mathscinet.ams.org) records transliterate Cyrillic and
+South-Slavic names with: `\cprime` (ь), `\Dbar`/`\dbar` (Đ/đ), `\cdprime`,
+`\bud`, `\cydot`, `\polhk`, `\soft` and the under-accents. Perl LaTeXML has
+`amsrefs.sty.ltxml` but **no** `mathscinet.sty.ltxml`, so the binding is a
+Rust-only addition — though a port of the real `.sty`, not an invention.
+`latexml_package/src/package/mathscinet_sty.rs`.
+
+**Mappings come from the file's own T1 branches**, which say what each glyph IS
+rather than how it is drawn: `\Dbar`→`\DJ` (U+0110), `\dbar`→`\dj` (U+0111),
+`\cprime`→`\tprime` (U+02B9), `\cdprime`→two of them (U+02BA), `\polhk`→`\k`,
+`\soft`→`\v`, `\udot`→`\d`. The Default branches overprint with `\accent` and
+`\hbox` kerning (`\Dbar` is
+`\leavevmode\lower.5ex\rlap{\hskip-.07em\accent"16}D`), which would reach the XML
+as a bare "D" (WISDOM #50). Two deliberate departures from the source: L36's
+`\RequirePackage{textcmds}` is not reproduced (it would raw-load a
+`\pcatcode`-juggling docstrip `.sty` for two commands whose results are inlined),
+and `\Cprime`/`\Cdprime` — `cyracc.def` L53-55 spellings that arrive with the
+same data but are absent from this `.sty` — are provided alongside.
+
+**Nothing auto-loads it, and that is the load-bearing decision.** The recursive
+`.bib` session already loads `url.sty` on a document's behalf (divergence #72),
+so doing the same for mathscinet is the obvious move. It would be wrong.
+Checked, not assumed, on witness 2605.11579: the paper never mentions
+`mathscinet` or `amsrefs`, and it uses `\bibliographystyle{alpha}` — and
+`alpha.bst` contains **zero** occurrences of `Dbar`, so no `.bst` `@preamble`
+supplies it either. `\Dbar` is therefore undefined in the author's own build:
+real pdflatex raises the same undefined control sequence. **The residual
+`undefined:\Dbar` is PARITY, not a defect**, and supplying the macro anyway would
+push our error count below what the author's toolchain produces — the one thing
+the canvas signal must never do. 2605.11579 stays at **1 error / 36 bibitems**,
+with that error now explained rather than outstanding.
+
+**Why a package and not an always-present kernel definition**, for `\Dbar`
+specifically. A format-chain definition runs before the document's preamble, and
+LaTeXML's `\newcommand` over an already-defined CS silently keeps the OLD meaning
+(no error, no warning), so an always-present vendor macro SHADOWS an author's
+own. Scanned 4,000 papers of arXiv 2605:
+
+| macro | authors define it | with `\newcommand` (would be shadowed) | used-but-undefined |
+|---|---|---|---|
+| `\cprime` family | 10 | 0 (all `\def`, which overrides cleanly) | ~20 |
+| `\Dbar` | 6 | **4** | 2 |
+| `\dbar` | 12 | 8 | 0 |
+
+An always-on `\Dbar` renders `Đ` where four authors wrote
+`\newcommand{\Dbar}{\bar{D}}` — verified, with zero diagnostics — i.e. it breaks
+more papers than it fixes. Inside a document that DOES load the package, the
+upstream `\ProvideTextCommand`/`\ProvideTextCommandDefault` deferral (kept as
+`mathscinet_sty.rs::provide`) yields to a name already taken. That is also what
+makes `\dbar` safe to bind here and nowhere else.
+
+**The `\cprime` family keeps an always-on stub as well, deliberately.** All three
+of its witnesses load the package by name — 2508.13753 L7, 2508.20226 L3,
+2509.07628 L13 — which corrects the `cyracc.def` / "no Cyrillic encoding
+otherwise loaded" justification the block used to carry. But the package is not
+the only way the family arrives: a `.bib` field carries `Gel\cprime fand` with no
+`\usepackage` behind it, and a MathSciNet export's `@preamble` may or may not
+define it. Removing the stub was measured to cost exactly that case
+(`bib_mr_reviewer_accent`'s `primerev` entry regains `undefined:\cprime`), and no
+author in the scan defines the family with `\newcommand`, so the stub shadows
+nobody. It moved out of `latex_constructs.rs` — which mirrors
+`latex_constructs.pool.ltxml` byte-for-byte and should hold no non-Perl
+definitions — into `latex_constructs_rust_only.rs` §5, the file that exists for
+exactly this, carrying its witnesses. `provide` in the binding then finds them
+already defined, the correct no-op. `\polhk`'s comment there claimed tipa.sty as
+its source; the real one is `mathscinet.sty` L111-113, corrected in place.
+
+**Measured**, same host: 2605.11579 `--includestyles` **1 error / 36 bibitems**
+(the `\Dbar` parity residual); 2508.13753 **0 errors**, `Kondratʹev` composing;
+2508.20226 **0 errors**; 2509.07628 `--includestyles` **0 errors**, `Drinfelʹ d`
+composing (its 6 bare-mode errors are an unloaded local `Latex-document.sty`,
+unrelated).
+
+Guards: `06_cluster_bibliography::bib_mathscinet_package_supplies_its_transliteration_glyphs`
+(a document that loads the package, exercising both body prose and a `.bib`
+`MRREVIEWER`; `\Dbar` is the discriminating assertion, since `\cprime` also has
+the stub beneath it) and
+`::bib_mathscinet_macro_yields_to_the_authors_own_definition` (a document that
+does not — RED under an always-on `\Dbar`, where the author's barred-D math
+renders `Đ`, and equally RED if the `.bib` session is made to auto-load).
+
 ## Known Upstream Perl Issues (brief)
 
 These are behaviors in the original Perl LaTeXML that are bugs or limitations, not

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2275,7 +2275,7 @@ this fixture, 203 on the witness) passed every bibliography guard silently.
 (percent in `abstract`, specials in `keywords`, and a third entry as the
 containment canary).
 
-### 74. A `.bib` field's content is DATA — `% & # _` are literal, not catcodes
+### 74. A `.bib` field's content is DATA — `% & # _ ^` are literal, not catcodes
 
 Supersedes the separate `%`-only and `&`-only entries this consolidates
 (PRs #405 and #409); `_` was a third instance of the same defect.
@@ -2302,19 +2302,35 @@ lexed*, not to the session.
 **Treatment 2 — synthesizing the `.bbl` and digesting it (be `pdflatex` pass 2).**
 Now the content must be valid TeX. We are the ones writing the `.bbl` and we
 know the author meant the literal character, so we escape at that boundary:
-`%`→`\%`, `&`→`\&`, `#`→`\#`, `_`→`\_`.
+`%`→`\%`, `&`→`\&`, `#`→`\#`, `_`→`\_`, `^`→`\textasciicircum{}`.
 `bibtex.rs::escape_bib_data_specials`. Escaping here rather than suppressing
 catcodes during digestion is what keeps the TeX regime intact **by
 construction**: `\emph{…}`, `{\v S}pakov` and `$x_1+x_2$` are already valid TeX
 and simply pass through.
 
-**Why `_` is in treatment 2 only.** A catcode is decided at tokenization, before
-anything knows whether it is inside `$…$` — and a subscript in a title's math
-(`title = {Bounds on $x_1+x_2$}`) is legitimate TeX that must keep working.
-Measured: adding `_` to treatment 1 silently flattened every subscript in a
-bibliography title. Only the escaper can be math-aware, so `_` lives there
-alone. The other three have no legitimate TeX meaning inside a `.bib` field,
-in math or out.
+**Why `_` and `^` are in treatment 2 only.** A catcode is decided at
+tokenization, before anything knows whether it is inside `$…$` — and a
+sub/superscript in a title's math (`title = {Bounds on $x^2+y_1$}`) is
+legitimate TeX that must keep working. Measured: adding `_` to treatment 1
+silently flattened every subscript in a bibliography title. Only the escaper can
+be math-aware, so the two scripting characters live there alone. The other three
+have no legitimate TeX meaning inside a `.bib` field, in math or out.
+
+**`^` is `_`'s twin, and the symmetry was verified rather than assumed.** Both
+are TeX scripting characters; `bibtex(1)`'s lexer gives neither any meaning
+inside an entry, so both are plain data; and outside math both raise the same
+diagnostic, "Script … can only appear in math mode". Checked end-to-end: a
+`note = {q _ r ^ s}` renders `q _ r ^ s`, zero errors, both characters intact.
+
+**But the escape is NOT `\` + the character, and that is the whole reason `^`
+needs its own arm** (`BIB_DATA_CARET`, placed before the generic
+`BIB_DATA_SPECIALS` arm). `\_` is the underscore text command; `\^` is the
+circumflex **accent**, so the generic arm would turn `^o` into "ô" — a wrong
+glyph, silently, where the author wrote a caret. `\textasciicircum{}` is the
+actual caret, and the braces are load-bearing so a following letter is not
+absorbed into the control word. Idempotency needs nothing new: `\textasciicircum`
+is a control word and is copied whole, `\^{}` is a control symbol and is copied
+as a pair.
 
 **The exclusion list is principled, not ad hoc.** A handler that consumes the
 field's characters *itself*, under its own catcode regime — `url`'s Verbatim
@@ -2345,7 +2361,8 @@ spellings and they must render identically.
 **Idempotency.** Most real `.bib` files already write `\&`, `\%`, `\_`. In the
 escaper a backslash consumes the next character as a pair and neither is
 re-examined, so `\&` stays `\&`. The tricky `\\&` falls out of the same rule:
-`\\` is consumed as one pair, leaving a genuinely bare `&` that IS escaped.
+`\\` is consumed as one pair, leaving a genuinely bare `&` that IS escaped —
+and so does `\\^`, which becomes `\\\textasciicircum{}`.
 
 **A nested data region.** url.sty reads `\url`/`\nolinkurl`/`\path`'s argument
 verbatim, so `howpublished = {\url{http://x.org/a%20b}}` must keep its `%20`.
@@ -2378,16 +2395,18 @@ applied to a `title`, and it covers `volume = {27 suppl_4}` and
 
 **Guards.** `06_cluster_bibliography::bib_field_specials_are_data_not_tex` (one
 ten-entry fixture, because the risk is precisely that fixing one case breaks
-another: the four specials bare, the same four already escaped rendering an
-IDENTICAL string, `$x_1+x_2$` keeping its `SUBSCRIPTOP`, `\emph` still markup,
+another: the five specials bare, the same five already escaped rendering an
+IDENTICAL string, `$x^2+y_1$` keeping BOTH its `SUPERSCRIPTOP` and its
+`SUBSCRIPTOP`, `\emph` still markup,
 `{\v S}pakov` still reverting, `%20` inside `\url{…}` intact, and `url`/`doi`
 values with no backslash); `::bib_field_percent_is_an_ordinary_character`;
 `::bib_bare_ampersand_is_literal_data`;
 `::bib_bare_ampersand_leaves_live_markup_alone`;
 `::bib_escaped_amp_entity_decodes_to_one_ampersand`;
-`55_bibtex::runaway_field_costs_only_its_own_entry`; and six
+`55_bibtex::runaway_field_costs_only_its_own_entry`; and seven
 `escape_bib_data_specials` unit tests in `bibtex.rs`, which isolate the `\\&`
-hazard that cannot live end-to-end (see below).
+hazard that cannot live end-to-end (see below) and pin
+`escape_specials_caret_is_textasciicircum_not_an_accent`.
 
 **Measured**, `--release` before/after on the same host, TOTAL document errors:
 
@@ -2423,12 +2442,17 @@ now prints "&".
 (`malformed:ltx:bibitem <ltx:bibitem> isn't allowed in <ltx:bib-title>`) with no
 special character anywhere in the entry — a pre-existing behaviour of `\\` in a
 bibliography, independent of this work, and the reason the `\\&` hazard is
-pinned by a unit test rather than end-to-end. `^` is deliberately outside the
-set: it is not in the authorized four, and outside math in a `.bib` field it is
-essentially always a typo (it also remains the live probe in
-`105_bib_field_digest_once`). An `&` inside a `.bib` field's `$\begin{array}…$`
-would lose its alignment meaning — treatment 1 is catcode-level and cannot be
-math-aware; no witness exhibits one.
+pinned by a unit test rather than end-to-end. An `&` inside a `.bib` field's
+`$\begin{array}…$` would lose its alignment meaning — treatment 1 is
+catcode-level and cannot be math-aware; no witness exhibits one.
+
+**A knock-on for the digest-once guard.** `105_bib_field_digest_once` needs a
+probe that re-raises on EVERY digest (an undefined macro self-heals into
+`<ltx:ERROR/>` on first sight and would pass with the bug present). It used `_`,
+then `^` when `_` became data; both are now data, so the probe moved to `\hline`
+in a `note`, which expands to `\noalign` — a context error with nothing to
+memoize. Both scripting characters stay in that fixture as the standing
+zero-error check.
 
 ### 75. A `.bib`-derived bibliography does not run the missing-`\bibitem` rescue
 

--- a/latexml_engine/src/bibtex.rs
+++ b/latexml_engine/src/bibtex.rs
@@ -263,11 +263,28 @@ fn bib_extract_text(field: &str) -> String {
     .unwrap_or_default()
 }
 
-/// The four TeX specials that a `.bib` field can only have meant literally.
+/// The TeX specials that a `.bib` field can only have meant literally, and whose
+/// escape is simply `\` + the character.
 ///
-/// Not `~` (a tie is plausible in a name) and not `^` (it only ever shows up in
-/// math here) — this is the maintainer-authorized set, no wider.
+/// Not `~` — a tie is plausible in a name. `^` belongs to the same authorized
+/// set but is NOT here, because `\^` is the circumflex accent and not an escaped
+/// caret; it gets its own arm and [`BIB_DATA_CARET`].
 const BIB_DATA_SPECIALS: [char; 4] = ['_', '&', '#', '%'];
+
+/// The escape for a bare `^`, which cannot be spelled `\` + the character.
+///
+/// `^` is `_`'s twin in this flow — both are TeX scripting characters, both are
+/// plain data to `bibtex(1)` (its lexer gives neither any meaning inside an
+/// entry), and both raise "Script … can only appear in math mode" once outside
+/// math. So the DATA-regime rule that covers `_` covers `^` on the same ground.
+///
+/// The escape spelling is where the symmetry stops, and it is a silent trap:
+/// `\_` is the underscore text command, but `\^` is the **circumflex accent**,
+/// so the generic `\` + character arm would turn `\Dbar okovi^c` into a "ĉ" and
+/// `^o` into "ô" — a wrong glyph rather than a diagnostic. `\textasciicircum` is
+/// the actual caret; the braces are load-bearing, so a following letter is not
+/// absorbed as the control word's continuation.
+const BIB_DATA_CARET: &str = "\\textasciicircum{}";
 
 /// The `.bib`-data -> TeX-source boundary: escape the specials a `.bst` would
 /// have escaped, so the synthesized entry line is valid TeX.
@@ -275,7 +292,7 @@ const BIB_DATA_SPECIALS: [char; 4] = ['_', '&', '#', '%'];
 /// Real BibTeX has TWO regimes and latexml-oxide collapses them into one pass.
 /// In the DATA regime (`.bib` read by `bibtex(1)`) a field's bytes are data:
 /// `%` is not a comment, `&` is not an alignment tab, `_` is not a subscript,
-/// `#` is not a parameter. Only in the TeX regime (the `.bbl` read by
+/// `^` is not a superscript, `#` is not a parameter. Only in the TeX regime (the `.bbl` read by
 /// `pdflatex`) do those catcodes exist — and what lands in the `.bbl` is
 /// whatever the `.bst` chose to write. We read `.bib` directly, with no `.bst`
 /// in the loop, so we are the component that decides what reaches the
@@ -290,13 +307,14 @@ const BIB_DATA_SPECIALS: [char; 4] = ['_', '&', '#', '%'];
 /// Two hazards, both guarded by
 /// `06_cluster_bibliography::bib_field_specials_are_data_not_tex`:
 ///
-/// * **Math.** `_` inside `$…$` is a real subscript, so math spans are skipped.
-///   `$`/`$$` toggle; `\(`/`\[` open and `\)`/`\]` close.
-/// * **Idempotency.** Most `.bib` files already write `\&`, `\%`, `\_`. A
-///   backslash therefore consumes the next character as a pair and neither is
-///   re-examined, so `\&` stays `\&`. The tricky case falls out of the same
-///   rule: in `\\&` the `\\` is consumed as one pair, leaving a genuinely bare
-///   `&` that IS escaped.
+/// * **Math.** `_`/`^` inside `$…$` are a real subscript and superscript, so
+///   math spans are skipped. `$`/`$$` toggle; `\(`/`\[` open and `\)`/`\]` close.
+/// * **Idempotency.** Most `.bib` files already write `\&`, `\%`, `\_`,
+///   `\textasciicircum`. A backslash therefore consumes the next character as a
+///   pair and neither is re-examined, so `\&` stays `\&` and `\^{}` stays
+///   `\^{}`; a control WORD is copied whole, so `\textasciicircum` survives. The
+///   tricky case falls out of the same rule: in `\\&` the `\\` is consumed as
+///   one pair, leaving a genuinely bare `&` that IS escaped.
 fn escape_bib_data_specials(value: &str) -> String {
   let mut out = String::with_capacity(value.len() + 8);
   let mut chars = value.chars().peekable();
@@ -348,6 +366,10 @@ fn escape_bib_data_specials(value: &str) -> String {
         }
         in_math = !in_math;
       },
+      // Before the generic arm, and deliberately: `\^` is the circumflex
+      // accent, so the generic `\` + character escape would render `^o` as "ô".
+      // See [`BIB_DATA_CARET`].
+      '^' if !in_math => out.push_str(BIB_DATA_CARET),
       _ if !in_math && BIB_DATA_SPECIALS.contains(&c) => {
         out.push('\\');
         out.push(c);
@@ -477,16 +499,18 @@ pub fn current_entry_field(name: &str) -> Option<Tokens> {
 /// splitting, date/pages/MR/Zbl assembly — build their tokens from the stored
 /// string and never go through that mouth.
 ///
-/// `_` is NOT in this set: a catcode is fixed at tokenization, before anything
-/// knows whether it is inside `$…$`, and a subscript in a title's math is
-/// legitimate TeX. It is handled by treatment 2 ([`bib_tex_tokens`]) instead.
+/// `_` and `^` are NOT in this set: a catcode is fixed at tokenization, before
+/// anything knows whether it is inside `$…$`, and a sub/superscript in a title's
+/// math is legitimate TeX. Both are handled by treatment 2
+/// ([`bib_tex_tokens`]) instead, which is the only one of the two that can be
+/// math-aware.
 fn tokenize_bib_field(text: impl Into<TeXString>) -> Tokens { mouth::tokenize_bib_literal(text) }
 
 /// Both treatments, for a raw `.bib` string that is about to become TeX tokens.
 ///
 /// Treatment 2 (`escape_bib_data_specials`) makes the data valid TeX — it is the
-/// only one of the two that can be math-aware, so it is what covers `_`; then
-/// treatment 1 ([`tokenize_bib_field`]) reads the result with `% & #` still inert,
+/// only one of the two that can be math-aware, so it is what covers `_` and `^`;
+/// then treatment 1 ([`tokenize_bib_field`]) reads the result with `% & #` still inert,
 /// covering whatever the escaper deliberately left alone (the inside of a
 /// `\url{…}`).
 ///
@@ -2674,17 +2698,38 @@ mod tests {
     );
   }
 
+  /// `^` is `_`'s twin — data to `bibtex(1)`, "Script … can only appear in math
+  /// mode" to TeX — but its escape is NOT `\` + the character: `\^` is the
+  /// circumflex accent, so `\^o` would silently render "ô" instead of "^o".
+  /// The braces are load-bearing too: without them `\textasciicircum` would
+  /// absorb a following letter into the control word.
+  #[test]
+  fn escape_specials_caret_is_textasciicircum_not_an_accent() {
+    assert_eq!(
+      escape_bib_data_specials("x^2 and ^o"),
+      r"x\textasciicircum{}2 and \textasciicircum{}o"
+    );
+    assert!(!escape_bib_data_specials("^o").starts_with(r"\^"));
+  }
+
   /// Idempotency. Most real `.bib` files already write `\&`, `\%`, `\_` — a
   /// blind escaper would turn `\&` into `\\&`, i.e. a line break followed by an
   /// ampersand. Escaping twice must equal escaping once.
   #[test]
   fn escape_specials_is_idempotent() {
-    let once = escape_bib_data_specials("AT&T at 95% with x_1");
+    let once = escape_bib_data_specials("AT&T at 95% with x_1 and x^2");
     assert_eq!(escape_bib_data_specials(&once), once);
     assert_eq!(
       escape_bib_data_specials(r"AT\&T at 95\% with x\_1"),
       r"AT\&T at 95\% with x\_1"
     );
+    // Both spellings a `.bib` uses for an already-escaped caret survive: the
+    // control WORD is copied whole, the control SYMBOL as a pair.
+    assert_eq!(
+      escape_bib_data_specials(r"x\textasciicircum{}2"),
+      r"x\textasciicircum{}2"
+    );
+    assert_eq!(escape_bib_data_specials(r"x\^{}2"), r"x\^{}2");
   }
 
   /// The tricky case the idempotency rule has to get right: in `\\&` the `\\`
@@ -2697,10 +2742,15 @@ mod tests {
       r"break \\\& more"
     );
     assert_eq!(escape_bib_data_specials(r"break \\_x"), r"break \\\_x");
+    assert_eq!(
+      escape_bib_data_specials(r"break \\^x"),
+      r"break \\\textasciicircum{}x"
+    );
   }
 
-  /// Math is the other hazard: `_` inside `$…$` is a real subscript and must
-  /// stay catcode 8, while the same character outside is data.
+  /// Math is the other hazard: `_`/`^` inside `$…$` are a real subscript and
+  /// superscript and must stay catcode 8/7, while the same characters outside
+  /// are data.
   #[test]
   fn escape_specials_skips_math() {
     assert_eq!(
@@ -2714,6 +2764,14 @@ mod tests {
     assert_eq!(
       escape_bib_data_specials(r"open \(x_1\) then y_2"),
       r"open \(x_1\) then y\_2"
+    );
+    assert_eq!(
+      escape_bib_data_specials("Bounds on $x^2+y_1$ for 10^6 cells"),
+      r"Bounds on $x^2+y_1$ for 10\textasciicircum{}6 cells"
+    );
+    assert_eq!(
+      escape_bib_data_specials(r"open \[x^2\] then y^3"),
+      r"open \[x^2\] then y\textasciicircum{}3"
     );
   }
 
@@ -2738,8 +2796,8 @@ mod tests {
   #[test]
   fn escape_specials_skips_a_verbatim_argument() {
     assert_eq!(
-      escape_bib_data_specials(r"\url{http://x.org/a%20b?c=1&d=2}"),
-      r"\url{http://x.org/a%20b?c=1&d=2}"
+      escape_bib_data_specials(r"\url{http://x.org/a%20b?c=1&d=2^3}"),
+      r"\url{http://x.org/a%20b?c=1&d=2^3}"
     );
     assert_eq!(
       escape_bib_data_specials(r"\href{http://x.org/a%20b}{AT&T}"),

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -4866,24 +4866,22 @@ LoadDefinitions!({
   // arXiv:2507.06392 / .09311 (ifacconf.cls — no Rust binding).
   DefMacro!("\\thanksref{}", "\\textsuperscript{#1}");
 
-  // `\cprime` / `\Cprime` / `\cdprime` / `\Cdprime` — Cyrillic
-  // transliteration markers used in BibTeX-generated bibliographies
-  // (cyracc.def L53-55 defines them as math-mode prime/dprime). They
-  // appear in Russian-authored references at the BBL stage where no
-  // Cyrillic encoding is otherwise loaded. Stub each as the Unicode
-  // modifier-letter-prime so the BBL renders cleanly. Witnesses:
-  // arXiv:2508.13753 / .20226 / 2509.07628 — 1 undefined-CS error
-  // each, Perl LaTeXML also lacks a universal def. Two-grep audit:
-  // not in Perl `*.ltxml`, defined in TL `cyracc.def` for math
-  // context only. Per WISDOM #50 the visual intent (apostrophe-like
-  // mark) is what survives the XML→HTML pipeline.
-  DefMacro!("\\cprime", "\u{02B9}");
-  DefMacro!("\\Cprime", "\u{02B9}");
-  DefMacro!("\\cdprime", "\u{02BA}");
-  DefMacro!("\\Cdprime", "\u{02BA}");
-  // `\polhk{char}` — Polish hook (ogonek) accent. Defined in tipa.sty
-  // for TS1-encoded composite output. Bibliographies use it directly
-  // (e.g. `\polhk{a}` → ą). Stub as identity so the bare char shows.
+  // NOTE: the `\cprime` / `\Cprime` / `\cdprime` / `\Cdprime` Cyrillic
+  // transliteration family used to live here, which kept a non-Perl definition
+  // in a file that mirrors `latex_constructs.pool.ltxml` byte-for-byte. They are
+  // not LaTeX kernel commands at all — they belong to `mathscinet.sty` (AMS, in
+  // the amsrefs bundle), now bound at
+  // `latexml_package/src/package/mathscinet_sty.rs`, which all three witnesses
+  // (arXiv:2508.13753 / .20226 / 2509.07628) actually load. The always-on stub
+  // they still need for `.bib`-borne use with no package moved to
+  // `latex_constructs_rust_only.rs` §5, carrying those witnesses.
+
+  // `\polhk{char}` — Polish hook (ogonek) accent. Its real home is
+  // `mathscinet.sty` L111-113 (NOT tipa.sty, as this comment said before the
+  // source was read), where every encoding branch defines it as the kernel
+  // accent `\k` — and `mathscinet_sty.rs` binds it that way. This identity stub
+  // stays as the fallback for a document that uses `\polhk{a}` without loading
+  // the package (bibliographies do), so the bare char still shows.
   // Witnesses: 2 papers in Stage-15 v3.
   def_macro_identity("\\polhk{}")?;
   // \@personname (now \lx@personname) and the ltx:personname sanitize Tag

--- a/latexml_engine/src/latex_constructs_rust_only.rs
+++ b/latexml_engine/src/latex_constructs_rust_only.rs
@@ -21,6 +21,8 @@
 //!    captures the values raw `latex.ltx` installs; these are defensive overrides for the NODUMP
 //!    path.
 //! 4. Misc Rust-side stubs (`\@latexbug`, `\maybe@end@title`, `\thebibliography@ID` empty default).
+//! 5. The MathSciNet `\cprime` transliteration family, always-on as a safety net beneath the real
+//!    `mathscinet.sty` binding — see the block itself for why both exist.
 use crate::prelude::*;
 
 #[rustfmt::skip]
@@ -402,4 +404,41 @@ LoadDefinitions!({
     lookup_meaning(&T_CS!("\\endfilecontents")).unwrap_or(Stored::None),
     Some(Scope::Global),
   );
+
+  //======================================================================
+  // 5. MathSciNet transliteration — the `\cprime` family, always-on
+  //
+  // `\cprime` / `\Cprime` / `\cdprime` / `\Cdprime` render the Russian
+  // soft/hard signs in transliterated names (`Gel\cprime fand` is
+  // Gelʹfand). Their real home is `mathscinet.sty` (AMS, amsrefs
+  // bundle), which `mathscinet_sty.rs` now binds — and all three
+  // witnesses below DO load that package (arXiv:2508.13753 L7,
+  // 2508.20226 L3, 2509.07628 L13), which corrects the claim in the
+  // comment these lines used to carry in `latex_constructs.rs`
+  // (cyracc.def, "no Cyrillic encoding otherwise loaded").
+  //
+  // They stay always-on anyway, because the package is not the only way
+  // they arrive: a `.bib` field carries `Gel\cprime fand` with no
+  // `\usepackage` behind it, and MathSciNet exports lean on an
+  // `@preamble` that may or may not define it (2605.11579's `biblo.bib`
+  // defines `\cprime` twenty-odd times; another export need not).
+  // Removing this stub was measured to cost exactly that case —
+  // `bib_mr_reviewer_accent`'s `primerev` entry regains
+  // `undefined:\cprime`. The `provide` in the binding then finds them
+  // already defined, which is the correct no-op.
+  //
+  // Contrast `\Dbar`, which is package-ONLY and deliberately so: four
+  // authors per 4,000 papers define it themselves with `\newcommand`,
+  // and an always-on definition would silently shadow them
+  // (OXIDIZED_DESIGN #78). No author in that scan defines the `\cprime`
+  // family with `\newcommand`, so this stub shadows nobody.
+  //
+  // Per WISDOM #50 the visual intent (an apostrophe-like mark) is what
+  // survives the XML→HTML pipeline; the TeX definitions are math-mode
+  // primes.
+  //======================================================================
+  DefMacro!("\\cprime", "\u{02B9}");
+  DefMacro!("\\Cprime", "\u{02B9}");
+  DefMacro!("\\cdprime", "\u{02BA}");
+  DefMacro!("\\Cdprime", "\u{02BA}");
 });

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -1174,3 +1174,82 @@ fn bib_mr_reviewer_accent_survives_reversion() {
     );
   }
 }
+
+/// The `mathscinet.sty` binding, on the load path a document actually uses.
+///
+/// `\Dbar` (Đ), `\cprime` (ь) and friends are not kernel commands: they belong
+/// to `mathscinet.sty`, AMS v1.05, shipped in the amsrefs bundle. Perl LaTeXML
+/// has `amsrefs.sty.ltxml` but no `mathscinet.sty.ltxml`, so the binding is a
+/// Rust-only addition — ported from the real `.sty`, whose T1 branches say what
+/// each glyph IS (`\Dbar`->`\DJ`, `\cprime`->`\tprime`) rather than how the
+/// Default branches draw it with `\accent` and `\hbox` kerning.
+///
+/// Both arrival points in one fixture: body prose (2508.13753 uses `\cprime`
+/// there, at L2131) and a `.bib` `MRREVIEWER` (2605.11579's `biblo.bib` L2059).
+/// All three `\cprime` witnesses load the package by name — 2508.13753 L7,
+/// 2508.20226 L3, 2509.07628 L13 — which is the evidence that moved the family
+/// out of `latex_constructs.rs` and into this binding.
+#[test]
+fn bib_mathscinet_package_supplies_its_transliteration_glyphs() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_mathscinet_package.tex");
+  // Composed characters, not source and not a silently-dropped letter.
+  for (needle, what) in [
+    ("Kondratʹev", "`\\cprime` in body prose"),
+    ("Đokovi", "`\\Dbar` in a bib reviewer field"),
+  ] {
+    assert!(
+      x.contains(needle),
+      "mathscinet: {what} did not compose ({needle:?} missing):\n{x}"
+    );
+  }
+  for leaked in ["Dbar", "cprime"] {
+    assert!(
+      !x.contains(leaked),
+      "mathscinet: `\\{leaked}` leaked into the output as source:\n{x}"
+    );
+  }
+  assert!(
+    x.contains("<bibitem"),
+    "mathscinet: no bibliography at all:\n{x}"
+  );
+}
+
+/// A document that does NOT load mathscinet keeps its own `\Dbar` — and nothing
+/// loads the package on its behalf.
+///
+/// Two things are pinned here, and the second is the one that is easy to lose.
+///
+/// 1. The binding must not become an always-present kernel definition. That
+///    would run BEFORE the document's preamble, and LaTeXML's `\newcommand` over
+///    an already-defined CS silently keeps the OLD meaning — no error, no
+///    warning — so the author's macro would be shadowed with nothing in the log.
+///    Measured on 4,000 papers of arXiv 2605: six define `\Dbar` themselves
+///    (four with `\newcommand`) against two that use it undefined, and all
+///    twelve `\dbar` definitions mean a thermodynamic differential or a barred
+///    derivative, never a Croatian letter.
+/// 2. The recursive `.bib` session must not auto-load the package either. It
+///    would be tempting — the session already loads `url.sty` that way — but
+///    `\Dbar` has no `.bst` behind it: witness 2605.11579 uses
+///    `\bibliographystyle{alpha}` and `alpha.bst` contains no `Dbar`, so real
+///    pdflatex raises the same undefined control sequence. Auto-loading would
+///    lower an error count below what the author's own build produces.
+#[test]
+fn bib_mathscinet_macro_yields_to_the_authors_own_definition() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_mathscinet_author_macro.tex");
+  // The author's own `\Dbar` is a barred D in math, and must survive verbatim.
+  assert!(
+    x.contains("<XMApp>"),
+    "author `\\Dbar`: the barred-D math did not render as math:\n{x}"
+  );
+  assert!(
+    !x.contains("Đ"),
+    "author `\\Dbar`: MathSciNet's Đ shadowed the author's own \
+     `\\newcommand{{\\Dbar}}` — the binding must not reach a document that \
+     never loads the package:\n{x}"
+  );
+  // …and the bibliography still renders, so the guard cannot pass by losing it.
+  assert!(
+    x.contains("<bibitem"),
+    "author `\\Dbar`: no bibliography at all:\n{x}"
+  );
+}

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -834,18 +834,22 @@ fn bib_field_specials_are_data_not_tex() {
     let e = block[s..].find("</text>").expect("bib-title close") + s;
     block[s..e].to_string()
   };
-  // 1. The four specials, bare, are literal text. `&` is XML-escaped on the way
+  // 1. The five specials, bare, are literal text. `&` is XML-escaped on the way
   //    out, which is the correct rendering of the character. `recase_title`
   //    lowercases (capitalize1, Perl parity), hence `at1g01010`.
-  let bare = "AT&amp;T dataset at1g01010_v2 at 95% with #3 replicates";
+  //    The trailing `^` is the one whose escape is NOT `\` + the character:
+  //    `\^` is the circumflex accent, so a generic escape would have rendered
+  //    the following letter accented ("ĉaret") instead of a caret.
+  let bare = "AT&amp;T dataset at1g01010_v2 at 95% with #3 replicates ^ caret";
   assert_eq!(
     title_of("barespecials"),
     bare,
-    "bib specials: bare `& _ % #` did not render literally:\n{x}"
+    "bib specials: bare `& _ % # ^` did not render literally:\n{x}"
   );
-  // 2. Idempotency: the entry that already wrote `\&`/`\_`/`\%`/`\#` renders
-  //    the SAME string. Had the escaper double-escaped, `\&` would have become
-  //    `\\&` — a line break followed by an ampersand.
+  // 2. Idempotency: the entry that already wrote `\&`/`\_`/`\%`/`\#`/
+  //    `\textasciicircum{}` renders the SAME string. Had the escaper
+  //    double-escaped, `\&` would have become `\\&` — a line break followed by
+  //    an ampersand.
   assert_eq!(
     title_of("preescaped"),
     title_of("barespecials"),

--- a/latexml_oxide/tests/105_bib_field_digest_once.rs
+++ b/latexml_oxide/tests/105_bib_field_digest_once.rs
@@ -1,11 +1,13 @@
 //! Regression test: a bibliography field value is digested EXACTLY ONCE.
 //!
-//! `convert_bib_file_to_xml` has two digesting paths — `interpret_tex_markup`
-//! (XML fragment, so `\url`/`\href`/font switches survive) and
-//! `interpret_tex_text` (plain string). They digest the SAME value, so running
-//! both on one field re-reports every error that field raises and re-runs any
-//! side effect its macros have. The markup path therefore runs first and
-//! suppresses the text path on success.
+//! The original defect was two digesting paths in the since-deleted
+//! `convert_bib_file_to_xml` string route — `interpret_tex_markup` (XML
+//! fragment, so `\url`/`\href`/font switches survive) and `interpret_tex_text`
+//! (plain string) — both run over the SAME value, so every error that field
+//! raised was reported twice and every macro side effect ran twice. That route
+//! is gone (`BIBLIOGRAPHY_WORKLIST.md` re-port item 1: the recursive `.bib`
+//! session replaced it), but the PROPERTY it violated is a standing one for
+//! whatever route is current, and it is cheap to keep pinned.
 //!
 //! This is guarded by counting `Error:` lines rather than by inspecting the XML,
 //! because the duplicate is invisible in the output — the rendered entry looked
@@ -18,25 +20,29 @@ use std::{path::Path, process::Command};
 
 /// Two properties this fixture must have, both learned the hard way:
 ///
-/// * `^` outside math raises `unexpected:^` on EVERY digest — unlike an
-///   undefined macro, which is defined as `<ltx:ERROR/>` on first sight and is
-///   therefore silently self-healing on a second pass. An undefined-macro
-///   fixture would pass even with the bug present.
-/// * The value must contain a BACKSLASH. Both interpret paths short-circuit on
-///   a value with no `\`, `~` or `$`, so `note={a ^ b}` never digests at all and
-///   the test goes vacuously green (observed: "digested 0 times"). `\textbf` is
-///   the carrier here because it needs no package.
+/// * The probe must raise its error on EVERY digest. An undefined macro will
+///   NOT do: it is defined as `<ltx:ERROR/>` on first sight and is therefore
+///   silently self-healing on a second pass, so an undefined-macro fixture
+///   passes even with the bug present. `\hline` in a `note` is the probe — it
+///   expands to `\noalign`, which is a CONTEXT error (`\noalign cannot be used
+///   here`) with nothing to memoize, so a second digest counts a second time.
+///   Verified: two entries each carrying one `\hline` produce exactly 2.
+/// * The value must contain a BACKSLASH. The interpretation paths short-circuit
+///   on a value with no `\`, `~` or `$`, so a punctuation-only probe never
+///   digests at all and the test goes vacuously green (observed: "digested 0
+///   times"). `\textbf` is the carrier in the second entry because it needs no
+///   package.
 ///
-/// `_` used to be the other probe, and no longer can be: OXIDIZED_DESIGN #74
-/// escapes `_ & # %` in a `.bib` field as DATA, so `note={a _ …}` now renders a
-/// literal underscore and raises nothing at all. The `a1` entry stays in the
-/// fixture as the standing check that escaping did not disturb the once-only
-/// property — it must contribute ZERO errors — while `a2`'s `^` (outside the
-/// escaped set) remains the live probe.
+/// `_` and `^` were the two earlier probes and neither can be one any more:
+/// OXIDIZED_DESIGN #74 escapes `_ & # %` and `^` in a `.bib` field as DATA, so
+/// `note={a _ … ^ …}` now renders the literal characters and raises nothing.
+/// The `a2` entry keeps both of them as the standing check that the escaping did
+/// not disturb the once-only property — it must contribute ZERO errors — while
+/// `a1`'s `\hline` is the live probe.
 const BIB: &str = r"@article{a1, author={Doe, J.}, title={T}, year={2020},
-  note={a _ \textbf{b}} }
+  note={a \hline \textbf{b}} }
 @article{a2, author={Roe, R.}, title={T2}, year={2021},
-  note={x ^ \textbf{y}} }
+  note={x _ y ^ z \textbf{w}} }
 ";
 
 const TEX: &str = r"\documentclass{article}
@@ -71,23 +77,26 @@ fn bib_field_errors_are_reported_once_not_once_per_digest() {
   // and would make this test vacuously green.
   let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
 
-  let needle = "Script ^ can only appear in math mode";
+  let needle = "\\noalign cannot be used here";
   let n = stderr.matches(needle).count();
   assert_eq!(
     n, 1,
     "the field was digested {n} times, not once — bibliography errors are \
      being multiplied into the document's error count.\nstderr:\n{stderr}"
   );
-  // `_` is DATA in a `.bib` field (OXIDIZED_DESIGN #74), so `a1` must raise
-  // nothing. Asserted rather than dropped: if the escaping ever regresses, this
-  // catches it here too, and once-per-digest would show up as a count of 2.
-  let n = stderr
-    .matches("Script _ can only appear in math mode")
-    .count();
-  assert_eq!(
-    n, 0,
-    "a `_` in a bib field is data and must raise nothing, got {n}.\nstderr:\n{stderr}"
-  );
+  // `_` and `^` are DATA in a `.bib` field (OXIDIZED_DESIGN #74), so `a2` must
+  // raise nothing. Asserted rather than dropped: if the escaping ever regresses
+  // this catches it here too, and once-per-digest would show up as a count of 2.
+  for script in ['_', '^'] {
+    let n = stderr
+      .matches(&format!("Script {script} can only appear in math mode"))
+      .count();
+    assert_eq!(
+      n, 0,
+      "a `{script}` in a bib field is data and must raise nothing, got {n}.\n\
+       stderr:\n{stderr}"
+    );
+  }
 }
 
 fn strip_ansi(s: &str) -> String {

--- a/latexml_oxide/tests/cluster_regressions/bib_field_specials.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_field_specials.bib
@@ -1,9 +1,10 @@
 % A `.bib` field's content is DATA, not TeX. Real BibTeX has two regimes and
 % latexml-oxide collapses them into one pass: in the DATA regime (`.bib` read by
 % `bibtex(1)`) `%` is not a comment, `&` is not an alignment tab, `_` is not a
-% subscript and `#` is not a parameter; only the `.bbl` that a `.bst` writes is
-% ever TeX. We read `.bib` directly, so we synthesize that `.bbl` ourselves and
-% must escape the four specials on the way. OXIDIZED_DESIGN #74.
+% subscript, `^` is not a superscript and `#` is not a parameter; only the `.bbl`
+% that a `.bst` writes is ever TeX. We read `.bib` directly, so we synthesize
+% that `.bbl` ourselves and must escape the five specials on the way.
+% OXIDIZED_DESIGN #74.
 %
 % ONE fixture, because the whole risk is that fixing one case breaks another —
 % the escaper has to be simultaneously literal, idempotent, math-aware and
@@ -18,12 +19,17 @@
 %   taylorfrancis  bare `&` in `publisher`, verbatim from witnesses 2605.01936
 %                  `references.bib` L1570 and 2605.06249 `CV.bib` L715/763
 %   surveystut     bare `&` in `journal`, from 2605.06249 `CV.bib` L1775
-%   barespecials   all four specials bare in one rendered `title`
-%   preescaped     all four already escaped — must render IDENTICALLY to
+%   barespecials   all five specials bare in one rendered `title` — the four
+%                  above plus `^`, whose escape is `\textasciicircum{}` and NOT
+%                  `\^`, which is the circumflex ACCENT (`\^o` would render "ô")
+%   preescaped     all five already escaped — must render IDENTICALLY to
 %                  `barespecials`, never `\\&`
-%   mathmarkup     `$x_1+x_2$` must stay math WITH A SUBSCRIPT, and `\emph`
-%                  must stay markup: the escaper skips math spans and never
-%                  touches `\`, so both are correct by construction
+%   mathmarkup     `$x^2+y_1$` must stay math WITH A SUPERSCRIPT AND A
+%                  SUBSCRIPT, and `\emph` must stay markup: the escaper skips
+%                  math spans and never touches `\`, so all are correct by
+%                  construction. `^` is in the same math span as `_` on purpose
+%                  — both are scripting characters and both must be left alone
+%                  inside `$…$` while being data outside it
 %   accent         a space-form accent (PR #399) must still revert
 %   urlencoded     `%20` inside `\url{...}` must NOT become `\%20` — url.sty
 %                  reads that argument verbatim, so it is a nested DATA region.
@@ -72,21 +78,21 @@
 
 @article{barespecials,
     author = {Amara Diallo},
-    title = {AT&T dataset AT1G01010_v2 at 95% with #3 replicates},
+    title = {AT&T dataset AT1G01010_v2 at 95% with #3 replicates ^ caret},
     journal = {J. Bibliographies},
     year = {2025},
 }
 
 @article{preescaped,
     author = {Nils Bergstr{\"o}m},
-    title = {AT\&T dataset AT1G01010\_v2 at 95\% with \#3 replicates},
+    title = {AT\&T dataset AT1G01010\_v2 at 95\% with \#3 replicates \textasciicircum{} caret},
     journal = {J. Bibliographies},
     year = {2025},
 }
 
 @article{mathmarkup,
     author = {Priya Raghavan},
-    title = {Bounds on $x_1+x_2$ in \emph{Drosophila} genetics},
+    title = {Bounds on $x^2+y_1$ in \emph{Drosophila} genetics},
     journal = {J. Bibliographies},
     year = {2025},
 }

--- a/latexml_oxide/tests/cluster_regressions/bib_mathscinet_author_macro.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_mathscinet_author_macro.bib
@@ -1,0 +1,11 @@
+% One ordinary entry, so the bibliography exists and the recursive `.bib`
+% session actually runs — which is half the point: the session must NOT pull in
+% `mathscinet.sty` while it is there. The assertion under test is in the BODY of
+% the driver `.tex`: the author's `\newcommand{\Dbar}` must still mean a barred D.
+
+@article{plainref,
+  author  = {F. Author},
+  title   = {An entry with nothing special in it},
+  journal = {J. Reviews},
+  year    = {2025}
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_mathscinet_author_macro.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_mathscinet_author_macro.tex
@@ -1,0 +1,26 @@
+% Driver for `bib_mathscinet_author_macro.bib`. The other half of
+% `bib_mathscinet_package.tex`: this document does NOT load mathscinet.
+%
+% The author defines `\Dbar` as a barred D — the commonest real meaning of the
+% name in mathematics, and what four of the six papers that define it in a
+% 4,000-paper scan of arXiv 2605 mean by it (2605.00730, 2605.00808, 2605.01550,
+% 2605.03484). MathSciNet's Đ must NOT displace it, from either direction:
+%
+%   * not from the LaTeX format chain — that runs BEFORE this preamble, and
+%     `\newcommand` over an already-defined CS silently keeps the old meaning,
+%     so an always-present `\Dbar` would win here with no diagnostic at all;
+%   * not from the recursive `.bib` session either. That session does load
+%     `url.sty` on a document's behalf, so auto-loading mathscinet the same way
+%     is a tempting move — but `\Dbar` has no `.bst` behind it (witness
+%     2605.11579 uses `\bibliographystyle{alpha}`, and `alpha.bst` contains no
+%     `Dbar`), so a paper that uses it without the package fails in real
+%     pdflatex too. Supplying it anyway would push our error count BELOW what
+%     the author's own build produces.
+\documentclass{article}
+\newcommand{\Dbar}{\ensuremath{\bar{D}}}
+\begin{document}
+The author's own operator: $\Dbar$.
+See \cite{plainref}.
+\bibliographystyle{plain}
+\bibliography{bib_mathscinet_author_macro}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/bib_mathscinet_package.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_mathscinet_package.bib
@@ -1,0 +1,17 @@
+% The MRREVIEWER shape from witness 2605.11579 (`biblo.bib` L2059), in a
+% document that DOES load mathscinet.sty — see the driver `.tex` for why that
+% distinction is the whole point of this fixture.
+%
+% `\Dbar okovi\'{c}` is Đoković. It is also a space-form accent case (the space
+% terminates the control word and the tokenizer eats it), so this entry needs
+% both the `untex()` reversion of `bib_mr_reviewer_accent.bib` AND the package
+% binding — a regression in either one shows up here.
+
+@article{dbarrev,
+  author      = {E. Author},
+  title       = {A MathSciNet glyph macro in a reviewer name},
+  journal     = {J. Reviews},
+  year        = {2025},
+  mrnumber    = {MR4567890},
+  MRREVIEWER  = {Dragomir \v{Z}. \Dbar okovi\'{c}}
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_mathscinet_package.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_mathscinet_package.tex
@@ -1,0 +1,26 @@
+% Driver for `bib_mathscinet_package.bib` — the mathscinet.sty binding, loaded
+% the way a real document loads it.
+%
+% `mathscinet.sty` (AMS, v1.05, in the amsrefs bundle) holds the transliteration
+% vocabulary MathSciNet records are written in: `\Dbar`/`\dbar` (Đ/đ), `\cprime`
+% (ь), `\cdprime`, `\bud`. A document gets it by naming it — as all three of the
+% `\cprime` witnesses do (2508.13753 L7, 2508.20226 L3, 2509.07628 L13) — or via
+% `amsrefs.sty` L217's `\RequirePackage{mathscinet}`.
+%
+% This exercises BOTH places the vocabulary shows up: the body prose (which is
+% where 2508.13753 uses `\cprime`, at its L2131) and a `.bib` field's MRREVIEWER
+% (witness 2605.11579's `biblo.bib` L2059).
+%
+% Note what is NOT claimed here: nothing loads this package on a document's
+% behalf. A paper that uses `\Dbar` without loading mathscinet gets an
+% undefined-CS error, which is PARITY — real pdflatex does too, and no `.bst`
+% supplies it (2605.11579 uses `\bibliographystyle{alpha}`; `alpha.bst` has no
+% `Dbar`). See `bib_mathscinet_author_macro.tex` for the other half of that.
+\documentclass{article}
+\usepackage{mathscinet}
+\begin{document}
+Body prose, as in 2508.13753: Kondrat\cprime ev and \Dbar okovi\'{c}.
+See \cite{dbarrev}.
+\bibliographystyle{plain}
+\bibliography{bib_mathscinet_package}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/bib_mr_reviewer_accent.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_mr_reviewer_accent.bib
@@ -19,6 +19,14 @@
 %
 % `zblreviewer` is here because the Zentralblatt path is the same code shape and
 % was fixed in the same commit; without an entry it would be untested.
+%
+% The witness's fourth shape, `\Dbar okovi\'{c}`, is deliberately NOT here. That
+% one is not a reversion bug: `\Dbar` belongs to `mathscinet.sty`, the witness
+% never loads it, and no `.bst` supplies it either (the paper uses
+% `\bibliographystyle{alpha}`, and `alpha.bst` contains no `Dbar`), so real
+% pdflatex raises the same undefined control sequence. Leaving it undefined is
+% PARITY. The package binding is exercised by `bib_mathscinet_package.{tex,bib}`,
+% which loads `mathscinet` the way a document actually does.
 
 @article{cedillarev,
   author      = {A. Author},

--- a/latexml_package/src/lib.rs
+++ b/latexml_package/src/lib.rs
@@ -250,6 +250,11 @@ pub const BINDINGS: &[(&str, &str, BindingLoader)] = &[
   ("mdwtab", "sty", package::mdwtab_sty::load_definitions),
   ("microtype", "sty", package::microtype_sty::load_definitions),
   ("amsrefs", "sty", package::amsrefs_sty::load_definitions),
+  (
+    "mathscinet",
+    "sty",
+    package::mathscinet_sty::load_definitions,
+  ),
   ("amsfonts", "sty", package::amsfonts_sty::load_definitions),
   ("amssymb", "sty", package::amssymb_sty::load_definitions),
   ("amsthm", "sty", package::amsthm_sty::load_definitions),

--- a/latexml_package/src/package.rs
+++ b/latexml_package/src/package.rs
@@ -291,6 +291,7 @@ pub mod mathpple_sty;
 pub mod mathptm_sty;
 pub mod mathptmx_sty;
 pub mod mathrsfs_sty;
+pub mod mathscinet_sty;
 pub mod mathtools_sty;
 pub mod mdwtab_sty;
 pub mod media9_sty;

--- a/latexml_package/src/package/mathscinet_sty.rs
+++ b/latexml_package/src/package/mathscinet_sty.rs
@@ -1,0 +1,137 @@
+//! mathscinet.sty — the AMS's transliteration vocabulary for MathSciNet output.
+//!
+//! Real source: `mathscinet.sty` v1.05 (2002/04/17), American Mathematical
+//! Society, LPPL, shipped in TeX Live as part of the **amsrefs** bundle
+//! (`texmf-dist/tex/latex/amsrefs/mathscinet.sty`). Perl LaTeXML has no binding
+//! for it — `\Dbar` and `\cprime` appear in no `.ltxml` file — so this is
+//! Rust-only, not a port of a Perl binding; the `.sty` itself is the ground truth.
+//!
+//! [MathSciNet](https://mathscinet.ams.org) is the AMS reviewing database, and
+//! its BibTeX export assembles a large share of pure-mathematics bibliographies.
+//! The macros here are how those records transliterate Cyrillic and South-Slavic
+//! names: `\cprime` for the soft sign ь, `\Dbar`/`\dbar` for Đ/đ.
+//!
+//! **Loaded the normal way, and only the normal way.** `\usepackage{mathscinet}`
+//! is the trigger, and `amsrefs.sty` L217 does
+//! `\RequirePackage{mathscinet}[2002/01/01]`. All three `\cprime` witnesses name
+//! the package themselves (2508.13753 L7, 2508.20226 L3, 2509.07628 L13) — they
+//! errored only because no binding existed.
+//!
+//! Nothing loads it on a document's behalf, and that is deliberate. The
+//! recursive `.bib` session does exactly that for `url.sty`, on the grounds that
+//! a real `.bst` writes `\providecommand{\url}` into the `.bbl`; the same
+//! argument does NOT hold here. Checked on witness 2605.11579: it never mentions
+//! mathscinet or amsrefs, and it uses `\bibliographystyle{alpha}` — `alpha.bst`
+//! contains no `Dbar` at all. So `\Dbar` is undefined in the author's own build
+//! too, real pdflatex raises the same undefined control sequence, and leaving it
+//! undefined is PARITY. Supplying it would push our error count below what the
+//! author's toolchain produces. Guard:
+//! `06_cluster_bibliography::bib_mathscinet_macro_yields_to_the_authors_own_definition`.
+//!
+//! **`\Provide…` semantics are load-bearing, not incidental.** The upstream file
+//! uses `\ProvideTextCommand`/`\ProvideTextCommandDefault` for the character
+//! commands, so an author who defined the name first keeps their meaning. That
+//! matters concretely: in a 4,000-paper scan of arXiv 2605, six papers define
+//! `\Dbar` themselves (four with `\newcommand`) and twelve define `\dbar` — and
+//! every one of those twelve means the inexact-differential đ of thermodynamics
+//! or a barred derivative, not a Croatian letter. Being a *package* rather than
+//! an always-present kernel definition is what keeps us out of their way, and
+//! `provide` below reproduces the deferral for the case where the package IS
+//! loaded.
+//!
+//! Each glyph binds the Unicode character carrying the author's visual intent
+//! (WISDOM #50). The upstream definitions build their glyphs by overprinting —
+//! `\Dbar` is `\leavevmode\lower.5ex\rlap{\hskip-.07em\accent"16}D` — which would
+//! reach the XML as a bare "D"; the mappings below are taken from the file's own
+//! **T1 branches**, which say what each glyph IS (`\Dbar`→`\DJ`, `\dbar`→`\dj`,
+//! `\polhk`→`\k`, `\soft`→`\v`, `\udot`→`\d`).
+//!
+//! The `\cprime` family additionally keeps an always-on stub in
+//! `latex_constructs_rust_only.rs` §5, for `.bib`-borne use in a document that
+//! loads no package; `provide` below then finds it defined, the correct no-op.
+//! That stub is NOT extended to `\Dbar` — see the collision counts above.
+//!
+//! Witnesses: 2508.13753, 2508.20226, 2509.07628 (`\cprime`); 2605.11579
+//! (`\Dbar` in `MRREVIEWER = {Dragomir \v{Z}. \Dbar okovi\'{c}}`, which stays a
+//! parity error because that paper loads no package and its `.bst` has no
+//! `Dbar`).
+use crate::prelude::*;
+
+/// `\ProvideTextCommandDefault` semantics: define only if the name is free.
+fn provide(proto: &str, body: &str) -> Result<()> {
+  let (cs_tok, params) = parse_prototype(proto, true)?;
+  if lookup_meaning(&cs_tok).is_some() {
+    return Ok(());
+  }
+  def_macro(
+    cs_tok,
+    params,
+    ExpansionBody::Tokens(mouth::tokenize_internal(body)),
+    None,
+  )?;
+  Ok(())
+}
+
+#[rustfmt::skip]
+LoadDefinitions!({
+  // L36 is `\RequirePackage{textcmds}`, deliberately NOT reproduced: textcmds
+  // has no binding, so requiring it would raw-load a docstrip `.sty` that plays
+  // `\pcatcode` games, to obtain exactly two commands (`\tprime`, `\tsup`) whose
+  // results are inlined below as the character and `\textsuperscript`.
+
+  // ---- Math alphabet shorthands (L38-49, verbatim) ----
+  provide("\\bold", "\\mathbf")?;
+  provide("\\scr", "\\mathcal")?;
+  // L41-49 defers \germ to \begin{document} only to diagnose a missing
+  // amsfonts; \mathfrak is always available here, so bind it directly.
+  provide("\\germ", "\\mathfrak")?;
+  // L50-52: superscript shorthands, both \tsup (textcmds).
+  provide("\\romsup{}", "\\textsuperscript{#1}")?;
+  provide("\\asup{}", "\\textsuperscript{#1}")?;
+  provide("\\hslash", "\\hbar")?;
+
+  // ---- Cyrillic / South-Slavic transliteration glyphs ----
+  // L57-58: \ProvideTextCommand{\Dbar}{T1}{\DJ}. T1's \DJ IS U+0110 LATIN
+  // CAPITAL LETTER D WITH STROKE, so the encoding branch names the character
+  // outright; the Default branch just draws it. Witness 2605.11579's
+  // `MRREVIEWER = {Dragomir \v{Z}. \Dbar okovi\'{c}}` — Đoković.
+  provide("\\Dbar", "\u{0110}")?;
+  // L63: \ProvideTextCommand{\dbar}{T1}{\dj} — U+0111, the lowercase đ.
+  // Safe to bind HERE and nowhere else: twelve of the twelve papers in the
+  // 2605 scan that define `\dbar` themselves mean a math differential, and a
+  // package binding cannot reach them unless they load the package.
+  provide("\\dbar", "\u{0111}")?;
+  // L75-77: \cprime is \tprime (U+02B9 MODIFIER LETTER PRIME), \cdprime is two
+  // of them (U+02BA MODIFIER LETTER DOUBLE PRIME), \bud is \cdprime.
+  // These render the Russian soft/hard signs in transliterated names —
+  // `Gel\cprime fand` is Gelʹfand. Witnesses 2508.13753 (body prose, L2131),
+  // 2508.20226, 2509.07628 (a pre-compiled `.bbl`).
+  provide("\\cprime", "\u{02B9}")?;
+  provide("\\cdprime", "\u{02BA}")?;
+  provide("\\bud", "\u{02BA}")?;
+  // L78: \cydot — a raised dot used in Cyrillic transliteration.
+  provide("\\cydot", "\u{00B7}")?;
+
+  // NOT in the real `mathscinet.sty`: `\Cprime`/`\Cdprime` are the capitalized
+  // spellings that `cyracc.def` (L53-55) and MathSciNet `.bst` preambles emit,
+  // and they arrive with exactly the same data as `\cprime`. Kept beside it so
+  // the four move together; the always-on stub in
+  // `latex_constructs_rust_only.rs` §5 covers the same four, so in practice
+  // `provide` finds them defined and these are the no-op they should be.
+  provide("\\Cprime", "\u{02B9}")?;
+  provide("\\Cdprime", "\u{02BA}")?;
+
+  // ---- Under-accents (L104-110) ----
+  // These use \DeclareTextCommandDefault, i.e. unconditional, and the file
+  // draws them with \@underaccent box kerning. The Unicode combining marks
+  // below are the same accents as characters, applied AFTER the base letter.
+  // \udot's own default IS the kernel \d (L109), and \polhk/\soft name kernel
+  // accents in every encoding branch they define (L111-113, L156-158).
+  DefMacro!("\\udot{}", "\\d{#1}");
+  DefMacro!("\\polhk{}", "\\k{#1}");
+  DefMacro!("\\soft{}", "\\v{#1}");
+  DefMacro!("\\utilde{}", "#1\u{0330}");  // combining tilde below
+  DefMacro!("\\uarc{}",   "#1\u{032E}");  // combining breve below
+  DefMacro!("\\lfhook{}", "#1\u{0326}");  // combining comma below
+  DefMacro!("\\dudot{}",  "#1\u{0324}");  // combining diaeresis below
+});

--- a/latexml_package/src/package/mathscinet_sty.rs
+++ b/latexml_package/src/package/mathscinet_sty.rs
@@ -58,7 +58,14 @@
 use crate::prelude::*;
 
 /// `\ProvideTextCommandDefault` semantics: define only if the name is free.
-fn provide(proto: &str, body: &str) -> Result<()> {
+///
+/// `body` is `&'static str` rather than `&str` because it is TeX source handed
+/// to the tokenizer, and `TeXString` (OXIDIZED_DESIGN — see `latexml_core::tokens`)
+/// only converts implicitly from a literal. Every caller below passes one, so
+/// this costs nothing and buys the guarantee: a runtime-built `String` — which
+/// is what a welded `Tokens::to_string()` arrives as — cannot reach this path
+/// without saying so via `TeXString::assembled`.
+fn provide(proto: &str, body: &'static str) -> Result<()> {
   let (cs_tok, params) = parse_prototype(proto, true)?;
   if lookup_meaning(&cs_tok).is_some() {
     return Ok(());


### PR DESCRIPTION
Two bibliography-fidelity changes, one commit each.

### 1. A `.bib` field's `^` is data — and its escape is not `\^`

`^` joins `_` in treatment 2 of OXIDIZED_DESIGN #74. The symmetry was
verified, not assumed: both are TeX scripting characters, both are plain data
to `bibtex(1)`, both raise "Script … can only appear in math mode" outside
math, and `note = {q _ r ^ s}` now renders `q _ r ^ s` with zero errors.

The escape needs its own match arm, because `\_` is the underscore command but
`\^` is the circumflex **accent** — the generic `\` + character arm would have
rendered `^o` as "ô", a wrong glyph, silently. `BIB_DATA_CARET` emits
`\textasciicircum{}`, braces included so a following letter is not absorbed.
Math-awareness and idempotency come for free from the existing structure.

Knock-on: `105_bib_field_digest_once` needs a probe that re-raises on every
digest. It used `_`, then `^`; both are data now, so it moves to `\hline`
(expands to `\noalign`, a context error with nothing to memoize). Its module
docs also described the deleted string route and now describe the current one.

### 2. `mathscinet.sty` gets a binding, loaded only when asked for

`\Dbar`, `\cprime` and friends belong to a real AMS package (v1.05, LPPL, in
the amsrefs bundle), not to the LaTeX kernel. Perl has `amsrefs.sty.ltxml` but
no `mathscinet.sty.ltxml`, so this is Rust-only — but a port of the real
`.sty`, with mappings taken from its own T1 branches.

Nothing auto-loads it. The `\cprime` family moves out of `latex_constructs.rs`
(which mirrors `latex_constructs.pool.ltxml` byte-for-byte) into
`latex_constructs_rust_only.rs` §5, keeping its always-on stub and its
witnesses.

## Decisions & open questions

**Did `^`/`_` symmetry hold under test?** Yes, on every axis checked — data to
`bibtex(1)`, same diagnostic outside math, same treatment-2 seam. The single
asymmetry is the escape spelling (`\^` is an accent), which is why `^` gets its
own arm rather than joining `BIB_DATA_SPECIALS`. Verified end-to-end and by
seven `escape_bib_data_specials` unit tests.

**Did I add `\dbar`?** Yes, but *only* in the package binding — never
always-on. Evidence both ways: the real `.sty` defines it
(`\ProvideTextCommand{\dbar}{T1}{\dj}`, đ U+0111), so the binding would be an
incomplete port without it; but in a 4,000-paper scan of arXiv 2605, **all
twelve** papers that define `\dbar` themselves mean the inexact-differential đ
of thermodynamics or a barred derivative — never a Croatian letter. A package
binding cannot reach a document that does not load it, which is exactly what
makes it safe here and unsafe anywhere else.

**The original `\Dbar` brief was factually wrong, and the fix is scoped
accordingly.** There is no `.bst` preamble behind it: witness 2605.11579 uses
`\bibliographystyle{alpha}`, `alpha.bst` contains zero occurrences of `Dbar`,
and the paper never loads `mathscinet` or `amsrefs`. So `\Dbar` is undefined in
the author's own build and real pdflatex raises the same error. **The residual
`undefined:\Dbar` is PARITY.** The witness stays at **1 error / 36 bibitems**
— the error is now explained rather than outstanding. An earlier iteration of
this branch had the recursive `.bib` session auto-load the package (mirroring
what it does for `url.sty`); that was removed, because it lowered the error
count below what the author's own toolchain produces.

**Load-ordering / blast-radius risk from moving the `\cprime` family — surfaced
rather than decided silently.** All three witnesses load `mathscinet` by name
(2508.13753 L7, 2508.20226 L3, 2509.07628 L13), which *refutes* the
`cyracc.def` / "no Cyrillic encoding otherwise loaded" justification the block
used to carry. But moving them to the binding alone was measured to break a
real case: `bib_mr_reviewer_accent`'s `primerev` entry regains
`undefined:\cprime`, because a `.bib` field carries `Gel\cprime fand` with no
`\usepackage` behind it. So they keep an always-on stub, relocated to
`latex_constructs_rust_only.rs` §5 — which restores `latex_constructs.rs` to
parity *and* preserves behaviour. No author in the scan defines the family with
`\newcommand`, so the stub shadows nobody. If you would rather they be
package-only, that is a one-block deletion, at the cost of `.bib`-borne usage.

**A separate rendering defect I did not touch.** Witness 2605.11579 renders
`MRREVIEWER = {Fran\c cois\ Digne}` as "Fran0cois Digne". It is pre-existing
and unrelated to this branch — the `bib_mr_reviewer_accent` fixture carries the
identical shape and renders "François Digne" correctly — so something in that
paper's `--includestyles` package set redefines `\c`. Not diagnosed further.

**`\polhk`'s comment in `latex_constructs.rs` claimed tipa.sty as its source.**
That is wrong; the real definition is `mathscinet.sty` L111-113, where every
encoding branch is the kernel accent `\k`. Comment corrected in place and the
binding maps it properly; the identity stub stays for documents that never load
the package.

## Verification

- Full suite **1726 passed / 0 failed** (baseline 1723 + 3 new guards).
- `cargo clippy --workspace --all-targets -- -D warnings` clean;
  `cargo doc --workspace` rustdoc-warning-clean; `cargo +nightly fmt --all` clean.
- Every new guard red-verified by reverting its fix: removing the caret arm
  fails 3 unit tests and the end-to-end guard; making `\Dbar` always-on fails
  the author-macro guard (the barred-D math renders `Đ`).
- Witnesses, same host: 2605.11579 `--includestyles` **1 error / 36 bibitems**
  (parity residual); 2508.13753 **0 errors**, `Kondratʹev`; 2508.20226 **0
  errors**; 2509.07628 `--includestyles` **0 errors**, `Drinfelʹ d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
