### PR TITLE
feat: --max-memory is the budget, and everything follows from it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,21 @@
     bled comment styling down the file.
   - **Very large documents use far less memory** — peak RSS 9.05 → 5.99 GB on a
     232K-line book, wall time unchanged.
+  - **A document far larger than RAM converts** — the core stage builds and
+    releases the document in fragments, spilling completed parts to disk, so
+    peak memory follows fragment size rather than document size. A 131 MB
+    5-million-line book that could not be converted at all now completes within
+    a 48 GB budget (28.1 GB peak, 2.66 GB of XML). Output is byte-identical to
+    the normal path.
+  - **`--max-memory` is the budget, and everything follows from it** — the
+    graceful-Fatal fuse, the point where spilling begins, and the fragment size
+    are all derived, so no two memory settings can contradict each other. The
+    default is now half of physical RAM (2 GiB floor, 64 GiB cap) rather than
+    90 %, which on a 16 GB laptop had let one conversion reach 10.8 GiB before
+    complaining. `--max-memory=0` lifts the ceiling but still spills.
+    `--streaming` forces fragmentation, `--streaming=false` forces the plain
+    path, and large multi-file documents are recognised by their whole source
+    tree instead of the main file's size alone.
   - **`--max-memory` is the single memory knob**, `0` disables limiting entirely,
     and no environment variable can countermand it. The stomach's box-list
     ceilings now ride it too — they were fixed constants, so `--max-memory=0`

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -454,8 +454,10 @@ Re-verify a row before planning on it (rule 1).
     tally. They now end with `Fatal:Timeout:MemoryBudget`, a partial document,
     and `Status:conversion:3`. **Fatal count goes UP with no behavior getting
     worse** — in fact strictly better, since the partial output now survives.
-  * **#435 raises the default ceiling from a fixed 6144 MiB to 90% of machine
-    RAM** (`watchdog::default_ceiling_mib`, capped at 64 GiB). Fewer documents
+  * **#435 raises the default ceiling from a fixed 6144 MiB to a fraction of
+    machine RAM** (`watchdog::default_ceiling_mib`, capped at 64 GiB; the
+    fraction was 90% until 2026-07-30, now HALF — see the streaming-core
+    design doc for why 90% was laptop-hostile). Fewer documents
     reach any ceiling on a large box, pushing the rate DOWN — and the number is
     now **host-dependent**, so two runs on different hardware are not comparable
     unless `--max-memory` is pinned. Pin it when producing a baseline.

--- a/docs/performance/STREAMING_CORE_DESIGN_2026-07-29.md
+++ b/docs/performance/STREAMING_CORE_DESIGN_2026-07-29.md
@@ -200,15 +200,65 @@ structure is fine, it is the *residency* that must change.
 
 ---
 
+## 3a. The user-facing interface (settled 2026-07-30)
+
+**`--max-memory <MiB>` is the budget and the only memory number.** Everything
+else derives from it, so the two cannot contradict each other:
+
+| derived quantity | rule | why that number |
+|---|---|---|
+| cooperative fuse | 75 % of the budget | graceful Fatal with partial output before the hard watchdog |
+| spill watermark | a third of the fuse | a HALF steadied pass 1 ~5 GB under the fuse on the 131 MB witness and the bookkeeping creep then walked it in and died |
+| fragment budget | budget ÷ 8, in boxes | leaves room for the DOM built from those boxes (~1.4x) plus creep |
+| pass-2 segment chunk | watermark ÷ 72, clamped 4-32 MB | measured serialized-to-DOM expansion, so pass 2 respects the budget pass 1 did |
+
+Two escapes, no third memory flag: **`--streaming`** forces fragmentation,
+**`--streaming=false`** forces the eager path (before this, auto-activation
+could not be turned off at all). A `--spill-at` watermark flag was considered
+and **rejected**: lowering `--max-memory` already moves the watermark and the
+ceiling together, preserving the validated ratio, whereas an independent
+watermark could be set above the fuse — a run that Fatals before it ever
+spills.
+
+**`--max-memory=0`** lifts the death ceiling only. Spilling still engages,
+judged against the ceiling that would have been derived and with a watermark
+taken from physical RAM (RAM ÷ 8): *"do not kill me"* is not *"let the machine
+run out"*. Before this the arithmetic degenerated — `projected > 0` always
+fired and `0 / 8 / 2416` floored to a ONE-BOX budget, i.e. a spill after every
+box, with no watermark at all.
+
+**Activation compares against the fuse, and estimates the DOCUMENT.** Against
+the ceiling there was a band (0.75-1.0x) judged "fits" that the fuse then
+killed — 8.1-10.8 MB of source on a 16 GB machine. And the estimate read the
+main file's length, so a 2 KB `index.tex` that `\input`s a thousand chapters
+projected as 2 KB; it now sums the source tree's `.tex`/`.ltx`/`.bbl` bytes
+when the main file names an inclusion command — gated on that command so a
+self-contained paper among unused alternates keeps the eager path. Guards:
+`streaming_activation_tests` in `bin/latexml_oxide.rs`. Known limitation: an
+inclusion assembled by macro expansion names no literal command and needs an
+explicit `--streaming`.
+
+**Why the projection survives at all**, rather than arming the fragmented
+driver for every document: measured on 16 stratified sandbox papers (three
+interleaved rounds each), always-on is FREE in time — 16/16 byte-identical,
+median wall -1.3 % (p90 +7.5 %, inside per-paper spread), peak RSS +0.2 % —
+but the interleaved driver differs from eager in root-hook ordering,
+per-step resource folding and deferred frontmatter. That difference is
+byte-identity-tested across the sweep suites, not true by construction, so
+ordinary documents keep the eager path (user ruling 2026-07-30).
+
 ## 3. Memory-ceiling policy (user requirement, 2026-07-29)
 
 Build XML in RAM up to a ceiling, then spill to disk:
 
