### PR TITLE
fix(preload): strip the bracket and .cls/.sty off the preload PI, as Perl does

### DIFF
--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -575,7 +575,10 @@ ask for review** — no code work expected. *(This entry read "PR #310 … Ready
 merge" until 2026-07-25, long after it merged.)*
 
 
-### R2 — `--preload=<cls>` alone trips the hook stack; class-name divergence — OPEN (re-verified 2026-07-25)
+### R2 — `--preload=<cls>` alone trips the hook stack — OPEN (re-verified 2026-07-29)
+
+*(The "class-name divergence" this heading used to also name was the second
+divergence below; it is fixed. Only the hook stack is still open.)*
 
 **Symptom.** `--preload=<any>.cls` prints `LaTeX hooks Error: Extra \PopDefaultHookLabel`
 (article/book/report; `.sty` clean; `\documentclass` clean; `LATEXML_NODUMP=1` clean).

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -46,13 +46,14 @@ families).*
 ## Ranked worklist — start here
 
 Ordered by: **does it reproduce today** → **is a real user affected** → **is it
-unblocked** → **effort**. Rows R1–R2 are small and self-contained; R4+ need a
-session of their own. Re-verify a row before planning on it (rule 1).
+unblocked** → **effort**. R1 is small and self-contained; R2's cheap half landed
+2026-07-29 and what remains of it, like R4+, needs a session of its own.
+Re-verify a row before planning on it (rule 1).
 
 | # | item | state | size | detail |
 |---|---|---|---|---|
 | **R1** | Upstream `brucemiller/LaTeXML#2852` — subfile `\documentclass` options | **OPEN upstream**, ours merged as #310 | minutes — chase review, no code | Open items |
