### PR TITLE
fix(acmart): \Description describes the image, not the float

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -2822,12 +2822,17 @@ Confirmed on `LaTeXML/t/complex/acm_aria.tex` (whose golden `acm_aria.xml`
 records the defect) and on arXiv **2607.21760** — an ACM accessibility paper
 with four figures and zero descriptions in its HTML.
 
-**`aria:labelledby` is NOT one of the defects.** acmart's documentation says
-"Unlike `\caption`, which is used alongside the image, `\Description` is
+**`aria:labelledby` on the float is a second defect.** acmart's documentation
+says "Unlike `\caption`, which is used alongside the image, `\Description` is
 intended to be used **instead of** the image", i.e. it is a *text alternative*,
-which in ARIA is name-like. Pointing a name relation at it is defensible; what
-goes wrong is only that the referenced note holds the short form while the long
-form is gone.
+which in ARIA is name-like — so pointing a name relation at it reads as
+defensible, and this entry originally said so. It is not: `aria-labelledby`
+sets the accessible **name**, and a float's name is its caption, so the
+relation displaces "Figure 1. caption text" and hides the caption from a screen
+reader. The alternative also belongs to the *image*, not to the float that
+contains it. Reported in review on brucemiller/LaTeXML#430 (`r3674103638`);
+Rust now puts the text on the lone `ltx:graphics` as `@alt` and never emits a
+name relation (`OXIDIZED_DESIGN_DIVERGENCES.md` #83).
 
 Two further problems do stand:
 
@@ -2846,8 +2851,11 @@ Two further problems do stand:
 
 **Fixed in Rust, deliberately diverging** (`latexml_package/src/package/acmart_cls.rs`;
 see `OXIDIZED_DESIGN_DIVERGENCES.md` #83): the description is read `Undigested`
-so nothing inside it expands, the short form becomes `aria:label` and the long
-form an `aria:describedby` block, and a dedicated XSLT template strips the
+so nothing inside it expands; where the float holds a lone image the short form
+becomes that image's `@alt` and the long form an `aria:describedby` block, and
+where it holds none or several (an empty float, a table, a multi-panel figure)
+both stay referenced from the float itself — never as a name relation, so the
+caption is always what names the float. A dedicated XSLT template strips the
 footnote scaffolding. `acm_aria.xml` was re-blessed — it previously matched Perl
 byte-for-byte and so certified the defect.
 

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2989,11 +2989,11 @@ review on brucemiller/LaTeXML#430 (`r3674103638`), which also asked for the
 `<img>` to receive `@alt` and not `@aria-label`. Nothing in this binding emits
 `aria-label` any more.
 
-Two shapes have no image to use. The author's annotation is never dropped, so
-it goes to the next best host — the enclosing float — as `aria:describedby`,
+Three shapes have no image to use. The author's annotation is never dropped, so
+it goes to the next best host — the enclosing element — as `aria:describedby`,
 which supplements the name rather than replacing it, so the caption survives
-either way. Both **`Warn!`**, since the result is second-best and the author
-can act on it:
+either way. All three **`Warn!`**, naming the actual cause, since the result is
+second-best and the author can act on it:
 
 * **no `ltx:graphics` in the float** — a figure built from tabular, text or
   TikZ content (which `t/complex/acm_aria` is), a `table` float, or an empty
@@ -3003,6 +3003,15 @@ can act on it:
   would assert that one sentence is the alternative for one panel, a claim the
   author never made. The review says "the first image"; we narrow that to the
   case where "first" is also "only", where it is unambiguous.
+* **outside any float** — a bare `\Description` in running text lands on
+  whatever element encloses it (a `<p>`, typically). Nothing to describe, but
+  the text is still carried.
+
+References ACCUMULATE rather than overwrite (`add_describedby`):
+`aria-describedby` is an id list, and a second `\Description` in the same float
+would otherwise write straight over the first one's reference, leaving that
+description sitting in the DOM announced by nothing — losing an annotation the
+author wrote.
 
 Only graphics **already built** are visible when `\Description` is constructed,
 so a `\Description` written *before* its `\includegraphics` falls into the

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -2953,7 +2953,7 @@ Guards: `06_cluster_frontmatter::frontmatter_spconf_keywords`,
 `frontmatter_spconf_keywords_braced`, `frontmatter_spconf_twoauthors` (all via
 `convert_to_xml_contrib_clean`, so a returning error fails them).
 
-### 83. acmart `\Description` becomes the figure's ARIA text alternative
+### 83. acmart `\Description` becomes the image's text alternative
 
 acmart documents `\Description` as "used **instead of** the image" (unlike
 `\caption`, "used alongside" it), so it is a *text alternative*, not
@@ -2964,20 +2964,54 @@ mandatory one, so the long description is digested and then discarded
 (`\Description{L}` produced no output at all). Recorded as
 `KNOWN_PERL_ERRORS.md` #66.
 
-Rust maps the two arguments to the two ARIA slots a text alternative uses:
+The thing a `\Description` is an alternative **to** is the image, so that is
+where it lands — as `@alt`, via `ltx:graphics/@description`
+(`LaTeXML-misc-xhtml.xsl` L167-171):
 
 | source | HTML |
 |---|---|
-| `\Description[s]{l}` | `aria-label` = `s`, `aria-describedby` → `l`'s block |
-| `\Description{l}`, `l` plain | `aria-label` = `l` (it replaces the image) |
-| `\Description{l}`, `l` with markup | `aria-describedby` → `l`'s block |
+| `\Description[s]{l}` | `<img alt="s" aria-describedby=`→`l>` |
+| `\Description{l}`, `l` plain | `<img alt="l">` (it replaces the image) |
+| `\Description{l}`, `l` with markup | `<img aria-describedby=`→`l>`, alt unchanged |
+| any, when `\includegraphics[alt=…]` is also present | author's alt kept, both notes referenced |
 
 `[short]` is the concise alternative and `{long}` the extended description, so
-`aria-label` / `aria-describedby` is their natural pairing. A lone description
-labels, because it is what stands in for the image — unless it carries markup,
-which an attribute cannot hold.
+`@alt` / `aria-describedby` is their natural pairing. A lone description takes
+the `@alt`, because it is what stands in for the image — unless it carries
+markup, which an attribute cannot hold, and the generic `alt` fallback ("Refer
+to caption") stands instead.
 
-Choosing between those slots is why the argument is read **`Undigested`**
+**Not `aria:label` on the `<ltx:figure>`**, which an earlier revision of this
+divergence used. `aria-label` sets the accessible **name**, and a float's name
+is its caption, so labelling the figure with the description displaced
+"Figure 1. caption text" and hid the caption from a screen reader — reported in
+review on brucemiller/LaTeXML#430 (`r3674103638`), which also asked for the
+`<img>` to receive `@alt` and not `@aria-label`. Nothing in this binding emits
+`aria-label` any more.
+
+Two shapes have no image to use. The author's annotation is never dropped, so
+it goes to the next best host — the enclosing float — as `aria:describedby`,
+which supplements the name rather than replacing it, so the caption survives
+either way. Both **`Warn!`**, since the result is second-best and the author
+can act on it:
+
+* **no `ltx:graphics` in the float** — a figure built from tabular, text or
+  TikZ content (which `t/complex/acm_aria` is), a `table` float, or an empty
+  one. There is no image to be an alternative to.
+* **more than one** — a `\Description` is scoped to the whole float, so on a
+  multi-panel figure it describes the ensemble. Making it panel 1's `@alt`
+  would assert that one sentence is the alternative for one panel, a claim the
+  author never made. The review says "the first image"; we narrow that to the
+  case where "first" is also "only", where it is unambiguous.
+
+Only graphics **already built** are visible when `\Description` is constructed,
+so a `\Description` written *before* its `\includegraphics` falls into the
+first case. That is the safe direction to fail — the description is still
+announced, just not as the image's alternative — the warning names it as a
+possible cause, and acmart's own documentation puts `\Description` after the
+graphic.
+
+Choosing between the slots is why the argument is read **`Undigested`**
 (`ExpansionLevel::Off`): the tokens must be inspected for control sequences
 *before* anything expands. That also means nothing inside a `\Description` is
 ever expanded — matching `acmart.cls` L895, which gobbles the argument, so
@@ -2989,10 +3023,12 @@ and four descriptions in its HTML.
 Both descriptions are emitted as separate `ltx:note`s with their own `xml:id`
 and class (`ltx_acm_description_short` / `ltx_acm_description`) — two distinct
 authored fields, so concatenating them into one element would produce a run-on
-no consumer could take apart. A block is referenced only when it is not already
-the label, so the same sentence is never both the name and the description; an
+no consumer could take apart. A block is referenced only when its text is not
+already the `@alt`, so the same sentence is never announced twice; an
 unreferenced hidden block is inert, since `display:none` content is announced
-only when something references it.
+only when something references it. Where both are referenced,
+`aria-describedby` takes a space-separated id list announced in order, short
+first.
 
 A dedicated template in `LaTeXML-meta-xhtml.xsl` strips the footnote
 scaffolding — the generic `ltx:note` rendering adds a `†` mark and a
@@ -3002,17 +3038,21 @@ and drops the `ltx_note` class, which these are not. Perl's `width`/`height`
 
 acmart's newer mechanism for the same purpose, `\includegraphics[alt=…]`
 (switched on by `\DocumentMetadata`), is handled separately in `graphicx_sty.rs`
-and lands on the `<img>` itself; we accept it unconditionally rather than gating
-it behind `\DocumentMetadata`, which is itself a no-op
-(`latex_constructs_rust_only.rs`). A document using BOTH mechanisms conveys the
-text twice — that is the author duplicating across two documented routes, and
-`\Description` is scoped to the float with no reliable way to associate it with
-one image.
+and sets the same `description` attribute; we accept it unconditionally rather
+than gating it behind `\DocumentMetadata`, which is itself a no-op
+(`latex_constructs_rust_only.rs`). When an author uses BOTH — e.g.
+arXiv:2607.21760, which repeats the same paragraph in each — the explicit
+`alt=` **wins**: it names one image, while `\Description` names the float, so
+the more specific statement stands and `\Description` only adds its
+`aria-describedby` references.
 
 Guard: `latexml_oxide/tests/complex/acm_aria.{tex,xml}` (re-blessed — it
-previously matched Perl byte-for-byte and so certified the defect) plus
-`110_acmart_description_aria.rs`, which asserts at the HTML level that all three
-rows of the table above hold and that no `aria-describedby` reference dangles.
+previously matched Perl byte-for-byte and so certified the defect; it has no
+graphics, so it pins the float-level branch) plus
+`110_acmart_description_aria.rs`, which drives six figures — one per branch
+above — through to HTML and asserts that each lands where the table says, that
+`aria-label` appears nowhere, that captions survive, and that no
+`aria-describedby` reference dangles.
 
 ## Known Upstream Perl Issues (brief)
 

--- a/latexml_oxide/tests/110_acmart_description_aria.rs
+++ b/latexml_oxide/tests/110_acmart_description_aria.rs
@@ -257,3 +257,88 @@ fn description_becomes_the_images_alt_text() {
     "expected a clean conversion:\n{stderr}",
   );
 }
+
+/// Two malformed-but-real shapes that must still not lose what the author
+/// wrote. Both were regressions caught in review of the change that moved
+/// `\Description` onto the image.
+const TEX_ODD: &str = "\\documentclass[acmsmall]{acmart}\n\
+  \\usepackage{graphicx}\n\
+  \\begin{document}\n\
+  Loose text. \\Description[LOOSESHORT]{LOOSELONG text} more text.\n\
+  \\begin{figure}\\includegraphics{none}\n\
+  \\caption{TWICE}\n\
+  \\Description[FIRSTSHORT]{FIRSTLONG text}\\Description[SECONDSHORT]{SECONDLONG text}\n\
+  \\end{figure}\n\
+  \\end{document}\n";
+
+#[test]
+fn description_never_loses_an_annotation() {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  let workdir = tempfile::tempdir().expect("create tempdir");
+  std::fs::write(workdir.path().join("d.tex"), TEX_ODD).expect("write d.tex");
+  std::fs::write(workdir.path().join("none.png"), PNG).expect("write none.png");
+
+  let output = Command::new(bin)
+    .args([
+      "d.tex",
+      "--dest",
+      "d.html",
+      "--format",
+      "html5",
+      "--nocomments",
+    ])
+    .current_dir(workdir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+  let stderr = String::from_utf8_lossy(&output.stderr);
+  let html = std::fs::read_to_string(workdir.path().join("d.html")).unwrap_or_default();
+  assert!(!html.is_empty(), "no HTML produced:\n{stderr}");
+
+  // A \Description outside any float has no image AND no float to fall back to.
+  // It still has to land somewhere, and the warning has to name the real cause
+  // rather than blame a float that isn't there.
+  assert!(
+    html.contains("LOOSELONG"),
+    "a \\Description outside a float was dropped:\n{html}",
+  );
+  assert!(
+    stderr.contains("outside any figure or table"),
+    "the warning must name the actual cause, not a missing image:\n{stderr}",
+  );
+
+  // A SECOND \Description in the same float must not overwrite the first one's
+  // reference — `aria-describedby` is an id list, and a clobbered id leaves
+  // that description hidden in the DOM and announced by nothing.
+  let imgs = img_tags(&html);
+  let refs = attr(imgs[0], "aria-describedby").unwrap_or_default();
+  assert!(
+    refs.split_whitespace().count() >= 3,
+    "a second \\Description clobbered the first one's reference; expected the \
+     first long id plus both of the second's, got {refs:?}:\n{}",
+    imgs[0]
+  );
+  assert_eq!(
+    attr(imgs[0], "alt"),
+    Some("FIRSTSHORT"),
+    "the first \\Description should still own the alt:\n{}",
+    imgs[0]
+  );
+
+  // Everything referenced still resolves, and every authored text is present.
+  let ids: Vec<String> = html
+    .match_indices("id=\"")
+    .filter_map(|(i, _)| {
+      let rest = &html[i + 4..];
+      rest.find('"').map(|e| rest[..e].to_string())
+    })
+    .collect();
+  for r in refs.split_whitespace() {
+    assert!(
+      ids.iter().any(|id| id == r),
+      "aria-describedby references '{r}', which no element defines:\n{html}",
+    );
+  }
+  for text in ["FIRSTLONG", "SECONDSHORT", "SECONDLONG"] {
+    assert!(html.contains(text), "{text} was lost:\n{html}");
+  }
+}

--- a/latexml_oxide/tests/110_acmart_description_aria.rs
+++ b/latexml_oxide/tests/110_acmart_description_aria.rs
@@ -1,17 +1,21 @@
-//! acmart `\Description` must reach the **HTML** as a usable ARIA description.
+//! acmart `\Description` must reach the **HTML** as a usable text alternative.
 //!
-//! The core-XML fixture (`tests/complex/acm_aria.{tex,xml}`) pins the element
-//! shape, but everything that makes this feature actually work for a screen
-//! reader happens in post-processing: `aria:describedby` has to survive as
-//! `aria-describedby`, the referenced ids have to resolve, and the referenced
-//! text has to be clean. A core-only test is green on all three failing.
+//! The core-XML fixture (`tests/complex/acm_aria.{tex,xml}`) pins the
+//! image-less shape, but everything that makes this feature actually work for a
+//! screen reader happens in post-processing: the description has to become the
+//! image's `@alt`, `aria:describedby` has to survive as `aria-describedby`, the
+//! referenced ids have to resolve, and the referenced text has to be clean. A
+//! core-only test is green on all of those failing.
 //!
 //! What this guards, all of which were broken before (see
 //! `KNOWN_PERL_ERRORS.md` #66, `OXIDIZED_DESIGN_DIVERGENCES.md` #83):
 //!   * the MANDATORY long description reached no output at all — Perl's
 //!     binding emits `#1`, the OPTIONAL short one, and drops `#2`
-//!   * the relation was `aria:labelledby`, which sets the accessible NAME and
-//!     so displaced the float's caption
+//!   * the relation was `aria:labelledby`, then `aria:label`, on the FLOAT.
+//!     Both set the accessible NAME, so both displaced the caption — the
+//!     reviewer report that prompted the current shape
+//!     (brucemiller/LaTeXML#430 r3674103638). The text alternative belongs on
+//!     the image, as `@alt`; nothing here may emit `aria-label` at all.
 //!   * the note carried footnote scaffolding, so the announced text began
 //!     "†† : " (`ltx_note_mark` twice, then an `ltx_note_type` prefix)
 //!   * an intermediate fix emitted the short description with NO id, leaving
@@ -19,31 +23,66 @@
 
 use std::{path::Path, process::Command};
 
-/// One figure per row of the mapping table in OXIDIZED_DESIGN_DIVERGENCES #83:
-/// short+long, lone plain, lone with markup.
+/// A real (1×1) PNG, so `\includegraphics` produces an `<img>` rather than a
+/// missing-file diagnostic — the whole point here is where the alt text lands.
+const PNG: &[u8] = include_bytes!("graphics/none.png");
+
+/// One figure per branch of the mapping in OXIDIZED_DESIGN_DIVERGENCES #83.
+/// The first four are the primary path (a lone image in the float); the last
+/// two are the cases that keep the wiring on the float.
 const TEX: &str = "\\documentclass[acmsmall]{acmart}\n\
+  \\usepackage{graphicx}\n\
   \\begin{document}\n\
-  \\begin{figure}\n\
-  \\caption{CAPTIONTEXT}\n\
+  \\begin{figure}\\includegraphics{none}\n\
+  \\caption{CAPTIONONE}\n\
   \\Description[SHORTDESC]{LONGDESC with \\emph{markup} inside}\n\
   \\end{figure}\n\
-  \\begin{figure}\n\
-  \\caption{SECONDCAPTION}\n\
+  \\begin{figure}\\includegraphics{none}\n\
+  \\caption{CAPTIONTWO}\n\
   \\Description{LONELYLONGDESC}\n\
   \\end{figure}\n\
-  \\begin{figure}\n\
-  \\caption{THIRDCAPTION}\n\
+  \\begin{figure}\\includegraphics{none}\n\
+  \\caption{CAPTIONTHREE}\n\
   \\Description{MARKUPDESC with \\emph{emphasis}}\n\
+  \\end{figure}\n\
+  \\begin{figure}\\includegraphics[alt={AUTHORALT}]{none}\n\
+  \\caption{CAPTIONFOUR}\n\
+  \\Description[SHORTFOUR]{LONGFOUR text}\n\
+  \\end{figure}\n\
+  \\begin{figure}\\includegraphics{none}\\includegraphics{none}\n\
+  \\caption{CAPTIONFIVE}\n\
+  \\Description[SHORTFIVE]{LONGFIVE text}\n\
+  \\end{figure}\n\
+  \\begin{figure}NOIMAGEHERE\n\
+  \\caption{CAPTIONSIX}\n\
+  \\Description[SHORTSIX]{LONGSIX text}\n\
   \\end{figure}\n\
   \\end{document}\n";
 
+/// Every `<img ...>` in the document, in order.
+fn img_tags(html: &str) -> Vec<&str> {
+  html
+    .match_indices("<img ")
+    .filter_map(|(i, _)| html[i..].find('>').map(|e| &html[i..i + e + 1]))
+    .collect()
+}
+
+/// The value of `attr` on `tag`, if present.
+fn attr<'a>(tag: &'a str, attr: &str) -> Option<&'a str> {
+  let needle = format!("{attr}=\"");
+  let start = tag.find(&needle)? + needle.len();
+  let rest = &tag[start..];
+  rest.find('"').map(|e| &rest[..e])
+}
+
 #[test]
