### PR TITLE
fix(fonts): AMSb's six negated relations were decoding to the empty string

### DIFF
--- a/latexml_oxide/tests/119_amsb_multichar_slots.rs
+++ b/latexml_oxide/tests/119_amsb_multichar_slots.rs
@@ -1,0 +1,72 @@
+//! A fontmap slot holding TWO characters must survive into the output.
+//!
+//! Perl fontmaps may store a multi-character string in a slot — the six `msbm`
+//! negated relations are base + U+0338 COMBINING LONG SOLIDUS OVERLAY
+//! (`amsb.fontmap.ltxml` L20, L21, L23). Rust's slot is a single
+//! `Option<char>`, so such entries live in a companion
+//! `DeclareFontMapMultichar!` table that `font::decode_str` consults first.
+//! `AMSb` had no such table, so these six slots decoded to the EMPTY STRING.
+//!
+//! Scope, checked rather than assumed: the familiar spellings `\nleqslant`,
+//! `\ngeqslant`, `\nleqq`, `\ngeqq`, `\nsubseteqq`, `\nsupseteqq` are bound by
+//! `amssymb` directly to explicit Unicode and never reach the fontmap — they
+//! were correct all along and are NOT a guard for this. Only direct slot
+//! access under the encoding exercises it.
+//!
+//! Expectations verified against same-host Perl LaTeXML 0.8.8.
+mod cluster;
+use cluster::convert_to_xml;
+
+/// Text inside `NAME[...]`, markup stripped, as codepoints.
+fn marker_chars(xml: &str, name: &str) -> Vec<u32> {
+  let open = format!("{name}[");
+  let start = xml
+    .find(&open)
+    .unwrap_or_else(|| panic!("marker {name}[ absent"))
+    + open.len();
+  let rest = &xml[start..];
+  let end = rest
+    .find(']')
+    .unwrap_or_else(|| panic!("marker {name}[ unclosed"));
+  let mut out = String::new();
+  let mut depth = 0usize;
+  for c in rest[..end].chars() {
+    match c {
+      '<' => depth += 1,
+      '>' => depth = depth.saturating_sub(1),
+      _ if depth == 0 => out.push(c),
+      _ => {},
+    }
+  }
+  out.chars().map(|c| c as u32).collect()
+}
+
+#[test]
+fn amsb_multichar_slots_keep_their_combining_overlay() {
+  let xml = convert_to_xml("tests/cluster_regressions/amsb_multichar_slots.tex");
+
+  // Control first: a single-char slot on the same path. If this fails the
+  // whole decode path broke, not the multichar table.
+  assert_eq!(
+    marker_chars(&xml, "OK"),
+    vec![0x1D538],
+    "the AMSb single-char path itself regressed (slot 65 should be 𝔸)"
+  );
+
+  for (marker, base) in [
+    ("S10", 0x2A7Du32),
+    ("S11", 0x2A7E),
+    ("S20", 0x2266),
+    ("S21", 0x2267),
+    ("S34", 0x2AC5),
+    ("S35", 0x2AC6),
+  ] {
+    assert_eq!(
+      marker_chars(&xml, marker),
+      vec![base, 0x0338],
+      "AMSb slot behind {marker} lost its U+0338 overlay — the \
+       DeclareFontMapMultichar! table is not being consulted, and the slot \
+       decodes to the empty string (Perl gives the pair)"
+    );
+  }
+}

--- a/latexml_oxide/tests/cluster_regressions/amsb_multichar_slots.tex
+++ b/latexml_oxide/tests/cluster_regressions/amsb_multichar_slots.tex
@@ -1,0 +1,23 @@
+% The six negated relations of `msbm` are stored by Perl as TWO-character
+% strings (base + U+0338 COMBINING LONG SOLIDUS OVERLAY). A Rust fontmap slot
+% is a single Option<char>, so they must be carried by a companion
+% DeclareFontMapMultichar! table — without it these slots decoded to NOTHING.
+%
+% Reached by DIRECT slot access under the AMSb encoding. The common spellings
+% \nleqslant, \ngeqslant, \nleqq, \ngeqq, \nsubseteqq, \nsupseteqq are bound
+% by amssymb straight to explicit Unicode and never touch the fontmap, so they
+% are NOT a guard for this — checked, and they were correct all along.
+%
+% OK[] is the control: a single-char slot on the same path, which worked
+% before and after, so a failure here means the whole path broke, not the
+% multichar table.
+\documentclass{article}
+\begin{document}
+S10[{\fontencoding{AMSb}\selectfont\symbol{10}}]
+S11[{\fontencoding{AMSb}\selectfont\symbol{11}}]
+S20[{\fontencoding{AMSb}\selectfont\symbol{20}}]
+S21[{\fontencoding{AMSb}\selectfont\symbol{21}}]
+S34[{\fontencoding{AMSb}\selectfont\symbol{34}}]
+S35[{\fontencoding{AMSb}\selectfont\symbol{35}}]
+OK[{\fontencoding{AMSb}\selectfont\symbol{65}}]
+\end{document}

