### PR TITLE
fix(captions): give \fnum@<type> an empty group so an arg-taking hook cannot eat the caption's brace

### DIFF
--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -52,7 +52,7 @@ Re-verify a row before planning on it (rule 1).
 
 | # | item | state | size | detail |
 |---|---|---|---|---|
-| **R1** | Upstream `brucemiller/LaTeXML#2852` — subfile `\documentclass` options | **OPEN upstream**, ours merged as #310 | minutes — chase review, no code | Open items |
+| **R1** | Upstream `brucemiller/LaTeXML#2852` — subfile `\documentclass` options | **OPEN upstream**, ours merged as #310; **CI all-green + mergeable, re-verified 2026-07-29** | nothing left but a review nudge — no code, no automatable step | Open items |
 | **R2** | `--preload=<cls>` trips the LaTeX hook stack (`Extra \PopDefaultHookLabel`) | **OPEN**, re-verified 2026-07-29 (1 error with `--preload=article.cls`, 0 without). The row's *second* divergence — the preload PI kept `[opts]`/`.cls` and never emitted `options=` — is ✅ **FIXED 2026-07-29** | hook half is **not** small: five measured dead ends, `(c)` now collapsed into the rejected `(a)`, and any real fix is TeX-side | Open items |
 | **R4** | biblatex `.bbl` `TokenLimit` loop (2605.17646) | ✅ **FIXED 2026-07-25** — self-referential `\let` on `setupPseudoBibitem` re-arm; shared with Perl | — | Open items |
 | **R5** | Bibliography targets + MakeBibliography re-port | **re-port items 1 and 3 LANDED**: a raw `.bib` is converted by the engine (recursive BibTeX session on the LIVE core state), the 727-line string route is deleted, the eager-tokenization gap that cost 151 papers is closed at the root, and the 13-field digest whitelist is gone — the `\bib@field@default@*` name sets now match Perl exactly (45 each). The 2026-07-27 follow-ups closed the `.bib`-as-DATA family (divergences #74/#78/#79/**#80**). Remaining: item 2 (unisort, citestyle `AY`, `Formatter::Year` suffix, doc-global NUMBER) and the missing-references target list | **item 2 + targets** — the re-port itself is done | [`BIBLIOGRAPHY_WORKLIST.md`](parity/BIBLIOGRAPHY_WORKLIST.md) |
@@ -64,6 +64,43 @@ Re-verify a row before planning on it (rule 1).
 | — | Two-pass streaming split | **deferred by user decision 2026-07-06**; trigger = a <64 GB target appears | — | [`STREAMING_POST_DESIGN_2026-07-06.md`](performance/STREAMING_POST_DESIGN_2026-07-06.md) |
 
 ## Current status
+
+- **2026-07-29 — an arg-taking `\fnum@<type>` absorbed the rest of the document
+  into an unclosed `<figure>`.** The one concrete, analysed-but-unfixed item of
+  R5's "missing references" family, parked since 2026-07-14 on "needs a user
+  decision + a full-suite diff". Both are now done: user-approved per the
+  `surpass-perl` protocol, and the full-suite diff is **empty**.
+  LaTeX's `\@makecaption` is `\sbox\@tempboxa{#1: #2}`, so the widely-copied
+  "`Fig. 1:` → `Fig. 1.`" hack — `\renewcommand*{\fnum@figure}[1]{...}` — works
+  under pdflatex by having the hook eat that `:` **token**. LaTeXML's separator
+  is a tag **attribute** (`\lx@tag[][: ]`), so the argument scan ran past the
+  hook and took the caption group's closing brace: the `<figure>` never closed
+  and every following section, **the bibliography included**, was absorbed into
+  it. That is the truncation mechanism, not a bad caption.
+  Fixed by expanding the hook as `\csname fnum@#1\endcsname{}` at all three
+  `fnum@` sites (`\lx@fnum@@`, `\lx@fnum@toc@@`, the theorem-header formatter);
+  `\lx@typerefnum@@` shares the shape and is deliberately excluded — no LaTeX
+  kernel feeds it a separator token. **SHARED-FAILURE, so this is a surpass**:
+  pdflatex 0 errors, same-host Perl 0.8.8 **9**, pre-fix Rust **7** on the
+  two-hook minimal form; the three-hook guard fixture goes **10 → 0**.
+  **The deferral's premise was wrong and that is the lesson**: "`\lx@fnum@@`
+  formats every figure/table caption in every document" — it does not. The
+  changed branch fires only where `\fnum@<type>` is *defined*; the untouched
+  `\lx@@fnum@@` default serves nearly every caption. Measured blast radius:
+  **106/106 targets, zero goldens re-blessed**, and three real papers whose
+  classes `\def\fnum@figure` (svjour3, aastex631, llncs) are byte-identical
+  before vs after.
+  **A second recorded claim did NOT survive re-measurement.** The 2026-07-14
+  note said "18 papers corpus-wide, 5 with no References", counted by
+  `grep 'lx@tag@intags'`. Live against the current fleet run that proxy gives
+  **23** papers over 2605+2606 (60,505 docs), but only **2** carry this cause's
+  actual signature — 2605.01731 (18 figures × 3 errors, confirmed live) and
+  2605.12842 (10 × 3). `\lx@tag@intags` has several causes; the proxy
+  over-attributes, and the "5 with no References" sub-claim is withdrawn. The
+  fix is justified on being right and free, not on breadth. Does NOT fix the
+  `close=": "` separator, so the caption still reads `Figure 1.: A caption.`.
+  OXIDIZED_DESIGN **#85**, KNOWN_PERL_ERRORS **#68**, guard
+  `06_cluster_regressions::cluster_fnum_arg_hook`.
 
 - **2026-07-27 (latest) — the `unexpected:fi` fatal cluster: `\meaning` of a
   `\chardef` token returned the internal class name.** GENUINE-RUST-ONLY,
@@ -565,8 +602,13 @@ residuals stay here so the live worklist keeps them visible:
 
 ### R1 — upstream `brucemiller/LaTeXML#2852`: a subfile's `\documentclass` options are not packages
 
-**OPEN upstream** (state checked 2026-07-25); **our half is already merged as PR
-#310**, so nothing is pending here in this repo. The allowlist was hand-split on
+**OPEN upstream**; **our half is already merged as PR #310**, so nothing is
+pending here in this repo. **CI re-verified 2026-07-29: all 15 checks SUCCESS**
+(TeX Live none/2021/2022/2023/2024/2025 × Perl 5.34-5.42, Linux + Windows),
+`mergeable`, not a draft, **zero reviews**, untouched since 2026-07-20. So the
+code side of this row is done and green; what is left is a review nudge to the
+maintainer, which is a human-voice action, not a task to automate. The
+allowlist was hand-split on
 `,` and missed every valued form (`[varwidth=5cm]` → `Error:undefined:{varwidth}`,
 pdflatex clean); it now reads `OptionalKeyVals` and matches on the key. The same
 fix is ported to Perl (`OptionalKeyVals` + `getPairs`) with a `t/structure` case

--- a/docs/parity/BIBLIOGRAPHY_WORKLIST.md
+++ b/docs/parity/BIBLIOGRAPHY_WORKLIST.md
@@ -540,7 +540,7 @@ the log). A `grep -rl '\begin{document}'` harness picks the first match, which
 for `2605.30360` was the decoy `proof.tex`, not `polyhist.tex` — that alone
 manufactured a false "still broken" verdict.
 
