### PR TITLE
fix(post): a graphics test asserting on subprocesses must bypass the cache

### DIFF
--- a/latexml_post/src/graphics.rs
+++ b/latexml_post/src/graphics.rs
@@ -179,6 +179,11 @@ pub struct Graphics {
   /// failure or timeout. 0 disables the path entirely.
   /// Tracks upstream brucemiller/LaTeXML#902.
   svg_threshold_kb: u32,
+  /// Whether conversions may be served from the shared, host-persistent
+  /// graphics cache. Threaded explicitly (rather than read from a global)
+  /// so a caller can guarantee its conversions actually run — see
+  /// [`crate::graphics_cache::CachePolicy`] and `with_cache_policy`.
+  cache_policy:     crate::graphics_cache::CachePolicy,
 }
 
 impl Graphics {
@@ -271,7 +276,23 @@ impl Graphics {
       type_properties,
       background: "#FFFFFF".to_string(),
       svg_threshold_kb: 0,
+      cache_policy: crate::graphics_cache::CachePolicy::default(),
     }
+  }
+
+  /// Choose whether conversions may be served from the shared,
+  /// host-persistent graphics cache. Defaults to
+  /// [`CachePolicy::Shared`](crate::graphics_cache::CachePolicy::Shared).
+  ///
+  /// Pass [`CachePolicy::Bypass`](crate::graphics_cache::CachePolicy::Bypass)
+  /// when the conversion *itself* is what matters — e.g. a test asserting
+  /// on how many converter subprocesses ran, which a cache hit would
+  /// silently satisfy without running any. The builder returns `self` so
+  /// it composes with `Graphics::new(...)`.
+  #[must_use]
+  pub fn with_cache_policy(mut self, policy: crate::graphics_cache::CachePolicy) -> Self {
+    self.cache_policy = policy;
+    self
   }
 
   /// Enable the vector-SVG path for PDFs under `kb` KB. When `kb == 0`
