### PR TITLE
spconf papers keep their Index Terms and author blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@
     filter text into the page, and `\keywords` renders again. The silence
     binding also restores diagnostics the real package's `\ErrorsOff` was
     swallowing.
+  - **ICASSP/Interspeech papers keep their Index Terms and author blocks** — the
+    `spconf` style's `keywords` environment and `\twoauthors` now become real
+    keyword and creator frontmatter instead of an undefined-environment error
+    (the largest such cluster in the arXiv sandbox corpora).
   - **`\usepackage{xparse}` no longer destroys the `\c` cedilla accent** — any
     document loading `xparse` or `expl3` rendered `Fran\c cois` as "Fran0cois",
     silently and with no error reported.

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -64,6 +64,26 @@ session of their own. Re-verify a row before planning on it (rule 1).
 
 ## Current status
 
+- **2026-07-27 (latest) — spconf.sty's `keywords` and `\twoauthors` were
+  unbound.** `Error:undefined:{keywords}` was the **single largest `undefined`
+  what** in the sandbox corpora — **94 tasks in sandbox-arxiv-2605, 49 in
+  sandbox-arxiv-2606**; 142 of those 143 papers ship a byte-identical
+  `spconf.sty`. The block is a bare `\def\keywords`/`\def\endkeywords` pair
+  (L211-214), not a `\newenvironment`, and `latexml_contrib/src/spconf_sty.rs`
+  covered neither. Bound as `\lx@begin@keywords[name={…:~}]` / `\lx@end@keywords`
+  — verbatim what Perl does for the same markup in `IEEEtran.cls.ltxml` L147-148
+  (spconf says the section was "adapted from IEEEtrans"; IEEEtran.cls L5286-5288
+  typesets it identically). Raw-loaded spconf gives Perl inline bold body text
+  and **zero creators in either configuration** (`\maketitle` is locked, so
+  spconf's own one never emits `\@name`) — **divergence #82**. Sibling gap
+  `\twoauthors` (3 papers) routed to the same author machinery; braced
+  `\keywords{a,b}` guarded with Perl's `\keywords@onearg` brace-peek (without it
+  the until-scan runs to EOF and swallows the body). Witnesses, bare and
+  `--preload=ar5iv.sty` alike: 2605.00480 1→0, 2605.00698 1→0, 2605.00721 1→0,
+  2605.01187 2→1 (residual `undefined:\bstctlcite`), 2605.05692 2→0, 2605.18923
+  1→0, 2605.26747 2→0. Guards
+  `06_cluster_frontmatter::{frontmatter_spconf_keywords,
+  frontmatter_spconf_keywords_braced, frontmatter_spconf_twoauthors}`.
 - **2026-07-27 — `\usepackage{xparse}` silently destroyed the `\c` cedilla
   accent (issue 421).** GENUINE-RUST-ONLY, **0 errors** both before and after —
   a wrong glyph, not a diagnostic, on any document loading `xparse`/`expl3`.
@@ -85,7 +105,7 @@ session of their own. Re-verify a row before planning on it (rule 1).
   audit: [`EXPL3_CATCODE_GAP_2026-06-08.md`](parity/diagnostics/EXPL3_CATCODE_GAP_2026-06-08.md)
   (third member of that family), method in **WISDOM #73**.
 
