### PR TITLE
fix(engine): \meaning of a \chardef token reports the character, not "Register"

### DIFF
--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -64,7 +64,52 @@ session of their own. Re-verify a row before planning on it (rule 1).
 
 ## Current status
 
-- **2026-07-27 (latest) — spconf.sty's `keywords` and `\twoauthors` were
+- **2026-07-27 (latest) — the `unexpected:fi` fatal cluster: `\meaning` of a
+  `\chardef` token returned the internal class name.** GENUINE-RUST-ONLY,
+  **18 papers, one cause.** Largest unclassified first-error cluster in the 186
+  `Fatal:TooManyErrors` papers of sandbox-arxiv-2605+2606:
+  `2605.{03971,04451,09005,15128,16720,29156,29341}`
+  `2606.{06712,07410,11290,11722,13769,14502,15753,18180,24256,26947}` — all 17
+  ship `bxcoloremoji.sty`. Rust `\meaning` had **no chardef arm**: CharDef and
+  plain Register are both `Stored::Register` (discriminated by `register_type`),
+  so a chardef fell through a catch-all and rendered as the literal string
+  `Register`. The dropped `"` is load-bearing — `bxcoloremoji.sty` L1373 recovers
+  the value with the delimited `\def\bxce@do#1"#2\relax`, so with no `"` the
+  argument scan runs away and swallows the `\fi\fi` of the enclosing
+  `\AtEndOfPackage{…\@whilenum…}` loop (L1366-1386). Those `\fi`s then executed
+  against an empty if-stack **from a macro body — hence the `at Anonymous String`
+  locator**, which is the tell that separates this from a source-level `\fi`.
+  Fixed faithfully per `TeX_Debugging.pool.ltxml` L166-168 (`\char` + `"` +
+  decimal). Measured, release + dumps, `--preload=ar5iv.sty`: **1002 -> 1-10
+  errors on all 17, zero `fi`, no fatal**; same-host Perl was 1-102 with no `fi`,
+  so post-fix Rust is at or below Perl on every witness. (Both caps must be named
+  or the deltas mislead: our 1002 is the tikz-raised 1000 cap, and Perl's lone
+  102 — 2606.11290 — is Perl's own `MAX_ERRORS`=100, so that one Perl total is
+  >=100 and unknown.) PR #426 fixed none of them (all 17 still reproduced at
+  `fc56b4d081`, which *is* #426). Guard `meaning_chardef`
+  (`latexml_oxide/tests/expansion/`). Perl's own two deviations from `tex.web`
+  L22897-22899 here (decimal not hex; `\char` for `\mathchardef`) are
+  deliberately inherited — recorded as `KNOWN_PERL_ERRORS` #65, which also warns
+  why Rust's populated `mathglyph` must NOT be used to revive the `\mathchar`
+  arm.
+  **Method note — first-error bucketing UNDER-counted this cluster.** Exactly 18
+  papers in 2605+2606 (of 60,513) ship `bxcoloremoji.sty`; 17 surfaced as
+  `unexpected:fi`, and the 18th, **2605.14271**, bucketed elsewhere because its
+  *first* error was `undefined:\SetTitleBoxVerticalShift` — yet it carried the
+  same two `fi` errors, was a real `Status:conversion:3`, and went **1002 -> 12**
+  (Perl 42) on the same fix. So a first-error histogram is a lower bound on a
+  cause's reach, not a census: confirm membership by the mechanism (here, "ships
+  the package"), then re-measure.
+  Second method note, the counterpart trap: a *heuristic* main-file pick
+  (largest `.tex` containing `\documentclass`) chose `macro.tex` for that paper
+  and manufactured a plausible-but-wrong 103 -> 1. Always take the main file
+  from cortex's own `Processing content` line.
+  Third: this worktree had **no dumps**, so the first sweeps ran in DEGRADED
+  raw-load mode. The tell was an identical error count (1003) across 17
+  *different* papers — a same-number-everywhere result is an environment
+  artifact until proven otherwise. `tools/make_formats.sh`, then re-measure.
+
+- **2026-07-27 (later still) — spconf.sty's `keywords` and `\twoauthors` were
   unbound.** `Error:undefined:{keywords}` was the **single largest `undefined`
   what** in the sandbox corpora — **94 tasks in sandbox-arxiv-2605, 49 in
   sandbox-arxiv-2606**; 142 of those 143 papers ship a byte-identical

