### PR TITLE
fix(bibliography): digest the cited entries, not the whole .bib library

### DIFF
--- a/latexml_engine/src/pre_bibtex.rs
+++ b/latexml_engine/src/pre_bibtex.rs
@@ -33,12 +33,51 @@
 //! - `skip_junk` is greedy: everything up to the next `@` is discarded (Perl L335-346: "anything
 //!   until @ as an implied comment").
 
-use std::collections::VecDeque;
+use std::{cell::RefCell, collections::VecDeque};
 
 use latexml_core::s;
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use crate::bibtex::{BibEntry, register_entry};
+
+thread_local! {
+  /// The cited-key filter for the next `.bib` digestion — see
+  /// [`set_wanted_keys`]. `None` means "digest every entry".
+  static WANTED_KEYS: RefCell<Option<HashSet<String>>> = const { RefCell::new(None) };
+}
+
+/// Restrict the next [`PreBibTeX::to_tex`] to the entries a document actually
+/// cites — what `bibtex(1)` itself has always done.
+///
+/// A `.bib` is a *library*, not a document: `anthology.bib` ships 80,558 ACL
+/// entries and the citing paper wants 10 of them. Parsing all of them is cheap
+/// (a string scan), but DIGESTING all of them is not — since the raw `.bib` is
+/// converted through the engine rather than by a string parser, each entry now
+/// costs a full expand/digest/construct cycle. Measured on 2605.07796
+/// (`anthology.bib`, 43.6 MB, 80 576 entries, 13 cited): 112 s and 4.8 GB RSS,
+/// which trips the memory budget and yields **zero** bibentries — the paper
+/// loses its whole bibliography and the conversion is killed by the 60 s
+/// timeout. The same shape covers 59 of the 69 papers in the corpus's
+/// `never_completed_with_retries` bucket (median 80 597 entries each).
+///
+/// `bibtex(1)` reads the `.aux`'s `\citation` records and emits only those
+/// entries (plus `crossref` targets, plus everything under `\nocite{*}`), so
+/// filtering here is *more* faithful to the real pipeline than digesting the
+/// library whole. Every entry is still REGISTERED — registration is a HashMap
+/// insert of already-parsed strings, and keeping it complete is what lets
+/// `crossref` and any by-key lookup still resolve against an uncited entry.
+///
+/// Pass `None` to digest everything (`\nocite{*}`, or no citation record at
+/// all). Cleared by [`clear_wanted_keys`]; the caller must do so, since the
+/// engine State is shared with the outer document.
+pub fn set_wanted_keys(keys: Option<Vec<String>>) {
+  WANTED_KEYS.with(|w| {
+    *w.borrow_mut() = keys.map(|ks| ks.iter().map(|k| k.to_lowercase()).collect());
+  });
+}
+
+/// Drop the cited-key filter installed by [`set_wanted_keys`].
+pub fn clear_wanted_keys() { WANTED_KEYS.with(|w| *w.borrow_mut() = None); }
 
 /// Default `@string`-style macros, populated on every new
 /// `PreBibTeX`. Mirrors Perl L34-57 `%default_macros`.
@@ -696,19 +735,105 @@ impl PreBibTeX {
       }
       register_entry(&parsed.key, entry);
     }
+    let wanted = WANTED_KEYS.with(|w| w.borrow().clone());
+    let selected = wanted.as_ref().map(|w| self.select_cited(w));
+    if let (Some(sel), Some(_)) = (selected.as_ref(), wanted.as_ref()) {
+      latexml_core::Info!(
+        "bibliography",
+        "filtered",
+        s!(
+          "Digesting {} of {} .bib entries (the cited set and its crossref/\\cite closure)",
+          sel.len(),
+          self.entries.len()
+        )
+      );
+    }
+
     let mut out = String::new();
     for pre in &self.preamble {
       out.push_str(pre);
       out.push('\n');
     }
     out.push_str("\\begin{bibtex@bibliography}\n");
