### PR TITLE
fix(fonts): \DeclareMathAlphabet maps NFSS codes to abstract font properties

### DIFF
--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -6966,14 +6966,31 @@ LoadDefinitions!({
   // Rust double-superscript, Perl clean). Faithful parity: leave them
   // undefined, exactly like the Perl runtime.
   // DeclareMathAlphabet: define math font command if not already defined
+  // Perl: latex_constructs.pool.ltxml L2677-2687. The arguments are NFSS
+  // codes, and Perl maps them to LaTeXML's abstract font properties through
+  // `lookupTeXFont` (Common/Font.pm L230-239) — the same
+  // family/series/shape tables `\selectfont` consults. Storing the raw codes
+  // instead put them straight into the XML: `\DeclareMathAlphabet{\mysf}{OT1}
+  // {cmss}{m}{n}` emitted `font="cmss m n"` where Perl emits
+  // `font="sansserif"`, and MathML then carried `mathvariant="normal"` for
+  // every such alphabet — so a declared sansserif/bold/italic alphabet
+  // rendered upright. `lookup_tex_font` was already a faithful port of
+  // `lookupTeXFont`, with no callers.
+  //
+  // Only DOCUMENT- and PACKAGE-declared alphabets were affected: the stock
+  // `\mathsf`/`\mathbf`/`\mathit`/`\mathrm` are bound directly in the pool and
+  // never route through here. Font packages (fouriernc, mathpazo, newtxmath, …)
+  // do declare their own.
   DefPrimitive!("\\DeclareMathAlphabet{}{}{}{}{}", sub[(cs, _enc, family, series, shape)] {
     let cs_tok = T_CS!(cs.to_string());
-    if !IsDefined!(&cs_tok) {
-      let font : Option<Font> = Some(fontmap!(
-        family => family.to_string(),
-        series => series.to_string(),
-        shape  => shape.to_string()
-      ));
+    // We won't override this, e.g. \mathrm by fouriernc.sty
+    if IsDefined!(&cs_tok) {
+      let csname = cs.to_string();
+      let message = s!("Ignoring redefinition (\\DeclareMathAlphabet) of '{csname}'");
+      Info!("ignore", csname, message);
+    } else {
+      let font : Option<Font> = Some(font::lookup_tex_font(
+        &family.to_string(), &series.to_string(), &shape.to_string()));
       DefPrimitive!(cs_tok, None, None, font => font);
     }
   });

--- a/latexml_oxide/tests/118_declaremathalphabet_props.rs
+++ b/latexml_oxide/tests/118_declaremathalphabet_props.rs
@@ -1,0 +1,63 @@
+//! `\DeclareMathAlphabet` maps NFSS codes to abstract font properties.
+//!
+//! Perl runs its three arguments through `lookupTeXFont`
+//! (`Common/Font.pm` L230-239) — the same family/series/shape tables
+//! `\selectfont` consults — before storing them (`latex_constructs.pool.ltxml`
+//! L2677-2687). Rust stored the raw NFSS codes, so
+//! `\DeclareMathAlphabet{\mysf}{OT1}{cmss}{m}{n}` emitted `font="cmss m n"`
+//! where Perl emits `font="sansserif"`, and the MathML then carried
+//! `mathvariant="normal"` for every declared alphabet — a sansserif, bold or
+//! italic alphabet rendered upright.
+//!
+//! `font::lookup_tex_font` was already a faithful port of `lookupTeXFont`
+//! with **no callers** — the same dead-helper shape as `ding_fontmap.rs`
+//! before the `\selectfont` fix.
+//!
+//! Blast radius is document- and package-declared alphabets only: the stock
+//! `\mathsf`/`\mathbf`/`\mathit`/`\mathrm` are bound directly in the pool and
+//! are unaffected (asserted below, so a future change cannot quietly route
+//! them through the broken path). Verified against same-host Perl 0.8.8,
+//! which emits `sansserif`, `bold`, `italic` for the declared trio.
+mod cluster;
+use cluster::convert_to_xml;
+
+/// The `font=` attribute of every `<XMTok>`, in document order.
+fn tok_fonts(xml: &str) -> Vec<String> {
+  let mut out = Vec::new();
+  for seg in xml.split("<XMTok").skip(1) {
+    let Some(end) = seg.find('>') else { continue };
+    let tag = &seg[..end];
+    if let Some(i) = tag.find("font=\"") {
+      let rest = &tag[i + 6..];
+      if let Some(j) = rest.find('"') {
+        out.push(rest[..j].to_string());
+      }
+    }
+  }
+  out
+}
+
+#[test]
+fn declared_math_alphabets_carry_abstract_font_properties() {
+  let xml = convert_to_xml("tests/cluster_regressions/declaremathalphabet_props.tex");
+  assert_eq!(
+    tok_fonts(&xml),
+    vec!["sansserif", "bold", "italic"],
+    "\\DeclareMathAlphabet stored raw NFSS codes again — Perl maps them \
+     through lookupTeXFont, and the raw form leaks into the XML as e.g. \
+     `font=\"cmss m n\"`, which costs the alphabet its MathML variant"
+  );
+}
+
+#[test]
+fn stock_math_alphabets_are_unaffected() {
+  // \mathsf/\mathbf/\mathit are bound directly in the pool, so they were
+  // already correct — pinned so a future change cannot quietly reroute them
+  // through the declaration path this test's sibling protects.
+  let xml = convert_to_xml("tests/cluster_regressions/stock_math_alphabets.tex");
+  assert_eq!(
+    tok_fonts(&xml),
+    vec!["sansserif", "bold", "italic"],
+    "a stock math alphabet lost its abstract font property"
+  );
+}

--- a/latexml_oxide/tests/cluster_regressions/declaremathalphabet_props.tex
+++ b/latexml_oxide/tests/cluster_regressions/declaremathalphabet_props.tex
@@ -1,0 +1,21 @@
+% `\DeclareMathAlphabet` must map its NFSS codes to LaTeXML's ABSTRACT font
+% properties, the way Perl's `lookupTeXFont` does — not store them raw.
+%
+% Storing them raw put the codes straight into the XML: `font="cmss m n"`
+% instead of `font="sansserif"`, and MathML then carried
+% `mathvariant="normal"` for every declared alphabet, so a sansserif/bold/
+% italic alphabet rendered upright.
+%
+% Only document- and package-declared alphabets route through here; the stock
+% \mathsf/\mathbf/\mathit are bound directly in the pool. Font packages
+% (fouriernc, mathpazo, newtxmath, …) declare their own, which is the real
+% population this protects.
+\documentclass{article}
+\makeatletter
+\DeclareMathAlphabet{\mysf}{OT1}{cmss}{m}{n}
+\DeclareMathAlphabet{\mybf}{OT1}{cmr}{bx}{n}
+\DeclareMathAlphabet{\myit}{OT1}{cmr}{m}{it}
+\makeatother
+\begin{document}
+$\mysf{A}$ $\mybf{A}$ $\myit{A}$
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/stock_math_alphabets.tex
+++ b/latexml_oxide/tests/cluster_regressions/stock_math_alphabets.tex
@@ -1,0 +1,9 @@
+% The STOCK math alphabets are bound directly in the pool and must NOT route
+% through `\DeclareMathAlphabet`. Companion to declaremathalphabet_props.tex:
+% that one pins the declared path, this one pins that the stock path stayed
+% off it. Same expected values in both, so a regression that reroutes the
+% stock alphabets through a broken declaration path is still caught.
+\documentclass{article}
+\begin{document}
+$\mathsf{A}$ $\mathbf{A}$ $\mathit{A}$
+\end{document}


### PR DESCRIPTION
Third of the font-selection chain audit (after #450 and #452). This one was tagged **unverified** in `SYNC_STATUS.md` — measured now, and it is real.

- **`\DeclareMathAlphabet` stored raw NFSS codes instead of abstract font properties.** Perl runs its three arguments through `lookupTeXFont` (`Common/Font.pm` L230-239) — the same family/series/shape tables `\selectfont` consults — before storing them (`latex_constructs.pool.ltxml` L2677-2687). Rust stored them verbatim, so they went straight into the XML:

  ```
  \DeclareMathAlphabet{\mysf}{OT1}{cmss}{m}{n}
  Perl: font="sansserif"        Rust: font="cmss m n"
  ```

  and the MathML then carried `mathvariant="normal"` for every declared alphabet — a declared sansserif, bold or italic alphabet **rendered upright**. Measured against same-host Perl 0.8.8: `['sansserif','bold','italic']` vs `['cmss m n','cmr bx n','cmr m it']`, plus 3 spurious `mathvariant="normal"` Perl does not emit.

- **`font::lookup_tex_font` was already a faithful port of `lookupTeXFont` — with zero callers.** That is the third instance of the same shape in this subsystem today, after `ding_fontmap.rs` (#450) and `\DeclareSymbolFont` (#452): correctly translated machinery that nothing invokes. No test catches it, because the output stays plausible.

- **Also adds Perl's `Info('ignore', …)`** on the already-defined branch (L2682-2683), which Rust was skipping silently — that is the branch that keeps e.g. `fouriernc.sty` from overriding `\mathrm`.

### Blast radius

Document- and package-declared alphabets only. The stock `\mathsf`/`\mathbf`/`\mathit`/`\mathrm` are bound directly in the pool and were already correct — I checked before assuming, and they are now **pinned by a second test** so a future change cannot quietly reroute them through the declaration path. The real population this protects is font packages that declare their own: `fouriernc`, `mathpazo`, `newtxmath`, and friends.

### Guard

`tests/118_declaremathalphabet_props.rs` with two fixtures. Red before / green after on the declared path (`left: ["cmss m n", "cmr bx n", "cmr m it"]`, `right: ["sansserif", "bold", "italic"]`), while the stock control stays green in **both** states — so the two paths remain distinguishable rather than the control merely duplicating the assertion.

### Verification

Full workspace suite **1828 passed / 0 failed**, exit 0. Rebased onto `main` with #450 and #452 merged, and all five guards from the three PRs re-run green together.