--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -2742,3 +2742,57 @@ Candidate to upstream, though not as a straight port: Perl has no dump to use as
 the membership oracle, so the upstream-shaped fix is to extend
 `TeX.pool.ltxml`'s list with at least `IfFileExists InputIfFileExists
 PassOptionsToClass providecommand`.
+
+---
+
+## 65. `\meaning` of a `\chardef` token prints the value in DECIMAL, and says `\char` for `\mathchardef`
+
+**Perl source:** `LaTeXML/Engine/TeX_Debugging.pool.ltxml` lines 166-168
+
+```perl
+elsif ($type =~ /chardef$/i) {    # from \chardef or \mathchardef
+  my $prefix = ($$definition{mathglyph} ? '\mathchar' : '\char');
+  $meaning = $prefix . '"' . $definition->valueOf->valueOf; }
+```
+
+**Symptom:** two deviations from real TeX, both benign in isolation but wrong
+for packages that parse `\meaning` to recover a character code.
+
+1. **Decimal, not hex.** `tex.web` L22897-22899 prints the value with
+   `print_hex`, i.e. `"` followed by *uppercase hexadecimal*. Perl interpolates
+   `valueOf->valueOf`, a Perl integer, so it renders decimal.
+2. **`\char` for a `\mathchardef`.** `tex.web` L22899 prints `\mathchar` for the
+   `math_given` command code. Perl's ternary keys off `$$definition{mathglyph}`,
+   but `Core/Definition/CharDef.pm` L32-35 blesses only
+   `cs/parameters/mode/value/encoding/registerType/readonly/locator` — no
+   `mathglyph` key is ever set on a CharDef — so the `\mathchar` arm is
+   unreachable and every chardef reports `\char`.
+
+**Minimal example:**
+```tex
+\newcount\mycnt  \mycnt="41
+\chardef\chA\mycnt
+\mathchardef\mcA="0141
+\meaning\chA   % TeX: \char"41      Perl/Rust: \char"65
+\meaning\mcA   % TeX: \mathchar"141 Perl/Rust: \char"321
+```
+
+**Real-world consequence:** `bxcoloremoji.sty` L1366-1386 builds emoji tag
+codepoints as `E00` concatenated with the `\meaning` tail, expecting hex — so
+`@A` resolves to `E0065` instead of `E0041` (a different tag character). Only
+the rarely used `@!`..`@~` tag range is affected; nothing errors.
+
+**Kept as-is in Rust** — deliberately. `latexml_engine/src/tex_debugging.rs`
+ports Perl exactly (`\char` + decimal, unconditionally), because `\meaning`
+output feeds goldens copied from Perl and every corpus baseline; switching to
+hex is a behaviour change with corpus-wide blast radius, not a local fix. The
+Rust `Register` *does* carry a decoded `mathglyph`, so the `\mathchar` arm could
+be revived at any time — that is the divergence the comment at the fix site
+warns against taking accidentally.
+
+Note this entry is about the *format* only. The Rust port separately had no
+chardef arm at all and returned the internal class name `Register`, dropping the
+`"` that packages split on; that was a Rust-only defect, fixed with guard
+`meaning_chardef` (`latexml_oxide/tests/expansion/meaning_chardef.{tex,xml}`).
+Candidate to upstream: both deviations are one-line fixes (`sprintf('%X')` and
+threading the math flag), but they change observable `\meaning` output.

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2532,7 +2532,11 @@ entries were consolidated it was merged into **#74** — which adds `^`, the
 two-treatment framing, and the exclusion list — and the number was **retired
 rather than renumbered**, because divergence numbers are cited verbatim from
 `.rs` comments and renumbering silently invalidates every citation. Nothing in
