### PR TITLE
fix(post): 2 GiB-plus core→post handoff spills to disk instead of dying on libxml2's i32 limit

### DIFF
--- a/latexml_oxide/src/post.rs
+++ b/latexml_oxide/src/post.rs
@@ -188,7 +188,92 @@ pub fn run_post_processing_from_file(path: &str, opts: &PostOptions) -> String {
   run_post_processing_impl(PostInput::File(path), opts)
 }
 
+/// The in-memory parse ceiling: libxml2's `xmlReadMemory` takes the buffer
+/// length as a C `int`, so a handoff string of `i32::MAX` bytes or more
+/// CANNOT be parsed from memory — it fails with "Document too large for
+/// i32". First witness to cross it: the 131 MB book's 2.68 GB core XML,
+/// single-invocation `.tex → .htm` (laptop UAT 2026-07-31; the streamed
+/// assembly exists only as serialized text, so post must re-parse it).
+/// Above the ceiling the handoff spills to a temp file beside the
+/// destination and takes the `PostInput::File` arm — the streaming-reader
+/// path that already parses this very document in the two-invocation flow.
+///
+/// Env-overridable for tests only (`LATEXML_POST_MEM_PARSE_LIMIT`): a real
+/// 2-GiB-plus fixture is not something CI can allocate, so the guard test
+/// drives the spill path with a tiny limit instead.
+fn post_mem_parse_limit() -> usize {
+  std::env::var("LATEXML_POST_MEM_PARSE_LIMIT")
+    .ok()
+    .and_then(|v| v.parse::<usize>().ok())
+    .unwrap_or(i32::MAX as usize)
+}
+
+/// Write an oversized handoff to a temp file for the streaming file parser.
+/// Beside the destination when there is one (writing to the destination
+/// directory is always allowed), else the system temp dir.
+fn spill_oversized_xml(xml: &str, opts: &PostOptions) -> std::io::Result<std::path::PathBuf> {
+  let dir = opts
+    .destination
+    .and_then(|d| {
+      std::path::Path::new(d)
+        .parent()
+        .map(std::path::Path::to_path_buf)
+    })
+    .filter(|d| !d.as_os_str().is_empty())
+    .unwrap_or_else(std::env::temp_dir);
+  let path = dir.join(format!("latexml-post-handoff-{}.xml", std::process::id()));
+  std::fs::write(&path, xml)?;
+  Ok(path)
+}
+
 fn run_post_processing_impl(input: PostInput, opts: &PostOptions) -> String {
+  // Oversized in-memory handoff → spill + streaming file parse (see
+  // `post_mem_parse_limit`). The temp file is removed on every exit path by
+  // the guard; a spill failure falls through to the memory parse, whose own
+  // error reporting then names the real problem.
+  let mut _spill_cleanup: Option<std::path::PathBuf> = None;
+  let spilled_path: Option<String>;
+  let input = match input {
+    PostInput::Xml(xml) if xml.len() >= post_mem_parse_limit() => {
+      match spill_oversized_xml(xml, opts) {
+        Ok(path) => {
+          // Operationally worth a line: a multi-GB temp file just appeared
+          // beside the destination. Also the guard test's engagement proof —
+          // without it a silently-failing spill would fall back to the memory
+          // parse and the test would pass vacuously.
+          latexml_core::Info!(
+            "post",
+            "spill",
+            format!(
+              "oversized handoff ({} bytes) spilled to {}",
+              xml.len(),
+              path.display()
+            )
+          );
+          spilled_path = Some(path.to_string_lossy().into_owned());
+          _spill_cleanup = Some(path);
+          PostInput::File(spilled_path.as_deref().expect("just set"))
+        },
+        Err(e) => {
+          latexml_core::Info!(
+            "post",
+            "spill",
+            format!("could not spill an oversized handoff ({e}); parsing from memory")
+          );
+          PostInput::Xml(xml)
+        },
+      }
+    },
+    other => other,
+  };
+  let result = run_post_processing_inner(input, opts);
+  if let Some(path) = _spill_cleanup {
+    let _ = std::fs::remove_file(path);
+  }
+  result
+}
+
+fn run_post_processing_inner(input: PostInput, opts: &PostOptions) -> String {
   let PostOptions {
     pmml,
     cmml,

--- a/latexml_oxide/tests/117_post_2gib_handoff.rs
+++ b/latexml_oxide/tests/117_post_2gib_handoff.rs
@@ -1,0 +1,110 @@
+//! The >2 GiB core→post handoff must not fail on libxml2's i32 buffer limit.
+//!
+//! `xmlReadMemory` takes its buffer length as a C `int`, so a single-invocation
+//! `.tex → .htm` conversion whose serialized core XML reaches `i32::MAX` bytes
+//! died with `Error:post:parse … Document too large for i32` and echoed raw
+//! XML into the `.htm`. First witness: the 131 MB book's 2.68 GB core XML
+//! (laptop UAT, 2026-07-31). The fix spills the oversized handoff to a temp
+//! file and takes the `PostInput::File` streaming-parser arm — the path that
+//! already parses that document in the two-invocation flow.
+//!
+//! CI cannot allocate a real >2 GiB fixture, so the spill path is driven with
+//! `LATEXML_POST_MEM_PARSE_LIMIT=1` (test-only override) on a small document:
+//! every handoff then takes the spill route. The success `Info!` line is the
+//! engagement proof — without it a silently-failing spill would fall back to
+//! the memory parse and this test would pass vacuously.
+
+use latexml::{converter::Converter, post::PostOptions};
+use latexml_core::common::{Config, OutputFormat};
+
+fn convert_core_xml() -> String {
+  let config = Config {
+    format: OutputFormat::XML,
+    ..Config::default()
+  };
+  let mut converter = Converter::from_config(config);
+  converter
+    .initialize_session()
+    .expect("can initialize session");
+  let resp = converter.convert("tests/structure/article.tex".to_string());
+  resp.result.expect("conversion produced XML output")
+}
+
+fn post_opts() -> PostOptions<'static> {
+  PostOptions {
+    pmml:                      true,
+    cmml:                      false,
+    keep_xmath:                false,
+    stylesheet:                Some("resources/XSLT/LaTeXML-html5.xsl"),
+    destination:               None,
+    source_directory:          Some("tests/structure"),
+    site_directory:            None,
+    search_paths:              &[],
+    nodefaultresources:        true,
+    css_files:                 &[],
+    js_files:                  &[],
+    noinvisibletimes:          false,
+    plane1:                    true,
+    hackplane1:                false,
+    mathtex:                   false,
+    navigationtoc:             None,
+    schemadocs:                false,
+    split:                     false,
+    split_xpath:               None,
+    split_naming:              None,
+    xslt_parameters:           &[],
+    graphics_svg_threshold_kb: 0,
+    graphicimages:             true,
+    timestamp:                 None,
+    icon:                      None,
+    whatsout:                  latexml_post::extract::Whatsout::default(),
+  }
+}
+
+#[test]
+fn oversized_handoff_spills_and_output_is_identical() {
+  // Info level: the engagement proof below is an `Info!` record, and without
+  // an installed logger the capture buffer never sees it.
+  let _ = latexml_core::util::logger::init(log::LevelFilter::Info);
+  let xml = convert_core_xml();
+
+  // Baseline: the ordinary in-memory handoff.
+  let baseline = latexml::post::run_post_processing(&xml, &post_opts());
+  assert!(
+    baseline.contains("<html"),
+    "baseline post-processing must produce HTML"
+  );
+
+  // Forced-spill: every handoff is "oversized" under a 1-byte limit.
+  // SAFETY: nextest runs each test in its own process; nothing else reads
+  // the environment concurrently in this one.
+  unsafe { std::env::set_var("LATEXML_POST_MEM_PARSE_LIMIT", "1") };
+  let outcome = latexml::post::run_post_processing_logged(&xml, &post_opts());
+  unsafe { std::env::remove_var("LATEXML_POST_MEM_PARSE_LIMIT") };
+
+  // Engagement proof: the spill really happened (not a silent fallback).
+  assert!(
+    outcome.log.contains("oversized handoff"),
+    "the spill path must engage under the test limit — log was:\n{}",
+    outcome.log
+  );
+  // The spilled temp file must be cleaned up.
+  let leftovers: Vec<_> = std::fs::read_dir(std::env::temp_dir())
+    .expect("temp dir readable")
+    .filter_map(|e| e.ok())
+    .filter(|e| {
+      e.file_name()
+        .to_string_lossy()
+        .starts_with(&format!("latexml-post-handoff-{}", std::process::id()))
+    })
+    .collect();
+  assert!(
+    leftovers.is_empty(),
+    "spilled handoff files must be removed: {leftovers:?}"
+  );
+  // And the output must be byte-identical to the in-memory parse.
+  assert_eq!(
+    baseline, outcome.html,
+    "the spill route must not change the post-processed output"
+  );
+}


### PR DESCRIPTION
Single-invocation `.tex → .htm` of the 131 MB witness failed at the core→post handoff: the 2.68 GB serialized core XML exceeds `xmlReadMemory`'s C-int length (laptop UAT report). Oversized handoffs now spill to a temp file beside the destination and take the streaming file-parser arm that already handles this document in the two-invocation flow. Guarded by `117_post_2gib_handoff` (engagement-proven, byte-identical output, cleanup checked). Suite 1842/1842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)