### PR TITLE
A .bib @preamble already executes; guard it, and keep the \cprime stub

### DIFF
--- a/docs/parity/BIBLIOGRAPHY_WORKLIST.md
+++ b/docs/parity/BIBLIOGRAPHY_WORKLIST.md
@@ -123,7 +123,7 @@ and fourteen times over in 2605.11579's `biblo.bib` (L4768, L6910, …).
 
 We read `.bib` directly, so that copy is ours to make — and it is made. Perl
 `Pre/BibTeX.pm::toTeX` L118-122 joins the preamble lines ahead of
-`\begin{bibtex@bibliography}`; `pre_bibtex::to_tex` L699-703 mirrors it
+`\begin{bibtex@bibliography}`; `pre_bibtex::to_tex` mirrors it
 **verbatim** — no `escape_bib_data_specials`, no
 `Mouth::with_bib_data_literals` — which is exactly right for treatment-2
 content. Measured end to end with a probe `@preamble` defining a macro nothing
@@ -148,8 +148,10 @@ green even if that string is never executed.
 motivation for checking, and the corpus says no. Scan of the first 600 papers of
 `/data/arxiv/2605/`: 7 use `\cprime` inside a `.bib`, and **6 of the 7 carry no
 `@preamble` at all** (the seventh, 2605.00097, has one but never uses
-`\cprime`). Measured with the raw-`.bib` route forced, `--includestyles`,
-`--release`, TOTAL document errors with-stub → without:
+`\cprime`). 2605.11579 sits outside that window and is added as the eighth row
+because it is the one paper whose `@preamble` covers real uses. Measured with
+the raw-`.bib` route forced, `--includestyles`, `--release`, TOTAL document
+errors with-stub → without:
 
 | paper | `@preamble` defines `\cprime`? | with → without |
 |---|---|---|

--- a/docs/parity/BIBLIOGRAPHY_WORKLIST.md
+++ b/docs/parity/BIBLIOGRAPHY_WORKLIST.md
@@ -111,6 +111,83 @@ it is a silent trap: `\_` is the underscore command but `\^` is the circumflex
 its own arm emitting `\textasciicircum{}`, braces included. This is what closed
 "the `^` third remains open" below.
 
