### PR TITLE
fix(bibliography): an unmatched $ in a .bib field is currency, not math

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2686,6 +2686,59 @@ the stub beneath it) and
 does not — RED under an always-on `\Dbar`, where the author's barred-D math
 renders `Đ`, and equally RED if the `.bib` session is made to auto-load).
 
+### 79. An UNMATCHED `$` in a `.bib` field is data, not a math shift
+
+Extends divergence #74 (a `.bib` field's content is DATA) to the one special it
+left out. Treatment 2's escaper is math-aware precisely so `$x_1+x_2$` passes
+through — but it treated `$` as an unconditional toggle, with no check that the
+toggles pair up.
+
+**The defect.** One stray `$` opens an inline-math group that never closes. A
+`.bib` is digested as ONE unit, so the leak crosses `\end{bib@entry}` and every
+subsequent element of every subsequent entry lands inside `<ltx:XMath>`:
+`<ltx:bib-organization> isn't allowed in <ltx:XMath>`, ~100 times over, tripping
+the 100-error cap and taking the whole document **Fatal**. Witness 2605.00166,
+`annote = {… costs … are probably of the order of $10 million. …}` — a literal
+currency dollar: **0 errors before the `.bib` became a real conversion, 103 and
+a Fatal after**. Across the 2605+2606 sandboxes, 33 of the 69 papers whose
+bibliography sub-conversion newly failed carry an odd `$` in a field, mostly in
+`title`, `abstract` and Mendeley-exported `keywords`/`mendeley-tags`.
+
+**The rule.** A `$` with no partner cannot be a math delimiter — there is no
+reading under which it opens a span that closes. It is therefore data, and `\$`
+is what a careful `.bst` author would have written, which is exactly #74's
+stated principle. With pure toggling an even count is always balanced, so only
+an odd count has an unmatched member; "immediately followed by an ASCII digit"
+is the tell that picks which one, and it settles the real cases:
+`of the order of $10 million` (demote the lone toggle), `$x$ costs $10` (demote
+the digit one, `$x$` stays math), `costs $10 and $x$` (note the *last* toggle
+would have been the wrong pick), `$1 and $2 and $3` (demote all three). With no
+digit anywhere, fall back to the trailing toggle.
+`bibtex.rs::demote_unmatched_dollars`.
+
+**SURPASS-PERL, and deliberately.** Same-host Perl cascades identically —
+`latexmlc` on 2605.00166 gives 102 errors and `Fatal:too_many_errors:100`, rc=1
+— because `\bibentry@create` interpolates the field raw into a fresh Mouth
+(`BibTeX.pool.ltxml` L155-166) with no escaping of any kind, and `Digested`
+(L230) then digests it live. Upstream *already agrees* an unmatched `$` is not
+math: `\bib@@title` balances it with `extract_delimited`, raises
+`Error('expected','$',…)` and **deletes** the stray (L324-330). It just applies
+that judgement to one field, and drops the character instead of keeping it. We
+apply it to every field and keep the character.
+
+Nothing is suppressed: this removes the CAUSE of the cascade, so the ~100
+`malformed:` errors are gone because the entry is now well-formed, not because
+they stopped being reported. It costs no fidelity against `pdflatex` either — a
+standard `.bst` never emits `annote` at all, so the character only ever reaches
+a tokenizer because we read the `.bib` directly, with no `.bst` in the loop.
+
+Guards: `bibtex.rs::escape_specials_lone_dollar_is_currency_not_math`,
+`::escape_specials_balanced_math_is_untouched`,
+`::escape_specials_digit_dollar_is_preferred_over_the_last`,
+`::escape_specials_all_currency_dollars_demote`,
+`::escape_specials_unmatched_dollar_without_a_digit_falls_back_to_the_last`,
+and `06_cluster_bibliography::bib_unmatched_dollar_does_not_leak_math`.
+
 ## Known Upstream Perl Issues (brief)
 
 These are behaviors in the original Perl LaTeXML that are bugs or limitations, not

