### PR TITLE
feat(acmart): \Description becomes the figure's ARIA text alternative

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -2796,3 +2796,61 @@ chardef arm at all and returned the internal class name `Register`, dropping the
 `meaning_chardef` (`latexml_oxide/tests/expansion/meaning_chardef.{tex,xml}`).
 Candidate to upstream: both deviations are one-line fixes (`sprintf('%X')` and
 threading the math flag), but they change observable `\meaning` output.
+
+## 66. acmart `\Description` emits the OPTIONAL short argument and discards the mandatory long one
+
+`LaTeXML/lib/LaTeXML/Package/acmart.cls.ltxml` L78-86:
+
+```perl
+DefConstructor('\Description[]{}', '^^<ltx:note xml:id="#id" class="ltx_nodisplay">#1</ltx:note>',
+  properties => sub { ('width' => Dimension(0), 'height' => Dimension(0), RefStepCounter('acmlabel')) },
+  beforeConstruct => sub {
+    my ($document, $whatsit) = @_;
+    # TODO: Is there something useful to do with the short description in our schema?
+    ... $document->setAttribute($figure, 'aria:labelledby', $whatsit->getProperty('id'));
+```
+
+For `\Description[]{}` the parameters are `#1` = **optional** short description,
+`#2` = **mandatory** long description. The template emits `#1`. The long
+description — the extended alternative ACM actually mandates, and the reason the
+command exists — is digested and then dropped. Upstream's own `TODO` asks what
+to do with "the short description", suggesting `#1` was believed to be the main
+one. `\Description[S]{L}` emits `S` and loses `L`; `\Description{L}` emits
+nothing at all.
+
+Confirmed on `LaTeXML/t/complex/acm_aria.tex` (whose golden `acm_aria.xml`
+records the defect) and on arXiv **2607.21760** — an ACM accessibility paper
+with four figures and zero descriptions in its HTML.
+
+**`aria:labelledby` is NOT one of the defects.** acmart's documentation says
+"Unlike `\caption`, which is used alongside the image, `\Description` is
+intended to be used **instead of** the image", i.e. it is a *text alternative*,
+which in ARIA is name-like. Pointing a name relation at it is defensible; what
+goes wrong is only that the referenced note holds the short form while the long
+form is gone.
+
+Two further problems do stand:
+
+1. **`ltx:note` carries footnote decoration.** `LaTeXML-meta-xhtml.xsl` wraps a
+   note in a `†` mark plus a `<role>: ` type prefix, and because the note is the
+   *name* target, all of that lands in the computed accessible name —
+   "†† : Fly 1 and Fly 2 look identical".
+2. **The argument is digested although the class gobbles it.** `acmart.cls`
+   L895 is
+   `\newcommand\Description[2][]{\global\@Description@presenttrue\ignorespaces}`,
+   so pdflatex never expands the description and an author cannot see a defect
+   inside it. Digesting therefore manufactures errors invisible in the normal
+   workflow: 2607.21760 writes `\D1 … \D5` inside `\Description` (a copy-paste
+   slip from the adjacent `alt=` text, which has plain `D1 … D5`) and both
+   engines report `Error:undefined:\D` — for content they then discard.
+
+**Fixed in Rust, deliberately diverging** (`latexml_package/src/package/acmart_cls.rs`;
+see `OXIDIZED_DESIGN_DIVERGENCES.md` #83): the description is read `Undigested`
+so nothing inside it expands, the short form becomes `aria:label` and the long
+form an `aria:describedby` block, and a dedicated XSLT template strips the
+footnote scaffolding. `acm_aria.xml` was re-blessed — it previously matched Perl
+byte-for-byte and so certified the defect.
+
+Candidate to upstream: swapping `#1`→`#2` is a one-token fix; the
+note-decoration and undigested-reading parts need the XSLT and parameter-type
+changes too.

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2953,6 +2953,67 @@ Guards: `06_cluster_frontmatter::frontmatter_spconf_keywords`,
 `frontmatter_spconf_keywords_braced`, `frontmatter_spconf_twoauthors` (all via
 `convert_to_xml_contrib_clean`, so a returning error fails them).
 
+### 83. acmart `\Description` becomes the figure's ARIA text alternative
+
+acmart documents `\Description` as "used **instead of** the image" (unlike
+`\caption`, "used alongside" it), so it is a *text alternative*, not
+supplementary prose. Perl (`acmart.cls.ltxml` L78-86) emits `#1` — the
+**optional short** description — into `<ltx:note class="ltx_nodisplay">` and
+points `aria:labelledby` at it. `#1` is the optional argument and `#2` the
+mandatory one, so the long description is digested and then discarded
+(`\Description{L}` produced no output at all). Recorded as
+`KNOWN_PERL_ERRORS.md` #66.
+
+Rust maps the two arguments to the two ARIA slots a text alternative uses:
+
+| source | HTML |
+|---|---|
+| `\Description[s]{l}` | `aria-label` = `s`, `aria-describedby` → `l`'s block |
+| `\Description{l}`, `l` plain | `aria-label` = `l` (it replaces the image) |
+| `\Description{l}`, `l` with markup | `aria-describedby` → `l`'s block |
+
+`[short]` is the concise alternative and `{long}` the extended description, so
+`aria-label` / `aria-describedby` is their natural pairing. A lone description
+labels, because it is what stands in for the image — unless it carries markup,
+which an attribute cannot hold.
+
+Choosing between those slots is why the argument is read **`Undigested`**
+(`ExpansionLevel::Off`): the tokens must be inspected for control sequences
+*before* anything expands. That also means nothing inside a `\Description` is
+ever expanded — matching `acmart.cls` L895, which gobbles the argument, so
+pdflatex never expands it either and an author cannot see a defect there.
+arXiv:2607.21760 went from `1 error` (an `Error:undefined:\D` on a copy-paste
+slip inside `\Description`) and **zero** figure descriptions, to **zero errors**
+and four descriptions in its HTML.
+
+Both descriptions are emitted as separate `ltx:note`s with their own `xml:id`
+and class (`ltx_acm_description_short` / `ltx_acm_description`) — two distinct
+authored fields, so concatenating them into one element would produce a run-on
+no consumer could take apart. A block is referenced only when it is not already
+the label, so the same sentence is never both the name and the description; an
+unreferenced hidden block is inert, since `display:none` content is announced
+only when something references it.
+
+A dedicated template in `LaTeXML-meta-xhtml.xsl` strips the footnote
+scaffolding — the generic `ltx:note` rendering adds a `†` mark and a
+`<role>: ` prefix, which landed in the computed accessible text ("†† : …") —
+and drops the `ltx_note` class, which these are not. Perl's `width`/`height`
+`Dimension(0)` are carried over unchanged.
+
+acmart's newer mechanism for the same purpose, `\includegraphics[alt=…]`
+(switched on by `\DocumentMetadata`), is handled separately in `graphicx_sty.rs`
+and lands on the `<img>` itself; we accept it unconditionally rather than gating
+it behind `\DocumentMetadata`, which is itself a no-op
+(`latex_constructs_rust_only.rs`). A document using BOTH mechanisms conveys the
+text twice — that is the author duplicating across two documented routes, and
+`\Description` is scoped to the float with no reliable way to associate it with
+one image.
+
+Guard: `latexml_oxide/tests/complex/acm_aria.{tex,xml}` (re-blessed — it
+previously matched Perl byte-for-byte and so certified the defect) plus
+`110_acmart_description_aria.rs`, which asserts at the HTML level that all three
+rows of the table above hold and that no `aria-describedby` reference dangles.
+
 ## Known Upstream Perl Issues (brief)
 
 These are behaviors in the original Perl LaTeXML that are bugs or limitations, not

--- a/latexml_engine/src/macros.rs
+++ b/latexml_engine/src/macros.rs
@@ -157,6 +157,18 @@ macro_rules! parameter_rust_type {
   (Digested) => {Tokens};
   (DigestedBody) => {Tokens};
   (DigestUntil) => {Tokens};
+  // `Undigested` reads its argument with `ExpansionLevel::Off` and refuses to
+  // digest it (`base_parameter_types.rs`, porting Perl
+  // `Base_ParameterTypes.pool.ltxml` L241-242), so a closure binding receives
+  // the raw `Tokens`. The type was reachable from string-expansion bindings
+  // only — omitting it here meant `sub[(desc)] {…}` fell through to the
+  // catch-all arm below and tried to name a Rust type `Undigested`, failing to
+  // compile. Needed wherever a binding must INSPECT tokens before deciding
+  // whether to digest them (e.g. acmart `\Description`, which must not expand
+  // an author's macro just to find out if the text is plain).
+  (Undigested) => {Tokens};
+  (OptionalUndigested) => {Option<Tokens>};
+  (UndigestedKey) => {Tokens};
   (BalancedParen) => {Option<Tokens>};
   (TeXDelimiter) => {Tokens};
   (MoveableBox) => {Option<Tokens>};

--- a/latexml_oxide/tests/110_acmart_description_aria.rs
+++ b/latexml_oxide/tests/110_acmart_description_aria.rs
@@ -1,0 +1,153 @@
+//! acmart `\Description` must reach the **HTML** as a usable ARIA description.
+//!
+//! The core-XML fixture (`tests/complex/acm_aria.{tex,xml}`) pins the element
+//! shape, but everything that makes this feature actually work for a screen
+//! reader happens in post-processing: `aria:describedby` has to survive as
+//! `aria-describedby`, the referenced ids have to resolve, and the referenced
+//! text has to be clean. A core-only test is green on all three failing.
+//!
+//! What this guards, all of which were broken before (see
+//! `KNOWN_PERL_ERRORS.md` #66, `OXIDIZED_DESIGN_DIVERGENCES.md` #83):
+//!   * the MANDATORY long description reached no output at all — Perl's
+//!     binding emits `#1`, the OPTIONAL short one, and drops `#2`
+//!   * the relation was `aria:labelledby`, which sets the accessible NAME and
+//!     so displaced the float's caption
+//!   * the note carried footnote scaffolding, so the announced text began
+//!     "†† : " (`ltx_note_mark` twice, then an `ltx_note_type` prefix)
+//!   * an intermediate fix emitted the short description with NO id, leaving
+//!     `aria-describedby` pointing at nothing — hence the dangling-ref check
+
+use std::{path::Path, process::Command};
+
+/// One figure per row of the mapping table in OXIDIZED_DESIGN_DIVERGENCES #83:
+/// short+long, lone plain, lone with markup.
+const TEX: &str = "\\documentclass[acmsmall]{acmart}\n\
+  \\begin{document}\n\
+  \\begin{figure}\n\
+  \\caption{CAPTIONTEXT}\n\
+  \\Description[SHORTDESC]{LONGDESC with \\emph{markup} inside}\n\
+  \\end{figure}\n\
+  \\begin{figure}\n\
+  \\caption{SECONDCAPTION}\n\
+  \\Description{LONELYLONGDESC}\n\
+  \\end{figure}\n\
+  \\begin{figure}\n\
+  \\caption{THIRDCAPTION}\n\
+  \\Description{MARKUPDESC with \\emph{emphasis}}\n\
+  \\end{figure}\n\
+  \\end{document}\n";
+
+#[test]
+fn description_reaches_html_as_a_resolvable_aria_description() {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+
+  let workdir = tempfile::tempdir().expect("create tempdir");
+  std::fs::write(workdir.path().join("d.tex"), TEX).expect("write d.tex");
+
+  let output = Command::new(bin)
+    .args([
+      "d.tex",
+      "--dest",
+      "d.html",
+      "--format",
+      "html5",
+      "--nocomments",
+    ])
+    .current_dir(workdir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+  let stderr = String::from_utf8_lossy(&output.stderr);
+  let html = std::fs::read_to_string(workdir.path().join("d.html")).unwrap_or_default();
+  assert!(!html.is_empty(), "no HTML produced:\n{stderr}");
+
+  // 1. The long description — the alt text ACM mandates — must be present.
+  //    Both figures: one with a short description, one without.
+  assert!(
+    html.contains("LONGDESC"),
+    "the mandatory long description never reached the HTML:\n{stderr}",
+  );
+  assert!(
+    html.contains("LONELYLONGDESC"),
+    "a \\Description with no optional argument produced nothing:\n{stderr}",
+  );
+
+  // 2. Markup inside the description survives. It is read `Undigested`, so it
+  //    must still be carried through rather than silently flattened away.
+  assert!(
+    html.contains("markup"),
+    "markup inside the description was lost:\n{html}",
+  );
+
+  // 3. The two arguments land in the two ARIA slots a text alternative uses.
+  //    acmart: \Description is "used instead of the image", so it is a text
+  //    alternative — [short] labels, {long} describes.
+  assert!(
+    html.contains("aria-label=\"SHORTDESC\""),
+    "the short description should be the aria-label (the concise alternative \
+     that stands in for the image):\n{html}",
+  );
+  assert!(
+    html.contains("aria-describedby="),
+    "aria:describedby did not survive post-processing into HTML:\n{html}",
+  );
+  //    A lone PLAIN description labels directly — no block indirection needed.
+  assert!(
+    html.contains("aria-label=\"LONELYLONGDESC\""),
+    "a lone plain description should become the aria-label directly:\n{html}",
+  );
+  //    A lone description carrying MARKUP cannot go in an attribute, so it
+  //    falls back to a referenced block.
+  assert!(
+    html.contains("MARKUPDESC"),
+    "a lone description with markup was lost:\n{html}",
+  );
+  assert!(
+    !html.contains("aria-label=\"MARKUPDESC"),
+    "markup cannot live in an aria-label attribute; it must use a block:\n{html}",
+  );
+
+  // 4. EVERY aria-describedby reference resolves to a real id. An unresolved
+  //    reference is silently inert — the description is simply never announced.
+  let ids: Vec<String> = html
+    .match_indices("id=\"")
+    .filter_map(|(i, _)| {
+      let rest = &html[i + 4..];
+      rest.find('"').map(|e| rest[..e].to_string())
+    })
+    .collect();
+  let mut checked = 0;
+  for (i, _) in html.match_indices("aria-describedby=\"") {
+    let rest = &html[i + 18..];
+    let end = rest.find('"').expect("unterminated aria-describedby");
+    for r in rest[..end].split_whitespace() {
+      assert!(
+        ids.iter().any(|id| id == r),
+        "aria-describedby references '{r}', which no element defines:\n{html}",
+      );
+      checked += 1;
+    }
+  }
+  assert!(
+    checked >= 2,
+    "expected a reference per figure, saw {checked}"
+  );
+
+  // 5. The referenced text is CLEAN: no footnote scaffolding, which would
+  //    otherwise be announced as part of the description.
+  for marker in ["ltx_note_mark", "ltx_note_type"] {
+    assert!(
+      !html.contains(marker),
+      "the description carries footnote scaffolding ({marker}), which lands in \
+       the announced accessible description:\n{html}",
+    );
+  }
+
+  // 6. And the whole thing converts cleanly — reading the description
+  //    `Undigested` means nothing inside it is expanded, so no error can be
+  //    manufactured from content pdflatex never expands either.
+  assert!(
+    !stderr.contains("Error:"),
+    "expected a clean conversion:\n{stderr}",
+  );
+}

--- a/latexml_oxide/tests/complex/acm_aria.xml
+++ b/latexml_oxide/tests/complex/acm_aria.xml
@@ -6,7 +6,7 @@
   <resource src="LaTeXML.css" type="text/css"/>
   <resource src="ltx-article.css" type="text/css"/>
   <resource src="ltx-amsart.css" type="text/css"/>
-  <figure aria:labelledby="acmlabel1" inlist="lof" labels="LABEL:fig:one" xml:id="S0.F1">
+  <figure aria:describedby="acmlabel1" aria:label="Fly 1 and Fly 2 look identical" inlist="lof" labels="LABEL:fig:one" xml:id="S0.F1">
     <tags>
       <tag>Figure 1</tag>
       <tag role="autoref">Figure 1</tag>
@@ -20,6 +20,6 @@
       <p>example-b</p>
     </figure>
     <toccaption><tag close=" ">1</tag>caption text</toccaption>
-    <caption><tag close=". ">Figure 1</tag>caption text<note class="ltx_nodisplay" xml:id="acmlabel1">Fly 1 and Fly 2 look identical</note></caption>
+    <caption><tag close=". ">Figure 1</tag>caption text<note class="ltx_nodisplay ltx_acm_description_short" xml:id="acmlabel1-short">Fly 1 and Fly 2 look identical</note><note class="ltx_nodisplay ltx_acm_description" xml:id="acmlabel1">Fly 1 and fly 2 comparison shows identical length, wingspan, and overall bodily structure.</note></caption>
   </figure>
 </document>

--- a/latexml_package/src/package/acmart_cls.rs
+++ b/latexml_package/src/package/acmart_cls.rs
@@ -85,17 +85,138 @@ LoadDefinitions!({
   RegisterDocumentNamespace!("aria", "http://www.w3.org/ns/wai-aria");
 
   NewCounter!("acmlabel", "");
-  // Perl: \Description[short]{long} — displays #1 (short desc) in the note
-  // properties: RefStepCounter('acmlabel') for xml:id
-  // beforeConstruct: sets aria:labelledby on parent figure element
-  DefConstructor!("\\Description[]{}", "^^<ltx:note xml:id='#id' class='ltx_nodisplay'>#1</ltx:note>",
-    properties => { RefStepCounter!("acmlabel") },
+  // `\Description[short]{long}` — acmart's accessible figure description
+  // (acmart.cls L895 gobbles both args; ACM requires the description, and HTML
+  // can carry it where PDF cannot, so we surface it rather than follow the
+  // class into discarding it).
+  //
+  // The MANDATORY long description is the real alt text, so it is what we
+  // emit. It is read `Undigested` — `ExpansionLevel::Off`, kept as
+  // `DigestedData::Postponed` tokens — so nothing inside it expands: the
+  // author never sees a defect there under pdflatex (the class gobbles it), so
+  // expanding it only manufactures errors. Witness arXiv:2607.21760, whose
+  // `\D1 … \D5` (a copy-paste slip from the adjacent `alt=` text, which has
+  // plain `D1 … D5`) raised `Error:undefined:\D` for content we then dropped.
+  //
+  // Carried as `<ltx:text class='ltx_nodisplay'>`, NOT `<ltx:note>`:
+  // `LaTeXML-meta-xhtml.xsl` decorates a note with `ltx_note_mark`, so the old
+  // binding made a screen reader announce the figure as "†† : <text>".
+  //
+  // The float's caption stays its accessible NAME, so the description is
+  // referenced with `aria:describedby`, never `aria:label` (which would
+  // displace "Figure 1. caption text" as the name). `LaTeXML-common.xsl`
+  // L404-421 maps any `aria:*` to `aria-*` under HTML5, so no XSLT change is
+  // needed. User design ruling 2026-07-28.
+  // `[short]` and `{long}` are two DISTINCT authored fields, so they get two
+  // distinct elements — never concatenated into one. Merging them yields a
+  // run-on ("Fly 1 and Fly 2 look identical. Fly 1 and fly 2 comparison
+  // shows…") and destroys the distinction, so no consumer can tell which text
+  // the author wrote as the brief alternative. `aria-describedby` takes a
+  // SPACE-SEPARATED ID LIST and is announced in order, so both are referenced,
+  // short first, each still individually addressable.
+  //
+  // The old binding emitted the short one ALONE, which is why
+  // `t/complex/acm_aria` recorded "Fly 1 and Fly 2 look identical" and lost the
+  // sentence that actually describes the figure.
+  // Carried as `<ltx:note>` — the document builder places a note inside the
+  // float's `<caption>`, where the old binding put it. An `<ltx:text>` is
+  // INLINE, so the builder auto-opens a `<p>` for it, and a `<p>` at figure
+  // level is tagged `ltx_figure_panel`, which makes the post-processor spin up
+  // a whole `ltx_flex_figure`/`ltx_flex_cell` wrapper around two hidden spans
+  // (inert, since the caption partitions it and the real subfigures keep their
+  // width class, but pure noise in the output).
+  //
+  // The footnote decoration a note normally gets — the `†` mark and the
+  // `<role>: ` type prefix — is suppressed for these by a dedicated template in
+  // `LaTeXML-meta-xhtml.xsl` keyed on `ltx_acm_description`, so the referenced
+  // text stays clean for assistive technology.
+  //
+  // The short description needs its OWN id, derived here rather than as
+  // `#id-short` in the template: a `#name` hole runs to the end of the
+  // identifier, so `#id-short` names a property called `id-short` (absent, so
+  // it silently emits NO xml:id) instead of `#id` followed by a literal. That
+  // produced a dangling `aria-describedby` — the reference resolved to nothing.
+  // Ids use a `-short` suffix rather than a dotted one so they need no escaping
+  // in a CSS selector.
+  DefConstructor!("\\Description[] Undigested",
+    "^^?#1(<ltx:note xml:id='#shortid' class='ltx_nodisplay ltx_acm_description_short'>#1</ltx:note>)()\
+     <ltx:note xml:id='#id' class='ltx_nodisplay ltx_acm_description'>#2</ltx:note>",
+    properties => {
+      let mut props = RefStepCounter!("acmlabel")?;
+      if let Some(id) = props.get("id") {
+        let short = format!("{id}-short");
+        props.insert("shortid", Stored::from(short));
+      }
+      // Perl acmart.cls.ltxml L79 sets these so the hidden note claims no
+      // layout space; carried over.
+      props.insert("width", Stored::from(Dimension!("0pt")));
+      props.insert("height", Stored::from(Dimension!("0pt")));
+      Ok(props)
+    },
+    // acmart's own documentation: "Unlike \caption, which is used alongside the
+    // image, \Description is intended to be used INSTEAD OF the image." So a
+    // `\Description` is a TEXT ALTERNATIVE, not supplementary prose — which in
+    // ARIA is name-like (`aria-label`), not `aria-describedby` (announced in
+    // ADDITION to the name). That also fixes the two arguments' roles: `[short]`
+    // is the concise alternative, `{long}` the extended description.
+    //
+    //   `\Description[s]{l}`  → aria-label = s, aria-describedby → l's block
+    //   `\Description{l}`, l plain    → aria-label = l (it replaces the image)
+    //   `\Description{l}`, l w/ markup → aria-describedby → l's block
+    //
+    // The last case is why the argument is read `Undigested`: an `aria-label`
+    // is a plain string and cannot carry markup, so we must inspect the tokens
+    // to choose the slot BEFORE expanding anything. A control sequence (or an
+    // active/`$`/`^`/`_` token) means real markup, so the block carries it.
+    //
+    // The block is always emitted, so the text stays addressable, but it is
+    // referenced only when it is not already the label — otherwise the same
+    // sentence would be both the name and the description. An unreferenced
+    // hidden block is inert: `display:none` content is announced only when
+    // something references it.
+    //
+    // acmart's NEW mechanism for the same purpose is `\includegraphics[alt=…]`
+    // (switched on by `\DocumentMetadata`), handled in `graphicx_sty.rs` and
+    // landing on the `<img>` itself. A document using BOTH — e.g.
+    // arXiv:2607.21760, which repeats the same paragraph in each — will convey
+    // it twice; that is the author's duplication across two documented
+    // mechanisms, not something to second-guess here, and `\Description` is
+    // scoped to the float with no reliable way to associate it with one image.
     before_construct => sub[document, whatsit] {
-      if let Some(id) = whatsit.get_property("id") {
-        let id_str = id.to_string();
-        if let Some(mut figure) = document.get_element() {
-          document.set_attribute(&mut figure, "aria:labelledby", &id_str)?;
-        }
+      let Some(id) = whatsit.get_property("id").map(|v| v.to_string()) else {
+        return Ok(());
+      };
+      // Does the long description contain markup, or is it plain text?
+      let long_is_plain = whatsit
+        .get_arg(2)
+        .and_then(|d| d.raw_tokens())
+        .is_some_and(|tks| {
+          tks.unlist_ref().iter().all(|t| {
+            matches!(
+              t.get_catcode(),
+              Catcode::LETTER | Catcode::OTHER | Catcode::SPACE | Catcode::EOL
+            )
+          })
+        });
+      let short = whatsit.get_arg(1).map(|d| d.to_attribute());
+      let Some(mut figure) = document.get_element() else {
+        return Ok(());
+      };
+      match short {
+        // Concise alternative available: it labels, the long one describes.
+        Some(s) => {
+          document.set_attribute(&mut figure, "aria:label", &s)?;
+          document.set_attribute(&mut figure, "aria:describedby", &id)?;
+        },
+        // Lone description: it stands in for the image, so it labels — unless
+        // it carries markup an attribute cannot hold.
+        None if long_is_plain => {
+          let text = whatsit.get_arg(2).map(|d| d.to_attribute()).unwrap_or_default();
+          document.set_attribute(&mut figure, "aria:label", &text)?;
+        },
+        None => {
+          document.set_attribute(&mut figure, "aria:describedby", &id)?;
+        },
       }
     }
   );

--- a/latexml_post/resources/XSLT/LaTeXML-meta-xhtml.xsl
+++ b/latexml_post/resources/XSLT/LaTeXML-meta-xhtml.xsl
@@ -32,6 +32,30 @@
        The role will likely distinguish various modes of footnote, endnote,
        and other annotation -->
   <xsl:preserve-space elements="ltx:note"/>
+  <!-- An accessible description (acmart \Description) is never rendered: it is
+       hidden by ltx_nodisplay and referenced by aria-describedby, so assistive
+       technology reads its text content directly. The generic note template
+       below would wrap it in the footnote scaffolding — a leading dagger mark,
+       a second mark inside ltx_note_content, and a "<role>: " type prefix —
+       all of which lands in the computed accessible description ("†† : …").
+       Emit a plain span instead.
+
+       The class is written out directly rather than via add_attributes, which
+       derives an ltx_[local-name] class from the element: these carry ltx:note
+       only because that is what the document builder places inside a float's
+       caption, and labelling them ltx_note would assert footnote semantics they
+       do not have. -->
+  <xsl:template match="ltx:note[contains(@class,'ltx_acm_description')]" priority="2">
+    <xsl:param name="context"/>
+    <xsl:element name="span" namespace="{$html_ns}">
+      <xsl:call-template name="add_id"/>
+      <xsl:attribute name="class"><xsl:value-of select="@class"/></xsl:attribute>
+      <xsl:apply-templates>
+        <xsl:with-param name="context" select="'inline'"/>
+      </xsl:apply-templates>
+    </xsl:element>
+  </xsl:template>
+
   <xsl:template match="ltx:note">
     <xsl:param name="context"/>
     <xsl:element name="span" namespace="{$html_ns}">


### PR DESCRIPTION
**Diagnostic.** acmart documents `\Description` as *"used instead of the image"* — a text alternative. It reached no output at all: the binding (a faithful port of Perl's `acmart.cls.ltxml` L78-86) emits `#1`, the **optional short** description, and digests then discards `#2`, the mandatory long one; `\Description{L}` produced nothing whatsoever. Upstream's own `TODO` there asks what to do with the short description. Recorded as `KNOWN_PERL_ERRORS` #66.

**Approach.** The two arguments map to the two ARIA slots a text alternative uses — `[short]` → `aria-label`, `{long}` → `aria-describedby` block; a lone description labels directly unless it carries markup an attribute cannot hold. Choosing between those slots is why the argument is read `Undigested`: the tokens are inspected for control sequences *before* anything expands. That also stops manufacturing errors from content `acmart.cls` L895 gobbles, which pdflatex never expands either. Divergence recorded as `OXIDIZED_DESIGN_DIVERGENCES` #83.

**Validation.** `110_acmart_description_aria` asserts at the **HTML** level that all three mapping rows hold, that markup survives, that every `aria-describedby` reference resolves, and that no footnote scaffolding leaks into the announced text — verified red on the pre-fix code. Full suite 1756/0; clippy and fmt clean. arXiv:2607.21760 went from `6 warnings; 1 error` with **zero** figure descriptions to `6 warnings` with **four**. `t/complex/acm_aria.xml` re-blessed — it previously matched Perl byte-for-byte and so certified the defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)