### PR TITLE
fix(fonts): sized delimiters scale to NOMINAL_FONT_SIZE, not a baked-in 10

### DIFF
--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -6966,14 +6966,31 @@ LoadDefinitions!({
   // Rust double-superscript, Perl clean). Faithful parity: leave them
   // undefined, exactly like the Perl runtime.
   // DeclareMathAlphabet: define math font command if not already defined
+  // Perl: latex_constructs.pool.ltxml L2677-2687. The arguments are NFSS
+  // codes, and Perl maps them to LaTeXML's abstract font properties through
+  // `lookupTeXFont` (Common/Font.pm L230-239) — the same
+  // family/series/shape tables `\selectfont` consults. Storing the raw codes
+  // instead put them straight into the XML: `\DeclareMathAlphabet{\mysf}{OT1}
+  // {cmss}{m}{n}` emitted `font="cmss m n"` where Perl emits
+  // `font="sansserif"`, and MathML then carried `mathvariant="normal"` for
+  // every such alphabet — so a declared sansserif/bold/italic alphabet
+  // rendered upright. `lookup_tex_font` was already a faithful port of
+  // `lookupTeXFont`, with no callers.
+  //
+  // Only DOCUMENT- and PACKAGE-declared alphabets were affected: the stock
+  // `\mathsf`/`\mathbf`/`\mathit`/`\mathrm` are bound directly in the pool and
+  // never route through here. Font packages (fouriernc, mathpazo, newtxmath, …)
+  // do declare their own.
   DefPrimitive!("\\DeclareMathAlphabet{}{}{}{}{}", sub[(cs, _enc, family, series, shape)] {
     let cs_tok = T_CS!(cs.to_string());
-    if !IsDefined!(&cs_tok) {
-      let font : Option<Font> = Some(fontmap!(
-        family => family.to_string(),
-        series => series.to_string(),
-        shape  => shape.to_string()
-      ));
+    // We won't override this, e.g. \mathrm by fouriernc.sty
+    if IsDefined!(&cs_tok) {
+      let csname = cs.to_string();
+      let message = s!("Ignoring redefinition (\\DeclareMathAlphabet) of '{csname}'");
+      Info!("ignore", csname, message);
+    } else {
+      let font : Option<Font> = Some(font::lookup_tex_font(
+        &family.to_string(), &series.to_string(), &shape.to_string()));
       DefPrimitive!(cs_tok, None, None, font => font);
     }
   });

--- a/latexml_engine/src/math_common.rs
+++ b/latexml_engine/src/math_common.rs
@@ -15,6 +15,30 @@ use crate::prelude::*;
 /// produces `Some(empty Parameters)`. Both yield the same `nargs = 0`
 /// downstream, but keeping the None form preserves struct-level parity
 /// for any consumer that distinguishes.
+/// The absolute font size Perl's `font => { size => '<symbolic>' }` resolves to.
+///
+/// Perl stores the SYMBOLIC name in the font spec and rationalizes it inside
+/// `Font::new` (`Common/Font.pm` L266), so `rationalizeFontSize` runs at font
+/// construction and multiplies by `DEFSIZE()` — which reads `NOMINAL_FONT_SIZE`
+/// from state at that moment. Rust's `Font::size` is an `Option<f64>`, so the
+/// symbolic name cannot survive into the struct and the multiplication has to
+/// happen here instead.
+///
+/// It must still happen at DIGEST time, not at pool-load time, which is why the
+/// call sites pass this through a `font => sub[_f]` closure rather than a
+/// literal. Hard-coding the product (`size => 12.0`, i.e. `1.2 * 10`) baked in
+/// the *default* `NOMINAL_FONT_SIZE`, so a class that changes it — `a0poster`
+/// sets 25, in both engines — got delimiters sized against the wrong body text:
+/// `\big(` came out at 48% instead of 120%, i.e. SMALLER than the surrounding
+/// text rather than half again as large. pdflatex renders `\big(` visibly
+/// larger than an adjacent `(`, and Perl agrees at 120%.
+fn symbolic_font_size(symbolic: &str) -> Font {
+  Font {
+    size: Some(font::rationalize_font_size(symbolic)),
+    ..Font::default()
+  }
+}
+
 fn def_math_atom(cs: &str, present: &str, role: Option<&str>, meaning: Option<&str>) -> Result<()> {
   let cs_tok = T_CS!(cs);
   let mut opts = MathPrimitiveOptions::default();
@@ -953,13 +977,13 @@ LoadDefinitions!({
   // in map and set name/meaning (but don't change role or stretchy).
   // Perl: font => { size => 'big' } where 'big' → 1.2 * DEFSIZE(10) = 12.0 absolute pt.
   // Named sizes map to absolute values, NOT scale factors.
-  DefConstructor!("\\big TeXDelimiter",  "#1", bounded => true, font => { size => 12.0 },
+  DefConstructor!("\\big TeXDelimiter",  "#1", bounded => true, font => sub[_f] { Ok(symbolic_font_size("big")) },
     after_construct => sub[document, _whatsit] { augment_delimiter_properties(document, "")?; });
-  DefConstructor!("\\Big TeXDelimiter",  "#1", bounded => true, font => { size => 16.0 },
+  DefConstructor!("\\Big TeXDelimiter",  "#1", bounded => true, font => sub[_f] { Ok(symbolic_font_size("Big")) },
     after_construct => sub[document, _whatsit] { augment_delimiter_properties(document, "")?; });
-  DefConstructor!("\\bigg TeXDelimiter", "#1", bounded => true, font => { size => 21.0 },
+  DefConstructor!("\\bigg TeXDelimiter", "#1", bounded => true, font => sub[_f] { Ok(symbolic_font_size("bigg")) },
     after_construct => sub[document, _whatsit] { augment_delimiter_properties(document, "")?; });
-  DefConstructor!("\\Bigg TeXDelimiter", "#1", bounded => true, font => { size => 26.0 },
+  DefConstructor!("\\Bigg TeXDelimiter", "#1", bounded => true, font => sub[_f] { Ok(symbolic_font_size("Bigg")) },
     after_construct => sub[document, _whatsit] { augment_delimiter_properties(document, "")?; });
 
   // sub addDelimiterRole {
@@ -978,32 +1002,32 @@ LoadDefinitions!({
   // Sized delimiters with role assignment (l=OPEN, m=MIDDLE, r=CLOSE)
   // Perl: font => { size => 'big' } where rationalizeFontSize('big') = 1.2 * DEFSIZE(10) = 12.0pt
   // Named sizes are absolute, not relative — must use `size` (not `scale`).
-  DefConstructor!("\\bigl TeXDelimiter",  "#1", bounded => true, font => { size => 12.0 },
+  DefConstructor!("\\bigl TeXDelimiter",  "#1", bounded => true, font => sub[_f] { Ok(symbolic_font_size("big")) },
     after_construct => sub[document, _whatsit] { augment_delimiter_properties(document, "OPEN")?; });
-  DefConstructor!("\\bigm TeXDelimiter",  "#1", bounded => true, font => { size => 12.0 },
+  DefConstructor!("\\bigm TeXDelimiter",  "#1", bounded => true, font => sub[_f] { Ok(symbolic_font_size("big")) },
     after_construct => sub[document, _whatsit] { augment_delimiter_properties(document, "MIDDLE")?; });
-  DefConstructor!("\\bigr TeXDelimiter",  "#1", bounded => true, font => { size => 12.0 },
+  DefConstructor!("\\bigr TeXDelimiter",  "#1", bounded => true, font => sub[_f] { Ok(symbolic_font_size("big")) },
     after_construct => sub[document, _whatsit] { augment_delimiter_properties(document, "CLOSE")?; });
 
-  DefConstructor!("\\Bigl TeXDelimiter",  "#1", bounded => true, font => { size => 16.0 },
+  DefConstructor!("\\Bigl TeXDelimiter",  "#1", bounded => true, font => sub[_f] { Ok(symbolic_font_size("Big")) },
     after_construct => sub[document, _whatsit] { augment_delimiter_properties(document, "OPEN")?; });
-  DefConstructor!("\\Bigm TeXDelimiter",  "#1", bounded => true, font => { size => 16.0 },
+  DefConstructor!("\\Bigm TeXDelimiter",  "#1", bounded => true, font => sub[_f] { Ok(symbolic_font_size("Big")) },
     after_construct => sub[document, _whatsit] { augment_delimiter_properties(document, "MIDDLE")?; });
-  DefConstructor!("\\Bigr TeXDelimiter",  "#1", bounded => true, font => { size => 16.0 },
+  DefConstructor!("\\Bigr TeXDelimiter",  "#1", bounded => true, font => sub[_f] { Ok(symbolic_font_size("Big")) },
     after_construct => sub[document, _whatsit] { augment_delimiter_properties(document, "CLOSE")?; });
 
-  DefConstructor!("\\biggl TeXDelimiter", "#1", bounded => true, font => { size => 21.0 },
+  DefConstructor!("\\biggl TeXDelimiter", "#1", bounded => true, font => sub[_f] { Ok(symbolic_font_size("bigg")) },
     after_construct => sub[document, _whatsit] { augment_delimiter_properties(document, "OPEN")?; });
-  DefConstructor!("\\biggm TeXDelimiter", "#1", bounded => true, font => { size => 21.0 },
+  DefConstructor!("\\biggm TeXDelimiter", "#1", bounded => true, font => sub[_f] { Ok(symbolic_font_size("bigg")) },
     after_construct => sub[document, _whatsit] { augment_delimiter_properties(document, "MIDDLE")?; });
-  DefConstructor!("\\biggr TeXDelimiter", "#1", bounded => true, font => { size => 21.0 },
+  DefConstructor!("\\biggr TeXDelimiter", "#1", bounded => true, font => sub[_f] { Ok(symbolic_font_size("bigg")) },
     after_construct => sub[document, _whatsit] { augment_delimiter_properties(document, "CLOSE")?; });
 
-  DefConstructor!("\\Biggl TeXDelimiter", "#1", bounded => true, font => { size => 26.0 },
+  DefConstructor!("\\Biggl TeXDelimiter", "#1", bounded => true, font => sub[_f] { Ok(symbolic_font_size("Bigg")) },
     after_construct => sub[document, _whatsit] { augment_delimiter_properties(document, "OPEN")?; });
-  DefConstructor!("\\Biggm TeXDelimiter", "#1", bounded => true, font => { size => 26.0 },
+  DefConstructor!("\\Biggm TeXDelimiter", "#1", bounded => true, font => sub[_f] { Ok(symbolic_font_size("Bigg")) },
     after_construct => sub[document, _whatsit] { augment_delimiter_properties(document, "MIDDLE")?; });
-  DefConstructor!("\\Biggr TeXDelimiter", "#1", bounded => true, font => { size => 26.0 },
+  DefConstructor!("\\Biggr TeXDelimiter", "#1", bounded => true, font => sub[_f] { Ok(symbolic_font_size("Bigg")) },
     after_construct => sub[document, _whatsit] { augment_delimiter_properties(document, "CLOSE")?; });
 
   Let!(&T_CS!("\\vert"), T_OTHER!("|"));

--- a/latexml_oxide/tests/118_declaremathalphabet_props.rs
+++ b/latexml_oxide/tests/118_declaremathalphabet_props.rs
@@ -1,0 +1,63 @@
+//! `\DeclareMathAlphabet` maps NFSS codes to abstract font properties.
+//!
+//! Perl runs its three arguments through `lookupTeXFont`
+//! (`Common/Font.pm` L230-239) — the same family/series/shape tables
+//! `\selectfont` consults — before storing them (`latex_constructs.pool.ltxml`
+//! L2677-2687). Rust stored the raw NFSS codes, so
+//! `\DeclareMathAlphabet{\mysf}{OT1}{cmss}{m}{n}` emitted `font="cmss m n"`
+//! where Perl emits `font="sansserif"`, and the MathML then carried
+//! `mathvariant="normal"` for every declared alphabet — a sansserif, bold or
+//! italic alphabet rendered upright.
+//!
+//! `font::lookup_tex_font` was already a faithful port of `lookupTeXFont`
+//! with **no callers** — the same dead-helper shape as `ding_fontmap.rs`
+//! before the `\selectfont` fix.
+//!
+//! Blast radius is document- and package-declared alphabets only: the stock
+//! `\mathsf`/`\mathbf`/`\mathit`/`\mathrm` are bound directly in the pool and
+//! are unaffected (asserted below, so a future change cannot quietly route
+//! them through the broken path). Verified against same-host Perl 0.8.8,
+//! which emits `sansserif`, `bold`, `italic` for the declared trio.
+mod cluster;
+use cluster::convert_to_xml;
+
+/// The `font=` attribute of every `<XMTok>`, in document order.
+fn tok_fonts(xml: &str) -> Vec<String> {
+  let mut out = Vec::new();
+  for seg in xml.split("<XMTok").skip(1) {
+    let Some(end) = seg.find('>') else { continue };
+    let tag = &seg[..end];
+    if let Some(i) = tag.find("font=\"") {
+      let rest = &tag[i + 6..];
+      if let Some(j) = rest.find('"') {
+        out.push(rest[..j].to_string());
+      }
+    }
+  }
+  out
+}
+
+#[test]
+fn declared_math_alphabets_carry_abstract_font_properties() {
+  let xml = convert_to_xml("tests/cluster_regressions/declaremathalphabet_props.tex");
+  assert_eq!(
+    tok_fonts(&xml),
+    vec!["sansserif", "bold", "italic"],
+    "\\DeclareMathAlphabet stored raw NFSS codes again — Perl maps them \
+     through lookupTeXFont, and the raw form leaks into the XML as e.g. \
+     `font=\"cmss m n\"`, which costs the alphabet its MathML variant"
+  );
+}
+
+#[test]
+fn stock_math_alphabets_are_unaffected() {
+  // \mathsf/\mathbf/\mathit are bound directly in the pool, so they were
+  // already correct — pinned so a future change cannot quietly reroute them
+  // through the declaration path this test's sibling protects.
+  let xml = convert_to_xml("tests/cluster_regressions/stock_math_alphabets.tex");
+  assert_eq!(
+    tok_fonts(&xml),
+    vec!["sansserif", "bold", "italic"],
+    "a stock math alphabet lost its abstract font property"
+  );
+}

--- a/latexml_oxide/tests/118_delimiter_size_nominal_font.rs
+++ b/latexml_oxide/tests/118_delimiter_size_nominal_font.rs
@@ -1,0 +1,60 @@
+//! Sized math delimiters scale to the document's NOMINAL_FONT_SIZE.
+//!
+//! Perl keeps the size SYMBOLIC in the font spec (`font => { size => 'big' }`)
+//! and rationalizes it inside `Font::new` (`Common/Font.pm` L266), so
+//! `rationalizeFontSize` multiplies by `DEFSIZE()` — which reads
+//! `NOMINAL_FONT_SIZE` from state — at font-construction time.
+//!
+//! Rust's `Font::size` is an `Option<f64>`, so the symbolic name cannot reach
+//! the struct and the multiplication happens at the binding instead. Hardcoding
+//! the product (`size => 12.0`, i.e. `1.2 * 10`) baked in the DEFAULT nominal
+//! size, so `a0poster` — which sets it to 25 in both engines — got `\big(` at
+//! 12/25 = 48%, i.e. *smaller* than body text, instead of 120%.
+//!
+//! Ground truth is pdflatex, not just Perl: it renders `\big(` visibly larger
+//! than an adjacent plain `(`. Perl agrees at 120%/160%.
+mod cluster;
+use cluster::convert_expecting_errors;
+
+fn sizes(xml: &str) -> Vec<String> {
+  let mut v: Vec<String> = Vec::new();
+  for seg in xml.split("fontsize=\"").skip(1) {
+    if let Some(end) = seg.find('"') {
+      v.push(seg[..end].to_string());
+    }
+  }
+  v.sort();
+  v.dedup();
+  v
+}
+
+#[test]
+fn sized_delimiters_scale_to_the_nominal_font_size() {
+  // NOTE the expected-error count. `a0poster` currently emits 4
+  // `Error:expected:<variable>` in Rust and ZERO in Perl 0.8.8 on this exact
+  // input — a Rust-only defect in the class binding, unrelated to delimiter
+  // sizing and tracked separately. It is pinned rather than tolerated: when
+  // that bug is fixed this assertion fails, which is the intended prompt to
+  // drop the count back to 0. Do not "fix" this by loosening the check.
+  let xml = convert_expecting_errors(
+    "tests/cluster_regressions/delimiter_size_nominal_font.tex",
+    4,
+  );
+  let got = sizes(&xml);
+  for want in ["120%", "160%"] {
+    assert!(
+      got.contains(&want.to_string()),
+      "expected a {want} delimiter under a0poster (NOMINAL_FONT_SIZE=25), got {got:?} — \
+       the \\big family is using a hardcoded absolute size again, so the \
+       delimiters are scaled against the wrong body size"
+    );
+  }
+  // The pre-fix answers. Named so a regression is unmistakable.
+  for bad in ["48%", "64%"] {
+    assert!(
+      !got.contains(&bad.to_string()),
+      "delimiter rendered at {bad} — that is 1.2*10 (or 1.6*10) measured \
+       against a 25pt body, i.e. the hardcoded-DEFSIZE regression"
+    );
+  }
+}

--- a/latexml_oxide/tests/cluster_regressions/declaremathalphabet_props.tex
+++ b/latexml_oxide/tests/cluster_regressions/declaremathalphabet_props.tex
@@ -1,0 +1,21 @@
+% `\DeclareMathAlphabet` must map its NFSS codes to LaTeXML's ABSTRACT font
+% properties, the way Perl's `lookupTeXFont` does — not store them raw.
+%
+% Storing them raw put the codes straight into the XML: `font="cmss m n"`
+% instead of `font="sansserif"`, and MathML then carried
+% `mathvariant="normal"` for every declared alphabet, so a sansserif/bold/
+% italic alphabet rendered upright.
+%
+% Only document- and package-declared alphabets route through here; the stock
+% \mathsf/\mathbf/\mathit are bound directly in the pool. Font packages
+% (fouriernc, mathpazo, newtxmath, …) declare their own, which is the real
+% population this protects.
+\documentclass{article}
+\makeatletter
+\DeclareMathAlphabet{\mysf}{OT1}{cmss}{m}{n}
+\DeclareMathAlphabet{\mybf}{OT1}{cmr}{bx}{n}
+\DeclareMathAlphabet{\myit}{OT1}{cmr}{m}{it}
+\makeatother
+\begin{document}
+$\mysf{A}$ $\mybf{A}$ $\myit{A}$
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/delimiter_size_nominal_font.tex
+++ b/latexml_oxide/tests/cluster_regressions/delimiter_size_nominal_font.tex
@@ -1,0 +1,13 @@
+% `\big`/`\Big`/… sizes are SYMBOLIC in Perl (`font => { size => 'big' }`) and
+% get multiplied by DEFSIZE() — i.e. NOMINAL_FONT_SIZE read from state — inside
+% Font::new. Rust's Font::size is an f64, so the multiplication happens at the
+% binding, and it must happen at DIGEST time, not pool-load time.
+%
+% a0poster sets NOMINAL_FONT_SIZE to 25 (both engines). With the product
+% hardcoded as 1.2*10=12.0pt, `\big(` came out at 12/25 = 48% — SMALLER than
+% body text — instead of 120%. pdflatex renders `\big(` visibly larger than an
+% adjacent `(`, and Perl gives 120%/160%.
+\documentclass{a0poster}
+\begin{document}
+$\big( x \big)$ $\Big[ y \Big]$
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/stock_math_alphabets.tex
+++ b/latexml_oxide/tests/cluster_regressions/stock_math_alphabets.tex
@@ -1,0 +1,9 @@
+% The STOCK math alphabets are bound directly in the pool and must NOT route
+% through `\DeclareMathAlphabet`. Companion to declaremathalphabet_props.tex:
+% that one pins the declared path, this one pins that the stock path stayed
+% off it. Same expected values in both, so a regression that reroutes the
+% stock alphabets through a broken declaration path is still caught.
+\documentclass{article}
+\begin{document}
+$\mathsf{A}$ $\mathbf{A}$ $\mathit{A}$
+\end{document}

--- a/latexml_package/src/package/mathtools_sty.rs
+++ b/latexml_package/src/package/mathtools_sty.rs
@@ -952,7 +952,7 @@ LoadDefinitions!({
   // Perl: UTF(0xD7) = × MULTIPLICATION SIGN
   // Perl: font => { size => 'Big' } where rationalizeFontSize('Big') = 1.6 * DEFSIZE(10) = 16.0pt
   DefMath!("\\bigtimes", None, "\u{00D7}", role => "MULOP", meaning => "times",
-    font => { size => 16.0 },
+    font => sub[_f] { Ok(Font { size: Some(font::rationalize_font_size("Big")), ..Font::default() }) },
     dynamic_scriptpos => true);
 
   //======================================================================


### PR DESCRIPTION
Found by first-principles comparison against **pdflatex**, not against Perl — which is what made it visible.

- **`\big`/`\Big`/`\bigg`/`\Bigg` were sized against a hardcoded body size of 10pt.** Perl keeps the size symbolic (`font => { size => 'big' }`) and rationalizes it inside `Font::new` (`Common/Font.pm` L266), multiplying by `DEFSIZE()` — which reads `NOMINAL_FONT_SIZE` from state at font-construction time. Rust's `Font::size` is an `Option<f64>`, so the symbolic name cannot reach the struct and the multiplication happens at the binding; it was written out as the product (`size => 12.0` = `1.2 * 10`).

  `a0poster` sets `NOMINAL_FONT_SIZE` to 25 — in **both** engines — so `\big(` rendered at 12/25 = **48%**, *smaller* than body text, instead of 120%.

- **pdflatex settles it:** `\big(` renders visibly larger than an adjacent plain `(`. Perl gives 120%/160%; Rust now agrees. So this is not a case of surpassing Perl — it was a Rust-only regression.

- **`font::rationalize_font_size` already existed as a faithful port of `rationalizeFontSize`, with zero callers** — the fourth instance of that exact shape in this subsystem, after `ding_fontmap` (#450), `\DeclareSymbolFont` (#452) and `lookup_tex_font` (#453). Wiring it requires *digest-time* evaluation, hence `font => sub[_f] { … }` rather than a literal: a pool-load-time call would read the nominal size before `a0poster` changes it. 17 sites.

### Guard

`tests/118_delimiter_size_nominal_font.rs`, red before / green after (`["40%","48%","64%"]` → 120%/160%).

It **pins a separate, newly-found Rust-only defect**: `a0poster` emits 4 `Error:expected:<variable>` where Perl 0.8.8 emits **zero** on the same input. I chose to pin the count rather than tolerate it, so fixing that bug turns this test red and prompts dropping the count back to 0.

### Not claimed

One `fontsize="40%"` element still differs in count under `a0poster` (Perl 4, Rust 3), both before and after this change. Unrelated and unresolved.

Full workspace suite **1830 passed / 0 failed**.