### PR TITLE
fix(fonts): \char decodes with FontDecode semantics, in math as in text

### DIFF
--- a/latexml_core/src/common/font.rs
+++ b/latexml_core/src/common/font.rs
@@ -2083,14 +2083,27 @@ pub fn decode(code: u8, encoding_opt: Option<String>, implicit: bool) -> Option<
   let encoding = match encoding_opt {
     Some(enc) => Cow::Owned(enc),
     None => {
+      // Perl `FontDecode`: `$encoding = $font->getEncoding || 'OT1'`
+      // (Package.pm L2877). The `|| 'OT1'` is NOT shared with
+      // `FontDecodeString` (L2906), whose port is `decode_string` below and
+      // which deliberately keeps the empty fallback — do not "align" the two.
+      //
+      // This branch is the one `\char` reaches (via `decode_str`, encoding
+      // `None`). It matters in MATH mode, where `Font::math_default()` sets
+      // `encoding: None` on purpose: without the default, the lookup ran
+      // against the empty encoding and `$\char65$` decoded to NOTHING where
+      // Perl gives `A`. The default lives here, rather than at the call site,
+      // so the font stays in scope for the `<enc>_<family>_fontmap`
+      // refinement below — resolving the encoding earlier and passing it in
+      // would silently drop `\ttfamily`'s `OT1_typewriter` variant.
       font = lookup_font();
       if let Some(ref font) = font {
         match font.get_encoding() {
-          None => Cow::Borrowed(""),
+          None => Cow::Borrowed("OT1"),
           Some(encoding) => encoding.clone(),
         }
       } else {
-        Cow::Borrowed("")
+        Cow::Borrowed("OT1")
       }
     },
   };

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -6588,11 +6588,16 @@ LoadDefinitions!({
     // the 4 GiB OOM boundary. With this Perl-faithful chain in place,
     // mathtext's override produces an equivalent chain that terminates
     // at the same `\T2A\i` primitive.
-    let code_value = code.value_of() as u8;
+    // `u8::try_from`, not `as u8`: Perl hands the Number straight to
+    // `CharDef->new` and the decode indexes the map, so an out-of-range code
+    // yields no glyph. A truncating cast wrapped it onto a valid slot instead.
+    let code_value = u8::try_from(code.value_of()).ok();
     let cs_str = cs.to_string();
     let encoding_str = Expand!(encoding).to_string();
     let ecs = T_CS!(s!("\\{encoding_str}{cs_str}"));
-    if let Some(replacement_value) = font::decode(code_value, Some(encoding_str), false) {
+    if let Some(replacement_value) =
+      code_value.and_then(|c| font::decode(c, Some(encoding_str), false))
+    {
       // Encoding-specific carries the actual glyph.
       def_primitive(ecs, None, Some(PrimitiveBody::from(replacement_value)),
         PrimitiveOptions::default())?;
@@ -6878,7 +6883,14 @@ LoadDefinitions!({
   // The next font declaration commands are based on
   // http://tex.loria.fr/general/new/fntguide.html
   // we ignore font encoding
-  DefPrimitive!("\\DeclareSymbolFont{}{}{}{}{}",
+  // Perl: latex_constructs.pool.ltxml L2664 —
+  // `\DeclareSymbolFont{} ExpandedPartially {}{}{}`. The encoding argument is
+  // `ExpandedPartially` because `fontmath.ltx` and most font packages write
+  // `\DeclareSymbolFont{operators}{\encodingdefault}{\rmdefault}{m}{n}`. Read
+  // unexpanded, the literal string `\encodingdefault` lands in
+  // `fontdeclaration@operators`, and every dependent `\DeclareMathSymbol` /
+  // `\DeclareMathAccent` then looks up a fontmap by that name and finds none.
+  DefPrimitive!("\\DeclareSymbolFont{} ExpandedPartially {}{}{}",
   sub[(name, enc, family, series, shape)] {
     AssignValue!(&s!("fontdeclaration@{}", name),
       fontmap!(family => family.to_string(),
@@ -10497,7 +10509,11 @@ LoadDefinitions!({
     before_digest => { DefMacro!("\\f@shape", ""); });
   DefConstructor!("\\textit@math{}", "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => "text",
     bounded      => true, font => { shape => "italic" }, alias => "\\textit",
-    before_digest => { DefMacro!("\\f@shape", "i"); });
+    // Perl: `DefMacro('\f@shape', 'it')` (latex_constructs.pool.ltxml L5255) —
+    // `it`, not `i`. Both keys map to `italic` in FONT_SHAPE, so this is only
+    // visible to code that reads `\f@shape` textually; the sibling
+    // `\textsl@math`/`\textsc@math` already use Perl's `sl`/`sc`.
+    before_digest => { DefMacro!("\\f@shape", "it"); });
   DefConstructor!("\\textsl@math{}", "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => "text",
     bounded      => true, font => { shape => "slanted" }, alias => "\\textsl",
     before_digest => { DefMacro!("\\f@shape", "sl"); });

--- a/latexml_engine/src/tex_character.rs
+++ b/latexml_engine/src/tex_character.rs
@@ -43,13 +43,38 @@ LoadDefinitions!({
   });
 
   // Perl: $stomach->enterHorizontal; Box($glyph, $adjfont, ...)
+  //
+  // Perl calls `FontDecode` here (TeX_Character.pool.ltxml L32-36), and
+  // `FontDecode` defaults the encoding to OT1 when the current font carries
+  // none — `$encoding = $font->getEncoding || 'OT1'` (Package.pm L2877).
+  // `FontDecodeString` (Package.pm L2906) deliberately has NO such default,
+  // and `font::decode_str` is the port of *that* one. The distinction is
+  // load-bearing in MATH mode, where `Font::math_default()` sets
+  // `encoding: None` on purpose (common/font.rs): with no default, the map
+  // lookup ran against the empty encoding and `$\char65$` produced NOTHING,
+  // where Perl gives `A`. So resolve the encoding the way FontDecode does and
+  // pass it explicitly. We keep calling `decode_str` rather than
+  // `content::font_decode` because only `decode_str` honours Perl's
+  // multi-char map entries (the `_fontmap_multichar` side table, T1's "SS",
+  // and the NBSP-prefixed combining accents) — Rust's `Fontmap` slot is a
+  // single `Option<char>`, so that handling lives in the string wrapper.
   DefPrimitive!("\\char Number", sub[(number)] {
     enter_horizontal();
     let number_tks = number.revert().unwrap_or_default().unlist();
-    let decoded = match font::decode_str(number.value_of() as u8, None, false) {
-      None => pin!(""),
-      Some(s) => s
-    };
+    // `u8::try_from`, not `as u8`: Perl guards `$code < 0` and then indexes
+    // `$$map[$code]`, so an out-of-range code yields no glyph. A truncating
+    // cast instead WRAPPED it onto a valid slot — `\char300` came out as `,`
+    // (300 & 0xFF = 44) rather than as nothing.
+    //
+    // The encoding stays `None` on purpose. Passing it explicitly would
+    // suppress the family-specific map: both Perl and `font::decode` consult
+    // `<enc>_<family>_fontmap` only on the branch that looked the font up
+    // itself (Perl assigns `$font` solely inside `if (!$encoding)`), so an
+    // explicit encoding costs `\ttfamily\char11` its `OT1_typewriter` ↑.
+    let decoded = u8::try_from(number.value_of())
+      .ok()
+      .and_then(|code| font::decode_str(code, None, false))
+      .unwrap_or_else(|| pin!(""));
     Tbox::new(
      decoded,
      None,

--- a/latexml_oxide/tests/117_char_font_decode.rs
+++ b/latexml_oxide/tests/117_char_font_decode.rs
@@ -1,0 +1,103 @@
+//! `\char` must decode with Perl's `FontDecode` semantics — including in math.
+//!
+//! Perl's `\char` calls `FontDecode` (`TeX_Character.pool.ltxml` L32-36), which
+//! defaults the encoding to OT1 when the current font carries none:
+//! `$encoding = $font->getEncoding || 'OT1'` (`Package.pm` L2877). Its sibling
+//! `FontDecodeString` (`Package.pm` L2906) deliberately has **no** such
+//! default, and `font::decode_str` is the port of that one — so calling it for
+//! `\char` inherited the wrong half of a deliberate Perl asymmetry.
+//!
+//! That only bites in math mode, because `Font::math_default()` sets
+//! `encoding: None` on purpose: `$\char65$` produced the empty string where
+//! Perl produces `A`. Text mode was unaffected, which is why it survived.
+//!
+//! Second defect in the same line: the code was cast `as u8`, so an
+//! out-of-range `\char300` wrapped onto slot 300 & 0xFF = 44 and printed `,`.
+//! Perl guards `$code < 0` and then indexes the map, so out-of-range yields no
+//! glyph at all.
+//!
+//! All expectations verified against same-host Perl LaTeXML 0.8.8, which
+//! renders this fixture as `MATH[A] TEXT[A]`, `OOBMATH[] OOBTEXT[]`,
+//! `SYMBOL[A] ACCENT[´]`.
+use latexml::util::test::convert_fixture;
+
+/// The text between `NAME[` and its `]`, with all markup stripped.
+fn marker(out: &str, name: &str) -> String {
+  let open = format!("{name}[");
+  let start = out
+    .find(&open)
+    .unwrap_or_else(|| panic!("marker {name}[ absent from the conversion output"))
+    + open.len();
+  let rest = &out[start..];
+  let end = rest
+    .find(']')
+    .unwrap_or_else(|| panic!("marker {name}[ is never closed"));
+  // Strip tags: math lands in <math>…</math> wrappers, text does not.
+  let inner = regex_lite_strip_tags(&rest[..end]);
+  inner.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Minimal tag stripper — avoids pulling a regex dep into a test.
+fn regex_lite_strip_tags(s: &str) -> String {
+  let mut out = String::new();
+  let mut depth = 0usize;
+  for c in s.chars() {
+    match c {
+      '<' => depth += 1,
+      '>' => depth = depth.saturating_sub(1),
+      _ if depth == 0 => out.push(c),
+      _ => {},
+    }
+  }
+  out
+}
+
+#[test]
+fn char_decodes_through_ot1_in_math_and_does_not_wrap_out_of_range() {
+  let r = convert_fixture("tests/cluster_regressions/char_font_decode.tex");
+  let out = r
+    .result
+    .unwrap_or_else(|| {
+      panic!(
+        "conversion produced no result (status_code={})",
+        r.status_code
+      )
+    })
+    .to_string();
+
+  // The regression: math mode fell through to an empty encoding.
+  assert_eq!(
+    marker(&out, "MATH"),
+    "A",
+    "`$\\char65$` did not decode — `\\char` is using FontDecodeString \
+     semantics again (no OT1 default) and silently drops the glyph in math, \
+     where Font::math_default() leaves the encoding unset"
+  );
+  assert_eq!(marker(&out, "TEXT"), "A", "`\\char65` broke in text mode");
+  assert_eq!(
+    marker(&out, "SYMBOL"),
+    "A",
+    "`$\\symbol{{65}}$` did not decode — \\symbol routes through \\char"
+  );
+
+  // Out of range must yield NOTHING, not a wrapped slot. `,` is the specific
+  // pre-fix answer (300 & 0xFF == 44), so name it in the message.
+  for m in ["OOBMATH", "OOBTEXT"] {
+    let got = marker(&out, m);
+    assert!(
+      got.is_empty(),
+      "`\\char300` produced {got:?} instead of nothing — the code is being \
+       truncated to u8 again (300 & 0xFF = 44 = `,`)"
+    );
+  }
+
+  // A slot whose OT1 entry is an accent still routes through decode_str, which
+  // is what carries Perl's multi-char map entries (NBSP-prefixed combining
+  // marks, T1's "SS"). Pins that the fix did not bypass that wrapper.
+  assert_eq!(
+    marker(&out, "ACCENT"),
+    "\u{00B4}",
+    "`\\char19` lost its OT1 acute accent — the multi-char/combining-mark \
+     handling in font::decode_str is being bypassed"
+  );
+}

--- a/latexml_oxide/tests/117_char_font_decode.rs
+++ b/latexml_oxide/tests/117_char_font_decode.rs
@@ -101,3 +101,46 @@ fn char_decodes_through_ot1_in_math_and_does_not_wrap_out_of_range() {
      handling in font::decode_str is being bypassed"
   );
 }
+
+/// `\DeclareSymbolFont`'s encoding argument must be expanded before storage.
+///
+/// Perl reads it as `ExpandedPartially` (latex_constructs.pool.ltxml L2664)
+/// because `fontmath.ltx` and most font packages write
+/// `\DeclareSymbolFont{operators}{\encodingdefault}{\rmdefault}{m}{n}`. Read
+/// unexpanded, the literal `\encodingdefault` is stored as the encoding and
+/// every dependent `\DeclareMathSymbol` looks up a fontmap of that name,
+/// finds none, and falls back to the raw code — silently, with no diagnostic.
+///
+/// Verified against same-host Perl 0.8.8, which yields `A` and `Γ`.
+#[test]
+fn symbol_font_encoding_argument_is_expanded_before_storage() {
+  let r = convert_fixture("tests/cluster_regressions/symbolfont_encoding_expansion.tex");
+  let out = r
+    .result
+    .unwrap_or_else(|| {
+      panic!(
+        "conversion produced no result (status_code={})",
+        r.status_code
+      )
+    })
+    .to_string();
+
+  // Slot 65 is a decoy: an un-decoded raw code 65 IS ASCII `A`, so it looks
+  // right either way. Asserted anyway so a regression that breaks BOTH slots
+  // is distinguishable from one that breaks only the non-ASCII path.
+  assert_eq!(
+    marker(&out, "DECOY"),
+    "A",
+    "slot 65 of the declared symbol font did not decode"
+  );
+
+  // Slot 0 is the tell: `Γ` through OT1, U+FFFD when the encoding was stored
+  // as the unexpanded string `\encodingdefault`.
+  assert_eq!(
+    marker(&out, "TELL"),
+    "\u{0393}",
+    "slot 0 decoded to something other than `Γ` — `\\DeclareSymbolFont` is \
+     storing its encoding argument unexpanded again, so the fontmap lookup \
+     misses and the raw code leaks through (pre-fix this was U+FFFD)"
+  );
+}

--- a/latexml_oxide/tests/cluster_regressions/char_font_decode.tex
+++ b/latexml_oxide/tests/cluster_regressions/char_font_decode.tex
@@ -1,0 +1,15 @@
+% `\char` decodes through Perl's FontDecode semantics, in math as in text.
+% Guard for two defects, both silent:
+%  - in MATH mode the encoding defaulted to nothing instead of OT1, so
+%    `$\char65$` produced NOTHING where Perl produces `A`;
+%  - the code was cast `as u8`, so an out-of-range `\char300` WRAPPED onto
+%    slot 44 and printed `,` instead of producing nothing.
+% Markers are prose so a failure shows which case broke.
+\documentclass{article}
+\begin{document}
+MATH[$\char65$] TEXT[\char65]
+
+OOBMATH[$\char300$] OOBTEXT[\char300]
+
+SYMBOL[$\symbol{65}$] ACCENT[\char19]
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/symbolfont_encoding_expansion.tex
+++ b/latexml_oxide/tests/cluster_regressions/symbolfont_encoding_expansion.tex
@@ -1,0 +1,18 @@
+% `\DeclareSymbolFont`'s encoding argument must be EXPANDED before it is
+% stored. This is the `fontmath.ltx` idiom verbatim: the encoding arrives as a
+% macro, not a literal. Read unexpanded, the string `\encodingdefault` lands in
+% `fontdeclaration@myops`, and every dependent `\DeclareMathSymbol` then looks
+% up a fontmap by that name and finds none — silently, with no diagnostic.
+%
+% Slot 0 is the tell. Un-decoded it becomes U+FFFD; through OT1 it is `Γ`.
+% Slot 65 is a decoy: a raw code 65 IS ASCII `A`, so it looks correct either
+% way and would have hidden the defect on its own.
+\documentclass{article}
+\makeatletter
+\DeclareSymbolFont{myops}{\encodingdefault}{\rmdefault}{m}{n}
+\DeclareMathSymbol{\myA}{\mathalpha}{myops}{65}
+\DeclareMathSymbol{\myGam}{\mathalpha}{myops}{0}
+\makeatother
+\begin{document}
+DECOY[$\myA$] TELL[$\myGam$]
+\end{document}


### PR DESCRIPTION
Follow-up to the `\selectfont` audit in #450 — the small, verified gaps in the sibling primitives of the same font-selection chain. Independent of #450 (branched off `main`).

- **`\char`/`\symbol` returned the empty string in math mode.** `$\char65$` gave nothing where Perl gives `A`. Perl's `\char` calls `FontDecode`, which defaults the encoding to OT1 when the current font carries none (`Package.pm` L2877); its sibling `FontDecodeString` (L2906) deliberately has **no** such default, and `font::decode_str` is the port of *that* one — so `\char` inherited the wrong half of a deliberate Perl asymmetry. Only visible in math, because `Font::math_default()` sets `encoding: None` on purpose, which is why it survived this long.
- **`as u8` truncation in `\char` and `\DeclareTextSymbol`.** Perl guards `$code < 0` then indexes the map, so out-of-range yields no glyph; the cast wrapped onto a valid slot instead and `\char300` printed `,` (300 & 0xFF = 44). Same defect class `charcode_to_char` already documents for `\catcode` (witness 2007.09691).
- **`\DeclareSymbolFont`'s encoding argument was missing Perl's `ExpandedPartially`** (`latex_constructs.pool.ltxml` L2664). `fontmath.ltx` and most font packages write `\DeclareSymbolFont{operators}{\encodingdefault}{\rmdefault}{m}{n}`, so the literal string `\encodingdefault` was being stored in `fontdeclaration@operators` and every dependent `\DeclareMathSymbol`/`\DeclareMathAccent` looked up a fontmap by that name.
- **`\textit@math` sets `\f@shape` to `it`,** matching Perl L5255 (was `i`). Both map to `italic`, so only a textual reader of `\f@shape` could tell.

### Where the OT1 default had to go

Not at the call site. Both Perl and `font::decode` consult `<enc>_<family>_fontmap` **only** on the branch that looked the font up themselves — Perl assigns `$font` solely inside `if (!$encoding)`. Resolving the encoding early and passing it in therefore silently drops the family-specific map. My first attempt did exactly that and `ot1_test` caught it: its golden expects `\ttfamily`'s `OT1_typewriter` variant (slots 11-15 = ↑ ↓ ' ¡ ¿) and I was producing plain OT1 (ﬀ ﬁ ﬂ ﬃ ﬄ). The default belongs inside `decode`'s no-encoding branch, where the font is still in scope. `decode_string` (the `FontDecodeString` port) keeps its empty fallback — the asymmetry is deliberate and is now commented on both sides so it does not get "aligned" later.

### Checked and deliberately not changed

`\typeout` is fine. Perl reads its argument as `ExpandedPartially` while Rust reads `{}` and calls `Expand!` in the body — same effect at a different layer. I had it queued as a fix until I read the body.

### Guard

`tests/117_char_font_decode.rs` + `tests/cluster_regressions/char_font_decode.tex`, red before / green after (`left: ""`, `right: "A"`). That directory is **not** glob-scanned by `tex_tests!`, so the fixture needs no golden and cannot pass vacuously. It also pins the accent slot, so the fix cannot bypass `decode_str`'s multi-char/combining-mark handling, and both out-of-range cases, naming `,` in the failure message.

### Verification

Full workspace suite **1825 passed / 0 failed**, exit 0. Expectations verified against same-host Perl LaTeXML 0.8.8, which renders the fixture as `MATH[A] TEXT[A]`, `OOBMATH[] OOBTEXT[]`, `SYMBOL[A] ACCENT[´]`.
