### PR TITLE
release: 0.7.5-rc4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,33 @@
     5-million-line book that could not be converted at all now completes within
     a 48 GB budget (28.1 GB peak, 2.66 GB of XML). Output is byte-identical to
     the normal path.
+  - **Post-processing no longer holds the whole site in memory** — pages are
+    scanned once, then rendered and written one at a time, so peak memory
+    follows a single page instead of the page count. A 40,201-page document
+    that grew to 80 GB and wrote nothing now completes flat at 16 GB, and the
+    stage is 2.5x faster (27:04 -> 10:48) with byte-identical output.
+  - **A query that cannot be answered is an error, not an empty result** —
+    whole-document XPath silently returned "no matches" when libxml2 refused
+    it, so on a large document nothing was cross-referenced, no MathML was
+    generated, and a 0-byte page was written with a success exit code. Those
+    queries are now answered by traversal, and a genuine failure says so.
+  - **Math parsing no longer frees nodes it is still using** — discarded
+    subtrees are released at a formula boundary rather than at the discard
+    site. The use-after-free behind this crashed 22 papers in a
+    30,000-document corpus run, and its formulas were real content, not
+    garbage. Releasing per formula also uses **less** memory than before the
+    fix: a 19.8 MB book peaks 7% lower streamed and 9% lower on the plain
+    path.
+  - **A `\Description` on a table is expected, not a defect** — acmart asks for
+    one on every float and a table has no image, so attaching the description
+    to the table is reported as information rather than a warning that demoted
+    otherwise-clean papers.
+  - **A memory limit set by a container is honoured** — the ceiling was derived
+    from the host's RAM, so a memory-limited container chose a budget it could
+    never reach and was killed by the kernel instead of stopping gracefully.
+  - **Post-processing stops gracefully rather than being killed** — it had no
+    cooperative memory check at all, so an oversized run died at the hard
+    ceiling with nothing written; pages that finish are now kept.
   - **`--max-memory` is the budget, and everything follows from it** — the
     graceful-Fatal fuse, the point where spilling begins, and the fragment size
     are all derived, so no two memory settings can contradict each other. The

--- a/latexml_oxide/Cargo.toml
+++ b/latexml_oxide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml"
-version = "0.7.5-rc3"
+version = "0.7.5-rc4"
 edition = "2024"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
 license = "CC0-1.0"


### PR DESCRIPTION
Version bump plus the changelog for what rc4 carries beyond rc3.

**Accepted on the real artifact and the real witness.** Built with the shipping recipe (`--no-default-features --features runtime-bindings --profile maxperf`, fat LTO, `panic=abort`) and run end to end on Nasser Abbasi's 131 MB `flat_index.tex`:

| stage | exit | wall | peak RSS | output |
|---|---|---|---|---|
| core (streaming, `--max-memory 48000`) | **0** | 1:10:29 | **29,836 MiB** | 2,676,923,786 B XML, 1 error |
| post (`--splitat subsubsection`) | **0** | 30:19 | 62,278 MiB | **115,519 pages**, 10.7 GB HTML, **0 errors** |

Core peak is 0.2% off the pre-change baseline (29,768 MiB) and sits well under its 36,000 MiB fuse, so the memory work costs this document nothing.

**The HTML is healthy, checked rather than assumed.** Over a 400-page sample: 89% carry math (1,422 `<math>`), 81% carry paragraphs, `xmllint` reports zero complaints, and there is exactly **one** distinct error payload — `{nowrap}`, an undefined macro in the author's own source (his `.rhai` bindings for it are empty stubs), rendered once on the pages that use it. No placeholder ids, no other error class.

**What landed since rc3**, each measured:
- **Post-processing holds one page, not the whole site** — a 40,201-page document that grew to 80 GB and wrote *nothing* now completes flat at 16 GB, 2.5× faster (27:04 → 10:48), byte-identical output (#451).
- **A query that cannot be answered is an error** — whole-document XPath silently returned "no matches" when libxml2 refused it, so large documents got no cross-references, no MathML, and a 0-byte page with a success exit code (#451).
- **Math parsing no longer frees nodes it is still using** — the use-after-free behind **22 corpus fatals**; releasing per formula instead leaves memory *below* the pre-fix baseline (−7% streamed, −8.8% eager) (#459, #460).
- **A described table is information, not a warning** — acmart requires `\Description` on every float and a table has no image, so clean papers were being demoted (#459).
- **A container's memory limit is honoured** (#461); **post stops gracefully instead of being hard-killed** (#462).
- **CI sharded** — gating job 47 → 28 min (#458).

**Corpus verification.** Clean rerun of sandbox-arxiv-2605 + 2606 (60,505 documents) on a quiet box: fatals **276 → 254** and **261 → 238**, matching the panic count. All 54 `parser.rs:1077` panics across both corpora fixed. Suite 1836/0. Perl-oracle markup parity on a 15-page split book (197/197 navigation links identical).

**Known limits, tracked not hidden:** the 131 MB witness's *post* stage needs an explicit `--max-memory` raise (~64 GB) because Split parses the whole document once — #147; and #159 (missing generator timestamp) awaits a policy decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
