### PR TITLE
perf(stomach): share the constructor definition instead of cloning it per whatsit

### DIFF
--- a/docs/performance/STREAMING_CORE_DESIGN_2026-07-29.md
+++ b/docs/performance/STREAMING_CORE_DESIGN_2026-07-29.md
@@ -215,6 +215,16 @@ byte-identical to the eager path on the whole test corpus. A streaming rewrite
 that silently drops a rule is exactly the kind of regression that greens a test
 suite and corrupts a corpus.
 
+**Settled dead-end — dropping the digested tree at the Build boundary.**
+`core_interface.rs` takes `digested: Digested` by value and last reads it at the
+`absorb` call, so the whole graph stays alive through Rewriting, Math Parsing and
+Finalizing; adding `drop(digested)` right after Build looks like a free
+multi-hundred-MB win. **It is not: measured 2026-07-29, interleaved A/B, release
+profile, 4.5 MB corpus — 6078/6073 MB baseline vs 6089/6080 MB with the drop,
+i.e. noise.** The reason is the whole point of S3: **peak RSS is reached _inside_
+Build**, so nothing done _after_ Build can lower it. Fragmenting has to happen
+within the digest→build loop, not around it. Do not re-attempt the outer drop.
+
 ---
 
 ## 5. Open questions
@@ -227,9 +237,38 @@ suite and corrupts a corpus.
    with no natural seam still needs bounding — section? A byte budget with a
    safe cut point? What happens to an alignment or math environment straddling
    the boundary?
-3. **Is the `Rc<Constructor>` per `invoke_token` (77,902 allocations on a 1.5 MB
-   slice) a real defect?** A definition should be looked up, not allocated per
-   invocation. Cheap to check, possibly a free win independent of this design.
+3. ~~**Is the `Rc<Constructor>` per `invoke_token` a real defect?**~~ **ANSWERED
+   2026-07-29, and the premise was wrong.** The *lookup* never allocated:
+   `Stored::Constructor` is already `Rc<Constructor>` (`common/store.rs`), so
+   `lookup_digestable_definition`'s `front.clone()` is a refcount bump. The
+   allocation was one level down, in `Constructor::invoke_primitive`, which built
+   the Whatsit's definition back-reference as `Rc::new(self.clone())` — a
+   **retained** deep clone (Whatsits live for the whole Build), 1:1 with
+   invocations, plus a placeholder `Rc<Expandable>` from `..Whatsit::default()`
+   that was overwritten immediately. Both fixed by routing the invoker's existing
+   handle through `Constructor::invoke_primitive_shared`. Measured: peak RSS
+   6074/6081 → 6041/6044 MB on a 4.5 MB math+prose corpus, wall unchanged,
+   output byte-identical. **Real but small — ~0.6%**, so it is a tidy-up, not a
+   lever on the 131 MB problem.
+
+   The same dhat run reorders the priorities for anyone optimizing constant
+   factors here (debug profile, math-dense fixture, so treat as shape not
+   absolute):
+   * `State::assign_internal`'s per-symbol `VecDeque<Stored>` growth is the
+     single largest byte consumer (52.2 MB / 181k blocks), and the State's own
+     top-level table adds 64.5 MB in 31 `with_capacity`/rehash blocks — together
+     ~26% of all bytes, from the binding store alone.
+   * The math parser (marpa ASF + `translate_node`) is 28.7% of blocks, 25.5% of
+     bytes, dominated by one 56-byte `Rc<Node<ByteToken>>` per parse node.
+   * The libxml/document layer is **block-heavy, byte-light** — ~44% of blocks
+     for ~8.6% of bytes — almost entirely 4–7 byte `String` copies out of
+     `Node::get_name` / `attr_node_value` / `get_properties`, i.e. FFI round
+     trips that re-copy tag and attribute names on every query. Caching qnames
+     would cut allocation *count*, not peak bytes.
+   * Caveat: dhat's stack depth cap (24) truncated the two largest block sites
+     (383k blocks of `format!`, 62k of `HashMap<String,String>::insert`) to no
+     project frame, so their callers are unattributed. Re-profile with a deeper
+     backtrace before chasing them.
 4. **Can the libxml2 DOM be made cheaper per node**, or is 5.7 KB/node simply
    what a `XMTok`-dense tree costs? If the latter, fragment size is bounded by
    node count rather than byte count, and the fragment policy must reflect that.

