### PR TITLE
docs: reconcile the bibliography-campaign docs with what actually landed

### DIFF
--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -54,11 +54,11 @@ session of their own. Re-verify a row before planning on it (rule 1).
 | **R1** | Upstream `brucemiller/LaTeXML#2852` — subfile `\documentclass` options | **OPEN upstream**, ours merged as #310 | minutes — chase review, no code | Open items |
 | **R2** | `--preload=<cls>` trips the LaTeX hook stack (`Extra \PopDefaultHookLabel`) | **OPEN**, re-verified 2026-07-25 (1 error with `--preload=article.cls`, 0 without) | small–medium, self-contained | Open items |
 | **R4** | biblatex `.bbl` `TokenLimit` loop (2605.17646) | ✅ **FIXED 2026-07-25** — self-referential `\let` on `setupPseudoBibitem` re-arm; shared with Perl | — | Open items |
-| **R5** | Bibliography targets + MakeBibliography re-port | **re-port item 1 LANDED 2026-07-26**: a raw `.bib` is converted by the engine (recursive BibTeX session on the LIVE core state), the 727-line string route is deleted, and the eager-tokenization gap that cost 151 papers is closed at the root. Six witnesses re-measured vs same-host `latexmlc`: Rust ≤ Perl errors and ≥ Perl references on every one. Remaining: items 2 (unisort, citestyle `AY`, `Formatter::Year` suffix, doc-global NUMBER) and the missing-references target list | **items 2+targets** — the re-port itself is done | [`BIBLIOGRAPHY_WORKLIST.md`](parity/BIBLIOGRAPHY_WORKLIST.md) |
+| **R5** | Bibliography targets + MakeBibliography re-port | **re-port items 1 and 3 LANDED**: a raw `.bib` is converted by the engine (recursive BibTeX session on the LIVE core state), the 727-line string route is deleted, the eager-tokenization gap that cost 151 papers is closed at the root, and the 13-field digest whitelist is gone — the `\bib@field@default@*` name sets now match Perl exactly (45 each). The 2026-07-27 follow-ups closed the `.bib`-as-DATA family (divergences #74/#78/#79/**#80**). Remaining: item 2 (unisort, citestyle `AY`, `Formatter::Year` suffix, doc-global NUMBER) and the missing-references target list | **item 2 + targets** — the re-port itself is done | [`BIBLIOGRAPHY_WORKLIST.md`](parity/BIBLIOGRAPHY_WORKLIST.md) |
 | **R6** | `ltx_env_<name>` env-markup class | user-requested, PLANNED | medium code, **large golden churn** → own branch | Open items |
 | **R7** | Beyond-Perl performance levers BP-1…BP-6 | POST-RELEASE; internal order BP-2 → BP-3 → BP-1 | **family** | [`BEYOND_PERL_LEVERS.md`](performance/BEYOND_PERL_LEVERS.md) |
 | **R8** | Content-MathML / math-parser gaps | **deferred by user directive 2026-06-20** | **family** — do not pick off in isolation | [`CONTENT_MATHML_GAPS.md`](math/CONTENT_MATHML_GAPS.md) |
-| **R9** | Deep deferred families (`.bst`, xy-pic, mode-frame, …) | parked; several carry explicit "do NOT start". **`.bst` sharpened 2026-07-27** — the `\Dbar` finding shows `.bst` files *vendor macro definitions*, so this is not only a formatting gap | **family** | [`DEFERRED_FAMILIES.md`](parity/DEFERRED_FAMILIES.md), and R9-BST below |
+| **R9** | Deep deferred families (`.bst`, xy-pic, mode-frame, …) | parked; several carry explicit "do NOT start". The `.bst` row's "`.bst` files *vendor macro definitions*" premise was **RETRACTED 2026-07-27** (`alpha.bst` has zero `Dbar`; the macro is `mathscinet.sty`'s) — it survives on label style / sort order / **field selection**, and the prerequisite is a corpus measurement of the `.bib`+`.bst`-with-no-`.bbl` population | **family** | [`DEFERRED_FAMILIES.md`](parity/DEFERRED_FAMILIES.md), and R9-BST below |
 | — | `\gls`/`\acrshort` in math mode (1705.10306) | **PARITY, blocked** on unrunnable Perl | — | do not chase; Open items |
 | — | Two-pass streaming split | **deferred by user decision 2026-07-06**; trigger = a <64 GB target appears | — | [`STREAMING_POST_DESIGN_2026-07-06.md`](performance/STREAMING_POST_DESIGN_2026-07-06.md) |
 
@@ -82,20 +82,58 @@ session of their own. Re-verify a row before planning on it (rule 1).
   `\cprime`→`\tprime`, `\polhk`→`\k`). **Nothing auto-loads it**, and that is
   the decision: witness 2605.11579 never loads the package and uses
   `\bibliographystyle{alpha}`, whose `.bst` has zero `Dbar`, so its
-  `undefined:\Dbar` is **PARITY** with the author's own pdflatex build — it
-  stays at 1 error / 36 bibitems, now explained. `\Dbar` is package-only for a
-  second measured reason: 4 of 4,000 arXiv-2605 papers define it with
-  `\newcommand`, which an always-on definition silently shadows (LaTeXML keeps
-  the OLD meaning, no diagnostic). The `\cprime` family keeps an always-on stub
-  — a `.bib` carries `Gel\cprime fand` with no `\usepackage` — but moved out of
-  `latex_constructs.rs` (Perl-parity file) into `latex_constructs_rust_only.rs`
-  §5 with its witnesses 2508.13753 / 2508.20226 / 2509.07628, all three of which
-  load the package by name, refuting the old `cyracc.def` justification.
-  Divergence **#78**. Guards `bib_mathscinet_package_supplies_its_transliteration_glyphs`,
+  `undefined:\Dbar` is **PARITY** with the author's own pdflatex build. `\Dbar`
+  is package-only for a second measured reason: 4 of 4,000 arXiv-2605 papers
+  define it with `\newcommand`, which an always-on definition silently shadows
+  (LaTeXML keeps the OLD meaning, no diagnostic). The `\cprime` family moved out
+  of `latex_constructs.rs` (Perl-parity file) into
+  `latex_constructs_rust_only.rs` §5 with its witnesses 2508.13753 / 2508.20226
+  / 2509.07628, all three of which load the package by name, refuting the old
+  `cyracc.def` justification. Divergence **#78**. Guards
+  `bib_mathscinet_package_supplies_its_transliteration_glyphs`,
   `bib_mathscinet_macro_yields_to_the_authors_own_definition`,
   `escape_specials_caret_is_textasciicircum_not_an_accent`.
+  *Two claims in this bullet were overturned within the day — see the next one.
+  The `\cprime` stub is **deleted**, not merely relocated; and 2605.11579 no
+  longer emits `undefined:\Dbar` (the reasoning stands, the witness went silent
+  because its `\Dbar` entry is uncited).*
 
-- **2026-07-26 (later still) — a bare `&` in a `.bib` field is data (OXIDIZED_DESIGN #74).**
+- **2026-07-27 (later) — the `.bib`-as-DATA family closed, and a `.bib` library
+  is filtered to its CITED entries.** Five PRs, in dependency order.
+  **#413** — `TeXString`, so a flattened `Tokens` cannot reach the tokenizer
+  (543→536 `to_string()` sites, 6 weld-risk families → 0; WISDOM **#71**).
+  **#416 — divergence #80, the big one:** Perl `Pre/BibTeX.pm::toTeX` L110-122
+  emits `\ProcessBibTeXEntry` for *every* entry, which was free under the old
+  string parser and is a full expand/digest/construct cycle since #396.
+  `anthology.bib` = 80,576 ACL entries for 9 cited; witness **2605.07796** went
+  112 s / 4.8 GB / memory-budget-tripped / **0 bibentries** / fleet-killed →
+  **10 s / 9 bibentries / 0 errors**. Same shape in **59 of the 69** 2605/2606
+  `never_completed_with_retries` papers. Filtering is *more* faithful —
+  `bibtex(1)` has always read the `.aux`'s `\citation` records — and is closed
+  over `crossref` and inner `\cite`; every entry stays registered; `None` (=
+  digest all) covers `\nocite{*}` and a missing `BIBLABEL` record.
+  **#417** — the `.bib` `@preamble` already executes (Perl `toTeX` L118-122 →
+  `pre_bibtex::to_tex`); guard + docs only, no behaviour change.
+  **#418 — divergence #79:** an unmatched `$` in a field is currency, not a math
+  shift; 2605.00166 went 103 errors + Fatal → 0, and same-host Perl cascades
+  identically.
+  **#419** — the always-on `\cprime` stub is **deleted**; the family is
+  `mathscinet.sty` vocabulary and lives only in the binding. Its justification
+  (four papers regaining `undefined:\cprime`) collapsed because #416 removed the
+  trigger: three of the four only regressed on **uncited** entries. Current main,
+  `--includestyles`: 2605.00173/.00186/.00190 **0 errors**, 2605.11579 **0**
+  (its own `@preamble` covers 17 uses), 2605.00305 **1** — the only cost, and
+  PARITY (it cites `MR710121`, loads no `mathscinet`/`amsrefs`, and `plain.bst`
+  has zero `cprime`, so pdflatex fails too).
+  **Standing consequence — re-measure any bibliography error count recorded
+  before 2026-07-27.** An error raised only by an uncited entry now disappears
+  without the macro becoming available; that is also what removed 2605.11579's
+  `undefined:\Dbar` (its `KacNilpotentorbits` entry, `biblo.bib` L2059, is
+  uncited). Guards: `filter_digests_only_the_cited_entries` + 7 siblings
+  (`pre_bibtex.rs`), `bib_preamble_defines_macros_for_the_whole_bibliography`,
+  `bib_unmatched_dollar_does_not_leak_math` + 5
+  `escape_specials_*` unit tests.
+
 - **2026-07-26 — undefined CSes from packages with no binding: `silence.sty`,
   bundled `arxiv.sty`/`PRIMEarxiv.sty`.** Long-standing gaps, **not** a
   regression: Perl 0.8.8 has no binding for either and reproduces the identical
@@ -113,7 +151,7 @@ session of their own. Re-verify a row before planning on it (rule 1).
   1→0, 4→1, 1→0, 1→0. Divergence #77. Guards `00_contrib::{silence_filters,
   arxiv_keywords, primearxiv_keywords}_test`, `106_arxiv_sty_defers_to_bundled`,
   `107_silence_keeps_diagnostics`.
-- **2026-07-26 (later still) — a bare `&` in a `.bib` field is data (OXIDIZED_DESIGN #75).**
+- **2026-07-26 (later still) — a bare `&` in a `.bib` field is data (OXIDIZED_DESIGN #74).**
   Seven 2605 witnesses carried `Error:unexpected:&` from `publisher` / `journal`
   / `booktitle` / `author` / `copyright` ("Taylor & Francis"). Not a Rust-only
   defect: same-host `latexmlc` raised the identical per-`&` count on all six
@@ -190,6 +228,10 @@ session of their own. Re-verify a row before planning on it (rule 1).
   0 unparsed math. This file was compacted the same day — see the header.
 
 - `cargo test --tests`: **1696 passing / 94 targets, 0 failed, 0 ignored**
+  — **STALE COUNT, re-run before quoting.** It is a 2026-07-26 measurement and
+  the seven PRs #403…#419 landed after it, several adding guards
+  (`filter_*` ×8, `escape_specials_*` ×6, `bib_preamble_*`, `bib_mathscinet_*`,
+  `bib_unmatched_dollar_*`), so the true figure is higher.
   (2026-07-26, on `main` @ `e07548e6b3`, dev box with ImageMagick + ghostscript +
   poppler **and `mutool`** installed, so the vector-SVG branch really ran — both
   `test_vector_svg_*` report ok, not skipped). Two claims carried here for weeks
@@ -267,6 +309,15 @@ history now live in the dated session archives:
 Working method (2026-06): **re-triage LARGE-error papers** (the single-error tail
 is exhausted) → bisect the doc to the trigger line → verify Perl with `--verbose`
 → fix the divergence. Random sweeps are low-yield.
+
+**Clustering trap — a bibliography sub-conversion's fatal has no fatal message.**
+It is deliberately downgraded to a trailing `Error:bibliography:convert` on the
+parent (`bib_session.rs` uses the post-phase reporters; Perl's
+`convertBibliography` returns empty-handed the same way,
+`MakeBibliography.pm` L240-242). So a sweep that clusters on **fatal messages**
+files those documents as "no fatal recorded" — measured **~80** in one run.
+Cluster on `Status:conversion:3` or the last `Error:` line. Mechanism and what
+DOES cross the boundary (`MergeStatus`): [`WISDOM.md`](parity/WISDOM.md) **#72**.
 
 **Cortex agentic API (reads open, no token):** `http://127.0.0.1:8000/api`.
 Recipe: `GET /api/reports/<corpus>/oxidized-tex-to-html/<severity>` → categories;