--- a/latexml_engine/src/bibtex.rs
+++ b/latexml_engine/src/bibtex.rs
@@ -315,8 +315,78 @@ const BIB_DATA_CARET: &str = "\\textasciicircum{}";
 ///   `\^{}`; a control WORD is copied whole, so `\textasciicircum` survives. The
 ///   tricky case falls out of the same rule: in `\\&` the `\\` is consumed as
 ///   one pair, leaving a genuinely bare `&` that IS escaped.
+///
+/// An UNMATCHED `$` is data too, and gets the same treatment — see
+/// [`demote_unmatched_dollars`].
 fn escape_bib_data_specials(value: &str) -> String {
+  // Pass 1 measures the `$` toggles; pass 2 emits, demoting the ones that
+  // cannot be math delimiters. Running the same scanner twice, rather than
+  // writing a second one, is what keeps the (subtle) skip rules in one place.
+  let toggles = scan_bib_data_specials(value, &[]).1;
+  let demote = demote_unmatched_dollars(&toggles);
+  scan_bib_data_specials(value, &demote).0
+}
+
+/// A `$` that never finds its partner cannot be a math shift — it is a currency
+/// sign the author typed, and `\$` is what a careful `.bst` would have written.
+///
+/// Without this, one stray `$` opens an inline-math group that swallows the rest
+/// of the entry AND every entry after it: the `.bib` is one digestion, so the
+/// leak crosses `\end{bib@entry}` and every following element lands inside
+/// `<ltx:XMath>` — `<ltx:bib-organization> isn't allowed in <ltx:XMath>`, ~100
+/// times, tripping the 100-error cap and taking the document Fatal. Witness
+/// 2605.00166 (`annote = {... costs ... of the order of $10 million ...}`, a
+/// literal currency dollar): 0 errors before, 103 and a Fatal after.
+///
+/// SURPASS-PERL, and deliberately: same-host Perl cascades identically here
+/// (`latexmlc` on 2605.00166 — 102 errors, `Fatal:too_many_errors:100`, rc=1),
+/// because `\bibentry@create` interpolates the field raw into a fresh Mouth
+/// (`BibTeX.pool.ltxml` L155-166) with no escaping of any kind. Perl only
+/// balances `$` in `\bib@@title`, where it raises `expected:$` and DELETES the
+/// stray (L324-330) — so upstream already agrees an unmatched `$` is not math;
+/// it just applies that judgement to one field and drops the character instead
+/// of keeping it. Nothing is suppressed here: this removes the CAUSE of the
+/// cascade, so the ~100 `malformed:` errors are gone because the entry is now
+/// well-formed, not because they stopped being reported. It costs no fidelity
+/// against `pdflatex` either — a real `.bst` never emits `annote`, so the
+/// character only reaches a tokenizer because we read the `.bib` directly.
+/// OXIDIZED_DESIGN #79.
+///
+/// `toggles[i]` says whether the i-th `$` toggle is immediately followed by an
+/// ASCII digit. With pure toggling an even count is always balanced, so only an
+/// odd count has an unmatched member. Which one to demote is a judgement call,
+/// and "followed by a digit" is the tell that settles the common cases:
+///
+/// * `of the order of $10 million` — the lone toggle is currency. Demote it.
+/// * `$x$ costs $10` — demoting the digit one leaves `$x$` intact as math.
+/// * `costs $10 and $x$` — likewise, and note the *last* toggle would have been
+///   the wrong pick here.
+/// * `$1 and $2 and $3` — all three are currency; demoting all three balances.
+/// * No digit anywhere: fall back to the last toggle, which is the unmatched one
+///   under pure toggling.
+fn demote_unmatched_dollars(toggles: &[bool]) -> Vec<usize> {
+  if toggles.len().is_multiple_of(2) {
+    return Vec::new(); // balanced — every `$` has a partner
+  }
+  let mut demote: Vec<usize> = (0..toggles.len()).filter(|&i| toggles[i]).collect();
+  // Still odd (no digit tell, or an even number of them): the trailing toggle
+  // is the one left without a partner.
+  if !(toggles.len() - demote.len()).is_multiple_of(2)
+    && let Some(last) = (0..toggles.len()).rev().find(|i| !demote.contains(i))
+  {
+    demote.push(last);
+  }
+  demote
+}
+
+/// The shared scanner behind [`escape_bib_data_specials`].
+///
+/// Returns the escaped text plus, per `$`-toggle in order, whether it is
+/// immediately followed by an ASCII digit. Toggles whose ordinal is in `demote`
+/// are emitted as the literal `\$` and do NOT flip math mode.
+fn scan_bib_data_specials(value: &str, demote: &[usize]) -> (String, Vec<bool>) {
   let mut out = String::with_capacity(value.len() + 8);
+  let mut toggles: Vec<bool> = Vec::new();
   let mut chars = value.chars().peekable();
   let mut in_math = false;
   while let Some(c) = chars.next() {
@@ -358,13 +428,24 @@ fn escape_bib_data_specials(value: &str) -> String {
         }
       },
       '$' => {
-        out.push('$');
         // `$$` is one display delimiter, not two toggles.
-        if chars.peek() == Some(&'$') {
+        let doubled = chars.peek() == Some(&'$');
+        if doubled {
           chars.next();
-          out.push('$');
         }
-        in_math = !in_math;
+        let ordinal = toggles.len();
+        toggles.push(chars.peek().is_some_and(char::is_ascii_digit));
+        if demote.contains(&ordinal) {
+          // Data, not a math shift: emit the character and stay in whatever
+          // mode we were in.
+          out.push_str(if doubled { "\\$\\$" } else { "\\$" });
+        } else {
+          out.push('$');
+          if doubled {
+            out.push('$');
+          }
+          in_math = !in_math;
+        }
       },
       // Before the generic arm, and deliberately: `\^` is the circumflex
       // accent, so the generic `\` + character escape would render `^o` as "ô".
@@ -377,7 +458,7 @@ fn escape_bib_data_specials(value: &str) -> String {
       _ => out.push(c),
     }
   }
-  out
+  (out, toggles)
 }
 
 /// Control words that read their own next argument as DATA, so the escaper must