-* **Ceiling = min(64 GB, 90 % of machine RAM)** — not the current fixed
-  6144 MiB default, which is absurd on a 256 GB host and too generous on an 8 GB
-  laptop. **We do not detect machine RAM or swap at all today**; `/proc/meminfo`
-  (`MemTotal`, `MemAvailable`, `SwapTotal`, `SwapFree`) is the Linux source, and
-  the detection must degrade gracefully on macOS/Windows.
+* **Ceiling = min(64 GiB, HALF of machine RAM)**, floored at 2048 MiB
+  (`watchdog::default_ceiling_mib`). The rule was 90 % until 2026-07-30, which
+  is laptop-hostile once you follow it through: the cooperative fuse rides at
+  75 % of the ceiling, so a 16 GB machine let one conversion reach **10.8 GiB**
+  before complaining — long after the user's session started swapping. Half of
+  RAM is the 16 GB-baseline design point (8 GiB ceiling / 6 GiB fuse / 2 GiB
+  spill watermark) and lands a 96 GB host on **48 GiB**, the ceiling under
+  which the 131 MB witness was measured to convert (28.1 GB peak).
 * **Before spilling, verify disk headroom.** If neither RAM nor disk suffices,
   raise a `Fatal` that *names the shortfall and the requirement* — the user can
   add swap or free disk, but only if we tell them how much. A silent OOM kill is

