### PR TITLE
fix(expl3): loading xparse/expl3 silently destroyed the \c cedilla accent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@
     filter text into the page, and `\keywords` renders again. The silence
     binding also restores diagnostics the real package's `\ErrorsOff` was
     swallowing.
+  - **`\usepackage{xparse}` no longer destroys the `\c` cedilla accent** — any
+    document loading `xparse` or `expl3` rendered `Fran\c cois` as "Fran0cois",
+    silently and with no error reported.
   - **A deferred package-load miss no longer poisons a later raw load.**
   - **Perl `.ltxml` bindings are never read as TeX** — file resolution used to hand
     back the `.ltxml` (Perl source) and tokenize it, so raw-loading a package that

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -64,6 +64,27 @@ session of their own. Re-verify a row before planning on it (rule 1).
 
 ## Current status
 
+- **2026-07-27 — `\usepackage{xparse}` silently destroyed the `\c` cedilla
+  accent (issue 421).** GENUINE-RUST-ONLY, **0 errors** both before and after —
+  a wrong glyph, not a diagnostic, on any document loading `xparse`/`expl3`.
+  `expl3_sty.rs` emitted the `\c_sys_*` constants through `raw_tex`, which
+  tokenizes with the AMBIENT catcodes; under the document regime (`_` = SUB)
+  `\edef\c_sys_shell_escape_int{0}` parsed as `\edef\c` + parameter text
+  `_sys_shell_escape_int`, so `\meaning\c` became
+  `macro:_sys_shell_escape_int->0` and `Fran\c cois` rendered **"Fran0cois"**
+  (Perl 0.8.8, same host: "François"). **The block was DELETED, not
+  re-tokenized** — measurement killed both of its premises: the constants are
+  already defined at package-load time with live values, and the block had never
+  run, so repairing its tokenization would have overwritten those with frozen
+  dummies + a hardcoded year. Perl's `expl3.sty.ltxml` has no such block. The
+  surviving raw expl3 chunk now goes through `with_expl_catcodes`
+  (save/restore, error path included). Witness 2605.11579: `Fran0cois` →
+  `François`, 0 errors, 36 bibitems, unchanged otherwise; named witnesses
+  2406.14142 / 2002.07146 byte-identical. Guard
+  `expl3_load_does_not_clobber_cedilla_accent`. Detail + the workspace-wide
+  audit: [`EXPL3_CATCODE_GAP_2026-06-08.md`](parity/diagnostics/EXPL3_CATCODE_GAP_2026-06-08.md)
+  (third member of that family), method in **WISDOM #73**.
+
 - **2026-07-27 — a `.bib` field's `^` is data too, and `mathscinet.sty` gets a
   binding.** Two changes, one PR. (a) `^` joins `_` in treatment 2 of
   **OXIDIZED_DESIGN #74** — verified symmetric with `_` rather than assumed