+#### `@preamble` is treatment 2, and it already executes — verified 2026-07-27
+
+`@preamble` is the one part of a `.bib` that `bibtex(1)` does **not** treat as
+data: it copies the block verbatim to the top of the `.bbl` (plain.bst
+`begin.bib`, `preamble$ write$`, ahead of `\begin{thebibliography}`), so pdflatex
+has the definitions before the first `\bibitem`. It is how a `.bib` ships the
+macros its own fields use, and MathSciNet's exporter emits one as a matter of
+course — `@preamble{"\def\cprime{$'$} "}` in 2605.00097's `referLiu.bib` (L11)
+and fourteen times over in 2605.11579's `biblo.bib` (L4768, L6910, …).
+
+We read `.bib` directly, so that copy is ours to make — and it is made. Perl
+`Pre/BibTeX.pm::toTeX` L118-122 joins the preamble lines ahead of
+`\begin{bibtex@bibliography}`; `pre_bibtex::to_tex` L699-703 mirrors it
+**verbatim** — no `escape_bib_data_specials`, no
+`Mouth::with_bib_data_literals` — which is exactly right for treatment-2
+content. Measured end to end with a probe `@preamble` defining a macro nothing
+else defines: **Rust 0 errors, same-host `latexmlc` 0 errors, both expand it**;
+delete the `@preamble` and both raise `undefined:`. **`\cprime` is a vacuous
+probe** for this question — the always-on stub in
+`latex_constructs_rust_only.rs` defines it either way, so a fresh name is
+required.
+
+Guard:
+`06_cluster_bibliography::bib_preamble_defines_macros_for_the_whole_bibliography`
+(fixture `cluster_regressions/bib_preamble.{tex,bib}`), pinning a `#1`
+parameter, `\&`/`\%` in a macro body, the `$'$` MathSciNet shape inside a name,
+and — via a second entry — that the definitions are installed **once before any
+entry**, not per entry. Red-verified twice: dropping the preamble from `to_tex`
+costs 4 errors, and routing it through `escape_bib_data_specials` kills the
+parameterized macro. The pre-existing `pre_bibtex::to_tex_includes_preamble`
+does **not** cover any of this — it asserts on the emitted *string*, so it stays
+green even if that string is never executed.
+
+**Consequence for the always-on `\cprime` stub: it stays.** Removing it was the
+motivation for checking, and the corpus says no. Scan of the first 600 papers of
+`/data/arxiv/2605/`: 7 use `\cprime` inside a `.bib`, and **6 of the 7 carry no
+`@preamble` at all** (the seventh, 2605.00097, has one but never uses
+`\cprime`). Measured with the raw-`.bib` route forced, `--includestyles`,
+`--release`, TOTAL document errors with-stub → without:
+
+| paper | `@preamble` defines `\cprime`? | with → without |
+|---|---|---|
+| 2605.00097 | yes, unused | 1 → 1 |
+| 2605.00173 | no | 0 → **1** `undefined:\cprime` |
+| 2605.00186 | no | 0 → **1** |
+| 2605.00190 | no | 0 → **1** |
+| 2605.00305 | no | 0 → **1** |
+| 2605.00316 | no | 2 → 2 (its `\cprime` is in `fjournal`, undigested) |
+| 2605.00584 | no | 0 → 0 (same) |
+| 2605.11579 | yes, 17 uses in `AUTHOR`/`TITLE`/`BOOKTITLE`/`MRREVIEWER` | 1 → 1 |
+
+2605.11579 is the informative row twice over: it is the only paper whose
+`@preamble` covers real uses, and it stays at its single unrelated
+`undefined:\Dbar` **with the stub gone** — the `@preamble` is carrying all 17.
+2605.00173 is the control: same field kind (`AUTHOR`), same binary, `+1` error,
+distinguished only by having no `@preamble`.
+
+Three of the four regressions are errors the real toolchain never produces, and
+that is the durable point: `bibtex(1)` copies only **cited** entries into the
+`.bbl`, and in 2605.00173/.00186/.00190 the `\cprime`-bearing entry is never
+cited — pdflatex never sees the macro. We digest every entry in the `.bib`, so
+the stub is what keeps that asymmetry from manufacturing a diagnostic. In
+2605.00305 the entry IS cited (`MR710121`, "Arnol\cprime d diffusion"), so there
+the stub renders text the reader sees.
+
+Same-host Perl was run over all eight (production profile, verbose) and is not a
+usable oracle for this question — it never raises `undefined:\cprime` anywhere,
+for reasons unrelated to the macro: 2605.00305 and 2605.00316 hit `MAX_ERRORS`
+(101 + Fatal) on a pgfparse flood long before MakeBibliography, 2605.00173/.00186/
+.00190 take their shipped `.bbl`, and on 2605.11579 Perl emits **zero**
+bibliography entries at all ("Missing Entry for citation" × 36, against Rust's
+36 rendered) — a silent total loss, not a clean run. The mechanism was confirmed
+against Perl on the controlled fixture instead, where both engines reach 0
+errors with every preamble macro expanded. Note Perl defines `\cprime`
+**nowhere** in `LaTeXML/lib`, so the stub is and stays a surpass-Perl
+divergence.
+
 ### Why the re-port is the real fix: eager tokenization defeats parameter types (measured 2026-07-26)
 
 The 2026-07-26 sandbox rerun quantified what the simplified parser costs. In

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2656,6 +2656,22 @@ exactly this, carrying its witnesses. `provide` in the binding then finds them
 already defined, the correct no-op. `\polhk`'s comment there claimed tipa.sty as
 its source; the real one is `mathscinet.sty` L111-113, corrected in place.
 
+*Re-measured 2026-07-27, and the "may or may not define it" is now a number.*
+The stub's redundancy was re-opened once `@preamble` execution was confirmed
+working end to end (it is Perl `Pre/BibTeX.pm::toTeX` L118-122, ported at
+`pre_bibtex::to_tex`, now guarded by
+`bib_preamble_defines_macros_for_the_whole_bibliography`) — a `.bib` that
+defines `\cprime` itself needs no stub. The corpus says the stub still earns its
+place: across the first 600 papers of arXiv 2605, **seven** use `\cprime` inside
+a `.bib` and **six carry no `@preamble` at all**. Deleting the four lines takes
+2605.00173/.00186/.00190/.00305 from 0 to 1 `undefined:\cprime` each, while
+2605.11579 — 17 uses, `@preamble`-covered — is unaffected either way. Three of
+those four are errors the real toolchain never produces, because `bibtex(1)`
+copies only *cited* entries into the `.bbl` and there the `\cprime`-bearing
+entry is uncited; we digest every entry, so the stub is what keeps that
+asymmetry from manufacturing a diagnostic. Per-paper table in
+[`BIBLIOGRAPHY_WORKLIST.md`](BIBLIOGRAPHY_WORKLIST.md).
+
 **Measured**, same host: 2605.11579 `--includestyles` **1 error / 36 bibitems**
 (the `\Dbar` parity residual); 2508.13753 **0 errors**, `Kondratʹev` composing;
 2508.20226 **0 errors**; 2509.07628 `--includestyles` **0 errors**, `Drinfelʹ d`