@@ -2772,6 +2853,86 @@ mod tests {
     assert_eq!(
       escape_bib_data_specials(r"open \[x^2\] then y^3"),
       r"open \[x^2\] then y\textasciicircum{}3"
+    );
+  }
+
+  // --- unmatched `$` is currency, not a math shift (OXIDIZED_DESIGN #79) ----
+  //
+  // One stray `$` used to open an inline-math group that never closed, and
+  // since a `.bib` is digested as ONE unit the leak crossed `\end{bib@entry}`
+  // and swallowed every following entry: ~100 `isn't allowed in <ltx:XMath>`,
+  // the 100-error cap, and a Fatal. Witness 2605.00166 (0 -> 103 errors).
+
+  /// A balanced field must keep behaving exactly as before — this is the
+  /// regression risk of the whole change.
+  #[test]
+  fn escape_specials_balanced_math_is_untouched() {
+    assert_eq!(
+      escape_bib_data_specials("Bounds on $x_1+x_2$ for AT1G_v2"),
+      r"Bounds on $x_1+x_2$ for AT1G\_v2"
+    );
+    assert_eq!(
+      escape_bib_data_specials("display $$a_1$$ then b_2"),
+      r"display $$a_1$$ then b\_2"
+    );
+    // Four toggles, all paired.
+    assert_eq!(
+      escape_bib_data_specials("$X$-band and $Y$-band"),
+      "$X$-band and $Y$-band"
+    );
+  }
+
+  /// The witness: a lone currency dollar in an `annote`.
+  #[test]
+  fn escape_specials_lone_dollar_is_currency_not_math() {
+    assert_eq!(
+      escape_bib_data_specials("costs of the order of $10 million."),
+      r"costs of the order of \$10 million."
+    );
+    // …and the escaped form stays escaped (idempotency).
+    assert_eq!(
+      escape_bib_data_specials(r"costs of the order of \$10 million."),
+      r"costs of the order of \$10 million."
+    );
+  }
+
+  /// With an odd count, the digit tell picks the currency dollar and leaves a
+  /// genuine math span alone — in BOTH orders, which is why "demote the last
+  /// toggle" alone would be wrong.
+  #[test]
+  fn escape_specials_digit_dollar_is_preferred_over_the_last() {
+    assert_eq!(escape_bib_data_specials("$x$ costs $10"), r"$x$ costs \$10");
+    assert_eq!(
+      escape_bib_data_specials("costs $10 and $x$"),
+      r"costs \$10 and $x$"
+    );
+  }
+
+  #[test]
+  fn escape_specials_all_currency_dollars_demote() {
+    assert_eq!(
+      escape_bib_data_specials("$1 and $2 and $3"),
+      r"\$1 and \$2 and \$3"
+    );
+  }
+
+  /// No digit anywhere: the trailing toggle is the one left without a partner.
+  #[test]
+  fn escape_specials_unmatched_dollar_without_a_digit_falls_back_to_the_last() {
+    assert_eq!(escape_bib_data_specials("a $ b"), r"a \$ b");
+    assert_eq!(
+      escape_bib_data_specials("$x$ and a stray $ here"),
+      r"$x$ and a stray \$ here"
+    );
+  }
+
+  /// Demoting must not strand the `_`/`^` rule: text after the demoted `$` is
+  /// OUT of math, so its scripting characters are data again.
+  #[test]
+  fn escape_specials_demoted_dollar_leaves_following_text_out_of_math() {
+    assert_eq!(
+      escape_bib_data_specials("cost $10 for x_1"),
+      r"cost \$10 for x\_1"
     );
   }
 

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -776,6 +776,63 @@ fn bib_bare_ampersand_leaves_live_markup_alone() {
     );
   }
 }