-    for entry in &self.entries {
+    for (i, entry) in self.entries.iter().enumerate() {
+      if selected.as_ref().is_some_and(|s| !s.contains(&i)) {
+        continue;
+      }
       out.push_str("\\ProcessBibTeXEntry{");
       out.push_str(&entry.key);
       out.push_str("}\n");
     }
     out.push_str("\\end{bibtex@bibliography}");
     Ok(out)
+  }
+
+  /// Indices of the entries to digest: those `wanted` by the citing document,
+  /// closed transitively over `crossref` targets and `\cite`s made from inside
+  /// an already-selected entry.
+  ///
+  /// The closure is what keeps the filter behaviour-preserving. `crossref` is
+  /// BibTeX's own inheritance link (an `@inproceedings` naming its
+  /// `@proceedings`), and `MakeBibliography`'s `getBibEntries` separately
+  /// pulls in entries a *bibentry* cites (a `note = {see also \cite{foo}}`),
+  /// so both edges have to be followed or a filtered run would drop an entry
+  /// the unfiltered one kept. Keys compare lowercased, matching
+  /// `register_entry` and `getBibEntries`.
+  fn select_cited(&self, wanted: &HashSet<String>) -> HashSet<usize> {
+    let mut by_key: HashMap<String, usize> = HashMap::default();
+    for (i, e) in self.entries.iter().enumerate() {
+      // First definition wins, as `register_entry`'s registry lookup would.
+      by_key.entry(e.key.to_lowercase()).or_insert(i);
+    }
+
+    let mut selected: HashSet<usize> = HashSet::default();
+    let mut queue: Vec<String> = wanted.iter().cloned().collect();
+    while let Some(key) = queue.pop() {
+      let Some(&i) = by_key.get(&key) else { continue };
+      if !selected.insert(i) {
+        continue;
+      }
+      for (name, value) in &self.entries[i].fields {
+        if name == "crossref" {
+          queue.push(value.trim().to_lowercase());
+        } else {
+          collect_cited_keys(value, &mut queue);
+        }
+      }
+    }
+    selected
+  }
+}
+
+/// Push every key of every `\cite`-family call in `value` onto `out`,
+/// lowercased. Deliberately loose — over-collecting only keeps an extra entry,
+/// while missing one would silently drop it from the bibliography.
+fn collect_cited_keys(value: &str, out: &mut Vec<String>) {
+  let mut rest = value;
+  while let Some(at) = rest.find("\\cite") {
+    rest = &rest[at + "\\cite".len()..];
+    // `\cite` + command tail (`p`, `t`, `year`, `*`, …) + any `[optional]`
+    // arguments + the `{...}` key list, in that order.
+    let mut tail = rest
+      .trim_start_matches(|c: char| c.is_ascii_alphabetic() || c == '*')
+      .trim_start();
+    while let Some(stripped) = tail.strip_prefix('[') {
+      match stripped.find(']') {
+        Some(end) => tail = stripped[end + 1..].trim_start(),
+        None => return,
+      }
+    }
+    let Some(stripped) = tail.strip_prefix('{') else {
+      continue;
+    };
+    let Some(end) = stripped.find('}') else {
+      continue;
+    };
+    for k in stripped[..end].split(',') {
+      let k = k.trim();
+      if !k.is_empty() {
+        out.push(k.to_lowercase());
+      }
+    }
   }
 }
 
@@ -1228,6 +1353,130 @@ value} }
     let tex = p.to_tex().unwrap();
     assert!(tex.starts_with("\\providecommand{\\noop}[1]{}"));
     crate::bibtex::reset();