@@ -2198,6 +2219,9 @@ impl Processor for Graphics {
       // call (the EPS-via-PDF internal pair counts as one).
       let subproc_count = AtomicU32::new(0);
       let subproc_ref = &subproc_count;
+      // Copy out of `self` before the scope: the worker closures must not
+      // borrow `self` (it is `&mut` here), and `CachePolicy` is `Copy`.
+      let cache_policy = self.cache_policy;
       // Unique conversion jobs only. Repeated nodes with the same
       // source/page/options share one subprocess result, while distinct
       // options keep separate outputs.
@@ -2264,6 +2288,7 @@ impl Processor for Graphics {
                         ext:     "svg",
                       };
                       let svg_res = crate::graphics_cache::with_cache_dims(
+                        cache_policy,
                         source,
                         abs_svg,
                         svg_key,
@@ -2303,6 +2328,7 @@ impl Processor for Graphics {
                         ext:     ext_from_path(abs_dest_str),
                       };
                       crate::graphics_cache::with_cache_dims(
+                        cache_policy,
                         source,
                         abs_dest_str,
                         raster_key,
@@ -2543,44 +2569,10 @@ impl Processor for Graphics {
 #[cfg(test)]
 mod tests {
   use super::*;
-
-  struct EnvGuard {
-    key: String,
-    old: Option<String>,
-  }
-
-  impl EnvGuard {
-    fn set(key: &str, value: &str) -> Self {
-      let old = std::env::var(key).ok();
-      // SAFETY: EnvGuard is a test-only helper (`#[cfg(test)] mod tests`),
-      // used in `process_coalesces_only_matching_conversion_options` to point
-      // PATH at a fake `convert` for the duration of one test. `set_var`/
-      // `remove_var` are `unsafe` in edition 2024 because a concurrent env
-      // read/write from another thread is a data race.
-      // FIXME: the single-threaded property is NOT formally guaranteed here —
-      // cargo's default test harness runs the binary's tests on multiple
-      // threads and other tests read the environment (`std::env::var`). Make
-      // this airtight by serializing env-mutating tests (e.g. `serial_test`).
-      unsafe { std::env::set_var(key, value) };
-      Self { key: key.to_string(), old }
-    }
-  }
-
-  impl Drop for EnvGuard {
-    fn drop(&mut self) {
-      if let Some(old) = &self.old {
-        // SAFETY: test-only restore of the value EnvGuard::set saved; same
-        // edition-2024 data-race rationale as in `set`.
-        // FIXME: single-threaded property not formally guaranteed (see `set`).
-        unsafe { std::env::set_var(&self.key, old) };
-      } else {
-        // SAFETY: test-only removal of a var EnvGuard::set introduced; same
-        // edition-2024 data-race rationale as in `set`.
-        // FIXME: single-threaded property not formally guaranteed (see `set`).
-        unsafe { std::env::remove_var(&self.key) };
-      }
-    }
-  }
+  // `EnvGuard` (env mutation, serialised + restored) and `TempDir`
+  // (unique name, removed on drop including on panic) are shared with
+  // `graphics_cache::tests`; see that module for the rationale.
+  use crate::test_env::{EnvGuard, TempDir};
 
   /// `run_with_timeout` kills the child and returns `None` when the
   /// process exceeds the deadline. Uses `sleep` as a stand-in for any
@@ -2626,8 +2618,7 @@ mod tests {
   /// attempt, large PDF does not, non-PDF is always skipped.
   #[test]
   fn should_try_svg_path_explicit_threshold() {
-    let tmp = std::env::temp_dir().join("latexml_graphics_svg_gate_test");
-    std::fs::create_dir_all(&tmp).unwrap();
+    let tmp = TempDir::new("svg_gate");
     let small_pdf = tmp.join("small.pdf");
     let big_pdf = tmp.join("big.pdf");
     let png = tmp.join("raster.png");
@@ -2649,8 +2640,6 @@ mod tests {
     assert!(!Graphics::should_try_svg_path(png.to_str().unwrap(), 200));
     // Missing file → false, not panic.
     assert!(!Graphics::should_try_svg_path("/no/such/file.pdf", 200));
-
-    std::fs::remove_dir_all(&tmp).ok();
   }
 
   /// Auto-detect path (`threshold_kb == 0`): vector-only PDFs trigger
@@ -2700,8 +2689,7 @@ mod tests {
 
   #[test]
   fn postscript_density_caps_huge_bounding_box() {
-    let tmp = std::env::temp_dir().join("latexml_graphics_density_test");
-    std::fs::create_dir_all(&tmp).unwrap();
+    let tmp = TempDir::new("ps_density");
     let normal = tmp.join("normal.eps");
     let huge = tmp.join("huge.eps");
     std::fs::write(
@@ -2727,13 +2715,12 @@ mod tests {
       read_postscript_bounding_box(huge.to_str().unwrap()),
       Some((11339.0, 11339.0))
     );
-
-    std::fs::remove_dir_all(&tmp).ok();
   }
 
   #[test]
   fn pdf_density_caps_huge_page_box() {
-    let tmp = std::env::temp_dir().join("latexml_graphics_pdf_density_test.pdf");
+    let dir = TempDir::new("pdf_density");
+    let tmp = dir.join("page.pdf");
     std::fs::write(
       &tmp,
       b"%PDF-1.4
@@ -2752,14 +2739,13 @@ endobj
       Graphics::raster_density_for_source(tmp.to_str().unwrap()),
       34
     );
-
-    std::fs::remove_file(&tmp).ok();
   }
 
   /// SVG viewBox parsing extracts width/height.
   #[test]
   fn read_svg_dimensions_parses_viewbox() {
-    let tmp = std::env::temp_dir().join("latexml_svg_dim_test.svg");
+    let dir = TempDir::new("svg_dim");
+    let tmp = dir.join("dims.svg");
     std::fs::write(
       &tmp,
       r#"<?xml version="1.0"?>
@@ -2770,13 +2756,13 @@ endobj
     .unwrap();
     let dims = Graphics::read_svg_dimensions(tmp.to_str().unwrap()).expect("dims");
     assert_eq!(dims, (640, 480));
-    std::fs::remove_file(&tmp).ok();
   }
 
   /// Falls back to width/height attrs when viewBox is missing.
   #[test]
   fn read_svg_dimensions_falls_back_to_width_height() {
-    let tmp = std::env::temp_dir().join("latexml_svg_dim_fallback.svg");
+    let dir = TempDir::new("svg_dim_fallback");
+    let tmp = dir.join("dims.svg");
     std::fs::write(
       &tmp,
       r#"<svg xmlns="http://www.w3.org/2000/svg" width="123.7pt" height="99.4pt">
@@ -2786,27 +2772,47 @@ endobj
     .unwrap();
     let dims = Graphics::read_svg_dimensions(tmp.to_str().unwrap()).expect("dims");
     assert_eq!(dims, (124, 99));
-    std::fs::remove_file(&tmp).ok();
   }
 
+  /// Three `<graphics>` nodes over one source: two share `options`, one
+  /// differs. `process` must coalesce the matching pair into a single
+  /// conversion and run a second one for the differing options — proven by
+  /// counting the lines a fake `convert` on `PATH` appends to its log.
+  ///
+  /// **The cache must be bypassed for this to mean anything.** The
+  /// observable here is "how many converter subprocesses ran", and
+  /// `graphics_cache` is content-addressed against a *host-persistent* root
+  /// (`$XDG_CACHE_HOME/latexml-oxide/graphics`). With the cache live this
+  /// test was self-poisoning: the first run stored the shim's output under a
+  /// key derived from these fixed source bytes, and every later run was
+  /// served from that entry, spawned nothing, and died on a missing log
+  /// (issue 401). The two jobs also share one cache key — same bytes, page,
+  /// density and extension, differing only in destination name — so even a
+  /// pristine cache could serve job two from job one and see a single log
+  /// line. `CachePolicy::Bypass` removes both, without touching any env var.
   #[test]
   #[cfg(unix)]
   fn process_coalesces_only_matching_conversion_options() {
     use std::os::unix::fs::PermissionsExt;
 
-    use crate::document::{PostDocument, PostDocumentOptions};
+    use crate::{
+      document::{PostDocument, PostDocumentOptions},
+      graphics_cache::CachePolicy,
+    };
 
-    let tmp = std::env::temp_dir().join(format!("latexml_graphics_dedupe_{}", std::process::id()));
-    std::fs::create_dir_all(&tmp).unwrap();
+    let tmp = TempDir::new("graphics_dedupe");
     let source = tmp.join("plot.ai");
     std::fs::write(&source, "%!PS-Adobe-3.0\n%%BoundingBox: 0 0 100 100\n").unwrap();
     let log = tmp.join("convert.log");
     let fake_convert = tmp.join("convert");
     // Log the args AND write a non-empty file at the dest (the last positional
     // arg) — `convert_image` now requires actual output, not just exit 0.
+    // The log path is derived from `$0` (the kernel hands a shebang script its
+    // resolved path, so PATH lookup still yields an absolute `dirname`) rather
+    // than from an env var: one less process-global to synchronise.
     std::fs::write(
       &fake_convert,
-      "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$LATEXML_FAKE_CONVERT_LOG\"\n\
+      "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$(dirname \"$0\")/convert.log\"\n\
        for a in \"$@\"; do d=\"$a\"; done\nprintf x > \"$d\"\nexit 0\n",
     )
     .unwrap();
@@ -2815,8 +2821,8 @@ endobj
     std::fs::set_permissions(&fake_convert, perms).unwrap();
 
     let old_path = std::env::var("PATH").unwrap_or_default();
-    let _path_guard = EnvGuard::set("PATH", &format!("{}:{}", tmp.display(), old_path));
-    let _log_guard = EnvGuard::set("LATEXML_FAKE_CONVERT_LOG", log.to_str().unwrap());
+    let mut env = EnvGuard::acquire();
+    env.set("PATH", &format!("{}:{}", tmp.path().display(), old_path));
     let xml = format!(
       r#"<?xml version="1.0"?>
 <document xmlns="http://dlmf.nist.gov/LaTeXML" xml:id="d">
@@ -2828,25 +2834,31 @@ endobj
     );
     let doc_opts = PostDocumentOptions {
       destination: Some(tmp.join("out.html").display().to_string()),
-      source_directory: Some(tmp.display().to_string()),
+      source_directory: Some(tmp.path().display().to_string()),
       ..Default::default()
     };
     let doc = PostDocument::new_from_string(&xml, doc_opts).unwrap();
-    let mut graphics = Graphics::new(None, true);
+    let mut graphics = Graphics::new(None, true).with_cache_policy(CachePolicy::Bypass);
     let nodes = graphics.to_process(&doc);
     assert_eq!(nodes.len(), 3);
 
     let docs = graphics.process(doc, nodes).unwrap();
     let out = docs[0].to_xml_string();
-    let log_lines = std::fs::read_to_string(&log).unwrap().lines().count();
+    let log_contents = std::fs::read_to_string(&log).unwrap_or_else(|e| {
+      panic!(
+        "fake `convert` never ran: no log at {} ({e}). The shim is on PATH and the cache is \
+         bypassed, so `process` should have spawned it.",
+        log.display()
+      )
+    });
     assert_eq!(
-      log_lines, 2,
-      "matching source/page/options should coalesce, but different options need separate conversions"
+      log_contents.lines().count(),
+      2,
+      "matching source/page/options should coalesce, but different options need separate \
+       conversions; convert log was:\n{log_contents}"
     );
     assert_eq!(out.matches(r#"imagesrc="plot.png""#).count(), 2);
     assert_eq!(out.matches(r#"imagesrc="x1.png""#).count(), 1);
-
-    std::fs::remove_dir_all(&tmp).ok();
   }
 
   /// A post-processing diagnostic raised on a WORKER THREAD must reach the MAIN

--- a/latexml_post/src/graphics_cache.rs
+++ b/latexml_post/src/graphics_cache.rs
@@ -180,6 +180,32 @@ pub fn reset_stats() {
   MISSES.store(0, Ordering::Relaxed);
 }
 
+/// Whether a given conversion consults the shared graphics cache.
+///
+/// The cache root is *process-global, host-persistent* state: it comes
+/// from `LATEXML_GRAPHICS_CACHE_DIR`, else
+/// `$XDG_CACHE_HOME/latexml-oxide/graphics`, which survives across runs
+/// and across unrelated conversions. A caller that needs its conversions
+/// to actually *run* — rather than be served from whatever a previous
+/// run on this host happened to leave behind — must be able to opt out,
+/// and must be able to do so **without mutating the environment**
+/// (`set_var` is process-wide and racy against every other thread).
+/// Hence an explicit, caller-threaded policy rather than another env var.
+///
+/// The env kill-switch `LATEXML_GRAPHICS_CACHE_OFF=1` still applies
+/// independently, inside [`lookup`] / [`store`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CachePolicy {
+  /// Consult and populate the shared cache. The production default.
+  #[default]
+  Shared,
+  /// Bypass the cache entirely: every conversion runs, nothing is read
+  /// and nothing is stored. Used where the *conversion itself* is the
+  /// observable under test, so a prior run's cached output must not be
+  /// able to substitute for it.
+  Bypass,
+}
+
 /// Render-shaping inputs that go into the cache key alongside source
 /// bytes. Two calls with the same `RenderKey` MUST produce
 /// byte-equivalent output (modulo metadata variation tools like
@@ -535,7 +561,11 @@ impl ConvertResult {
 ///
 /// Callers without a dimension hook can pass `measure = || None` to
 /// get the bytes-only cache behaviour.
+///
+/// `policy` decides whether the shared cache is consulted at all; see
+/// [`CachePolicy`].
 pub fn with_cache_dims<F, M>(
+  policy: CachePolicy,
   source: &str,
   dest: &str,
   key: RenderKey,
@@ -546,6 +576,12 @@ where
   F: FnOnce() -> bool,
   M: FnOnce() -> Option<CachedDims>,
 {
+  if policy == CachePolicy::Bypass {
+    if !convert() {
+      return ConvertResult::Failed;
+    }
+    return ConvertResult::Ok { dims: measure() };
+  }
   if let Some(hit) = lookup(source, dest, key) {
     if let Some(d) = hit.dims {
       return ConvertResult::Ok { dims: Some(d) };
@@ -574,8 +610,22 @@ where
 /// Bytes-only cache wrapper. Use when the caller doesn't need
 /// dimensions cached (e.g. SVG path where viewBox dims are cheap to
 /// re-read from disk). Returns `true` on success.
-pub fn with_cache<F>(source: &str, dest: &str, key: RenderKey, convert: F) -> bool
-where F: FnOnce() -> bool {
+///
+/// `policy` decides whether the shared cache is consulted at all; see
+/// [`CachePolicy`].
+pub fn with_cache<F>(
+  policy: CachePolicy,
+  source: &str,
+  dest: &str,
+  key: RenderKey,
+  convert: F,
+) -> bool
+where
+  F: FnOnce() -> bool,
+{
+  if policy == CachePolicy::Bypass {
+    return convert();
+  }
   if lookup(source, dest, key).is_some() {
     return true;
   }
@@ -609,17 +659,32 @@ mod tests {
     fs::write(path, bytes).unwrap();
   }
 
-  // The cache_root() OnceLock locks the cache root on first call. To
-  // isolate per-test directories we'd need to reset the OnceLock,
-  // which the public API doesn't support. Instead, share one cache
-  // directory across tests and use unique source bytes per test.
+  // These tests exercise the cache itself, so they need a real cache
+  // root — pointed at a scratch directory rather than the developer's
+  // `~/.cache`. One directory is shared across them (with unique source
+  // bytes per test) because the root is read from the environment, which
+  // is process-global.
+  //
+  // The env write is deliberately NOT undone: it stays set for the rest
+  // of the binary's life, and `LATEXML_GRAPHICS_CACHE_DIR` is leaked into
+  // any test that runs afterwards. That is tolerable only because no
+  // other test's correctness depends on the cache root any more — the one
+  // that used to, `graphics::tests::process_coalesces_only_matching_
+  // conversion_options`, now bypasses the cache explicitly via
+  // `CachePolicy::Bypass` instead of racing this setter (issue 401).
+  // Taking the shared `env_lock` keeps the write from interleaving with
+  // that test's `PATH` window.
   static SHARED_DIR: OnceLock<PathBuf> = OnceLock::new();
   fn shared_cache_dir() -> &'static Path {
     SHARED_DIR.get_or_init(|| {
       let dir = temp_dir("shared");
-      // SAFETY: tests run in their own process; the env-var write is
-      // serialized by the OnceLock initializer (only the first caller
-      // runs the closure).
+      let _lock = crate::test_env::env_lock()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+      // SAFETY: `set_var` is `unsafe` in edition 2024 because concurrent
+      // env access from another thread is a data race. We hold the
+      // binary-wide `env_lock`, so no other env-mutating test runs
+      // concurrently, and only the first caller runs this initializer.
       unsafe {
         std::env::set_var("LATEXML_GRAPHICS_CACHE_DIR", &dir);
       }
@@ -676,18 +741,30 @@ mod tests {
       ext:     "png",
     };
     let mut spawn_calls = 0u32;
-    let ok1 = with_cache(src.to_str().unwrap(), dest1.to_str().unwrap(), key, || {
-      spawn_calls += 1;
-      fs::write(&dest1, b"converted-output").unwrap();
-      true
-    });
+    let ok1 = with_cache(
+      CachePolicy::Shared,
+      src.to_str().unwrap(),
+      dest1.to_str().unwrap(),
+      key,
+      || {
+        spawn_calls += 1;
+        fs::write(&dest1, b"converted-output").unwrap();
+        true
+      },
+    );
     assert!(ok1);
     assert_eq!(spawn_calls, 1, "first call must spawn");
 
-    let ok2 = with_cache(src.to_str().unwrap(), dest2.to_str().unwrap(), key, || {
-      spawn_calls += 1;
-      true
-    });
+    let ok2 = with_cache(
+      CachePolicy::Shared,
+      src.to_str().unwrap(),
+      dest2.to_str().unwrap(),
+      key,
+      || {
+        spawn_calls += 1;
+        true
+      },
+    );
     assert!(ok2);
     assert_eq!(spawn_calls, 1, "second call must NOT spawn");
     assert_eq!(
@@ -714,6 +791,7 @@ mod tests {
     let mut measure_calls = 0u32;
     // First call: miss → spawn + measure → store dims.
     let dims1 = with_cache_dims(
+      CachePolicy::Shared,
       src.to_str().unwrap(),
       dest1.to_str().unwrap(),
       key,
@@ -733,6 +811,7 @@ mod tests {
 
     // Second call: hit → sidecar replay, NO spawn, NO measure.
     let dims2 = with_cache_dims(
+      CachePolicy::Shared,
       src.to_str().unwrap(),
       dest2.to_str().unwrap(),
       key,
@@ -771,6 +850,7 @@ mod tests {
     };
     let mut calls = 0u32;
     let ok_png = with_cache(
+      CachePolicy::Shared,
       src.to_str().unwrap(),
       dest_png.to_str().unwrap(),
       key_png,
@@ -781,6 +861,7 @@ mod tests {
       },
     );
     let ok_svg = with_cache(
+      CachePolicy::Shared,
       src.to_str().unwrap(),
       dest_svg.to_str().unwrap(),
       key_svg,
@@ -808,17 +889,29 @@ mod tests {
       ext:     "png",
     };
     let mut calls = 0u32;
-    let ok = with_cache(src.to_str().unwrap(), dest.to_str().unwrap(), key, || {
-      calls += 1;
-      // simulate spawn failure: did NOT write dest, returned false
-      false
-    });
+    let ok = with_cache(
+      CachePolicy::Shared,
+      src.to_str().unwrap(),
+      dest.to_str().unwrap(),
+      key,
+      || {
+        calls += 1;
+        // simulate spawn failure: did NOT write dest, returned false
+        false
+      },
+    );
     assert!(!ok);
     assert_eq!(calls, 1);
-    let ok2 = with_cache(src.to_str().unwrap(), dest.to_str().unwrap(), key, || {
-      calls += 1;
-      false
-    });
+    let ok2 = with_cache(
+      CachePolicy::Shared,
+      src.to_str().unwrap(),
+      dest.to_str().unwrap(),
+      key,
+      || {
+        calls += 1;
+        false
+      },
+    );
     assert!(!ok2);
     assert_eq!(calls, 2, "cache must not memoise failures");
   }
@@ -846,11 +939,17 @@ mod tests {
     };
     let mut calls = 0u32;
     // Step 1: register a fresh entry via with_cache. Cache file is on disk.
-    let ok = with_cache(src.to_str().unwrap(), dest1.to_str().unwrap(), key, || {
-      calls += 1;
-      fs::write(&dest1, b"v1-bytes").unwrap();
-      true
-    });
+    let ok = with_cache(
+      CachePolicy::Shared,
+      src.to_str().unwrap(),
+      dest1.to_str().unwrap(),
+      key,
+      || {
+        calls += 1;
+        fs::write(&dest1, b"v1-bytes").unwrap();
+        true
+      },
+    );
     assert!(ok);
     assert_eq!(calls, 1);
 
@@ -875,11 +974,17 @@ mod tests {
     // Step 4: with_cache must regenerate quietly. The closure should fire,
     // producing fresh output bytes. After this, the cache should hold the
     // new entry again.
-    let ok2 = with_cache(src.to_str().unwrap(), dest2.to_str().unwrap(), key, || {
-      calls += 1;
-      fs::write(&dest2, b"v2-bytes-regenerated").unwrap();
-      true
-    });
+    let ok2 = with_cache(
+      CachePolicy::Shared,
+      src.to_str().unwrap(),
+      dest2.to_str().unwrap(),
+      key,
+      || {
+        calls += 1;
+        fs::write(&dest2, b"v2-bytes-regenerated").unwrap();
+        true
+      },
+    );
     assert!(ok2);
     assert_eq!(
       calls, 2,
@@ -933,6 +1038,7 @@ mod tests {
 
     let dest = dir.join("out.png");
     let result = with_cache_dims(
+      CachePolicy::Shared,
       src.to_str().unwrap(),
       dest.to_str().unwrap(),
       key,
@@ -976,7 +1082,7 @@ mod tests {
         let dir_s = dir_s.clone();
         s.spawn(move || {
           let dest = format!("{dir_s}/dest_{i}.png");
-          with_cache(&src_s, &dest, key, || {
+          with_cache(CachePolicy::Shared, &src_s, &dest, key, || {
             // Tiny artificial work to encourage interleaving.
             std::thread::sleep(std::time::Duration::from_millis(5));
             fs::write(&dest, b"final-bytes").unwrap();

--- a/latexml_post/src/lib.rs
+++ b/latexml_post/src/lib.rs
@@ -69,6 +69,11 @@ pub mod writer;
 pub mod xmath;
 pub mod xslt;
 
+/// Shared helpers for the process-global state (`env`, `/tmp`) that this
+/// crate's multi-threaded unit tests contend over.
+#[cfg(test)]
+mod test_env;
+
 use std::sync::LazyLock;
 
 use document::PostDocument;

--- a/latexml_post/src/test_env.rs
+++ b/latexml_post/src/test_env.rs
@@ -1,0 +1,133 @@
+//! Test-only helpers for the two process-global resources this crate's
+//! unit tests touch: the **environment** and **temporary directories**.
+//!
+//! `cargo test` runs every test in one binary on many threads, so both
+//! are shared mutable state. Two concrete hazards this module closes:
+//!
+//! * **Env-var interleaving.** `graphics::tests` points `PATH` at a fake
+//!   converter, and `graphics_cache::tests` sets
+//!   `LATEXML_GRAPHICS_CACHE_DIR`. Rust's own `ENV_LOCK` makes the
+//!   individual `set_var`/`var` calls safe against each other, but it does
+//!   nothing about *ordering*: without a lock spanning the whole
+//!   set → use → restore window, which test observes which value is
+//!   scheduler-dependent. [`EnvGuard`] holds [`env_lock`] for that whole
+//!   window, so the interleaving is gone rather than merely unlikely.
+//!
+//! * **Leaked temp dirs.** A fixed-name dir under `/tmp` collides between
+//!   two concurrent `cargo test` runs, and a dir cleaned up only on the
+//!   success path accumulates forever once a test starts failing.
+//!   [`TempDir`] gives each call a unique name and removes it in `Drop`,
+//!   which runs on the panic path too.
+//!
+//! Residual, deliberately not papered over: a C library linked into the
+//! test binary (libxml2, kpathsea) can call `getenv` concurrently with a
+//! `setenv` here, which no Rust-side lock can serialise. That is why the
+//! graphics cache is steered by an explicit
+//! [`CachePolicy`](crate::graphics_cache::CachePolicy) argument rather
+//! than by an env var — correctness must not rest on this lock.
+
+use std::{
+  path::{Path, PathBuf},
+  sync::{Mutex, MutexGuard, OnceLock},
+};
+
+/// The lock serialising every environment mutation in this test binary.
+///
+/// Anything that calls `set_var`/`remove_var` must hold it — normally by
+/// going through [`EnvGuard`].
+pub(crate) fn env_lock() -> &'static Mutex<()> {
+  static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+  LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Sets environment variables for the duration of a test and restores
+/// their previous values on drop — holding [`env_lock`] throughout, so no
+/// other env-mutating test can observe or clobber the window.
+///
+/// Acquire once and call [`set`](EnvGuard::set) for each variable: the
+/// lock is **not** reentrant, so two live guards on one thread would
+/// deadlock.
+pub(crate) struct EnvGuard {
+  /// Held for the guard's lifetime; released in `Drop` after the restore.
+  _lock: MutexGuard<'static, ()>,
+  /// `(key, previous value)`, restored in reverse order.
+  saved: Vec<(String, Option<String>)>,
+}
+
+impl EnvGuard {
+  /// Take the env lock. Recovers from a poisoned mutex: a panicking test
+  /// elsewhere must not cascade into unrelated failures here, and the
+  /// guarded data is `()`, so there is no broken invariant to inherit.
+  pub(crate) fn acquire() -> Self {
+    let lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    Self { _lock: lock, saved: Vec::new() }
+  }
+
+  /// Set `key` to `value`, remembering the prior value for restoration.
+  pub(crate) fn set(&mut self, key: &str, value: &str) {
+    self.saved.push((key.to_string(), std::env::var(key).ok()));
+    // SAFETY: `set_var` is `unsafe` in edition 2024 because a concurrent
+    // env read/write from another thread is a data race. We hold
+    // `env_lock` for the guard's whole lifetime, so no other env-mutating
+    // test in this binary runs concurrently, and Rust's internal
+    // `ENV_LOCK` covers `std::env::var` readers.
+    unsafe { std::env::set_var(key, value) };
+  }
+}
+
+impl Drop for EnvGuard {
+  fn drop(&mut self) {
+    // Reverse order, so repeated sets of one key unwind to the original.
+    for (key, old) in self.saved.drain(..).rev() {
+      match old {
+        // SAFETY: restoring a value this guard saved, still under
+        // `env_lock`; same rationale as `set`.
+        Some(v) => unsafe { std::env::set_var(&key, v) },
+        // SAFETY: removing a var this guard introduced; same rationale.
+        None => unsafe { std::env::remove_var(&key) },
+      }
+    }
+  }
+}
+
+/// A uniquely-named temporary directory that deletes itself on drop.
+///
+/// Unlike a fixed `env::temp_dir().join("some_test")`, the name embeds
+/// the pid and a monotonic counter, so concurrent `cargo test` runs (and
+/// concurrent tests within one run) never share a directory. `Drop` runs
+/// on the unwind path, so a failing assertion cleans up too — the reason
+/// `/tmp` used to fill with `latexml_graphics_dedupe_*` leftovers.
+pub(crate) struct TempDir {
+  path: PathBuf,
+}
+
+impl TempDir {
+  /// Create `<tmp>/latexml_post_<label>_<pid>_<n>`, failing loudly — a
+  /// test that cannot get its fixture directory must not continue.
+  pub(crate) fn new(label: &str) -> Self {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let path =
+      std::env::temp_dir().join(format!("latexml_post_{label}_{}_{n}", std::process::id()));
+    // A leftover from a recycled pid would otherwise leak stale files
+    // into this run's fixture.
+    let _ = std::fs::remove_dir_all(&path);
+    std::fs::create_dir_all(&path)
+      .unwrap_or_else(|e| panic!("could not create temp dir {}: {e}", path.display()));
+    Self { path }
+  }
+
+  pub(crate) fn path(&self) -> &Path { &self.path }
+
+  /// Path to `name` inside this directory.
+  pub(crate) fn join(&self, name: &str) -> PathBuf { self.path.join(name) }
+}
+
+impl Drop for TempDir {
+  fn drop(&mut self) {
+    // Best-effort: a failure to clean up must never mask the test's own
+    // outcome (and would double-panic during unwind).
+    let _ = std::fs::remove_dir_all(&self.path);
+  }
+}


### PR DESCRIPTION
Addresses issue 401.

## Diagnostic

**The `PATH` hypothesis is refuted.** `graphics.rs` holds the only `set_var("PATH")` in the workspace, and nothing removes the shim's directory from it. The shim was never invoked for a different reason.

`Graphics::process` routes every conversion through `graphics_cache`, which is **on by default** and content-addressed against a **host-persistent** root, `$XDG_CACHE_HOME/latexml-oxide/graphics`. The test's fake source is a fixed byte string, so its cache key is constant across runs. Direct proof — the key computed from those bytes (page 0, density 120, `png`) was sitting in the developer cache as a **1-byte** file, exactly the `printf x` the shim writes:

```
~/.cache/latexml-oxide/graphics/c9/c94cc22a4b00...960f.png   1 byte
```

The test was **self-poisoning**. Removing that entry and running twice shows the whole mechanism:

| run | result |
|---|---|
| entry removed, run 1 | **ok** — shim spawns, entry re-created |
| run 2 | **FAILED** — cache hit, no subprocess, no log, `NotFound` |

So on any machine that had ever run this test, it failed *permanently*, not intermittently.

What made it *look* flaky is the second half. `cache_root()` re-reads `LATEXML_GRAPHICS_CACHE_DIR` on every call, and `graphics_cache::tests::shared_cache_dir()` — in the same test binary, on another thread — points that variable at a fresh scratch dir. Whoever wins decides the outcome:

* full-target run: the cache-dir setter usually wins first → empty cache → miss → shim runs → **pass** (measured 20/20);
* single test (`--exact`): nothing sets the variable → persistent XDG root → hit → **fail** (measured 20/20).

CI passes on both platforms because a fresh runner's cache is empty. That fully accounts for "passes in full-suite runs, fails in others".

There is a second, independent race in the same test: the two "different options" jobs differ only in *destination name*. Same source bytes, page, density and extension ⇒ **same cache key**. They run on parallel workers, so even against a pristine cache, job two can be served from job one and produce one log line instead of two.

## Approach

Remove the process-global dependency rather than skip or serialise around it.

* **`graphics_cache::CachePolicy` (`Shared` | `Bypass`)** threaded explicitly through `with_cache_dims` / `with_cache`, and carried on `Graphics` via `with_cache_policy`. Production default is unchanged (`Shared`). The test selects `Bypass`, so nothing process-global — and no prior run's output — can decide whether its conversions actually run. This kills both races above.
* **The shim locates its own log via `$0`** instead of `LATEXML_FAKE_CONVERT_LOG` (the kernel hands a shebang script its resolved path), dropping one env var entirely.
* **`unwrap()` → explanatory panic**, so a future failure states what it means instead of printing `Os { code: 2 }`.
* **`test_env` module** (test-only): `EnvGuard` now holds a binary-wide lock across its whole set → use → restore window — closing the standing `FIXME` — and a RAII `TempDir` gives unique names and removes itself on the **panic** path. The remaining fixed-name `/tmp` paths in `graphics.rs` tests moved over too; those would collide between two concurrent `cargo test` runs.

Deliberately **not** a self-skip, per the hazard called out in CLAUDE.md and in the issue.

## Validation

Pass rate over 20 consecutive runs, same host, `-j 10`:

| | before | after |
|---|---|---|
| `--exact process_coalesces_only_matching_conversion_options` | **0 / 20** | **20 / 20** |
| full `-p latexml_post --lib` target | 20 / 20 | **20 / 20** |

The after-fix isolated runs were done with the poisoned cache entry **still present** — the first one passed before I removed it, which is the point.

Leaked temp dirs after the 40 post-fix runs: **0** (`/tmp/latexml_post_*`). The 71 pre-existing `/tmp/latexml_graphics_dedupe_*` and the bogus cache entry were cleaned up.

Full suite: **1743 passed / 0 failed** across 101 targets, `cargo test --tests --no-fail-fast` exiting **0** — the stated baseline, with this test now passing reliably. (Measured without a pipe: `cargo test … | tail` reports *`tail`'s* status, which is a false green.)

`tools/lint.sh` — the whole pre-push/CI gate — passes: `fmt --check`, workspace `clippy --all-targets -D warnings`, rustdoc `-D warnings`, the xml:id ratchet, vendored-native audit, `cargo-deny`, `cargo-machete`.

## Decisions & open questions

* **Why a policy argument and not `LATEXML_GRAPHICS_CACHE_OFF`?** That flag is memoised in a `OnceLock`, so whichever test touched it first would pin it for the whole binary and leak into the `graphics_cache` tests, which need the cache **on**. An argument is per-call and cannot leak.
* **`CachePolicy` is not test-only scaffolding.** It is the programmatic form of the existing `LATEXML_GRAPHICS_CACHE_OFF` kill-switch, and a reasonable knob for any caller wanting reproducible conversion behaviour.
* **The env lock is honest about its limits.** Rust's own `ENV_LOCK` already makes `set_var`/`var` safe against each other; what this lock adds is *ordering* across a test's whole window. It cannot serialise a `getenv` from a linked C library (libxml2, kpathsea). That residual is documented in `test_env.rs`, and is precisely why the cache is steered by an argument instead of an env var — correctness does not rest on the lock.
* **`graphics_cache::tests` still leaks `LATEXML_GRAPHICS_CACHE_DIR`** for the rest of the binary's life (it is set inside a `OnceLock` initialiser and never restored). That is now harmless, since no other test's correctness depends on the cache root, and I left it rather than widen this PR — noted in a comment at the site.
* **Not addressed here:** whether `Graphics::process` *should* dedupe two jobs that share a cache key but differ in destination. Today it converts twice and the cache may collapse them; that is a (beyond-Perl) efficiency question, not a correctness one, and changing it would change what this test asserts.
* Separately filed while reproducing an unrelated witness: issue 421 (`xparse`/`expl3` clobbers `\c`, so `Fran\c cois` renders `Fran0cois`) — Rust-only, Perl renders it correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
