### PR TITLE
fix(hyperref): \href in a Semiverbatim argument no longer expands forever

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -2528,3 +2528,62 @@ block, so the full author list survives in the body (max label on the witness
 `cluster_bib_long_author_list_refnum`. Candidate to upstream — the fix upstream is
 to route the refnum through the already-present `do_names_short` and stop
 skipping the first block.
+
+## 62. `\href` in a **Semiverbatim** argument expands forever (`doi = {\href{…}{…}}` hangs `latexmlc`)
+
+`hyperref.sty.ltxml` expands `\href` into a stream that re-emits `\href`:
+
+```perl
+DefMacro('\href HyperVerbatim {}', '\lx@hyper@url@\href{}{}{#1}{#2}');
+```
+
+The re-emitted `\href` exists only to fill `\lx@hyper@url@`'s reversion slot
+`#1` (`Undigested`), and is normally consumed as an argument without expanding.
+But `Core/Parameter.pm` L123-132 pre-expands a **semiverbatim** argument before
+digesting it —
+
+```perl
+# If semiverbatim, Expand (before digest), so tokens can be neutralized; BLECH!!!!
+while (defined(my $token = $gullet->getPendingComment || $gullet->readXToken(1))) {
+```
+
+— and `readXToken(1)` sets `$fully_expand = $toplevel = 1`, which by
+`Core/Gullet.pm` L408-409 expands even a `isProtected` definition. That pass
+linearizes tokens one at a time and never reaches `\lx@hyper@url@`'s parameter
+list, so `\lx@hyper@url@` is kept (a Constructor, not expandable) and the
+re-emitted `\href` is expanded again: `\href` → `\lx@hyper@url@\href{}{}…` →
+`\href` → … unbounded.
+
+Minimal trigger — a 7-line `.bib`, since `\bib@field@default@doi` reads
+`Semiverbatim` and INSPIRE exports DOIs wrapped in a link:
+
+```bibtex
+@article{K,
+  author = {Doe, Jane}, title = {{T}}, journal = {J}, year = {2021},
+  doi = {\href{https://doi.org/10.5281/zenodo.19852912}{10.5281/zenodo.19852912}},
+}
+```
+
+```latex
+\documentclass{article}\usepackage{hyperref}
+\begin{document}\cite{K}.\bibliographystyle{plain}\bibliography{thatfile}\end{document}
+```
+
+Measured same-host: `latexmlc` does not terminate — killed at 300 s (rc=124),
+`Status:conversion:3`. Perl `latexml` alone is unaffected only because it never
+reads the `.bib`; the loop is in the post-processing bibliography session.
+Witnesses arXiv 2605.00181, 2605.19650, 2606.06645 (each has exactly this
+`doi = {\href{…}{…}}`), which Perl `latexml` converts cleanly in 8-28 s.
+
+Related to entry 57 (`\save@bibitem`): both are a definition whose expansion
+names itself, surviving only where nothing re-expands it.
+
+**Fixed in Rust** in `hyperref_sty.rs` by putting the command NAME in the
+reversion slot as an OTHER-catcode token rather than the live control sequence —
+which is what the sibling `\url` path (`\lx@hyper@url`) already does
+(`Tokens!(cmd.as_other())`). Inert under every expansion regime, and it
+stringifies and reverts identically. Guard
+`href_in_semiverbatim_bib_field_does_not_loop`
+(`latexml_oxide/tests/59_href_semiverbatim_loop.rs`); the `\edef`/`\xdef` half of
+the same defect is guarded by `58_href_edef_loop.rs`. Candidate to upstream —
+the same one-token change applies to `hyperref.sty.ltxml`.

--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -2569,11 +2569,18 @@ Minimal trigger — a 7-line `.bib`, since `\bib@field@default@doi` reads
 \begin{document}\cite{K}.\bibliographystyle{plain}\bibliography{thatfile}\end{document}
 ```
 
-Measured same-host: `latexmlc` does not terminate — killed at 300 s (rc=124),
-`Status:conversion:3`. Perl `latexml` alone is unaffected only because it never
-reads the `.bib`; the loop is in the post-processing bibliography session.
-Witnesses arXiv 2605.00181, 2605.19650, 2606.06645 (each has exactly this
-`doi = {\href{…}{…}}`), which Perl `latexml` converts cleanly in 8-28 s.
+Measured same-host on an IDLE box (1-min load 4.5), as an A/B against the
+identical document with the `\href` removed from the `doi` field:
+
+| `latexmlc` on | wall | status |
+|---|---|---|
+| `doi = {10.5281/zenodo.19852912}` | **3.7 s** | `Status:conversion:0` |
+| `doi = {\href{https://doi.org/…}{…}}` | **439 s, killed (rc=124)** | `Status:conversion:3` |
+
+so it is a hang, not slowness. Perl `latexml` alone is unaffected only because
+it never reads the `.bib`; the loop is in the post-processing bibliography
+session. Witnesses arXiv 2605.00181, 2605.19650, 2606.06645 (each has exactly
+this `doi = {\href{…}{…}}`), which Perl `latexml` converts cleanly in 8-28 s.
 
 Related to entry 57 (`\save@bibitem`): both are a definition whose expansion
 names itself, surviving only where nothing re-expands it.

--- a/latexml_engine/src/tex_math.rs
+++ b/latexml_engine/src/tex_math.rs
@@ -1532,6 +1532,19 @@ LoadDefinitions!({
   // dispatches through the `\lx@generalized@over` constructor.
   // Driver for OOM regression: `\edef\theequation{$\binom{n}{m}$}`
   // from amsmath `\tag` (witness 2311.16416 proof.tex L287).
+  //
+  // KNOWN RESIDUAL: `protected` does NOT cover every forced expansion.
+  // `Parameter::digest` pre-expands a **Semiverbatim** argument with
+  // `fully_expand = true` (Perl `Core/Parameter.pm` L123-132 +
+  // `Core/Gullet.pm` L408-409), which expands protected macros by design —
+  // so the loop is still reachable there. Demonstrated:
+  // `doi = {10.1000/a \over b}` in a `.bib` (the `doi` field is read
+  // Semiverbatim) still runs away. The same defect in `\href` was closed by
+  // putting the command NAME in the reversion slot as an OTHER-catcode token
+  // instead of the live CS (`hyperref_sty.rs`, `KNOWN_PERL_ERRORS.md` #62);
+  // the identical one-token recipe applies here, and is left undone only
+  // because no corpus paper exercises it and these reversions are pinned by
+  // the math `tex=` goldens.
   DefMacro!(
     "\\above Dimension",
     "\\lx@generalized@over{\\above #1}{meaning=divide,thickness=#1}",

--- a/latexml_oxide/tests/59_href_semiverbatim_loop.rs
+++ b/latexml_oxide/tests/59_href_semiverbatim_loop.rs
@@ -1,0 +1,64 @@
+//! `\href` inside a **Semiverbatim** argument must not infinite-loop.
+//!
+//! The other half of the defect [`58_href_edef_loop`](../58_href_edef_loop.rs)
+//! guards. LaTeXML expands `\href{u}{t}` to
+//! `\lx@hyper@url@\href{}{}{u}{t}` — the re-emitted `\href` exists only to fill
+//! the constructor's reversion slot `#1`. PR "href protected" stopped the
+//! `\edef`/`\xdef` re-expansion by marking `\href` `protected`, but ONE seam
+//! legitimately expands protected macros: `Parameter::digest`'s semiverbatim
+//! pre-expansion (Perl `Core/Parameter.pm` L123-132, "If semiverbatim, Expand
+//! (before digest), so tokens can be neutralized") reads with
+//! `fully_expand = true` (Perl `Core/Gullet.pm` L408-409). That pass linearizes
+//! tokens one at a time and never reaches `\lx@hyper@url@`'s parameter list, so
+//! it expanded the re-emitted `\href` as an ordinary macro — forever.
+//!
+//! Reached from a `.bib`: `\bib@field@default@doi` reads `Semiverbatim`, and
+//! INSPIRE exports DOIs as `doi = {\href{https://doi.org/…}{…}}`. Witnesses
+//! 2605.00181, 2605.19650, 2606.06645 — all three took
+//! `Fatal:Timeout:Recursion` ("a window of 6 token(s) repeated 100+ times")
+//! during the recursive bibliography session and lost the whole bibliography;
+//! the fatal aborted the document. Perl `latexmlc` **hangs** on the same input
+//! (rc=124 after 300 s on the 7-line reproducer), so this is a shared upstream
+//! bug — see `docs/parity/KNOWN_PERL_ERRORS.md`.
+//!
+//! Fix: the reversion slot carries the command NAME as an OTHER-catcode token
+//! instead of the live control sequence, exactly as the sibling `\url` path
+//! (`\lx@hyper@url`) has always done. Inert to every expansion regime, and
+//! stringifies/reverts identically — so the self-reference is structurally
+//! impossible rather than dependent on a flag one seam is entitled to ignore.
+mod cluster;
+use cluster::convert_and_post_clean;
+
+/// The runaway manifested as a `Fatal:` with no bibliography at all;
+/// `convert_and_post_clean` asserts zero POST-stage `Error:` markers, which is
+/// where the recursive `.bib` session reports (a core-only guard was blind to
+/// this — see the helper's doc).
+#[test]
+fn href_in_semiverbatim_bib_field_does_not_loop() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_href_in_identifier_field.tex");
+
+  // Both entries must survive. Before the fix the session died on the first
+  // one and `MakeBibliography` fell back to no bibliography whatsoever.
+  assert!(
+    x.contains("<bibitem") || x.contains("bibitem"),
+    "no bibliography at all — the \\href expansion loop likely re-triggered:\n{x}"
+  );
+  for needle in ["A Paper With A Wrapped DOI", "A Flux Concentrator"] {
+    assert!(
+      x.contains(needle),
+      "{needle:?} missing from the bibliography:\n{x}"
+    );
+  }
+  // The DOI field still produces its identifier element — the fix must not
+  // have silenced the runaway by dropping the field. (What the identifier
+  // *reads* is a separate, pre-existing matter: a link macro inside a
+  // Semiverbatim field stringifies with its command name, and `\url` in the
+  // same position has always done the same. Not asserted here.)
+  // `MakeBibliography` rewrites `ltx:bib-identifier[@scheme='doi']` into the
+  // entry's external link, so the surviving marker in POST output is the
+  // `dx.doi.org` href it builds.
+  assert!(
+    x.contains("dx.doi.org"),
+    "the wrapped DOI field produced no doi link:\n{x}"
+  );
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_href_in_identifier_field.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_href_in_identifier_field.bib
@@ -1,0 +1,29 @@
+% Witnesses: arXiv 2605.00181, 2605.19650, 2606.06645 — three JHEP/JCAP/JINST
+% papers whose INSPIRE-exported `.bib` wraps the DOI in an `\href`. Every one
+% took `Fatal:Timeout:Recursion` ("Infinite expansion loop: a window of 6
+% token(s) repeated 100+ times") and lost its whole bibliography.
+%
+% `\bib@field@default@doi` reads its value `Semiverbatim`, and
+% `Parameter::digest` pre-expands a semiverbatim argument with
+% `fully_expand = true` (Perl `Core/Parameter.pm` L123-132). That linearizing
+% pass expanded `\href`, whose body re-emits `\href` for the
+% `\lx@hyper@url@` reversion slot — so it expanded again, forever.
+@article{HrefDoi2021,
+  author  = {Doe, Jane and Roe, Richard},
+  title   = {{A Paper With A Wrapped DOI}},
+  journal = {J. Testing},
+  volume  = {27},
+  pages   = {13401},
+  doi     = {\href{https://doi.org/10.5281/zenodo.19852912}{10.5281/zenodo.19852912}},
+  year    = {2021},
+}
+
+% The same shape in `booktitle` — a Digested field rather than a Semiverbatim
+% one, so it never looped; it is here to keep the two paths side by side.
+@inproceedings{HrefBooktitle2021,
+  author    = {Enomoto, Yoshinori},
+  title     = {{A Flux Concentrator}},
+  booktitle = {\href{https://jacow.org/ipac2021/papers/wepab144.pdf}{Proc. IPAC'21}},
+  pages     = {2954-2956},
+  year      = {2021},
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_href_in_identifier_field.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_href_in_identifier_field.tex
@@ -1,0 +1,9 @@
+% `\href` inside a Semiverbatim `.bib` field must not expand forever.
+% See bib_href_in_identifier_field.bib for the witnesses and the mechanism.
+\documentclass{article}
+\usepackage{hyperref}
+\begin{document}
+Wrapped DOI \cite{HrefDoi2021}, wrapped booktitle \cite{HrefBooktitle2021}.
+\bibliographystyle{plain}
+\bibliography{bib_href_in_identifier_field}
+\end{document}

--- a/latexml_package/src/package/hyperref_sty.rs
+++ b/latexml_package/src/package/hyperref_sty.rs
@@ -344,11 +344,62 @@ LoadDefinitions!({
   // expands exactly as before — only edef-family contexts defer it.
   // Witness 2110.10227 (ems-journal.sty `\Emsaffil`→`\build@ffil`'s
   // `\xdef\ems@temp{…\href{mailto:…}{\mbox{…}}…}`).
-  DefMacro!(
-    "\\href HyperVerbatim {}",
-    "\\lx@hyper@url@\\href{}{}{#1}{#2}",
-    protected => true
-  );
+  //
+  // The `protected` flag alone is NOT enough, because one seam legitimately
+  // expands protected macros: `Parameter::digest`'s semiverbatim
+  // pre-expansion (`parameter.rs`, Perl `Core/Parameter.pm` L123-132 —
+  // "If semiverbatim, Expand (before digest), so tokens can be neutralized")
+  // calls `readXToken` with `$toplevel=1`, hence `fully_expand=1`, hence
+  // protected macros DO expand there (Perl `Core/Gullet.pm` L408-409). That
+  // pass linearizes tokens one at a time and never reaches
+  // `\lx@hyper@url@`'s parameter list — `\lx@hyper@url@` is a Constructor, so
+  // it is kept as-is and the next token read is the re-emitted `\href`, which
+  // expands again. Rust matches Perl at that seam, so the flag cannot be the
+  // fix.
+  //
+  // So the reversion slot carries the command NAME rather than the live
+  // command: an OTHER-catcode `\href` is inert to every expansion regime
+  // while stringifying and reverting exactly as the control sequence did.
+  // This is what the sibling `\url` path (`\lx@hyper@url` below) has always
+  // done — `Tokens!(cmd.as_other())` — so the two now agree, and the
+  // self-reference is structurally impossible rather than flag-dependent.
+  //
+  // Witnesses: `doi = {\href{https://doi.org/…}{…}}` in a `.bib` reaches
+  // `\bib@field@default@doi Semiverbatim` and looped until the gullet cycle
+  // guard fired — 2605.00181, 2605.19650, 2606.06645 (all
+  // `Fatal:Timeout:Recursion`, bibliography lost, document aborted). Perl
+  // `latexmlc` HANGS on the same input, so this is a shared upstream bug
+  // (`KNOWN_PERL_ERRORS.md`). Guard:
+  // `latexml_oxide/tests/59_href_semiverbatim_loop.rs`.
+  //
+  // Kept as a Token body (not a closure) so the definition still serializes
+  // into a dump (CLAUDE.md strict-LoadFormat rule 3); `T_OTHER!` is the only
+  // thing a `DefMacro!` string literal cannot spell.
+  {
+    let (href_cs, href_params) = parse_prototype("\\href HyperVerbatim {}", true)?;
+    def_macro(
+      href_cs,
+      href_params,
+      ExpansionBody::Tokens(Tokens!(
+        T_CS!("\\lx@hyper@url@"),
+        T_OTHER!("\\href"),
+        T_BEGIN!(),
+        T_END!(),
+        T_BEGIN!(),
+        T_END!(),
+        T_BEGIN!(),
+        T_ARG!(1),
+        T_END!(),
+        T_BEGIN!(),
+        T_ARG!(2),
+        T_END!()
+      )),
+      Some(ExpandableOptions {
+        protected: true,
+        ..ExpandableOptions::default()
+      }),
+    )?;
+  }
 
   // \XeTeXLinkBox{content} — hyperref.sty L4915/4947 wraps content in
   // a XeTeX hyperlink target box. We don't model XeTeX-specific link


### PR DESCRIPTION
## Diagnostic

Three of the four probed runaway papers — `2605.00181`, `2605.19650`, `2606.06645` —
share **one** cause, which is why their wall times were near-identical: each burns the
same fixed cycle-guard budget on the same loop.

Their `.bib` files have exactly one thing in common: an INSPIRE-style
`doi = {\href{https://doi.org/…}{…}}`. `\bib@field@default@doi` reads its value
**`Semiverbatim`**, and `Parameter::digest` pre-expands a semiverbatim argument before
digesting it (Perl `Core/Parameter.pm` L123-132, *"If semiverbatim, Expand (before
digest), so tokens can be neutralized; BLECH!!!!"*) with `readXToken(1)` →
`fully_expand = 1`, which by Perl `Core/Gullet.pm` L408-409 expands **even a protected**
definition.

`\href` expands to `\lx@hyper@url@\href{}{}{#1}{#2}` — the re-emitted `\href` exists only
to fill `\lx@hyper@url@`'s `Undigested` reversion slot. That pre-expansion pass linearizes
tokens one at a time and never reaches the constructor's parameter list: `\lx@hyper@url@`
is a Constructor (not expandable) so it is kept, the next token read is the re-emitted
`\href`, and it expands again. The gullet cycle guard names it exactly:

```
[debug-fatal] last 512 read tokens: … "\lx@hyper@url@" "\href" "{" "}" "{" "}" "\lx@hyper@url@" "\href" …
Fatal:Timeout:Recursion  Infinite expansion loop: a window of 6 token(s) repeated 100+ times
```

`\href` was already marked `protected` for the `\edef`/`\xdef` half of this defect
(`58_href_edef_loop.rs`). This is the half that flag cannot reach — and Rust matches Perl
at that seam, so the flag was never going to be the fix.

**Minimal reproducer:** a 7-line `.bib` with one `doi = {\href{…}{…}}` field.

**Same-host Perl classification.** Perl `latexml` converts all three papers cleanly
(3 warnings / no problems / 2 warnings) only because it never reads the `.bib`; the loop
lives in the post-processing bibliography session. Perl **`latexmlc`** hangs, verified as
an A/B on the same box — the *identical* document with the `\href` removed from the `doi`
field completes in **3.7 s** (`Status:conversion:0`), while the `\href` version does not
finish (rc=124, `Status:conversion:3`). Shared upstream bug, recorded as
`KNOWN_PERL_ERRORS.md` #62, candidate to upstream.

The fourth paper, `2605.16752` (`Fatal:Timeout:TokenLimit`), is a **different** cause and
**parity**: its token ring shows a `pgfkeys`/`pgfplots` `compat` key grind (aperiodic —
which is why it reaches the 400 M token limit rather than the cycle guard), it contains no
`\href` at all, and same-host Perl did not finish it within 900 s. Unchanged by this PR
(12.9 s → 12.9 s, byte-identical diagnostic), and left alone.

## Approach

Put the command **name** in the reversion slot instead of the live command: an
OTHER-catcode `\href` is inert to every expansion regime while stringifying and reverting
identically. This is what the sibling `\url` path (`\lx@hyper@url`) has always done —
`Tokens!(cmd.as_other())` — so the two now agree and the self-reference is *structurally*
impossible rather than dependent on a flag one seam is entitled to ignore.

No limit was raised and no diagnostic suppressed. Kept as a Token body (not a closure) so
the definition still serializes into a dump (CLAUDE.md strict-`LoadFormat` rule 3);
`T_OTHER!` is the only piece a `DefMacro!` string literal cannot spell.

## Validation

> **On measurement.** Most of this session ran at load ≈110 (a 30 k-paper `cortex_worker`
> fleet plus sibling builds). The timings below were **re-taken after the box drained, at
> 1-min load 6-8, strictly serial**. The load-*independent* evidence — the limit
> diagnostics (`Recursion`/`TokenLimit` count expansions, not seconds), error counts,
> bibitem counts, byte-identical XML, the corpus scan, the suite — is what the claims rest
> on; the durations are corroboration. For the record, the loaded and idle runs gave the
> same verdicts and durations within ~40 % (e.g. 2605.00181 before: 8.6 s loaded, 6.3 s
> idle), and a contention-matched paired run (alternating before/after, 3 repeats) was
> consistent to ±0.1 s per arm.

Exhaustive scan of the trigger across `2605`+`2606` (60,513 papers, 44,189 with a `.bib`)
found **7** carriers. All 7 recover.

Idle box, serial, `--release`, `--timeout 420`:

| paper | before | after |
|---|---|---|
| 2605.00181 | `Fatal:Timeout:Recursion`, 1 error, **0** bibitems, 6.3 s | clean, 0 errors, **95** bibitems, 1.1 s |
| 2605.19650 | `Fatal:Timeout:Recursion`, 1 error, **0** bibitems, 6.2 s | clean, 0 errors, **18** bibitems, 0.3 s |
| 2606.06645 | `Fatal:Timeout:Recursion`, 1 error, **0** bibitems, 6.4 s | clean, 0 errors, **88** bibitems, 0.8 s |
| 2605.16752 | `Fatal:Timeout:TokenLimit`, 12.9 s | **unchanged** — different cause, parity |

The other three carriers (measured during the busy window; verdicts, not durations):

| paper | before | after |
|---|---|---|
| 2606.23410 | `Fatal`, 1 error, 0 bibitems | clean, 0 errors, **134** bibitems |
| 2605.26213 | killed at the 60 s wall-clock watchdog | clean, 0 errors, **141** bibitems |
| 2605.08971 | killed at the 60 s wall-clock watchdog | clean, 0 errors |
| 2605.22440 | killed at the 60 s wall-clock watchdog | clean, 0 errors, **79** bibitems (with `--timeout 420`) |

Error counts 1 → 0 on every recovered paper. Nothing was lowered by suppressing a
diagnostic: the fatals are gone because the loop is gone, and the bibliographies that were
lost are back.

Output-neutral (no timing involved): `hypertest`, `hyperchars`, `url`, `urls`, `orc`,
`amsrefs_basic` and `hyperurls` all produce **byte-identical** XML before and after.

- New guard `59_href_semiverbatim_loop.rs` + `bib_href_in_identifier_field.{tex,bib}`,
  **red-verified** against the pre-fix binding (fails with the exact runaway signature —
  `Error:bibliography:convert … token_limit … infinite loop?`) and green after. It uses
  `convert_and_post_clean`, so it gates the POST stage where the recursive `.bib` session
  reports; a core-only guard is blind here.
- `cargo test --tests --no-fail-fast`: **1744 passed / 0 failed** (baseline 1743 + this
  guard).
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all` clean.

## Decisions & open questions

- **Why the binding and not the engine.** The obvious alternative is to make
  `Parameter::digest`'s semiverbatim pre-expansion pass `fully_expand = false`. Rejected:
  Rust is a faithful translation of Perl there (`readXToken(1)` ⇒ `$fully_expand = 1`), it
  is a hot shared seam, and a macro whose expansion names itself has no fixpoint under
  *any* full-expansion pass. The defect is the self-reference, not the seam.

- **Known residual, same shape, deliberately not fixed:** `\over` / `\atop` / `\above` /
  `\choose` / `\brace` / `\brack` / `\Sb` / `\Sp` all expand to
  `\lx@generalized@over{\over}{…}` — a Constructor with an `Undigested` reversion slot
  holding the live CS, i.e. the identical shape. Demonstrated live:
  `doi = {10.1000/a \over b}` in a `.bib` still runs away today. Not fixed here because no
  corpus paper exercises it (the exhaustive scan found zero) and those reversions are
  pinned by the math `tex=` goldens, so the change deserves its own measured PR. The
  comment in `tex_math.rs` claimed `protected` covered this family; it now records the
  hole and the one-token recipe that closes it.

- **Cosmetic residual, out of scope:** a link macro inside a Semiverbatim identifier field
  stringifies with its command name, so the recovered DOI reads
  `dx.doi.org/%5Chrefhttps%3A//doi.org/…`. Pre-existing and not specific to `\href` — the
  already-shipping `\url` in the same field produces `%5Curl%7B…%7D`. The guard therefore
  asserts the identifier *survives*, not what it reads.

- **Found in passing, not touched:** `2605.08971` converts cleanly now but reports
  `38 bibentries, 0 cited` despite 60 `\cite` calls — `isprs.cls` swallows them in the CORE
  stage (0 `<ltx:cite>`). Core output is byte-identical before/after this change, so it is
  pre-existing and belongs to the citation-registration family.

- **The 85/87/87 s from the original probe are not reproduced here** — this binary trips
  the cycle guard at ~6 s idle. Same diagnostic, same window of 6 tokens; the gap is
  binary/profile (the fleet's `cortex_worker` carries extra memory guards), not behaviour.
  Worth a glance if the fleet baseline matters, but it does not change the verdict.