-| **R2** | `--preload=<cls>` trips the LaTeX hook stack (`Extra \PopDefaultHookLabel`) | **OPEN**, re-verified 2026-07-25 (1 error with `--preload=article.cls`, 0 without) | small–medium, self-contained | Open items |
+| **R2** | `--preload=<cls>` trips the LaTeX hook stack (`Extra \PopDefaultHookLabel`) | **OPEN**, re-verified 2026-07-29 (1 error with `--preload=article.cls`, 0 without). The row's *second* divergence — the preload PI kept `[opts]`/`.cls` and never emitted `options=` — is ✅ **FIXED 2026-07-29** | hook half is **not** small: five measured dead ends, `(c)` now collapsed into the rejected `(a)`, and any real fix is TeX-side | Open items |
 | **R4** | biblatex `.bbl` `TokenLimit` loop (2605.17646) | ✅ **FIXED 2026-07-25** — self-referential `\let` on `setupPseudoBibitem` re-arm; shared with Perl | — | Open items |
 | **R5** | Bibliography targets + MakeBibliography re-port | **re-port items 1 and 3 LANDED**: a raw `.bib` is converted by the engine (recursive BibTeX session on the LIVE core state), the 727-line string route is deleted, the eager-tokenization gap that cost 151 papers is closed at the root, and the 13-field digest whitelist is gone — the `\bib@field@default@*` name sets now match Perl exactly (45 each). The 2026-07-27 follow-ups closed the `.bib`-as-DATA family (divergences #74/#78/#79/**#80**). Remaining: item 2 (unisort, citestyle `AY`, `Formatter::Year` suffix, doc-global NUMBER) and the missing-references target list | **item 2 + targets** — the re-port itself is done | [`BIBLIOGRAPHY_WORKLIST.md`](parity/BIBLIOGRAPHY_WORKLIST.md) |
 | **R6** | `ltx_env_<name>` env-markup class | user-requested, PLANNED | medium code, **large golden churn** → own branch | Open items |
@@ -636,11 +637,39 @@ adopted, make it conditional on the pool being unloaded and LOG it. (b) Pair the
 push's actual *meaning* rather than to definedness. (c) Make the pool load before any
 handleoptions push. (b)/(c) address the cause.
 
-**Second divergence, same area.** `\documentclass{article}` → `<?latexml class="article"?>`
-but `--preload=article.cls` → `<?latexml class="article.cls"?>`; **Perl emits
-`class="article"` for both.** Otherwise the two paths' output is byte-identical, so the
-preload does load `article_cls.rs` correctly; `parse_preload_spec` splits correctly to
-`("article","cls")`, so the extension is re-attached further in.
+**(c) collapses into (a) — checked 2026-07-29.** The pool load is not *ours* to reorder:
+`LoadPool('LaTeX')` is the **class binding's own first statement**, in Perl
+(`article.cls.ltxml` L5) exactly as in Rust (`article_cls.rs:4`), and it runs *inside*
+`InputDefinitions`, i.e. after the `\@pushfilename`. Perl's ordering is therefore
+identical to ours — Perl is silent only for the dump reason above. So "load the pool
+earlier" means hoisting it out of the binding, which is the same Rust-only divergence
+that got (a) rejected. That leaves (b), or a TeX-side repair of the stack at the moment
+`LoadPool` swaps `\@pushfilename`'s meaning underneath an already-open frame.
+
+**Second divergence, same area — ✅ FIXED 2026-07-29.** It was wider than recorded here:
+the preload-PI loop (`core_interface.rs`, the `for preload in &self.preload` block) is a
+translation of Perl `Core.pm` L268-277, whose three `s///` rewrite `$preload` **in place**.
+`Regex::replace_all` *returns* the rewritten string instead, and all three results were
+discarded, so **nothing was ever stripped and no `options` attribute was ever emitted**:
+
+| `--preload=` | was | Perl (and now) |
+|---|---|---|
+| `article.cls` | `class="article.cls"` | `class="article"` |
+| `[twocolumn,11pt]article.cls` | `class="[twocolumn,11pt]article.cls"` | `class="article" options="twocolumn,11pt"` |
+| `[dvipsnames]color.sty` | `package="[dvipsnames]color.sty"` | `package="color" options="dvipsnames"` |
+
+**Not cosmetic:** `latexml_post`'s `find_documentclass_and_packages` parses these PIs and
+`latex_images.rs:pre_preamble` emits the result as a literal `\documentclass[…]{…}` /
+`\usepackage[…]{…}`, so `--mathimages`/`--graphicimages` on any preload-driven conversion
+was writing `\documentclass{article.cls}` and losing every preload option.
+
+Fixed by stripping the bracket and the suffix off a `&str` cursor, Perl-faithfully:
+only the two literal `.cls`/`.sty` suffixes (so `mystyle.tex` keeps its extension, as in
+Perl), and an empty bracket contributes no attribute (Perl's `($options ? … : ())` is
+falsy on `""`). Deliberately **not** routed through `parse_preload_spec`, which splits on
+the last `.` and would eat any extension. Guard: `109_preload_pi_attributes.rs`, a
+six-shape table whose every expectation was ground-truthed byte-for-byte against Perl
+LaTeXML 0.8.8 on the same input.
 
 ### R4 — biblatex `.bbl` TokenLimit loop, 2605.17646 — ✅ FIXED 2026-07-25
 

--- a/latexml_oxide/src/core_interface.rs
+++ b/latexml_oxide/src/core_interface.rs
@@ -27,7 +27,7 @@ use latexml_core::{
 };
 use latexml_math_parser::MathParser;
 use once_cell::sync::Lazy;
-use regex::{Captures, Regex};
+use regex::Regex;
 use rustc_hash::FxHashMap as HashMap;
 
 // Process-once cached env var (see WISDOM #56 — getenv hot-path race).
@@ -52,8 +52,8 @@ use latexml_package::prelude::{
   InputDefinitionOptions, InputOptions, input_content, input_definitions,
 };
 
-static CLS_EXT_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"\.cls$").unwrap());
-static STY_EXT_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"\.sty$").unwrap());
+/// Perl `Core.pm` L272 `s/^\[([^\]]*)\]//` — the preload option bracket, which
+/// comes at the *front* of the spec (`[twocolumn,11pt]article.cls`).
 static LATEX_OPTION_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^\[([^\]]*)\]").unwrap());
 
 // Regex for parsing DefMathRewrite calls from .latexml files