--- a/latexml_core/src/definition/constructor.rs
+++ b/latexml_core/src/definition/constructor.rs
@@ -272,16 +272,36 @@ impl fmt::Display for Constructor {
 impl Object for Constructor {
   fn stringify(&self) -> String { <Self as Definition>::stringify_type(self, "Constructor") }
 }
-impl Definition for Constructor {
-  fn before_digest(&self) -> Option<&Vec<BeforeDigestClosure>> { Some(&self.before_digest) }
-  fn after_digest(&self) -> Option<&Vec<DigestionClosure>> { Some(&self.after_digest) }
-  fn after_digest_body(&self) -> Option<&Vec<DigestionClosure>> { Some(&self.after_digest_body) }
-  fn capture_body(&self) -> bool { self.capture_body }
-  fn get_sizer(&self) -> Option<SizingClosure> { self.sizer.clone() }
-  fn invoke(&self, _once_only: bool) -> Result<Tokens> { Ok(Tokens!()) }
-  /// Digest the constructor; This should occur in the Stomach to create a Whatsit.
-  /// The whatsit which will be further processed to create the document.
-  fn invoke_primitive(&self) -> Result<Vec<Digested>> {
+impl Constructor {
+  /// Digest through the `Rc<Constructor>` the state table already holds, instead
+  /// of deep-cloning the definition for every invocation.
+  ///
+  /// Every Whatsit keeps a back-reference to the definition that built it
+  /// ([`Whatsit::definition`]), and [`Definition::invoke_primitive`] fills that
+  /// slot with `Rc::new(self.clone())` — a **fresh deep clone per invocation**,
+  /// carrying the `Parameters` and all three `Vec<Rc<dyn Fn…>>` hook lists with
+  /// it. Those clones are not transient: a Whatsit lives in the digested tree
+  /// for the whole Build, so a document retains one private copy of the
+  /// constructor per construct it uses. Measured with dhat (2026-07-29, debug
+  /// profile, math-dense fixture): the `Rc<Constructor>` itself was 1,215 blocks
+  /// / 349,920 B — an exact 1:1 with the 1,215 constructor invocations — plus
+  /// 3,638 blocks / 314,816 B inside `<Constructor as Clone>::clone` for the
+  /// parameters and hook vectors.
+  ///
+  /// The state table's entry is `Stored::Constructor(Rc<Constructor>)`
+  /// (`common/store.rs`), so the invoker is already holding a shareable handle;
+  /// passing it through turns that whole per-invocation cost into a refcount
+  /// bump. Sharing is sound because the definition is immutable once installed —
+  /// nothing calls `Rc::get_mut` on it, and `PartialEq for Whatsit` compares
+  /// definitions **by value** (`*self.definition == *other.definition`), so a
+  /// shared handle compares exactly as a private clone did.
+  pub fn invoke_primitive_shared(me: &Rc<Constructor>) -> Result<Vec<Digested>> {
+    me.digest_to_whatsit(Rc::clone(me) as Rc<dyn Definition>)
+  }
+
+  /// The body of constructor digestion, parameterized by the handle to install
+  /// as the Whatsit's [`Whatsit::definition`] back-reference.
+  fn digest_to_whatsit(&self, definition: Rc<dyn Definition>) -> Result<Vec<Digested>> {
     Debug!("invoke_primitive for {:?}", self.get_cs());
     // Call any `Before' code.
     // TODO: profiling / tracing
@@ -336,11 +356,18 @@ impl Definition for Constructor {
     // $properties{level}   = $stomach->getBoxingLevel;
 
     // Now create the Whatsit, itself.
+    // Every field is named rather than `..Whatsit::default()`: the default
+    // builds a placeholder `Rc::new(Expandable::default())` for `definition`
+    // that this literal immediately overwrites, so the functional-update form
+    // allocated and dropped one `Rc<Expandable>` per constructor invocation
+    // (dhat 2026-07-29: 1,215 blocks / 145,800 B, again 1:1 with invocations).
     let mut whatsit = Whatsit {
-      definition: Rc::new(self.clone()),
+      definition,
       args,
       properties,
-      ..Whatsit::default()
+      reversion: None,
+      dual_reversion: None,
+      locator: None,
     };
     // Perl `Core/Definition/Constructor.pm` L106:
     //   `$props{locator} = $stomach->getGullet->getLocator`
@@ -401,6 +428,25 @@ impl Definition for Constructor {
     result.extend(post);
     result.extend(post_post);
     Ok(result)
+  }
+}
+
+impl Definition for Constructor {
+  fn before_digest(&self) -> Option<&Vec<BeforeDigestClosure>> { Some(&self.before_digest) }
+  fn after_digest(&self) -> Option<&Vec<DigestionClosure>> { Some(&self.after_digest) }
+  fn after_digest_body(&self) -> Option<&Vec<DigestionClosure>> { Some(&self.after_digest_body) }
+  fn capture_body(&self) -> bool { self.capture_body }
+  fn get_sizer(&self) -> Option<SizingClosure> { self.sizer.clone() }
+  fn invoke(&self, _once_only: bool) -> Result<Tokens> { Ok(Tokens!()) }
+  /// Digest the constructor; This should occur in the Stomach to create a Whatsit.
+  /// The whatsit which will be further processed to create the document.
+  ///
+  /// Allocates a fresh `Rc` for the Whatsit's back-reference. Callers that
+  /// already hold the state table's `Rc<Constructor>` should use
+  /// [`Constructor::invoke_primitive_shared`] instead, which reuses it — see
+  /// there for why that matters.
+  fn invoke_primitive(&self) -> Result<Vec<Digested>> {
+    self.digest_to_whatsit(Rc::new(self.clone()))
   }
 
   fn get_cs(&self) -> Cow<'_, Token> { Cow::Borrowed(&self.cs) }

--- a/latexml_core/src/stomach.rs
+++ b/latexml_core/src/stomach.rs
@@ -1614,7 +1614,10 @@ pub fn invoke_token(input_token: &Token) -> Result<Vec<Digested>> {
         {
           assign_meaning(&token, relax_meaning, Some(Scope::Local));
         }
-        result = meaning.invoke_primitive()?;
+        // `meaning` IS the state table's `Rc<Constructor>`, so hand it to the
+        // Whatsit rather than letting `invoke_primitive` deep-clone the
+        // definition once per invocation (see `Constructor::invoke_primitive_shared`).
+        result = Constructor::invoke_primitive_shared(&meaning)?;
         if !meaning.is_prefix() {
           clear_prefixes(); // Clear prefixes unless we just set one.
         }


### PR DESCRIPTION
**Diagnostic.** Every Whatsit keeps a back-reference to the definition that built it, and `Constructor::invoke_primitive` filled that slot with `Rc::new(self.clone())` — a fresh deep clone (Parameters + three `Vec<Rc<dyn Fn>>` hook lists) per invocation. The clones are **retained**, not transient: a Whatsit lives in the digested tree for the whole Build, so a document held one private copy of the constructor per construct it used. The same literal's `..Whatsit::default()` also built an `Rc<Expandable>` placeholder it immediately overwrote.

**Approach.** The state table already stores `Stored::Constructor(Rc<Constructor>)`, so `stomach::invoke_token` is holding a shareable handle — route it through the new `Constructor::invoke_primitive_shared` and the deep clone becomes a refcount bump. `invoke_primitive` keeps the allocating path for callers reaching a Constructor through `dyn Definition`. Sound because the definition is immutable once installed (no `Rc::get_mut` anywhere) and `PartialEq for Whatsit` compares definitions **by value**.

**Validation.** Release, interleaved A/B, 4.5 MB math+prose corpus → 41 MB output: peak RSS **6074/6081 → 6041/6044 MB**, wall unchanged (~36.8 s), output **byte-identical**. Full suite **1760/0**; clippy + fmt clean. Honest scope: this is ~0.6%, a tidy-up rather than a lever on the 131 MB case.

Also answers open question 3 of the streaming design — whose premise was wrong (the lookup never allocated) — and records the `drop(digested)` dead-end, which measures as noise because peak RSS is reached *inside* Build.