### PR TITLE
docs(audit): record libxml 0.3.21 re-verification; fix declared-license phrase

### DIFF
--- a/docs/release/LICENSE_INVENTORY.md
+++ b/docs/release/LICENSE_INVENTORY.md
@@ -214,7 +214,7 @@ original five signals despite being the largest native surface in the binary.
 | **libmarpa 8.6.2** | `libmarpa-sys` (git, `dginev/marpa`) | `MIT OR Apache-2.0` | `marpa.c`/`marpa_ami.c`/`marpa_codes.c` → **MIT** © 2018 Jeffrey Kegler; `marpa_avl.c`/`marpa_tavl.c` (Ben Pfaff's libavl) → **LGPL-3.0+** © FSF; `marpa_obs.c` (GNU obstack) → **LGPL-2.1+** © FSF | §3.3 |
 | **mimalloc** | `libmimalloc-sys` | `MIT` + crate-root `LICENSE.txt` © 2019 **Octavian Oncescu** (the wrapper author) | `c_src/mimalloc/**` → **MIT** © 2018-2025 **Microsoft Corporation, Daan Leijen** — a different holder than the harvested text | §3.4 |
 | **libkpathsea** | `kpathsea_sys` | `MIT OR Apache-2.0`, **no LICENSE file** | kpathsea C at `KPSE_REF` → **LGPL-2.1+** © Karl Berry, Olaf Weber et al. | §3.2 |
-| libxml2 / libxslt | `libxml` / `libxslt` | `MIT OR Apache-2.0` | system libxml2/libxslt/libexslt → **MIT** © Daniel Veillard — static in release | §3.1 |
+| libxml2 / libxslt | `libxml` / `libxslt` | `MIT` (naming the wrapper, not Veillard) | system libxml2/libxslt/libexslt → **MIT** © Daniel Veillard — static in release | §3.1 |
 
 How each evades the automated gate:
 - **libmarpa** vendors a **tarball**, so its `COPYING`/`COPYING.LESSER` are invisible

--- a/tools/audit_vendored_natives.py
+++ b/tools/audit_vendored_natives.py
@@ -195,11 +195,15 @@ AUDITED = {
         "link.) Attributed in THIRD-PARTY-NOTICES 3.2; static LGPL -> relink 3.5."
     ),
     "libxml": ("0.3.21",
-        "Binds libxml2 -- (c) Daniel Veillard, MIT -- which the crate's own "
-        "'MIT OR Apache-2.0' does not name. Linked via pkg-config + rustc-link-lib "
+        "Binds libxml2 -- (c) Daniel Veillard, MIT -- whom the crate's own 'MIT' "
+        "field does not name as holder. Linked via pkg-config + rustc-link-lib "
         "rather than compiled here, and STATIC on every release leg "
         "(tools/build_static_libxml.sh, built --without-zlib/lzma/icu so nothing else "
-        "comes with it). Permissive, so no relink duty. Attributed in NOTICES 3.1."
+        "comes with it). Permissive, so no relink duty. Attributed in NOTICES 3.1. "
+        "0.3.19 -> 0.3.21 diffed 2026-08-02 (crates.io tarballs): pure-Rust wrapper "
+        "changes only (set_linked visibility, get_namespaces array free); build.rs "
+        "still link-only, zero cc::Build, no native files, license field 'MIT' "
+        "unchanged."
     ),
     "libxslt": ("0.1.5",
         "Binds libxslt/libexslt -- (c) Daniel Veillard, MIT -- same shape as libxml "


### PR DESCRIPTION
**Diagnostic.** The overnight audit-drift (libxml/psm/stacker) was already re-pinned by #480, which raced this PR to main. What main still lacks: the libxml pin carries no re-verification evidence, and both the AUDITED reason and the LICENSE_INVENTORY §D.2 cell claim the fork crates declare `MIT OR Apache-2.0` — they declare plain `MIT`.

**Approach.** Rebuilt on current main as the accuracy residual only: record the libxml 0.3.19→0.3.21 crates.io tarball-diff verdict (pure-Rust wrapper changes, link-only build.rs, no native files) and correct the declared-license phrase in both places.

**Validation.** `tools/audit_vendored_natives.py` green on current main's resolution; docs/tool-comment change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)