+
+/// An unmatched `$` in a `.bib` field is a currency sign, not a math shift.
+///
+/// Witness 2605.00166 (`annote = {… of the order of $10 million …}`): **0
+/// errors** before the raw `.bib` became a real conversion, **103 and a Fatal**
+/// after. A `.bib` is digested as ONE unit, so the never-closed inline-math
+/// group crossed `\end{bib@entry}` and every subsequent element landed inside
+/// `<ltx:XMath>` — `<ltx:bib-organization> isn't allowed in <ltx:XMath>` ~100
+/// times, tripping the 100-error cap. Across the 2605+2606 sandboxes, 33 of the
+/// 69 papers whose bibliography sub-conversion newly failed carry an odd `$`.
+///
+/// Authorized surpass-Perl (OXIDIZED_DESIGN #79): same-host Perl cascades
+/// identically (`latexmlc` on 2605.00166 gives 102 errors,
+/// `Fatal:too_many_errors:100`, rc=1), because `\bibentry@create` interpolates
+/// the field raw into a fresh Mouth. Upstream already agrees an unmatched `$`
+/// is not math — `\bib@@title` errors and DELETES it — it just applies that to
+/// one field and drops the character. Nothing is suppressed here: the cascade
+/// is gone because the entry is well-formed, and `convert_and_post_clean`
+/// enforces the zero-post-error gate.
+///
+/// The load-bearing assertion is `aftermath`, the LAST entry: containment. If a
+/// stray `$` leaks again it is the first thing to disappear.
+#[test]
+fn bib_unmatched_dollar_does_not_leak_math() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_unmatched_dollar.tex");
+  assert!(
+    x.contains("<bibitem"),
+    "unmatched $: no bibliography at all:\n{x}"
+  );
+  // Every entry survives — `aftermath` sits after all three stray-`$` entries.
+  for needle in [
+    "Okonkwo",
+    "Lindqvist",
+    "Diallo",
+    "Park",
+    "Raghavan",
+    "containment canary",
+  ] {
+    assert!(
+      x.contains(needle),
+      "unmatched $: {needle:?} was swallowed by a leaked math group:\n{x}"
+    );
+  }
+  // The currency amount survives as TEXT rather than being absorbed into math.
+  assert!(
+    x.contains("10 million"),
+    "unmatched $: the currency amount vanished:\n{x}"
+  );
+  // …while a genuinely balanced span is still parsed as math: `$x_1+x_2$` in
+  // `mathandcurrency` keeps its subscript, so demoting the later `$8` did not
+  // disturb the earlier pair.
+  assert!(
+    x.contains(r#"role="SUBSCRIPTOP""#),
+    "unmatched $: balanced `$x_1+x_2$` stopped being math:\n{x}"
+  );
+}
+
 /// A `.bib` field's content is DATA, not TeX: a bare `_`, `&`, `#` or `%` is
 /// the literal character. `AT&T` renders "AT&T"; `AT1G01010_v2` renders
 /// "AT1G01010_v2". Witnesses: 2605.06926 (8 `unexpected:_`, four `eprint` PDF