@@ -566,7 +617,11 @@ definitions*. **That claim was wrong and is retracted.** Checked afterwards:
   `\cdprime` and `\bud`;
 * **the witness does not load `mathscinet.sty`**, so real pdflatex on that source
   raises the same undefined control sequence. `undefined:\Dbar` there is
-  **PARITY**, not a defect — see R9-MSC below.
+  **PARITY**, not a defect — see R9-MSC below, which is now DONE. (The witness
+  stopped *emitting* that error on 2026-07-27 for an unrelated reason: divergence
+  **#80** digests only cited entries, and its `\Dbar` entry is uncited. The
+  parity reasoning is unchanged; the witness is just no longer a demonstration
+  of it.)
 
 **What survives the correction.** The row still stands, on its original and
 independently-true footing: we read `.bib` directly, never execute the `.bst`,
@@ -576,6 +631,13 @@ approximated by hand — OXIDIZED_DESIGN **#73** neutralizes `abstract`/`keyword
 `contents` precisely because no standard `.bst` declares them in its `ENTRY`
 list, which is a `.bst` fact we hard-coded rather than computed. A `.bst` we can
 execute is what would replace that guess with an answer.
+
+**One half of that shrank 2026-07-27.** *Entry* selection no longer needs a
+`.bst` at all: divergence **#80** takes the cited set from the document's own
+`BIBLABEL` records — the same information `bibtex(1)` reads out of the `.aux` —
+so which entries reach the `.bbl` is now computed, not guessed. What remains
+`.bst`-shaped is *field* selection (#73's hard-coded three), label style and sort
+order.
 
 **The lesson worth keeping** is about method, not `.bst`: the vendoring claim was
 recalled from memory and written into a merged doc without checking the witness's
@@ -616,25 +678,27 @@ step.
 decision — this row exists to stop the next `\Dbar` from being patched in
 isolation without the context above.
 
-### R9-MSC — `mathscinet.sty` binding — SMALL, unblocked
+### R9-MSC — `mathscinet.sty` binding — ✅ DONE 2026-07-27 (PRs #415 + #419)
 
-`mathscinet.sty` (amsrefs, v1.05) defines the transliteration glyphs that
-mathematics bibliographies use: `\Dbar` (Đ), `\cprime`, `\cdprime`, `\bud`.
-**Perl LaTeXML has `amsrefs.sty.ltxml` but no `mathscinet.sty.ltxml`**, and
-neither do we — so a document that legitimately loads the package still gets
-`undefined:` for all of them. A binding is the faithful fix and is small.
+Closed. `latexml_package/src/package/mathscinet_sty.rs` binds the AMS v1.05
+package (amsrefs bundle), and the `\cprime`/`\Cprime`/`\cdprime`/`\Cdprime`
+family that used to sit always-on in `latex_constructs.rs` — the LaTeX **kernel**
+file, which must track `latex_constructs.pool.ltxml` — was moved out and then
+**deleted**: it is package vocabulary, a paper gets it by loading the package (or
+`amsrefs`, `amsrefs.sty` L217) or via its own `.bib` `@preamble`. The three
+witnesses that opened this row all load the package by name (2508.13753 L7,
+2508.20226 L3, 2509.07628 L13), refuting the `cyracc.def` justification the old
+comment carried. Full record: divergence **#78**; the corpus tables and the
+retracted "the stub stays" verdict are in
+[`BIBLIOGRAPHY_WORKLIST.md`](parity/BIBLIOGRAPHY_WORKLIST.md).
 
-Note what it does **not** fix: witness **2605.11579** does not load the package,
-so its `undefined:\Dbar` is correct and stays. Do not use that witness to
-measure this work.
-
-Related and unresolved: `\cprime`/`\Cprime`/`\cdprime`/`\Cdprime` are
-currently defined in `latex_constructs.rs:4859-4874` — the LaTeX **kernel** file,
-which is meant to track Perl's `latex_constructs.pool.ltxml` — with a comment
-citing `cyracc.def`. `mathscinet.sty` defines them too and is the likelier origin
-for bibliography usage. Whether they move into the binding or stay always-on
-(they appear at BBL stage with no package loaded — witnesses 2508.13753,
-2508.20226, 2509.07628) needs a decision backed by re-running those three.
+**The one thing to carry forward:** this row said "witness 2605.11579's
+`undefined:\Dbar` is correct and stays — do not use that witness to measure this
+work." The *reasoning* is still right (that paper loads no package and
+`alpha.bst` has zero `Dbar`, so pdflatex fails too) but the witness no longer
+**shows** the error: since divergence **#80** only cited entries are digested,
+and its `KacNilpotentorbits` entry (`biblo.bib` L2059) is uncited. Still do not
+measure with it — now because it is silent, not because it is parity.
 
 ### R6 — `ltx_env_<name>` env-markup class — PLANNED, needs its own branch (churns every test XML)
 **User-requested generic enhancement** (2026-06-27): tag environment wrapper markup

--- a/docs/parity/BIBLIOGRAPHY_WORKLIST.md
+++ b/docs/parity/BIBLIOGRAPHY_WORKLIST.md
@@ -4,6 +4,18 @@
 > work: the surveyed "missing references" target list (2026-07-12) and the
 > MakeBibliography full-parity re-port (user directive 2026-07-04 — reuse TeX
 > interpretation, no special-case parser).
+>
+> **State, 2026-07-27.** Re-port **items 1 and 3 are DONE**; the open work is
+> item 2 (unisort, citestyle `AY`, `Formatter::Year` suffix, doc-global NUMBER)
+> and the missing-references target list. The `.bib`-as-DATA family closed as
+> divergences **#73 #74 #75 #78 #79 #80**.
+>
+> **Two reading rules for this file.** (1) The three **INTERIM** blocks under the
+> re-port are HISTORY — every identifier they name was deleted with the string
+> route; they are kept for the properties, witnesses and traps that outlive the
+> code, and they carry their own banner. (2) **Re-measure any error count dated
+> before 2026-07-27**: divergence #80 stopped digesting uncited entries, so a
+> count can have dropped without anything being fixed.
 
 ### The governing design tension: two regimes collapsed into one pass
 
@@ -36,7 +48,10 @@ explicit rather than fixing symptoms:**
    cross into regime B at all. That — not "nothing renders `ltx:bib-extract`" —
    is the principled justification for OXIDIZED_DESIGN **#73** reading them
    verbatim. The weaker rendering-based argument in that entry predates this
-   frame.
+   frame. **Entry selection is the same rule one level up:** `bibtex(1)` copies
+   only the `.aux`'s cited keys (plus `crossref` targets, plus `\nocite{*}`) into
+   the `.bbl`, so an uncited entry never crosses into regime B either —
+   OXIDIZED_DESIGN **#80**, and the section below.
 
 2. **The right seam for specials is an escape at the A→B boundary, not catcode
    suppression during digestion.** When a field's data-string crosses into the
@@ -128,10 +143,12 @@ We read `.bib` directly, so that copy is ours to make — and it is made. Perl
 `Mouth::with_bib_data_literals` — which is exactly right for treatment-2
 content. Measured end to end with a probe `@preamble` defining a macro nothing
 else defines: **Rust 0 errors, same-host `latexmlc` 0 errors, both expand it**;