+  }
+
+  // --- the cited-key filter (set_wanted_keys) ------------------------------
+  //
+  // A `.bib` is a library: `anthology.bib` is 80 576 entries and the citing
+  // paper wants 9. Digesting the library whole cost 112 s / 4.8 GB and lost
+  // the bibliography outright on witness 2605.07796.
+
+  /// Run `to_tex` under a cited-key filter, always clearing it again — a leaked
+  /// filter would silently shrink every later `.bib` in the same thread.
+  fn to_tex_wanted(src: &str, wanted: Option<&[&str]>) -> String {
+    crate::bibtex::reset();
+    set_wanted_keys(wanted.map(|w| w.iter().map(|s| s.to_string()).collect()));
+    let mut p = PreBibTeX::new_from_string(src);
+    let tex = p.to_tex().expect("to_tex");
+    clear_wanted_keys();
+    tex
+  }
+
+  const LIBRARY: &str = r#"
+@article{cited, title = {C}}
+@article{uncited, title = {U}}
+@article{alsouncited, title = {A}}
+"#;
+
+  #[test]
+  fn no_filter_digests_every_entry() {
+    let tex = to_tex_wanted(LIBRARY, None);
+    assert!(tex.contains("\\ProcessBibTeXEntry{cited}"));
+    assert!(tex.contains("\\ProcessBibTeXEntry{uncited}"));
+    assert!(tex.contains("\\ProcessBibTeXEntry{alsouncited}"));
+    crate::bibtex::reset();
+  }
+
+  #[test]
+  fn filter_digests_only_the_cited_entries() {
+    let tex = to_tex_wanted(LIBRARY, Some(&["cited"]));
+    assert!(tex.contains("\\ProcessBibTeXEntry{cited}"));
+    assert!(!tex.contains("\\ProcessBibTeXEntry{uncited}"));
+    assert!(!tex.contains("\\ProcessBibTeXEntry{alsouncited}"));
+    crate::bibtex::reset();
+  }
+
+  /// Registration stays COMPLETE even when digestion is filtered: it is a cheap
+  /// map insert, and `crossref` / by-key lookup must still resolve an entry the
+  /// document never cited.
+  #[test]
+  fn filter_still_registers_every_entry() {
+    let _ = to_tex_wanted(LIBRARY, Some(&["cited"]));
+    assert!(crate::bibtex::lookup_entry("cited").is_some());
+    assert!(crate::bibtex::lookup_entry("uncited").is_some());
+    crate::bibtex::reset();
+  }
+
+  #[test]
+  fn filter_is_case_insensitive_like_the_registry() {
+    let tex = to_tex_wanted(LIBRARY, Some(&["CiTeD"]));
+    assert!(tex.contains("\\ProcessBibTeXEntry{cited}"));
+    crate::bibtex::reset();
+  }
+
+  /// BibTeX's own inheritance edge: an `@inproceedings` naming its
+  /// `@proceedings` needs that parent digested even though nobody cites it.
+  #[test]
+  fn filter_follows_crossref() {
+    let tex = to_tex_wanted(
+      r#"
+@inproceedings{paper, title = {P}, crossref = {proc}}
+@proceedings{proc, title = {Proceedings}}
+@article{unrelated, title = {U}}
+"#,
+      Some(&["paper"]),
+    );
+    assert!(tex.contains("\\ProcessBibTeXEntry{paper}"));
+    assert!(tex.contains("\\ProcessBibTeXEntry{proc}"));
+    assert!(!tex.contains("\\ProcessBibTeXEntry{unrelated}"));
+    crate::bibtex::reset();
+  }
+
+  /// `getBibEntries` transitively includes entries a *bibentry* cites, so the
+  /// filter has to follow that edge too or a filtered run would drop one the
+  /// unfiltered run kept.
+  #[test]
+  fn filter_follows_a_cite_from_inside_an_entry() {
+    let tex = to_tex_wanted(
+      r#"
+@article{outer, title = {O}, note = {see also \cite{inner}}}
+@article{inner, title = {I}, note = {and \citep[cf.][]{deep}}}
+@article{deep, title = {D}}
+@article{unrelated, title = {U}}
+"#,
+      Some(&["outer"]),
+    );
+    assert!(tex.contains("\\ProcessBibTeXEntry{outer}"));
+    assert!(tex.contains("\\ProcessBibTeXEntry{inner}"));
+    assert!(tex.contains("\\ProcessBibTeXEntry{deep}"));
+    assert!(!tex.contains("\\ProcessBibTeXEntry{unrelated}"));
+    crate::bibtex::reset();
+  }
+
+  /// A cited key that the `.bib` does not define must not abort the selection —
+  /// `MakeBibliography` reports it as a missing key downstream.
+  #[test]
+  fn filter_tolerates_a_cited_key_with_no_entry() {
+    let tex = to_tex_wanted(LIBRARY, Some(&["cited", "nosuchkey"]));
+    assert!(tex.contains("\\ProcessBibTeXEntry{cited}"));
+    assert!(tex.contains("\\begin{bibtex@bibliography}"));
+    crate::bibtex::reset();
+  }
+
+  #[test]
+  fn cite_key_scanner_handles_the_cite_family() {
+    let mut got = Vec::new();
+    collect_cited_keys(r"a \cite{one} b \citep[see][p.2]{two,three} c", &mut got);
+    assert_eq!(got, vec!["one", "two", "three"]);
+
+    let mut got = Vec::new();
+    collect_cited_keys(r"\cite*{Star} and \citeyear{Y}", &mut got);
+    assert_eq!(got, vec!["star", "y"]);
+
+    // No key list, and an unterminated optional argument: neither may panic.
+    let mut got = Vec::new();
+    collect_cited_keys(r"\cite and \cite[oops", &mut got);
+    assert!(got.is_empty());
   }
 
   // Internal helper tests.