-the tree cites `OXIDIZED_DESIGN #76`. Next free number: **#81**.
+the tree cites `OXIDIZED_DESIGN #76`. For the next free number see the header at
+the top of this file — it is the single authoritative counter. (This spot used to
+restate it and drifted stale at **#81** while the header had already moved on;
+restating the number in two places is what makes it get taken out from under
+people.)
 
 ### 77. `silence.sty` and the bundled `arxiv.sty` family get bindings Perl does not have
 

--- a/latexml_engine/src/tex_debugging.rs
+++ b/latexml_engine/src/tex_debugging.rs
@@ -126,7 +126,33 @@ LoadDefinitions!({
           meaning.push_str(&text);
         },
         Stored::Register(register) => {
-          meaning = register.get_address().to_string();
+          // Perl dispatches on the *concrete* class here. A CharDef is a
+          // subclass of Register, but `ref $definition` yields
+          // `...::Definition::CharDef`, which misses the `/register$/` arm and
+          // lands on the `/chardef$/` one. We store both as `Stored::Register`,
+          // discriminated by `register_type`, so test the chardef case first.
+          // Perl: Engine/TeX_Debugging.pool.ltxml L166-168.
+          if matches!(register.register_type, RegisterType::CharDef) {
+            // Perl reads `($$definition{mathglyph} ? '\mathchar' : '\char')`,
+            // but `Core/Definition/CharDef.pm` L32-35 blesses only
+            // cs/parameters/mode/value/encoding/registerType/readonly/locator —
+            // no `mathglyph` key is ever set on a CharDef, so Perl's ternary
+            // always yields `\char`, including for `\mathchardef`. Our
+            // `Register` *does* carry a decoded `mathglyph`, so branching on it
+            // would silently diverge from Perl; emit `\char` unconditionally.
+            let value = register
+              .value
+              .clone()
+              .map_or(0, NumericOps::value_of);
+            // The literal `"` is load-bearing: packages recover the character
+            // value by splitting \meaning on it with a delimited argument
+            // (bxcoloremoji.sty's `\def\bxce@do#1"#2\relax`). Without it the
+            // scan runs away and swallows the enclosing \fi tokens — witnesses
+            // arXiv 2605.03971, 2606.06712 (a 1000-error `unexpected:fi` flood).
+            meaning = format!("\\char\"{value}");
+          } else {
+            meaning = register.get_address().to_string();
+          }
         },
         Stored::Expandable(expandable) => {
           // short-circuit some troublesome discrepancies with TeX, which end up macros on our end,

--- a/latexml_oxide/tests/expansion/meaning_chardef.tex
+++ b/latexml_oxide/tests/expansion/meaning_chardef.tex
@@ -1,0 +1,26 @@
+\documentclass{article}
+% \meaning of a \chardef / \mathchardef token must report the character value
+% behind a literal " separator (Perl: TeX_Debugging.pool.ltxml L166-168), not
+% the internal definition class. Packages recover the value by splitting the
+% result on that ", so a missing " turns the delimited-argument scan into a
+% runaway that swallows the surrounding \fi tokens.
+% \grabtail below is bxcoloremoji.sty's idiom.
+% Witnesses: arXiv 2605.03971, 2606.06712 (both ship bxcoloremoji.sty).
+\newcount\mycnt
+\mycnt="41
+\chardef\chA\mycnt
+\mathchardef\mcA="0141
+\def\grabtail#1"#2\relax{\def\thetail{#2}}
+\begin{document}
+
+M1[\meaning\chA]
+
+M2[\meaning\mcA]
+
+\expandafter\grabtail\meaning\chA\relax
+T1[\thetail]
+
+\expandafter\grabtail\meaning\mcA\relax
+T2[\thetail]
+
+\end{document}

--- a/latexml_oxide/tests/expansion/meaning_chardef.xml
+++ b/latexml_oxide/tests/expansion/meaning_chardef.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <para xml:id="p1">
+    <p>M1[“char”65]</p>
+  </para>
+  <para xml:id="p2">
+    <p>M2[“char”321]</p>
+  </para>
+  <para xml:id="p3">
+    <p>T1[65]</p>
+  </para>
+  <para xml:id="p4">
+    <p>T2[321]</p>
+  </para>
+</document>


### PR DESCRIPTION
Clears the largest unclassified fatal cluster in sandbox-arxiv-2605+2606: 17 papers whose first error is `unexpected:fi`. One cause, all 17.

## Diagnostic

Rust's `\meaning` had **no chardef arm**. A `CharDef` and a plain `Register` are both `Stored::Register` here, discriminated by `register_type`, so a chardef fell through a catch-all and rendered as the literal string `Register`. Perl dispatches on the concrete class — `ref` yields `...::Definition::CharDef`, which misses the `/register$/` arm — and builds `\char"<value>` at `Engine/TeX_Debugging.pool.ltxml` L166-168.

The dropped `"` is load-bearing. `bxcoloremoji.sty` (shipped by all 17 papers) recovers the character value with a delimited argument, `\def\bxce@do#1"#2\relax`. With no `"` in the string the argument scan runs away and swallows the `\fi\fi` of the enclosing `\AtEndOfPackage{…\@whilenum…}` loop (L1366-1386). Those `\fi` tokens then execute against an empty if-stack **from a macro body** — which is exactly why the locator reads `at Anonymous String` rather than a file:line, with a 1000-error cascade behind it.

## Approach

Port Perl exactly: test the chardef case first, emit `\char` + `"` + the decimal value.

Perl's two deviations from `tex.web` L22897-22899 — decimal instead of hex, and `\char` for `\mathchardef` — are inherited **deliberately**, and recorded as `KNOWN_PERL_ERRORS` #65. Perl's ternary keys off `$$definition{mathglyph}`, but `Core/Definition/CharDef.pm` L32-35 never sets that key, so the `\mathchar` arm is unreachable upstream. Our `Register` *does* carry a decoded `mathglyph`, so branching on it would have been a silent divergence; the comment at the fix site says so.

## Validation

Release build with dumps, `--preload=ar5iv.sty --path=…/ar5iv-bindings/bindings`, main file taken from each paper's own cortex `Processing content` line. Perl 0.8.8 (rev `0d02309d`) same host, verbose, ANSI-stripped.

| witness | Rust before | Rust after | Perl |
|---|---|---|---|
| 2605.03971 | 1002 | 2 | 50 |
| 2605.04451 | 1002 | 1 | 2 |
| 2605.09005 | 1002 | 1 | 51 |
| 2605.15128 | 1002 | 1 | 37 |
| 2605.16720 | 1002 | 1 | 2 |
| 2605.29156 | 1002 | 1 | 3 |
| 2605.29341 | 1002 | 8 | 11 |
| 2606.06712 | 1002 | 3 | 11 |
| 2606.07410 | 1002 | 1 | 12 |
| 2606.11290 | 1002 | 10 | 102 |
| 2606.11722 | 1002 | 1 | 29 |
| 2606.13769 | 1002 | 4 | 5 |
| 2606.14502 | 1002 | 1 | 2 |
| 2606.15753 | 1002 | 4 | 4 |
| 2606.18180 | 1002 | 1 | 1 |
| 2606.24256 | 1002 | 1 | 5 |
| 2606.26947 | 1002 | 1 | 2 |

All 17 went `rc=1` + `Fatal:TooManyErrors` to `rc=0`, with **zero** `unexpected:fi`. Perl never raised `unexpected:fi` on any of them, so the verdict is GENUINE-RUST-ONLY throughout; post-fix Rust is at or below Perl on every witness.

- Guard `meaning_chardef` (`latexml_oxide/tests/expansion/meaning_chardef.{tex,xml}`), hand-authored golden, independently confirmed against Perl. Red before the fix (`T1[Register]` — the runaway scan), green after (`T1[65]`).
- Full suite **1751 passed / 0 failed**.
- `cargo +nightly clippy --workspace --all-targets -- -D warnings` clean; `cargo +nightly fmt --all` applied.
- Lateral regression sweep over 62 unrelated papers: **62/62 identical** before vs after. Includes the two witnesses already named in this file's comments, `2110.11931` and `1908.01908` (0 errors both sides).

Note: PR #426 fixed none of these — all 17 still reproduced at `fc56b4d081`, which *is* #426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)