### PR TITLE
fix(bibliography): AY is the abbreviated label, and four more MakeBibliography gaps

### DIFF
--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -55,7 +55,7 @@ Re-verify a row before planning on it (rule 1).
 | **R1** | Upstream `brucemiller/LaTeXML#2852` — subfile `\documentclass` options | **OPEN upstream**, ours merged as #310 | minutes — chase review, no code | Open items |
 | **R2** | `--preload=<cls>` trips the LaTeX hook stack (`Extra \PopDefaultHookLabel`) | **OPEN**, re-verified 2026-07-29 (1 error with `--preload=article.cls`, 0 without). The row's *second* divergence — the preload PI kept `[opts]`/`.cls` and never emitted `options=` — is ✅ **FIXED 2026-07-29** | hook half is **not** small: five measured dead ends, `(c)` now collapsed into the rejected `(a)`, and any real fix is TeX-side | Open items |
 | **R4** | biblatex `.bbl` `TokenLimit` loop (2605.17646) | ✅ **FIXED 2026-07-25** — self-referential `\let` on `setupPseudoBibitem` re-arm; shared with Perl | — | Open items |
-| **R5** | Bibliography targets + MakeBibliography re-port | **re-port items 1 and 3 LANDED**: a raw `.bib` is converted by the engine (recursive BibTeX session on the LIVE core state), the 727-line string route is deleted, the eager-tokenization gap that cost 151 papers is closed at the root, and the 13-field digest whitelist is gone — the `\bib@field@default@*` name sets now match Perl exactly (45 each). The 2026-07-27 follow-ups closed the `.bib`-as-DATA family (divergences #74/#78/#79/**#80**). Remaining: item 2 (unisort, citestyle `AY`, `Formatter::Year` suffix, doc-global NUMBER) and the missing-references target list | **item 2 + targets** — the re-port itself is done | [`BIBLIOGRAPHY_WORKLIST.md`](parity/BIBLIOGRAPHY_WORKLIST.md) |
+| **R5** | Bibliography targets + MakeBibliography re-port | **the re-port is DONE** — items 1 and 3 landed 2026-07-26/27 (recursive BibTeX session on the LIVE core state, the 727-line string route deleted, the 13-field digest whitelist gone: the `\bib@field@default@*` name sets match Perl exactly, 45 each; `.bib`-as-DATA closed as divergences #74/#78/#79/**#80**), and **item 2 landed 2026-07-29** (citestyle `AY`, short-name `{ay}`, collating `unisort`, format-order NUMBER). Remaining: the missing-references target list | **targets only** | [`BIBLIOGRAPHY_WORKLIST.md`](parity/BIBLIOGRAPHY_WORKLIST.md) |
 | **R6** | `ltx_env_<name>` env-markup class | user-requested, PLANNED | medium code, **large golden churn** → own branch | Open items |
 | **R7** | Beyond-Perl performance levers BP-1…BP-6 | POST-RELEASE; internal order BP-2 → BP-3 → BP-1 | **family** | [`BEYOND_PERL_LEVERS.md`](performance/BEYOND_PERL_LEVERS.md) |
 | **R8** | Content-MathML / math-parser gaps | **deferred by user directive 2026-06-20** | **family** — do not pick off in isolation | [`CONTENT_MATHML_GAPS.md`](math/CONTENT_MATHML_GAPS.md) |
@@ -65,7 +65,42 @@ Re-verify a row before planning on it (rule 1).
 
 ## Current status
 
-- **2026-07-27 (latest) — the `unexpected:fi` fatal cluster: `\meaning` of a
+- **2026-07-29 (latest) — `\bibliographystyle{alpha}` produced the wrong label
+  shape, and duplicate author-years were never disambiguated.** R5 item 2, the
+  four secondary `MakeBibliography` parity gaps, all in
+  `latexml_post/src/make_bibliography.rs`. The reaching one: Perl branches on
+  `citestyle` three ways (L481-517) and **`AY` is the abbreviated `[AS64]`
+  label**, class `ltx_bib_abbrv` — Rust read `AY` as the spelled-out
+  author-year and `alpha`, a string nothing emits, as the abbreviated one, so
+  every `\bibliographystyle{alpha}` document got author-year refnums (and
+  natbib's `super` fell to numbers instead of author-year). Second: Perl keys
+  disambiguation and the split bucket off the SHORT name form (`"Smith et al"`,
+  L326-337) and only the SORT off the full names; Rust used the full names for
+  all three, so two 3+-author entries sharing a first author and year never
+  collided and **neither got its `a`/`b` suffix**. Third: `unisort` collates
+  (`Ångström` belongs between `Adams` and `Baker`, not after `Smith`) — ported
+  at UCA's primary level with no new dependency, divergence **#84**. Fourth:
+  `NUMBER` is assigned in FORMAT order, which is initial-major under
+  `--splitbibliography`, not in document-global sortkey order (non-split output
+  unchanged). Also fixed because the citestyle repair makes it reachable for
+  every alpha document: `make_alpha_label` byte-indexed the per-author initials
+  (`&aa[..3]`), a char-boundary panic on `Ångström`.
+  **One of the four was NOT a gap** — `Formatter::Year` correctly omits the
+  suffix. Perl's `do_year` reads the ARRAY `@…::SUFFIX` while `formatBibEntry`
+  binds the SCALAR `$…::SUFFIX`, so the letter never reached the body upstream
+  either; measured Perl prints ` (1999)` and `alpha.bst` agrees.
+  **KNOWN_PERL_ERRORS #67** — the audit item was read off the sigil, which is
+  the same "verify the file, not the recollection" trap R9-BST already records.
+  Every expectation ground-truthed against same-host Perl 0.8.8 on the fixture,
+  after which the two engines' bibliographies are byte-identical there. Guard
+  `06_cluster_bibliography::cluster_bib_alpha_style_labels` (verified RED on
+  the pre-fix tree: author-year classes, `Ångström` last, no suffixes).
+  **Found, not fixed:** a Rust `<ltx:biblist>` has `xml:id` but no `fragid`, and
+  `add_id` emits the HTML `id` from `@fragid` only, so Perl's `<ul id="bib.L1">`
+  is a bare `<ul>` here. Pre-existing; the XSLT is byte-identical between the
+  engines, so the cause is whatever assigns `fragid` to a post-created node.
+
+- **2026-07-27 — the `unexpected:fi` fatal cluster: `\meaning` of a
   `\chardef` token returned the internal class name.** GENUINE-RUST-ONLY,
   **18 papers, one cause.** Largest unclassified first-error cluster in the 186
   `Fatal:TooManyErrors` papers of sandbox-arxiv-2605+2606:
@@ -346,14 +381,16 @@ Re-verify a row before planning on it (rule 1).
   2606.13010 (arXiv/html_feedback#6624) now converts at 0 errors / 0 warnings /
   0 unparsed math. This file was compacted the same day — see the header.
 
-- `cargo test --tests`: **1760 passing / 105 targets, 0 failed, 0 ignored**
-  (2026-07-29, on `main` @ `d5684f0bcf`, dev box with ImageMagick + ghostscript +
-  poppler **and `mutool`** installed, so the vector-SVG branch really ran — both
-  `test_vector_svg_*` report ok, not skipped). Re-run before quoting: the count
-  moves with every PR that adds a guard. It rose from the long-quoted 1696 / 94
-  targets (2026-07-26 @ `e07548e6b3`) as #403…#419 and then #430/#432/#434/#435
-  landed — the last four adding `110_acmart_description_aria` and
-  `111_build_memory_guard`. Two claims carried here for weeks
+- `cargo test --tests`: **1763 passing / 106 targets, 0 failed, 0 ignored**
+  (2026-07-29, `main` @ `48de8eaa5f` plus the R5-item-2 guard, dev box with
+  ImageMagick + ghostscript + poppler **and `mutool`** installed, so the
+  vector-SVG branch really ran — both `test_vector_svg_*` report ok, not
+  skipped). Re-run before quoting: the count moves with every PR that adds a
+  guard. It rose from the long-quoted 1696 / 94 targets (2026-07-26 @
+  `e07548e6b3`) as #403…#419, then #430/#432/#434/#435 (adding
+  `110_acmart_description_aria` and `111_build_memory_guard`), then #442's
+  `109_preload_pi_attributes` — which is the 106th target, so a
+  "105 targets" quote predates it. Two claims carried here for weeks
   did **not** reproduce and have been dropped:
   `latexml_post::graphics::process_coalesces_only_matching_conversion_options`,
   long labelled "the one red, known local-only artifact", passes; and `mutool` is

--- a/docs/parity/BIBLIOGRAPHY_WORKLIST.md
+++ b/docs/parity/BIBLIOGRAPHY_WORKLIST.md
@@ -854,10 +854,11 @@ FULL RE-PORT — item 1 LANDED 2026-07-26:
      inside `get_bib_entries`; Perl assigns it in FORMAT order (`local $NUMBER`
      L55, `++$NUMBER` L418), which under `--splitbibliography` is
      initial-major. Moved to `process`, walking the same order the biblists are
-     built in. Non-split output is unchanged (the two orders coincide); split
-     output now follows Perl whenever an entry's `initial` is not the first
-     letter of its sortkey, which `Post::initial`'s leading-non-letter skip
-     makes possible.
+     built in. **This changes no output today** and the PR says so: `post.rs`
+     constructs the processor with `split = false` and `--splitbibliography` is
+     in the deferred CLI cluster, so the split branch is unreachable; the
+     non-split walk numbers in exactly the order the old pass did. It is a
+     correctness fix for when that flag lands.
    * **`Formatter::Year` does NOT drop a suffix** — the audit item was read off
      the Perl source's sigil. `do_year` L613-615 reads the ARRAY `@…::SUFFIX`
      while L417 binds the SCALAR `$…::SUFFIX`, so the letter never reached the

--- a/docs/parity/BIBLIOGRAPHY_WORKLIST.md
+++ b/docs/parity/BIBLIOGRAPHY_WORKLIST.md
@@ -5,10 +5,11 @@
 > MakeBibliography full-parity re-port (user directive 2026-07-04 — reuse TeX
 > interpretation, no special-case parser).
 >
-> **State, 2026-07-27.** Re-port **items 1 and 3 are DONE**; the open work is
-> item 2 (unisort, citestyle `AY`, `Formatter::Year` suffix, doc-global NUMBER)
-> and the missing-references target list. The `.bib`-as-DATA family closed as
-> divergences **#73 #74 #75 #78 #79 #80**.
+> **State, 2026-07-29.** The MakeBibliography re-port is **DONE** — items 1, 2
+> and 3 all landed. The only open work in this file is the missing-references
+> target list. The `.bib`-as-DATA family closed as divergences
+> **#73 #74 #75 #78 #79 #80**; item 2's collation approximation is **#84** and
+> its one non-gap is **KNOWN_PERL_ERRORS #67**.
 >
 > **Two reading rules for this file.** (1) The three **INTERIM** blocks under the
 > re-port are HISTORY — every identifier they name was deleted with the string
@@ -822,11 +823,60 @@ FULL RE-PORT — item 1 LANDED 2026-07-26:
    Measured on `bib_field_no_url_package` (full pipeline, both engines):
    Rust **0 errors / 3 bibitems**, same-host `latexmlc` **7 errors / 3
    bibitems** with the note truncated. The gap is divergence #72.
-2. Secondary parity gaps from the audit: `unisort` (Unicode collation) vs
-   `Vec::sort()`; citestyle semantics swapped (`AY` should be the
-   abbreviated `[AA+yy]` label, not full author-year); `Formatter::Year`
-   drops the disambiguation `@SUFFIX`; document-global NUMBER across split
-   documents.
+2. **DONE 2026-07-29.** The four secondary parity gaps from the audit, plus a
+   fifth found while checking them and a latent panic the first fix made
+   reachable. All five live in `latexml_post/src/make_bibliography.rs`; the
+   whole set is guarded by
+   `06_cluster_bibliography::cluster_bib_alpha_style_labels` over
+   `cluster_regressions/bib_alpha_style.{tex,bib}`, whose every expectation was
+   ground-truthed against same-host Perl LaTeXML 0.8.8 — after which the Rust
+   and Perl bibliographies are **byte-identical** on that fixture (modulo the
+   pre-existing `biblist` id noted below).
+
+   * **citestyle semantics were SWAPPED** — the one with real corpus reach.
+     Perl L481-517 has exactly three branches: `numbers` → `[1]`; **`AY` → the
+     abbreviated `[AS64]` label** (class `ltx_bib_abbrv`); *anything else* →
+     spelled-out author-year. Rust read `AY` as author-year, `alpha` (a string
+     nothing emits) as the abbreviated one, and every unknown value as
+     `numbers`. Since `\bibliographystyle{alpha}` sets `CITE_STYLE=AY` (Perl
+     `$BIBSTYLES`, `latex_constructs.pool.ltxml` L3953-3961 — the Rust table
+     matches), **every alpha-styled document got the wrong label shape**, and
+     natbib's `super` fell to numbers instead of author-year.
+   * **`{ay}` and `{initial}` were keyed off the wrong name string.** Perl
+     computes two (L318-337): the full `$sortnames` keys the sort, the SHORT
+     `$names` ("Smith et al") keys disambiguation and the split-by-initial
+     bucket. Rust used the full form for all three, so two 3+-author entries
+     sharing a first author and year never collided and **neither was ever
+     given its `a`/`b` suffix**.
+   * **`unisort`** — now collates (primary-level UCA, no new dependency);
+     divergence **#84** records what that does and does not reproduce.
+   * **doc-global NUMBER** — was assigned in document-global sortkey order
+     inside `get_bib_entries`; Perl assigns it in FORMAT order (`local $NUMBER`
+     L55, `++$NUMBER` L418), which under `--splitbibliography` is
+     initial-major. Moved to `process`, walking the same order the biblists are
+     built in. Non-split output is unchanged (the two orders coincide); split
+     output now follows Perl whenever an entry's `initial` is not the first
+     letter of its sortkey, which `Post::initial`'s leading-non-letter skip
+     makes possible.
+   * **`Formatter::Year` does NOT drop a suffix** — the audit item was read off
+     the Perl source's sigil. `do_year` L613-615 reads the ARRAY `@…::SUFFIX`
+     while L417 binds the SCALAR `$…::SUFFIX`, so the letter never reached the
+     body in Perl either; measured Perl output is ` (1999)`, and `alpha.bst`
+     agrees. **KNOWN_PERL_ERRORS #67**; the non-emission is now pinned by the
+     guard so it is not "fixed" back.
+   * **`make_alpha_label` byte-indexed a UTF-8 string** — `aa.len() > 3` /
+     `&aa[..3]` over per-author initials, so a multi-byte initial (`Ångström`)
+     could panic on a char boundary. Character-based now, and the stray
+     `to_uppercase()` Perl's multi-name branch does not have is gone. Latent
+     before, reachable for every `alpha` document after the citestyle repair —
+     which is why it is in this change and not a follow-up.
+
+   **Found, not fixed (separate defect):** a Rust `<ltx:biblist>` carries
+   `xml:id` but no `fragid`, and the XSLT's `add_id` emits the HTML `id` from
+   `@fragid` only — so Perl's `<ul id="bib.L1">` comes out as a bare `<ul>` in
+   Rust. Pre-existing, unrelated to this change, and the XSLT template is
+   byte-identical between the engines, so the divergence is upstream of it in
+   whatever assigns `fragid` to a post-created node.
 3. **Field-interpretation whitelist — RESOLVED by item 1, not by widening the
    list.** Flagged by the 2026-07-05 commit review of `ede2bdcc2c`: the
    `.bib`→XML path in `make_bibliography.rs` digested only 13 fields

--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -2862,3 +2862,50 @@ byte-for-byte and so certified the defect.
 Candidate to upstream: swapping `#1`→`#2` is a one-token fix; the
 note-decoration and undigested-reading parts need the XSLT and parameter-type
 changes too.
+
+## 67. `do_year`'s bibliography disambiguation suffix is dead code — a sigil mismatch
+
+`LaTeXML/lib/LaTeXML/Post/MakeBibliography.pm` binds the entry's disambiguation
+letter as a **scalar** and reads it back as an **array**:
+
+```perl
+# L417, in formatBibEntry:
+local $LaTeXML::Post::MakeBibliography::SUFFIX = $$entry{suffix};
+# L613-615, in do_year:
+return (' (', @stuff, @LaTeXML::Post::MakeBibliography::SUFFIX, ')');
+```
+
+`$Pkg::SUFFIX` and `@Pkg::SUFFIX` are different Perl variables. The array is
+never assigned anywhere in the distribution (`grep -rn '@SUFFIX' LaTeXML/lib/`
+is empty), so it always interpolates to nothing and the letter never reaches the
+entry body — only the refnum label, which reads `$$entry{suffix}` directly.
+
+**Minimal trigger** — two entries sharing an author+year (`latexml_oxide/tests/
+cluster_regressions/bib_alpha_style.{tex,bib}`, entries `wide1`/`wide2`), under
+`\bibliographystyle{alpha}`. Same-host Perl LaTeXML 0.8.8 renders
+
+```html
+<span class="ltx_tag ltx_bib_abbrv …">[SBC99a]</span> … <span class="ltx_text ltx_bib_year"> (1999)</span>
+```
+
+— suffix on the label, bare year in the body.
+
+**Not fixed, in either engine, and that is deliberate.** The dead code's evident
+intent (a disambiguated body year) is what author-year styles like
+`apalike.bst` print, but the styles that actually reach this branch do not want
+it: `alpha.bst` prints the bare `1999` in the entry body, exactly as Perl
+already does. And Rust's author-year branch drops the first block's year
+outright (OXIDIZED_DESIGN #71), so "fixing" the sigil would change output *only*
+for the alpha and numeric styles — precisely where it would be wrong. Rust
+therefore matches Perl's behaviour, with the reason recorded at the seam
+(`make_bibliography.rs`, `Formatter::Year`) and pinned by
+`06_cluster_bibliography::cluster_bib_alpha_style_labels`.
+
+Worth knowing because the *source* reads as though the suffix is emitted: an
+audit item in `BIBLIOGRAPHY_WORKLIST.md` ("`Formatter::Year` drops the
+disambiguation `@SUFFIX`") was opened off that reading and closed only when the
+Perl output was measured.
+
+Candidate to upstream: deleting the dead `@…::SUFFIX` interpolation, or a
+style-conditional emission. Not a one-token `$`/`@` swap — that would change
+alpha-styled output for the worse.

--- a/docs/parity/OXIDIZED_DESIGN.md
+++ b/docs/parity/OXIDIZED_DESIGN.md
@@ -9,7 +9,7 @@ This file is the **index + overview**. The detail lives in a themed family:
 
 | Theme file | What it holds |
 |---|---|
-| [OXIDIZED_DESIGN_DIVERGENCES.md](OXIDIZED_DESIGN_DIVERGENCES.md) | The numbered **Intentional Divergences from Perl** (`#1–#15`, `#17–#18`, `#19–#65`) + a brief Known-Upstream-Perl-Issues list. Code comments cite these as `OXIDIZED_DESIGN #N`. |
+| [OXIDIZED_DESIGN_DIVERGENCES.md](OXIDIZED_DESIGN_DIVERGENCES.md) | The numbered **Intentional Divergences from Perl** (`#1–#15`, `#17–#18`, `#19–#84`) + a brief Known-Upstream-Perl-Issues list. Code comments cite these as `OXIDIZED_DESIGN #N`. |
 | [OXIDIZED_DESIGN_MATH.md](../math/OXIDIZED_DESIGN_MATH.md) | Marpa math-parser design: `#16` design rules + the grammar-rule cluster `#7–#18`. |
 | [OXIDIZED_DESIGN_TYPES.md](OXIDIZED_DESIGN_TYPES.md) | Type-system improvements (behavior-neutral) + tactical internal pitfalls. |
 | [OXIDIZED_DESIGN_FUTURE_WORK.md](OXIDIZED_DESIGN_FUTURE_WORK.md) | Beyond-parity directions not yet built. |
@@ -18,12 +18,12 @@ This file is the **index + overview**. The detail lives in a themed family:
 > `.rs` comments reference them — so they are kept verbatim, which means three
 > quirks: (1) the numbers are **not globally unique** (the math cluster `#7–#18`
 > collides by value with divergences `#7–#18`); (2) a code-referenced number
-> resolves to the file above that owns that *topic* — most (`#1–#15`, `#19–#80`)
+> resolves to the file above that owns that *topic* — most (`#1–#15`, `#19–#84`)
 > are in DIVERGENCES, the math ones (incl. the code-referenced **`#18` = f(x)
 > "Speculative function application"**) are in MATH; (3) **`#76` is a retired
 > number** — its entry was consolidated into `#74` and the number was not
 > reused, so a gap in the sequence is expected, not a missing file. Next free
-> number: **#81**. When in doubt,
+> number: **#85**. When in doubt,
 > `grep '### N\.' docs/parity/OXIDIZED_DESIGN_*.md docs/math/OXIDIZED_DESIGN_MATH.md`.
 
 ---

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -3075,10 +3075,15 @@ was exiled past `z`: on `bib_alpha_style.tex`, `Ångström` sorted **after**
 
 `make_bibliography.rs::unisort` now collates. It reproduces UCA's **primary**
 level only — NFD-decompose, drop combining marks, case-fold — and breaks ties on
-the raw key, whose codepoint order already sorts uppercase first, matching
-`upper_before_lower`. That is **exact** for accented Latin, which is what these
-keys actually contain (surnames, then the year, title and bibkey, all
-lowercased before comparison, so case never reaches the tie-break in practice).
+the raw key. That is **exact** for accented Latin, which is what these keys
+actually contain.
+
+`upper_before_lower` needs no counterpart at all here, and the honest reason is
+that it is **moot**, not that the tie-break reproduces it: `getBibEntries`
+lowercases the whole sort key before it is ever stored
+(`format!(...).to_lowercase()`), so no comparison this function performs can
+see a case difference. Codepoint order on the raw key does happen to sort
+uppercase first, but that property is never exercised.
 
 It **diverges** from Perl for: orders that cross scripts, letters with no
 canonical decomposition (`Ø`, `Æ`, `Ł`, `Đ`), and locale tailorings (Swedish

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -3064,6 +3064,33 @@ above — through to HTML and asserts that each lands where the table says, that
 `aria-label` appears nowhere, that captions survive, and that no
 `aria-describedby` reference dangles.
 
+### 84. Bibliography sort keys collate at UCA's PRIMARY level, not by full UCA
+
+Perl's `Post::unisort` (`Post.pm` L1399-1403) sorts the bibliography sort keys
+with a `Unicode::Collate::Locale` built from the document's `xml:lang` and
+configured `variable => 'non-ignorable'`, `upper_before_lower => 1`. The Rust
+port called `Vec::sort()` — plain codepoint order — so every non-ASCII surname
+was exiled past `z`: on `bib_alpha_style.tex`, `Ångström` sorted **after**
+`Smith` where Perl (and every real `.bst`) puts it between `Adams` and `Baker`.
+
+`make_bibliography.rs::unisort` now collates. It reproduces UCA's **primary**
+level only — NFD-decompose, drop combining marks, case-fold — and breaks ties on
+the raw key, whose codepoint order already sorts uppercase first, matching
+`upper_before_lower`. That is **exact** for accented Latin, which is what these
+keys actually contain (surnames, then the year, title and bibkey, all
+lowercased before comparison, so case never reaches the tie-break in practice).
+
+It **diverges** from Perl for: orders that cross scripts, letters with no
+canonical decomposition (`Ø`, `Æ`, `Ł`, `Đ`), and locale tailorings (Swedish
+sorts `Ö` last, German does not). Closing those means a DUCET table, i.e. a new
+dependency shipping embedded collation data — declined on the standing
+dependency-conservatism rule, and the approximation stays inside the range Perl
+itself ships: `Post.pm` L123-128 falls back to a codepoint `DumbCollator`
+whenever `Unicode::Collate` is not installed, which is strictly worse than this.
+
+Guard: `06_cluster_bibliography::cluster_bib_alpha_style_labels`, whose expected
+order was ground-truthed against same-host Perl LaTeXML 0.8.8 on the fixture.
+
 ## Known Upstream Perl Issues (brief)
 
 These are behaviors in the original Perl LaTeXML that are bugs or limitations, not

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -1370,3 +1370,91 @@ fn bib_preamble_defines_macros_for_the_whole_bibliography() {
     "@preamble: a preamble macro leaked into the output as source:\n{x}"
   );
 }
+/// The secondary `MakeBibliography` parity gaps of SYNC_STATUS R5 item 2, on one
+/// alpha-styled document: the swapped `citestyle` mapping, the disambiguation
+/// key read off the wrong name string, collating `unisort`, format-order
+/// numbering — and the fourth audit item that turned out NOT to be a gap. See
+/// `bib_alpha_style.tex` for the list and `bib_alpha_style_refs.bib` for why
+/// each entry is present.
+///
+/// Every expectation here is ground-truthed against same-host Perl LaTeXML
+/// 0.8.8 on this exact fixture, after which the two engines' bibliographies are
+/// byte-identical on it.
+#[test]
+fn cluster_bib_alpha_style_labels() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_alpha_style.tex");
+
+  // Every bibitem in document order, as (refnum class, refnum text).
+  let mut labels: Vec<(String, String)> = Vec::new();
+  let mut rest = x.as_str();
+  while let Some(i) = rest.find("<bibitem") {
+    let item_end = rest[i..]
+      .find("</bibitem>")
+      .map(|e| i + e)
+      .unwrap_or(rest.len());
+    let item = &rest[i..item_end];
+    if let Some(r) = item.find(r#"role="refnum""#) {
+      let tag_start = item[..r].rfind("<tag").expect("refnum tag start");
+      let tag = &item[tag_start..];
+      let class = tag
+        .find(r#"class=""#)
+        .map(|c| {
+          let c = tag_start + c + 7;
+          let e = item[c..].find('"').expect("class end") + c;
+          item[c..e].to_string()
+        })
+        .unwrap_or_default();
+      let open = tag.find('>').expect("tag open") + tag_start + 1;
+      let close = item[open..].find("</tag>").expect("tag close") + open;
+      labels.push((class, item[open..close].to_string()));
+    }
+    rest = &rest[item_end..];
+  }
+
+  // Gap 1 — `\bibliographystyle{alpha}` (CITE_STYLE=AY) is Perl's ABBREVIATED
+  // label branch, not the spelled-out author-year one.
+  assert!(
+    labels.iter().all(|(c, _)| c == "ltx_bib_abbrv"),
+    "every refnum should be an abbreviated alpha label, got {labels:?}\n{x}"
+  );
+  assert!(
+    !x.contains("ltx_bib_author-year"),
+    "an alpha bibliography must not emit author-year refnums:\n{x}"
+  );
+
+  // Gap 4 — collation: `ångström` sorts between `adams` and `baker`, not after
+  // every ASCII letter as a codepoint sort would place it. (The numbering that
+  // rides on the same order is asserted by construction: the labels are read in
+  // document order.)
+  // Gap 2 — the two `Smith`-led entries share Perl's short-form `{ay}`, so they
+  // are disambiguated `a`/`b`; a full-author key never collides.
+  // Also covers the `make_alpha_label` char-boundary panic: `Ångström`'s
+  // multi-byte initial used to be byte-sliced.
+  let texts: Vec<&str> = labels.iter().map(|(_, t)| t.as_str()).collect();
+  assert_eq!(
+    texts,
+    vec!["ADA01", "\u{c5}NG02", "BAK03", "SBC99a", "SDE99b"],
+    "bibitem order and alpha labels:\n{x}"
+  );
+
+  // Gap 3 was NOT a gap — KNOWN_PERL_ERRORS #67. Perl's `do_year` reads the
+  // ARRAY `@…::SUFFIX` while `formatBibEntry` binds the SCALAR `$…::SUFFIX`,
+  // so the letter never reaches the entry body; same-host Perl 0.8.8 prints
+  // ` (1999)` here, and `alpha.bst` agrees. Pinned so a future reader of
+  // L613-615 does not "fix" it back.
+  for needle in ["An alpha study", "A beta study"] {
+    let i = x
+      .find(needle)
+      .unwrap_or_else(|| panic!("no entry titled {needle} in:\n{x}"));
+    let start = x[..i].rfind("<bibitem").expect("bibitem start");
+    let end = x[start..]
+      .find("</bibitem>")
+      .map(|e| start + e)
+      .unwrap_or(x.len());
+    let item = &x[start..end];
+    assert!(
+      item.contains("(1999)") && !item.contains("(1999a)") && !item.contains("(1999b)"),
+      "the entry body of {needle} should carry the bare year, as Perl does:\n{item}"
+    );
+  }
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_alpha_style.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_alpha_style.tex
@@ -1,0 +1,24 @@
+% MakeBibliography secondary parity gaps (SYNC_STATUS R5 item 2). Four
+% independent divergences from `LaTeXML::Post::MakeBibliography`, all visible
+% on this one document:
+%
+% 1. citestyle semantics were SWAPPED. `\bibliographystyle{alpha}` sets
+%    CITE_STYLE=AY (Perl $BIBSTYLES, latex_constructs.pool.ltxml L3953-3961),
+%    and Perl's `AY` branch (L485-503) is the ABBREVIATED `[ADA01]` label,
+%    class `ltx_bib_abbrv`. Rust mapped `AY` to the spelled-out author-year
+%    branch instead, so every alpha-styled document got the wrong label shape.
+% 2. `{ay}`, the disambiguation key, is Perl's SHORT name form (L326-336), not
+%    the full sort-names — see the `wide1`/`wide2` note in the .bib.
+% 3. NOT a gap after all: `do_year` (L613-615) reads the ARRAY `@...::SUFFIX`
+%    while `formatBibEntry` (L417) binds the SCALAR `$...::SUFFIX`, so the
+%    letter never reaches the entry body. Same-host Perl prints " (1999)", and
+%    `alpha.bst` agrees. KNOWN_PERL_ERRORS #67.
+% 4. `Post::unisort` collates; Rust sorted by codepoint — see the `angstrom`
+%    note in the .bib.
+\documentclass{article}
+\begin{document}
+Citing \cite{adams}, \cite{angstrom}, \cite{baker}, \cite{wide1} and
+\cite{wide2}.
+\bibliographystyle{alpha}
+\bibliography{bib_alpha_style_refs}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/bib_alpha_style_refs.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_alpha_style_refs.bib
@@ -1,0 +1,41 @@
+% Fixture for `cluster_bib_alpha_style_labels` — see the test for what each
+% entry is here to prove.
+%
+% `adams` / `angstrom` / `baker` exist ONLY for their sort order: by Unicode
+% codepoint "ångström" follows every ASCII letter and lands last, while the
+% UCA collation Perl's `Post::unisort` uses puts it between "adams" and
+% "baker" (its primary weight is plain `a`).
+@article{adams,
+  author  = {Adams, Alan},
+  title   = {A first work},
+  journal = {Journal of Firsts},
+  year    = {2001}
+}
+@article{angstrom,
+  author  = {Ångström, Anders},
+  title   = {On radiation},
+  journal = {Journal of Radiation},
+  year    = {2002}
+}
+@article{baker,
+  author  = {Baker, Bea},
+  title   = {A second work},
+  journal = {Journal of Seconds},
+  year    = {2003}
+}
+% Same FIRST author and year, different coauthors. Perl's disambiguation key
+% is the SHORT name form ("Smith et al"), so these two collide and take the
+% suffixes `a` and `b`; keying on the full author list — as the Rust port did
+% — makes them distinct and neither entry is ever disambiguated.
+@article{wide1,
+  author  = {Smith, Alice and Brown, Bob and Clark, Carol},
+  title   = {An alpha study},
+  journal = {Journal of Studies},
+  year    = {1999}
+}
+@article{wide2,
+  author  = {Smith, Alice and Davis, Dan and Evans, Eve},
+  title   = {A beta study},
+  journal = {Journal of Studies},
+  year    = {1999}
+}

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -611,22 +611,16 @@ impl MakeBibliography {
             let year = extract_four_digit_year(&date_content);
             entry.year = year.clone();
 
-            // Perl L330 selects the date for {ay} and the sortkey with the
-            // UNION xpath `ltx:bib-date[@role="publication"] | ltx:bib-type`
-            // (whichever comes first in document order), so a dateless entry
-            // sorts under its type ("techreport", …) rather than under the
-            // empty string. The label year (`entry.year`) keeps coming from
-            // the date alone, as in Perl, where the tags are built from their
-            // own `@year` nodes.
-            let date = if date_content.is_empty() {
-              PostDocument::findnodes_foreign("ltx:bib-type", bibentry)
-                .into_iter()
-                .next()
-                .map(|n| extract_four_digit_year(&n.get_content()))
-                .unwrap_or_default()
-            } else {
-              year.clone()
-            };
+            // The {ay}/sortkey date is the publication date ALONE, on purpose.
+            // Perl L330 unions it with `ltx:bib-type`
+            // (`ltx:bib-date[@role="publication"] | ltx:bib-type`, whichever
+            // comes first in document order); querying the two separately is a
+            // settled decision here, so that a `type` field cannot displace the
+            // year — see BIBLIOGRAPHY_WORKLIST, "bib-type is safe to emit".
+            // A "date else type" stand-in was written while porting the sortkey
+            // and REMOVED on review: it contradicts that decision, it is not
+            // Perl's rule anyway for an entry carrying both, and it would move
+            // sort keys (and with them numbering) with no test or witness.
 
             // Title
             let title = PostDocument::findnodes_foreign("ltx:bib-title", bibentry)
@@ -648,11 +642,11 @@ impl MakeBibliography {
             // that Perl groups as "Smith et al.1999" carry different coauthor
             // lists, so their full-name keys never collide and neither entry
             // ever got its `a`/`b` suffix.
-            entry.author_year = format!("{}.{}", short_names, date);
+            entry.author_year = format!("{}.{}", short_names, year);
             entry.initial = PostDocument::initial(&short_names, true);
 
             // Sort key — Perl L338, from the FULL sort-names.
-            let sort_key = format!("{}.{}.{}.{}", sort_names, date, title, bibkey).to_lowercase();
+            let sort_key = format!("{}.{}.{}.{}", sort_names, year, title, bibkey).to_lowercase();
             entry.sort_key = sort_key.clone();
 
             // Enqueue transitive citations
@@ -1485,8 +1479,17 @@ impl Processor for MakeBibliography {
       }
 
       // Read citation style from element attributes
+      // Perl L481 is `$STYLE{citestyle} || 'numbers'`, and `||` is falsy on the
+      // EMPTY string as well as on absent — so an empty attribute must reach
+      // `numbers`, not the `else` branch. Before the mapping repair below an
+      // empty value fell through to `_ => Numbers` by luck; with `_` now
+      // meaning author-year it has to be excluded explicitly, or the repair
+      // would introduce an unfaithfulness of its own. Our own engine cannot
+      // emit `citestyle=""` (`Document::set_attribute` skips empty values), but
+      // `latexml_post` also consumes XML it did not produce.
       let citestyle_str = bib
         .get_attribute("citestyle")
+        .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "numbers".to_string());
       // Perl L481-517 branches on exactly three cases, and the mapping was
       // inverted here: `AY` is the ABBREVIATED `[AS64]` label (L485, class
@@ -1530,6 +1533,14 @@ impl Processor for MakeBibliography {
       // the document-global sortkey order; the two coincide whenever an
       // entry's `initial` is the first letter of its sortkey, which is the
       // common case but not guaranteed (`initial` skips leading non-letters).
+      //
+      // NOTE ON REACH: `self.split` is currently always false — `post.rs`
+      // constructs this processor with `split = false` and
+      // `--splitbibliography` sits in the deferred CLI cluster. So moving the
+      // counter here changes NO production output today; the non-split walk
+      // numbers in the same order the old in-`get_bib_entries` pass did. It is
+      // done for when that flag lands, and because the counter belongs with
+      // the walk it counts.
       let mut number = 0u32;
 
       if self.split {
@@ -1549,9 +1560,15 @@ impl Processor for MakeBibliography {
         for initial in &initials {
           // Number this group, then format it — the order Perl's single
           // `++$NUMBER`-as-you-format walk produces.
+          // The keys came out of `entries` a few lines above, so a miss is a
+          // logic error, not input-dependent — `debug_assert` makes it loud in
+          // dev/test without risking a production abort (`maxperf` sets
+          // `panic = "abort"`). Incrementing INSIDE the lookup also means a
+          // miss could never silently burn a number and shift the whole list.
           for key in &by_initial[initial] {
-            number += 1;
+            debug_assert!(entries.contains_key(key), "grouped key {key} left entries");
             if let Some(entry) = entries.get_mut(key) {
+              number += 1;
               entry.number = number;
             }
           }
@@ -1568,8 +1585,9 @@ impl Processor for MakeBibliography {
         let mut sorted_keys: Vec<String> = entries.keys().cloned().collect();
         unisort(&mut sorted_keys);
         for key in &sorted_keys {
-          number += 1;
+          debug_assert!(entries.contains_key(key), "sorted key {key} left entries");
           if let Some(entry) = entries.get_mut(key) {
+            number += 1;
             entry.number = number;
           }
         }

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -2825,10 +2825,11 @@ fn format_links(doc: &PostDocument, nodes: &[Node]) -> Vec<NodeData> {
 ///
 /// **Documented approximation** (OXIDIZED_DESIGN #84): we reproduce UCA's
 /// PRIMARY level for Latin script only — NFD-decompose, drop the combining
-/// marks, case-fold — and break ties on the raw string, whose codepoint order
-/// already sorts uppercase before lowercase, matching `upper_before_lower`.
-/// That is exact for accented Latin (the input this actually sees: author
-/// surnames and titles), and diverges from Perl for script-crossing orders,
+/// marks, case-fold — and break ties on the raw string. That is exact for
+/// accented Latin (the input this actually sees: author surnames and titles).
+/// Perl's `upper_before_lower` needs no counterpart because it is MOOT: the
+/// sort keys are `to_lowercase()`d when built, so no comparison here can see a
+/// case difference. It diverges from Perl for script-crossing orders,
 /// non-decomposable letters (`Ø`, `Æ`, `Ł`) and locale tailorings — none of
 /// which a DUCET table could be added for without a new dependency carrying
 /// embedded collation data. `Post.pm` L123-128 shows Perl itself falling back

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -590,30 +590,16 @@ impl MakeBibliography {
         Some(mut entry) => {
           // Extract metadata from bibentry XML node (if available)
           if let Some(ref bibentry) = entry.bibentry {
+            // Perl L318-328 computes TWO name strings and uses them for
+            // different things: `$sortnames` (every "Surname Givenname",
+            // joined) keys the sort, while `$names` (the SHORT form — "A and
+            // B", "A et al") keys `{ay}` and `{initial}`. `extract_names`
+            // already carries Perl's bib-key → bib-title fallback (both
+            // strings then hold the same text), so no second fallback chain is
+            // needed here.
             let (sort_names, short_names, _full_names) = extract_names(doc, bibentry);
             entry.sort_names = sort_names.clone();
-            entry.authors_short = short_names;
-
-            let names_for_sort = if sort_names.is_empty() {
-              // Try bib-key or bib-title as fallback
-              match PostDocument::findnodes_foreign("ltx:bib-key", bibentry)
-                .into_iter()
-                .next()
-              {
-                Some(key_node) => key_node.get_content(),
-                _ => {
-                  match PostDocument::findnodes_foreign("ltx:bib-title", bibentry)
-                    .into_iter()
-                    .next()
-                  {
-                    Some(title_node) => title_node.get_content(),
-                    _ => bibkey.clone(),
-                  }
-                },
-              }
-            } else {
-              sort_names
-            };
+            entry.authors_short = short_names.clone();
 
             // Year
             let date_content =
@@ -624,6 +610,23 @@ impl MakeBibliography {
                 .unwrap_or_default();
             let year = extract_four_digit_year(&date_content);
             entry.year = year.clone();
+
+            // Perl L330 selects the date for {ay} and the sortkey with the
+            // UNION xpath `ltx:bib-date[@role="publication"] | ltx:bib-type`
+            // (whichever comes first in document order), so a dateless entry
+            // sorts under its type ("techreport", …) rather than under the
+            // empty string. The label year (`entry.year`) keeps coming from
+            // the date alone, as in Perl, where the tags are built from their
+            // own `@year` nodes.
+            let date = if date_content.is_empty() {
+              PostDocument::findnodes_foreign("ltx:bib-type", bibentry)
+                .into_iter()
+                .next()
+                .map(|n| extract_four_digit_year(&n.get_content()))
+                .unwrap_or_default()
+            } else {
+              year.clone()
+            };
 
             // Title
             let title = PostDocument::findnodes_foreign("ltx:bib-title", bibentry)
@@ -639,13 +642,17 @@ impl MakeBibliography {
               .unwrap_or_else(|| "misc".to_string());
             entry.entry_type = entry_type;
 
-            // Author+year for suffix detection
-            entry.author_year = format!("{}.{}", names_for_sort, year);
-            entry.initial = PostDocument::initial(&names_for_sort, true);
+            // Author+year for suffix detection — Perl L336 `"$names.$date"`,
+            // i.e. the SHORT names. Using the full sort-names here silently
+            // disabled disambiguation for every 3+-author paper: two entries
+            // that Perl groups as "Smith et al.1999" carry different coauthor
+            // lists, so their full-name keys never collide and neither entry
+            // ever got its `a`/`b` suffix.
+            entry.author_year = format!("{}.{}", short_names, date);
+            entry.initial = PostDocument::initial(&short_names, true);
 
-            // Sort key
-            let sort_key =
-              format!("{}.{}.{}.{}", names_for_sort, year, title, bibkey).to_lowercase();
+            // Sort key — Perl L338, from the FULL sort-names.
+            let sort_key = format!("{}.{}.{}.{}", sort_names, date, title, bibkey).to_lowercase();
             entry.sort_key = sort_key.clone();
 
             // Enqueue transitive citations
@@ -755,8 +762,9 @@ impl MakeBibliography {
     );
 
     // Step 5: Sort and detect duplicate author+year → assign suffixes.
+    // Perl L357 `$doc->unisort(keys %$included)`.
     let mut sorted_keys: Vec<String> = included.keys().cloned().collect();
-    sorted_keys.sort();
+    unisort(&mut sorted_keys);
 
     // Port of suffix detection: track by author_year, assign suffixes when duplicated.
     let mut ay_last: HashMap<String, String> = HashMap::default(); // ay → last sort_key with this ay
@@ -794,14 +802,10 @@ impl MakeBibliography {
       }
     }
 
-    // Assign numbers in sort order
-    let mut number = 0u32;
-    for key in &sorted_keys {
-      number += 1;
-      if let Some(entry) = included.get_mut(key) {
-        entry.number = number;
-      }
-    }
+    // Numbering is NOT done here: Perl assigns it in FORMAT order
+    // (`++$NUMBER` inside `formatBibEntry` L418), which is initial-major once
+    // `--splitbibliography` is on. It happens in `process`, alongside the walk
+    // that builds the biblists.
 
     (included, bib_docs)
   }
@@ -836,11 +840,12 @@ impl MakeBibliography {
       format!("{}.L1", bib_id)
     };
 
-    let mut sorted_keys: Vec<&String> = entries.keys().collect();
-    sorted_keys.sort();
+    // Perl L398 `$doc->unisort(keys %$entries)`.
+    let mut sorted_keys: Vec<String> = entries.keys().cloned().collect();
+    unisort(&mut sorted_keys);
     let items: Vec<NodeData> = sorted_keys
       .iter()
-      .filter_map(|key| entries.get(*key))
+      .filter_map(|key| entries.get(key))
       .map(|entry| self.format_bib_entry(doc, bib_id, entry, style))
       .collect();
 
@@ -1308,14 +1313,22 @@ impl MakeBibliography {
         surnames = doc.findnodes_at("ltx:bib-name[@role='editor']/ltx:surname", Some(bibentry));
       }
       if surnames.len() > 1 {
-        let mut aa: String = surnames
+        // Perl L497-500: `join('', map { substr($_->textContent, 0, 1) })`,
+        // truncated to `substr($aa, 0, 3) . "+"` past three. Both are
+        // CHARACTER operations, and neither uppercases — only the single-name
+        // branch below carries Perl's `uc`. Byte indexing here used to panic
+        // outright on a multi-byte initial (`Ångström`), which the citestyle
+        // repair makes reachable for every `\bibliographystyle{alpha}`
+        // document rather than the handful that spelled the style `alpha`.
+        let initials: Vec<char> = surnames
           .iter()
-          .map(|n| n.get_content().chars().next().unwrap_or('?').to_string())
+          .map(|n| n.get_content().chars().next().unwrap_or('?'))
           .collect();
-        if aa.len() > 3 {
-          aa = format!("{}+", &aa[..3]);
+        if initials.len() > 3 {
+          format!("{}+", initials[..3].iter().collect::<String>())
+        } else {
+          initials.iter().collect::<String>()
         }
-        aa.to_uppercase()
       } else if !surnames.is_empty() {
         let text = surnames[0].get_content();
         text.chars().take(3).collect::<String>().to_uppercase()
@@ -1475,14 +1488,23 @@ impl Processor for MakeBibliography {
       let citestyle_str = bib
         .get_attribute("citestyle")
         .unwrap_or_else(|| "numbers".to_string());
+      // Perl L481-517 branches on exactly three cases, and the mapping was
+      // inverted here: `AY` is the ABBREVIATED `[AS64]` label (L485, class
+      // `ltx_bib_abbrv`), NOT the spelled-out author-year one, and ANY other
+      // non-`numbers` value takes the author-year `else` branch rather than
+      // falling back to numbers. `\bibliographystyle{alpha}` sets
+      // `CITE_STYLE=AY` (`latex_constructs.rs::lookup_bibstyle_params`, Perl
+      // `$BIBSTYLES` L3953-3961), so every alpha-styled document was getting
+      // author-year refnums where Perl — and the `.bst` the author chose —
+      // give `[AS64]`.
       let style = match citestyle_str.as_str() {
-        "AY" | "authoryear" | "author-year" => CitationStyle::AuthorYear,
-        "alpha" | "Alpha" => CitationStyle::Alpha,
-        _ => CitationStyle::Numbers,
+        "numbers" => CitationStyle::Numbers,
+        "AY" => CitationStyle::Alpha,
+        _ => CitationStyle::AuthorYear,
       };
 
       // bib_docs must be kept alive as long as entries (bibentry Nodes reference them)
-      let (entries, _bib_docs) = self.get_bib_entries(&doc, bib);
+      let (mut entries, _bib_docs) = self.get_bib_entries(&doc, bib);
       if entries.is_empty() {
         Info!(
           "bibliography",
@@ -1501,28 +1523,56 @@ impl Processor for MakeBibliography {
         })
         .unwrap_or_else(|| "bib".to_string());
 
+      // Perl `local $LaTeXML::Post::MakeBibliography::NUMBER = 0` (L55) —
+      // reset per `ltx:bibliography`, then incremented once per entry as it is
+      // FORMATTED (L418). Under `--splitbibliography` that walk is
+      // initial-major, so the counter follows the initial groups rather than
+      // the document-global sortkey order; the two coincide whenever an
+      // entry's `initial` is the first letter of its sortkey, which is the
+      // common case but not guaranteed (`initial` skips leading non-letters).
+      let mut number = 0u32;
+
       if self.split {
         // Split by initial letter
-        let mut by_initial: HashMap<String, HashMap<String, &BibEntryData>> = HashMap::default();
+        let mut by_initial: HashMap<String, Vec<String>> = HashMap::default();
         for (key, entry) in &entries {
           by_initial
             .entry(entry.initial.clone())
             .or_default()
-            .insert(key.clone(), entry);
+            .push(key.clone());
         }
-        let mut initials: Vec<&String> = by_initial.keys().collect();
+        let mut initials: Vec<String> = by_initial.keys().cloned().collect();
         initials.sort();
-        for initial in initials {
+        for group in by_initial.values_mut() {
+          unisort(group);
+        }
+        for initial in &initials {
+          // Number this group, then format it — the order Perl's single
+          // `++$NUMBER`-as-you-format walk produces.
+          for key in &by_initial[initial] {
+            number += 1;
+            if let Some(entry) = entries.get_mut(key) {
+              entry.number = number;
+            }
+          }
           // Build a subset HashMap for this initial
           let subset: HashMap<String, BibEntryData> = by_initial[initial]
             .iter()
-            .map(|(k, e)| (k.clone(), clone_entry(e)))
+            .filter_map(|k| entries.get(k).map(|e| (k.clone(), clone_entry(e))))
             .collect();
           let biblist = self.make_bibliography_list(&doc, &bib_id, Some(initial), &subset, &style);
           let mut bib_mut = bib.clone();
           doc.add_nodes(&mut bib_mut, &[biblist]);
         }
       } else {
+        let mut sorted_keys: Vec<String> = entries.keys().cloned().collect();
+        unisort(&mut sorted_keys);
+        for key in &sorted_keys {
+          number += 1;
+          if let Some(entry) = entries.get_mut(key) {
+            entry.number = number;
+          }
+        }
         let biblist = self.make_bibliography_list(&doc, &bib_id, None, &entries, &style);
         let mut bib_mut = bib.clone();
         doc.add_nodes(&mut bib_mut, &[biblist]);
@@ -2509,7 +2559,16 @@ fn apply_formatter(doc: &PostDocument, formatter: Formatter, nodes: &[Node]) -> 
       result
     },
     Formatter::Year => {
-      let suffix = ""; // Suffix is handled elsewhere
+      // NO disambiguation suffix here, deliberately — see KNOWN_PERL_ERRORS
+      // #67. Perl `do_year` (L613-615) reads `@…::SUFFIX`, the ARRAY, while
+      // `formatBibEntry` L417 binds `$…::SUFFIX`, the SCALAR: two different
+      // Perl variables, so the array is always empty and the letter never
+      // reaches the entry body. Measured, not assumed — same-host Perl 0.8.8
+      // on `bib_alpha_style.tex` prints `[SBC99a]` as the label and ` (1999)`
+      // as the body year. `alpha.bst` agrees, so this is the right output and
+      // there is no gap to close; the audit item that flagged one was read off
+      // the sigil.
+      let suffix = "";
       let content: Vec<NodeData> = nodes
         .iter()
         .map(|n| {
@@ -2738,6 +2797,42 @@ fn format_links(doc: &PostDocument, nodes: &[Node]) -> Vec<NodeData> {
 
 // ======================================================================
 // Utility functions
+
+/// Sort bibliography sort-keys the way Perl's `Post::unisort` does.
+///
+/// Perl (`Post.pm` L1399-1403) hands the keys to a `Unicode::Collate::Locale`
+/// built with `variable => 'non-ignorable'` and `upper_before_lower => 1` — a
+/// full UCA collation, so `Šmith` lands next to `Smith` rather than after every
+/// ASCII letter, which is what a plain codepoint `sort()` produces.
+///
+/// **Documented approximation** (OXIDIZED_DESIGN #84): we reproduce UCA's
+/// PRIMARY level for Latin script only — NFD-decompose, drop the combining
+/// marks, case-fold — and break ties on the raw string, whose codepoint order
+/// already sorts uppercase before lowercase, matching `upper_before_lower`.
+/// That is exact for accented Latin (the input this actually sees: author
+/// surnames and titles), and diverges from Perl for script-crossing orders,
+/// non-decomposable letters (`Ø`, `Æ`, `Ł`) and locale tailorings — none of
+/// which a DUCET table could be added for without a new dependency carrying
+/// embedded collation data. `Post.pm` L123-128 shows Perl itself falling back
+/// to a codepoint `DumbCollator` when `Unicode::Collate` is unavailable, so a
+/// documented approximation stays inside the range of behaviours Perl ships.
+///
+/// The sort is otherwise total and deterministic: equal primary keys fall back
+/// to the raw key, and the raw keys are the (unique) hash keys of the entry
+/// map.
+fn unisort(keys: &mut [String]) {
+  keys.sort_by_cached_key(|k| (collation_primary_key(k), k.clone()));
+}
+
+/// The primary-level collation weight of a sort-key: NFD, combining marks
+/// dropped, case-folded. See [`unisort`].
+fn collation_primary_key(s: &str) -> String {
+  use unicode_normalization::{UnicodeNormalization, char::is_combining_mark};
+  s.nfd()
+    .filter(|c| !is_combining_mark(*c))
+    .flat_map(char::to_lowercase)
+    .collect()
+}
 
 /// Extract author names from a bibentry node.
 ///


### PR DESCRIPTION
SYNC_STATUS **R5 item 2** — the secondary parity gaps of the MakeBibliography
re-port. All five fixes are in `latexml_post/src/make_bibliography.rs`, all
measured against same-host Perl LaTeXML 0.8.8.

### The reaching one: `citestyle` was inverted

Perl branches three ways (`MakeBibliography.pm` L481-517):

| `citestyle` | Perl | Rust before |
|---|---|---|
| `numbers` | `[1]`, `ltx_bib_key` | same |
| **`AY`** | **abbreviated `[AS64]`, `ltx_bib_abbrv`** | spelled-out author-year |
| anything else | author-year | `numbers` |
| `alpha` (nothing emits this) | author-year | abbreviated |

`\bibliographystyle{alpha}` sets `CITE_STYLE=AY` (Perl `$BIBSTYLES`,
`latex_constructs.pool.ltxml` L3953-3961; the Rust table matches), so **every
alpha-styled document got the wrong label shape**, and natbib's `super` fell to
numbers instead of author-year.

### The rest

* **`{ay}` and `{initial}` were keyed off the wrong name string.** Perl computes
  two (L318-337): the full `$sortnames` keys the sort, the SHORT `$names`
  (`"Smith et al"`) keys disambiguation and the split-by-initial bucket. Rust
  used the full form for all three, so two 3+-author entries sharing a first
  author and year never collided and **neither was ever given its `a`/`b`
  suffix**.
* **`unisort` now collates.** Perl uses `Unicode::Collate` (`Post.pm`
  L1399-1403); Rust called `Vec::sort()`, exiling every non-ASCII surname past
  `z` (`Ångström` after `Smith`). Ported at UCA's **primary** level through the
  `unicode-normalization` dep `latexml_post` already carries — **no new
  dependency**. `OXIDIZED_DESIGN #84` records what it does not reproduce
  (non-decomposable letters, cross-script order, locale tailorings) and why that
  stays inside the range Perl ships (`Post.pm` L123-128 falls back to a
  codepoint `DumbCollator`).
* **`NUMBER` is assigned in FORMAT order** (Perl `local $NUMBER` L55,
  `++$NUMBER` L418), which is initial-major under `--splitbibliography`, not in
  document-global sortkey order. **This changes no output today** — `post.rs`
  builds the processor with `split = false` and `--splitbibliography` is in the
  deferred CLI cluster, so the split branch is unreachable and the non-split
  walk numbers in exactly the order the old pass did. It is a correctness fix
  for when that flag lands.
* **`make_alpha_label` byte-indexed a UTF-8 string** — `aa.len() > 3` /
  `&aa[..3]` over the per-author initials, a char-boundary panic on a multi-byte
  initial (`Ångström`). Latent before, **reachable for every alpha document
  after the citestyle repair**, so it is fixed here rather than deferred. Also
  drops the `to_uppercase()` Perl's multi-name branch does not have.

### One of the four audit items was NOT a gap

`Formatter::Year` correctly omits the suffix. Perl's `do_year` (L613-615) reads
the **array** `@…::SUFFIX` while `formatBibEntry` (L417) binds the **scalar**
`$…::SUFFIX` — different Perl variables, and the array is assigned nowhere in
the distribution, so the letter never reached the entry body upstream either.
Measured Perl prints `[SBC99a]` on the label and ` (1999)` in the body, and
`alpha.bst` agrees. Recorded as **KNOWN_PERL_ERRORS #67**; the non-emission is
now pinned by the guard so a future reader of L613-615 does not "fix" it back.
(I implemented the "fix" first and reverted it when Perl's actual output
disagreed — the same "verify the file, not the recollection" trap R9-BST
records.)

### Verification

* Guard `06_cluster_bibliography::cluster_bib_alpha_style_labels` over
  `cluster_regressions/bib_alpha_style.{tex,bib}` — **verified RED on the
  pre-fix tree**: author-year classes, `Ångström` last, no suffixes.
* Every expectation ground-truthed against same-host Perl 0.8.8 on that
  fixture, after which the two engines' bibliographies are **byte-identical**
  on it (modulo the pre-existing `biblist` id noted below).
* **No lateral drift:** real witnesses `2310.18318` (`.bbl` route,
  `\bibliographystyle{alpha}`, 52 bibitems) and `2512.05067` (raw `.bib`,
  `unsrt`, 13 bibitems) are byte-identical before vs after, 0 errors each.
* Suite **1763 passing / 106 targets, 0 failed**; `clippy --workspace
  --all-targets -D warnings` and `cargo doc --workspace` clean.

### Found, not fixed

A Rust `<ltx:biblist>` carries `xml:id` but no `fragid`, and the XSLT's `add_id`
emits the HTML `id` from `@fragid` only — so Perl's `<ul id="bib.L1">` comes out
as a bare `<ul>` here. Pre-existing and unrelated to this change; the XSLT
template is byte-identical between the engines, so the divergence is upstream of
it in whatever assigns `fragid` to a post-created node.

### Self-review pass before merge (commit `e325122948`)

Three overreaches in the first commit, found by attacking the diff:

1. **The citestyle repair introduced an unfaithfulness of its own.** Perl L481
   is `$STYLE{citestyle} || 'numbers'`, and `||` is falsy on the **empty
   string** too. Before the repair an empty attribute fell to `_ => Numbers`
   and matched Perl by luck; with `_` now meaning author-year it had to be
   excluded explicitly. Our engine cannot emit `citestyle=""`
   (`Document::set_attribute` skips empty values), but `latexml_post` also
   consumes XML it did not produce.
2. **Removed a `bib-type` fallback for the sortkey date.** Not one of the four
   item-2 gaps; not Perl's rule either (the union XPath takes whichever element
   comes *first in document order*, not "date else type"); and
   `BIBLIOGRAPHY_WORKLIST` already records querying the two separately as a
   settled decision so a `type` field cannot displace the year — the hunk
   silently contradicted it, with no test and no witness, while moving sort keys
   and numbering.
3. **Scoped the NUMBER claim to what it delivers** (above).

Plus: two silent-skip shapes in the numbering walk could have burned a number
and shifted the whole list if the invariant broke. Now `debug_assert!` — loud in
dev/test, safe in production, where `maxperf`'s `panic = "abort"` makes a panic
on an "impossible" case worse than degrading. (`panic!` was written first and
reverted for exactly that reason.)

Re-gated after the fixes: clippy clean, **106/106 targets, 1763 tests, 0
failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