--- a/latexml_oxide/src/bib_session.rs
+++ b/latexml_oxide/src/bib_session.rs
@@ -218,15 +218,19 @@ fn convert(request: &BibConversionRequest) -> Option<PostDocument> {
     provide_url_command()?;
     latexml_core::stomach::digest(latexml_core::mouth::tokenize(BBL_STANDARD_FALLBACKS))?;
 
-    // `noinitialize` because the session above is already the one we want:
-    // `digest_file`'s own initialization would call `initialize_singletons` a
-    // second time on this thread, which re-runs the pools' `Let!`s and resets
-    // the REPORT the outer document is still counting into.
+    // Digest only what the document cites — a `.bib` is a library, and
+    // `bibtex(1)` reads the `.aux`'s `\citation` records rather than the whole
+    // file. Set around `digest_file` only: the filter lives in the same
+    // thread-local State the outer document uses, so leaving it installed
+    // would leak into any later `.bib` in this process.
+    latexml_engine::pre_bibtex::set_wanted_keys(request.wanted_keys.clone());
     let digested = core.digest_file(source.clone(), DigestionOptions {
       mode: Some(DigestionMode::BibTeX),
       noinitialize: Some(true),
       ..DigestionOptions::default()
-    })?;
+    });
+    latexml_engine::pre_bibtex::clear_wanted_keys();
+    let digested = digested?;
     let document = core.convert_document(digested)?;
     Ok(PostDocument::new(document.document, PostDocumentOptions {
       source_directory: Some(".".to_string()),

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -56,6 +56,13 @@ pub struct BibConversionRequest {
   /// bibliography's fields are the article's TeX, so they need the article's
   /// class and packages to mean anything.
   pub preloads:     Vec<String>,
+  /// The keys the document cites, or `None` to convert every entry.
+  ///
+  /// A `.bib` is a library: the converter should digest the cited entries (and
+  /// their `crossref`/`\cite` closure) rather than the whole file, exactly as
+  /// `bibtex(1)` does from the `.aux`'s `\citation` records. `None` means no
+  /// citation record was available, or the document said `\nocite{*}`.
+  pub wanted_keys:  Option<Vec<String>>,
 }
 
 /// Convert raw BibTeX into a document containing `ltx:bibentry` elements.
@@ -182,7 +189,14 @@ impl MakeBibliography {
   /// Locates .bib.xml files from:
   ///   - Command-line options (overrides)
   ///   - //ltx:bibliography[@files] attribute
-  fn get_bibliographies(&self, doc: &PostDocument) -> Vec<PostDocument> {
+  ///
+  /// `wanted_keys` is forwarded to the recursive raw-`.bib` conversion so it
+  /// digests only the cited entries; see [`BibConversionRequest::wanted_keys`].
+  fn get_bibliographies(
+    &self,
+    doc: &PostDocument,
+    wanted_keys: Option<&Vec<String>>,
+  ) -> Vec<PostDocument> {
     let mut bibnames: Vec<String> = Vec::new();
     let mut from_bibliography = false;
 
@@ -314,6 +328,7 @@ impl MakeBibliography {
             sources: rawbibs,
             search_paths: search_paths.to_vec(),
             preloads,
+            wanted_keys: wanted_keys.cloned(),
           };
           match convert(&request) {
             Some(bibdoc) => bibs.push(bibdoc),
@@ -396,6 +411,36 @@ impl MakeBibliography {
     }
   }
 
+  /// The bib keys this document cites, for the recursive raw-`.bib` conversion
+  /// to digest instead of the whole library.
+  ///
+  /// Reads the same `BIBLABEL:<list>:<key>` ObjectDB records that Step 2 of
+  /// [`Self::get_bib_entries`] scans — they are written during the document
+  /// conversion, so they are already complete by the time post-processing asks.
+  /// Returns `None` (= convert everything) for `\nocite{*}`, and also when no
+  /// `BIBLABEL` record exists at all: an empty filter and "no citation data"
+  /// are indistinguishable here, and dropping every entry on a missing record
+  /// would be a silent, unrecoverable loss.
+  fn cited_keys(&self, lists: &[&str]) -> Option<Vec<String>> {
+    let mut keys: Vec<String> = Vec::new();
+    for db_key in self.db.get_keys() {
+      let Some(rest) = db_key.strip_prefix("BIBLABEL:") else {
+        continue;
+      };
+      let Some((list, bibkey)) = rest.split_once(':') else {
+        continue;
+      };
+      if !lists.contains(&list) {
+        continue;
+      }
+      if bibkey == "*" {
+        return None; // `\nocite{*}` — the document wants the whole library.
+      }
+      keys.push(bibkey.to_string());
+    }
+    (!keys.is_empty()).then_some(keys)
+  }
+
   fn get_bib_entries(
     &self,
     doc: &PostDocument,
@@ -411,7 +456,7 @@ impl MakeBibliography {
     // Import bibentry nodes into the main document so that XPath queries
     // (which use the main document's namespace context) work correctly.
     let mut entries: HashMap<String, BibEntryData> = HashMap::default();
-    let bib_docs = self.get_bibliographies(doc);
+    let bib_docs = self.get_bibliographies(doc, self.cited_keys(&lists).as_ref());
     for bibdoc in &bib_docs {
       Self::scan_bibentries(&mut entries, bibdoc);
     }


### PR DESCRIPTION
A `.bib` is a library, not a document. `anthology.bib` ships **80,576** ACL entries and the citing paper wants **9**. Since the raw `.bib` became a real conversion (#396) rather than a string parse, every entry costs a full expand/digest/construct cycle — so we now digest the whole library at engine prices to use a handful of entries.

Measured on `2605.07796` (`anthology.bib`, 43.6 MB, 80,576 entries, 9 cited): **112 s and 4.8 GB RSS**, tripping the memory budget and producing **zero** bibentries — the paper loses its whole bibliography, and the fleet's 60 s timeout kills the conversion outright.

`bibtex(1)` has always read the `.aux`'s `\citation` records and emitted only those entries, plus `crossref` targets, plus everything under `\nocite{*}`. Filtering here is therefore *more* faithful to the real pipeline than digesting the library whole.

`MakeBibliography` already knows the cited set (`BIBLABEL:<list>:<key>` ObjectDB records, written during the document conversion). They now travel to the recursive session as `BibConversionRequest::wanted_keys`, and `PreBibTeX::to_tex` emits `\ProcessBibTeXEntry` only for the selected entries.

### Impact

Found while characterizing a fatal-rate regression in the 2605/2606 sandboxes (+72 / +73 fatals). This shape covers **59 of the 69** papers in the `never_completed_with_retries` bucket (median 80,597 entries each).

| witness | before | after |
|---|---|---|
| `2605.07796` | 112 s, 4.8 GB, 0 bibentries, killed | **10 s, 9 bibentries, 0 errors** |

9 of the 10 papers that had converted *cleanly* before the regression recover; the tenth (`2605.16752`) is an unrelated `Fatal:Timeout:TokenLimit`. The recovered output matches what the pre-#396 run produced (`formatted 9 entries`).

Suite **1735 passed / 0 failed** (baseline 1727 + 8 new guards); clippy `-D warnings` and `cargo +nightly fmt --all` clean. Every guard red-verified by neutering the filter.

## Decisions & open questions

- **Selection is closed transitively over two edges**, so a filtered run keeps everything an unfiltered one kept: `crossref` (BibTeX's own inheritance link — an `@inproceedings` naming its `@proceedings`) and a `\cite` made from *inside* an already-selected entry, which `getBibEntries` separately follows. Missing either would silently drop an entry.
- **Registration stays complete.** Only *digestion* is filtered. Registering is a map insert of already-parsed strings, and keeping it complete is what lets `crossref` and by-key lookup still resolve against an entry nobody cited.
- **`None` means "digest everything"**, used for `\nocite{*}` and — deliberately — when no `BIBLABEL` record exists at all. An empty filter and absent citation data are indistinguishable at that point, and dropping every entry on a missing record would be a silent, unrecoverable loss. This is the fail-safe direction, at the cost of not optimizing that (rare) case.
- **No diagnostic is suppressed.** Uncited entries were already discarded downstream by `MakeBibliography`; this only stops paying to digest them. Errors *inside* a cited entry are still raised exactly as before.
- **The thread-local filter is cleared around `digest_file`**, because the recursive session shares the outer document's State — a leaked filter would shrink a later `.bib` in the same process.
- Open: the `\cite`-scanner is a deliberately loose textual scan (over-collecting only keeps an extra entry; missing one would drop it). It does not understand a `\cite` produced by macro expansion inside a field. No witness for that yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