--- a/latexml_engine/src/latex_constructs_rust_only.rs
+++ b/latexml_engine/src/latex_constructs_rust_only.rs
@@ -427,6 +427,29 @@ LoadDefinitions!({
   // `undefined:\cprime`. The `provide` in the binding then finds them
   // already defined, which is the correct no-op.
   //
+  // Re-measured on the corpus 2026-07-27, because `@preamble` execution
+  // works (it is Perl `Pre/BibTeX.pm::toTeX` L118-122, ported at
+  // `pre_bibtex::to_tex`, guarded by
+  // `bib_preamble_defines_macros_for_the_whole_bibliography`) and would
+  // in principle make this stub redundant. It does not: across the first
+  // 600 papers of arXiv 2605, SEVEN use `\cprime` inside a `.bib` and
+  // **six of them carry no `@preamble` at all** — nothing defines it
+  // anywhere in their source. Deleting these four lines takes 2605.00173,
+  // 2605.00186, 2605.00190 and 2605.00305 from 0 to 1 `undefined:\cprime`
+  // each, while the one paper that DOES define it in its `@preamble`
+  // (2605.11579, 17 uses across `AUTHOR`/`TITLE`/`BOOKTITLE`/`MRREVIEWER`)
+  // is unaffected either way. Detail + table in
+  // `docs/parity/BIBLIOGRAPHY_WORKLIST.md`.
+  //
+  // Three of those four regressions would also be errors the real toolchain
+  // never produces: `bibtex(1)` copies only CITED entries into the `.bbl`,
+  // and in 2605.00173/.00186/.00190 the `\cprime`-bearing entry is never
+  // cited, so pdflatex never sees the macro. We digest every entry in the
+  // `.bib`, so the stub is what keeps that asymmetry from manufacturing a
+  // diagnostic. (2605.00305 is the fourth, and there the entry IS cited —
+  // `MR710121`, "Arnol\cprime d diffusion" — so the stub renders content the
+  // reader sees.)
+  //
   // Contrast `\Dbar`, which is package-ONLY and deliberately so: four
   // authors per 4,000 papers define it themselves with `\newcommand`,
   // and an always-on definition would silently shadow them

--- a/latexml_engine/src/pre_bibtex.rs
+++ b/latexml_engine/src/pre_bibtex.rs
@@ -697,6 +697,23 @@ impl PreBibTeX {
       register_entry(&parsed.key, entry);
     }
     let mut out = String::new();
+    // `@preamble` is the one part of a `.bib` that is NOT data — `bibtex(1)`
+    // copies it verbatim to the top of the `.bbl` (plain.bst `begin.bib`:
+    // `preamble$ write$`, ahead of `\begin{thebibliography}`), so pdflatex has
+    // its definitions before the first `\bibitem`. Perl L118-122 emits it in
+    // the same position, and so must we: it is how a `.bib` ships the macros
+    // its own fields use, and MathSciNet exports lean on it
+    // (`@preamble{"\def\cprime{$'$} "}` — 2605.00097 `referLiu.bib` L11,
+    // 2605.11579 `biblo.bib` L4768/L6910/… fourteen times).
+    //
+    // It goes out RAW, and must keep going out raw. In the two-treatment frame
+    // (`docs/parity/BIBLIOGRAPHY_WORKLIST.md`) this is treatment 2 — TeX
+    // source — so it must never pass through `escape_bib_data_specials` (which
+    // would turn `\def\cprime{$'$}` into inert text) nor be read under
+    // `Mouth::with_bib_data_literals`. Guard:
+    // `06_cluster_bibliography::bib_preamble_defines_macros_for_the_whole_bibliography`
+    // — `to_tex_includes_preamble` below only checks the emitted STRING, so it
+    // stays green if the string is later escaped or never executed.
     for pre in &self.preamble {
       out.push_str(pre);
       out.push('\n');

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -1253,3 +1253,63 @@ fn bib_mathscinet_macro_yields_to_the_authors_own_definition() {
     "author `\\Dbar`: no bibliography at all:\n{x}"
   );
 }
+
+/// A `.bib`'s `@preamble` is TeX source, executed once before any entry.
+///
+/// This is the one part of a `.bib` that `bibtex(1)` does not treat as data: it
+/// copies the block verbatim to the top of the `.bbl` (plain.bst `begin.bib`,
+/// `preamble$ write$`, ahead of `\begin{thebibliography}`), so pdflatex has the
+/// definitions before the first `\bibitem`. It is how a `.bib` ships the macros
+/// its own fields use, and MathSciNet's exporter emits one routinely —
+/// `@preamble{"\def\cprime{$'$} "}` in 2605.00097's `referLiu.bib` (L11) and
+/// fourteen times over in 2605.11579's `biblo.bib` (L4768, L6910, …).
+///
+/// We read `.bib` directly, so performing that copy is ours to do: Perl
+/// `Pre/BibTeX.pm::toTeX` L118-122 joins the preamble lines ahead of
+/// `\begin{bibtex@bibliography}`, and `pre_bibtex::to_tex` mirrors it. Verified
+/// end to end against same-host `latexmlc` on this exact fixture: both engines
+/// 0 errors, both expand every macro.
+///
+/// Under the two-treatment frame (`docs/parity/BIBLIOGRAPHY_WORKLIST.md`) the
+/// preamble belongs to treatment 2 — the TeX regime — and must therefore NOT
+/// pass through `escape_bib_data_specials`, which would turn `\def\cprime{$'$}`
+/// into inert text. Nothing else guards that: `to_tex_includes_preamble`
+/// (`pre_bibtex.rs`) asserts on the emitted STRING, so it stays green even if
+/// the string is never executed, is escaped on the way to the tokenizer, or is
+/// read under `Mouth::with_bib_data_literals`.
+///
+/// The fixture's macro names are unique to it on purpose. `\cprime` is defined
+/// always-on in `latex_constructs_rust_only.rs`, so probing with it would pass
+/// whether or not the preamble ran at all.
+#[test]
+fn bib_preamble_defines_macros_for_the_whole_bibliography() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_preamble.tex");
+  // A parameter survives: `#` reaches the tokenizer at catcode 6, so
+  // `\newcommand{\bibpreamblearg}[1]{[[#1]]}` is a real one-argument macro.
+  assert!(
+    x.contains("[[ARGWORKS]]"),
+    "@preamble: the parameterized macro did not expand:\n{x}"
+  );
+  // `\&` and `\%` in the preamble are TeX escapes, not data to be re-escaped.
+  assert!(
+    x.contains("Taylor &amp; Francis"),
+    "@preamble: `\\&` in a preamble macro body did not render:\n{x}"
+  );
+  // The SECOND entry uses a preamble macro: the definitions are installed once,
+  // before the entries, not scoped to whichever entry happens to be first.
+  assert!(
+    x.contains("100%"),
+    "@preamble: the second entry lost the preamble macro — definitions must \
+     outlive the first entry:\n{x}"
+  );
+  // The MathSciNet shape verbatim, in the field it actually occupies: a name.
+  // `$'$` composes to a prime, and no source leaks.
+  assert!(
+    x.contains("Gel\u{2032}fand"),
+    "@preamble: `\\def\\bibpreambleprime{{$'$}}` did not compose in a name:\n{x}"
+  );
+  assert!(
+    !x.contains("bibpreamble"),
+    "@preamble: a preamble macro leaked into the output as source:\n{x}"
+  );
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_preamble.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_preamble.bib
@@ -1,0 +1,49 @@
+% `@preamble` is the one part of a `.bib` that BibTeX does NOT treat as data:
+% `bibtex(1)` copies it verbatim to the top of the `.bbl` (plain.bst's
+% `begin.bib`: `preamble$ write$` before `\begin{thebibliography}`), so pdflatex
+% executes it before any `\bibitem`. It is how a `.bib` ships the macros its own
+% fields use, and MathSciNet's exporter emits one as a matter of course —
+% witnesses 2605.00097 (`referLiu.bib` L11) and 2605.11579 (`biblo.bib`, the
+% same block fourteen times, L4768/L6910/...), both exactly
+% `@preamble{"\def\cprime{$'$} "}`.
+%
+% We read `.bib` directly, with no `bibtex(1)` and no `.bbl`, so the copy is
+% ours to perform: `pre_bibtex::to_tex` emits the preamble lines ahead of
+% `\begin{bibtex@bibliography}` (Perl `Pre/BibTeX.pm` L118-122).
+%
+% The macro names here are deliberately unique to this fixture. `\cprime` itself
+% would be a vacuous probe: `latex_constructs_rust_only.rs` defines it
+% always-on, so the entry would render whether or not the preamble ran.
+%
+% What each block is here to pin:
+%   * `$'$` — the MathSciNet shape verbatim. It is also the treatment-2 canary:
+%     `escape_bib_data_specials` would turn a `.bib` FIELD's `$`/`\` into
+%     something inert, and applying it here would destroy the definition.
+%   * `[1]{[[#1]]}` — a parameter. `#` is BibTeX's concatenation operator
+%     between values, but inside a quoted string it is literal, and the emitted
+%     line must reach the tokenizer with catcode 6 intact.
+%   * `\&` and `\%` — specials that are data in a field and TeX here.
+%   * the second entry uses a preamble macro, which pins the ORDERING: once per
+%     `.bib`, before any entry, not per-entry.
+
+@preamble{"\def\bibpreambleprime{$'$} "}
+
+@preamble{
+  "\newcommand{\bibpreamblearg}[1]{[[#1]]}
+   \def\bibpreambleamp{Taylor \& Francis}
+   \def\bibpreamblepct{100\%}"
+}
+
+@article{firstentry,
+  author  = {Gel\bibpreambleprime fand, I. M.},
+  title   = {Arg \bibpreamblearg{ARGWORKS} and \bibpreambleamp},
+  journal = {J. Probe},
+  year    = {2020},
+}
+
+@article{secondentry,
+  author  = {Other, B.},
+  title   = {The second entry still sees \bibpreamblepct},
+  journal = {J. Probe},
+  year    = {2021},
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_preamble.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_preamble.tex
@@ -1,0 +1,8 @@
+% Driver for `bib_preamble.bib`. Loads NO package: every macro the entries use
+% has to come from the `.bib`'s own `@preamble`. See the `.bib` header.
+\documentclass{article}
+\begin{document}
+See \cite{firstentry,secondentry}.
+\bibliographystyle{plain}
+\bibliography{bib_preamble}
+\end{document}


### PR DESCRIPTION
## Diagnostic

The premise under investigation was that a `.bib`'s `@preamble` is parsed but never executed — `pre_bibtex.rs` has a `preamble: Vec<String>` and a `parse_preamble()`, and no obvious consumer. **It is executed.** Of the four candidate explanations (never executed / wrong scope / too late / correct-but-masked), the answer is the last one: correct, in the right scope, at the right time.

Proved with a probe whose `@preamble` defines a macro nothing else defines (`\cprime` is a vacuous probe here — `latex_constructs_rust_only.rs` defines it always-on, so it would pass either way):

| probe | Rust | same-host `latexmlc` |
|---|---|---|
| `@preamble{"\def\zzprobe{ZZPROBEWORKS} "}`, used in a `title`, no package loaded | 0 errors, expands | 0 errors, expands |
| the same `.bib` with the `@preamble` deleted | `Error:undefined:\zzprobe` | same |

Also verified: multiple `@preamble` blocks in one file, a `#1` parameter, `\&`/`\%` bodies, cross-**file** sharing (`\bibliography{a,b}` where only `a.bib` has the preamble), and the direct `latexml_oxide foo.bib` route.

Perl is the same mechanism, not a divergence: `Pre/BibTeX.pm::toTeX` L118-122 joins the preamble lines ahead of `\begin{bibtex@bibliography}`, `Core.pm` L160-162 feeds that to the digester, and `MakeBibliography.pm` L203-226 reaches it via `type => "BibTeX"`. `pre_bibtex::to_tex` L699-703 mirrors it verbatim. Nothing to port.

The design constraint holds too: the preamble goes out **raw**. `escape_bib_data_specials` is applied to entry values, not to it, and `Mouth::with_bib_data_literals` is on the per-entry mouth in `\ProcessBibTeXEntry` (`bibtex.rs` L2369), not the wrapper. That is correct — under the two-treatment frame the preamble is treatment 2.

## Approach

No behaviour change. What was actually missing is a **guard**, and the gap is specific: `pre_bibtex::to_tex_includes_preamble` asserts on the emitted *string*, so it stays green if that string is later escaped, read under `with_bib_data_literals`, or never executed. The active treatment-1/treatment-2 escaping work runs straight through this file, and one seam too wide would silently turn `\def\cprime{$'$}` into inert text.

- `06_cluster_bibliography::bib_preamble_defines_macros_for_the_whole_bibliography` + fixture `cluster_regressions/bib_preamble.{tex,bib}`. Pins a `#1` parameter arriving at catcode 6, `\&`/`\%` in a macro body, the MathSciNet `$'$` shape inside a name, and — via a second entry — that definitions are installed once *before* any entry rather than per entry. Fixture macro names are unique to it, so the always-on stub cannot mask a failure.
- A comment at the emission site saying why the preamble must keep going out raw, pointing at the guard.
- `docs/parity/BIBLIOGRAPHY_WORKLIST.md`: a subsection under "the two treatments" recording the verified negative and the stub measurement.

## Validation

- `cargo test --tests --no-fail-fast`: **1728 passed / 0 failed** (baseline 1727, +1 for the new guard).
- `cargo +nightly clippy --workspace --all-targets -- -D warnings` clean; `cargo +nightly fmt --all` clean.
- Red-verified **twice**, by reverting: dropping the preamble from `to_tex` → 4 errors; routing it through `escape_bib_data_specials` → the parameterized macro dies.
- Same-host Perl on the fixture: 0 errors, every macro expanded, matching.

**The `\cprime` stub was measured and must stay.** Removing it was the motivating hypothesis; the corpus refuses. Scan of the first 600 papers of `/data/arxiv/2605/`: 7 use `\cprime` inside a `.bib`, and **6 of the 7 have no `@preamble` at all**. Raw-`.bib` route forced, `--includestyles`, `--release`, total document errors with-stub → without:

| paper | `@preamble` defines `\cprime`? | with → without |
|---|---|---|
| 2605.00097 | yes, but never uses it | 1 → 1 |
| 2605.00173 | no | 0 → **1** `undefined:\cprime` |
| 2605.00186 | no | 0 → **1** |
| 2605.00190 | no | 0 → **1** |
| 2605.00305 | no | 0 → **1** |
| 2605.00316 | no | 2 → 2 (`\cprime` only in `fjournal`, undigested) |
| 2605.00584 | no | 0 → 0 (same) |
| 2605.11579 | yes, 17 uses in `AUTHOR`/`TITLE`/`BOOKTITLE`/`MRREVIEWER` | 1 → 1 |

2605.11579 and 2605.00173 are the matched pair: same field kind, same binary, opposite outcome, distinguished only by the `@preamble`. That is the real-paper confirmation that preamble execution does the work where it is present.

## Decisions & open questions

- **`@preamble` needs no code change** — the finding's premise was falsified before anything was built. Reporting that is the deliverable; a "fix" here would have been a no-op wrapped in risk.
- **The stub stays, and the argument improved.** Three of the four regressions are errors the *real toolchain never produces*: `bibtex(1)` copies only **cited** entries into the `.bbl`, and in 2605.00173/.00186/.00190 the `\cprime`-bearing entry is never cited, so pdflatex never sees the macro. We digest every entry; the stub is what stops that asymmetry manufacturing a diagnostic. 2605.00305 is the exception that cites its entry (`MR710121`, "Arnol\cprime d diffusion"), so there the stub renders text the reader sees. `mathscinet_sty.rs` is untouched.
- **Perl is not a usable oracle for the stub question**, and this is worth knowing before someone re-runs it: it raises `undefined:\cprime` on none of the eight, for unrelated reasons — 2605.00305/.00316 hit `MAX_ERRORS` (101 + Fatal) on a pgfparse flood before MakeBibliography, .00173/.00186/.00190 take their shipped `.bbl`, and on 2605.11579 Perl emits **zero** bibliography entries ("Missing Entry for citation" × 36) against our 36 rendered. Perl defines `\cprime` nowhere in `LaTeXML/lib`, so the stub is and remains a surpass-Perl divergence; the parity evidence for the mechanism comes from the controlled fixture.
- **Open, not addressed here.** (a) The preamble's `\def`s land in the shared live State, so with several bibliographies in one document, bib A's macros are still in scope for bib B; Perl spins a fresh converter per `convertBibliography` and would not leak. Harmless today (post-processing does no further document digestion) and it is the same trade the "reuse the live State" decision already made, but it is a real difference. (b) 2605.00097 carries a Rust-only `undefined:\orgensen` where Perl is clean — checked and **not** an accent-weld regression: the `.bib` literally contains `AUTHOR = {J\orgensen, Peter}` (a corrupted `J{\o}rgensen`), and the delta is the known "we digest every entry, Perl digests fewer" divergence. Left alone.
