### PR TITLE
fix(fonts): a multi-character fontmap slot survives \DeclareTextSymbol

### DIFF
--- a/latexml_core/src/common/font.rs
+++ b/latexml_core/src/common/font.rs
@@ -2072,6 +2072,20 @@ fn lookup_multichar_override(code: u8, encoding_opt: Option<&str>) -> Option<Str
   if encoding.is_empty() {
     return None;
   }
+  // The multichar table ships in the same binding as the map array, so it is
+  // absent until that binding is loaded. This lookup runs BEFORE `decode` —
+  // which is what triggers the load — so without preloading here, the very
+  // first decode for an encoding misses the table and silently falls back to
+  // the single-char array value.
+  //
+  // That is not merely a lost first call: `\DeclareTextSymbol` bakes the
+  // decoded result into a primitive body at DECLARATION time, in the preamble,
+  // before any `\fontencoding{T2B}` has loaded the map. So T2B slot 128 was
+  // frozen as `Ӷ` (U+04F6) instead of `Ӷ̶` (U+04F6 U+0336) — a different
+  // letter, its stroke dropped — for the rest of the document. Perl has no
+  // such hazard: `FontDecode` calls `LoadFontMap` first and then indexes one
+  // map whose slot already holds the whole string.
+  let _ = preload_font_map(&encoding);
   let mapname = format!("{encoding}_fontmap_multichar");
   with_value(&mapname, |val_opt| {
     if let Some(Stored::HashString(map)) = val_opt {

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -6595,11 +6595,19 @@ LoadDefinitions!({
     let cs_str = cs.to_string();
     let encoding_str = Expand!(encoding).to_string();
     let ecs = T_CS!(s!("\\{encoding_str}{cs_str}"));
+    // `decode_str`, not `decode`: a fontmap slot may hold MORE than one
+    // character. Perl's `FontDecode` returns the whole string
+    // (`$$map[$code]`), and Rust splits that across a single-`char` array plus
+    // the `_fontmap_multichar` side table — which only `decode_str` consults,
+    // along with T1's `SS` and the NBSP-prefixed combining accents. Decoding
+    // with `decode` silently dropped the second character: T2B slot 128 came
+    // out as `Ӷ` (U+04F6) instead of `Ӷ̶` (U+04F6 U+0336), i.e. a DIFFERENT
+    // letter with its stroke removed, where Perl keeps the pair.
     if let Some(replacement_value) =
-      code_value.and_then(|c| font::decode(c, Some(encoding_str), false))
+      code_value.and_then(|c| font::decode_str(c, Some(encoding_str), false))
     {
       // Encoding-specific carries the actual glyph.
-      def_primitive(ecs, None, Some(PrimitiveBody::from(replacement_value)),
+      def_primitive(ecs, None, Some(PrimitiveBody::String(replacement_value)),
         PrimitiveOptions::default())?;
     } else if IsDefinable!(&ecs) {
       // Can't decode: install no-op fallback so downstream chains find

--- a/latexml_oxide/tests/120_multichar_slot_paths.rs
+++ b/latexml_oxide/tests/120_multichar_slot_paths.rs
@@ -1,0 +1,96 @@
+//! Every decode path must honour a multi-character fontmap slot.
+//!
+//! Perl's `FontDecode` returns `$$map[$code]` whole, so a slot holding two
+//! characters just works on every path. Rust splits the representation: the
+//! array slot is a single `Option<char>` and multi-char entries live in a
+//! `_fontmap_multichar` side table. Only `font::decode_str` consults that
+//! table, so any caller of the single-`char` `font::decode` silently drops the
+//! second character.
+//!
+//! T2B slot 128 is U+04F6 + U+0336 COMBINING LONG STROKE OVERLAY. Dropping the
+//! overlay leaves U+04F6 — a *different* letter.
+//!
+//! There was also an ORDERING defect: `lookup_multichar_override` read the
+//! table from state but ran *before* `decode`, which is what triggers the map
+//! load. `\DeclareTextSymbol` decodes in the preamble and bakes the result
+//! into a primitive body, so it hit the table before it existed and froze the
+//! stripped letter for the whole document.
+//!
+//! Expectations verified against same-host Perl LaTeXML 0.8.8.
+mod cluster;
+use cluster::convert_to_xml;
+
+fn marker_chars(xml: &str, name: &str) -> Vec<u32> {
+  let open = format!("{name}[");
+  let start = xml
+    .find(&open)
+    .unwrap_or_else(|| panic!("marker {name}[ absent"))
+    + open.len();
+  let rest = &xml[start..];
+  let end = rest
+    .find(']')
+    .unwrap_or_else(|| panic!("marker {name}[ unclosed"));
+  let mut out = String::new();
+  let mut depth = 0usize;
+  for c in rest[..end].chars() {
+    match c {
+      '<' => depth += 1,
+      '>' => depth = depth.saturating_sub(1),
+      _ if depth == 0 => out.push(c),
+      _ => {},
+    }
+  }
+  // Drop layout whitespace; only the glyph matters.
+  out
+    .chars()
+    .map(|c| c as u32)
+    .filter(|c| *c != 0x0A && *c != 0x20)
+    .collect()
+}
+
+#[test]
+fn declare_text_symbol_keeps_a_multichar_slot() {
+  let xml = convert_to_xml("tests/cluster_regressions/multichar_slot_paths.tex");
+  assert_eq!(
+    marker_chars(&xml, "TS"),
+    vec![0x04F6, 0x0336],
+    "\\DeclareTextSymbol dropped the U+0336 overlay — either it is back on \
+     font::decode instead of decode_str, or the multichar table is again being \
+     consulted before the fontmap binding is loaded (it decodes in the \
+     preamble, so it must preload the map itself)"
+  );
+}
+
+#[test]
+fn symbol_keeps_a_multichar_slot() {
+  // Control: the same slot at document time, when the map is already loaded.
+  // Worked before the fix; a failure here means the whole path broke.
+  let xml = convert_to_xml("tests/cluster_regressions/multichar_slot_paths.tex");
+  assert_eq!(
+    marker_chars(&xml, "SYM"),
+    vec![0x04F6, 0x0336],
+    "\\symbol lost a multichar slot"
+  );
+}
+
+/// KNOWN REMAINING GAP — pinned, not endorsed.
+///
+/// `\DeclareMathSymbol` routes through `mathchar.rs`, which calls the
+/// single-`char` `font::decode` and stores the result in a
+/// `glyph: Option<char>` field. Carrying a pair there needs that field to
+/// become a string — a real type change through the math-char pipeline, so it
+/// is deliberately out of scope here rather than done badly.
+///
+/// Perl gives `[U+04F6, U+0336]`. When this is fixed, THIS TEST WILL FAIL —
+/// that is the intent. Update it to the Perl value and delete this note.
+#[test]
+fn declare_math_symbol_still_drops_the_overlay_known_gap() {
+  let xml = convert_to_xml("tests/cluster_regressions/multichar_slot_paths.tex");
+  assert_eq!(
+    marker_chars(&xml, "MS"),
+    vec![0x04F6],
+    "the math-char decode path changed — if it now yields [0x04F6, 0x0336] \
+     this gap is FIXED: update this test to expect the pair and remove it from \
+     the known-gap list"
+  );
+}

--- a/latexml_oxide/tests/cluster_regressions/multichar_slot_paths.tex
+++ b/latexml_oxide/tests/cluster_regressions/multichar_slot_paths.tex
@@ -1,0 +1,25 @@
+% A fontmap slot may hold MORE than one character (Perl returns the whole
+% string from `$$map[$code]`). Rust splits that across a single-char array plus
+% a `_fontmap_multichar` side table, so every decode path must consult BOTH.
+%
+% T2B slot 128 is U+04F6 + U+0336 (a stroked letter). Dropping the overlay
+% yields U+04F6 alone — a DIFFERENT letter.
+%
+% TS: \DeclareTextSymbol — decodes in the PREAMBLE, before any \fontencoding
+%     has loaded the T2B binding, and bakes the result into a primitive body.
+%     This is why the multichar lookup must preload the map itself.
+% SYM: \symbol at document time, when the map is already loaded — the easy
+%     path, which worked all along; here as a control.
+% MS: \DeclareMathSymbol — routes through mathchar's single-`char` decode.
+%     KNOWN REMAINING GAP, see the test.
+\documentclass{article}
+\makeatletter
+\DeclareTextSymbol{\mcA}{T2B}{128}
+\DeclareSymbolFont{myf}{T2B}{cmr}{m}{n}
+\DeclareMathSymbol{\mcM}{\mathord}{myf}{128}
+\makeatother
+\begin{document}
+TS[{\fontencoding{T2B}\selectfont\mcA}]
+SYM[{\fontencoding{T2B}\selectfont\symbol{128}}]
+MS[$\mcM$]
+\end{document}


### PR DESCRIPTION
Low-hanging follow-up to #455. Perl's `FontDecode` returns `$$map[$code]` whole, so a slot holding two characters works on every path. Rust splits the representation — single-`char` array plus a `_fontmap_multichar` side table — so every decode path must consult both. T2B slot 128 is U+04F6 + U+0336 COMBINING LONG STROKE OVERLAY; dropping the overlay leaves U+04F6, a **different letter**.

**Two defects, one symptom.** Fixing the first changed nothing, which is what exposed the second:

1. `\DeclareTextSymbol` called the single-`char` `font::decode`, which never consults the side table. Now `decode_str`.
2. An **ordering** defect in `lookup_multichar_override`: it read `{enc}_fontmap_multichar` from state but ran *before* `decode`, which is what triggers the binding load. So the first decode for an encoding missed the table and fell back to the array's single char. Not just a lost first call — `\DeclareTextSymbol` decodes in the **preamble**, before any `\fontencoding{T2B}`, and bakes the result into a primitive body, freezing the stripped letter for the whole document. Fixed by preloading the map in the override lookup, mirroring `load_font_map`'s own preload-then-read shape. Perl has no such hazard: one map, loaded first, slot already holds the string.

Verified against same-host Perl 0.8.8 — both engines now give [U+04F6, U+0336]; Rust gave [U+04F6].

### Known remaining gap — pinned, not silent

`\DeclareMathSymbol` routes through `mathchar.rs`, whose `props.glyph` is `Option<char>`. Carrying a pair needs that field to become a string — a real type change through the math-char pipeline, deliberately out of scope here rather than done badly. `declare_math_symbol_still_drops_the_overlay_known_gap` **asserts today's wrong value** and its doc comment says that fixing the gap *should* break it, with instructions to update.

### Guard

`tests/120_multichar_slot_paths.rs` — red before / green after on `\DeclareTextSymbol` (`left: [1270]`, `right: [1270, 822]`), with `\symbol` (map already loaded) as a control that stays green in **both** states, so a whole-path regression stays distinguishable.

Full workspace suite **1833 passed / 0 failed**.