--- a/docs/parity/WISDOM.md
+++ b/docs/parity/WISDOM.md
@@ -2763,3 +2763,36 @@ collapse that is deliberately downgraded.
 the CORE stage, so a post-stage error flood passes every bibliography guard
 silently — 17 errors on one fixture, 203 on its witness, all green. Use
 `convert_and_post_clean` for anything in this path (see OXIDIZED_DESIGN #73).
+
+## #73 `raw_tex` is the only binding-side path that TOKENIZES a CS name — so binding-authored expl3 TeX needs the expl3 catcode regime
+
+**The trap.** `RawTeX!` → `stomach::raw_tex` builds a `Mouth` and reads it with
+the **ambient** catcode table (`at_letter: true` is the only override). Under the
+document regime `_` is SUB, so a CS name written in a raw string terminates at its
+first `_`: `\edef\c_sys_shell_escape_int{0}` is `\edef\c` with parameter text
+`_sys_shell_escape_int` and body `0`. The intended constant is never defined, and
+a **short, real** CS is silently rebound — here LaTeX's cedilla accent `\c`, so
+every later `Fran\c cois` rendered "Fran0cois" with **zero errors** while Perl
+rendered "François" (issue 421; `expl3_sty.rs`, witness arXiv 2605.11579). The
+same shape threatens any `\c…`/`\v…`/`\u…`-prefixed expl3 name.
+
+**The rule.** Binding-authored expl3-syntax raw TeX must run inside the
+`\ExplSyntaxOn` regime — `expl3_sty.rs::with_expl_catcodes` saves the ambient
+`:`/`_` catcodes, sets LETTER, and restores on both the success and error paths.
+Do NOT hardcode the restore to OTHER/SUB: the caller may itself be an expl3
+package (that mistake is the older half of this family, in
+`docs/parity/diagnostics/EXPL3_CATCODE_GAP_2026-06-08.md`).
+
+**The cheaper escape.** `T_CS!`, `Let!` and `parse_prototype`
+(`def_macro_noop`, `def_macro_identity`, `def_primitive_noop`, …) build the CS
+name as a **string** and never reach the tokenizer — `def_parser.rs::CS_RE`
+admits `[a-zA-Z@_]+(?::[a-zA-Z]*)?` for exactly this reason. Prefer them for
+expl3 names; reach for `raw_tex` only when you need real TeX control flow.
+
+**Diagnosing it.** The symptom is a *wrong glyph*, not an error — grep the
+output for the corrupted rendering, and probe `\meaning\<cs>` (a rebound accent
+reads `macro:_…->…`). To ask whether a `\c_sys_*`-style constant is really
+defined, use `\number\csname …\endcsname`, not bare
+`\csname …\endcsname`: an `\int_const:Nn` chardef ≥ 256 expands to a glyph the
+font lacks and renders as *nothing*, which reads exactly like "undefined" and
+sent this investigation down a wrong path once.

--- a/docs/parity/diagnostics/EXPL3_CATCODE_GAP_2026-06-08.md
+++ b/docs/parity/diagnostics/EXPL3_CATCODE_GAP_2026-06-08.md
@@ -74,6 +74,17 @@
 > (`06_cluster_regressions`) — asserts the accents round-trip AND that the
 > document regime survives the load (`_`=8, `:`=12, `~`=13).
 >
+> Branch nuance, measured: the "already defined, live" finding is the **dump**
+> path (the shipped one). Under `LATEXML_NODUMP=1`, where `expl3.sty` really
+> does `\input expl3-code.tex` in-session, `\c_sys_year_int` / `\c_sys_month_int`
+> come back **UNDEF** — but that is unchanged by this fix (the block never
+> defined them either), and that path already ends in the pre-existing
+> "Conversion failed: 1 fatal error" from the dangling-group half below, before
+> and after, on the same input. The cedilla fix does apply there too
+> (`Fran0cois` → `François`). Whether the raw-load branch should gain a
+> *branch-gated* constants patch-up with real (not frozen) values is an open
+> question, not a regression.
+>
 > Method note worth keeping: `raw_tex` is the ONLY binding-side path that
 > tokenizes a CS name; `T_CS!`, `Let!` and `parse_prototype`
 > (`def_macro_noop` &c.) build the name as a string and are catcode-independent

--- a/docs/parity/diagnostics/EXPL3_CATCODE_GAP_2026-06-08.md
+++ b/docs/parity/diagnostics/EXPL3_CATCODE_GAP_2026-06-08.md
@@ -41,6 +41,51 @@
 > dead ends below are still valuable (four band-aids, all regressing
 > `glossary_test`) — that is why the entry is kept.
 
+> ## ✅ A THIRD member of the family, found + FIXED 2026-07-27 (issue 421)
+>
+> Same family, opposite direction, and **not** a kernel `\ExplSyntaxOff` problem:
+> here the wrong regime was in **our own binding's raw TeX**, not in the raw
+> `.sty` read. `expl3_sty.rs` emitted the `\c_sys_*` system constants through
+> `raw_tex`, which tokenizes with the **ambient** catcodes. After the expl3 load
+> the ambient (document) regime is the correct `_` = SUB — so
+> `\edef\c_sys_shell_escape_int{0}` parsed as `\edef\c` with parameter text
+> `_sys_shell_escape_int` and body `0`, **rebinding LaTeX's cedilla accent
+> `\c`**. `\meaning\c` = `macro:_sys_shell_escape_int->0`; every later
+> `Fran\c cois` rendered **"Fran0cois", silently, with 0 errors**, where
+> same-host Perl 0.8.8 renders "François" ⇒ GENUINE-RUST-ONLY. Blast radius: any
+> document loading `xparse` or `expl3`. Four lines reproduce it (no paper, no
+> `--includestyles`); witness arXiv **2605.11579** (`biblo.bib`
+> `MRREVIEWER = {Fran\c cois\ Digne}`), whose production sandbox output carries
+> `Fran0cois` at `Status:conversion:0`.
+>
+> **Fix: the block was DELETED**, not re-tokenized. Both premises behind it were
+> false, measured: (1) the `\c_sys_{minute,hour,day,month,year}_int` /
+> `_timestamp_str` / `_shell_escape_int` constants **are** already defined, at
+> package-load time, with live values (`\number\csname c_sys_year_int\endcsname`
+> right after `\usepackage{xparse}` gives the real year; `c_sys_minute_int`
+> advances between runs) — only `\c_sys_jobname_str` ever needed the `Let!`;
+> (2) the block never ran at all, so "fixing" its tokenization would have
+> *replaced* those live values with frozen dummies and a hardcoded year. Perl's
+> `expl3.sty.ltxml` has no such block either (it is 3 lines). The one remaining
+> raw expl3 chunk in the file (`\__kernel_msg_info:nnxx`) now goes through
+> `expl3_sty.rs::with_expl_catcodes`, which SAVES and restores the ambient
+> `:`/`_` catcodes instead of hardcoding OTHER/SUB, and restores on the error
+> path too. Guard: `expl3_load_does_not_clobber_cedilla_accent`
+> (`06_cluster_regressions`) — asserts the accents round-trip AND that the
+> document regime survives the load (`_`=8, `:`=12, `~`=13).
+>
+> Method note worth keeping: `raw_tex` is the ONLY binding-side path that
+> tokenizes a CS name; `T_CS!`, `Let!` and `parse_prototype`
+> (`def_macro_noop` &c.) build the name as a string and are catcode-independent
+> — `def_parser.rs`'s `CS_RE` already admits `_`/`:` for exactly this reason. An
+> audit of every `RawTeX!`/`raw_tex` literal in the workspace found this as the
+> only site *defining* an expl3-named CS; `siunitx_sty.rs`'s `\sisetup` block
+> mentions `\c__siunitx_mu_tl` / `\__siunitx_unit_mathrm:n` inside stored key
+> *values* (no `\def`, inert per its own comment), so it cannot clobber. A
+> 16-package accent sweep (xparse, expl3, siunitx, l3keys2e, mhsetup, fontspec,
+> tikz, hyperref, biblatex, amsmath, xcolor, pgfplots, tcolorbox, glossaries,
+> mathtools vs a no-package baseline) is byte-identical at 0 errors.
+
 **Status (2026-06-08, SUPERSEDED — see above): OPEN, deep. The single biggest
 Rust-only error gap on the sampled corpus (2112.11932: Rust 1003 vs Perl 5,
 +998). Four band-aid fixes were tried and ALL regress something; reverted. The

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -372,3 +372,41 @@ fn inline_end_lstlisting_does_not_swallow_the_document() {
     "inline \\end{{lstlisting}}: the listing body was lost:\n{x}"
   );
 }