--- a/latexml_package/src/package/amsb_fontmap.rs
+++ b/latexml_package/src/package/amsb_fontmap.rs
@@ -39,4 +39,26 @@ LoadDefinitions!({
     // 0x78-0x7F
     '\u{21B6}', '\u{21B7}', '\u{03DD}', '\u{03F0}', '\u{1D55C}', '\u{210F}', '\u{210F}', '\u{03F6}'
   ]);
+  // The six negated relations of `msbm`. Perl stores each as a TWO-character
+  // string — base glyph plus U+0338 COMBINING LONG SOLIDUS OVERLAY —
+  // (amsb.fontmap.ltxml L20, L21, L23). A Rust fontmap slot is a single
+  // `Option<char>` and cannot hold a pair, so the array above carries `None`
+  // at these positions and the pairs live here; `decode_str` consults this
+  // table before the array.
+  //
+  // Without it the slots decoded to NOTHING — verified against Perl 0.8.8 via
+  // `\fontencoding{AMSb}\selectfont\symbol{10}`, which yields U+2A7D U+0338 in
+  // Perl and an empty string in Rust. Note the common spellings `\nleqslant`,
+  // `\ngeqslant`, `\nleqq`, `\ngeqq`, `\nsubseteqq`, `\nsupseteqq` are NOT
+  // affected: `amssymb` binds those directly to explicit Unicode and never
+  // reaches the fontmap. Only direct slot access (`\symbol`/`\char` under this
+  // encoding) does.
+  DeclareFontMapMultichar!("AMSb", {
+    0x0Au8 => "\u{2A7D}\u{0338}",   // \nleqslant
+    0x0Bu8 => "\u{2A7E}\u{0338}",   // \ngeqslant
+    0x14u8 => "\u{2266}\u{0338}",   // \nleqq
+    0x15u8 => "\u{2267}\u{0338}",   // \ngeqq
+    0x22u8 => "\u{2AC5}\u{0338}",   // \nsubseteqq
+    0x23u8 => "\u{2AC6}\u{0338}",   // \nsupseteqq
+  });
 });


### PR DESCRIPTION
From a slot-by-slot audit of all 24 font maps, Perl vs Rust — **4048 slots compared, 0 wrong characters, 0 off-by-N**. These were the only reachable losses.

- **Six `AMSb` slots decoded to nothing.** Perl fontmaps may hold a *multi-character* string in a slot; the six `msbm` negated relations are base + U+0338 COMBINING LONG SOLIDUS OVERLAY (`amsb.fontmap.ltxml` L20/L21/L23). A Rust slot is a single `Option<char>` and cannot hold a pair, so such entries belong in a companion `DeclareFontMapMultichar!` table that `font::decode_str` consults first. `AMSb` had none — the array carried `None` and the file's own comments recorded the gap rather than closing it.

  Verified against same-host Perl 0.8.8 via `\fontencoding{AMSb}\selectfont\symbol{10}`: Perl yields U+2A7D U+0338, Rust yielded an empty string.

### Scope — narrower than it first looked

The familiar spellings `\nleqslant`, `\ngeqslant`, `\nleqq`, `\ngeqq`, `\nsubseteqq`, `\nsupseteqq` are bound by `amssymb` **straight to explicit Unicode** and never reach the fontmap. I checked before writing the fixture: they were byte-identical to Perl all along, so they are *not* a guard for this. Only direct slot access under the encoding exercises the defect — which is why the fixture uses `\symbol` and says so.

### Guard

`tests/119_amsb_multichar_slots.rs`, red before / green after (`left: []`, `right: [0x2A7D, 0x0338]`). A single-char slot on the same path serves as a control, so a whole-path regression stays distinguishable from a multichar-table one.

### Known adjacent gap, not fixed here

The multichar table is **bypassed** on the single-`char` `font::decode` path (`mathchar.rs`, and `\DeclareTextSymbol`), so the 27 slots that *are* covered elsewhere lose their combining mark when reached that way. Perl's `FontDecode` returns the full string on every path. That is a deeper change and wants its own PR.

Full workspace suite **1829 passed / 0 failed**.