-#### `\renewcommand*{\fnum@figure}[1]` truncates the document — ANALYSED 2026-07-14, NOT fixed (needs a decision)
+#### `\renewcommand*{\fnum@figure}[1]` truncates the document — ✅ FIXED 2026-07-29 (surpass, OXIDIZED_DESIGN #85)
 
 Witness `2605.01731` (cas-sc): 18 figures × 3 errors
 (`\lx@tag@intags`/`\lx@tag`/`\end{figure}` "Attempt to end mode
@@ -567,13 +567,34 @@ LaTeXML has no `:` token to eat: `\format@title@figure` is
 a token. So `\csname fnum@figure\endcsname` (Base_Utility L1041-1043) grabs the
 group's closing `}` instead, wrecking the caption and cascading.
 
-This is **PARITY** — Perl's `\lx@fnum@@` is identical — so fixing it is a
-surpass-Perl divergence, and both engines are wrong vs the PDF. Candidate fix:
-expand as `\csname fnum@#1\endcsname{}` so an arg-taking `\fnum@<type>` eats a
-harmless empty group (reproducing pdflatex's result) while a normal 0-arg one
-just gains an empty group. **Not done**: `\lx@fnum@@` formats every figure/table
-caption in every document — blast radius far out of proportion to 18 papers, and
-release-week bias is stabilize. Needs a user decision + a full-suite diff.
+This is **PARITY** — Perl's `\lx@fnum@@` is identical — so fixing it was a
+surpass-Perl divergence, and both engines were wrong vs the PDF. **Landed
+2026-07-29** as the candidate fix this entry proposed: expand as `\csname
+fnum@#1\endcsname{}`, so an arg-taking `\fnum@<type>` eats a harmless empty
+group (reproducing pdflatex's result) while a 0-arg one just gains one.
+User-approved per the `surpass-perl` protocol, and extended to all three
+`fnum@` hooks — `\lx@fnum@@`, `\lx@fnum@toc@@` and the theorem-header
+formatter. `\lx@typerefnum@@` shares the shape but is deliberately excluded: no
+LaTeX kernel feeds it a separator token, so the pdflatex-compatibility argument
+does not reach it.
+
+**The blast-radius fear did not materialise, and that is the correction worth
+keeping.** This entry deferred the fix because "`\lx@fnum@@` formats every
+figure/table caption in every document". It does not: the changed branch fires
+only where `\fnum@<type>` is *defined*, and the untouched `\lx@@fnum@@` default
+is what serves nearly every caption. Measured full suite after the change:
+**106/106 targets, zero goldens re-blessed**. Guard fixture
+`cluster_regressions/fnum_arg_hook.tex` goes **10 errors -> 0** (all three
+hooks); same-host Perl 0.8.8 raises 9 on the two-hook form, pdflatex 0. Three
+real papers whose classes `\def\fnum@figure` (svjour3, aastex631, llncs) are
+byte-identical before vs after. **Breadth re-measured 2026-07-29 and reduced:**
+the `grep 'lx@tag@intags'` proxy behind "18 papers, 5 with no References" gives
+23 papers on the current fleet run, of which only 2 carry this cause's signature
+(2605.01731, 2605.12842) — the symptom has several causes.
+Caveat: the `close=": "` separator is untouched, so the caption still reads
+`Figure 1.: A caption.` — the win is error-freedom and an un-truncated
+document, not punctuation parity. Full record: OXIDIZED_DESIGN **#85** /
+KNOWN_PERL_ERRORS **#68**.
 
 Minimal repro (article + subfigure + the `\renewcommand*` above) reproduces the
 exact 3-error signature; `cas-sc` is NOT implicated (it was the first

--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -2862,3 +2862,71 @@ byte-for-byte and so certified the defect.
 Candidate to upstream: swapping `#1`→`#2` is a one-token fix; the
 note-decoration and undigested-reading parts need the XSLT and parameter-type
 changes too.
+
+## 68. An arg-taking `\fnum@<type>` swallows the caption's closing brace and absorbs the rest of the document
+
+`LaTeXML/lib/LaTeXML/Engine/Base_Utility.pool.ltxml` L1041-1043 expands the
+author's caption-number hook bare:
+
+```perl
+DefMacro('\lx@fnum@@{}',
+  '{\normalfont\@ifundefined{fnum@font@#1}{}{\csname fnum@font@#1\endcsname}'
+    . '\@ifundefined{fnum@#1}{\lx@@fnum@@{#1}}{\csname fnum@#1\endcsname}}');
+```
+
+Real `\fnum@<type>` takes no argument. But LaTeX's `\@makecaption` is
+`\sbox\@tempboxa{#1: #2}`, so a **one-argument** `\fnum@<type>` eats the `:`
+that follows it — which is exactly the point of the widely-copied "change
+`Fig. 1:` to `Fig. 1.`" hack:
+
+```tex
+\makeatletter
+\renewcommand*{\fnum@figure}[1]{\figurename~\thefigure.}
+\makeatother
+```
+
+LaTeXML has no `:` **token** to eat: its separator is a tag **attribute**
+(`\lx@tag[][: ]`, `latex_constructs.pool.ltxml` L3158-3159). So the argument
+scan runs past the hook and takes the caption group's closing brace instead. The
+`<figure>` never closes, and **every following section — the bibliography
+included — is absorbed into it**, which is why the symptom presents as a
+truncated document with no References section rather than as a bad caption.
+
+**Minimal trigger** (`latexml_oxide/tests/cluster_regressions/fnum_arg_hook.tex`
+covers all three hooks; plain `article` suffices — `cas-sc` is not implicated):
+
+```tex
+\documentclass{article}
+\makeatletter
+\renewcommand*{\fnum@figure}[1]{\figurename~\thefigure.}
+\makeatother
+\begin{document}
+\section{First}
+\begin{figure}\caption{A caption.}\end{figure}
+\section{Second}
+Text after the figure must survive.
+\end{document}
+```
+
+Measured on that input: **pdflatex 0 errors** (renders `Figure 1. A caption.`),
+**Perl LaTeXML 0.8.8 nine errors**, pre-fix Rust seven — same
+`\lx@tag@intags` / `\lx@tag` / `\end{figure}` "Attempt to end mode
+restricted_horizontal" signature in both engines. Witnesses `2605.01731`
+(18 figures × 3 errors) and `2605.12842` (10 × 3), both confirmed live on the
+current fleet run. **Breadth is smaller than once recorded:** a 2026-07-14 note
+claimed 18 papers from a `grep 'lx@tag@intags'` proxy; re-measured 2026-07-29
+that proxy gives 23 papers across sandbox-arxiv-2605+2606 (60,505 docs) of which
+only **2** carry this cause's actual signature — the symptom has several causes,
+so the proxy over-attributes.
+
+**Fixed in Rust** as a deliberate surpass — `OXIDIZED_DESIGN #85`: the hook is
+expanded as `\csname fnum@#1\endcsname{}`, giving an arg-taking definition a
+harmless empty group and reproducing pdflatex's result, while the 0-arg hooks
+that are the normal case are unaffected. Guard
+`06_cluster_regressions::cluster_fnum_arg_hook`.
+
+Candidate to upstream: the one-token change applies verbatim to the Perl
+definition, and to `\lx@fnum@toc@@` L1065-1066 and the theorem-header formatter
+alongside it. Note the fix does NOT reach the `close=": "` separator, so the
+caption still reads `Figure 1.: A caption.` in both engines — closing that gap
+needs the tag attribute to become conditional, which is a larger change.

--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -2925,8 +2925,8 @@ harmless empty group and reproducing pdflatex's result, while the 0-arg hooks
 that are the normal case are unaffected. Guard
 `06_cluster_regressions::cluster_fnum_arg_hook`.
 
-Candidate to upstream: the one-token change applies verbatim to the Perl
-definition, and to `\lx@fnum@toc@@` L1065-1066 and the theorem-header formatter
-alongside it. Note the fix does NOT reach the `close=": "` separator, so the
+Reported upstream as **brucemiller/LaTeXML#2856**: the one-token change applies
+verbatim to the Perl definition, and to `\lx@fnum@toc@@` L1065-1066 and the
+theorem-header formatter alongside it. Note the fix does NOT reach the `close=": "` separator, so the
 caption still reads `Figure 1.: A caption.` in both engines — closing that gap
 needs the tag attribute to become conditional, which is a larger change.

--- a/docs/parity/OXIDIZED_DESIGN.md
+++ b/docs/parity/OXIDIZED_DESIGN.md
@@ -9,7 +9,7 @@ This file is the **index + overview**. The detail lives in a themed family:
 
 | Theme file | What it holds |
 |---|---|
-| [OXIDIZED_DESIGN_DIVERGENCES.md](OXIDIZED_DESIGN_DIVERGENCES.md) | The numbered **Intentional Divergences from Perl** (`#1–#15`, `#17–#18`, `#19–#65`) + a brief Known-Upstream-Perl-Issues list. Code comments cite these as `OXIDIZED_DESIGN #N`. |
+| [OXIDIZED_DESIGN_DIVERGENCES.md](OXIDIZED_DESIGN_DIVERGENCES.md) | The numbered **Intentional Divergences from Perl** (`#1–#15`, `#17–#18`, `#19–#85`) + a brief Known-Upstream-Perl-Issues list. Code comments cite these as `OXIDIZED_DESIGN #N`. |
 | [OXIDIZED_DESIGN_MATH.md](../math/OXIDIZED_DESIGN_MATH.md) | Marpa math-parser design: `#16` design rules + the grammar-rule cluster `#7–#18`. |
 | [OXIDIZED_DESIGN_TYPES.md](OXIDIZED_DESIGN_TYPES.md) | Type-system improvements (behavior-neutral) + tactical internal pitfalls. |
 | [OXIDIZED_DESIGN_FUTURE_WORK.md](OXIDIZED_DESIGN_FUTURE_WORK.md) | Beyond-parity directions not yet built. |
@@ -18,12 +18,14 @@ This file is the **index + overview**. The detail lives in a themed family:
 > `.rs` comments reference them — so they are kept verbatim, which means three
 > quirks: (1) the numbers are **not globally unique** (the math cluster `#7–#18`
 > collides by value with divergences `#7–#18`); (2) a code-referenced number
-> resolves to the file above that owns that *topic* — most (`#1–#15`, `#19–#80`)
+> resolves to the file above that owns that *topic* — most (`#1–#15`, `#19–#85`)
 > are in DIVERGENCES, the math ones (incl. the code-referenced **`#18` = f(x)
 > "Speculative function application"**) are in MATH; (3) **`#76` is a retired
 > number** — its entry was consolidated into `#74` and the number was not
 > reused, so a gap in the sequence is expected, not a missing file. Next free
-> number: **#81**. When in doubt,
+> number: **#86**. (**#84** is claimed by the concurrent bibliography
+> branch — PR #445 — so on this branch alone the sequence skips it.)
+> When in doubt,
 > `grep '### N\.' docs/parity/OXIDIZED_DESIGN_*.md docs/math/OXIDIZED_DESIGN_MATH.md`.
 
 ---

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -3140,7 +3140,7 @@ Perl 0.8.8 raises **9** errors and pre-fix Rust raised **7**; pdflatex raises
 re-blessed.
 
 **Upstream.** Perl's definition is byte-identical, so the same one-token fix
-applies there; filed against `brucemiller/LaTeXML`. Also
+applies there — filed as **brucemiller/LaTeXML#2856**. Also
 `KNOWN_PERL_ERRORS.md` #68.
 
 Guard: `06_cluster_regressions::cluster_fnum_arg_hook`.

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -3064,6 +3064,87 @@ above — through to HTML and asserts that each lands where the table says, that
 `aria-label` appears nowhere, that captions survive, and that no
 `aria-describedby` reference dangles.
 
+### 85. `\fnum@<type>` is expanded with an empty group, so an arg-taking author redefinition cannot eat the caption's closing brace
+
+**Perl behavior.** `\lx@fnum@@` (`Base_Utility.pool.ltxml` L1041-1043) expands
+the author's hook bare — `\@ifundefined{fnum@#1}{\lx@@fnum@@{#1}}{\csname
+fnum@#1\endcsname}`. Rust's definition was byte-identical.
+
+**Rust behavior.** The same, plus a trailing empty group: `{\csname
+fnum@#1\endcsname{}}`. Applied at all three `fnum@` hook sites —
+`\lx@fnum@@` and `\lx@fnum@toc@@` (`base_utilities.rs`) and the theorem-header
+formatter (`latex_constructs.rs`).
+
+**Why.** Real `\fnum@<type>` takes no argument, but LaTeX's `\@makecaption` is
+`\sbox\@tempboxa{#1: #2}`, so a *one-argument* `\fnum@<type>` eats the `:` that
+follows it. That is a widely-copied author hack — "change `Fig. 1:` to
+`Fig. 1.`":
+
+```tex
+\makeatletter
+\renewcommand*{\fnum@figure}[1]{\figurename~\thefigure.}
+\makeatother
+```
+
+pdflatex accepts it and prints `Figure 1. A caption.` LaTeXML has **no `:` token
+to eat** — its separator is a tag ATTRIBUTE (`\lx@tag[][: ]`,
+`latex_constructs.pool.ltxml` L3158-3159) — so the argument scan ran past the
+hook and swallowed the caption group's closing brace. The `<figure>` then never
+closed and **every following section, the bibliography included, was absorbed
+into it**: to a reader the document is truncated. The empty group gives an
+arg-taking hook something harmless to consume, reproducing pdflatex's result,
+and is inert for the 0-arg hooks that are the normal case (`\fnum@subfigure`,
+`\fnum@lstlisting`, `\fnum@sidebar`, `\fnum@ALC@line`, `\fnum@equation`, and the
+dynamic ones `enumitem`/`newfloat` create).
+
+Not a TeX-semantics change: it does not redefine argument scanning, and the
+`\lx@@fnum@@` default branch — what fires when no `\fnum@<type>` exists at all,
+i.e. for nearly every figure and table caption — is untouched.
+
+**What this does NOT buy.** The rendered separator still comes from the tag's
+`close=": "` attribute, so the caption reads `Figure 1.: A caption.` rather than
+pdflatex's `Figure 1. A caption.` The divergence buys **error-freedom and an
+un-truncated document**, not punctuation parity. Suppressing the attribute when
+the hook is arg-taking would be a second, far more speculative change and is
+deliberately not part of this one.
+
+**`\lx@typerefnum@@` has the identical shape and is deliberately NOT changed.**
+`typerefnum@<type>` is a LaTeXML-internal hook with no LaTeX kernel behind it,
+so no author writes an arg-taking version to eat a separator token that LaTeXML
+never emits. The pdflatex-compatibility argument does not reach it, and without
+that argument the change would be speculative.
+
+**Witnesses.** `2605.01731` (cas-sc, 18 figures x 3 errors -> body collapsed to
+one section, 19 `<bibref>` but no `<bibliography>` element) and `2605.12842`
+(10 x 3). `cas-sc` is NOT implicated — plain `article` reproduces; that was the
+first hypothesis and it was wrong.
+
+**Breadth — re-measured live 2026-07-29, and the recorded figure does NOT hold.**
+The 2026-07-14 note claimed "18 papers corpus-wide" from a `grep 'lx@tag@intags'`
+proxy. Against the current fleet run that proxy yields **23 papers** across
+sandbox-arxiv-2605 (9) + 2606 (14), 60,505 documents — but only **2** of the 23
+carry the signature this cause actually produces (equal counts of
+`unexpected:\lx@tag@intags`, `unexpected:\lx@tag` and `unexpected:\end{figure}`,
+one triple per figure): **2605.01731** (18 figures x 3) and **2605.12842**
+(10 x 3). Several more match partially (2606.06276 18/18 but no `\end{figure}`;
+2606.18583, 2606.23565). So `\lx@tag@intags` is a **shared symptom with multiple
+causes** and over-attributes to this one; the "5 of them with no References"
+sub-claim is likewise unverified and is withdrawn. Witness 2605.01731 itself is
+confirmed live on the fleet binary with exactly the recorded 18x3 signature.
+
+**Measured.** Guard fixture `cluster_regressions/fnum_arg_hook.tex`, which
+exercises all three hooks: **10 errors -> 0**, and the bibliography stops being
+absorbed into the unclosed `<figure>`. On the two-hook minimal form, same-host
+Perl 0.8.8 raises **9** errors and pre-fix Rust raised **7**; pdflatex raises
+**0**. Full suite unchanged by the divergence — 106/106 targets, no golden
+re-blessed.
+
+**Upstream.** Perl's definition is byte-identical, so the same one-token fix
+applies there; filed against `brucemiller/LaTeXML`. Also
+`KNOWN_PERL_ERRORS.md` #68.
+
+Guard: `06_cluster_regressions::cluster_fnum_arg_hook`.
+
 ## Known Upstream Perl Issues (brief)
 
 These are behaviors in the original Perl LaTeXML that are bugs or limitations, not

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -1300,9 +1300,23 @@ LoadDefinitions!({
   );
   DefMacro!(r"\lx@refnum@compose@{}{}", r"\if.#1.#2\else#2\space#1\fi");
 
+  // The `{}` after `\endcsname` is OXIDIZED_DESIGN #85, a deliberate divergence
+  // from Perl's otherwise byte-identical `Base_Utility.pool.ltxml` L1041-1043.
+  // LaTeX's `\@makecaption` is `\sbox\@tempboxa{#1: #2}`, so the widely-copied
+  // "Fig. 1: -> Fig. 1." hack —
+  //   \renewcommand*{\fnum@figure}[1]{\figurename~\thefigure.}
+  // — works under pdflatex by having the hook eat that `:` TOKEN. LaTeXML has
+  // no `:` to eat: the separator is a tag ATTRIBUTE (`\lx@tag[][: ]`,
+  // `latex_constructs.rs::format@title@figure`). So the argument scan ran past
+  // the hook and swallowed the caption group's closing brace — the `<figure>`
+  // never closed and every following section, bibliography included, was
+  // absorbed into it. The empty group gives an arg-taking hook something
+  // harmless to consume and is inert for the 0-arg hooks that are the normal
+  // case. The `\lx@@fnum@@` branch below — what fires when no `\fnum@<type>`
+  // exists at all, i.e. for nearly every caption — is untouched.
   DefMacro!(
     r"\lx@fnum@@{}",
-    r"{\normalfont\@ifundefined{fnum@font@#1}{}{\csname fnum@font@#1\endcsname}\@ifundefined{fnum@#1}{\lx@@fnum@@{#1}}{\csname fnum@#1\endcsname}}"
+    r"{\normalfont\@ifundefined{fnum@font@#1}{}{\csname fnum@font@#1\endcsname}\@ifundefined{fnum@#1}{\lx@@fnum@@{#1}}{\csname fnum@#1\endcsname{}}}"
   );
 
   // Really seems like <type>name should take precedence over \lx@name@<type>,
@@ -1319,9 +1333,15 @@ LoadDefinitions!({
   // \\lx@fnum@toc@{type} is similar, but formats the number for use within \\toctitle
   // Customize by defining \\fnum@toc@<type> or \\fnum@tocfont@<type>
   // Default uses just \\the<counter>, else composes using \\lx@@fnum@@{type}
+  // Same `{}` as `\lx@fnum@@` above, same reason — OXIDIZED_DESIGN #85.
+  // (`\lx@typerefnum@@` below has the identical *shape* but is deliberately NOT
+  // changed: `typerefnum@<type>` is a LaTeXML-internal hook with no LaTeX
+  // kernel behind it, so no author writes an arg-taking version to eat a
+  // separator token that LaTeXML never emits. The divergence is justified by
+  // pdflatex compatibility, and that argument does not reach this one.)
   DefMacro!(
     r"\lx@fnum@toc@@{}",
-    r"{\normalfont\@ifundefined{fnum@tocfont@#1}{}{\csname fnum@tocfont@#1\endcsname}\@ifundefined{fnum@toc@#1}{\lx@the@@{#1}}{\csname fnum@toc@#1\endcsname}}"
+    r"{\normalfont\@ifundefined{fnum@tocfont@#1}{}{\csname fnum@tocfont@#1\endcsname}\@ifundefined{fnum@toc@#1}{\lx@the@@{#1}}{\csname fnum@toc@#1\endcsname{}}}"
   );
 
   //----------------------------------------------------------------------

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -1531,7 +1531,12 @@ pub fn define_new_theorem(
       "#1"
     };
     let fmt_str = s!(
-      "{{\\the\\thm@headfont\\lx@tag{{\\csname fnum@{thmset_str}\\endcsname}}{{{note_part}}}\\the\\thm@headpunct}}"
+      // The `{}` after `\endcsname` is OXIDIZED_DESIGN #85 — see `\lx@fnum@@`
+      // in `base_utilities.rs`. A theorem set's `\fnum@<set>` reaches the same
+      // trap: an author redefinition that takes an argument (to eat LaTeX's
+      // separator token) otherwise scans past the hook and swallows the tag
+      // group's closing brace.
+      "{{\\the\\thm@headfont\\lx@tag{{\\csname fnum@{thmset_str}\\endcsname{{}}}}{{{note_part}}}\\the\\thm@headpunct}}"
     );
     let params = parse_parameters("{}", &format_cs_token, true)?;
     DefMacro!(

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -410,3 +410,70 @@ fn expl3_load_does_not_clobber_cedilla_accent() {
      (expected `_`=8, `:`=12, `~`=13):\n{x}"
   );
 }
+
+/// An author's `\fnum@<type>` redefined to TAKE AN ARGUMENT — the widely-copied
+/// "Fig. 1: → Fig. 1." hack. Real `\fnum@<type>` takes none, but LaTeX's
+/// `\@makecaption` is `\sbox\@tempboxa{#1: #2}`, so a one-argument version eats
+/// the `:` that follows; pdflatex accepts it (measured: 0 errors, renders
+/// "Figure 1. A caption.").
+///
+/// LaTeXML has no `:` TOKEN to eat — the separator is a tag ATTRIBUTE
+/// (`\lx@tag[][: ]`) — so the argument scan ran past the hook and swallowed the
+/// caption group's closing brace: the `<figure>` never closed and **every
+/// following section, the bibliography included, was absorbed into it**. That is
+/// the truncation mechanism behind witnesses 2605.01731 (18 figures x 3 errors)
+/// and 2605.12842 (10 x 3), both confirmed live on the fleet run. A 2026-07-14
+/// note put the breadth at 18 papers via a `grep 'lx@tag@intags'` proxy; that
+/// proxy re-measures to 23 papers over 2605+2606, only 2 of which carry this
+/// cause's signature — the symptom has several causes.
+///
+/// SHARED-FAILURE, not a Rust-only defect: same-host Perl 0.8.8 raises 9 errors
+/// on the two-hook form and Rust raised 7, so fixing it is a deliberate
+/// surpass — **OXIDIZED_DESIGN #85**, `KNOWN_PERL_ERRORS #68`. Pre-fix this
+/// fixture raised **10** errors.
+///
+/// All three `\csname fnum@…\endcsname` hooks are exercised: the caption one
+/// (`\lx@fnum@@`), the toc one (`\lx@fnum@toc@@`) and the theorem-header one
+/// (`latex_constructs.rs`).
+#[test]
+fn cluster_fnum_arg_hook() {
+  // `convert_to_xml` is the strict 0-error gate AND returns the XML.
+  let x = convert_to_xml("tests/cluster_regressions/fnum_arg_hook.tex");
+  // The figure closes, so what follows it is a SIBLING, not a descendant.
+  // This is the property that actually matters — an unclosed <figure> is what
+  // swallowed the rest of the document.
+  let bib = x
+    .find("<bibliography")
+    .expect("no bibliography element:\n{x}");
+  assert!(
+    x[..bib].contains("</figure>"),
+    "the <figure> must close before the bibliography — an open one absorbs it:\n{x}"
+  );
+  assert_eq!(
+    x.matches("<section").count(),
+    2,
+    "both sections should be siblings at top level:\n{x}"
+  );
+  assert!(
+    x.contains("Text after must survive"),
+    "the body after the figure was lost:\n{x}"
+  );
+  // Each arg-taking hook actually supplied the label it defines: the caption's
+  // `\figurename~\thefigure.`, the toccaption's bare `\thefigure.`, and the
+  // theorem's `\thethmx.` — none of them the default that fires when no
+  // `\fnum@<type>` exists.
+  // NBSP, not a space: the hook body is `\figurename~\thefigure.`, so the `~`
+  // is itself evidence that the author's definition ran rather than the default.
+  assert!(
+    x.contains("<tag close=\": \">Figure\u{a0}1.</tag>"),
+    "\\fnum@figure did not supply the caption tag:\n{x}"
+  );
+  assert!(
+    x.contains(r#"<tag close=" ">1.</tag>"#),
+    "\\fnum@toc@figure did not supply the toccaption tag:\n{x}"
+  );
+  assert!(
+    x.contains("<theorem") && x.contains(r#"<tag>1.</tag>"#),
+    "\\fnum@thmx did not supply the theorem header tag:\n{x}"
+  );
+}

--- a/latexml_oxide/tests/cluster_regressions/fnum_arg_hook.tex
+++ b/latexml_oxide/tests/cluster_regressions/fnum_arg_hook.tex
@@ -1,0 +1,50 @@
+% OXIDIZED_DESIGN #85 / KNOWN_PERL_ERRORS #68 — an author's `\fnum@<type>`
+% redefined to TAKE AN ARGUMENT.
+%
+% Real `\fnum@<type>` takes none, but LaTeX's `\@makecaption` is
+% `\sbox\@tempboxa{#1: #2}`, so a one-argument version eats the `:` that
+% follows. That is the widely-copied "Fig. 1: -> Fig. 1." hack, and pdflatex
+% accepts it (verified: 0 errors, renders "Figure 1. A caption.").
+%
+% LaTeXML has no `:` TOKEN to eat — the separator is a tag ATTRIBUTE
+% (`\lx@tag[][: ]`) — so the argument scan used to run past the hook and
+% swallow the caption group's closing brace. The `<figure>` never closed and
+% every following section, THE BIBLIOGRAPHY INCLUDED, was absorbed into it:
+% 7 errors in Rust, 9 in same-host Perl 0.8.8, and a document that looks
+% truncated to a reader. Witnesses 2605.01731 (cas-sc, 18 figures x 3 errors)
+% and 2605.12842 (10 x 3), both confirmed live on the fleet run 2026-07-29 —
+% but plain `article` reproduces, the class is not implicated. (A 2026-07-14
+% note claimed 18 papers via a `grep 'lx@tag@intags'` proxy; re-measured, that
+% proxy gives 23 papers over 2605+2606 of which only 2 carry this cause's
+% signature — the symptom has several causes.)
+%
+% All three `\csname fnum@...\endcsname` hooks are covered here: the caption
+% one, the toc one, and the theorem-header one.
+\documentclass{article}
+\usepackage{amsthm}
+\newtheorem{thmx}{Theorem}
+\makeatletter
+\renewcommand*{\fnum@figure}[1]{\figurename~\thefigure.}
+\renewcommand*{\fnum@toc@figure}[1]{\thefigure.}
+\renewcommand*{\fnum@thmx}[1]{\thethmx.}
+\makeatother
+\begin{document}
+
+\section{First}
+Text before.
+
+\begin{figure}
+  \caption{A caption.}
+\end{figure}
+
+\begin{thmx}
+  A theorem body.
+\end{thmx}
+
+\section{Second}
+Text after must survive, as a sibling of the figure and not inside it.
+
+\begin{thebibliography}{9}
+\bibitem{a} An entry.
+\end{thebibliography}
+\end{document}


### PR DESCRIPTION
An author's `\fnum@<type>` **redefined to take an argument** swallowed the caption
group's closing brace, so the `<figure>` never closed and every following
section — the bibliography included — was absorbed into it. The symptom presents
as "my References section vanished", not as a bad caption.

Closes the one concrete, analysed-but-unfixed item of R5's "missing references"
family, parked since 2026-07-14 on *"needs a user decision + a full-suite diff"*.

### The input

Real `\fnum@<type>` takes no argument, but LaTeX's `\@makecaption` is
`\sbox\@tempboxa{#1: #2}`, so a one-argument version eats the `:` that follows —
the widely-copied "`Fig. 1:` → `Fig. 1.`" hack:

```tex
\makeatletter
\renewcommand*{\fnum@figure}[1]{\figurename~\thefigure.}
\makeatother
```

LaTeXML has no `:` **token** to eat: its separator is a tag **attribute**
(`\lx@tag[][: ]`). So the argument scan ran past the hook.

| engine | minimal repro |
|---|---|
| pdflatex | **0 errors**, renders `Figure 1. A caption.` |
| Perl LaTeXML 0.8.8 | **9 errors** |
| Rust, before | **7 errors** |
| Rust, after | **0 errors** |

SHARED-FAILURE, so this is a deliberate **surpass** — OXIDIZED_DESIGN **#85**,
KNOWN_PERL_ERRORS **#68** — approved per the `surpass-perl` protocol.

### The fix

Expand the hook as `\csname fnum@#1\endcsname{}`. An arg-taking definition eats
the harmless empty group and reproduces pdflatex's result; a 0-arg one simply
gains one, which is inert. Applied at all three `fnum@` sites: `\lx@fnum@@`,
`\lx@fnum@toc@@` and the theorem-header formatter.

`\lx@typerefnum@@` has the identical shape and is **deliberately excluded** — no
LaTeX kernel feeds it a separator token, so the pdflatex-compatibility argument
does not reach it and the change would be speculative.

### Two recorded claims did not survive re-measurement

Both are corrected in the docs rather than repeated.

1. **"blast radius far out of proportion to 18 papers"** — the reason this sat
   unfixed. It is wrong: the changed branch fires only where `\fnum@<type>` is
   *defined*; the untouched `\lx@@fnum@@` default is what serves nearly every
   caption. Measured: **106/106 targets, 1763 tests, zero goldens re-blessed**,
   and three real papers whose classes `\def\fnum@figure` (svjour3, aastex631,
   llncs) are **byte-identical** before vs after.
2. **"18 papers corpus-wide, 5 with no References"** — counted by a
   `grep 'lx@tag@intags'` proxy. Live against the current fleet run that proxy
   gives **23** papers over sandbox-arxiv-2605+2606 (60,505 docs), but only
   **2** carry this cause's signature (equal counts of `\lx@tag@intags` /
   `\lx@tag` / `\end{figure}`, one triple per figure): **2605.01731** (18 × 3,
   confirmed live, exactly as recorded) and **2605.12842** (10 × 3). The symptom
   has several causes; the EMPTY-References sub-claim is **withdrawn**.

So the justification is "right and free", not breadth.

### Scope limit

This does **not** fix the `close=": "` separator, so the caption still reads
`Figure 1.: A caption.` rather than pdflatex's `Figure 1. A caption.` Making
that attribute conditional on the hook being arg-taking is a larger, more
speculative change and is deliberately out of scope.

### Verification

* Guard `06_cluster_regressions::cluster_fnum_arg_hook` over
  `cluster_regressions/fnum_arg_hook.tex`, exercising all three hooks:
  **10 errors → 0**. Verified **red** pre-fix, with the bibliography absorbed
  into the unclosed `<figure>`.
* `clippy --workspace --all-targets -D warnings` and `cargo doc --workspace`
  clean.
* Upstream issue filed against `brucemiller/LaTeXML` (the Perl definition is
  byte-identical; no prior issue existed).

### Note for review order

This branch is cut from `main` and claims divergence **#85**; **#84** belongs to
the concurrent bibliography PR #445. The `OXIDIZED_DESIGN.md` "next free number"
line will conflict trivially with whichever of the two merges second.

### Self-review pass before merge

The load-bearing claim here is "**inert for the 0-arg hooks that are the normal
case**". Reviewed by testing each consumer class against a real pre-fix baseline
(`git checkout main -- <files>`, not a stash — see the caveat below):

| consumer | probe | result |
|---|---|---|
| hook **undefined** (`\csname` → `\relax`, so the `{}` is a bare empty group) — the common case for every theorem, figure and table | `\newtheorem` + `figure` + `table` document | byte-identical |
| hook **defined 0-arg** by a class | three real papers: svjour3, aastex631, llncs | byte-identical |
| hook **redefined via `\let`/`def`** by a package | mathtools `\newtagform` / `\usetagform` (`\fnum@equation`) | byte-identical |
| hook **arg-taking** | guard fixture, all three sites | 10 errors → 0 |

**A caveat on my own method, since it briefly produced two bogus results:** once
the fix is committed, `git stash push <paths>` has nothing to stash, so a
following `git stash pop` restores an *unrelated* stash and the "before" binary
still contains the fix. Two probes were re-run after hitting exactly that; the
numbers above are from an explicit checkout of the pre-fix files. The earlier
A/Bs in this PR (minimal repro 7 → 0, fixture 10 → 0 red/green, the three real
papers) were taken pre-commit and are unaffected — the red/green one visibly
changed output, which proves the revert took effect.

No correctness defect found in the change itself. Two limitations stay
documented rather than hidden: the `close=": "` separator (above), and
`\lx@typerefnum@@` being deliberately excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