--- a/latexml_oxide/tests/cluster_regressions/bib_unmatched_dollar.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_unmatched_dollar.bib
@@ -1,0 +1,45 @@
+% An UNMATCHED `$` in a .bib field is a currency sign, not a math shift.
+% OXIDIZED_DESIGN #79. Witness 2605.00166 (`annote = {... of the order of
+% $10 million ...}`): 0 errors before the raw .bib became a real conversion,
+% 103 errors and a Fatal after, because the stray `$` opened an inline-math
+% group that never closed and — a .bib being ONE digestion — swallowed every
+% following entry into <ltx:XMath>.
+%
+% Entry order is load-bearing: `aftermath` sits LAST so that it is the canary
+% for containment. If a stray `$` ever leaks again, it is the first entry to
+% disappear.
+
+@article{currency,
+  author = {Okonkwo, A.},
+  title = {Klystron programme costs of the order of $10 million},
+  journal = {Accelerator Review},
+  year = {2019}
+}
+
+@article{mathandcurrency,
+  author = {Lindqvist, B.},
+  title = {Bounds on $x_1+x_2$ for repairs costing $8 each},
+  journal = {Journal of Estimates},
+  year = {2020}
+}
+
+@article{straynodigit,
+  author = {Diallo, C.},
+  title = {A stray $ shift with no amount after it},
+  journal = {Typesetting Notes},
+  year = {2021}
+}
+
+@article{balancedmath,
+  author = {Park, D.},
+  title = {Genuine math $X$-band and $y^2$ survive untouched},
+  journal = {Physics Letters},
+  year = {2022}
+}
+
+@article{aftermath,
+  author = {Raghavan, E.},
+  title = {The containment canary},
+  journal = {Last Entry Quarterly},
+  year = {2023}
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_unmatched_dollar.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_unmatched_dollar.tex
@@ -1,0 +1,9 @@
+% Driver for `bib_unmatched_dollar.bib`. An unmatched `$` in a field is a
+% currency sign, and must not open a math group that swallows the rest of the
+% bibliography. See the `.bib` header and OXIDIZED_DESIGN #79.
+\documentclass{article}
+\begin{document}
+See \cite{currency,mathandcurrency,straynodigit,balancedmath,aftermath}.
+\bibliographystyle{plain}
+\bibliography{bib_unmatched_dollar}
+\end{document}


### PR DESCRIPTION
## Diagnostic

One stray `$` in a `.bib` field opened an inline-math group that never closed. A `.bib` is digested as **one** unit, so the leak crossed `\end{bib@entry}` and every subsequent element of every subsequent entry landed inside `<ltx:XMath>` — `<ltx:bib-organization> isn't allowed in <ltx:XMath>`, ~100 times over, tripping the 100-error cap and taking the whole document **Fatal**.

Witness `2605.00166`, an `annote` field reading `… costs … are probably of the order of $10 million. …` — a literal currency dollar:

