### PR TITLE
fix(math): stop freeing mid-parse — a use-after-free behind 22 corpus fatals

### DIFF
--- a/latexml_math_parser/src/data.rs
+++ b/latexml_math_parser/src/data.rs
@@ -265,3 +265,36 @@ mod tests {
     MATH_IDSTORE.with(|cell| assert!(cell.borrow().is_none()));
   }
 }
+
+thread_local! {
+  /// Subtrees discarded during math parsing, retained until the parse finishes.
+  static PENDING_DISCARDS: RefCell<Vec<Node>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Detach `node` now, free it AFTER math parsing.
+///
+/// Freeing mid-parse is a use-after-free: the parse holds live `Node` handles
+/// in several places at once — the formula list `parse_math` collects up front,
+/// the `MATH_IDSTORE` snapshot, `LOSTNODES`, XMDual bookkeeping — and a freed
+/// node's memory is promptly recycled. The observed crash read a node name
+/// whose bytes had already become `_pvis`, an attribute name from a later
+/// allocation (witness 2605.00812, 344 formulae, dies on the 305th; 14 such
+/// fatals in the 2026-07-30 sandbox-arxiv-2605 rerun).
+///
+/// Chasing those references one at a time does not converge — purging the
+/// idstore snapshot alone still segfaulted. Deferring closes every window at
+/// once, and it is bounded: under streaming, math parsing runs per FRAGMENT,
+/// so the queue is fragment-sized, not document-sized.
+///
+/// The node is UNLINKED immediately, so the tree — and therefore the output —
+/// is exactly as if it had been freed here.
+pub fn defer_discard(mut node: Node) {
+  node.unlink();
+  PENDING_DISCARDS.with(|cell| cell.borrow_mut().push(node));
+}
+
+/// Hand back everything queued by [`defer_discard`], for the caller to free once
+/// no parse state references it.
+pub fn take_pending_discards() -> Vec<Node> {
+  PENDING_DISCARDS.with(|cell| std::mem::take(&mut *cell.borrow_mut()))
+}

--- a/latexml_math_parser/src/parser.rs
+++ b/latexml_math_parser/src/parser.rs
@@ -843,7 +843,7 @@ impl MathParser {
                 // Dropped for good — unrecord any id it carries, then free
                 // (an unlinked doc-owned node otherwise leaks).
                 document.unrecord_node_ids(&xmref);
-                document.discard_subtree(xmref);
+                crate::data::defer_discard(xmref);
                 unlinks += 1;
               },
               Some(new_id) => {
@@ -874,6 +874,34 @@ impl MathParser {
       // manipulation (findnodes/set_attribute) after parse_math breaks Marpa
       // grammar precomputation for subsequent test runs. Applied in caller instead.
       note_end("Math Parsing");
+    }
+    // Everything discarded during the parse is freed HERE, once no parse state
+    // can still reach it: the up-front formula list is exhausted, the
+    // `MATH_IDSTORE` snapshot is cleared, LOSTNODES is drained, and the kludge
+    // pass (which discards too) has run. Freeing at the discard sites instead
+    // is a use-after-free — see `crate::data::defer_discard`.
+    // A queued subtree can CONTAIN another queued node — the parse discards a
+    // wrapper and, separately, something inside it — so freeing naively double
+    // frees ("double free or corruption (out)"). Testing the inner entry
+    // afterwards does not work either: `free_subtree` neutralizes only the
+    // wrappers registered with the document, so an unregistered handle keeps a
+    // dangling pointer that still looks live.
+    //
+    // Record every pointer in a subtree BEFORE releasing it — while the memory
+    // is still valid to walk — and skip anything already covered.
+    let mut released: rustc_hash::FxHashSet<usize> = rustc_hash::FxHashSet::default();
+    fn mark(node: &Node, released: &mut rustc_hash::FxHashSet<usize>) {
+      released.insert(node.to_hashable());
+      for child in node.get_child_nodes() {
+        mark(&child, released);
+      }
+    }
+    for node in crate::data::take_pending_discards() {
+      if released.contains(&node.to_hashable()) {
+        continue;
+      }
+      mark(&node, &mut released);
+      document.discard_subtree(node);
     }
     Ok(())
   }
@@ -976,7 +1004,7 @@ impl MathParser {
         let _ = new_app.add_child(&mut xmref);
         // replace_tree_free: new_app is a standalone built tree — copied
         // into place, then both it and the replaced XMRef are freed.
-        let _ = document.replace_tree_free(new_app, ref_node);
+        let _ = replace_tree_deferred(document, new_app, ref_node);
       }
     }
     Ok(())