@@ -404,20 +404,42 @@ impl DigestionAPI for Core {
       if preload.ends_with(".pool") {
         continue;
       }
-      let mut options: Option<String> = None;
-      LATEX_OPTION_REGEX.replace_all(preload, |refs: &Captures| -> String {
-        options = Some(refs.get(1).map_or("", |m| m.as_str()).to_string());
-        String::new()
-      });
-      if preload.ends_with(".cls") {
-        CLS_EXT_REGEX.replace_all(preload, "");
-        let attributes = map! {s!("class") => preload.to_string()};
-        document.insert_pi("latexml", Some(attributes))?;
-      } else {
-        STY_EXT_REGEX.replace_all(preload, "");
-        let attributes = map! {s!("package") => preload.to_string()};
-        document.insert_pi("latexml", Some(attributes))?;
+      // Perl `Core.pm` L268-277 rewrites `$preload` IN PLACE with `s///`, so
+      // the option bracket and the `.cls`/`.sty` suffix are gone from the
+      // string that becomes the attribute value, and the captured options ride
+      // along as a second attribute. `Regex::replace_all` RETURNS a new string
+      // rather than mutating its input, so discarding the result — as this loop
+      // did until 2026-07-29 — stripped nothing at all:
+      // `--preload=[twocolumn,11pt]article.cls` emitted
+      // `<?latexml class="[twocolumn,11pt]article.cls"?>` where Perl emits
+      // `<?latexml class="article" options="twocolumn,11pt"?>`.
+      //
+      // Deliberately NOT routed through `parse_preload_spec` above: that
+      // splits on the LAST `.` and so would also eat a non-package extension
+      // (`--preload=mystyle.tex` -> `package="mystyle"`), while Perl strips
+      // only the two literal suffixes and leaves anything else attached. It
+      // also trims/drops empty options, where Perl passes `$1` verbatim.
+      let mut spec: &str = preload;
+      let mut options: &str = "";
+      if let Some(bracket) = LATEX_OPTION_REGEX.captures(spec) {
+        options = bracket.get(1).map_or("", |m| m.as_str());
+        spec = &spec[bracket.get(0).map_or(0, |m| m.end())..];
       }
+      let mut attributes: HashMap<String, String> = HashMap::default();
+      // Perl's `($options ? (options => $options) : ())`: an empty bracket
+      // (`[]name.sty`) is falsy, so it contributes no attribute at all.
+      if !options.is_empty() {
+        attributes.insert(s!("options"), options.to_string());
+      }
+      if let Some(class) = spec.strip_suffix(".cls") {
+        attributes.insert(s!("class"), class.to_string());
+      } else {
+        attributes.insert(
+          s!("package"),
+          spec.strip_suffix(".sty").unwrap_or(spec).to_string(),
+        );
+      }
+      document.insert_pi("latexml", Some(attributes))?;
     }
     Debug!("Doc absorb: {:?}", digested);
 

--- a/latexml_oxide/tests/109_preload_pi_attributes.rs
+++ b/latexml_oxide/tests/109_preload_pi_attributes.rs
@@ -1,0 +1,68 @@
+//! The `<?latexml class=…?>` / `<?latexml package=…?>` PIs that a `--preload`
+//! contributes to the document.
+//!
+//! Perl `Core.pm` L268-277 rewrites the preload spec IN PLACE with `s///`
+//! before it becomes an attribute value: the leading `[…]` option bracket and a
+//! `.cls`/`.sty` suffix are stripped off, and the bracket's contents come back
+//! as a separate `options` attribute. The Rust port used `Regex::replace_all`,
+//! which *returns* the rewritten string instead of mutating its input, and
+//! discarded every result — so nothing was ever stripped and the options
+//! attribute was never emitted (`SYNC_STATUS.md` R2, second divergence; the
+//! entry recorded only the `.cls` half of it).
+//!
+//! Every expectation below was ground-truthed against Perl LaTeXML 0.8.8 on the
+//! same input, not just read off `Core.pm`.
+
+use std::{path::Path, process::Command};
+
+/// No `\documentclass` — a preloaded class is the point of the exercise, and
+/// this is the exact input the Perl comparison was run on.
+const DOC: &str = "\\begin{document}\nHello.\n\\end{document}\n";
+
+fn preload_pi(spec: &str) -> String {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+  let workdir = tempfile::tempdir().expect("create tempdir");
+  std::fs::write(workdir.path().join("p.tex"), DOC).expect("write p.tex");
+  let output = Command::new(bin)
+    .args(["p.tex", "--dest", "p.xml", "--nocomments"])
+    .arg(format!("--preload={spec}"))
+    .current_dir(workdir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+  let xml = std::fs::read_to_string(workdir.path().join("p.xml")).unwrap_or_else(|e| {
+    let stderr = String::from_utf8_lossy(&output.stderr).replace('\u{1b}', "");
+    panic!("no output for --preload={spec}: {e}\n{stderr}");
+  });
+  xml
+    .lines()
+    .find(|l| l.starts_with("<?latexml class=") || l.starts_with("<?latexml package="))
+    .unwrap_or("<<no class/package PI>>")
+    .to_string()
+}
+
+#[test]
+fn preload_spec_is_stripped_to_its_bare_name_in_the_pi() {
+  // (spec, expected PI) — verbatim Perl LaTeXML 0.8.8 output.
+  let cases = [
+    ("article.cls", "<?latexml class=\"article\"?>"),
+    (
+      "[twocolumn,11pt]article.cls",
+      "<?latexml class=\"article\" options=\"twocolumn,11pt\"?>",
+    ),
+    (
+      "[dvipsnames]color.sty",
+      "<?latexml package=\"color\" options=\"dvipsnames\"?>",
+    ),
+    ("color.sty", "<?latexml package=\"color\"?>"),
+    // An empty bracket is FALSY in Perl, so it contributes no attribute.
+    ("[]color.sty", "<?latexml package=\"color\"?>"),
+    // Only the two literal package suffixes are stripped — anything else stays
+    // attached. This is why the loop cannot reuse `parse_preload_spec`, which
+    // splits on the last `.` and would emit `package="mystyle"` here.
+    ("mystyle.tex", "<?latexml package=\"mystyle.tex\"?>"),
+  ];
+  for (spec, expected) in cases {
+    assert_eq!(preload_pi(spec), expected, "--preload={spec}");
+  }
+}


### PR DESCRIPTION
Closes the **second divergence** of `SYNC_STATUS.md` R2. The hook-stack half of that row stays open.

## The bug

Perl `Core.pm` L268-277 rewrites the preload spec **in place** with three `s///` before it becomes a `<?latexml class=…?>` / `<?latexml package=…?>` attribute: the leading `[…]` option bracket and a `.cls`/`.sty` suffix come off, and the bracket's contents come back as a separate `options` attribute.

The port used `Regex::replace_all`, which **returns** the rewritten string rather than mutating its input — and all three results were discarded. So nothing was ever stripped, and the `options` attribute was never emitted at all. R2 recorded only the `.cls` half of this; it is wider:

| `--preload=` | before | Perl (and now) |
|---|---|---|
| `article.cls` | `class="article.cls"` | `class="article"` |
| `[twocolumn,11pt]article.cls` | `class="[twocolumn,11pt]article.cls"` | `class="article" options="twocolumn,11pt"` |
| `[dvipsnames]color.sty` | `package="[dvipsnames]color.sty"` | `package="color" options="dvipsnames"` |

## Why it is not cosmetic

`latexml_post::processor::find_documentclass_and_packages` parses these PIs back out, and `latex_images::pre_preamble` emits the result as a **literal** `\documentclass[…]{…}` / `\usepackage[…]{…}`. So `--mathimages` / `--graphicimages` on any preload-driven conversion was writing `\documentclass{article.cls}` — not a class LaTeX can find — and silently dropping every preload option.

## The fix

Strip off a `&str` cursor, Perl-faithfully:

* only the two **literal** `.cls`/`.sty` suffixes, so `mystyle.tex` keeps its extension exactly as in Perl;
* an empty bracket contributes no attribute (Perl's `($options ? … : ())` is falsy on `""`);
* deliberately **not** routed through the neighbouring `parse_preload_spec`, which splits on the last `.` and would eat any extension — a comment records this so it is not "simplified" back.

`insert_pi` already ordered `class`/`package`/`options` first, so attribute order matches Perl with no change there.

## Verification

New guard `109_preload_pi_attributes.rs` — a six-shape table whose **every expectation was ground-truthed byte-for-byte against Perl LaTeXML 0.8.8** on the same input, including the two edge cases (`[]color.sty`, `mystyle.tex`) that were derived by reading `Core.pm` and then confirmed rather than assumed. The production `--preload=ar5iv.sty` shape was checked against Perl too (`package="ar5iv"`, both).

* `cargo test --tests` — **1762 passed / 0 failed**, 106 targets
* `cargo clippy --workspace --all-targets -- -D warnings` — clean

## Also in this PR (docs only)

R2's remaining hook-stack half gains a measured note: candidate fix **(c)** ("make the pool load before any handleoptions push") **collapses into the already-rejected (a)**. `LoadPool('LaTeX')` is the class binding's own first statement — Perl `article.cls.ltxml` L5 exactly as Rust `article_cls.rs:4` — and runs *inside* `InputDefinitions`, after the `\@pushfilename`. Perl's ordering is therefore identical to ours; it is silent only for the dump reason already in the entry. Reordering it means hoisting the pool load out of the binding, which is the same Rust-only divergence that got (a) rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
