### PR TITLE
ci: run tests with nextest, sharded 4 ways — the suite was serialized

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -12,11 +12,32 @@
 # ZERO doctests (`cargo test --doc --workspace` reports 0 passed), while CI
 # already invoked `cargo test --tests`, which excludes them too.
 
+# Tests that assert on the process's own RSS must never run beside each other.
+#
+# They drive a conversion to a `--max-memory` ceiling and require the COOPERATIVE
+# guard to name the breach (`Fatal:Timeout:MemoryBudget`). `cargo test` never ran
+# them concurrently — they live in different binaries, and binaries were
+# serialized — but nextest schedules across ALL binaries, so on a small runner
+# (macOS CI is 3 vCPU / 7 GB) the two of them overlapped, the machine went to
+# memory pressure, and the run died by a different path before the cooperative
+# guard could fire: non-zero exit but no Fatal line, failing
+# `115_streaming_cli` after 209 s. Caught by this change's own CI.
+#
+# `threads-required = "num-test-threads"` makes each of them occupy the WHOLE
+# concurrency budget, so it runs alone — exactly the guarantee `cargo test` gave
+# them implicitly. A `max-threads = 1` group would only stop the two from
+# overlapping EACH OTHER, leaving a heavy tikz/pgf sibling free to spike GBs
+# beside them, which is the same hazard by another name.
+
 [profile.default]
 # A failing run should report EVERY failure, not stop at the first binary —
 # the same reason the repo's canonical command carries `--no-fail-fast`.
 fail-fast = false
 failure-output = "immediate-final"
+
+[[profile.default.overrides]]
+filter = 'test(=streaming_flag_is_byte_identical_and_fatal_contract_holds) + test(=over_budget_build_degrades_gracefully_instead_of_being_killed)'
+threads-required = "num-test-threads"
 
 [profile.ci]
 fail-fast = false
@@ -30,3 +51,7 @@ test-threads = 2
 # test here is ~86 s locally and CI builds at opt-level=0, so 60 s is a
 # "tell me", not a failure; 20 periods (20 min) is the hard stop.
 slow-timeout = { period = "60s", terminate-after = 20 }
+
+[[profile.ci.overrides]]
+filter = 'test(=streaming_flag_is_byte_identical_and_fatal_contract_holds) + test(=over_budget_build_degrades_gracefully_instead_of_being_killed)'
+threads-required = "num-test-threads"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,32 @@
+# cargo-nextest configuration.
+#
+# WHY: `cargo test` runs each test BINARY to completion before starting the
+# next, parallelising only *within* a binary. This workspace has 122 test
+# targets whose in-binary execution sums to ~398 s, so that sum is the wall
+# floor no matter how many cores are free. nextest schedules every test as its
+# own process across all cores, making the critical path the slowest single
+# TEST. Measured back-to-back on the same 128-core box, same 1835 tests, both
+# green: `cargo test` 8:48.38 vs `cargo nextest run` 1:26.76 — 6.1x.
+#
+# Coverage is unchanged: nextest does not run doctests, and this workspace has
+# ZERO doctests (`cargo test --doc --workspace` reports 0 passed), while CI
+# already invoked `cargo test --tests`, which excludes them too.
+
+[profile.default]
+# A failing run should report EVERY failure, not stop at the first binary —
+# the same reason the repo's canonical command carries `--no-fail-fast`.
+fail-fast = false
+failure-output = "immediate-final"
+
+[profile.ci]
+fail-fast = false
+failure-output = "immediate-final"
+# GitHub's ubuntu-latest/macos runners are 4 vCPU / 16 GB, and a conversion is
+# memory-hungry: keep the historical concurrency of `--test-threads=2`. Under
+# nextest each test is its own PROCESS, so this is also strictly kinder to the
+# RSS fuse than 2 threads sharing one process's address space.
+test-threads = 2
+# Surface a hung test instead of letting it eat the job timeout. The slowest
+# test here is ~86 s locally and CI builds at opt-level=0, so 60 s is a
+# "tell me", not a failure; 20 periods (20 min) is the hard stop.
+slow-timeout = { period = "60s", terminate-after = 20 }

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -125,9 +125,24 @@ jobs:
         run: tools/miri_check.sh
 
   test:
-    name: latexml-oxide CI
+    # Sharded across 4 runners. The suite's cost is ~398 s of in-binary
+    # execution spread over 122 test targets, and `cargo test` runs those
+    # targets SEQUENTIALLY — so the test step was 18.7 min on Linux / 29.4 min
+    # on macOS while compilation (warm rust-cache) was only 2.2 / 4.7 min.
+    # Splitting the test list across runners is the fix that does NOT raise
+    # per-runner memory: each shard still runs 2 tests at a time inside its own
+    # 16 GB (see `test-threads` in .config/nextest.toml). `--partition` is
+    # exact — measured 524 + 462 + 433 + 416 = 1835, the whole suite.
+    name: latexml-oxide CI (shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     timeout-minutes: 50
+    strategy:
+      # One shard's failure must not cancel the others: we want the FULL
+      # failure picture from a red run, the same reason the local command
+      # carries --no-fail-fast.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     env:
       # Runner: ubuntu-latest = 4 vCPU / 16 GB RAM / ~14 GB disk.
       #
@@ -147,7 +162,7 @@ jobs:
       #    codegen-units; the profile fix addresses that directly.
       #  * mold linker — ~2-4× faster than ld and streams symbols
       #    rather than slurping into RAM.
-      #  * --test-threads=2 — pgf/tikz cells can spike to GB-scale
+      #  * test concurrency of 2 — pgf/tikz cells can spike to GB-scale
       #    working sets; conservative parallelism leaves headroom.
       CARGO_BUILD_JOBS: "2"
       CARGO_INCREMENTAL: "0"
@@ -217,11 +232,17 @@ jobs:
       # warm rust-cache hit this is a no-op; on a cold cache it's the main
       # memory-pressure phase and isolating it from the test phase is
       # what fits the job back inside the 16 GB runner budget.
+      - name: install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
       - name: build test binaries
-        run: cargo test --profile ci --tests --workspace --no-run
+        run: cargo nextest run --cargo-profile ci --profile ci --workspace --no-run
 
       - name: run tests
-        run: cargo test --profile ci --tests --workspace -- --test-threads=2
+        # `--cargo-profile ci` selects the Cargo profile; `--profile ci`
+        # selects the NEXTEST profile (.config/nextest.toml). They are
+        # different knobs that happen to share a name.
+        run: cargo nextest run --cargo-profile ci --profile ci --workspace --partition count:${{ matrix.shard }}/4
 
   # macOS mirror of the Linux job above (issue #217). Same `ci` profile,
   # same make-formats → build → run flow; only the platform deps differ:
@@ -234,12 +255,18 @@ jobs:
   # is documented in README.md but not gated here — it lacks the package set
   # the full suite needs.)
   macos:
-    name: latexml-oxide CI (macOS)
+    name: latexml-oxide CI (macOS shard ${{ matrix.shard }}/4)
     runs-on: macos-15
     # 3 vCPU / 7 GB RAM — tighter than the 16 GB Linux runner, so the same
     # RAM-tuned `ci` profile + jobs=2 apply; the cold build dominates, so
     # allow more wall-clock than the Linux leg.
     timeout-minutes: 120
+    # Sharded like the Linux leg, and this is where it pays most: macOS was the
+    # gating job at ~47 min, of which 29.4 min was the sequential test step.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     env:
       CARGO_BUILD_JOBS: "2"
       CARGO_INCREMENTAL: "0"
@@ -286,7 +313,13 @@ jobs:
         env:
           PROFILE: ci
         run: tools/make_formats.sh
+      - name: install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
       - name: build test binaries
-        run: cargo test --profile ci --tests --workspace --no-run
+        run: cargo nextest run --cargo-profile ci --profile ci --workspace --no-run
       - name: run tests
-        run: cargo test --profile ci --tests --workspace -- --test-threads=2
+        # `--cargo-profile ci` selects the Cargo profile; `--profile ci`
+        # selects the NEXTEST profile (.config/nextest.toml). They are
+        # different knobs that happen to share a name.
+        run: cargo nextest run --cargo-profile ci --profile ci --workspace --partition count:${{ matrix.shard }}/4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,14 @@ cargo build --no-default-features --features runtime-bindings --profile maxperf 
 
 **Important:** A compile-time plugin discovers test suite files. When adding a new `[name].tex` / `[name].xml` test pair, run `cargo clean` to force rediscovery.
 
+**Run the suite with `cargo nextest run --workspace`.** `cargo test` runs each of
+the ~122 test binaries to completion before starting the next, parallelising only
+*within* a binary, so its wall floor is the ~398 s sum of them. nextest schedules
+every test as its own process across all cores. Measured back-to-back, same 1835
+tests, both green: **8:48 → 1:27 (6.1×)**. Coverage is identical — nextest skips
+doctests and this workspace has none. `cargo test --workspace --tests
+--no-fail-fast` remains valid and is still the way to read a per-binary tally.
+
 Gates: `cargo clippy --workspace --all-targets -- -D warnings` and `cargo doc
 --workspace` (rustdoc warnings are errors) are enforced by CI's `lint` job and the
 pre-push hook. Rustdoc matters more than it looks — a broken intra-doc link renders as


### PR DESCRIPTION
**Diagnostic.** `cargo test` runs each test *binary* to completion before starting the next, parallelising only within a binary. This workspace has **122 test targets** whose in-binary execution sums to **~398 s**, so that sum was the wall floor regardless of free cores. CI paid the same tax and could not buy its way out with threads — the runners are 4 vCPU / 16 GB and a conversion is memory-hungry, hence `--test-threads=2`. The test step was **18.7 min on Linux / 29.4 min on macOS**, while compilation on a warm `rust-cache` was only 2.2 / 4.7 min.

**Approach.** Run tests with `cargo nextest` (one process per test, globally scheduled) and shard both jobs 4 ways with `--partition count:N/4` — more *runners*, not more threads, so per-runner memory is unchanged and each shard still runs 2 tests at a time inside its own 16 GB.

**Validation.** Measured back-to-back on the same box, same 1835 tests, both green: **`cargo test` 8:48.38 → `cargo nextest run` 1:26.76 (6.1×)**. Partitioning is exact — 524 + 462 + 433 + 416 = **1835**, the whole suite, nothing dropped or duplicated. Coverage is unchanged: nextest skips doctests, this workspace has **zero** (`cargo test --doc --workspace` → 0 passed), and CI already used `--tests`, which excludes them. `fail-fast: false` keeps a red run reporting every shard. Branch protection lists no required check names, so shard-suffixed job names break nothing. This PR's own CI is the end-to-end proof of the new workflow.

Expected: macOS, the gating job at ~47 min, drops to roughly 24; Linux ~28 → ~13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)