### PR TITLE
chore(audit): re-verify clang-sys at 1.9.1 and move the pin

### DIFF
--- a/tools/audit_vendored_natives.py
+++ b/tools/audit_vendored_natives.py
@@ -141,9 +141,12 @@ AUDITED = {
     "system-deps": ("6.2.2",
         "src/tests/lib/libteststatic.a -- a test fixture.",
     ),
-    "clang-sys": ("1.8.1",
+    "clang-sys": ("1.9.1",
         "links = \"clang\": libclang is loaded by bindgen at BUILD time. No libclang "
-        "code enters our binary.",
+        "code enters our binary. Re-verified at 1.9.1 (2026-07-29): file inventory "
+        "identical to the audited 1.8.1 apart from an added Cargo.lock, license still "
+        "Apache-2.0, links key unchanged, and build.rs compiles no C (no cc::Build). "
+        "The only native-ish file is tests/header.h, a test fixture.",
     ),
     "prettyplease": ("0.2.37",
         "links = \"prettyplease02\" is the cargo version-lock trick, not a native "


### PR DESCRIPTION
**Diagnostic.** `Cargo.lock` is gitignored, so CI resolves fresh. `clang-sys` 1.9.1 published and the lint job's vendored-native audit now fails on **every new PR** — `audited at v1.8.1, tree has v1.9.1` (hit on #438; #436/#437 pre-date the bump). Nothing to do with those changes.

**Approach.** The gate is version-pinned by design — "a version bump can swap the vendored library (and its license) entirely" — so the fix is to re-check and move the pin, not loosen it. Re-verified rather than assumed: the 1.8.1→1.9.1 file inventory is **identical** apart from an added `Cargo.lock`, license still `Apache-2.0`, `links = "clang"` unchanged, `build.rs` compiles no C (no `cc::Build`/`cmake`), and the only native-ish file is still `tests/header.h`, a test fixture. The recorded verdict — libclang is dlopened by bindgen at build time, no libclang code enters our binary — holds. No §D.2 row needed: that table lists crates whose vendored native code actually *ships*, and clang-sys is exonerated precisely because none does.

**Validation.** `python3 tools/audit_vendored_natives.py` → `OK: all 18 native-code crates in the shipped tree are audited.`