-- **2026-07-27 (latest) — the LaTeX kernel autoloads on ANY undefined kernel
+- **2026-07-27 — the LaTeX kernel autoloads on ANY undefined kernel
   CS, not just a curated trigger list.** A document may legitimately use a
   kernel command before `\documentclass` (real LaTeX has no "before the
   kernel"), but LaTeXML only loads `LaTeX.pool` on a *trigger* CS — Perl

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2921,16 +2921,23 @@ i.e. `ltx:keywords` with the label in `@name` and the print-only `---` separator
 normalized to `:~`. So the divergence is only against *raw-loaded* spconf; against
 Perl's own binding for the same markup it is a verbatim follow.
 
+The same file's `\twoauthors{names1}{affil1}{names2}{affil2}` (L183-190) is bound
+alongside, routed to `\author{#1 \\ #2 \and #3 \\ #4}` so each pair becomes a
+creator with its own affiliation instead of a zero-argument `<ltx:ERROR/>` whose
+four braced arguments leak into the body as text.
+
 **Corpus scale.** `{keywords}` is the single largest `undefined` *what* in the
 sandbox corpora: **94 tasks in sandbox-arxiv-2605**, **49 in sandbox-arxiv-2606**;
-142 of those 143 papers ship a byte-identical `spconf.sty`.
+142 of those 143 papers ship a byte-identical `spconf.sty`. `\twoauthors` adds 3.
 
 **Measured**, before → after, identical in bare and `--preload=ar5iv.sty` mode:
 2605.00480 **1 → 0**, 2605.00698 **1 → 0**, 2605.00721 **1 → 0**, 2605.01187
-**2 → 1** (residual `undefined:\bstctlcite`, unrelated).
+**2 → 1** (residual `undefined:\bstctlcite`, unrelated), 2605.05692 **2 → 0**,
+2605.18923 **1 → 0**, 2605.26747 **2 → 0**.
 
-Guard: `06_cluster_frontmatter::frontmatter_spconf_keywords` (via
-`convert_to_xml_contrib_clean`, so a returning error fails it).
+Guards: `06_cluster_frontmatter::frontmatter_spconf_keywords`,
+`06_cluster_frontmatter::frontmatter_spconf_twoauthors` (both via
+`convert_to_xml_contrib_clean`, so a returning error fails them).
 
 ## Known Upstream Perl Issues (brief)
 

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2921,6 +2921,16 @@ i.e. `ltx:keywords` with the label in `@name` and the print-only `---` separator
 normalized to `:~`. So the divergence is only against *raw-loaded* spconf; against
 Perl's own binding for the same markup it is a verbatim follow.
 
+`\keywords` is argument-less in the `.sty`, so `\keywords{a, b}` is legal there
+too — the group just typesets after the label. Routed straight to the environment
+opener that form has no `\endkeywords` to stop at and
+`\lx@add@frontmatter@until` scans to EOF, pulling the whole body inside
+`<ltx:keywords>` (loudly: `malformed:ltx:section`, `malformed:ltx:document`). The
+binding peeks for a `{` and dispatches to a one-argument form, exactly as Perl
+does for the same legacy pair in `IEEEtran.cls.ltxml` L398-404
+(`\keywords@onearg`). No corpus paper hits it today (`undefined:\keywords` has
+zero reports in either sandbox corpus), but the form is valid spconf input.
+
 The same file's `\twoauthors{names1}{affil1}{names2}{affil2}` (L183-190) is bound
 alongside, routed to `\author{#1 \\ #2 \and #3 \\ #4}` so each pair becomes a
 creator with its own affiliation instead of a zero-argument `<ltx:ERROR/>` whose
@@ -2936,7 +2946,7 @@ sandbox corpora: **94 tasks in sandbox-arxiv-2605**, **49 in sandbox-arxiv-2606*
 2605.18923 **1 → 0**, 2605.26747 **2 → 0**.
 
 Guards: `06_cluster_frontmatter::frontmatter_spconf_keywords`,
-`06_cluster_frontmatter::frontmatter_spconf_twoauthors` (both via
+`frontmatter_spconf_keywords_braced`, `frontmatter_spconf_twoauthors` (all via
 `convert_to_xml_contrib_clean`, so a returning error fails them).
 
 ## Known Upstream Perl Issues (brief)

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4,7 +4,7 @@
 
 > **Numbering note:** the `### N` numbers are load-bearing (referenced from `.rs` comments) and are kept verbatim. `#16` and the math-grammar entries `#7–#18` live in [OXIDIZED_DESIGN_MATH.md](../math/OXIDIZED_DESIGN_MATH.md); in particular the code-referenced **`#18` is the f(x) "Speculative function application"** entry there, *not* the "Source-Level Bindings" `#18` below.
 >
-> **`#76` is a RETIRED number, not an omission** — its entry was consolidated into `#74` and the number was deliberately not reused (see the placeholder in sequence below). Next free number: **#81**.
+> **`#76` is a RETIRED number, not an omission** — its entry was consolidated into `#74` and the number was deliberately not reused (see the placeholder in sequence below). Next free number: **#83**.
 
 ---
 
@@ -2881,6 +2881,56 @@ expands to `\ext@arrow #2{\arrowfill@#3}{##1}{##2}`, and the `\mkern` quadruple
 `\newextarrow{\xtwoheadleftarrow}{500{40}}{…}` braces the 40. So all seven
 parameters of `\ext@arrow` and all four of `\arrowfill@` are `{}`. Guard
 `06_cluster_math::cluster_ext_arrow_braced_mkern`.
+
+### 82. spconf.sty's `keywords` block becomes `ltx:keywords` frontmatter, not inline body text
+
+**Perl behaviour.** `spconf.sty` (the ICASSP/ICIP/Interspeech conference style,
+bundled inside the paper) has no `.ltxml` — not in `LaTeXML/lib/LaTeXML/Package/`,
+not in the installed 0.8.8 tree. Its "Index Terms" block is a bare plain-TeX
+environment pair, not a `\newenvironment` (spconf.sty L211-214):
+
+```tex
+\def\keywords{\vspace{.5em}{\bfseries\textit{Index Terms}---\,\relax}}
+\def\endkeywords{\par}
+```
+
+Measured, same-host Perl 0.8.8, verbose, witness 2605.00480 (`main.tex`):
+**bare** = 4 errors (`\name`, `\address`, `\ninept`, `{keywords}`);
+**`--includestyles`** = 0 errors, because the raw `.sty` is read — but the block
+then lands in the body as
+`<para><p><text font="bold italic">Index Terms<text>—…`, with **no `ltx:keywords`
+element**. Perl produces **zero `<creator>` and zero `<keywords>` for these papers
+in either configuration**: LaTeXML locks `\maketitle`, so spconf's own
+`\def\maketitle` — the only thing that would ever emit the stashed `\@name` — is
+ignored (`Info:ignore:\maketitle:locked`). That is why this binding is registered
+unconditionally rather than gated on `INCLUDE_STYLES` the way the bundled
+`arxiv.sty` is (#77): deferring to the raw file here *loses* the frontmatter.
+
+**We bind it as structured frontmatter.** `latexml_contrib/src/spconf_sty.rs`
+defines `\keywords` → `\lx@begin@keywords[name={\spconf@keywordsname:~}]` and
+`\endkeywords` → `\lx@end@keywords`, mirroring the `.sty`'s `\def` pair rather
+than declaring a `DefEnvironment!` (so a document calling the two macros directly
+also works). The label rides in `@name`, not in the content; the XSLT renders it
+as the block's `<h6 class="ltx_title ltx_title_keywords">`.
+
+**Why this exact shape.** spconf.sty's own comment says the section was "adapted
+from IEEEtrans", and IEEEtran.cls L5286-5288 typesets it identically
+(`\textit{\IEEEkeywordsname}---`). Perl LaTeXML **does** bind that construct, in
+`IEEEtran.cls.ltxml` L147-148 — as `\lx@begin@keywords[name={\IEEEkeywordsname:~}]`,
+i.e. `ltx:keywords` with the label in `@name` and the print-only `---` separator
+normalized to `:~`. So the divergence is only against *raw-loaded* spconf; against
+Perl's own binding for the same markup it is a verbatim follow.
+
+**Corpus scale.** `{keywords}` is the single largest `undefined` *what* in the
+sandbox corpora: **94 tasks in sandbox-arxiv-2605**, **49 in sandbox-arxiv-2606**;
+142 of those 143 papers ship a byte-identical `spconf.sty`.
+
+**Measured**, before → after, identical in bare and `--preload=ar5iv.sty` mode:
+2605.00480 **1 → 0**, 2605.00698 **1 → 0**, 2605.00721 **1 → 0**, 2605.01187
+**2 → 1** (residual `undefined:\bstctlcite`, unrelated).
+
+Guard: `06_cluster_frontmatter::frontmatter_spconf_keywords` (via
+`convert_to_xml_contrib_clean`, so a returning error fails it).
 
 ## Known Upstream Perl Issues (brief)
 

--- a/latexml_contrib/src/spconf_sty.rs
+++ b/latexml_contrib/src/spconf_sty.rs
@@ -10,6 +10,12 @@
 //! 2309.14838, 2405.13379, 2605.10272). Route `\name` through the standard
 //! author machinery so the comma/superscript-marked list becomes structured
 //! creators, and keep `\address`/`\email` as frontmatter.
+//!
+//! The same file's `keywords` block (the "Index Terms" list) is a bare
+//! `\def\keywords`/`\def\endkeywords` pair, so `\begin{keywords}` found no
+//! environment at all — the single largest `undefined` cluster in the sandbox
+//! corpora (94 papers in sandbox-arxiv-2605, 49 in 2606; witnesses 2605.00480,
+//! 2605.00698, 2605.00721, 2605.01187). See the `\keywords` binding below.
 use latexml_package::prelude::*;
 
 LoadDefinitions!({
@@ -27,6 +33,29 @@ LoadDefinitions!({
     "\\email{}",
     "\\lx@add@frontmatter{ltx:note}[role=email]{#1}"
   );
+  // The "Index Terms" block (spconf.sty L211-214):
+  //   \def\keywords{\vspace{.5em}{\bfseries\textit{Index Terms}---\,\relax}}
+  //   \def\endkeywords{\par}
+  // — a plain-TeX environment pair, not a `\newenvironment`, so
+  // `\begin{keywords}` runs `\keywords` and `\end{keywords}` runs
+  // `\endkeywords`. Mirror the pair rather than declaring a `DefEnvironment!`,
+  // both because that is what the `.sty` does and because it keeps a document
+  // that calls the two macros directly (without `\begin`/`\end`) working.
+  //
+  // spconf.sty says this section was "adapted from IEEEtrans", and IEEEtran.cls
+  // L5286-5288 typesets it identically (`\textit{\IEEEkeywordsname}---`). Perl
+  // LaTeXML binds that very construct in IEEEtran.cls.ltxml L147-148 as the
+  // structured `ltx:keywords` frontmatter, carrying the label in `@name` and
+  // normalizing the print-only `---` separator to `:~`. Follow that precedent
+  // exactly: the label is metadata (the XSLT renders `@name` as the block's
+  // `<h6 class="ltx_title_keywords">` title), not content of the keyword list.
+  // Raw-loaded spconf leaves it as inline body text instead — OXIDIZED_DESIGN #82.
+  DefMacro!("\\spconf@keywordsname", "Index Terms");
+  DefMacro!(
+    "\\keywords",
+    "\\lx@begin@keywords[name={\\spconf@keywordsname:~}]"
+  );
+  DefMacro!("\\endkeywords", "\\lx@end@keywords");
   // spconf uppercases the title; keep LaTeX's `\title` semantics (no forced
   // uppercase — casing is presentational and belongs in CSS).
   DefMacro!("\\ninept", "");

--- a/latexml_contrib/src/spconf_sty.rs
+++ b/latexml_contrib/src/spconf_sty.rs
@@ -33,6 +33,16 @@ LoadDefinitions!({
     "\\email{}",
     "\\lx@add@frontmatter{ltx:note}[role=email]{#1}"
   );
+  // `\twoauthors{names1}{affil1}{names2}{affil2}` (spconf.sty L183-190) — the
+  // side-by-side two-author title block, typeset as two `tabular`s that
+  // overwrite `\@name` and blank `\@address`. Feed the same author machinery
+  // as `\name`: `\and` separates the two groups, and within a group the `\\`
+  // line after the names is that group's affiliation (`\lx@add@authors`,
+  // base_utilities.rs L950-960). Witnesses 2605.05692, 2605.18923, 2605.26747.
+  DefMacro!(
+    "\\twoauthors{}{}{}{}",
+    "\\author{#1 \\\\ #2 \\and #3 \\\\ #4}"
+  );
   // The "Index Terms" block (spconf.sty L211-214):
   //   \def\keywords{\vspace{.5em}{\bfseries\textit{Index Terms}---\,\relax}}
   //   \def\endkeywords{\par}

--- a/latexml_contrib/src/spconf_sty.rs
+++ b/latexml_contrib/src/spconf_sty.rs
@@ -62,8 +62,29 @@ LoadDefinitions!({
   // Raw-loaded spconf leaves it as inline body text instead — OXIDIZED_DESIGN #82.
   DefMacro!("\\spconf@keywordsname", "Index Terms");
   DefMacro!(
-    "\\keywords",
+    "\\spconf@begin@keywords",
     "\\lx@begin@keywords[name={\\spconf@keywordsname:~}]"
+  );
+  // `\keywords` is argument-less in the `.sty`, so `\keywords{a, b}` is also
+  // legal there — the group simply typesets after the label. Routed straight to
+  // the environment opener, that form has no `\endkeywords` to stop at and
+  // `\lx@add@frontmatter@until` scans to EOF, pulling the rest of the document
+  // inside `<ltx:keywords>` (loudly — `malformed:ltx:section` and friends — but
+  // the body is wrecked, where before it was one undefined error with the text
+  // intact). Peek for a `{` and dispatch, exactly as Perl does for the same
+  // legacy pair in IEEEtran.cls.ltxml L398-404 (`\keywords@onearg`).
+  DefMacro!("\\keywords", sub[_args] {
+    if let Some(t) = read_token()? {
+      unread(Tokens!(t));
+      if t.get_catcode() == Catcode::BEGIN {
+        return Ok(Tokens!(T_CS!("\\spconf@keywords@onearg")));
+      }
+    }
+    Ok(Tokens!(T_CS!("\\spconf@begin@keywords")))
+  });
+  DefMacro!(
+    "\\spconf@keywords@onearg{}",
+    "\\spconf@begin@keywords #1\\lx@end@keywords"
   );
   DefMacro!("\\endkeywords", "\\lx@end@keywords");
   // spconf uppercases the title; keep LaTeX's `\title` semantics (no forced

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -137,6 +137,27 @@ fn frontmatter_spconf_keywords() {
     "spconf `Index Terms` label leaked into the content:\n{x}"
   );
 }
+/// spconf's `\keywords` is argument-less, so the braced `\keywords{a, b}` form
+/// is legal too. Routed to the bare environment opener it would find no
+/// `\endkeywords` and scan to EOF, dragging the whole body into
+/// `<ltx:keywords>`; the `{`-peek (Perl's `\keywords@onearg`, IEEEtran.cls.ltxml
+/// L398-404) must close the block after the argument.
+#[test]
+fn frontmatter_spconf_keywords_braced() {
+  let x = convert_to_xml_contrib_clean(
+    "tests/cluster_regressions/frontmatter_spconf_keywords_braced.tex",
+  );
+  // The `@name` separator is a `~` tie (U+00A0), so match around it.
+  assert!(
+    x.contains("<keywords name=\"Index Terms:")
+      && x.contains(">Speech recognition, deep learning</keywords>"),
+    "braced spconf `\\keywords{{…}}` did not close after its argument:\n{x}"
+  );
+  assert!(
+    x.contains("<section"),
+    "the document body was swallowed into the keywords block:\n{x}"
+  );
+}
 /// spconf.sty `\twoauthors{N1}{A1}{N2}{A2}` (L183-190) — the side-by-side
 /// two-author title block. Each pair must become a creator with its own
 /// affiliation instead of an undefined-token `<ltx:ERROR/>`.

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -9,7 +9,7 @@
 //! [`mod cluster`](cluster).
 
 mod cluster;
-use cluster::{convert_to_xml, convert_to_xml_contrib};
+use cluster::{convert_to_xml, convert_to_xml_contrib, convert_to_xml_contrib_clean};
 
 /// acmart `\author[F. Poli]{Federico Poli}`: the real class is `\author[2][]`
 /// (optional running-head short name + full name). The name must render, and
@@ -109,6 +109,33 @@ fn frontmatter_spconf_name() {
   let x = convert_to_xml_contrib("tests/cluster_regressions/frontmatter_spconf_name.tex");
   assert!(x.contains("Alice Smith"), "spconf author 1 missing:\n{x}");
   assert!(x.contains("Bob Jones"), "spconf author 2 missing:\n{x}");
+}
+/// spconf.sty `\begin{keywords}…\end{keywords}` — the "Index Terms" block, a
+/// bare `\def\keywords`/`\def\endkeywords` pair (spconf.sty L211-214), not a
+/// `\newenvironment`. It must become structured `ltx:keywords` frontmatter
+/// with the label in `@name`, not bounce as an undefined environment (94 papers
+/// in sandbox-arxiv-2605, 49 in 2606 — the single largest `undefined` what).
+/// Witnesses 2605.00480, 2605.00698, 2605.00721, 2605.01187.
+#[test]
+fn frontmatter_spconf_keywords() {
+  let x = convert_to_xml_contrib_clean("tests/cluster_regressions/frontmatter_spconf_keywords.tex");
+  assert!(
+    x.contains("<keywords"),
+    "spconf keywords did not become ltx:keywords frontmatter:\n{x}"
+  );
+  assert!(
+    x.contains("Speech recognition, deep learning"),
+    "spconf keyword list missing:\n{x}"
+  );
+  assert!(
+    x.contains("name=\"Index Terms:"),
+    "spconf keywords label not carried in @name:\n{x}"
+  );
+  // The label is an attribute, never inline content of the block.
+  assert!(
+    !x.contains(">Index Terms"),
+    "spconf `Index Terms` label leaked into the content:\n{x}"
+  );
 }
 /// atlasdoc `\AtlasTitle{…}` / `\AtlasAbstract{…}` / `\AtlasOrcid[orcid]{Name}`:
 /// the frontmatter macros of the (very large, unbound) ATLAS class must not leak

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -137,6 +137,27 @@ fn frontmatter_spconf_keywords() {
     "spconf `Index Terms` label leaked into the content:\n{x}"
   );
 }
+/// spconf.sty `\twoauthors{N1}{A1}{N2}{A2}` (L183-190) — the side-by-side
+/// two-author title block. Each pair must become a creator with its own
+/// affiliation instead of an undefined-token `<ltx:ERROR/>`.
+/// Witnesses 2605.05692, 2605.18923, 2605.26747.
+#[test]
+fn frontmatter_spconf_twoauthors() {
+  let x =
+    convert_to_xml_contrib_clean("tests/cluster_regressions/frontmatter_spconf_twoauthors.tex");
+  assert!(
+    x.contains("<personname>Alice Smith</personname>"),
+    "twoauthors author 1 is not a creator:\n{x}"
+  );
+  assert!(
+    x.contains("<personname>Bob Jones</personname>"),
+    "twoauthors author 2 is not a creator:\n{x}"
+  );
+  assert!(
+    x.contains("University A") && x.contains("University B"),
+    "twoauthors affiliations missing:\n{x}"
+  );
+}
 /// atlasdoc `\AtlasTitle{…}` / `\AtlasAbstract{…}` / `\AtlasOrcid[orcid]{Name}`:
 /// the frontmatter macros of the (very large, unbound) ATLAS class must not leak
 /// as literal text — the title/abstract render and the collaboration author

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_spconf_keywords.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_spconf_keywords.tex
@@ -1,0 +1,17 @@
+\documentclass{article}
+\usepackage{spconf}
+\title{A Study of Speech}
+\name{Alice Smith}
+\address{University A}
+\begin{document}
+\ninept
+\maketitle
+\begin{abstract}
+An abstract.
+\end{abstract}
+\begin{keywords}
+Speech recognition, deep learning
+\end{keywords}
+\section{Introduction}
+Body text.
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_spconf_keywords_braced.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_spconf_keywords_braced.tex
@@ -1,0 +1,10 @@
+\documentclass{article}
+\usepackage{spconf}
+\title{A Study of Speech}
+\name{Alice Smith}
+\begin{document}
+\maketitle
+\keywords{Speech recognition, deep learning}
+\section{Introduction}
+Body text that must stay outside the keywords block.
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_spconf_twoauthors.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_spconf_twoauthors.tex
@@ -1,0 +1,10 @@
+\documentclass{article}
+\usepackage{spconf}
+\title{A Study of Speech}
+\twoauthors
+  {Alice Smith}{University A}
+  {Bob Jones}{University B}
+\begin{document}
+\maketitle
+Body text.
+\end{document}


### PR DESCRIPTION
### Diagnostic

`Error:undefined:{keywords}` was the single largest `undefined` *what* in the sandbox corpora — **94 tasks in `sandbox-arxiv-2605`, 49 in `sandbox-arxiv-2606`**. 142 of those 143 papers are ICASSP/Interspeech submissions shipping a byte-identical `spconf.sty`, which defines the "Index Terms" block as a bare plain-TeX pair rather than a `\newenvironment`:

```tex
\def\keywords{\vspace{.5em}{\bfseries\textit{Index Terms}---\,\relax}}
\def\endkeywords{\par}
```

`latexml_contrib/src/spconf_sty.rs` covered `\name`/`\address`/`\email` but neither half of that pair, so `\begin{keywords}` found no environment. The same file's `\twoauthors` (3 more papers, all shipping `spconf.sty`) was likewise unbound and recovered as a zero-argument `<ltx:ERROR/>`, spilling its four braced arguments into the body as text. (`\copyrightnotice`, the other neighbour in that `.sty`, was checked: its 3 corpus reports are all `cai26.cls`, unrelated — spconf's is already a no-op here.)

### Approach

Mirror the `.sty`'s `\def` pair rather than declaring a `DefEnvironment!`, so a document calling the two macros directly also works, and route it to `\lx@begin@keywords` / `\lx@end@keywords` with the label carried in `@name`.

That shape is not invented. `spconf.sty` says its keywords section was "adapted from IEEEtrans", `IEEEtran.cls` L5286-5288 typesets it identically, and **Perl LaTeXML binds that very construct** in `IEEEtran.cls.ltxml` L147-148 as `\lx@begin@keywords[name={\IEEEkeywordsname:~}]` — `ltx:keywords` with the label in `@name` and the print-only `---` separator normalized to `:~`. So this follows Perl's own binding for the same markup.

Perl has no `spconf.sty.ltxml`, so it raw-loads the real file; measured on 2605.00480, that yields `<para><p><text font="bold italic">Index Terms…` and **no `ltx:keywords` element** — and **zero `<creator>` in either configuration**, because LaTeXML locks `\maketitle` and spconf's own `\def\maketitle` (the only thing that would emit the stashed `\@name`) is ignored. That measured comparison is recorded as **`OXIDIZED_DESIGN #82`**, together with why this binding stays unconditional instead of deferring to the raw file the way bundled `arxiv.sty` does (#77).

`\twoauthors{N1}{A1}{N2}{A2}` routes to the same author machinery `\name` uses, so each pair becomes a creator with its own `contact[affiliation]`.

### Validation

Guards `06_cluster_frontmatter::frontmatter_spconf_keywords` and `06_cluster_frontmatter::frontmatter_spconf_twoauthors`, both through `convert_to_xml_contrib_clean` (zero-`Error:` gate), written red before the fix and confirmed failing on the undefined-environment error.

Per-witness error counts, **identical bare and under `--preload=ar5iv.sty`**, gated on cortex's own `Processing content` main file:

| paper | before | after |
|---|---|---|
| 2605.00480 | 1 | 0 |
| 2605.00698 | 1 | 0 |
| 2605.00721 | 1 | 0 |
| 2605.01187 | 2 | 1 (`undefined:\bstctlcite`, unrelated) |
| 2605.05692 | 2 | 0 |
| 2605.18923 | 1 | 0 |
| 2605.26747 | 2 | 0 |

Same-host Perl 0.8.8 on 2605.00480, verbose: bare **4 errors** (`\name`, `\address`, `\ninept`, `{keywords}`), `--includestyles` 0 but with the frontmatter flattened into the body.

Full suite **1752 passed / 0 failed** (103 targets, exit 0); `clippy --workspace --all-targets -D warnings` clean; `fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)