@@ -1074,7 +1102,33 @@ impl MathParser {
     // foreach my $n ($document->findnodes("descendant-or-self::*[\@xml:id]",
     // $xnode)) {     my $id = $n->getAttribute('xml:id');
     //     $LaTeXML::MathParser::IDREFS{$id} = $n; }
-    let mut p = xnode.get_parent().unwrap();
+    // The formula list is collected UP FRONT (`parse_math`'s `findnodes`), but
+    // parsing one formula can free another's node — the discard sites in this
+    // file free C-side memory now and neutralize the Rust wrappers with it
+    // (libxml 0.3.17 `free_subtree`; before that a discarded node merely
+    // leaked, so it stayed reachable and this could not be observed). A
+    // detached entry then reaches us with no parent, and this used to
+    // `unwrap()` — a PANIC that killed the whole conversion: 14 documents in
+    // the 2026-07-30 sandbox-arxiv-2605 rerun went error -> fatal on exactly
+    // this line, witness 2605.00812 (344 formulae, dies on the 305th).
+    //
+    // There is nothing to parse in a node that is no longer in the document,
+    // so skip it — but say so, because a formula vanishing from the tree is
+    // not something to pass over in silence.
+    let Some(mut p) = xnode.get_parent() else {
+      // A formula queued by `parse_math`'s up-front scan is no longer in the
+      // document. That must not happen now that discards are deferred
+      // (`crate::data::defer_discard`), so reaching here means the tree was
+      // mutated underneath the parse — and CONTINUING is the dangerous option:
+      // an earlier version of this guard skipped instead, kept parsing a
+      // corrupt tree, and turned a panic into a SIGSEGV. Stop this conversion
+      // cleanly, with a named cause and whatever output already exists.
+      fatal!(
+        XMath,
+        Malformed,
+        "an XMath node was detached before it could be parsed"
+      );
+    };
     match self.parse_rec(xnode, "Anything,", document)? {
       Some(result) => {
         // Add text representation to the containing Math element.
@@ -1182,13 +1236,13 @@ impl MathParser {
               .pop()
               .expect("append_tree appended the parse result");
             for child in old_children {
-              document.discard_subtree(child);
+              crate::data::defer_discard(child);
             }
             if let Some(root) = result_root {
               // The result was a standalone built tree (not one of the old
               // children); free it too — disjoint from the frees above (a
               // detached root has no parent, old children had one).
-              document.discard_subtree(root);
+              crate::data::defer_discard(root);
             }
           } else {
             // Replace the whole node for XMArg, XMWrap; preserve some attributes
@@ -1236,7 +1290,7 @@ impl MathParser {
               document.set_attribute(&mut result, &key, &value)?;
               // }
             }
-            if let Some(r) = document.replace_tree_free(result.clone(), node)? {
+            if let Some(r) = replace_tree_deferred(document, result.clone(), node)? {
               result = r;
             }
             // If replace_tree_free returns None, node was already detached
@@ -1473,14 +1527,14 @@ impl MathParser {
     }
     for child in &discarded {
       if !replacements.contains(child) {
-        document.discard_subtree(child.clone());
+        crate::data::defer_discard(child.clone());
       }
     }
     for shell in unwrapped_shells {
       // A fresh wrapper from the CLOSE branch; an ORIGINAL XMWrap child was
       // already freed through `discarded` above — don't free it twice.
       if !discarded.contains(&shell) {
-        document.discard_subtree(shell);
+        crate::data::defer_discard(shell);
       }
     }
     // D3b: the replacements re-parented above may carry xml:id attrs
@@ -1683,7 +1737,7 @@ impl MathParser {
           }
         }
         for root in garbage_roots {
-          document.discard_subtree(root);
+          crate::data::defer_discard(root);
         }
         let result = element_nodes(mathnode).remove(0);
         //END reparent.
@@ -3275,6 +3329,24 @@ fn p_get_attribute(item: &Node, key: &str) -> Option<String> {
   } else {
     None
   }
+}
+
+/// `Document::replace_tree_free`, with the FREE deferred to the end of math
+/// parsing — see [`crate::data::defer_discard`] for why freeing mid-parse is a
+/// use-after-free. The tree ends up identical; only the moment of `xmlFreeNode`
+/// moves.
+fn replace_tree_deferred(document: &mut Document, new: Node, old: Node) -> Result<Option<Node>> {
+  // Resolve new's standalone root BEFORE the swap, exactly as
+  // `replace_tree_free` does — afterwards the chain may no longer be walkable.
+  let new_root = detached_root(&new);
+  let inserted = document.replace_tree(new, old.clone())?;
+  if inserted.is_some() {
+    crate::data::defer_discard(old);
+    if let Some(root) = new_root {
+      crate::data::defer_discard(root);
+    }
+  }
+  Ok(inserted)
 }
 
 #[cfg(test)]

--- a/latexml_oxide/tests/110_acmart_description_aria.rs
+++ b/latexml_oxide/tests/110_acmart_description_aria.rs
@@ -342,3 +342,65 @@ fn description_never_loses_an_annotation() {
     assert!(html.contains(text), "{text} was lost:\n{html}");
   }
 }
+
+/// A `\Description` in a TABLE float is the author doing exactly what acmart
+/// asks — a table has no image, so the table itself is where the description
+/// belongs. That must be reported as INFO, never as a warning.
+///
+/// It was a warning until 2026-07-30, and it dominated the regressions in that
+/// day's `sandbox-arxiv-2605` rerun: 27 of 45 sampled documents that fell from
+/// `no_problem` to `warning` carried this one message, purely for having a
+/// described table.
+const TEX_TABLE: &str = "\\documentclass[acmsmall]{acmart}\n\
+  \\usepackage{graphicx}\n\
+  \\begin{document}\n\
+  \\begin{table}\n\
+  \\caption{A table with no image in it}\n\
+  \\begin{tabular}{ll}a & b\\\\c & d\\end{tabular}\n\
+  \\Description[TABLESHORT]{TABLELONG description of the tabular data}\n\
+  \\end{table}\n\
+  \\end{document}\n";
+
+#[test]
+fn a_described_table_is_reported_as_info_not_a_warning() {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  let workdir = tempfile::tempdir().expect("create tempdir");
+  std::fs::write(workdir.path().join("t.tex"), TEX_TABLE).expect("write t.tex");
+
+  let output = Command::new(bin)
+    .args([
+      "t.tex",
+      "--dest",
+      "t.html",
+      "--format",
+      "html5",
+      "--nocomments",
+    ])
+    .current_dir(workdir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+  let stderr = String::from_utf8_lossy(&output.stderr);
+  let html = std::fs::read_to_string(workdir.path().join("t.html")).unwrap_or_default();
+  assert!(!html.is_empty(), "no HTML produced:\n{stderr}");
+
+  // The description must still be attached — this is a severity change, not a
+  // behaviour change.
+  assert!(
+    html.contains("aria-describedby="),
+    "the table must still carry the description:\n{html}",
+  );
+  assert!(
+    html.contains("TABLELONG"),
+    "the long description text must survive into the HTML:\n{html}",
+  );
+
+  // …and the paper must stay clean. A described table is not an anomaly.
+  assert!(
+    !stderr.contains("Warning:unexpected:\\Description"),
+    "a described TABLE must not warn — it is the expected shape:\n{stderr}",
+  );
+  assert!(
+    !stderr.contains("Error:"),
+    "expected a clean conversion:\n{stderr}",
+  );
+}

--- a/latexml_package/src/package/acmart_cls.rs
+++ b/latexml_package/src/package/acmart_cls.rs
@@ -313,21 +313,35 @@ LoadDefinitions!({
           described_by.push(id);
           add_describedby(document, &mut figure, &described_by)?;
           let host = figure.get_name();
-          let why = if !graphics.is_empty() {
-            s!("it holds more than one image, so which one is described is ambiguous")
-          } else if host == "figure" || host == "table" {
-            s!("the float has no image to describe (a table, or a \\Description \
-                written before its \\includegraphics)")
+          if graphics.is_empty() && host == "table" {
+            // NOT a fallback: a table float has no image BY CONSTRUCTION, and
+            // acmart asks for a `\Description` on every float — so the table
+            // itself is where the description belongs, and this is the author
+            // doing the right thing. Warning here demoted otherwise-clean
+            // papers: 27 of 45 sampled `no_problem -> warning` regressions in
+            // the 2026-07-30 sandbox-arxiv-2605 rerun were this one message.
+            // Report it (the attachment point is worth knowing), as INFO.
+            Info!("aria", "\\Description",
+              &s!("attached to the enclosing <table> as aria:describedby — a \
+                   table has no image to describe, so this is where the \
+                   description belongs"));
           } else {
-            // Not a float at all — `\Description` outside a figure/table, where
-            // acmart's own `\@Description@present` bookkeeping expects it.
-            s!("it is outside any figure or table, so there is no image to describe")
-          };
-          Warn!("unexpected", "\\Description",
-            &s!("attached to the enclosing <{host}> as aria:describedby, because \
-                 {why}. The text is still announced, but it is not any image's \
-                 alt text; put a \\Description after the \\includegraphics it \
-                 describes, or use \\includegraphics[alt=...] per image"));
+            let why = if !graphics.is_empty() {
+              s!("it holds more than one image, so which one is described is ambiguous")
+            } else if host == "figure" {
+              s!("the float has no image to describe (a \\Description written \
+                  before its \\includegraphics, or a figure with no graphic)")
+            } else {
+              // Not a float at all — `\Description` outside a figure/table,
+              // where acmart's own `\@Description@present` bookkeeping expects it.
+              s!("it is outside any figure or table, so there is no image to describe")
+            };
+            Warn!("unexpected", "\\Description",
+              &s!("attached to the enclosing <{host}> as aria:describedby, because \
+                   {why}. The text is still announced, but it is not any image's \
+                   alt text; put a \\Description after the \\includegraphics it \
+                   describes, or use \\includegraphics[alt=...] per image"));
+          }
         },
       }
     }


### PR DESCRIPTION
Both fixes came out of triaging the 2026-07-30 `sandbox-arxiv-2605` rerun (30,079 docs), which improved in aggregate — 566 improved vs 279 regressed, errors 4,143 → 3,974 — while hiding two distinct regressions underneath.

**1. Use-after-free in math parsing (the severe one).** 22 papers went fatal on a single bug: 14 `error→fatal`, 7 `warning→fatal`, 1 `no_problem→fatal`, all `parser.rs:1077: called Option::unwrap() on a None value`. The node was not merely detached — it was **freed and recycled**: a symbolized backtrace (witness `2605.00812`, 344 formulae, dies on the 305th) lands in `resolve_xmref` → `Node::get_name()` on a name pointer of `0x736976705f`, the ASCII bytes `_pvis` — an XMDual attribute name from a later allocation sitting in the corpse.

Cause is #448's discard sites. Freeing only became *real* in libxml 0.3.17 (`free_subtree`); before that a discarded subtree merely leaked, so stale handles stayed readable. But a math parse holds live `Node` handles in several places at once — the formula list collected up front, the `MATH_IDSTORE` snapshot, LOSTNODES, XMDual bookkeeping — so freeing at the discard site releases memory the parse still uses. Purging just the idstore snapshot **still segfaulted**, so this defers *all* frees to the end of `parse_math`, closing every window at once. Bounded: under streaming, math parsing runs per fragment.

Two traps, both pinned in comments: a queued subtree can contain another queued node (naive drain → `double free or corruption (out)`), and testing an entry afterwards doesn't work because `free_subtree` neutralizes only document-registered wrappers. Pointers are recorded *before* release, while still safe to walk.

The parentless case now raises a named Fatal rather than `unwrap`. An interim version *skipped* instead, kept parsing a corrupt tree, and converted the panic into a **SIGSEGV** — failing fast is the safer contract, and it keeps the partial output.

**2. `\Description` on a table was reported as a defect.** 27 of 45 sampled `no_problem→warning` regressions carried `Warning:unexpected:\Description`. Nothing was wrong with those papers: acmart asks for a `\Description` on every float, a table has no image by construction, so attaching it to the table is correct. Now `Info:aria:\Description`; the multi-image and image-less-*figure* arms keep their Warning because those are real anomalies.

**Validation.** Witness converts (exit 0, 1,798,028 bytes, 0 panics, **0 detached formulas** — so those formulas are real content that now parses, not garbage being skipped). **All 14** `error→fatal` documents re-run with no crash. Suite **1836/0**, clippy + fmt clean.

Not included, tracked separately: the remaining `warning→error` regressions are diverse (`\g_luabridge_method_int`, babel, `\lst@TestEOLChar`), and the 2 `no_problem→error` `post/xpath` entries are #451 deliberately surfacing a previously-silent `ltx:XMath` failure — plausibly the same corrupt DOM, so worth re-checking after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)