-delete the `@preamble` and both raise `undefined:`. **`\cprime` is a vacuous
-probe** for this question — the always-on stub in
-`latex_constructs_rust_only.rs` defines it either way, so a fresh name is
-required.
+delete the `@preamble` and both raise `undefined:`. A fresh name is still the
+right probe: at the time this was measured `\cprime` was a **vacuous** one,
+because an always-on stub in `latex_constructs_rust_only.rs` defined it either
+way. That stub is gone (below), so `\cprime` would work now — but any name the
+kernel or a binding might also supply re-opens the same trap, so the fixture
+keeps macro names unique to itself.
 
 Guard:
 `06_cluster_bibliography::bib_preamble_defines_macros_for_the_whole_bibliography`
@@ -144,53 +161,94 @@ parameterized macro. The pre-existing `pre_bibtex::to_tex_includes_preamble`
 does **not** cover any of this — it asserts on the emitted *string*, so it stays
 green even if that string is never executed.
 
-**Consequence for the always-on `\cprime` stub: it stays.** Removing it was the
-motivation for checking, and the corpus says no. Scan of the first 600 papers of
-`/data/arxiv/2605/`: 7 use `\cprime` inside a `.bib`, and **6 of the 7 carry no
-`@preamble` at all** (the seventh, 2605.00097, has one but never uses
-`\cprime`). 2605.11579 sits outside that window and is added as the eighth row
-because it is the one paper whose `@preamble` covers real uses. Measured with
-the raw-`.bib` route forced, `--includestyles`, `--release`, TOTAL document
-errors with-stub → without:
+#### Entry selection: digest the CITED entries, not the library — LANDED 2026-07-27
 
-| paper | `@preamble` defines `\cprime`? | with → without |
-|---|---|---|
-| 2605.00097 | yes, unused | 1 → 1 |
-| 2605.00173 | no | 0 → **1** `undefined:\cprime` |
-| 2605.00186 | no | 0 → **1** |
-| 2605.00190 | no | 0 → **1** |
-| 2605.00305 | no | 0 → **1** |
-| 2605.00316 | no | 2 → 2 (its `\cprime` is in `fjournal`, undigested) |
-| 2605.00584 | no | 0 → 0 (same) |
-| 2605.11579 | yes, 17 uses in `AUTHOR`/`TITLE`/`BOOKTITLE`/`MRREVIEWER` | 1 → 1 |
+Full design record: OXIDIZED_DESIGN **#80**. What belongs on this worklist:
 
-2605.11579 is the informative row twice over: it is the only paper whose
-`@preamble` covers real uses, and it stays at its single unrelated
-`undefined:\Dbar` **with the stub gone** — the `@preamble` is carrying all 17.
-2605.00173 is the control: same field kind (`AUTHOR`), same binary, `+1` error,
-distinguished only by having no `@preamble`.
+* **A `.bib` is a library, not a document.** Perl `Pre/BibTeX.pm::toTeX` L110-122
+  emits `\ProcessBibTeXEntry` for every entry unconditionally. That was cheap
+  under the old string parser; since the raw `.bib` became a real conversion
+  (item 1 below) each entry is a full expand/digest/construct cycle.
+* **Cost, measured.** `anthology.bib` = 80,576 ACL entries for 9 cited. Witness
+  **2605.07796**: 112 s / 4.8 GB RSS / memory budget tripped / **0 bibentries**
+  (the whole bibliography lost) / killed by the fleet's 60 s timeout →
+  **10 s / 9 bibentries / 0 errors**. Same shape in **59 of the 69** 2605/2606
+  `never_completed_with_retries` papers (median 80,597 entries).
+* **It is more faithful, not less** — `bibtex(1)` has always filtered on the
+  `.aux`'s `\citation` records. Selection is closed over `crossref` and over a
+  `\cite` made from inside a selected entry; every entry is still *registered*, so
+  by-key lookup still resolves; `None` (= digest everything) covers `\nocite{*}`
+  and a missing `BIBLABEL` record.
+* **Standing consequence for this worklist: re-measure before believing any
+  bibliography error count recorded before 2026-07-27.** An error raised only by
+  an uncited entry now disappears without the underlying macro becoming
+  available. It already invalidated the `\cprime` stub verdict directly below and
+  2605.11579's `undefined:\Dbar` residual.
 
-Three of the four regressions are errors the real toolchain never produces, and
-that is the durable point: `bibtex(1)` copies only **cited** entries into the
-`.bbl`, and in 2605.00173/.00186/.00190 the `\cprime`-bearing entry is never
-cited — pdflatex never sees the macro. We digest every entry in the `.bib`, so
-the stub is what keeps that asymmetry from manufacturing a diagnostic. In
-2605.00305 the entry IS cited (`MR710121`, "Arnol\cprime d diffusion"), so there
-the stub renders text the reader sees.
+#### The always-on `\cprime` stub — DELETED 2026-07-27 (it was "it stays" for one day)
 
-Same-host Perl was run over all eight (production profile, verbose) and is not a
-usable oracle for this question — it never raises `undefined:\cprime` anywhere,
-for reasons unrelated to the macro: 2605.00305 and 2605.00316 hit `MAX_ERRORS`
-(101 + Fatal) on a pgfparse flood long before MakeBibliography, 2605.00173/.00186/
-.00190 take their shipped `.bbl`, and on 2605.11579 Perl emits **zero**
-bibliography entries at all ("Missing Entry for citation" × 36, against Rust's
-36 rendered) — a silent total loss, not a clean run. The mechanism was confirmed
-against Perl on the controlled fixture instead, where both engines reach 0
-errors with every preamble macro expanded. Note Perl defines `\cprime`
-**nowhere** in `LaTeXML/lib`, so the stub is and stays a surpass-Perl
-divergence.
+**Current rule:** `\cprime`/`\Cprime`/`\cdprime`/`\Cdprime` are `mathscinet.sty`
+vocabulary and live only in `latexml_package/src/package/mathscinet_sty.rs`. A
+paper gets them by loading `mathscinet` (or `amsrefs`, `amsrefs.sty` L217
+`\RequirePackage{mathscinet}[2002/01/01]`), or by carrying the definition in its
+own `.bib` `@preamble` — which executes, per the section above. Divergence
+**#78**.
 