| | errors | bibliography | status |
|---|---|---|---|
| before the raw `.bib` became a real conversion (#396) | 0 | (none built) | `no_problem` |
| after | **103** | lost entirely | **Fatal** |
| with this PR | **0** | 24 entries formatted | ok |

`escape_bib_data_specials` is math-aware precisely so `$x_1+x_2$` passes through, but it treated `$` as an unconditional toggle with no check that the toggles pair up.

Found while characterizing a fatal-rate regression in the 2605/2606 sandboxes (+72 / +73 fatals). **33 of the 69** papers whose bibliography sub-conversion newly failed carry an odd `$` in a field — mostly `title`, `abstract`, and Mendeley-exported `keywords`/`mendeley-tags`.

## Approach

Extends divergence #74 (*a `.bib` field's content is DATA*) to the one special it left out. A `$` with no partner cannot be a math delimiter — there is no reading under which it opens a span that closes — so it is data, and `\$` is what a careful `.bst` would have written, which is exactly #74's stated principle.

With pure toggling an even count is always balanced, so only an **odd** count has an unmatched member. *Which* one to demote is a judgement call, and "immediately followed by an ASCII digit" is the tell that settles the real cases:

| field | demoted | result |
|---|---|---|
| `of the order of $10 million` | the lone toggle | `\$10 million` |
| `$x$ costs $10` | the digit one | `$x$` stays math |
| `costs $10 and $x$` | the digit one | *the last toggle would have been the wrong pick* |
| `$1 and $2 and $3` | all three | balanced |
| `a $ b` (no digit) | the trailing toggle | fallback |

The escaper is now **one scanner run twice** — measure, then emit — so the subtle skip rules (control words, verbatim arguments, `\(`/`\[` spans, idempotency) stay in a single place rather than being duplicated in a pre-pass.

## Validation

Rebased onto `301326e573` (main, including #416 and #417). Suite **1743 passed / 0 failed** (1735 after #416, +1 from #417's guard, +7 new here). `cargo clippy --workspace --all-targets -- -D warnings` and `cargo +nightly fmt --all` clean. Witness re-measured **serially on an idle box** (load 1.57) with `--includestyles`: 0 errors, 24 formatted entries, 2.1 s.

Red-verified by reverting the demotion **on the new base**: `bib_unmatched_dollar_does_not_leak_math` fails with the *exact* production cascade (`Attempt to close a group that switched to mode math` → `\end{bib@entry}` → `isn't allowed in <ltx:XMath>`), and witness `2605.00166` still yields **103 errors**.

**#416 does not mask this witness.** Re-measured after the rebase, `2605.00166` logs `Digesting 24 of 24 .bib entries` — every entry is cited, so the cited-only filter never reaches the offending `annote`. The two fixes are independently load-bearing; a cited entry carries a stray `$` just as easily as an uncited one.

Guards: the new `06_cluster_bibliography::bib_unmatched_dollar_does_not_leak_math` fixture (its **last** entry is the containment canary — if a stray `$` ever leaks again it is the first thing to disappear), plus six escaper unit tests in `bibtex.rs`, including `escape_specials_balanced_math_is_untouched` for the regression risk.

## Decisions & open questions

- **This is SURPASS-PERL, and deliberate — recorded as OXIDIZED_DESIGN #79.** Same-host Perl cascades *identically*: `latexmlc` on `2605.00166` gives 102 errors and `Fatal:too_many_errors:100`, rc=1, because `\bibentry@create` interpolates the field raw into a fresh Mouth (`BibTeX.pool.ltxml` L155-166) with no escaping of any kind. So this is **not** a Rust-only bug — it is a shared defect we are choosing to fix.
- **Upstream already agrees an unmatched `$` is not math.** `\bib@@title` balances it, raises `Error('expected','$')` and **deletes** the stray (L324-330). Perl just applies that judgement to *one* field and drops the character; we apply it to every field and keep the character.
- **Nothing is suppressed.** This removes the *cause* of the cascade, so the ~100 `malformed:` errors are gone because the entry is now well-formed, not because they stopped being reported. `convert_and_post_clean` enforces the zero-post-error gate, so the guard cannot pass by silence.
- **No fidelity cost against `pdflatex`.** A standard `.bst` never emits `annote` at all, so the character only ever reaches a tokenizer because we read the `.bib` directly, with no `.bst` in the loop.
- **Open — the ambiguous residue.** When a field has an odd `$` count and *no* digit tell, "demote the trailing toggle" is a guess; it guarantees a balanced, contained result but may pick the wrong `$` in a field mixing real math with a stray. That is strictly better than today (an unbalanced field cascaded across the whole bibliography), but it is a heuristic, not a parse.
- Independent of #416 (now merged): that fix addresses the *giant-library* cluster of the same regression, this one the *stray-`$`* cluster. Verified non-overlapping on the witness above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