-fn description_reaches_html_as_a_resolvable_aria_description() {
+fn description_becomes_the_images_alt_text() {
   let bin = env!("CARGO_BIN_EXE_latexml_oxide");
   assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
 
   let workdir = tempfile::tempdir().expect("create tempdir");
   std::fs::write(workdir.path().join("d.tex"), TEX).expect("write d.tex");
+  std::fs::write(workdir.path().join("none.png"), PNG).expect("write none.png");
 
   let output = Command::new(bin)
     .args([
@@ -61,53 +100,120 @@ fn description_reaches_html_as_a_resolvable_aria_description() {
   let html = std::fs::read_to_string(workdir.path().join("d.html")).unwrap_or_default();
   assert!(!html.is_empty(), "no HTML produced:\n{stderr}");
 
-  // 1. The long description — the alt text ACM mandates — must be present.
-  //    Both figures: one with a short description, one without.
+  // 0. NOTHING here may set an accessible NAME. `aria-label` on the float was
+  //    the reported defect: it replaces the name, and a figure's name is its
+  //    caption, so the caption stopped being announced.
   assert!(
-    html.contains("LONGDESC"),
-    "the mandatory long description never reached the HTML:\n{stderr}",
+    !html.contains("aria-label"),
+    "\\Description must never set an accessible name — that displaces the \
+     caption (brucemiller/LaTeXML#430 r3674103638):\n{html}",
   );
+  for caption in ["CAPTIONONE", "CAPTIONTWO", "CAPTIONSIX"] {
+    assert!(
+      html.contains(caption),
+      "caption {caption} vanished:\n{html}"
+    );
+  }
+
+  // 1. The long description — the alternative ACM mandates — must be present.
+  for text in ["LONGDESC", "LONELYLONGDESC", "MARKUPDESC", "LONGSIX"] {
+    assert!(
+      html.contains(text),
+      "the description {text} never reached the HTML:\n{stderr}",
+    );
+  }
+
+  let imgs = img_tags(&html);
   assert!(
-    html.contains("LONELYLONGDESC"),
-    "a \\Description with no optional argument produced nothing:\n{stderr}",
+    imgs.len() >= 6,
+    "expected an <img> per graphic, saw {}:\n{html}",
+    imgs.len()
   );
 
-  // 2. Markup inside the description survives. It is read `Undigested`, so it
-  //    must still be carried through rather than silently flattened away.
-  assert!(
-    html.contains("markup"),
-    "markup inside the description was lost:\n{html}",
+  // 2. A lone image in the float IS what the description is an alternative to,
+  //    so it carries it — as `@alt`, the attribute an <img> has for exactly
+  //    this, not `aria-label`. `[short]` is the concise alternative; a lone
+  //    plain `{long}` stands in directly.
+  assert_eq!(
+    attr(imgs[0], "alt"),
+    Some("SHORTDESC"),
+    "the short description should be the image's alt:\n{}",
+    imgs[0]
+  );
+  assert_eq!(
+    attr(imgs[1], "alt"),
+    Some("LONELYLONGDESC"),
+    "a lone plain description should become the alt directly:\n{}",
+    imgs[1]
   );
 
-  // 3. The two arguments land in the two ARIA slots a text alternative uses.
-  //    acmart: \Description is "used instead of the image", so it is a text
-  //    alternative — [short] labels, {long} describes.
-  assert!(
-    html.contains("aria-label=\"SHORTDESC\""),
-    "the short description should be the aria-label (the concise alternative \
-     that stands in for the image):\n{html}",
+  // 3. A lone description carrying MARKUP cannot go in an attribute, so the alt
+  //    keeps the generic fallback and the text is referenced as a block.
+  assert_eq!(
+    attr(imgs[2], "alt"),
+    Some("Refer to caption"),
+    "markup cannot live in an alt attribute; it must fall back to a block:\n{}",
+    imgs[2]
   );
   assert!(
-    html.contains("aria-describedby="),
-    "aria:describedby did not survive post-processing into HTML:\n{html}",
-  );
-  //    A lone PLAIN description labels directly — no block indirection needed.
-  assert!(
-    html.contains("aria-label=\"LONELYLONGDESC\""),
-    "a lone plain description should become the aria-label directly:\n{html}",
-  );
-  //    A lone description carrying MARKUP cannot go in an attribute, so it
-  //    falls back to a referenced block.
-  assert!(
-    html.contains("MARKUPDESC"),
-    "a lone description with markup was lost:\n{html}",
-  );
-  assert!(
-    !html.contains("aria-label=\"MARKUPDESC"),
-    "markup cannot live in an aria-label attribute; it must use a block:\n{html}",
+    attr(imgs[2], "aria-describedby").is_some(),
+    "a markup-bearing description must still be referenced:\n{}",
+    imgs[2]
   );
 
-  // 4. EVERY aria-describedby reference resolves to a real id. An unresolved
+  // 4. An explicit `\includegraphics[alt=…]` names ONE image while \Description
+  //    names the float, so the more specific statement wins and we only add
+  //    references — never clobber the author's alt.
+  assert_eq!(
+    attr(imgs[3], "alt"),
+    Some("AUTHORALT"),
+    "an explicit alt= must survive a competing \\Description:\n{}",
+    imgs[3]
+  );
+  let refs_four = attr(imgs[3], "aria-describedby").unwrap_or_default();
+  assert_eq!(
+    refs_four.split_whitespace().count(),
+    2,
+    "with the alt already taken, BOTH descriptions should be referenced:\n{}",
+    imgs[3]
+  );
+
+  // 5. Several images: the description covers the ensemble, so it stays on the
+  //    float rather than being asserted as panel 1's alternative.
+  for img in &imgs[4..6] {
+    assert_eq!(
+      attr(img, "alt"),
+      Some("Refer to caption"),
+      "a multi-panel figure's description must not be claimed by one panel:\n{img}",
+    );
+  }
+  assert!(
+    html.contains("aria-describedby=\"acmlabel5-short acmlabel5\""),
+    "a multi-image float should carry the references itself:\n{html}",
+  );
+  // …and the image-less float likewise, which is the acm_aria fixture's shape.
+  assert!(
+    html.contains("aria-describedby=\"acmlabel6-short acmlabel6\""),
+    "an image-less float should carry the references itself:\n{html}",
+  );
+
+  // 5b. Falling back to the float is second-best, so it is announced — but ONLY
+  //     then. Exactly the two floats above may warn; the four lone-image
+  //     figures must be silent, or every ordinary ACM paper turns noisy.
+  let warnings = stderr.matches("Warning:unexpected:\\Description").count();
+  assert_eq!(
+    warnings, 2,
+    "expected a warning for the multi-image and the image-less float, and \
+     silence for the four that found their image:\n{stderr}",
+  );
+  for reason in ["more than one image", "no image to describe"] {
+    assert!(
+      stderr.contains(reason),
+      "the warning should say WHY it fell back ({reason}):\n{stderr}",
+    );
+  }
+
+  // 6. EVERY aria-describedby reference resolves to a real id. An unresolved
   //    reference is silently inert — the description is simply never announced.
   let ids: Vec<String> = html
     .match_indices("id=\"")
@@ -129,11 +235,11 @@ fn description_reaches_html_as_a_resolvable_aria_description() {
     }
   }
   assert!(
-    checked >= 2,
-    "expected a reference per figure, saw {checked}"
+    checked >= 6,
+    "expected a reference per describing figure, saw {checked}"
   );
 
-  // 5. The referenced text is CLEAN: no footnote scaffolding, which would
+  // 7. The referenced text is CLEAN: no footnote scaffolding, which would
   //    otherwise be announced as part of the description.
   for marker in ["ltx_note_mark", "ltx_note_type"] {
     assert!(
@@ -143,7 +249,7 @@ fn description_reaches_html_as_a_resolvable_aria_description() {
     );
   }
 
-  // 6. And the whole thing converts cleanly — reading the description
+  // 8. And the whole thing converts cleanly — reading the description
   //    `Undigested` means nothing inside it is expanded, so no error can be
   //    manufactured from content pdflatex never expands either.
   assert!(

--- a/latexml_oxide/tests/complex/acm_aria.xml
+++ b/latexml_oxide/tests/complex/acm_aria.xml
@@ -6,7 +6,7 @@
   <resource src="LaTeXML.css" type="text/css"/>
   <resource src="ltx-article.css" type="text/css"/>
   <resource src="ltx-amsart.css" type="text/css"/>
-  <figure aria:describedby="acmlabel1" aria:label="Fly 1 and Fly 2 look identical" inlist="lof" labels="LABEL:fig:one" xml:id="S0.F1">
+  <figure aria:describedby="acmlabel1-short acmlabel1" inlist="lof" labels="LABEL:fig:one" xml:id="S0.F1">
     <tags>
       <tag>Figure 1</tag>
       <tag role="autoref">Figure 1</tag>

--- a/latexml_package/src/package/acmart_cls.rs
+++ b/latexml_package/src/package/acmart_cls.rs
@@ -99,14 +99,17 @@ LoadDefinitions!({
   // plain `D1 … D5`) raised `Error:undefined:\D` for content we then dropped.
   //
   // `LaTeXML-common.xsl` L404-421 maps any `aria:*` attribute to `aria-*`
-  // under HTML5, so setting them here needs no XSLT change. Which ARIA slot
-  // each argument lands in is the `before_construct` table below.
+  // under HTML5, so setting them here needs no XSLT change. WHICH element
+  // they land on, and which slot each argument fills, is the
+  // `before_construct` table below.
   //
   // `[short]` and `{long}` are two DISTINCT authored fields, so they get two
   // distinct elements — never concatenated into one. Merging them yields a
   // run-on ("Fly 1 and Fly 2 look identical. Fly 1 and fly 2 comparison
   // shows…") and destroys the distinction, so no consumer can tell which text
-  // the author wrote as the brief alternative.
+  // the author wrote as the brief alternative. `aria-describedby` takes a
+  // SPACE-SEPARATED ID LIST and is announced in order, so where both are
+  // referenced it is short first, each still individually addressable.
   //
   // The old binding emitted the short one ALONE, which is why
   // `t/complex/acm_aria` recorded "Fly 1 and Fly 2 look identical" and lost the
@@ -125,15 +128,16 @@ LoadDefinitions!({
   // `LaTeXML-meta-xhtml.xsl` keyed on `ltx_acm_description`, so the referenced
   // text stays clean for assistive technology.
   //
-  // The short description gets its own id so it stays individually
-  // addressable (nothing references it today — its text goes into
-  // `aria-label` — but an anchor on authored content costs nothing). It is
-  // derived in `properties` rather than written as `#id-short` in the
-  // template, which does NOT work: a `#name` hole runs to the end of the
-  // identifier, so `#id-short` names a property called `id-short` — absent,
-  // so the element silently emits NO xml:id at all — instead of `#id`
-  // followed by a literal `-short`. Ids use a `-short` suffix rather than a
-  // dotted one so they need no escaping in a CSS selector.
+  // The short description needs its OWN id: it is referenced by
+  // `aria-describedby` whenever its text is not the one that became the
+  // image's `@alt`. It is derived in `properties` rather than written as
+  // `#id-short` in the template, which does NOT work: a `#name` hole runs to
+  // the end of the identifier, so `#id-short` names a property called
+  // `id-short` — absent, so the element silently emits NO xml:id at all —
+  // instead of `#id` followed by a literal `-short`. That produced a dangling
+  // `aria-describedby`, a reference resolving to nothing. Ids use a `-short`
+  // suffix rather than a dotted one so they need no escaping in a CSS
+  // selector.
   DefConstructor!("\\Description[] Undigested",
     "^^?#1(<ltx:note xml:id='#shortid' class='ltx_nodisplay ltx_acm_description_short'>#1</ltx:note>)()\
      <ltx:note xml:id='#id' class='ltx_nodisplay ltx_acm_description'>#2</ltx:note>",
@@ -151,33 +155,66 @@ LoadDefinitions!({
     },
     // acmart's own documentation: "Unlike \caption, which is used alongside the
     // image, \Description is intended to be used INSTEAD OF the image." So a
-    // `\Description` is a TEXT ALTERNATIVE, not supplementary prose — which in
-    // ARIA is name-like (`aria-label`), not `aria-describedby` (announced in
-    // ADDITION to the name). That also fixes the two arguments' roles: `[short]`
-    // is the concise alternative, `{long}` the extended description.
+    // `\Description` is a TEXT ALTERNATIVE — and the thing it is an alternative
+    // TO is the image, not the float. It therefore lands on the IMAGE:
     //
-    //   `\Description[s]{l}`  → aria-label = s, aria-describedby → l's block
-    //   `\Description{l}`, l plain    → aria-label = l (it replaces the image)
-    //   `\Description{l}`, l w/ markup → aria-describedby → l's block
+    //   `\Description[s]{l}`           → img @alt = s, aria-describedby → l
+    //   `\Description{l}`, l plain     → img @alt = l (it replaces the image)
+    //   `\Description{l}`, l w/ markup → img @alt untouched, describedby → l
     //
-    // The last case is why the argument is read `Undigested`: an `aria-label`
-    // is a plain string and cannot carry markup, so we must inspect the tokens
-    // to choose the slot BEFORE expanding anything. A control sequence (or an
+    // `@alt` (via `ltx:graphics/@description`, `LaTeXML-misc-xhtml.xsl` L167-171)
+    // rather than `aria-label`, because that is the attribute an `<img>` has for
+    // exactly this purpose and the one assistive technology expects there.
+    //
+    // NOT `aria:label` on the `<ltx:figure>`, which is what this binding did
+    // before: `aria-label` sets the accessible NAME, and a float's name is its
+    // caption, so labelling the figure with the description DISPLACED
+    // "Figure 1. caption text" and hid the caption from a screen reader
+    // (reviewer report, brucemiller/LaTeXML#430 r3674103638; the fix that
+    // review asks for is precisely "label + description should be attached to
+    // the first image in the figure … and the `<img>` tag eventually gets
+    // `@alt` and not `@aria-label`").
+    //
+    // The markup case is why the argument is read `Undigested`: `@alt` is a
+    // plain string and cannot carry markup, so we must inspect the tokens to
+    // choose the slot BEFORE expanding anything. A control sequence (or an
     // active/`$`/`^`/`_` token) means real markup, so the block carries it.
     //
     // The block is always emitted, so the text stays addressable, but it is
-    // referenced only when it is not already the label — otherwise the same
-    // sentence would be both the name and the description. An unreferenced
-    // hidden block is inert: `display:none` content is announced only when
-    // something references it.
+    // referenced only when it is not already the `@alt` — otherwise the same
+    // sentence would be announced twice. An unreferenced hidden block is inert:
+    // `display:none` content is announced only when something references it.
     //
-    // acmart's NEW mechanism for the same purpose is `\includegraphics[alt=…]`
+    // TWO CASES HAVE NO IMAGE TO USE. An author's annotation is never dropped,
+    // so it goes to the next best host — the enclosing float — as
+    // `aria:describedby`, which supplements the name instead of replacing it,
+    // so the caption survives either way. Both `Warn!`, because the result is
+    // second-best and the author can do something about it:
+    //
+    //  * No `ltx:graphics` in the float at all — a figure built from tabular,
+    //    text or TikZ content (`t/complex/acm_aria` is one), a `table` float,
+    //    or an empty one. There is no image to be the alternative to.
+    //  * MORE than one. A `\Description` is scoped to the whole float, so on a
+    //    multi-panel figure it describes the ensemble; making it panel 1's
+    //    `@alt` would assert that one sentence is the alternative for one
+    //    panel, which is a claim the author never made. The review says "the
+    //    first image"; we narrow that to the case where "first" is also "only",
+    //    where it is unambiguous.
+    //
+    // We can only see the graphics ALREADY BUILT when `\Description` is
+    // constructed, so a `\Description` written BEFORE its `\includegraphics`
+    // falls into the first case. That is the safe direction to fail — the
+    // description is still announced, just not as the image's alternative — the
+    // warning names it as a possible cause, and acmart's own documentation puts
+    // `\Description` after the graphic.
+    //
+    // acmart's NEWER mechanism for the same purpose is `\includegraphics[alt=…]`
     // (switched on by `\DocumentMetadata`), handled in `graphicx_sty.rs` and
-    // landing on the `<img>` itself. A document using BOTH — e.g.
-    // arXiv:2607.21760, which repeats the same paragraph in each — will convey
-    // it twice; that is the author's duplication across two documented
-    // mechanisms, not something to second-guess here, and `\Description` is
-    // scoped to the float with no reliable way to associate it with one image.
+    // landing on the same `description` attribute. When an author uses BOTH —
+    // e.g. arXiv:2607.21760, which repeats the same paragraph in each — the
+    // explicit `alt=` WINS: it names one image, while `\Description` names the
+    // float, so the more specific statement stands. `\Description` then only
+    // adds its `aria-describedby` references.
     before_construct => sub[document, whatsit] {
       let Some(id) = whatsit.get_property("id").map(|v| v.to_string()) else {
         return Ok(());
@@ -194,24 +231,81 @@ LoadDefinitions!({
             )
           })
         });
-      let short = whatsit.get_arg(1).map(|d| d.to_attribute());
+      // `\Description[]{…}` gives an empty optional argument, which the
+      // template's `?#1(…)` declines to emit — so there is no short note and
+      // no id to reference. Treat it as absent.
+      let short = whatsit
+        .get_arg(1)
+        .map(|d| d.to_attribute())
+        .filter(|s| !s.is_empty());
+      let short_id = whatsit.get_property("shortid").map(|v| v.to_string());
       let Some(mut figure) = document.get_element() else {
         return Ok(());
       };
-      match short {
-        // Concise alternative available: it labels, the long one describes.
-        Some(s) => {
-          document.set_attribute(&mut figure, "aria:label", &s)?;
-          document.set_attribute(&mut figure, "aria:describedby", &id)?;
+      let mut graphics = document.findnodes(".//ltx:graphics", Some(&figure));
+      // Exactly one image: it IS the figure, so the description is its
+      // alternative. Zero or several: see the note above, keep it on the float.
+      let lone_graphic = (graphics.len() == 1).then(|| graphics.remove(0));
+      let mut described_by: Vec<String> = Vec::new();
+      match lone_graphic {
+        Some(mut graphic) => {
+          // `\includegraphics[alt=…]` already spoke for this image; it is the
+          // more specific statement, so it stands.
+          let alt = if graphic.get_attribute("description").is_some() {
+            None
+          } else if short.is_some() {
+            short.clone()
+          } else if long_is_plain {
+            whatsit.get_arg(2).map(|d| d.to_attribute())
+          } else {
+            None
+          };
+          match alt {
+            // Something of ours became the alternative. Whatever did NOT is
+            // still worth announcing, so reference it.
+            Some(text) => {
+              document.set_attribute(&mut graphic, "description", &text)?;
+              if short.is_some() {
+                described_by.push(id);
+              }
+            },
+            // Nothing of ours is the alternative — the author's own `alt=`
+            // holds it, or the lone description carries markup. Reference
+            // everything we emitted.
+            None => {
+              if short.is_some() && let Some(sid) = short_id {
+                described_by.push(sid);
+              }
+              described_by.push(id);
+            },
+          }
+          if !described_by.is_empty() {
+            document.set_attribute(&mut graphic, "aria:describedby", &described_by.join(" "))?;
+          }
         },
-        // Lone description: it stands in for the image, so it labels — unless
-        // it carries markup an attribute cannot hold.
-        None if long_is_plain => {
-          let text = whatsit.get_arg(2).map(|d| d.to_attribute()).unwrap_or_default();
-          document.set_attribute(&mut figure, "aria:label", &text)?;
-        },
+        // Nowhere better to put it. Attach to the float rather than drop the
+        // author's annotation, and say so — the text is still announced, but
+        // not as the alternative for any one image, which is what a
+        // `\Description` is for.
         None => {
-          document.set_attribute(&mut figure, "aria:describedby", &id)?;
+          if short.is_some() && let Some(sid) = short_id {
+            described_by.push(sid);
+          }
+          described_by.push(id);
+          document.set_attribute(&mut figure, "aria:describedby", &described_by.join(" "))?;
+          let why = if graphics.is_empty() {
+            "the float has no image to describe (a table, or a \\Description \
+             written before its \\includegraphics)"
+          } else {
+            "the float has more than one image, so which one it describes is \
+             ambiguous"
+          };
+          Warn!("unexpected", "\\Description",
+            &s!("attached to the enclosing {} as aria:describedby, because {}. \
+                 The text is still announced, but it is not any image's alt \
+                 text; put a \\Description after the \\includegraphics it \
+                 describes, or use \\includegraphics[alt=...] per image",
+              figure.get_name(), why));
         },
       }
     }

--- a/latexml_package/src/package/acmart_cls.rs
+++ b/latexml_package/src/package/acmart_cls.rs
@@ -5,6 +5,25 @@ use crate::{
   prelude::*,
 };
 
+/// Add `ids` to `node`'s `aria:describedby`, keeping whatever is already there.
+///
+/// `aria-describedby` is an id LIST, and a second `\Description` in the same
+/// float (or one alongside another that already wired the same host) would
+/// otherwise `set_attribute` straight over the first one's reference, leaving
+/// that description hidden in the DOM and announced by nothing — silently
+/// losing an annotation the author wrote. Existing ids keep their position,
+/// since order is announcement order.
+fn add_describedby(document: &mut Document, node: &mut Node, ids: &[String]) -> Result<()> {
+  let existing = node.get_attribute("aria:describedby").unwrap_or_default();
+  let mut refs: Vec<&str> = existing.split_whitespace().collect();
+  for id in ids {
+    if !refs.contains(&id.as_str()) {
+      refs.push(id);
+    }
+  }
+  document.set_attribute(node, "aria:describedby", &refs.join(" "))
+}
+
 #[rustfmt::skip]
 LoadDefinitions!({
   // Perl: LoadClass('amsart', withoptions => 1)
@@ -280,32 +299,35 @@ LoadDefinitions!({
             },
           }
           if !described_by.is_empty() {
-            document.set_attribute(&mut graphic, "aria:describedby", &described_by.join(" "))?;
+            add_describedby(document, &mut graphic, &described_by)?;
           }
         },
-        // Nowhere better to put it. Attach to the float rather than drop the
-        // author's annotation, and say so — the text is still announced, but
-        // not as the alternative for any one image, which is what a
-        // `\Description` is for.
+        // Nowhere better to put it. Attach to the enclosing element rather than
+        // drop the author's annotation, and say so — the text is still
+        // announced, but not as the alternative for any one image, which is
+        // what a `\Description` is for.
         None => {
           if short.is_some() && let Some(sid) = short_id {
             described_by.push(sid);
           }
           described_by.push(id);
-          document.set_attribute(&mut figure, "aria:describedby", &described_by.join(" "))?;
-          let why = if graphics.is_empty() {
-            "the float has no image to describe (a table, or a \\Description \
-             written before its \\includegraphics)"
+          add_describedby(document, &mut figure, &described_by)?;
+          let host = figure.get_name();
+          let why = if !graphics.is_empty() {
+            s!("it holds more than one image, so which one is described is ambiguous")
+          } else if host == "figure" || host == "table" {
+            s!("the float has no image to describe (a table, or a \\Description \
+                written before its \\includegraphics)")
           } else {
-            "the float has more than one image, so which one it describes is \
-             ambiguous"
+            // Not a float at all — `\Description` outside a figure/table, where
+            // acmart's own `\@Description@present` bookkeeping expects it.
+            s!("it is outside any figure or table, so there is no image to describe")
           };
           Warn!("unexpected", "\\Description",
-            &s!("attached to the enclosing {} as aria:describedby, because {}. \
-                 The text is still announced, but it is not any image's alt \
-                 text; put a \\Description after the \\includegraphics it \
-                 describes, or use \\includegraphics[alt=...] per image",
-              figure.get_name(), why));
+            &s!("attached to the enclosing <{host}> as aria:describedby, because \
+                 {why}. The text is still announced, but it is not any image's \
+                 alt text; put a \\Description after the \\includegraphics it \
+                 describes, or use \\includegraphics[alt=...] per image"));
         },
       }
     }


### PR DESCRIPTION
Refines #430 per @xworld21's review, [`r3674103638`](https://github.com/dginev/latexml-oxide/pull/430#discussion_r3674103638).

**Diagnostic.** `aria-label` on the `<ltx:figure>` sets the accessible **name**, and a float's name is its caption — so labelling the figure with the description displaced "Figure 1. caption text" and hid the caption from a screen reader. The review also asked that the `<img>` end up with `@alt`, not `@aria-label`. Both stand: a `\Description` is a text alternative, and the thing it is an alternative **to** is the image, not the float that contains it. `KNOWN_PERL_ERRORS` #66 asserted the opposite ("`aria:labelledby` is NOT one of the defects") — corrected here.

**Approach.** With a lone `ltx:graphics` in the float the text lands on it: `[short]` — or a plain lone `{long}` — becomes `description`, i.e. `@alt` in HTML, and whatever did not become the alt is referenced with `aria:describedby`. An explicit `\includegraphics[alt=…]` names one image while `\Description` names the float, so the more specific statement wins and we only add references. No `aria:label` is emitted anywhere any more.

| float shape | where it lands | warns |
|---|---|---|
| lone image | `<img alt="…">` + `aria-describedby` for the other field | no |
| lone image, author's `alt=` present | author's alt kept, both notes referenced | no |
| **several images** | float, `aria-describedby` | yes — which one is ambiguous |
| **no image** (table, empty, tabular/TikZ figure) | float, `aria-describedby` | yes — nothing to describe |

The annotation is never dropped — with no image to use it goes to the enclosing float, always as `aria:describedby`, which supplements the name instead of replacing it, so the caption keeps naming the float either way. Both fallbacks `Warn!` with the reason and a suggested fix, since the result is second-best:

```
Warning:unexpected:\Description attached to the enclosing table as aria:describedby,
  because the float has no image to describe (a table, or a \Description written
  before its \includegraphics). The text is still announced, but it is not any
  image's alt text; put a \Description after the \includegraphics it describes,
  or use \includegraphics[alt=...] per image
```

Only graphics **already built** are visible when `\Description` is constructed, so a `\Description` written before its `\includegraphics` takes the float branch — the safe direction to fail, and the warning names it as a cause.

**One deliberate narrowing.** The review says "the first image"; this implements "the *only* image". A `\Description` is scoped to the whole float, so on a multi-panel figure it describes the ensemble — making it panel 1's `@alt` would assert that one sentence is the alternative for one panel, which the author never wrote. That case warns and stays on the float. Trivial to widen if the literal reading is preferred.

**Validation.** `110_acmart_description_aria.rs` drives six figures — one per branch — through to HTML and asserts each lands where the table says, that `aria-label` appears nowhere, that captions survive, that exactly the two fallbacks warn (the four lone-image paths stay silent, so ordinary ACM papers do not turn noisy), and that no `aria-describedby` reference dangles. `complex/acm_aria.xml` re-blessed: it has no graphics, so it now pins the float-level branch. Full suite **1760/0**; clippy and fmt clean.

**Notes for review.**

* #436 corrects stale comments in the same block; this rewrites that block and subsumes those corrections, so whichever lands second will conflict — #436 is redundant if this goes in.
* **Pre-existing, not addressed here:** the markup branch does not render markup. Because the argument is read `Undigested`, `\Description{MARKUPC with \emph{emph}}` reaches the HTML as literal `MARKUPC with \emph{emph}` — backslash and braces included — in the block assistive technology reads. #430's `html.contains("markup")` passes on the raw characters, so it never caught this. Fixing it means digesting, which reverses the divergence recorded in `OXIDIZED_DESIGN_DIVERGENCES` #83 (not manufacturing errors from content `acmart.cls` gobbles), so it needs a design call rather than a patch here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