-### Why the re-port is the real fix: eager tokenization defeats parameter types (measured 2026-07-26)
+**Why the earlier "it stays" verdict was overturned, and it is worth keeping.**
+That verdict was measured against a binary that digested **every** entry of a
+`.bib` library. Three of its four regression papers only regressed because their
+`\cprime`-bearing entry is **uncited** — `bibtex(1)` never copies such an entry
+into the `.bbl`, so pdflatex never sees the macro, and the diagnostic was
+manufactured by us. Divergence **#80** (digest the cited entries only) removed
+that asymmetry structurally, and the justification collapsed with it. *The
+measurement was right; its baseline moved under it within the day. A "regression
+without the fix" measured against a defective baseline measures the defect.*
+
+Original scan, kept because re-deriving it costs a corpus sweep: across the first
+600 papers of `/data/arxiv/2605/`, **7** use `\cprime` inside a `.bib` and **6 of
+the 7 carry no `@preamble` at all** (the seventh, 2605.00097, has one but never
+uses `\cprime`); 2605.11579 sits outside that window and is the one paper whose
+`@preamble` covers real uses.
+
+Re-measured on current main (stub gone), `--includestyles`, idle box, serial —
+TOTAL document errors and `undefined:\cprime`:
+
+| paper | `@preamble` defines `\cprime`? | errors | `undefined:\cprime` |
+|---|---|---|---|
+| 2605.00173 | no | 0 | 0 — `MR2562222` (`bibliography.bib` L885) is uncited |
+| 2605.00186 | no | 0 | 0 — same shape |
+| 2605.00190 | no | 0 | 0 — same shape |
+| 2605.00305 | no | **1** | **1** — the only real cost |
+| 2605.11579 | yes, 17 uses in `AUTHOR`/`TITLE`/`BOOKTITLE`/`MRREVIEWER` | 0 | 0 |
+
+2605.00305 is the honest residual and the row to keep: it **cites** `MR710121`
+(`mybib.bib` L26, `MRREVIEWER = {V.\ Z.\ Enol\cprime ski\u i}`), loads neither
+`mathscinet` nor `amsrefs`, ships no `@preamble`, and uses
+`\bibliographystyle{plain}` — `plain.bst` contains zero `cprime`. Real pdflatex
+raises the same undefined control sequence, so this is PARITY, and supplying the
+macro anyway would push our error count below the author's own toolchain.
+2605.11579 is informative twice over: its 14 `@preamble` blocks (`biblo.bib`
+L4768/L6910/…) carry all 17 uses, and its formerly-standing `undefined:\Dbar`
+went away too — `KacNilpotentorbits` (`biblo.bib` L2059) is uncited (#80), not
+newly defined.
+
+Two rows from the with/without table are dropped as uninformative once the
+baseline changed but are recorded so they are not re-measured: 2605.00316's
+`\cprime` sits in `fjournal` (undigested — 2 errors either way) and 2605.00584
+was 0 → 0.
+
+Same-host Perl is **not a usable oracle for this question** (production profile,
+verbose, all eight): it never raises `undefined:\cprime` anywhere, for reasons
+unrelated to the macro — 2605.00305 and 2605.00316 hit `MAX_ERRORS` (101 + Fatal)
+on a pgfparse flood long before MakeBibliography, 2605.00173/.00186/.00190 take
+their shipped `.bbl`, and on 2605.11579 Perl emits **zero** bibliography entries
+at all ("Missing Entry for citation" × 36, against Rust's 36 rendered) — a silent
+total loss, not a clean run. The mechanism was confirmed against Perl on the
+controlled fixture instead, where both engines reach 0 errors with every preamble
+macro expanded. Perl defines `\cprime` **nowhere** in `LaTeXML/lib`, so the
+`mathscinet.sty` binding that now owns it is a surpass-Perl divergence — see #78.
+
+### Why the re-port was the real fix: eager tokenization defeats parameter types — DIAGNOSIS 2026-07-26, FIX LANDED 2026-07-26/27
 
 The 2026-07-26 sandbox rerun quantified what the simplified parser costs. In
 `sandbox-arxiv-2605` (30,079 docs) the rc2→rc3 window moved **90 papers
@@ -206,7 +264,10 @@ Three sub-causes, and they are NOT three bugs — they are one architectural gap
 | `expected:}` | 32 + 17 | percent-ENCODED URLs — `%` at catcode 14 comments out the rest of the line, closing brace included |
 | `unexpected:_` / `&` / `^`, `misdefined:#` | 61 | TeX specials that are literal inside a URL |
 
-The first two are fixed (#391: `BBL_STANDARD_FALLBACKS`, `BibCatcodeScope`).
+The first two are fixed (#391: `BBL_STANDARD_FALLBACKS`, `BibCatcodeScope` — the
+latter has since **retired**, as predicted below once the engine route landed; it
+exists in no source file today, `BBL_STANDARD_FALLBACKS` lives on in
+`latexml_oxide/src/bib_session.rs` as the recursive session's preamble).
 The third is fixed too (below), but NOT by widening the catcode phase, and that
 constraint is why: `$a_b$` and `$x^2$` in a title are legitimate, so
 neutralizing `_`/`^` file-wide would trade one regression for another. Only the
@@ -223,8 +284,9 @@ it had to cover are in OXIDIZED_DESIGN #74: the entry line in
 `\ProcessBibTeXEntry` plus `\bib@@title` and `\bib@@pages`, both of which
 re-read the RAW field instead of using the value the entry line passed them, so
 escaping only the entry line silently missed every `title`. Guard
-`06_cluster_bibliography::bib_field_specials_are_data_not_tex` plus six
-`escape_bib_data_specials` unit tests. Seven witnesses, TOTAL document errors,
+`06_cluster_bibliography::bib_field_specials_are_data_not_tex` plus the
+`escape_specials_*` unit tests in `bibtex.rs` (six at the time; **13** today,
+after the `^` arm and #79's five unmatched-`$` cases). Seven witnesses, TOTAL document errors,
 `--release` before→after: 2605.06926 8→0, 2605.01936 13→0, 2605.04604 2→0,
 2605.08986 2→0, 2605.11300 1→0, 2605.05898 1→0, 2605.06249 3→0. **30 → 0** —
 every one converts clean.
@@ -249,47 +311,58 @@ Note `note` and `howpublished` are in the ordinary 34 — Perl survives
 `note = {\url{…%20…}}` not because the FIELD is Semiverbatim but because
 `\url` itself is, and lazy consumption lets it act.
 
-`latexml_engine/src/bibtex.rs` already does this correctly for the pool route:
-`open_mouth(Mouth::new(&lines.join("\n"))?, true)` (≈L1888) with
-`\bib@field@default@url Verbatim` (L1577), and a comment at L1809-1821 saying
-why it is load-bearing — a pre-tokenized `Explode!` stream "did neither"
-(witness 2508.17585). `make_bibliography.rs` instead calls `tokenize()` then
-`digest()`, which is **eager**: every catcode is fixed before any handler runs,
-so no parameter type can ever take effect.
+`latexml_engine/src/bibtex.rs` already did this correctly for the pool route:
+`open_mouth(Mouth::new(&lines.join("\n"))?, true)` with
+`\bib@field@default@url Verbatim`, and a comment there saying why it is
+load-bearing — a pre-tokenized `Explode!` stream "did neither" (witness
+2508.17585). `make_bibliography.rs` instead called `tokenize()` then `digest()`,
+which is **eager**: every catcode is fixed before any handler runs, so no
+parameter type could ever take effect. **That eager path is gone** — item 1 below
+deleted it, and every `.bib` now reaches the tokenizer through the pool route's
+lazy Mouth. (Line numbers into `bibtex.rs` are deliberately dropped here: the
+file has been edited in every PR of this campaign and the old `L1577`/`L1809`/
+`L1888` anchors no longer point where they did. Perl `file:line` citations are
+stable and are kept.)
 
 **Relation to issue 386** (build XML through libxml, not string concatenation).
-Separate axes that meet in this one file, and the dependency runs one way.
-Issue 386 is about OUTPUT — `interpret_tex_markup` currently returns a *serialized
-XML string* spliced into the bibliography behind three trust gates, which is
-exactly issue 386's complaint. This section is about INPUT — how the field is
-tokenized. Routing field interpretation through the pool path makes the output
-arrive as DOM nodes, so **doing this re-port also settles the `make_bibliography.rs` portion of
-issue 386 as a side effect; doing 386 first does not help here.** Do not attack that portion of issue 386 separately.
+Separate axes that met in this one file, and the dependency ran one way.
+Issue 386 is about OUTPUT — `interpret_tex_markup` returned a *serialized XML
+string* spliced into the bibliography behind three trust gates, which was exactly
+issue 386's complaint. This section is about INPUT — how the field is tokenized.
+Routing field interpretation through the pool path made the output arrive as DOM
+nodes, so **the re-port settled the `make_bibliography.rs` portion of issue 386 as
+a side effect** — landed with item 1 below (`PostDocument::new(XmlDoc)`, no
+serialize/reparse). Do not attack that portion of issue 386 separately.
 
-**Consequence for planning.** The remaining 61 errors are bounded by this gap,
-not by a new defect. A per-field `Tokens::neutralize` (`tokens.rs:371`, the
-existing "retroactively imitate what Semiverbatim would have done" helper —
-note its comment explains why it deliberately does NOT cover `%`) would close
-most of them as an interim, but it imitates the mechanism rather than using it.
-The durable fix is this re-port: route field interpretation through the lazy
-Mouth.
+**Consequence for planning — SETTLED, the interim was never taken.** The 61
+residual errors were bounded by this gap, not by a new defect. The considered
+interim was a per-field `Tokens::neutralize` (`tokens.rs`, the existing
+"retroactively imitate what Semiverbatim would have done" helper — its comment
+explains why it deliberately does NOT cover `%`); it imitates the mechanism
+rather than using it, and was **not** taken. The durable fix landed instead:
+item 1 routes field interpretation through the lazy Mouth, and #74/#79 close the
+specials at the data→TeX boundary.
 
 **Maintainer policy, 2026-07-26 — a `.bib` field's content is DATA, not TeX.**
-A bare `%`, `&`, `_` is the literal character; "Taylor & Francis" renders with
-its ampersand. Authorized surpass-Perl *and* surpass-pdflatex: LaTeXML reads
-`.bib` directly, with no `.bst` and no `bibtex(1)`, so it decides what reaches
-the tokenizer. **The boundary is blast radius, not character:**
+A bare `%`, `&`, `_`, `#`, `^` is the literal character; "Taylor & Francis"
+renders with its ampersand. Authorized surpass-Perl *and* surpass-pdflatex:
+LaTeXML reads `.bib` directly, with no `.bst` and no `bibtex(1)`, so it decides
+what reaches the tokenizer.
 
-* *Regime A, per-Mouth* — a character destructive in ANY field, with no Perl
-  per-field idiom to follow. `%`, `&`, `#` and `_` are all here (#74).
-  `Mouth::with_bib_data_literals()`, deliberately NOT a
-  State catcode, so a `.sty` raw-loaded from inside a field handler — and the
-  document — keep TeX's meaning.
-* *Regime B, per-field parameter type* — harmful only in specific fields where
-  Perl already has the idiom. `_` (PR #403) is here: `eprint`/`preprint`/
-  `archive` get `Semiverbatim`, mirroring `doi`/`isbn`/`issn`/`lccn`/`pii`.
+> **RETRACTED, and the retraction is the design.** This block once read "the
+> boundary is blast radius, not character", splitting the five specials into a
+> per-Mouth *regime A* (`% & # _`) and a per-field-parameter-type *regime B*
+> (`_` via `Semiverbatim` on `eprint`/`preprint`/`archive`). **Neither half
+> survived implementation.** `_` is NOT in the Mouth set — `mouth.rs`'s
+> `with_bib_data_literals` is `% & #` only, and its doc says why — and no
+> `Semiverbatim` was ever put on `eprint`/`preprint`/`archive`: they are plain
+> `\bib@@field{ltx:bib-links}` macros in both engines (`bibtex.rs` L2030/L2053/
+> L2055, `BibTeX.pool.ltxml` L712/L724/L728). The correct frame is the **two
+> treatments** above — both apply, at different points, and the split is by
+> *treatment*, not by blast radius: treatment 1 covers `% & #`, treatment 2
+> covers all five. The retired divergence **#76** was this reading's entry.
 
-**Both regime-A seams are required.** The value reaches a tokenizer by two
+**Both treatment-1 seams are required.** The value reaches a tokenizer by two
 independent routes: the per-entry Mouth, and the handlers that re-read the
 stored RAW field and tokenize it themselves (`\bib@@title` recasing,
 `current_entry_field`, name splitting, date/pages assembly, MR/Zbl). The
@@ -516,11 +589,14 @@ Perl never fails here (`Mouth.pm` L75-80: decode with `Encode::FB_DEFAULT`, or
 pass the raw bytes through when `PERL_INPUT_ENCODING` is undef) — so this was
 **GENUINE-RUST-ONLY**, not parity.
 
-Fix: both `.bib` read sites (`pre_bibtex::new_from_file` engine-side,
-`make_bibliography::convert_bib_file_to_xml` post-side) now decode via the new
-shared `latexml_core::mouth::decode_input_bytes` — UTF-8, else a **Latin-1
+Fix: both `.bib` read sites decode via the shared
+`latexml_core::mouth::decode_input_bytes` — UTF-8, else a **Latin-1
 passthrough** (lossless byte → char, so accented names survive intact instead of
 collapsing to U+FFFD; legacy `.bib` files are overwhelmingly Latin-1/Cp1252).
+The sites are `pre_bibtex::new_from_file` engine-side and — since item 1 deleted
+`make_bibliography::convert_bib_file_to_xml`, which was the post-side one — the
+multi-file concatenation in `bib_session::payload`, which inherited the
+obligation and the witness.
 The Mouth's own no-encoding branch now calls the same helper, so there is one
 implementation rather than three (the "bespoke duplicate shadowing a faithful
 port" anti-pattern has already bitten twice here).
@@ -529,7 +605,7 @@ Breadth: 17 papers corpus-wide, 10 of them EMPTY. All 10 recovered: **0 → 336
 references** (7/15/5/22/57/25/39/48/108/10), 0 dangling.
 
 Red/green tests: `pre_bibtex::tests::non_utf8_bib_file_is_read_not_rejected`
-(engine reader) **and** `06_cluster_regressions::non_utf8_bib_file_still_yields_a_bibliography`
+(engine reader) **and** `06_cluster_bibliography::non_utf8_bib_file_still_yields_a_bibliography`
 (post path — where the production failure actually was; the engine-side test
 alone would NOT have guarded it). Fixture `cluster_regressions/cp1252_refs.bib`
 carries a raw `0xe9`; it is asserted non-UTF-8 so the test cannot go vacuous.
@@ -554,6 +630,20 @@ replaces Perl's 63-line recursive-core-session `convertBibliography` with
 `is_braced_group`, `convert_bib_file_to_xml`, plus the whole
 metadata-fallback path that exists only because no real bibentry XML is
 produced).
+
+> **The three INTERIMs below are HISTORY, superseded by item 1 (landed
+> 2026-07-26).** Every identifier they name — `convert_bib_file_to_xml`,
+> `interpret_tex_markup`, `interpret_tex_text`, `parse_bibtex`,
+> `read_bib_value`, `strip_braces` — was **deleted** with the string route
+> (−727 lines); `grep`ping for them in `make_bibliography.rs` today returns
+> nothing. They are kept, not pruned, for the three things that outlive the
+> code: the *properties* the current route must also satisfy (digest each field
+> exactly once, keep markup, emit every field kind), their **witnesses**
+> (2607.00045, the eleven field kinds, `KNOWN_PERL_ERRORS #60`), and the traps
+> that cost a wrong first cut. The live guards are
+> `06_cluster_bibliography::bib_field_markup_survives_into_the_bibliography` and
+> `105_bib_field_digest_once`, both of which were re-pointed at the current
+> route.
 
 INTERIM (landed 2026-07-04): field VALUES now go through the real engine —
 `interpret_tex_text` = `digest(mouth::tokenize(v)).to_string()` against the
@@ -629,8 +719,10 @@ entries carry `note = {\url{...}}`. Raw-TeX tokens in the rendered bibliography
 **46 → 2**, live links **0 → 45**; the 2 residuals are the gated `$\psi$` title
 and one `url={\url{...}}` that **Perl renders equally broken**
 (`href="\urlhttps://arxiv.org/abs/quant-ph/0510095"`) — parity, not ours.
-Guard: `06_cluster_regressions::bib_field_markup_survives_into_the_bibliography`
+Guard: `06_cluster_bibliography::bib_field_markup_survives_into_the_bibliography`
 (fixture carries a `\&` so a text-escaping regression cannot pass silently).
+*(Guards moved out of `06_cluster_regressions` when PR #400 split the
+bibliography cluster into its own test file.)*
 
 THIRD INTERIM — fields that reached NO emit branch (landed 2026-07-25). Found by
 asking what else the reported family ("content missing from References") could
@@ -735,23 +827,27 @@ FULL RE-PORT — item 1 LANDED 2026-07-26:
    abbreviated `[AA+yy]` label, not full author-year); `Formatter::Year`
    drops the disambiguation `@SUFFIX`; document-global NUMBER across split
    documents.
-3. **Field-interpretation whitelist (first stage, not yet Perl-faithful)** —
-   flagged by the 2026-07-05 commit review of `ede2bdcc2c`. The `.bib`→XML
-   path (`make_bibliography.rs`) only digests 13 fields
+3. **Field-interpretation whitelist — RESOLVED by item 1, not by widening the
+   list.** Flagged by the 2026-07-05 commit review of `ede2bdcc2c`: the
+   `.bib`→XML path in `make_bibliography.rs` digested only 13 fields
    (author/editor/title/year/journal/journaltitle/booktitle/volume/number/
-   issue/pages/publisher/note). Perl's `BibTeX.pool.ltxml` has ~28
+   issue/pages/publisher/note), while Perl's `BibTeX.pool.ltxml` has ~28
    `\bib@field@default@*` constructors that DO digest — incl. `abstract`
    (L708), `keywords` (L732), `annote` (L680), `series`, `institution`,
    `organization`, `school`, `edition`, `chapter`, `howpublished`,
-   `translator`, `subtitle`, `type` — so Perl raises (and MergeStatus'es) the
-   undefined-macro errors those fields carry, while Rust currently does NOT.
-   The commit's original "mirrors Perl" comment was factually inverted
-   (corrected in-code 2026-07-05). Decision (user, 2026-07-05): keep the
-   narrow set FOR NOW as a first stage — it suppresses the junk-field error
-   floods of ADS/Zotero exports — but the eventual target is Perl's full
-   rendering-field set. Bounded blast radius: this path only fires for raw
-   `.bib` inputs WITHOUT a `.bbl`. Widen when the full re-port (item 1) lands
-   the recursive core session, which digests fields the Perl way by
-   construction.
+   `translator`, `subtitle`, `type` — so Perl raised (and MergeStatus'ed) the
+   undefined-macro errors those fields carry and Rust did not. (The commit's
+   original "mirrors Perl" comment was factually inverted; corrected in-code
+   2026-07-05.) The 2026-07-05 decision was to keep the narrow set as a first
+   stage and widen it when the recursive core session landed. It landed, and it
+   **digests fields the Perl way by construction** — there is no whitelist left
+   to widen: the 13-name constant went with the string route, and the
+   `\bib@field@default@*` name sets now match exactly (**45 unique names on each
+   side**, `bibtex.rs` vs `BibTeX.pool.ltxml`; `diff` of the two sorted lists is
+   empty). **Three of those constructors are a deliberate exception, not an
+   omission:** `abstract`/`keywords`/`contents` are read `Verbatim` per
+   divergence **#73**, and that is the sole surviving narrowing of Perl's set. The ADS/Zotero junk-field error floods the whitelist
+   was suppressing are handled at their root instead, by the DATA-regime
+   treatments (#74/#79).
 
 Witness: 2605.00223 (ADS .bib: `{\'\i}`, `~` ties, `\aap`, bare DOIs).

--- a/docs/parity/DEFERRED_FAMILIES.md
+++ b/docs/parity/DEFERRED_FAMILIES.md
@@ -35,6 +35,14 @@
   (value-less `[@attr]` predicate treated as always-true; `split('/')` fragmenting a
   predicate's `../`). Fixed: corporate-author detection in `parse_bib_authors`, and a
   bracket-aware / existence-checking `findnodes_by_traversal`.
+  **Stale identifiers, kept for the record:** `convert_bib_file_to_xml` and
+  `parse_bib_authors` no longer exist — the whole simplified `.bib` parser was
+  deleted 2026-07-26 when a raw `.bib` became a recursive engine conversion
+  ([`BIBLIOGRAPHY_WORKLIST.md`](BIBLIOGRAPHY_WORKLIST.md) re-port item 1), so
+  name splitting is now `bibtex.rs`'s port of `BibTeX.pool`. `findnodes_by_traversal`
+  is unaffected. **No named guard survives for the corporate-author half**
+  (`grep` for "corporate" / "W3C Math Working Group" across the tests returns
+  nothing), so re-verify it on this witness before relying on it.
 
 - **`Fatal:Stomach:Recursion` (43 cortex Rust-service fatals) — TRIAGED 2026-06-28,
   mostly SHARED / Rust-better; ~1 Rust-only over-fatal DEFERRED (deep core).** Two

--- a/docs/parity/OXIDIZED_DESIGN.md
+++ b/docs/parity/OXIDIZED_DESIGN.md
@@ -15,13 +15,16 @@ This file is the **index + overview**. The detail lives in a themed family:
 | [OXIDIZED_DESIGN_FUTURE_WORK.md](OXIDIZED_DESIGN_FUTURE_WORK.md) | Beyond-parity directions not yet built. |
 
 > **Finding a divergence by number.** The `### N` numbers are load-bearing —
-> `.rs` comments reference them — so they are kept verbatim, which means two
-> pre-existing quirks: (1) the numbers are **not globally unique** (the math
-> cluster `#7–#18` collides by value with divergences `#7–#18`); (2) a
-> code-referenced number resolves to the file above that owns that *topic*.
-> Most (`#1–#15`, `#19–#65`) are in DIVERGENCES; the math ones (incl. the
-> code-referenced **`#18` = f(x) "Speculative function application"**) are in
-> MATH. When in doubt, `grep '### N\.' docs/OXIDIZED_DESIGN_*.md`.
+> `.rs` comments reference them — so they are kept verbatim, which means three
+> quirks: (1) the numbers are **not globally unique** (the math cluster `#7–#18`
+> collides by value with divergences `#7–#18`); (2) a code-referenced number
+> resolves to the file above that owns that *topic* — most (`#1–#15`, `#19–#80`)
+> are in DIVERGENCES, the math ones (incl. the code-referenced **`#18` = f(x)
+> "Speculative function application"**) are in MATH; (3) **`#76` is a retired
+> number** — its entry was consolidated into `#74` and the number was not
+> reused, so a gap in the sequence is expected, not a missing file. Next free
+> number: **#81**. When in doubt,
+> `grep '### N\.' docs/parity/OXIDIZED_DESIGN_*.md docs/math/OXIDIZED_DESIGN_MATH.md`.
 
 ---
 

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -3,6 +3,8 @@
 [← OXIDIZED_DESIGN.md](OXIDIZED_DESIGN.md) · Deliberate breaks with Perl behavior, numbered. Code comments reference these as `OXIDIZED_DESIGN #N`.
 
 > **Numbering note:** the `### N` numbers are load-bearing (referenced from `.rs` comments) and are kept verbatim. `#16` and the math-grammar entries `#7–#18` live in [OXIDIZED_DESIGN_MATH.md](../math/OXIDIZED_DESIGN_MATH.md); in particular the code-referenced **`#18` is the f(x) "Speculative function application"** entry there, *not* the "Source-Level Bindings" `#18` below.
+>
+> **`#76` is a RETIRED number, not an omission** — its entry was consolidated into `#74` and the number was deliberately not reused (see the placeholder in sequence below). Next free number: **#81**.
 
 ---
 
@@ -2193,9 +2195,11 @@ It cannot mask a diagnostic for a correct document: a document that loads
 `url`/`hyperref` keeps its own definition — `input_definitions` early-returns on
 its `_loaded` flag and `\providecommand` defers.
 
-Guards: `06_cluster_regressions::bib_field_bbl_fallbacks_render_without_a_url_package`
+Guards: `06_cluster_bibliography::bib_field_bbl_fallbacks_render_without_a_url_package`
 (no url package) and `::bib_field_markup_survives_into_the_bibliography`
-(hyperref loaded — hyperref's `\url` must still win).
+(hyperref loaded — hyperref's `\url` must still win). *(Both moved out of
+`06_cluster_regressions` when PR #400 split the bibliography cluster into its own
+test file.)*
 
 ### 73. A `.bib` `abstract`/`keywords`/`contents` field is read verbatim, not digested
 
@@ -2403,9 +2407,10 @@ values with no backslash); `::bib_field_percent_is_an_ordinary_character`;
 `::bib_bare_ampersand_is_literal_data`;
 `::bib_bare_ampersand_leaves_live_markup_alone`;
 `::bib_escaped_amp_entity_decodes_to_one_ampersand`;
-`55_bibtex::runaway_field_costs_only_its_own_entry`; and seven
-`escape_bib_data_specials` unit tests in `bibtex.rs`, which isolate the `\\&`
-hazard that cannot live end-to-end (see below) and pin
+`55_bibtex::runaway_field_costs_only_its_own_entry`; and the `escape_specials_*`
+unit tests in `bibtex.rs` (seven when this entry landed, **13** today — #79 added
+the five unmatched-`$` cases), which isolate the `\\&` hazard that cannot live
+end-to-end (see below) and pin
 `escape_specials_caret_is_textasciicircum_not_an_accent`.
 
 **Measured**, `--release` before/after on the same host, TOTAL document errors:
@@ -2430,12 +2435,14 @@ hazard that cannot live end-to-end (see below) and pin
 
 **193 → 0.** Two residuals are unrelated to this cluster and were unchanged by
 it: 2605.00879's remaining error is `undefined:\mathsemicolon`, and 2605.11579
-(listed for the `_` cluster) has 5 errors before AND after with zero
+(listed for the `_` cluster) had 5 errors before AND after with zero
 `unexpected:_` in either — its apparent three were an artifact of measuring in
 the DEGRADED no-dump mode a fresh worktree starts in. Run
-`tools/make_formats.sh` before believing any error count. 2605.00833 is a
-RENDERING witness, not an error-count one: its `\&amp;` printed as "&amp;" and
-now prints "&".
+`tools/make_formats.sh` before believing any error count. (That 5 no longer
+reproduces: 2605.11579 is at **0** on current main, because #80 stopped digesting
+its uncited entries — a second reason to re-measure rather than quote.)
+2605.00833 is a RENDERING witness, not an error-count one: its `\&amp;` printed
+as "&amp;" and now prints "&".
 
 **Known not covered.** A literal `\\` in a title makes
 `\bib@field@default@title` open a nested `<ltx:bibitem>`
@@ -2515,6 +2522,17 @@ session that `MakeBibliography` drives during POST). Fixture
 `bib_field_blank_line.{bib,tex}` carries all three witness shapes: a blank line
 in `title`, in `author`, in a `note`-routed `Annote`, plus the `\\` note — 6
 errors RED, 0 GREEN.
+
+### 76. — RETIRED NUMBER, deliberately unused. Do NOT reuse it.
+
+Not a mistake and not a gap to fill. #76 briefly held "A `.bib` field's content is
+DATA — `_ & # %` are literal, not catcodes", whose first witness was the
+underscores in an `eprint` PDF URL. When the separate `%`-only and `&`-only
+entries were consolidated it was merged into **#74** — which adds `^`, the
+two-treatment framing, and the exclusion list — and the number was **retired
+rather than renumbered**, because divergence numbers are cited verbatim from
+`.rs` comments and renumbering silently invalidates every citation. Nothing in
+the tree cites `OXIDIZED_DESIGN #76`. Next free number: **#81**.
 
 ### 77. `silence.sty` and the bundled `arxiv.sty` family get bindings Perl does not have
 
@@ -2618,14 +2636,15 @@ supplies it either. `\Dbar` is therefore undefined in the author's own build:
 real pdflatex raises the same undefined control sequence. **The residual
 `undefined:\Dbar` is PARITY, not a defect**, and supplying the macro anyway would
 push our error count below what the author's toolchain produces — the one thing
-the canvas signal must never do. 2605.11579 stays at **1 error / 36 bibitems**,
-with that error now explained rather than outstanding.
+the canvas signal must never do. (That witness no longer *shows* the residual —
+see the measurement below — because its `\Dbar` entry is uncited, not because
+anything about this reasoning changed.)
 
-**Why a package and not an always-present kernel definition**, for `\Dbar`
-specifically. A format-chain definition runs before the document's preamble, and
-LaTeXML's `\newcommand` over an already-defined CS silently keeps the OLD meaning
-(no error, no warning), so an always-present vendor macro SHADOWS an author's
-own. Scanned 4,000 papers of arXiv 2605:
+**Why a package and not an always-present kernel definition.** A format-chain
+definition runs before the document's preamble, and LaTeXML's `\newcommand` over
+an already-defined CS silently keeps the OLD meaning (no error, no warning), so
+an always-present vendor macro SHADOWS an author's own. Scanned 4,000 papers of
+arXiv 2605:
 
 | macro | authors define it | with `\newcommand` (would be shadowed) | used-but-undefined |
 |---|---|---|---|
@@ -2640,51 +2659,78 @@ upstream `\ProvideTextCommand`/`\ProvideTextCommandDefault` deferral (kept as
 `mathscinet_sty.rs::provide`) yields to a name already taken. That is also what
 makes `\dbar` safe to bind here and nowhere else.
 
-**The `\cprime` family keeps an always-on stub as well, deliberately.** All three
-of its witnesses load the package by name — 2508.13753 L7, 2508.20226 L3,
-2509.07628 L13 — which corrects the `cyracc.def` / "no Cyrillic encoding
-otherwise loaded" justification the block used to carry. But the package is not
-the only way the family arrives: a `.bib` field carries `Gel\cprime fand` with no
-`\usepackage` behind it, and a MathSciNet export's `@preamble` may or may not
-define it. Removing the stub was measured to cost exactly that case
-(`bib_mr_reviewer_accent`'s `primerev` entry regains `undefined:\cprime`), and no
-author in the scan defines the family with `\newcommand`, so the stub shadows
-nobody. It moved out of `latex_constructs.rs` — which mirrors
-`latex_constructs.pool.ltxml` byte-for-byte and should hold no non-Perl
-definitions — into `latex_constructs_rust_only.rs` §5, the file that exists for
-exactly this, carrying its witnesses. `provide` in the binding then finds them
-already defined, the correct no-op. `\polhk`'s comment there claimed tipa.sty as
-its source; the real one is `mathscinet.sty` L111-113, corrected in place.
+Read the `\cprime` row correctly: **zero** authors define that family with
+`\newcommand`, so a stub for it would have shadowed nobody. Shadowing is the
+`\Dbar`/`\dbar` argument, not the `\cprime` one — the `\cprime` family is
+package-only because the errors that motivated a stub were manufactured by
+digesting uncited entries (below), and because vendor vocabulary belongs to the
+vendor's binding.
 
-*Re-measured 2026-07-27, and the "may or may not define it" is now a number.*
-The stub's redundancy was re-opened once `@preamble` execution was confirmed
-working end to end (it is Perl `Pre/BibTeX.pm::toTeX` L118-122, ported at
-`pre_bibtex::to_tex`, now guarded by
-`bib_preamble_defines_macros_for_the_whole_bibliography`) — a `.bib` that
-defines `\cprime` itself needs no stub. The corpus says the stub still earns its
-place: across the first 600 papers of arXiv 2605, **seven** use `\cprime` inside
-a `.bib` and **six carry no `@preamble` at all**. Deleting the four lines takes
-2605.00173/.00186/.00190/.00305 from 0 to 1 `undefined:\cprime` each, while
-2605.11579 — 17 uses, `@preamble`-covered — is unaffected either way. Three of
-those four are errors the real toolchain never produces, because `bibtex(1)`
-copies only *cited* entries into the `.bbl` and there the `\cprime`-bearing
-entry is uncited; we digest every entry, so the stub is what keeps that
-asymmetry from manufacturing a diagnostic. Per-paper table in
+**The `\cprime` family is package vocabulary too — there is NO always-on stub**
+(deleted 2026-07-27; the block it left behind in
+`latex_constructs_rust_only.rs` records why). All three of its witnesses load the
+package by name — 2508.13753 L7, 2508.20226 L3, 2509.07628 L13 — which corrects
+the `cyracc.def` / "no Cyrillic encoding otherwise loaded" justification the
+family used to carry. The stub briefly lived in `latex_constructs.rs`, then moved
+to `latex_constructs_rust_only.rs` §5 (the Perl-parity file mirrors
+`latex_constructs.pool.ltxml` byte-for-byte and must hold no non-Perl
+definitions), then went away entirely. `\polhk` stays behind in
+`latex_constructs.rs` as a fallback; its comment there claimed tipa.sty as its
+source, and the real one is `mathscinet.sty` L111-113, corrected in place.
+
+**Why the stub's justification collapsed.** It rested on four papers regaining
+`undefined:\cprime` without it (2605.00173/.00186/.00190/.00305). Three of the
+four were artifacts of a defect since fixed: we digested EVERY entry of a `.bib`
+library, so we met `\cprime` in entries `bibtex(1)` never copies into the `.bbl`.
+Since **divergence #80** digests only the CITED entries, that trigger is gone
+structurally rather than papered over — and a definition that is always live can
+shadow an author's own, the same hazard that kept `\Dbar` package-only from the
+start.
+
+**The rule, therefore.** `mathscinet.sty`'s vocabulary belongs to its binding. A
+paper gets it the way the real toolchain gives it: by loading `mathscinet` (or
+`amsrefs`, which `\RequirePackage{mathscinet}[2002/01/01]`s it at `amsrefs.sty`
+L217), or by carrying the definition in its own `.bib` `@preamble` — which
+executes, faithfully to Perl (`Pre/BibTeX.pm::toTeX` L118-122 →
+`pre_bibtex::to_tex`), guarded by
+`bib_preamble_defines_macros_for_the_whole_bibliography`.
+
+**Measured** on current main, `--includestyles`, idle box, serial — total
+document errors and `undefined:\cprime` count:
+
+| paper | errors | `undefined:\cprime` | why |
+|---|---|---|---|
+| 2605.00173 / .00186 / .00190 | 0 | 0 | the `\cprime`-bearing entry is **uncited** (2605.00173: `MR2562222`, `bibliography.bib` L885), so #80 never digests it |
+| 2605.00305 | 1 | 1 | **the only real cost, and it is honest.** It CITES `MR710121` (`mybib.bib` L26, `MRREVIEWER = {V.\ Z.\ Enol\cprime ski\u i}`), loads neither `mathscinet` nor `amsrefs`, ships no `@preamble`, and uses `\bibliographystyle{plain}` — `plain.bst` contains zero `cprime`. Real pdflatex fails there too |
+| 2605.11579 | 0 | 0 | its own `.bib` `@preamble` — 14 copies of `\def\cprime{$'$}`, `biblo.bib` L4768/L6910/… — covers all 17 uses |
+
+So the whole cost of package-only is one paper and one PARITY diagnostic. Earlier
+corpus framing, kept because it is expensive to re-derive: across the first 600
+papers of arXiv 2605, **seven** use `\cprime` inside a `.bib` and **six carry no
+`@preamble` at all**; per-paper table in
 [`BIBLIOGRAPHY_WORKLIST.md`](BIBLIOGRAPHY_WORKLIST.md).
 
-**Measured**, same host: 2605.11579 `--includestyles` **1 error / 36 bibitems**
-(the `\Dbar` parity residual); 2508.13753 **0 errors**, `Kondratʹev` composing;
+**Measured**, same host: 2508.13753 **0 errors**, `Kondratʹev` composing;
 2508.20226 **0 errors**; 2509.07628 `--includestyles` **0 errors**, `Drinfelʹ d`
 composing (its 6 bare-mode errors are an unloaded local `Latex-document.sty`,
-unrelated).
+unrelated). 2605.11579 measured **1 error / 36 bibitems** before #416 and **0
+errors** after: the `\Dbar` residual vanished not because the macro became
+available but because the entry carrying it (`KacNilpotentorbits`, `biblo.bib`
+L2059) is **uncited**, so #80 never digests it. The PARITY reasoning above is
+unchanged — a paper that CITES a `\Dbar` entry while loading no package still
+gets the diagnostic — but that case is now pinned by the guard fixture alone, not
+by this witness.
 
 Guards: `06_cluster_bibliography::bib_mathscinet_package_supplies_its_transliteration_glyphs`
 (a document that loads the package, exercising both body prose and a `.bib`
-`MRREVIEWER`; `\Dbar` is the discriminating assertion, since `\cprime` also has
-the stub beneath it) and
+`MRREVIEWER`; `\Dbar` was the discriminating assertion while `\cprime` had a stub
+beneath it — both are package-only now, so either discriminates) and
 `::bib_mathscinet_macro_yields_to_the_authors_own_definition` (a document that
 does not — RED under an always-on `\Dbar`, where the author's barred-D math
 renders `Đ`, and equally RED if the `.bib` session is made to auto-load).
+`bib_mr_reviewer_accent.tex`, whose `primerev` entry carries `Gel\cprime fand`,
+now loads the package: that fixture is about accent welds surviving reversion,
+not about macro availability.
 
 ### 79. An UNMATCHED `$` in a `.bib` field is data, not a math shift
 
@@ -2738,6 +2784,69 @@ Guards: `bibtex.rs::escape_specials_lone_dollar_is_currency_not_math`,
 `::escape_specials_all_currency_dollars_demote`,
 `::escape_specials_unmatched_dollar_without_a_digit_falls_back_to_the_last`,
 and `06_cluster_bibliography::bib_unmatched_dollar_does_not_leak_math`.
+
+### 80. A `.bib` library is digested down to the CITED entries
+
+**Perl behaviour.** `Pre/BibTeX.pm::toTeX` (L110-122) emits one
+`\ProcessBibTeXEntry{key}` per entry in the file, unconditionally, and the whole
+block is then digested. That was affordable while a raw `.bib` was read by a
+hand-rolled string parser; since it became a real conversion (PR #396) every
+entry costs a full expand/digest/construct cycle.
+
+**What that cost.** A `.bib` is a library, not a document: `anthology.bib` ships
+**80,576** ACL entries and the citing paper wants **9**. Witness **2605.07796**:
+112 s and 4.8 GB RSS, tripping the memory budget and producing **zero**
+bibentries — the paper loses its whole bibliography — with the fleet's 60 s
+timeout killing the conversion outright. The same shape covers **59 of the 69**
+papers in the 2605/2606 sandbox `never_completed_with_retries` bucket (median
+80,597 entries each); 10 of them had converted cleanly before #396.
+
+**Rust behaviour.** `pre_bibtex::to_tex` emits `\ProcessBibTeXEntry` only for the
+selected entries. The cited set is not guessed: `MakeBibliography` already holds
+it as the `BIBLABEL:<list>:<key>` ObjectDB records written during the *document*
+conversion, so it is complete before post-processing asks. It travels as
+`BibConversionRequest::wanted_keys` → `pre_bibtex::set_wanted_keys` (a
+thread-local the caller must `clear_wanted_keys` after use).
+
+**Why this is MORE faithful, not less.** `bibtex(1)` has always read the `.aux`'s
+`\citation` records and emitted only those entries, plus `crossref` targets, plus
+everything under `\nocite{*}`. Filtering here reproduces the real pipeline;
+digesting the library whole never did.
+
+**Selection is closed transitively** (`pre_bibtex::select_cited`) over both edges
+that can reach an uncited entry — `crossref`, BibTeX's own inheritance link, and
+a `\cite` made from inside an already-selected entry, which `getBibEntries`
+follows — so a filtered run keeps everything an unfiltered one kept.
+
+**Every entry is still REGISTERED** (`bibtex::register_entry`, Perl's
+`assignValue 'BIBENTRY@<lc-key>'` at L114-116). That is a map insert of
+already-parsed strings, and keeping it complete is what lets `crossref` and by-key
+lookup resolve against an entry nobody cited.
+
+**`None` means "digest everything"**, and is used for `\nocite{*}` and —
+deliberately — when no `BIBLABEL` record exists at all: an empty filter and absent
+citation data are indistinguishable, and dropping every entry on a missing record
+would be a silent, unrecoverable total loss.
+
+**Measured.** 2605.07796: 112 s / 0 bibentries / killed → **10 s / 9 bibentries /
+0 errors**, matching what the pre-#396 run produced. 9 of the 10 cleanly-converting
+regressions recover; the tenth (2605.16752) is an unrelated
+`Fatal:Timeout:TokenLimit`.
+
+**A knock-on that invalidates older measurements, and is expensive to
+rediscover.** An error raised only by an *uncited* entry now disappears without
+the macro becoming available. That is what took 2605.00173/.00186/.00190 off the
+`undefined:\cprime` list and what removed 2605.11579's `undefined:\Dbar` residual
+(its `KacNilpotentorbits` entry, `biblo.bib` L2059, is uncited) — see #78.
+**Re-measure any bibliography error count recorded before 2026-07-27** rather than
+reading a drop as a fix.
+
+Guards (`pre_bibtex.rs`): `filter_digests_only_the_cited_entries`,
+`filter_follows_crossref`, `filter_follows_a_cite_from_inside_an_entry`,
+`filter_still_registers_every_entry`,
+`filter_is_case_insensitive_like_the_registry`,
+`filter_tolerates_a_cited_key_with_no_entry`, `no_filter_digests_every_entry`,
+`cite_key_scanner_handles_the_cite_family`.
 
 ## Known Upstream Perl Issues (brief)
 

--- a/docs/parity/WISDOM.md
+++ b/docs/parity/WISDOM.md
@@ -2690,7 +2690,13 @@ protects itself by author discipline alone. That failed three times here, each
 found by a user-visible failure years later: `\bib@@names` (PR #399),
 `dcolumn`/`overpic` (PR #400), and `\bib@synthesize@mr` (issue 410 —
 `MRREVIEWER = {Dragomir \v{Z}. \Dbar okovi\'{c}}` → `undefined:\Dbarokovi`;
-witness 2605.11579, 5 welds over 36 bibitems, Perl 0).
+witness 2605.11579, 5 welds over 36 bibitems, Perl 0). *Re-measure that count
+before quoting it: OXIDIZED_DESIGN **#80** now digests only the CITED entries, so
+the `\Dbar` one (`KacNilpotentorbits`, `biblo.bib` L2059) is no longer read at
+all. Other accented `MRREVIEWER`s **are** in cited entries (`BM93`
+`{Fran\c cois\ Digne}`, `Nek03` `{Marcos\ Mari\~no}`, …), so the shape still
+occurs — only the tally moved. The guard fixture, not the paper, is what pins
+this.*
 
 **The rule.** All three mouth entry points — `mouth::tokenize`,
 `mouth::tokenize_internal`, `mouth::tokenize_bib_literal` — and therefore
@@ -2726,3 +2732,34 @@ NOT be `Into<TeXString>`, `&'static str` must be; plus a `compile_fail`
 doctest), `bib_name_space_form_accent_survives_reversion`,
 `bib_mr_reviewer_accent_survives_reversion`. Related: [[#70]] (the same
 "withhold the operation and the class disappears" shape).
+
+## #72 A bibliography sub-conversion's FATAL carries no fatal-severity message — it surfaces on the parent as a trailing `error bibliography/convert`
+
+**The trap.** Mining a corpus run by clustering on **fatal messages** buckets
+these documents as *"no fatal recorded"* — measured, **~80 documents** in one
+sweep. Their conversion really did die; the death simply has no `Fatal:` line to
+cluster on. Cluster on the **status code** (`Status:conversion:3`) or on the
+document's last `Error:` instead, and treat `bibliography/convert` as a
+fatal-class marker.
+
+**Why it is built this way, and why it is right.** `bib_session.rs` imports the
+**post-phase** diagnostic macros (`latexml_post::{Error, Info}`), which are plain
+reporters with none of the too-many-errors escalation the engine-side `Error!`
+carries. The recursive `.bib` session runs *inside* post-processing, so an
+inner-session failure must not itself become a document Fatal — and Perl's
+`convertBibliography` does the same, returning empty-handed
+(`MakeBibliography.pm` L240-242). The `Err` arm therefore emits
+`Error!("bibliography", "convert", "Recursive bibliography conversion failed: …")`
+and returns `None`.
+
+**What DOES cross the boundary** — do not confuse the two. Perl's `MergeStatus`
+(`MakeBibliography.pm` L237, `Common/Error.pm` L669-686) adds the inner session's
+tally to the outer document's, so a `.bib` that raises *errors* makes the
+document an error document. Rust gets that for free by sharing the live core
+State (the counters never left). It is only the *fatal severity* of a sub-session
+collapse that is deliberately downgraded.
+
+**Consequence for guards.** The ordinary `convert_and_post` test helper gates only
+the CORE stage, so a post-stage error flood passes every bibliography guard
+silently — 17 errors on one fixture, 203 on its witness, all green. Use
+`convert_and_post_clean` for anything in this path (see OXIDIZED_DESIGN #73).

--- a/docs/performance/STABILITY_WITNESSES.md
+++ b/docs/performance/STABILITY_WITNESSES.md
@@ -464,6 +464,37 @@ output-neutrality validation — so it was **reverted, not shipped**. Recorded h
 candidate future consistency fix.
 Re-measure with the current binary first (sweep records go stale).
 
+## Cluster I — a `.bib` LIBRARY digested whole → timeout + memory budget — ✅ FIXED 2026-07-27
+
+**Symptom.** `never_completed_with_retries`: the fleet's 60 s lease expires, or
+`Fatal:Timeout:MemoryBudget` fires, on a paper whose *body* is unremarkable. The
+tell is a huge `.bib` next to a short document.
+
+**Cause.** A `.bib` is a library, not a document. Once a raw `.bib` became a real
+conversion (PR #396) instead of a string parse, every entry cost a full
+expand/digest/construct cycle — and Perl's `Pre/BibTeX.pm::toTeX` (L110-122),
+which we follow, emits `\ProcessBibTeXEntry` for **every** entry in the file.
+`anthology.bib` ships **80,576** ACL entries; the citing paper wants **9**.
+
+**Witness `2605.07796`** (`anthology.bib`, 43.6 MB): **112 s / 4.8 GB RSS**,
+memory budget tripped, **0 bibentries produced** (the paper loses its whole
+bibliography), conversion killed by the 60 s timeout → **10 s / 9 bibentries /
+0 errors**, matching what the pre-#396 run produced.
+
+**Breadth.** **59 of the 69** papers in the 2605/2606 sandbox
+`never_completed_with_retries` bucket share this shape (median **80,597** entries
+each); 10 of them had converted cleanly before #396. 9 of those 10 recover; the
+tenth, `2605.16752`, is an unrelated `Fatal:Timeout:TokenLimit` and stays a live
+witness.
+
+**Fix.** Digest only the CITED entries plus their `crossref`/`\cite` closure —
+what `bibtex(1)` has always done from the `.aux`'s `\citation` records. Design,
+faithfulness argument and guards: OXIDIZED_DESIGN **#80**.
+
+**Note for anyone re-measuring an older reliability row here:** an error or cost
+attributable to an *uncited* entry disappears with this change. Re-measure rather
+than reading a drop as a separate fix.
+
 ## Method notes
 
 - Sweep failure logs: `~/data/large_scale_canvas_3/canvas/stage_*/failures/<id>.<KIND>.log`.


### PR DESCRIPTION
Docs only — no `.rs` changes.

## Diagnostic

Nineteen PRs landed in rapid succession and several documents were left arguing
positions that later PRs falsified. The sharpest case: **`OXIDIZED_DESIGN #78`
and `BIBLIOGRAPHY_WORKLIST.md` both argued the always-on
`\cprime`/`\Cprime`/`\cdprime`/`\Cdprime` stub *stays*** — while PR #419 had
already deleted it. The justification (four papers regaining `undefined:\cprime`
without it) had collapsed one PR earlier: **#416** made us digest only the
**cited** entries of a `.bib`, and three of those four papers only regressed
because their `\cprime`-bearing entry was *uncited*.

Auditing outward from there turned up more:

| claim, as merged | status |
|---|---|
| `#78`: the `\cprime` stub stays; 2605.11579 stays at 1 error / 36 bibitems | **stale** — stub deleted; witness at 0 |
| `BIBLIOGRAPHY_WORKLIST`: "Consequence for the always-on `\cprime` stub: it stays" | **stale** — same |
| `BIBLIOGRAPHY_WORKLIST`: "The boundary is blast radius, not character" (regime A `% & # _` per-Mouth; regime B `_` via `Semiverbatim` on `eprint`/`preprint`/`archive`) | **both halves false** — `_` is not in the Mouth set, and those three fields are plain `\bib@@field` macros in *both* engines |
| re-port item 3: the 13-field digest whitelist is pending, "widen when item 1 lands" | **resolved** — item 1 landed; the `\bib@field@default@*` name sets now match Perl exactly |
| `SYNC_STATUS` R9 ranked row: "`.bst` files *vendor macro definitions*" | **retracted** by R9-BST itself, two rows down |
| `SYNC_STATUS` R9-MSC: "`mathscinet.sty` binding — SMALL, unblocked … neither do we" | **done** (PRs #415 + #419) |
| `SYNC_STATUS`: a duplicate "bare `&` is data" bullet, one citing `OXIDIZED_DESIGN #75` | **wrong number** (#75 is the pseudo-`\bibitem` rescue) — it is #74 |
| three guards cited as `06_cluster_regressions::` | **moved** to `06_cluster_bibliography` in PR #400 |
| `BibCatcodeScope`, `convert_bib_file_to_xml`, `interpret_tex_markup`, `interpret_tex_text`, `parse_bib_authors` | **deleted**, still named as live code |
| PR #416 itself | **no doc record anywhere** |

## Approach

Verified every claim against the code and the guard names it cites *before*
rewriting it — the campaign has already produced two merged-but-wrong claims.

* `#78` rewritten to the current rule: `mathscinet.sty` vocabulary belongs to its
  binding; a paper gets it by loading the package (or `amsrefs`, which
  `\RequirePackage`s it at `amsrefs.sty` L217) or via its own `.bib` `@preamble`.
  The per-paper table is re-based on the current-main measurement, with each row
  given its *reason* — checked in the corpus, not inferred:
  * 2605.00173's `\cprime` entry is `MR2562222` (`bibliography.bib` L885), which
    no `.tex` cites.
  * **2605.00305 is the only real cost, and it is honest**: it *cites* `MR710121`
    (`mybib.bib` L26, `MRREVIEWER = {V.\ Z.\ Enol\cprime ski\u i}`), loads
    neither `mathscinet` nor `amsrefs`, ships no `@preamble`, and uses
    `\bibliographystyle{plain}` — `plain.bst` contains zero `cprime`. pdflatex
    fails there too.
  * 2605.11579's `@preamble` (14 copies of `\def\cprime{$'$}`, `biblo.bib`
    L4768/L6910/…) covers its 17 uses.
* **New divergence `#80`** for PR #416, which had no record in any doc. It is a
  real divergence — Perl's `Pre/BibTeX.pm::toTeX` L110-122 emits
  `\ProcessBibTeXEntry` for *every* entry — and #78's rewrite depends on it.
* **`#76` gets an explicit retired-number placeholder.** It was consolidated into
  `#74`; a bare gap reads as a mistake and invites reuse, which would silently
  invalidate `.rs` citations. Next free number is recorded as `#81`.
* Two facts the campaign proved but never wrote down are now recorded:
  **`WISDOM #72`** (a bibliography sub-conversion's fatal carries no
  fatal-severity message) and **`STABILITY_WITNESSES` cluster I** (the
  `.bib`-library timeout/OOM family).
* Superseded-but-valuable material is **banner-marked, not pruned** — the three
  re-port INTERIMs keep their witnesses, traps and properties under a banner
  saying every identifier they name is deleted.

## Validation

No build required (docs only). Every rewritten claim was checked against the
tree:

* **Corpus, on the witnesses themselves.** `KacNilpotentorbits` (2605.11579's
  sole `\Dbar` entry, `biblo.bib` L2059) and `MR2562222` (2605.00173) appear in
  no `\cite`; `MR710121` (2605.00305) does. `plain.bst` and `alpha.bst` contain
  zero `cprime`/`Dbar`. `amsrefs.sty` L217 `\RequirePackage{mathscinet}`
  confirmed.
* **Guard names** all resolve to real `#[test]` functions — the eight `filter_*`
  in `pre_bibtex.rs`, `bib_preamble_defines_macros_for_the_whole_bibliography`,
  the two `bib_mathscinet_*`, `bib_unmatched_dollar_does_not_leak_math`. The
  three `06_cluster_regressions::` bibliography citations were **wrong** and are
  corrected.
* **Counted, not recalled**: the `\bib@field@default@*` name sets are **45 on
  each side** and `diff` of the sorted lists is empty; `escape_specials_*` is
  **13** unit tests, not the six/seven the docs claimed.
* **Deleted identifiers** confirmed absent by grep before being marked as such.
* Relative markdown links in all seven touched files resolve (0 broken).

## Decisions & open questions

1. **Minting `#80` rather than leaving #416 undocumented.** It changes what
   reaches the digester relative to Perl, and it is the load-bearing premise of
   the `#78` rewrite, so it needed a citable number. Nothing in the tree cites
   `#80` yet — if a sibling PR wants that number for something else, this is the
   one to renumber, and it should be done before anything in `.rs` cites it.
2. **Error counts are the supplied current-main measurement**
   (`--includestyles`, idle box, serial). I did not re-run conversions: the
   available binaries predate #418/#419 and three agents share the box. The
   *mechanism* behind each row is independently verified in the corpus, above.
   2605.11579's pre-#416 "36 bibitems" is kept and attributed to that older
   measurement rather than restated as current.
3. **`ISSUE_AUDIT.md` deliberately untouched.** Its own header says it "drifts
   fast — re-run the one-liner rather than incrementally editing rows", and its
   2026-07-26 stamp predates this campaign. It needs a `gh` refresh, not a patch.
4. **The 1696-test count is flagged, not corrected.** Seven PRs added guards
   since it was taken; running the suite here would contend with the siblings.
5. **Three stale `.rs` comments found and left alone** (docs-only scope), all
   describing the `\cprime` stub as still present; none affects behaviour. They
   are listed in the handoff report.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
