### PR TITLE
An \ext@arrow mkern amount may be braced; the rest of the unclosed-math cluster is Perl's too

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -2594,3 +2594,74 @@ stringifies and reverts identically. Guard
 (`latexml_oxide/tests/59_href_semiverbatim_loop.rs`); the `\edef`/`\xdef` half of
 the same defect is guarded by `58_href_edef_loop.rs`. Candidate to upstream —
 the same one-token change applies to `hyperref.sty.ltxml`.
+
+---
+
+## 63. An unclosed math region swallows the rest of the document — in BOTH engines
+
+**Symptom.** One macro-level breakage inside `$…$` / `\[…\]` / an
+`align`-family body leaves the math group open. Digestion never returns to text
+mode, so every following `_`, `^`, `&`, `\end{…}` and section break is an error
+and the whole remainder of the document lands inside a single `<ltx:XMath>` — the
+leak surfaces in `<ltx:title>`, `<ltx:tag>`, `<ltx:proof>`. The engine then hits
+its `too_many_errors` circuit breaker and produces no document at all.
+
+**This is shared, not a Rust regression.** Classified 2026-07-27 against
+same-host Perl 0.8.8 (`/usr/local/bin/latexml`, verbose — never `--quiet` —
+`--preload=ar5iv.sty --path=ar5iv-bindings/bindings`, the fleet's ar5iv
+profile, each paper's cortex-chosen main file). **At shipped defaults Perl goes
+`Fatal:too_many_errors` on all eleven witnesses**, at 101 errors + the fatal;
+we go fatal at 1001 + the fatal, because `tikz.sty` raises our `MAX_ERRORS` to
+1000 while Perl's `Core/State.pm` L96 default of 100 has no override anywhere in
+its tree. Same severity, same outcome, different amount of diagnostics on the way
+down.
+
+Lifting both caps (Perl: a preloaded binding doing
+`AssignValue('MAX_ERRORS'=>100000)`; Rust: a throwaway patch to the two circuit
+breakers in `common/error.rs`) shows the flood itself is the same flood — same
+first error, same classes, frequently the same counts:
+
+| witness | Perl uncapped | Rust uncapped | first error (both engines, same site) |
+|---|---|---|---|
+| 2605.03113 | 1956 | 1953 | `undefined:\overarrow@` — amsmath internal behind a hand-rolled `\overrightharpoon` via `\mathpalette` |
+| 2605.05934 | 4211¹ | 3604 | `\lx@begin@alignment` in math — mhchem `\ce{}` inside a `\bea`/`\eea` alignment (see also #53) |
+| 2605.07772 | 100002² | 2040 | `undefined:\usephysicsmodule` (physics2) |
+| 2605.09261 | 926³ | 1079 | custom tikz `diagram` env inside `align*` |
+| 2605.11190 | 19984 | 1159 | `\input` of a tikz `\matrix` whose cells carry `$…$`, inside `align*` |
+| 2605.12930 | 2842 | 1097 | tikz-cd "Diagrams cannot be nested" |
+| 2605.15522 | 614 | OOM⁴ | mathtools `\DeclarePairedDelimiterX` starred form spanning lines |
+| 2605.15678 | 1976¹ | 2024 | `undefined:\nin`; author `\def\({\left(}` `\def\){\right)}` |
+| 2605.23308 | 1055 | OOM⁴ | `\g{c}{summ}` custom macro inside `align*` |
+| 2605.30732 | 1137 | 1173 | `\brackets{…}` group leak inside `equation*` |
+| 2606.01903 | 258 | 1810 | `undefined:\ext@arrow` — **the one Rust-only case, see below** |
+
+¹ killed at the harness timeout, count is a floor. ² hit the raised cap.
+³ Perl ends in `Fatal:perl:deep_recursion` rather than finishing.
+⁴ with the circuit breaker removed the runaway exhausts RAM and is SIGKILLed —
+which is what the breaker exists to prevent.
+
+Two rows are worth reading as exact matches rather than "same order of
+magnitude". 2605.05934, uncapped on both sides: `XMHint` 260,
+`\lx@end@inline@math` 189, `unexpected:_` 71, `bibitem` 64,
+`\lx@begin@alignment` 45 — five classes identical, and the same first error at
+the same line:col. 2605.23308, our *capped* run against Perl uncapped:
+`unexpected:_` 160 = 160, `unexpected:^` 104 = 104, `\lx@begin@alignment`
+54 = 54 — i.e. we saturate before we can diverge.
+
+**The one exception, fixed:** `2606.01903` was GENUINE-RUST-ONLY. Perl has no
+`\ext@arrow` binding at all, so it errors once and recovers; we bind it, and the
+binding read four of its seven undelimited arguments as `Token`, splitting
+`extpfeil`'s braced `\mkern` amount `{40}` and spilling a `}` that closed the
+display math. Fixed (OXIDIZED_DESIGN #81, guard
+`06_cluster_math::cluster_ext_arrow_braced_mkern`): 1002 errors + fatal → **0**.
+Grepping the 536 currently-fatal 2605+2606 papers for
+`ext@arrow|extpfeil|newextarrow` found one more of the same shape, 2606.14212
+(`\xtwoheadrightarrow` in an `align*`): 194 errors + fatal → **0**, against 3
+in Perl.
+
+**Not to be "fixed" into a divergence.** The remaining ten need their individual
+undefined internals (`\overarrow@`, `\underarrow@`, `\usephysicsmodule`, …)
+implemented before the math can close — each of those is a capability Perl also
+lacks, so adding them is beyond-Perl work, not parity work. Do not mistake the
+1000-vs-100 error-cap difference for a divergence: it is a diagnostics budget,
+and both engines fail these papers.

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2848,6 +2848,40 @@ Guards (`pre_bibtex.rs`): `filter_digests_only_the_cited_entries`,
 `filter_tolerates_a_cited_key_with_no_entry`, `no_filter_digests_every_entry`,
 `cite_key_scanner_handles_the_cite_family`.
 
+### 81. amsmath's `\ext@arrow` / `\arrowfill@` internals get bindings Perl does not have
+
+**Perl behaviour.** `LaTeXML/lib/LaTeXML/Package/amsmath.sty.ltxml` binds the
+*public* extensible arrows (`\xrightarrow`, `\xleftarrow`, …) as constructors and
+never defines the internals they are built from. `\ext@arrow` (amsmath.sty L1012,
+`\def\ext@arrow#1#2#3#4#5#6#7`) and `\arrowfill@` (L971, `\def\arrowfill@#1#2#3#4`)
+are therefore **undefined** in Perl in every configuration that does not raw-load
+`amsmath.sty` itself. Any package or preamble that builds its own arrow on top of
+them — `extpfeil.sty`'s `\newextarrow`, `mathtools`' `\xhookrightarrow`, a
+hand-rolled `\newcommand*{\xfoo}[2][]{\ext@arrow …}` — hits
+`Error:undefined:\ext@arrow` plus `Error:undefined:\arrowfill@`, and the arrow's
+own arguments then leak into the surrounding math as text.
+
+**We define both** (`latexml_package/src/package/amsmath_sty.rs`), passing through
+to `\to^{above}_{below}` and `\to` respectively — we do not model stretchy arrow
+rendering, but the arity is what the binding is for. Witnesses 2411.17873 and
+2412.00464 (amsmath's own `\ext@arrow 0359\rightarrowfill@…`), 1308.1071
+(`extpfeil`'s `\xmapsto`), 2606.01903 (`extpfeil`'s `\xtwoheadleftarrow`). On
+2606.01903 this is the whole difference between the two engines: same-host Perl
+0.8.8, verbose, ar5iv profile, reports **258 errors** with `MAX_ERRORS` lifted
+(and `Fatal:too_many_errors` at 102 with the shipped cap of 100); we report **0**.
+
+**The parameters are TeX undelimited arguments, all of them.** Each `#n` of a
+plain `\def` reads a single token OR a balanced `{…}` group. Spelling any of them
+`Token` in the parameter spec reads only the opening `{` of a braced argument and
+spills the remainder — including its closing `}` — back into the stream, where the
+stray `}` closes the enclosing math group and everything after it is swallowed
+into the leaked `<ltx:XMath>`. The braced form is not exotic: `\newextarrow`
+expands to `\ext@arrow #2{\arrowfill@#3}{##1}{##2}`, and the `\mkern` quadruple
+`#2` is only four bare digits when every amount is a single digit —
+`\newextarrow{\xtwoheadleftarrow}{500{40}}{…}` braces the 40. So all seven
+parameters of `\ext@arrow` and all four of `\arrowfill@` are `{}`. Guard
+`06_cluster_math::cluster_ext_arrow_braced_mkern`.
+
 ## Known Upstream Perl Issues (brief)
 
 These are behaviors in the original Perl LaTeXML that are bugs or limitations, not

--- a/latexml_oxide/tests/06_cluster_math.rs
+++ b/latexml_oxide/tests/06_cluster_math.rs
@@ -238,3 +238,31 @@ fn cluster_hdotsfor_columns() {
     "expected 3 + 2 dots cells, got:\n{x}"
   );
 }
+/// amsmath's `\def\ext@arrow#1#2#3#4#5#6#7` (and `\arrowfill@#1#2#3#4`) take
+/// plain TeX undelimited arguments — a single token OR a balanced group. Our
+/// binding spelled the first four `Token`, which reads only the opening `{` of
+/// a braced argument and spills the rest, including its `}`, back into the
+/// stream; the stray `}` then closes the enclosing display math and everything
+/// after it is swallowed into the leaked `<ltx:XMath>`. extpfeil.sty's
+/// `\newextarrow{\xtwoheadleftarrow}{500{40}}{…}` is exactly that shape — an
+/// `\mkern` amount of 40 has to be braced. Witness arXiv 2606.01903 (Perl,
+/// which defines no `\ext@arrow` at all, reports 258 errors; we ran into the
+/// 1000-error cap). Red without the fix: `Error:unexpected:} Attempt to close a
+/// group that switched to mode display_math`, and the `\simeq` above-label is
+/// replaced by a `0` SUBscript scavenged from the leaked `{40}`.
+#[test]
+fn cluster_ext_arrow_braced_mkern() {
+  let x = convert_to_xml("tests/cluster_regressions/ext_arrow_braced_mkern.tex");
+  assert!(
+    x.contains(r#"<XMApp role="POSTSUPERSCRIPT""#) && x.contains(r#"name="simeq""#),
+    "the \\ext@arrow above-label must survive as a superscript on the arrow:\n{x}"
+  );
+  assert!(
+    !x.contains(r#"<XMApp role="POSTSUBSCRIPT""#),
+    "a POSTSUBSCRIPT here means the braced `{{40}}` mkern amount leaked into the math:\n{x}"
+  );
+  assert!(
+    x.contains("<p>Text after the display must survive.</p>"),
+    "text after the display must stay OUTSIDE the math, in its own paragraph:\n{x}"
+  );
+}

--- a/latexml_oxide/tests/cluster_regressions/ext_arrow_braced_mkern.tex
+++ b/latexml_oxide/tests/cluster_regressions/ext_arrow_braced_mkern.tex
@@ -1,0 +1,18 @@
+\documentclass{article}
+\usepackage{amsmath}
+\makeatletter
+% Exactly what extpfeil.sty's \newextarrow generates:
+%   \newcommand*{#1}[2][]{\ext@arrow #2{\arrowfill@#3}{##1}{##2}}
+% for \newextarrow{\xtwoheadleftarrow}{500{40}}{\relbar\relbar\relbar}.
+% The FOURTH \mkern amount is the braced group `{40}` (an amount >= 10 has
+% to be braced), and the arrow renderer's own first argument is braced too.
+% Both are plain TeX undelimited arguments of \ext@arrow / \arrowfill@.
+\newcommand*{\xtwoheadleftarrowish}[2][]{%
+  \ext@arrow 500{40}{\arrowfill@{\relbar\relbar}\relbar\relbar}{#1}{#2}}
+\makeatother
+\begin{document}
+\[
+  A \xtwoheadleftarrowish{\simeq} B
+\]
+Text after the display must survive.
+\end{document}

--- a/latexml_package/src/package/amsmath_sty.rs
+++ b/latexml_package/src/package/amsmath_sty.rs
@@ -583,28 +583,37 @@ LoadDefinitions!({
     "\\lx@long@arrow{\\xrightarrow}{\\lx@stretchy@rightarrow}"
   );
 
-  // amsmath.sty L1013: \ext@arrow #1#2#3#4#5#6#7 — the internal extension-arrow
-  // builder. Args: #1..#4 are mkern digit-tokens, #5 is the arrow renderer
-  // CS (e.g. \rightarrowfill@) OR a `{...}` group (extpfeil's
-  // \newextarrow generates `\ext@arrow #2{\arrowfill@#3}{...}{...}`
-  // where `{\arrowfill@#3}` is a braced group), #6 is below-label,
-  // #7 is above-label. Use `{}` for the 5th arg so it reads either
-  // a single token OR a balanced group (TeX-semantic `#5` —
-  // matches Perl `\def\ext@arrow#1#2#3#4#5#6#7`).
-  // User code occasionally calls \ext@arrow directly when defining custom
-  // arrows. Pass-through to plain \to^{above}_{below} so the math renders.
-  // amsmath.sty L972: \arrowfill@ #1#2#3#4 — 4 CS tokens; we don't model
-  // stretchy arrow rendering, stub as \to.
-  // Witness 2411.17873, 2412.00464 (amsmath's own arrows);
-  // 1308.1071 (extpfeil's \xmapsto = `\ext@arrow 0599{\arrowfill@
-  // {\mapstochar\relbar}\relbar\rightarrow}{a}{f}` — `Token` for
-  // arg 5 read only the `{` and left the rest as unmatched group,
-  // crashing display math with "Attempt to end mode display_math").
+  // amsmath.sty L1012: `\def\ext@arrow#1#2#3#4#5#6#7` — the internal
+  // extension-arrow builder. #1..#4 are the four `\mkern` amounts, #5 the
+  // arrow renderer, #6 the below-label, #7 the above-label.
+  // amsmath.sty L971: `\def\arrowfill@#1#2#3#4` — the stretchy-arrow renderer.
+  // User code calls both directly when defining custom arrows; we don't model
+  // stretchy rendering, so pass through to plain `\to^{above}_{below}` / `\to`.
+  //
+  // EVERY parameter of both is a plain TeX undelimited argument: it reads a
+  // single token OR a balanced `{...}` group. Spelling any of them `Token`
+  // reads only the opening `{` of a braced argument and spills the remainder
+  // (including its closing `}`) back into the stream, where the stray `}`
+  // closes the enclosing math group and the rest of the document is swallowed
+  // into the leaked `<ltx:XMath>`. So all seven / all four are `{}`.
+  //
+  // The braced form is what extpfeil.sty's `\newextarrow` generates:
+  //   \newcommand*{#1}[2][]{\ext@arrow #2{\arrowfill@#3}{##1}{##2}}
+  // with `#2` an mkern quadruple that is NOT always four single digits —
+  // `\newextarrow{\xtwoheadleftarrow}{500{40}}{…}` makes #4 the group `{40}`
+  // (an mkern amount ≥ 10 has to be braced), and `{\arrowfill@#3}` makes #5 a
+  // group whose own first argument may be braced in turn
+  // (`\arrowfill@{\mapstochar\relbar}\relbar\rightarrow`).
+  // Witnesses: 2411.17873, 2412.00464 (amsmath's own `0359`/`3095` arrows);
+  // 1308.1071 (extpfeil `\xmapsto`, arg 5); 2606.01903 and 2606.14212
+  // (extpfeil `\xtwoheadleftarrow`/`\xtwoheadrightarrow`, arg 4 — 258 and 3
+  // errors in Perl, which has no `\ext@arrow` at all, vs a 1000-error runaway
+  // and a 194-error one here).
   DefMacro!(
-    "\\ext@arrow Token Token Token Token {}{}{}",
+    "\\ext@arrow {}{}{}{}{}{}{}",
     "{\\mathrel{\\to}\\@ifnotempty{#7}{^{#7}}\\@ifnotempty{#6}{_{#6}}}"
   );
-  DefMacro!("\\arrowfill@ Token Token Token Token", "\\to");
+  DefMacro!("\\arrowfill@ {}{}{}{}", "\\to");
   DefMacro!("\\rightarrowfill@", "\\rightarrow");
   DefMacro!("\\leftarrowfill@", "\\leftarrow");
   DefMacro!("\\leftrightarrowfill@", "\\leftrightarrow");


### PR DESCRIPTION
## Diagnostic

The `too_many_errors` cluster whose signature is *an unclosed math region swallows the rest of the document* (the leak surfacing in `<ltx:title>`, `<ltx:tag>`, `<ltx:proof>`) had never been classified against Perl. It has now been, and it is **ten parts parity, one part ours**.

The live fleet rerun is on this exact `main` (`git_sha 01e1ea5a94` in the result telemetry), so the cluster was re-derived from the on-disk result zips rather than the cortex DB, which lags a run in progress. Eleven papers reach the 1000-error cap with this signature: `2605.{03113,05934,07772,09261,11190,12930,15522,15678,23308,30732}` and `2606.01903`. All eleven reproduce locally at 1002 (= 1001 errors + the fatal).

**At shipped defaults Perl fails all eleven too.** Same-host `/usr/local/bin/latexml` 0.8.8, verbose (never `--quiet`), `--preload=ar5iv.sty --path=ar5iv-bindings/bindings`, each paper's cortex-chosen main file: every one ends `rc=1`, 101 errors + `Fatal:too_many_errors`. Our number is 1001 + fatal only because `tikz.sty` raises `MAX_ERRORS` to 1000, while Perl's `Core/State.pm` L96 default of 100 has no override anywhere in its tree. Same severity, same outcome — a diagnostics budget, not a divergence.

Lifting both circuit breakers (Perl: a preloaded binding setting `MAX_ERRORS=100000`; ours: a throwaway patch, not in this PR) shows it is the *same* flood — same first error at the same source site, same classes, and on two witnesses the same counts to the unit (2605.23308: `unexpected:_` 160 = 160, `^` 104 = 104, `\lx@begin@alignment` 54 = 54; 2605.05934: five classes identical). Uncapped totals, Perl vs us: 1956/1953, 4211¹/3604, 100002²/2040, 926³/1079, 19984/1159, 2842/1097, 614/OOM⁴, 1976¹/2024, 1055/OOM⁴, 1137/1173. Each paper's trigger is its own (an undefined `\overarrow@`, `\usephysicsmodule`, a tikz `\matrix` with `$…$` cells inside `align*`, tikz-cd nesting, an author `\def\({\left(}`, …) — the *shape* is shared, the cause is per-paper, and every cause is a capability Perl lacks as well.

¹ killed at the harness timeout, a floor. ² hit the raised cap. ³ Perl ends in `Fatal:perl:deep_recursion`. ⁴ with the breaker removed the runaway exhausts RAM and is SIGKILLed — which is what the breaker is for.

**The exception is `2606.01903`, and it is ours.** amsmath's `\def\ext@arrow#1#2#3#4#5#6#7` and `\def\arrowfill@#1#2#3#4` take plain TeX undelimited arguments — a single token *or* a balanced group. Our bindings spelled four of the seven (and all four of `\arrowfill@`'s) `Token`, which reads only the opening `{` of a braced argument and spills the remainder, its closing `}` included, back into the stream. That stray `}` closes the enclosing display math. The braced form is exactly what `extpfeil.sty`'s `\newextarrow` generates: the `\mkern` quadruple is four bare digits only while every amount is a single digit, and `\newextarrow{\xtwoheadleftarrow}{500{40}}{…}` has to brace the 40. Perl cannot hit this — it defines no `\ext@arrow` at all — so the bug is 100 % Rust-only.

## Approach

All seven parameters of `\ext@arrow` and all four of `\arrowfill@` become `{}`, matching the `\def`. Nothing else changes: single-token arguments (amsmath's own `0359`/`3095`) read identically, and the expansion bodies are untouched.

Because Perl reports these two internals as undefined rather than binding them, our now-correct handling leaves us *below* Perl's error count on affected papers. That gap is the pre-existing binding, not a suppressed diagnostic, and it is recorded as **OXIDIZED_DESIGN #81** (#80 was taken by a sibling PR while this one was open, as was KNOWN_PERL_ERRORS #62; #76 left alone as the retraction gap). The parity verdict for the other ten is **KNOWN_PERL_ERRORS #63**, with the per-paper trigger table, both uncapped totals, and an explicit "do not mistake the error-cap difference for a divergence".

## Validation

| witness | before | after | same-host Perl |
|---|---|---|---|
| 2606.01903 | 1002 + fatal | **0** | 102 + fatal (default) · 258 (uncapped) |
| 2606.14212 | 194 + fatal | **0** | 3 |
| 1308.1071 / 2411.17873 / 2412.00464 (prior `\ext@arrow` witnesses) | 0 | 0 | — |
| the other ten cluster papers | 1002 + fatal | 1002 + fatal (parity) | 102 + fatal, all ten |

`2606.14212` was found by grepping the 536 currently-fatal 2605+2606 papers for `ext@arrow|extpfeil|newextarrow`; the other four hits (`2605.{20598,25628,27193}`, and `2605.11190`/`2605.09261` from the cluster) are unchanged — their `\ext@arrow` use is not the braced-mkern shape and they fail for other reasons.

New guard `06_cluster_math::cluster_ext_arrow_braced_mkern` over `tests/cluster_regressions/ext_arrow_braced_mkern.tex`, an 18-line fixture that reproduces `\newextarrow`'s expansion without needing the raw `.sty`. Red-verified by reverting the fix: `Error:unexpected:} Attempt to close a group that switched to mode display_math`, and the `\simeq` above-label is replaced by a `0` SUBscript scavenged from the leaked `{40}`. The guard asserts all three — zero errors, the label as a `POSTSUPERSCRIPT`, and the following text in its own `<p>` outside the math.

`cargo test --tests --no-fail-fast`: **1745 passed / 0 failed** (101 targets; the 1744 baseline on `268b109475` plus this guard). `cargo +nightly clippy --workspace --all-targets -- -D warnings` clean; `cargo +nightly fmt --all` clean.

## Decisions & open questions

- **I did not touch `tikz.sty`'s `MAX_ERRORS = 1000`.** It is the reason this cluster reads as "1000-error cap" where Perl reads as 100, and lowering it to Perl's default would restore literal parity and stop us spending 10× the compute on a doomed paper. But its comment says it exists so tikz papers that legitimately exceed 100 errors still *finish*, and dropping it would convert an unknown number of `error` papers into `fatal`. That is a corpus-wide call, not a side effect of this PR.
- **The remaining ten are beyond-Perl work, deliberately not started here.** Closing them means implementing internals Perl also lacks — `\overarrow@`/`\underarrow@` (amsmath, the `2605.03113` trigger, and the natural neighbour of the `\ext@arrow` family this PR touches), `\usephysicsmodule` (physics2), and so on. Each is a new capability with its own divergence entry, not a translation fix, so each deserves its own PR.
- **`\ext@arrow`'s output is still `ltx_math_unparsed`.** The stub emits `{\mathrel{\to}^{above}_{below}}`, which the math grammar does not parse, where the public `\xrightarrow` goes through the `\lx@long@arrow` constructor and does. Routing the stub through `\lx@long@arrow` would likely fix that, but it changes the `tex=` reversion on three existing witnesses, so it is out of scope here.
- **The two `OOM⁴` cells are not a product signal.** They are uncapped-Rust triage runs with the circuit breakers patched out; the shipped binary caps and exits cleanly. I mention them only because they are the strongest evidence the breaker earns its keep.
- The cluster membership differs slightly from the brief's 7-in-2605/4-in-2606 split (I measured 10 and 1). The brief's split predates the current fleet pass; my list is re-derived from result zips carrying `git_sha 01e1ea5a94`. Two of the brief's named witnesses moved: `2605.01522` is **30 errors, status 2** on this `main` (the fleet's own 10:01 result agrees), i.e. already better than Perl's 51 — not a member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