+/// `\usepackage{xparse}` (or `expl3`) must not clobber LaTeX's cedilla accent.
+///
+/// `expl3_sty.rs` used to `\edef` the `\c_sys_*` system constants through
+/// `raw_tex`, which tokenizes with the AMBIENT catcodes. After the expl3 load
+/// the document regime has `_` = SUB, so `\edef\c_sys_shell_escape_int{0}`
+/// parsed as `\edef\c` with parameter text `_sys_shell_escape_int` and body `0`:
+/// it rebound LaTeX's cedilla accent `\c` (`\meaning\c` =
+/// `macro:_sys_shell_escape_int->0`) and defined none of the constants. Every
+/// later `Fran\c cois` then rendered "Fran0cois" — silently, with 0 errors —
+/// where Perl LaTeXML renders "François" (GENUINE-RUST-ONLY; issue 421, witness
+/// arXiv 2605.11579's `MRREVIEWER = {Fran\c cois\ Digne}`). The block was dead
+/// code — expl3 defines those constants itself, with live values — so it was
+/// deleted rather than re-tokenized.
+///
+/// Two properties, because the accent is only the symptom: the accents
+/// round-trip, AND the document catcode regime that made the corruption
+/// possible is intact after the expl3/xparse load (`_` = 8, `:` = 12, `~` = 13
+/// — a leaked `\ExplSyntaxOn` regime would show up here first).
+/// (Post-processing is not involved: the corruption happens in the gullet, so
+/// the engine XML is the right layer.)
+#[test]
+fn expl3_load_does_not_clobber_cedilla_accent() {
+  let x = convert_to_xml("tests/cluster_regressions/expl3_accent_catcode.tex");
+  assert!(
+    x.contains("François") && x.contains('Ç') && x.contains('Ş') && x.contains('ţ'),
+    "\\usepackage{{xparse}} clobbered the \\c cedilla accent:\n{x}"
+  );
+  assert!(
+    !x.contains("Fran0cois"),
+    "\\c expanded to a `\\c_sys_…` macro body — expl3-syntax raw TeX was \
+     tokenized outside the expl3 catcode regime:\n{x}"
+  );
+  assert!(
+    x.contains("catcodes: [8][12][13]"),
+    "the document catcode regime did not survive \\usepackage{{xparse}} \
+     (expected `_`=8, `:`=12, `~`=13):\n{x}"
+  );
+}

