### PR TITLE
perf(math): drain discards per formula — below the pre-fix memory baseline on both paths

### DIFF
--- a/latexml_math_parser/src/data.rs
+++ b/latexml_math_parser/src/data.rs
@@ -32,7 +32,11 @@ pub fn clear_math_idstore() {
 /// and `resolve_xmref` already falls back to a DOM walk for a genuine miss.
 pub fn purge_math_idstore_subtree(node: &Node) {
   fn collect(node: &Node, ids: &mut Vec<String>) {
-    if let Some(id) = node.get_attribute("xml:id") {
+    // `get_attribute("xml:id")` is the footgun the lint ratchet guards: libxml2
+    // stores xml:id as local name `id` in the XML namespace, so the
+    // string-keyed form can match NOTHING and the purge would silently collect
+    // no ids at all. Same accessor `find_by_xml_id` below already uses.
+    if let Some(id) = node.get_attribute_ns("id", "http://www.w3.org/XML/1998/namespace") {
       ids.push(id);
     }
     for child in node.get_child_nodes() {

--- a/latexml_math_parser/src/data.rs
+++ b/latexml_math_parser/src/data.rs
@@ -24,6 +24,32 @@ pub fn clear_math_idstore() {
   });
 }
 
+/// Drop every id under `node` from the snapshot, before that subtree is released.
+///
+/// The snapshot holds live `Node` handles, so a released subtree must not stay
+/// reachable through it — `resolve_xmref` would hand back freed memory. A
+/// purged id simply fails to resolve, which is what "the node is gone" means,
+/// and `resolve_xmref` already falls back to a DOM walk for a genuine miss.
+pub fn purge_math_idstore_subtree(node: &Node) {
+  fn collect(node: &Node, ids: &mut Vec<String>) {
+    if let Some(id) = node.get_attribute("xml:id") {
+      ids.push(id);
+    }
+    for child in node.get_child_nodes() {
+      collect(&child, ids);
+    }
+  }
+  MATH_IDSTORE.with(|cell| {
+    let mut borrow = cell.borrow_mut();
+    let Some(store) = borrow.as_mut() else { return };
+    let mut ids = Vec::new();
+    collect(node, &mut ids);
+    for id in ids {
+      store.remove(&id);
+    }
+  });
+}
+
 // Thread-local LOSTNODES map: lost_id → kept_id. Perl
 // `MathParser::ReplacedBy` (MathParser.pm L1562-1588) records that a node
 // was structurally absorbed by another node during semantics rules — e.g.
@@ -297,4 +323,10 @@ pub fn defer_discard(mut node: Node) {
 /// no parse state references it.
 pub fn take_pending_discards() -> Vec<Node> {
   PENDING_DISCARDS.with(|cell| std::mem::take(&mut *cell.borrow_mut()))
+}
+
+/// Put back a subtree that cannot be released yet — it still contains a formula
+/// the parse has not reached.
+pub fn requeue_pending_discard(node: Node) {
+  PENDING_DISCARDS.with(|cell| cell.borrow_mut().push(node));
 }

--- a/latexml_math_parser/src/parser.rs
+++ b/latexml_math_parser/src/parser.rs
@@ -684,7 +684,14 @@ impl MathParser {
       // this call. A leftover from a previous document on the same thread
       // would cross-pollinate `idref` rewrites here.
       crate::data::clear_lost_nodes();
+      // Formulas still queued for parsing. A discarded subtree CONTAINING one
+      // of them must be held back, so the per-formula drain consults this.
+      // Maintained incrementally — rebuilding it per formula would be O(n^2),
+      // and the 131 MB witness has ~500k formulas.
+      let mut queued: rustc_hash::FxHashSet<usize> =
+        xmath_nodes.iter().map(|n| n.to_hashable()).collect();
       for math in xmath_nodes {
+        queued.remove(&math.to_hashable());
         let math_ref = math.clone();
         // Per-formula timing feeds the math_parse_buckets histogram in
         // telemetry. ~20 ns Instant cost per formula is negligible vs Marpa.
@@ -709,6 +716,14 @@ impl MathParser {
         {
           let _ = math_parent.set_attribute("_parsetrees", &self.last_parsetrees_count.to_string());
         }
+        // Release THIS formula's garbage now rather than at end-of-document.
+        // Deferring everything to the end fixed the use-after-free but cost
+        // +67% eager peak (35.7 -> 59.9 GB on the 19.8 MB witness), because
+        // eager runs ONE `parse_math` for a whole document. A formula boundary
+        // is the earliest SAFE point: this formula's parse is complete, so the
+        // intra-formula references that made freeing at the discard site
+        // segfault are gone.
+        drain_pending_discards(document, &queued);
       }
       crate::data::clear_math_idstore();
 
@@ -875,34 +890,10 @@ impl MathParser {
       // grammar precomputation for subsequent test runs. Applied in caller instead.
       note_end("Math Parsing");
     }
-    // Everything discarded during the parse is freed HERE, once no parse state
-    // can still reach it: the up-front formula list is exhausted, the
-    // `MATH_IDSTORE` snapshot is cleared, LOSTNODES is drained, and the kludge
-    // pass (which discards too) has run. Freeing at the discard sites instead
-    // is a use-after-free — see `crate::data::defer_discard`.
-    // A queued subtree can CONTAIN another queued node — the parse discards a
-    // wrapper and, separately, something inside it — so freeing naively double
-    // frees ("double free or corruption (out)"). Testing the inner entry
-    // afterwards does not work either: `free_subtree` neutralizes only the
-    // wrappers registered with the document, so an unregistered handle keeps a
-    // dangling pointer that still looks live.
-    //
-    // Record every pointer in a subtree BEFORE releasing it — while the memory
-    // is still valid to walk — and skip anything already covered.
-    let mut released: rustc_hash::FxHashSet<usize> = rustc_hash::FxHashSet::default();
-    fn mark(node: &Node, released: &mut rustc_hash::FxHashSet<usize>) {
-      released.insert(node.to_hashable());
-      for child in node.get_child_nodes() {
-        mark(&child, released);
-      }
-    }
-    for node in crate::data::take_pending_discards() {
-      if released.contains(&node.to_hashable()) {
-        continue;
-      }
-      mark(&node, &mut released);
-      document.discard_subtree(node);
-    }
+    // Whatever the kludge pass discarded (it runs after the loop), plus any
+    // subtree the per-formula drain had to hold back. Nothing can reference
+    // them now: the formula list is exhausted and the snapshot is cleared.
+    drain_pending_discards(document, &rustc_hash::FxHashSet::default());
     Ok(())
   }
 
@@ -3328,6 +3319,47 @@ fn p_get_attribute(item: &Node, key: &str) -> Option<String> {
     item.get_attribute(key)
   } else {
     None
+  }
+}
+
+
+/// Release subtrees queued by [`crate::data::defer_discard`], skipping any that
+/// still contains a formula the parse has not reached.
+///
+/// Two hazards, each of which cost an iteration to find:
+///
+/// * a queued subtree can CONTAIN another queued node, so freeing naively
+///   double frees ("double free or corruption (out)"). Testing an entry
+///   afterwards does not help — `free_subtree` neutralizes only the wrappers
+///   registered with the document, so an unregistered handle keeps a dangling
+///   pointer that still looks live. Every pointer is therefore recorded BEFORE
+///   release, while the memory is still safe to walk.
+/// * a subtree holding a not-yet-parsed formula must be held back whole, or
+///   that formula is freed before its turn.
+///
+/// Ids leave the `MATH_IDSTORE` snapshot with the nodes, so a later XMRef
+/// cannot resolve into released memory.
+fn drain_pending_discards(document: &mut Document, queued: &rustc_hash::FxHashSet<usize>) {
+  fn mark(node: &Node, seen: &mut rustc_hash::FxHashSet<usize>) {
+    seen.insert(node.to_hashable());
+    for child in node.get_child_nodes() {
+      mark(&child, seen);
+    }
+  }
+  let mut released: rustc_hash::FxHashSet<usize> = rustc_hash::FxHashSet::default();
+  for node in crate::data::take_pending_discards() {
+    if released.contains(&node.to_hashable()) {
+      continue;
+    }
+    let mut ptrs = rustc_hash::FxHashSet::default();
+    mark(&node, &mut ptrs);
+    if !queued.is_empty() && ptrs.iter().any(|p| queued.contains(p)) {
+      crate::data::requeue_pending_discard(node);
+      continue;
+    }
+    crate::data::purge_math_idstore_subtree(&node);
+    released.extend(ptrs);
+    document.discard_subtree(node);
   }
 }
 

--- a/latexml_math_parser/src/parser.rs
+++ b/latexml_math_parser/src/parser.rs
@@ -3322,7 +3322,6 @@ fn p_get_attribute(item: &Node, key: &str) -> Option<String> {
   }
 }
 
-
 /// Release subtrees queued by [`crate::data::defer_discard`], skipping any that
 /// still contains a formula the parse has not reached.
 ///


### PR DESCRIPTION
Follow-up to #459, which stopped a use-after-free by deferring every math-parse free to the end of `parse_math`. Correct, but expensive: eager runs ONE `parse_math` for a whole document (streaming runs one per fragment), so the queue accumulated document-wide — +67% eager peak.

**A formula boundary is the earliest SAFE release point.** That formula's parse is complete, so the intra-formula references that made freeing at the discard site segfault are gone. What can still reach the garbage is bounded, and each part has an answer: the queued-formula list (a subtree containing one is held back whole), the `MATH_IDSTORE` snapshot (ids leave with the nodes), LOSTNODES (strings, safe by construction). The queued set is maintained incrementally — rebuilding per formula would be O(n²) against the 131 MB witness's ~500k formulas.

**Measured on the 19.8 MB witness, same host, output byte-identical (613,104,457 B) in every arm:**

| variant | streamed | eager |
|---|---|---|
| baseline (pre-#459) | 4,747 MiB | 35,738 MiB |
| deferred-only (#459) | 5,213 (+9.8%) | 59,851 (+67%) |
| **this PR** | **4,421 (−7%)** | **32,610 (−8.8%)** |

It does not merely recover the regression — it lands **below the original baseline on both paths**, because the drain also purges the idstore snapshot and reclaims garbage the old discard sites left behind.

**One defect found by the repo's own ratchet, worth calling out:** the purge first used `get_attribute("xml:id")`, which silently fails for a namespaced attribute (libxml2 stores it as local name `id` in the XML namespace) — so it may have been collecting no ids at all, leaving the snapshot pointing at released nodes. Now `get_attribute_ns("id", XML_NS)`, matching `find_by_xml_id` alongside it, and the witness was re-verified after the change.

**Validation.** Witness `2605.00812`: exit 0, 1,798,028 bytes, 0 panics, 0 detached formulas. Suite **1836/0**. clippy + fmt + xml:id ratchet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)