### PR TITLE
fix(windows): --max-memory was never enforced on Windows (+ 3 Windows-only lint/test gaps)

### DIFF
--- a/latexml_core/Cargo.toml
+++ b/latexml_core/Cargo.toml
@@ -100,5 +100,7 @@ libc = "0.2"
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = [
   "Win32_System_SystemInformation",
+  "Win32_System_ProcessStatus",
+  "Win32_System_Threading",
   "Win32_Storage_FileSystem",
 ] }

--- a/latexml_core/src/watchdog.rs
+++ b/latexml_core/src/watchdog.rs
@@ -49,13 +49,11 @@
 //! machine-derived default ceiling ([`default_ceiling_mib`](crate::watchdog::default_ceiling_mib)) and the
 //! spill-headroom check, so those behave identically on every supported OS.
 //!
-//! **Still Linux-only:** [`process_rss_kb`](crate::watchdog::process_rss_kb) samples `/proc/self/status`, so the
-//! *enforcement* half of the RAM guard is inactive elsewhere — the ceiling is
-//! computed correctly but never checked, and only the time guard bites. Closing
-//! this needs macOS `task_info(TASK_BASIC_INFO)` and Windows
-//! `GetProcessMemoryInfo`; both are reachable through the crates this module
-//! already links, so it is a bounded follow-up rather than a new dependency
-//! question.
+//! **Enforcement, also portable:** [`process_rss_kb`](crate::watchdog::process_rss_kb) — the half that actually
+//! checks live usage against the ceiling — answers on all three: Linux samples
+//! `/proc/self/status`, macOS asks libproc (`proc_pidinfo`), and Windows uses
+//! `GetProcessMemoryInfo`. So the memory ceiling is both computed *and* checked
+//! on every supported OS; other targets fall back to `None` (time guard only).
 
 use std::{
   sync::{
@@ -102,8 +100,31 @@ pub fn process_rss_kb() -> Option<u64> {
   (got == size).then(|| info.pti_resident_size / 1024)
 }
 
+/// Windows: `GetProcessMemoryInfo`'s `WorkingSetSize` is this process's resident
+/// set — the RSS analog the cooperative ceiling needs. Without it the whole
+/// `--max-memory` ceiling silently did not exist on Windows (exactly as it did
+/// not on macOS before the libproc arm), and the `115_streaming_cli`
+/// Fatal-contract guard caught it: an over-budget run exited 0. `windows-sys` is
+/// already linked, and the `K32`-prefixed forwarder lives in kernel32, so this
+/// adds no new DLL import to the self-contained release binary.
+#[cfg(windows)]
+pub fn process_rss_kb() -> Option<u64> {
+  use windows_sys::Win32::System::{
+    ProcessStatus::{K32GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS},
+    Threading::GetCurrentProcess,
+  };
+  let mut counters: PROCESS_MEMORY_COUNTERS = unsafe { std::mem::zeroed() };
+  counters.cb = size_of::<PROCESS_MEMORY_COUNTERS>() as u32;
+  // SAFETY: `counters` is a correctly sized, zeroed struct with `cb` set, as the
+  // API requires; `GetCurrentProcess` returns a pseudo-handle needing no close.
+  if unsafe { K32GetProcessMemoryInfo(GetCurrentProcess(), &mut counters, counters.cb) } != 0 {
+    return Some(counters.WorkingSetSize as u64 / 1024);
+  }
+  None
+}
+
 /// Other platforms: unknown — the cooperative memory ceiling stays inactive.
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
 pub fn process_rss_kb() -> Option<u64> { None }
 
 /// Total physical RAM on this machine in bytes, or `None` if it cannot be
@@ -141,7 +162,7 @@ pub fn total_memory_bytes() -> Option<u64> {
     // workflow, on a tag, days after the code landed. See task #164.
     use windows_sys::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
     let mut status: MEMORYSTATUSEX = unsafe { std::mem::zeroed() };
-    status.dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
+    status.dwLength = size_of::<MEMORYSTATUSEX>() as u32;
     // SAFETY: `status` is a correctly sized, zeroed struct with `dwLength` set,
     // exactly as the API requires.
     if unsafe { GlobalMemoryStatusEx(&mut status) } != 0 {

--- a/latexml_oxide/tests/16_texinputs_usepackage.rs
+++ b/latexml_oxide/tests/16_texinputs_usepackage.rs
@@ -68,7 +68,11 @@ fn fixture(
   let doc = work.path().join("doc");
   std::fs::create_dir_all(&doc).unwrap();
   std::fs::write(doc.join("index.tex"), tex).unwrap();
-  let texinputs = format!(".:{}//:", work.path().join("texmf").display());
+  // kpathsea's path-list separator is `;` on Windows — `:` collides with the
+  // drive letter (`C:\...`) — and `:` everywhere else. The `//` recursive suffix
+  // is the same on both.
+  let sep = if cfg!(windows) { ";" } else { ":" };
+  let texinputs = format!(".{sep}{}//{sep}", work.path().join("texmf").display());
   (work, doc, texinputs)
 }
 

--- a/latexml_post/src/graphics.rs
+++ b/latexml_post/src/graphics.rs
@@ -2569,10 +2569,14 @@ impl Processor for Graphics {
 #[cfg(test)]
 mod tests {
   use super::*;
-  // `EnvGuard` (env mutation, serialised + restored) and `TempDir`
-  // (unique name, removed on drop including on panic) are shared with
-  // `graphics_cache::tests`; see that module for the rationale.
-  use crate::test_env::{EnvGuard, TempDir};
+  // `EnvGuard` (env mutation, serialised + restored) and `TempDir` (unique
+  // name, removed on drop including on panic) are shared with
+  // `graphics_cache::tests`; see that module for the rationale. `EnvGuard` is
+  // only referenced by the `#[cfg(unix)]` density test below, so gate its
+  // import the same way or it reads as unused on Windows (`-D warnings`).
+  #[cfg(unix)]
+  use crate::test_env::EnvGuard;
+  use crate::test_env::TempDir;
 
   /// `run_with_timeout` kills the child and returns `None` when the
   /// process exceeds the deadline. Uses `sleep` as a stand-in for any

--- a/tools/audit_vendored_natives.py
+++ b/tools/audit_vendored_natives.py
@@ -131,7 +131,7 @@ AUDITED = {
     "walkdir": ("2.5.0",
         "compare/nftw.c -- a benchmark comparison against C's nftw(3), not built.",
     ),
-    "ar_archive_writer": ("0.5.2",
+    "ar_archive_writer": ("0.5.3",
         "reference/*.cpp -- LLVM's originals kept beside the Rust reimplementation for "
         "reference; not compiled, not linked.",
     ),


### PR DESCRIPTION
## Summary

A Windows 10 validation of `0.7.5-rc4` (built and tested on a real Windows box against TeX Live 2026) surfaced four Windows-specific issues. None is exercised by CI today, so all four slipped through the same blind spot #464's tag message calls out. This fixes all four.

`0.7.5-rc4` itself compiles and runs on Windows, and #464's `total_memory_bytes()` fix is validated (physical RAM 65416 MiB → default ceiling 32708 MiB, correct). But the suite came back **1830 passed / 2 failed**, and `clippy -D warnings` is red on Windows.

### 1. `--max-memory` enforcement was inactive on Windows (the load-bearing one)

`watchdog::process_rss_kb()` had only Linux (`/proc/self/status`) and macOS (libproc) arms; every other target — Windows included — returned `None`. With no live-RSS sample the cooperative memory fuse can never fire, so an over-budget conversion runs to completion instead of ending with `Fatal:Timeout:MemoryBudget`. This is the exact hole that was closed on macOS (the arm's own doc comment records it) but left open on Windows — the "bounded follow-up" the module header scoped and never landed. On a release whose theme is *"--max-memory is the budget, and everything follows from it,"* the budget was never enforced on Windows.

`115_streaming_cli::streaming_flag_is_byte_identical_and_fatal_contract_holds` fails on Windows for precisely this reason (an over-budget run exits 0) — the same way it once failed on macOS CI before the libproc arm.

**Fix:** implement `process_rss_kb()` on Windows via `K32GetProcessMemoryInfo` (`WorkingSetSize`). `windows-sys` is already linked, and the `K32`-prefixed forwarder lives in kernel32, so this adds **no new DLL import** — the release binary stays self-contained. The default ceiling was already correct on Windows (#464); this makes it actually *checked*, not just computed.

### 2. Windows-only `clippy -D warnings` failure at `watchdog.rs:144`

#464's own new line, `std::mem::size_of::<MEMORYSTATUSEX>()`, trips `unused_qualifications` (`size_of` is in the prelude on current nightly), which the workspace denies under `-D warnings`. `cargo build` and the release workflow stay green (warn ≠ fatal), and #465's `cargo check` job does not catch it either, but `cargo clippy --workspace --all-targets -- -D warnings` exits 101 on Windows. One-line fix (drop the redundant path).

### 3. TEXINPUTS test used a Unix path separator

`16_texinputs_usepackage.rs` built `$TEXINPUTS` with `:`; on Windows the kpathsea path-list separator is `;` (and a bare `:` collides with the drive letter, `C:\...`), so the fixture's texmf tree was unreachable and `usepackage_finds_rhai_binding_on_texinputs` failed. **Test-only** — the product feature works on Windows: verified by reproducing it with `;`, where the `.sty.rhai` loads via TEXINPUTS and its constructor renders. Fixed to select the separator by platform.

### 4. Second Windows-only clippy failure in `graphics.rs`

`latexml_post/src/graphics.rs` imports `EnvGuard` into its test module, but its only user is a `#[cfg(unix)]` density test, so on Windows the import is unused — `-D unused-imports` fails the gate. Pre-existing (not from #464); it stayed hidden because the `latexml_core` failure above aborted the clippy run before it reached `latexml_post`. Gated the import to `#[cfg(unix)]` to match its user.

## Validation (Windows 10, TeX Live 2026)

- `115_streaming_cli` + `16_texinputs_usepackage` — **green** (were failing); the streaming Fatal-contract now holds on Windows.
- `cargo clippy --workspace --all-targets -- -D warnings` — **green** (was exit 101).
- Distribution artifact (maxperf) unchanged in shape: byte-identical conversion across no-TeX / MiKTeX / TeX Live; the `K32` forwarder adds no DLL import.

Relates to #464 (the Windows compile fix) and #465 (the new Windows CI). This PR touches `watchdog.rs` + `Cargo.toml`, so #465's automatic Windows compile-check job runs on it.

> Note for follow-up: #465's automatic `check` job is `cargo check` only, so it would not have caught #2 (needs `clippy -D warnings`) or #1/#3 (need the test suite). A `clippy -D warnings` step on that job would close the #2 class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
