### PR TITLE
fix(windows): MEMORYSTATUSEX — this arm had never compiled

### DIFF
--- a/latexml_core/src/watchdog.rs
+++ b/latexml_core/src/watchdog.rs
@@ -132,11 +132,16 @@ pub fn total_memory_bytes() -> Option<u64> {
   }
   #[cfg(windows)]
   {
-    use windows_sys::Win32::System::SystemInformation::{
-      GLOBAL_MEMORY_STATUS_EX, GlobalMemoryStatusEx,
-    };
-    let mut status: GLOBAL_MEMORY_STATUS_EX = unsafe { std::mem::zeroed() };
-    status.dwLength = std::mem::size_of::<GLOBAL_MEMORY_STATUS_EX>() as u32;
+    // `MEMORYSTATUSEX` is what windows-sys calls this, mirroring the Win32
+    // header. This arm originally said `GLOBAL_MEMORY_STATUS_EX` — a spelling
+    // from a different generation of the bindings — while Cargo.toml pinned
+    // `windows-sys = "0.61"`, so it never matched the version it declared and
+    // has NEVER compiled. It survived because CI builds Linux and macOS only:
+    // the first Windows compile of this file was the 0.7.5-rc4 RELEASE
+    // workflow, on a tag, days after the code landed. See task #164.
+    use windows_sys::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
+    let mut status: MEMORYSTATUSEX = unsafe { std::mem::zeroed() };
+    status.dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
     // SAFETY: `status` is a correctly sized, zeroed struct with `dwLength` set,
     // exactly as the API requires.
     if unsafe { GlobalMemoryStatusEx(&mut status) } != 0 {


### PR DESCRIPTION
**Diagnostic.** The rc4 release workflow failed its Windows leg with

```
error[E0432]: unresolved import
  windows_sys::Win32::System::SystemInformation::GLOBAL_MEMORY_STATUS_EX
```

windows-sys calls that struct `MEMORYSTATUSEX`, mirroring the Win32 header. `GLOBAL_MEMORY_STATUS_EX` is a spelling from a different generation of the bindings — and `latexml_core/Cargo.toml` has pinned `windows-sys = "0.61"` since the code was written (#435, 2026-07-29). So the arm never matched the version it declares and **has never compiled**. rc3 was tagged 2026-07-26, three days earlier, so rc4's Windows leg is the first compile of this file, full stop.

*(An earlier draft of this description blamed dependency drift through an untracked `Cargo.lock`. That was wrong — the version requirement is correct and pinned; the code simply did not match it.)*

**Approach.** Use the name the pinned version exports. `GetDiskFreeSpaceExW`, the only other windows-sys symbol in the tree, was audited at the same time and is correct for 0.61.

**Validation, against the real target rather than by reading.** A full workspace check for `x86_64-pc-windows-msvc` cannot run on Linux — the C build scripts invoke `cc-rs`, which fails with `failed to find tool "lib.exe"` — which is exactly why this arm went unexercised. So both Windows arms were lifted verbatim into a throwaway crate depending only on `windows-sys`, and that **type-checks under `--target x86_64-pc-windows-msvc` with windows-sys 0.61.2**. Linux unaffected: clippy clean, `watchdog` tests 9/0.

**The real defect is process, not spelling — filed as #164.** CI builds ubuntu and macOS only, so `#[cfg(windows)]` code in `latexml_core` is first compiled by the *release* workflow, on a *tag*, after lint, miri and 1836 tests have gone green. A `cargo check` on a windows runner would have caught this in the PR that introduced it, three days earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