--- a/latexml_oxide/tests/cluster_regressions/expl3_accent_catcode.tex
+++ b/latexml_oxide/tests/cluster_regressions/expl3_accent_catcode.tex
@@ -1,0 +1,7 @@
+\documentclass{article}
+\usepackage{xparse}
+\begin{document}
+Fran\c cois \c C \c{S} \c{t}
+
+catcodes: [\the\catcode`\_][\the\catcode`\:][\the\catcode`\~]
+\end{document}

--- a/latexml_package/src/package/expl3_sty.rs
+++ b/latexml_package/src/package/expl3_sty.rs
@@ -173,7 +173,10 @@ LoadDefinitions!({
   //  * They ARE defined, at package-load time and with live values — probing
   //    `\number\csname c_sys_year_int\endcsname` right after `\usepackage{xparse}`
   //    gives the real year, and `c_sys_minute_int` advances between runs. Only
-  //    `\c_sys_jobname_str` needed the `Let!` above.
+  //    `\c_sys_jobname_str` needed the `Let!` above. (That is the dump path. On
+  //    the `LATEXML_NODUMP=1` raw-load branch they come back undefined — but the
+  //    block did not define them there either, so nothing changed; that branch
+  //    dies earlier anyway, on the expl3-code codepoint group.)
   //  * The block never actually ran. Written as raw TeX, it was tokenized with
   //    the AMBIENT catcodes, and after the expl3 load the document regime has
   //    `_` = SUB — so `\edef\c_sys_minute_int{0}` parsed as `\edef\c` with

--- a/latexml_package/src/package/expl3_sty.rs
+++ b/latexml_package/src/package/expl3_sty.rs
@@ -1,5 +1,45 @@
 use crate::prelude::*;
 
+/// Run a chunk of our own expl3-syntax TeX under the expl3 catcode regime.
+///
+/// **Every `raw_tex` chunk in this file that names an expl3 CS must go through
+/// here.** Real expl3 code always lives between `\ExplSyntaxOn` and
+/// `\ExplSyntaxOff`, which make `:` and `_` LETTER so a name like
+/// `\c_sys_shell_escape_int` is a SINGLE control sequence. `raw_tex` tokenizes
+/// with the **ambient** catcodes, and after the expl3 load the ambient
+/// (document) regime has `_` = SUB (8) — so an unwrapped chunk mis-tokenizes:
+/// the CS terminates at the first `_`, and `\edef\c_sys_shell_escape_int{0}`
+/// becomes `\edef\c` with parameter text `_sys_shell_escape_int` and body `0`,
+/// silently rebinding LaTeX's cedilla accent `\c` (`Fran\c cois` → "Fran0cois",
+/// no error at all, where Perl renders "François"). That was issue 421 —
+/// witness arXiv 2605.11579; see the NOTE at the deleted `\c_sys_*` block.
+///
+/// Catcode-INDEPENDENT alternatives, when they fit, are safer still: `T_CS!` /
+/// `Let!` / `parse_prototype` (`def_macro_noop` &c.) build the CS name as a
+/// string and never reach the tokenizer.
+///
+/// We cannot delegate to `\ExplSyntaxOn`/`\ExplSyntaxOff` here: our expl3
+/// kernel's `\ExplSyntaxOff` is incomplete (the reason xparse_sty.rs and
+/// siunitx_sty.rs hardcode a `~`/`:`/`_` restore after their raw loads —
+/// docs/parity/diagnostics/EXPL3_CATCODE_GAP_2026-06-08.md). Instead this
+/// saves the ambient catcodes of `:`/`_`, installs the expl3 LETTER regime for
+/// the duration, and restores the saved values — including on the error path,
+/// so a failing chunk cannot leak the LETTER regime into the document.
+fn with_expl_catcodes<T>(body: impl FnOnce() -> Result<T>) -> Result<T> {
+  // (char, catcode to fall back to if the ambient table has no entry — the
+  // document/plain-TeX default for that char).
+  const EXPL_LETTERS: [(char, Catcode); 2] = [(':', Catcode::OTHER), ('_', Catcode::SUB)];
+  let saved = EXPL_LETTERS.map(|(c, dflt)| lookup_catcode(c).unwrap_or(dflt));
+  for (c, _) in EXPL_LETTERS {
+    assign_catcode(c, Catcode::LETTER, Some(Scope::Global));
+  }
+  let result = body();
+  for ((c, _), cc) in EXPL_LETTERS.into_iter().zip(saved) {
+    assign_catcode(c, cc, Some(Scope::Global));
+  }
+  result
+}
+
 #[rustfmt::skip]
 LoadDefinitions!({
   // Strict-Perl translation of LaTeXML/lib/LaTeXML/Package/expl3.sty.ltxml:
@@ -53,11 +93,7 @@ LoadDefinitions!({
   // expl3-code.tex. On the dump path the guard short-circuits the
   // re-load and the dump already provides the right state.
   if raw_load_will_run {
-    assign_catcode(':', Catcode::LETTER, Some(Scope::Global));
-    assign_catcode('_', Catcode::LETTER, Some(Scope::Global));
-    raw_tex(r"\protected\gdef\__kernel_msg_info:nnxx#1#2#3#4{}")?;
-    assign_catcode(':', Catcode::OTHER, Some(Scope::Global));
-    assign_catcode('_', Catcode::SUB, Some(Scope::Global));
+    with_expl_catcodes(|| raw_tex(r"\protected\gdef\__kernel_msg_info:nnxx#1#2#3#4{}"))?;
   }
 
   // expl3 case-folding override.
@@ -97,21 +133,20 @@ LoadDefinitions!({
     Ok(Tokenize!(TeXString::assembled(format!("{{{}}}{{}}{{}}", result_cp))))
   });
 
-  // expl3 system-info constants normally bound by `\g__sys_everyjob_tl`
-  // expansion at job start (via `\everyjob`). Our engine never fires
-  // `\everyjob` (matching Perl's gap), so the tl never runs and these
-  // CSes stay undefined. When packages like `duckuments.sty` then do
+  // `\c_sys_jobname_str` is one of the system-info constants bound by
+  // `\g__sys_everyjob_tl` at job start (via `\everyjob`), which our engine
+  // never fires (matching Perl's gap). When packages like `duckuments.sty`
+  // then do
   //   `\str_if_eq_p:Vn \c_sys_jobname_str { example-image-duck }`
   // the V-expansion triggers `\if_int_compare:w` cascades on Rust
   // (Perl emits one undefined error and recovers; Rust's recovery
   // re-fires per scan, surfacing 21+ relational-token cascades).
   //
-  // Mirror the body of `\g__sys_everyjob_tl` for the constants
-  // duckuments-class packages actually consume — `\c_sys_jobname_str`
-  // (= jobname) plus the date/time int constants. Use plain `\Let`/
-  // `\edef` aliases rather than the full `\str_const:Ne` machinery
-  // because those expl3 constructors themselves require a working
-  // `\c_sys_jobname_str` at definition time.
+  // A plain `\Let` alias to `\jobname`, rather than the full `\str_const:Ne`
+  // machinery — those expl3 constructors themselves require a working
+  // `\c_sys_jobname_str` at definition time. The sibling date/time int
+  // constants need NO such patch-up: they are already defined, with live
+  // values, by the time a package body runs (see the NOTE below).
   //
   // Driver: 2406.14142 (duckuments cascade, 21 errors → 4 expected
   // (matching Perl's residual undefined-CS count)).
@@ -129,15 +164,31 @@ LoadDefinitions!({
   // non-clearing version.)
   Let!("\\hbox_unpack_clear:N", "\\hbox_unpack_drop:N");
 
-  RawTeX!(r"
-    \edef\c_sys_minute_int{0}%
-    \edef\c_sys_hour_int{0}%
-    \edef\c_sys_day_int{1}%
-    \edef\c_sys_month_int{1}%
-    \edef\c_sys_year_int{2026}%
-    \edef\c_sys_timestamp_str{}%
-    \edef\c_sys_shell_escape_int{0}%
-  ");
+  // NOTE (issue 421): there used to be a `RawTeX!` block here `\edef`-ing the
+  // seven `\c_sys_{minute,hour,day,month,year}_int` / `\c_sys_timestamp_str` /
+  // `\c_sys_shell_escape_int` constants, on the belief that they stay undefined
+  // because we never fire `\everyjob`. **Do not re-add it.** Both halves of that
+  // belief were wrong, measured on the current engine:
+  //
+  //  * They ARE defined, at package-load time and with live values — probing
+  //    `\number\csname c_sys_year_int\endcsname` right after `\usepackage{xparse}`
+  //    gives the real year, and `c_sys_minute_int` advances between runs. Only
+  //    `\c_sys_jobname_str` needed the `Let!` above.
+  //  * The block never actually ran. Written as raw TeX, it was tokenized with
+  //    the AMBIENT catcodes, and after the expl3 load the document regime has
+  //    `_` = SUB — so `\edef\c_sys_minute_int{0}` parsed as `\edef\c` with
+  //    parameter text `_sys_minute_int`. It defined none of the constants and
+  //    instead REBOUND LaTeX's cedilla accent `\c` (`\meaning\c` =
+  //    `macro:_sys_shell_escape_int->0`), so every later `Fran\c cois` rendered
+  //    "Fran0cois" — silently, 0 errors, where Perl renders "François".
+  //    Witness arXiv 2605.11579; guard
+  //    `expl3_load_does_not_clobber_cedilla_accent`.
+  //
+  // Fixing only the tokenization would have been worse than deleting: the
+  // constants would then overwrite expl3's live clock values with frozen
+  // dummies (and a hardcoded year). Perl's expl3.sty.ltxml has no such block
+  // either — it is three lines. Any FUTURE expl3-syntax raw TeX added to this
+  // file must go through `with_expl_catcodes`.
 
   // expl3 l3regex is handled NATIVELY by the real expl3 VM (loaded from
   // expl3-code.tex: \__regex_compile:n / \__regex_build:n / \__regex_match:n,


### PR DESCRIPTION
Loading `xparse` (or `expl3`) silently destroyed LaTeX's `\c` cedilla accent:
`Fran\c cois` rendered **"Fran0cois"**, with **zero errors**, on any document
using either package. Same-host Perl 0.8.8 renders "François" — GENUINE-RUST-ONLY.
Fixes the report in issue 421.

Four lines reproduce it (no paper, no `--includestyles`):

```latex
\documentclass{article}
\usepackage{xparse}
\begin{document}
Fran\c cois
\end{document}
```

## Diagnostic

`expl3_sty.rs` emitted the `\c_sys_*` system constants through `RawTeX!` →
`stomach::raw_tex`, which builds a `Mouth` and reads it with the **ambient**
catcode table. After the expl3 load the ambient (document) regime has `_` = SUB
— which is correct for the document — so the raw chunk mis-tokenized:
`\edef\c_sys_shell_escape_int{0}` parsed as `\edef\c` with parameter text
`_sys_shell_escape_int` and body `0`. It defined **none** of the seven constants
and instead rebound the cedilla accent; `\meaning\c` came back as
`macro:_sys_shell_escape_int->0`, matching the report exactly.

This is a third member of the family in
`docs/parity/diagnostics/EXPL3_CATCODE_GAP_2026-06-08.md`, but a different one:
the wrong regime is in **our own binding's raw TeX**, not in the raw `.sty` read.
None of the four band-aids that doc records as reverted apply, and none were
re-attempted.

## Approach

**The block is deleted, not re-tokenized.** Wrapping it in `\ExplSyntaxOn` was
the obvious fix and would have been wrong — measurement killed both premises
behind the block:

* The constants **are** already defined, at package-load time, with live values.
  Probing right after `\usepackage{xparse}`:
  `\number\csname c_sys_year_int\endcsname` → the real year, `c_sys_month_int`
  → 7, and `c_sys_minute_int` advances between runs. Only `\c_sys_jobname_str`
  ever needed the `Let!` that stays.
* The block had **never run** — it only ever defined `\c`. Repairing its
  tokenization would therefore have *overwritten* expl3's live clock values with
  frozen dummies (`minute` 0, `day` 1, `month` 1) and a hardcoded year.

Perl's `expl3.sty.ltxml` has no such block either — it is three lines.

The one remaining raw expl3 chunk in the file (`\__kernel_msg_info:nnxx`) now
goes through a new `with_expl_catcodes`, which **saves and restores** the ambient
`:`/`_` catcodes — on the error path too — rather than hardcoding OTHER/SUB, and
whose doc comment records the trap so the next raw chunk does not repeat it.

The defect class was audited workspace-wide: `raw_tex` is the only binding-side
path that tokenizes a CS name (`T_CS!`, `Let!` and `parse_prototype` build it as
a string; `def_parser.rs::CS_RE` already admits `_`/`:` for this reason), and
this was the only site *defining* an expl3-named CS through it. `siunitx_sty.rs`
names `\c__siunitx_mu_tl` inside stored `\sisetup` key *values* — no `\def`, so
it cannot clobber.

## Validation

| | before | after |
|---|---|---|
| 4-line reproducer | `Fran0cois`, 0 errors | **`François`**, 0 errors |
| witness 2605.11579 (`MRREVIEWER = {Fran\c cois\ Digne}`) | `Fran0cois`, 0 errors, 36 bibitems | **`François`**, 0 errors, 36 bibitems |
| `bib_mr_reviewer_accent` + `\usepackage{xparse}` (copy; in-tree fixture untouched) | `Fran0cois` ×2 | **`François`** ×2 |
| Perl 0.8.8, same host, reproducer | `François`, 0 errors | — |

* Guard `expl3_load_does_not_clobber_cedilla_accent` (`06_cluster_regressions`)
  pins **both** halves — the accents round-trip (`\c c`, `\c C`, `\c{S}`,
  `\c{t}`) **and** the document catcode regime survives the load (`_`=8, `:`=12,
  `~`=13), so "protect `\c` and leave the regime wrong" cannot pass it.
  Red-verified by reverting the binding (fails on `Fran0cois`).
* Named witnesses in the touched comments re-converted: **2406.14142**
  (duckuments) and **2002.07146** (mmacells) — 0 errors and byte-identical
  output before and after.
* 16-package accent sweep (xparse, expl3, siunitx, l3keys2e, mhsetup, fontspec,
  tikz, hyperref, biblatex, amsmath, xcolor, pgfplots, tcolorbox, glossaries,
  mathtools) against a no-package baseline: byte-identical, 0 errors on every row.
* `cargo test --tests --no-fail-fast`: **101 targets, 1744 passed, 0 failed**,
  exit code 0 (1743 baseline + the new guard).
* `cargo +nightly clippy --workspace --all-targets -- -D warnings` clean;
  `cargo +nightly fmt --all` no-op.

## Decisions & open questions

* **Delete vs. wrap.** Deleting is both more faithful (Perl has no such block)
  and strictly better behaviour. Kept `with_expl_catcodes` even though it now has
  a single call site: it is where the invariant and the trap are written down, and
  it upgrades that site's hardcoded OTHER/SUB restore to a real save/restore.
* **The measurement that nearly went wrong**, recorded in WISDOM #73: a bare
  `\csname c_sys_year_int\endcsname` probe printed *nothing* before the fix, which
  reads exactly like "undefined" — but an `\int_const:Nn` chardef ≥ 256 just has
  no glyph in the font. `\number\csname …\endcsname` is the correct probe, and it
  is what overturned the "the constants are missing" premise.
* **Dump vs. `LATEXML_NODUMP`.** "Already defined, live" is the **dump** path —
  the shipped one. On the raw-load branch (`LATEXML_NODUMP=1`, where `expl3.sty`
  really re-inputs `expl3-code.tex`) `\c_sys_year_int` / `\c_sys_month_int` come
  back undefined; measured before *and* after, so the deleted block changed
  nothing there either, and that branch already ends in a pre-existing
  "Conversion failed: 1 fatal error" (the dangling-codepoint-group half of the
  diagnostic doc) on the same input. The cedilla fix applies on both branches
  (`Fran0cois` → `François`). Whether the raw-load branch deserves a
  *branch-gated* patch-up with real values is left open — it would be new
  behaviour, not part of this bug.
* **Not addressed here:** the two open halves of
  `EXPL3_CATCODE_GAP_2026-06-08.md` (the incomplete kernel `\ExplSyntaxOff`, and
  the codepoint-data block that dangles a group) are untouched — this bug is
  independent of both, and the doc's four reverted band-aids remain on record.
* **`siunitx_sty.rs`'s `\sisetup` block** carries expl3 names in stored key values
  written outside the regime. It is inert today (its own comment says those 50
  keys are read by nothing), so it is left alone rather than churned; noted in the
  diagnostic doc in case a future change starts reading them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