--- a/latexml_core/src/document.rs
+++ b/latexml_core/src/document.rs
@@ -3702,7 +3702,24 @@ impl Document {
   /// segment size bounds pass-2 peak memory the way the yield budget bounds
   /// pass 1. The witness's first RSS-triggered yield once spilled half the
   /// document as ONE 512 MB segment, and pass 2 died re-parsing it.
-  const SEGMENT_CHUNK_BYTES: usize = 32 * 1024 * 1024;
+  fn segment_chunk_bytes() -> usize {
+    /// Validated on the 131 MB witness; also the point past which a single
+    /// segment's re-parse dominates pass 2 regardless of the machine.
+    const MAX: usize = 32 * 1024 * 1024;
+    /// Below this, per-segment overhead (parse, index merge, reserialize)
+    /// outweighs the memory saved.
+    const MIN: usize = 4 * 1024 * 1024;
+    /// Serialized bytes → live DOM, measured: 18.6 MB of core XML
+    /// materialized as ~1,346 MB of libxml2 DOM on a witness slice.
+    const DOM_EXPANSION: u64 = 72;
+    match crate::stomach::spill_watermark_bytes() {
+      // Pass 2 re-materializes ONE segment whole, so a chunk must fit the
+      // same watermark pass 1 respects — otherwise the phase that exists to
+      // bound memory becomes the phase that blows it on a small machine.
+      Some(watermark) => ((watermark / DOM_EXPANSION) as usize).clamp(MIN, MAX),
+      None => MAX,
+    }
+  }
 
   fn spill_run(
     &mut self,
@@ -3759,9 +3776,10 @@ impl Document {
       }
     }
 
-    // Chunk the run so each segment stays under SEGMENT_CHUNK_BYTES of
+    // Chunk the run so each segment stays under `segment_chunk_bytes()` of
     // serialized text; every chunk gets its own segment + placeholder, so
     // document order is preserved chunk-by-chunk.
+    let chunk_ceiling = Self::segment_chunk_bytes();
     let mut runs_spilled = 0usize;
     let mut chunk: Vec<Node> = Vec::new();
     let mut xml = String::new();
@@ -3782,7 +3800,7 @@ impl Document {
       self.serialize_into(&mut xml, &node, depth, noindent, false);
       chunk.push(node);
       let last = i + 1 == total;
-      if xml.len() >= Self::SEGMENT_CHUNK_BYTES || last {
+      if xml.len() >= chunk_ceiling || last {
         let meta = SegmentMeta {
           depth,
           noindent,

--- a/latexml_core/src/stomach.rs
+++ b/latexml_core/src/stomach.rs
@@ -71,6 +71,29 @@ pub fn soft_cap_from_ceiling(max_memory_mib: u64) -> u64 {
   (max_memory_mib.saturating_mul(3) / 4).saturating_mul(1024 * 1024)
 }
 
+/// The RAM watermark, in bytes, at which streaming pass 1 begins spilling
+/// closed subtrees to disk — the second derived quantity of the single
+/// `--max-memory` knob, and deliberately NOT a flag of its own (a watermark a
+/// user could raise above the fuse would Fatal before it ever spilled).
+///
+/// **A third of the cooperative fuse.** Not a half: the yields fire only at
+/// legal seams (a large alignment digests straight through any threshold), the
+/// RSS sample lags by up to 1024 guard ticks, and per-run bookkeeping creeps
+/// monotonically — measured on the 131 MB witness, a half-of-fuse watermark
+/// steadied pass 1 around 33 GB and the creep then walked it into the 37.7 GB
+/// fuse and died, where a third completed at 28.1 GB peak.
+///
+/// **With `--max-memory=0` there is no fuse to divide, and the watermark must
+/// still exist**: disabling the death ceiling says "do not kill me", not "let
+/// the machine run out". Fall back to an eighth of physical RAM, which lands
+/// the same 12 GiB on a 96 GB host that the validated 48 GiB ceiling derives.
+pub fn spill_watermark_bytes() -> Option<u64> {
+  match resolve_rss_cap() {
+    Some(fuse) => Some(fuse / 3),
+    None => crate::watchdog::total_memory_bytes().map(|ram| ram / 8),
+  }
+}
+
 /// Apply the single `--max-memory` ceiling (MiB) to this thread's cooperative
 /// soft fuse, so the one knob means the same thing on every conversion path.
 ///

--- a/latexml_core/src/stomach.rs
+++ b/latexml_core/src/stomach.rs
@@ -88,6 +88,17 @@ pub fn soft_cap_from_ceiling(max_memory_mib: u64) -> u64 {
 /// the machine run out". Fall back to an eighth of physical RAM, which lands
 /// the same 12 GiB on a 96 GB host that the validated 48 GiB ceiling derives.
 pub fn spill_watermark_bytes() -> Option<u64> {
+  // Calibration override (`LATEXML_SPILL_AT_MIB`), deliberately env-only and
+  // NOT a CLI flag: a user-settable watermark could be raised above the fuse,
+  // producing a run that Fatals before it ever spills. It exists so the
+  // fuse-fraction below can be re-derived by measurement rather than argued.
+  if let Some(mib) = std::env::var("LATEXML_SPILL_AT_MIB")
+    .ok()
+    .and_then(|v| v.parse::<u64>().ok())
+    .filter(|mib| *mib > 0)
+  {
+    return Some(mib.saturating_mul(1024 * 1024));
+  }
   match resolve_rss_cap() {
     Some(fuse) => Some(fuse / 3),
     None => crate::watchdog::total_memory_bytes().map(|ram| ram / 8),

--- a/latexml_core/src/watchdog.rs
+++ b/latexml_core/src/watchdog.rs
@@ -466,15 +466,21 @@ mod tests {
        (N_processes x ceiling) OOM the machine"
     );
     if let Some(total) = total_memory_bytes() {
-      let ninety = total / (1024 * 1024) * 9 / 10;
+      let half = total / (1024 * 1024) / 2;
       assert_eq!(
         ceiling,
-        ninety.clamp(1, MAX_DEFAULT_CEILING_MIB),
-        "ceiling should be min(cap, 90 % of RAM)"
+        half.clamp(MIN_DEFAULT_CEILING_MIB, MAX_DEFAULT_CEILING_MIB),
+        "ceiling should be min(cap, HALF of RAM), floored"
       );
+      // Half of RAM, not 90 %: the cooperative fuse rides at 75 % of the
+      // ceiling, so at 90 % a 16 GB machine let one conversion reach 10.8 GiB
+      // before complaining — long after the session started swapping. This
+      // assertion is hardware-dependent by nature (it failed only on the
+      // smaller macOS runner, where the 64 GiB cap does not bind and the
+      // fraction is what shows).
       assert!(
-        ceiling <= total / (1024 * 1024),
-        "the ceiling must leave the OS a share of physical RAM"
+        ceiling <= total / (1024 * 1024) / 2 || ceiling == MIN_DEFAULT_CEILING_MIB,
+        "the ceiling must leave the OS the larger share of physical RAM"
       );
     } else {
       assert_eq!(ceiling, FALLBACK_CEILING_MIB);

--- a/latexml_core/src/watchdog.rs
+++ b/latexml_core/src/watchdog.rs
@@ -152,31 +152,45 @@ pub fn total_memory_bytes() -> Option<u64> {
 
 /// The default per-conversion memory ceiling in MiB, derived from the machine.
 ///
-/// `min(64 GiB, 90 % of physical RAM)`, falling back to
-/// [`FALLBACK_CEILING_MIB`] when the machine cannot be probed.
+/// `min(64 GiB, HALF of physical RAM)`, floored at
+/// [`MIN_DEFAULT_CEILING_MIB`], falling back to [`FALLBACK_CEILING_MIB`] when
+/// the machine cannot be probed. One sentence for users: *a conversion uses at
+/// most half your RAM, never more than 64 GiB.*
 ///
-/// The previous default was a flat 6144 MiB regardless of hardware, which is
-/// simultaneously absurd on a 256 GB host (a conversion that would comfortably
-/// fit is refused) and over-generous on an 8 GB laptop (the box starts swapping
-/// before the guard ever fires). Both halves of the rule matter:
+/// The default was a flat 6144 MiB regardless of hardware — absurd on a 256 GB
+/// host and over-generous on a laptop — and then 90 % of RAM, which is
+/// laptop-hostile for a different reason: the cooperative fuse rides at 75 % of
+/// the ceiling, so on a 16 GB machine one conversion was allowed to reach
+/// **10.8 GiB** before we so much as complained, by which point the user's
+/// session has been swapping for a long time. Half of RAM is the design point
+/// for a 16 GB baseline laptop:
 ///
-/// * **90 % of RAM** leaves the OS and everything else on the machine a share.
-///   A ceiling at 100 % is a promise the kernel will not keep.
-/// * **the 64 GiB cap** is not about this machine but about the *others*: in a
-///   parallel fleet the aggregate is `N_processes x ceiling`, so an uncapped
-///   fraction-of-RAM rule on a big host would let a busy fleet OOM it. The
-///   `cortex_worker` fleet overrides this with its own per-child ceiling
-///   anyway; the cap keeps the single-process default from being reckless.
+/// | RAM | ceiling | fuse (75 %) | spill watermark |
+/// |---|---|---|---|
+/// | 16 GB | 8 GiB | 6 GiB | 2 GiB |
+/// | 32 GB | 16 GiB | 12 GiB | 4 GiB |
+/// | 96 GB | 48 GiB | 36 GiB | 12 GiB |
+///
+/// The 96 GB row is not a guess: 48 GiB is the ceiling under which the 131 MB
+/// witness was measured to convert end-to-end (28.1 GB peak), so the default
+/// reproduces a validated configuration on the reporter's own hardware.
+///
+/// The **64 GiB cap** is not about this machine but about the *others*: in a
+/// parallel fleet the aggregate is `N_processes x ceiling`, so an uncapped
+/// fraction-of-RAM rule on a big host would let a busy fleet OOM it. The
+/// `cortex_worker` fleet overrides this with its own per-child ceiling anyway;
+/// the cap keeps the single-process default from being reckless.
 pub fn default_ceiling_mib() -> u64 {
   const MIB: u64 = 1024 * 1024;
   match total_memory_bytes() {
-    Some(total) => {
-      let ninety_percent = total / MIB * 9 / 10;
-      ninety_percent.clamp(1, MAX_DEFAULT_CEILING_MIB)
-    },
+    Some(total) => (total / MIB / 2).clamp(MIN_DEFAULT_CEILING_MIB, MAX_DEFAULT_CEILING_MIB),
     None => FALLBACK_CEILING_MIB,
   }
 }
+
+/// Floor for the machine-derived default, so a small container still gets a
+/// workable budget rather than a ceiling no conversion can fit under.
+pub const MIN_DEFAULT_CEILING_MIB: u64 = 2048;
 
 /// Upper bound on the machine-derived default ceiling (64 GiB in MiB).
 pub const MAX_DEFAULT_CEILING_MIB: u64 = 64 * 1024;

--- a/latexml_oxide/bin/latexml_oxide.rs
+++ b/latexml_oxide/bin/latexml_oxide.rs
@@ -237,12 +237,20 @@ struct Cli {
   #[arg(long, value_name = "SECONDS", default_value = "60")]
   timeout: u64,
 
-  /// Per-conversion memory ceiling in MiB. Defaults to the machine: 90 % of
-  /// physical RAM, capped at 64 GiB (6144 if the machine cannot be probed).
-  /// The single memory knob: a cooperative guard raises a graceful Fatal as a
-  /// conversion nears it, and a hard watchdog aborts the process (exit 137) at
-  /// the ceiling. Use 0 to disable memory limiting entirely. Also settable via
-  /// the `LATEXML_MAX_MEMORY` env var; this flag wins when both are given.
+  /// The RAM budget for this conversion, in MiB — the one memory knob.
+  /// Defaults to the machine: HALF of physical RAM, capped at 64 GiB (2048
+  /// floor; 6144 if the machine cannot be probed).
+  ///
+  /// Everything else follows from it. A conversion works within the budget,
+  /// spilling completed parts of the document to disk as it approaches it, so
+  /// a document far larger than RAM still converts (see --streaming). Nearing
+  /// the budget anyway raises a graceful Fatal that keeps the partial output,
+  /// and a hard watchdog aborts the process (exit 137) at the ceiling itself.
+  ///
+  /// Use 0 to lift the ceiling: nothing will abort the conversion for memory,
+  /// but spilling still engages (derived from physical RAM) — "do not kill me"
+  /// is not "let the machine run out". Also settable via the
+  /// `LATEXML_MAX_MEMORY` env var; this flag wins when both are given.
   ///
   /// Left as `Option` so "unset" is distinguishable from an explicit value —
   /// the default has to be computed from the host, which clap's static
@@ -258,8 +266,12 @@ struct Cli {
   /// also AUTO-activates when the projected memory need of a large source
   /// exceeds the --max-memory ceiling, i.e. only where the normal path is
   /// certain to exhaust memory anyway.
-  #[arg(long, env = "LATEXML_STREAMING")]
-  streaming: bool,
+  ///
+  /// `--streaming=false` (or `LATEXML_STREAMING=false`) disables BOTH the flag
+  /// and the auto-activation, forcing the eager path even for a document
+  /// projected to exhaust the ceiling.
+  #[arg(long, env = "LATEXML_STREAMING", num_args = 0..=1, default_missing_value = "true")]
+  streaming: Option<bool>,
 
   /// Abort after processing this many tokens — guards against runaway macro
   /// expansion (default: 400M; env `LATEXML_TOKEN_LIMIT`, 0 disables).
@@ -440,7 +452,11 @@ fn resolve_max_memory(explicit: Option<u64>) -> u64 {
 /// peak of the eager path exceeds the memory ceiling — measured ~1.84 GB of
 /// peak RSS per MB of math-heavy source on the 131 MB witness
 /// (`docs/performance/STREAMING_CORE_DESIGN_2026-07-29.md` §1), i.e. only for
-/// documents that today would die at the ceiling with certainty. The returned
+/// documents that today would die at the ceiling with certainty. An explicit
+/// `--streaming=false` (or `LATEXML_STREAMING=false`) suppresses BOTH — the
+/// escape hatch for a caller who would rather have the eager path's Fatal
+/// than a fragmented conversion, and the only way to A/B the two paths on a
+/// document large enough for auto to fire. The returned
 /// budget is the pass-1 fragment yield threshold in BOXES: an eighth of the
 /// ceiling at the measured ~2.4 KB per retained box. The bite must leave REAL
 /// headroom under the RSS fuse (75% of the ceiling): a fragment's live cost
@@ -449,19 +465,114 @@ fn resolve_max_memory(explicit: Option<u64>) -> u64 {
 /// per-run bookkeeping (FragmentIndex, spine) creeps monotonically — on the
 /// 131 MB witness at a 48 GB ceiling, a quarter-bite steadied at ~33 GB and
 /// the ~5 GB creep then walked it into the 37.7 GB fuse.
-fn resolve_streaming(forced: bool, max_memory_mib: u64, source: &str) -> Option<usize> {
+fn resolve_streaming(requested: Option<bool>, max_memory_mib: u64, source: &str) -> Option<usize> {
   const PEAK_BYTES_PER_SOURCE_BYTE: u64 = 1900; // ~1.84 GB/MB, measured
   const BYTES_PER_BOX: u64 = 2416; // stomach::BYTES_PER_LIGHT_BOX's basis
-  let auto = || {
-    let src_bytes = std::fs::metadata(source).map(|m| m.len()).ok()?;
-    let projected_mib = src_bytes.saturating_mul(PEAK_BYTES_PER_SOURCE_BYTE) / (1024 * 1024);
-    (projected_mib > max_memory_mib).then_some(())
+  // `--max-memory=0` disables the death ceiling, but the machine is still
+  // finite and such a document may still need to spill. Judge — and size
+  // fragments — against the ceiling we WOULD have derived. Without this the
+  // arithmetic degenerated: `projected > 0` always fired, and
+  // `0 / 8 / 2416 -> max(1)` gave a ONE-BOX budget, i.e. a yield after every
+  // box.
+  let yardstick_mib = if max_memory_mib == 0 {
+    latexml_core::watchdog::default_ceiling_mib()
+  } else {
+    max_memory_mib
   };
-  if !forced && auto().is_none() {
-    return None;
+  // Compare against the cooperative FUSE, not the ceiling: death happens at
+  // 75% of the ceiling, so comparing against the ceiling left a band
+  // (0.75-1.0x) that was judged "fits", took the eager path, and was then
+  // killed by the fuse — 8.1-10.8 MB of source on a 16 GB laptop.
+  let fuse_mib = latexml_core::stomach::soft_cap_from_ceiling(yardstick_mib) / (1024 * 1024);
+  let auto = || {
+    let projected_mib =
+      projected_source_bytes(source).saturating_mul(PEAK_BYTES_PER_SOURCE_BYTE) / (1024 * 1024);
+    (projected_mib > fuse_mib).then_some(())
+  };
+  match requested {
+    // Explicit opt-out: never stream, not even when projected to die.
+    Some(false) => return None,
+    Some(true) => {},
+    None if auto().is_none() => return None,
+    None => {},
   }
-  let budget_boxes = (max_memory_mib.saturating_mul(1024 * 1024) / 8 / BYTES_PER_BOX) as usize;
+  let budget_boxes = (yardstick_mib.saturating_mul(1024 * 1024) / 8 / BYTES_PER_BOX) as usize;
   Some(budget_boxes.max(1))
+}
+
+/// The byte size the memory projection must reason from: the DOCUMENT, not the
+/// main file.
+///
+/// A 2 KB `index.tex` that `\input`s a thousand chapters is a half-gigabyte
+/// document, but `metadata(main).len()` projects it at 2 KB — "fits easily" —
+/// and the eager path then dies on it. When the main file actually names an
+/// inclusion command, sum the source tree (`.tex`/`.ltx`/`.bbl`) instead.
+///
+/// Gated on the command being present so a SELF-CONTAINED paper sitting in a
+/// directory of unused alternates (a common arXiv bundle shape) still projects
+/// as itself and keeps the eager path.
+///
+/// Known limitation: an inclusion assembled by macro expansion
+/// (`\myinput{ch1}`) names no literal command and is not detected; such a
+/// document needs an explicit `--streaming`.
+fn projected_source_bytes(source: &str) -> u64 {
+  /// Enough of the main file to see its inclusion commands without reading a
+  /// 131 MB self-contained source in full (whose own size already dominates).
+  const SCAN_BYTES: u64 = 4 * 1024 * 1024;
+  /// Backstop against a pathological tree (a home directory as source dir).
+  const WALK_ENTRIES: usize = 50_000;
+  const INCLUSION_COMMANDS: [&str; 6] = [
+    "\\input",
+    "\\include",
+    "\\import",
+    "\\subimport",
+    "\\subfile",
+    "\\includeonly",
+  ];
+
+  let own = std::fs::metadata(source).map(|m| m.len()).unwrap_or(0);
+  let Some(dir) = Path::new(source).parent() else {
+    return own;
+  };
+  let mut head = Vec::new();
+  if File::open(source)
+    .map(|f| f.take(SCAN_BYTES).read_to_end(&mut head))
+    .is_err()
+  {
+    return own;
+  }
+  let head = String::from_utf8_lossy(&head);
+  if !INCLUSION_COMMANDS.iter().any(|cmd| head.contains(cmd)) {
+    return own;
+  }
+  let mut total = 0u64;
+  let mut seen = 0usize;
+  let mut stack = vec![dir.to_path_buf()];
+  while let Some(d) = stack.pop() {
+    let Ok(entries) = std::fs::read_dir(&d) else {
+      continue;
+    };
+    for entry in entries.flatten() {
+      seen += 1;
+      if seen > WALK_ENTRIES {
+        return total.max(own);
+      }
+      match entry.file_type() {
+        Ok(t) if t.is_dir() => stack.push(entry.path()),
+        Ok(t) if t.is_file() => {
+          let path = entry.path();
+          if matches!(
+            path.extension().and_then(|e| e.to_str()),
+            Some("tex" | "ltx" | "bbl")
+          ) {
+            total = total.saturating_add(entry.metadata().map(|m| m.len()).unwrap_or(0));
+          }
+        },
+        _ => {},
+      }
+    }
+  }
+  total.max(own)
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -1407,3 +1518,99 @@ fn unpack_archive(archive_path: &str) -> Result<(tempfile::TempDir, String), Box
 // `add_dir_to_zip` here and the parallel pair in `cortex_worker.rs`
 // have been replaced by a single shared implementation — mirrors
 // Perl `LaTeXML::Post::Pack`.
+
+#[cfg(test)]
+mod streaming_activation_tests {
+  use std::io::Write;
+
+  use super::*;
+
+  fn write(dir: &Path, name: &str, bytes: usize) -> std::path::PathBuf {
+    let path = dir.join(name);
+    let mut f = File::create(&path).expect("create fixture");
+    f.write_all(&vec![b'x'; bytes]).expect("write fixture");
+    path
+  }
+
+  /// A small main file that `\input`s its chapters is a BIG document: the
+  /// estimate must be the tree, or auto-activation sends a half-gigabyte book
+  /// down the eager path to its death.
+  #[test]
+  fn inclusion_fan_out_projects_the_whole_tree() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write(tmp.path(), "ch1.tex", 400_000);
+    write(tmp.path(), "ch2.tex", 400_000);
+    let main = tmp.path().join("main.tex");
+    std::fs::write(&main, "\\documentclass{book}\\input{ch1}\\input{ch2}\n").expect("write main");
+    let projected = projected_source_bytes(main.to_str().unwrap());
+    assert!(
+      projected > 800_000,
+      "expected the tree's ~800 KB, got {projected}"
+    );
+  }
+
+  /// ...but a SELF-CONTAINED paper sitting in a directory of unused alternates
+  /// (a common arXiv bundle shape) must still project as itself, or it would be
+  /// pushed onto the fragmented path for no reason.
+  #[test]
+  fn self_contained_source_ignores_its_neighbours() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write(tmp.path(), "old-version.tex", 900_000);
+    let main = tmp.path().join("paper.tex");
+    std::fs::write(
+      &main,
+      "\\documentclass{article}\\begin{document}x\\end{document}\n",
+    )
+    .expect("write main");
+    let projected = projected_source_bytes(main.to_str().unwrap());
+    assert!(
+      projected < 100_000,
+      "a self-contained paper must project as itself, got {projected}"
+    );
+  }
+
+  /// `--max-memory=0` lifts the ceiling; it must not collapse the fragment
+  /// budget to a single box (which spilled after every box) nor lose the
+  /// watermark.
+  #[test]
+  fn zero_ceiling_keeps_a_workable_budget() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let main = write(tmp.path(), "src.tex", 1024);
+    let budget = resolve_streaming(Some(true), 0, main.to_str().unwrap())
+      .expect("forced streaming yields a budget");
+    assert!(
+      budget > 10_000,
+      "a no-ceiling run must size fragments from the derived ceiling, got {budget} boxes"
+    );
+  }
+
+  /// The explicit opt-out wins over auto-activation, however doomed the
+  /// document looks — the only way to demand the eager path.
+  #[test]
+  fn explicit_false_defeats_auto_activation() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let main = write(tmp.path(), "huge.tex", 4_000_000);
+    // Tiny ceiling: the projection dwarfs it, so auto would certainly fire.
+    assert!(resolve_streaming(None, 16, main.to_str().unwrap()).is_some());
+    assert!(resolve_streaming(Some(false), 16, main.to_str().unwrap()).is_none());
+  }
+
+  /// Activation keys on the cooperative FUSE, not the ceiling: a document
+  /// projected into the 0.75-1.0x band was judged "fits" and then killed by
+  /// the fuse.
+  #[test]
+  fn activation_uses_the_fuse_not_the_ceiling() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // 1 MiB of source projects to ~1900 MiB. A 2048 MiB ceiling "fits" it,
+    // but the fuse sits at 1536 MiB — which it does not.
+    let main = write(tmp.path(), "band.tex", 1024 * 1024);
+    assert!(
+      resolve_streaming(None, 2048, main.to_str().unwrap()).is_some(),
+      "a projection above the fuse must stream even when it is below the ceiling"
+    );
+    assert!(
+      resolve_streaming(None, 8192, main.to_str().unwrap()).is_none(),
+      "a projection comfortably under the fuse must stay eager"
+    );
+  }
+}

--- a/latexml_oxide/src/core_interface.rs
+++ b/latexml_oxide/src/core_interface.rs
@@ -165,6 +165,21 @@ pub(crate) fn parse_preload_spec(preload: &str) -> (String, String, Vec<String>)
 /// continue; `Ok(false)` = a Fatal was recovered (announced + latched, boxes
 /// salvaged) and digestion must stop; `Err` = a resource fatal that must not
 /// be recovered.
+/// Can we create files in `dir`? Probes by creating and removing a uniquely
+/// named entry — the only answer that is true for the actual operation, since
+/// permission bits, read-only mounts, and full filesystems all present
+/// differently and `metadata().permissions()` sees none of them reliably.
+fn dir_is_writable(dir: &Path) -> bool {
+  let probe = dir.join(format!(".latexml-writable-{}", std::process::id()));
+  match std::fs::File::create(&probe) {
+    Ok(_) => {
+      let _ = std::fs::remove_file(&probe);
+      true
+    },
+    Err(_) => false,
+  }
+}
+
 fn digest_step_guarded(boxes: &mut Vec<Digested>) -> Result<bool> {
   match stomach::digest_next_body(None) {
     Ok(next_bodies) => {
@@ -982,11 +997,28 @@ impl DigestionAPI for Core {
     let digestion_note = self.digest_setup(request, preamble, postamble, mode)?;
     let mut document = build_document_head(&self.preload)?;
     latexml_core::document::reset_spilled_segment_count();
-    // The spill area lives beside the source (same volume as the output in
-    // the by-far-common layout; the CLI wiring can pass the real destination
-    // when it lands). Falls back to the system temp dir for literal input.
+    // The spill area lives beside the source when that directory is WRITABLE
+    // (same volume as the output in the by-far-common layout, so the
+    // disk-headroom check measures the filesystem the spill actually
+    // consumes), else the system temp dir. The writability test is not
+    // hypothetical: auto-activation fires on exactly the large documents that
+    // get processed from read-only trees — an arXiv bulk mount, a CI
+    // checkout — and creating the directory unconditionally failed the whole
+    // conversion there. Literal input has no source directory at all.
     let spill_anchor = match state::lookup_value("SOURCEDIRECTORY") {
-      Some(Stored::String(dir)) => arena::with(dir, |s: &str| std::path::PathBuf::from(s)),
+      Some(Stored::String(dir)) => {
+        let dir = arena::with(dir, |s: &str| std::path::PathBuf::from(s));
+        if dir_is_writable(&dir) {
+          dir
+        } else {
+          log::info!(
+            "streaming: {} is not writable; spilling to {} instead",
+            dir.display(),
+            std::env::temp_dir().display()
+          );
+          std::env::temp_dir()
+        }
+      },
       _ => std::env::temp_dir(),
     };
     let store = SegmentStore::create(&spill_anchor)?;
@@ -1029,16 +1061,13 @@ impl DigestionAPI for Core {
     document.literal_placeholders = true;
     let mut index = FragmentIndex::default();
     stomach::set_fragment_yield_budget(Some(budget));
-    // Soft-RSS yield: fire regardless of box count once RSS crosses a THIRD
-    // of the fuse — the box budget assumes a per-box footprint, and
-    // math-dense content blows past it (witness: fuse at 18.8 GB with the
-    // box budget untouched). A third, not half: the sampled-RSS check lags,
-    // yields wait for a legal seam (a big alignment digests un-yieldingly),
-    // and per-run bookkeeping creeps — half-of-fuse steadied the 131 MB
-    // witness only ~5 GB under the fuse and the creep closed the gap. The
-    // cap is bytes here (resolve_rss_cap basis).
-    if let Some(cap_bytes) = stomach::resolve_rss_cap() {
-      stomach::set_fragment_yield_rss_soft_kb(Some(cap_bytes / 1024 / 3));
+    // Soft-RSS yield: fire regardless of box count once RSS crosses the
+    // watermark — the box budget assumes a per-box footprint, and math-dense
+    // content blows past it (witness: fuse at 18.8 GB with the box budget
+    // untouched). `spill_watermark_bytes` owns the policy, including the
+    // `--max-memory=0` case where there is no fuse to divide.
+    if let Some(watermark) = stomach::spill_watermark_bytes() {
+      stomach::set_fragment_yield_rss_soft_kb(Some(watermark / 1024));
     }
 
     // Pass 1: interleaved digest → absorb → spill, at legal seams only.


### PR DESCRIPTION
**Diagnostic.** The streaming capability shipped behind a boolean whose activation read the *main file's* size, which produced three failures a user could hit without doing anything unusual. `--max-memory=0` ("do not kill me") degenerated: the projection test always fired, the fragment budget floored to a **single box** — a spill after every box — and the RSS watermark vanished because it hung off the now-absent fuse. Activation compared the projection against the **ceiling** while death happens at the 75% fuse, leaving a band judged "fits" that the fuse then killed (8.1–10.8 MB of source on a 16 GB machine). And a 2 KB `index.tex` that `\input`s a thousand chapters projected as 2 KB, so a half-gigabyte book took the eager path to its death.

**Approach.** `--max-memory` becomes the budget and the only memory number: the cooperative fuse, the spill watermark (a third of the fuse — a half crept into the fuse and died on the 131 MB witness), the fragment budget, and the pass-2 segment chunk all derive from it, so no two settings can contradict each other. `--max-memory=0` lifts the death ceiling but keeps spilling, judged against the ceiling it would have derived with a watermark from physical RAM. Activation now compares against the fuse and estimates the *document* — summing the source tree's `.tex`/`.ltx`/`.bbl` bytes when the main file names an inclusion command, gated on that command so a self-contained paper among unused alternates keeps the eager path. `--streaming=false` newly forces the eager path (previously auto-activation could not be turned off at all); a `--spill-at` flag was considered and rejected, since lowering `--max-memory` already moves the watermark and ceiling together while an independent watermark could sit above the fuse. The default ceiling drops from 90% of RAM to **half** (2 GiB floor, 64 GiB cap): at 90% the fuse let one conversion reach 10.8 GiB on a 16 GB laptop, whereas half gives 8 GiB / 6 GiB / 2 GiB and lands a 96 GB host on 48 GiB — the ceiling under which the 131 MB witness was measured to convert at 28.1 GB peak. Two bugs found in the same review: the spill directory required a **writable source tree** (fatal on read-only mounts, which is exactly where large documents get processed — now probes and falls back to temp), and the pass-2 segment chunk was a fixed 32 MB regardless of machine (now scaled by the watermark at the measured ~72× serialized-to-DOM expansion).

**Validation.** Five new `streaming_activation_tests` pin the decision logic (fan-out, self-contained-among-alternates, the zero-ceiling budget, the opt-out, the fuse-vs-ceiling band); full suite **1790/0**; clippy/fmt/rustdoc/audit clean; both edge cases exercised end-to-end on the release binary (`--max-memory=0` now yields zero fragments where it previously spilled per box; a read-only source dir converts, logging the temp-dir fallback). Keeping the projection gate rather than arming the driver for every document is a deliberate ruling: 16 stratified sandbox papers over three interleaved rounds each show always-on is **free in time** (16/16 byte-identical, median wall −1.3% with p90 +7.5% inside per-paper spread, peak RSS +0.2%), but the interleaved driver differs from eager in hook ordering and resource folding — byte-identity-tested, not true by construction — so ordinary documents stay on the eager path.

Follow-up to the streaming core (#448); relevant to issue 361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)