### PR TITLE
fix(diag): every printed diagnostic counts — lossless tally across all phases

### DIFF
--- a/latexml_core/src/binding/content.rs
+++ b/latexml_core/src/binding/content.rs
@@ -11,7 +11,7 @@ use crate::{
   common::{
     arena,
     arena::SymStr,
-    error::*,
+    error::{emit_error, *},
     font::{Font, Fontmap},
     model,
   },
@@ -3175,9 +3175,13 @@ pub fn set_condition(if_token: &Token, value: bool, scope: Option<Scope>) {
     let_i(if_token, &target, scope);
     return;
   }
-  log::error!(
-    "Expected a conditional defined by \\newif, got '{}'",
-    if_token.stringify()
+  emit_error(
+    "expected",
+    "newif",
+    &format!(
+      "Expected a conditional defined by \\newif, got '{}'",
+      if_token.stringify()
+    ),
   );
 }
 

--- a/latexml_core/src/binding/def/macros.rs
+++ b/latexml_core/src/binding/def/macros.rs
@@ -294,9 +294,10 @@ macro_rules! prop_digested {
       ),
       None => Vec::new(),
       other => {
-        log::warn!(
-          "Please extend the api_macros::prop_digested macro to support: {:?}",
-          other
+        $crate::common::error::emit_warn(
+          "unimplemented",
+          "prop_digested",
+          &format!("Please extend the api_macros::prop_digested macro to support: {other:?}"),
         );
         // Return empty vec instead of panicking
         Vec::new()

--- a/latexml_core/src/common/error.rs
+++ b/latexml_core/src/common/error.rs
@@ -34,6 +34,44 @@ pub enum LogStatus {
 #[thread_local]
 pub static REPORT: Lazy<RefCell<LogState>> = Lazy::new(|| RefCell::new(LogState::default()));
 
+/// Depth of diagnostic-macro emission on this thread (see [`macro_diag_guard`]).
+/// A depth counter, not a bool: `Error!` can raise `Fatal!` inside its own
+/// scope (the too-many-errors escalation), nesting two guards.
+#[thread_local]
+static MACRO_DIAG_DEPTH: std::cell::Cell<u32> = std::cell::Cell::new(0);
+
+/// RAII marker: "the log record currently being emitted comes from a
+/// diagnostic macro that already counted itself via [`note_status`]".
+///
+/// The tally has TWO producers which must never overlap: the macros
+/// (`Info!`/`Warn!`/`Error!`/`Fatal!`/`Debug!`) count at RAISE time — even when
+/// output is suppressed, which the `MAX_ERRORS` cap depends on — and the
+/// logger backend counts every OTHER record it prints (raw `log::warn!` and
+/// friends, which previously printed `Warning:` lines that no counter ever
+/// saw: the 131 MB witness logged 12,105 `Warning:` lines and reported
+/// "2 warnings"). This guard is how the logger tells the two apart.
+pub struct MacroDiagGuard(());
+impl Drop for MacroDiagGuard {
+  fn drop(&mut self) { MACRO_DIAG_DEPTH.set(MACRO_DIAG_DEPTH.get().saturating_sub(1)); }
+}
+#[must_use = "the guard must live across the log emission it marks"]
+pub fn macro_diag_guard() -> MacroDiagGuard {
+  MACRO_DIAG_DEPTH.set(MACRO_DIAG_DEPTH.get() + 1);
+  MacroDiagGuard(())
+}
+
+/// Count a diagnostic record observed by the logger backend, unless it was
+/// emitted by a macro (already counted at raise time) or the report is
+/// mid-borrow (a raw log call from inside a `report_mut!` scope must not
+/// panic the conversion over a tally increment — matching the logger's own
+/// `try_borrow` discipline for `LOG_BUFFER`).
+pub fn note_status_from_logger(status: LogStatus) {
+  if MACRO_DIAG_DEPTH.get() > 0 || REPORT.try_borrow_mut().is_err() {
+    return;
+  }
+  note_status(status, None);
+}
+
 /// When true, Error!/Warn!/Info! macros still count in the report
 /// but do **not** emit anything to stderr/log.
 /// Used by tests that are known to produce errors in both Perl and Rust.
@@ -478,6 +516,7 @@ pub fn debug_enabled(name: &str) -> bool {
 macro_rules! DebugFeature {
   ($feature:literal, $($arg:tt)*) => {{
     if $crate::common::error::debug_enabled($feature) {
+      let __diag_guard = $crate::common::error::macro_diag_guard();
       $crate::common::error::note_status(
         $crate::common::error::LogStatus::Debug, None);
       use log::debug;
@@ -489,6 +528,7 @@ macro_rules! DebugFeature {
 #[macro_export]
 macro_rules! Debug {
   ($category:expr_2021, $object:expr_2021, $message:expr_2021) => {{
+    let __diag_guard = $crate::common::error::macro_diag_guard();
     $crate::common::error::note_status(
       $crate::common::error::LogStatus::Debug, None);
     use log::debug;
@@ -496,6 +536,7 @@ macro_rules! Debug {
       $crate::generate_message!($message))
   }};
  ($category:expr_2021, $object:expr_2021, $message:expr_2021, $($details:expr_2021),*) => {{
+    let __diag_guard = $crate::common::error::macro_diag_guard();
     $crate::common::error::note_status(
       $crate::common::error::LogStatus::Debug, None);
     use log::debug;
@@ -503,6 +544,7 @@ macro_rules! Debug {
       $crate::generate_message!($message, $($details),*))
   }};
   ($($simple:expr_2021),*) => {{
+    let __diag_guard = $crate::common::error::macro_diag_guard();
     $crate::common::error::note_status(
       $crate::common::error::LogStatus::Debug, None);
     use log::debug;
@@ -514,6 +556,7 @@ macro_rules! Debug {
 #[macro_export]
 macro_rules! Info {
   ($category:expr_2021, $object:expr_2021, $message:expr_2021) => {{
+    let __diag_guard = $crate::common::error::macro_diag_guard();
     $crate::common::error::note_status(
       $crate::common::error::LogStatus::Info, None);
     use log::info;
@@ -521,6 +564,7 @@ macro_rules! Info {
       $crate::generate_message!($message))
   }};
  ($category:expr_2021, $object:expr_2021, $message:expr_2021, $($details:expr_2021),*) => {{
+  let __diag_guard = $crate::common::error::macro_diag_guard();
   $crate::common::error::note_status(
     $crate::common::error::LogStatus::Info, None);
     use log::info;
@@ -528,6 +572,7 @@ macro_rules! Info {
     $crate::generate_message!($message, $($details),*))
   }};
   ($($simple:expr_2021),*) => {{
+    let __diag_guard = $crate::common::error::macro_diag_guard();
     $crate::common::error::note_status(
       $crate::common::error::LogStatus::Info, None);
     use log::info;
@@ -539,6 +584,7 @@ macro_rules! Info {
 #[macro_export]
 macro_rules! Warn {
   ($category:expr_2021, $object:expr_2021, $message:expr_2021) => {{
+    let __diag_guard = $crate::common::error::macro_diag_guard();
     $crate::common::error::note_status(
       $crate::common::error::LogStatus::Warning, None);
     if !$crate::common::error::is_log_output_suppressed() {
@@ -548,6 +594,7 @@ macro_rules! Warn {
     }
   }};
  ($category:expr_2021, $object:expr_2021, $message:expr_2021, $($details:expr_2021),*) => {{
+    let __diag_guard = $crate::common::error::macro_diag_guard();
     $crate::common::error::note_status(
       $crate::common::error::LogStatus::Warning, None);
     if !$crate::common::error::is_log_output_suppressed() {
@@ -564,6 +611,7 @@ macro_rules! Error {
     $crate::Error!($category,$object,$message,"")
   }};
  ($category:expr_2021, $object:expr_2021, $message:expr_2021, $($details:expr_2021),*) => {{
+    let __diag_guard = $crate::common::error::macro_diag_guard();
     $crate::common::error::note_status(
       $crate::common::error::LogStatus::Error, None);
     if !$crate::common::error::is_log_output_suppressed() {
@@ -633,12 +681,14 @@ macro_rules! Fatal {
       // but never latch the document's sticky fatal. The Err return below
       // still aborts the failing digestion; its caller degrades
       // gracefully. A document must not be lost to a broken bibliography.
+      let __diag_guard = $crate::common::error::macro_diag_guard();
       $crate::common::error::note_status($crate::common::error::LogStatus::Error, None);
       if !$crate::common::error::is_log_output_suppressed() {
         use log::error;
         error!(target: "demoted_fatal", "{}", $message);
       }
     } else {
+      let __diag_guard = $crate::common::error::macro_diag_guard();
       $crate::common::error::note_status($crate::common::error::LogStatus::Fatal, None);
     }
     {
@@ -867,6 +917,9 @@ impl fmt::Display for Error {
 impl Error {
   pub fn log_fatal(&self) {
     let target_str = s!("Fatal:{:?}:{:?} ", self.target, self.category);
+    // This emission is accounted by the note_status below — mark it so the
+    // logger backend does not also treat it as a raw record.
+    let __diag_guard = macro_diag_guard();
     use log::error;
     error!(target: &target_str, "{}", self.message);
     // Mark the global report as fatal so cortex_worker's exit code is

--- a/latexml_core/src/common/error.rs
+++ b/latexml_core/src/common/error.rs
@@ -72,9 +72,11 @@ pub fn note_status_from_logger(status: LogStatus) {
   note_status(status, None);
 }
 
-/// When true, Error!/Warn!/Info! macros still count in the report
-/// but do **not** emit anything to stderr/log.
-/// Used by tests that are known to produce errors in both Perl and Rust.
+/// When true, Debug!/Info!/Warn! (and their emit_* forms) still count in
+/// the report but do **not** emit anything to stderr/log. `Error!`/`Fatal!`
+/// are NOT suppressible — they emit unconditionally (user decision
+/// 2026-08-03), so success-rate aggregation (cortex) never loses them.
+/// Used by tests/dump-builds that deliberately exercise noisy paths.
 #[thread_local]
 static SUPPRESS_LOG_OUTPUT: std::cell::Cell<bool> = std::cell::Cell::new(false);
 
@@ -155,9 +157,10 @@ pub fn note_consecutive_error(key: &str) -> usize {
 /// The ONE emission primitive every diagnostic flows through (DRY pass,
 /// user directive 2026-08-02): count on the emitting thread's `REPORT`,
 /// then log with the pre-formatted `target`, respecting output suppression —
-/// EXCEPT for `Fatal` records, which are never suppressed: the release
-/// dump-build gate and every success-rate measurement grep for `Fatal:`
-/// lines, so muting them would hide exactly the signal those exist for.
+/// EXCEPT for `Error` and `Fatal` records, which are emitted UNCONDITIONALLY
+/// (user decision 2026-08-03): frameworks such as cortex aggregate success
+/// rates from `Error:`/`Fatal:` lines, so muting either would hide exactly
+/// the signal they measure. Suppression mutes Debug/Info/Warning only.
 /// The `MacroDiagGuard` marks the emission so the logger backend does not
 /// count it a second time.
 pub fn emit_record(status: LogStatus, target: &str, message: &str) {
@@ -168,9 +171,9 @@ pub fn emit_record(status: LogStatus, target: &str, message: &str) {
     LogStatus::Warning => log::Level::Warn,
     _ => log::Level::Error,
   };
-  let is_fatal = matches!(status, LogStatus::Fatal);
+  let unconditional = matches!(status, LogStatus::Error | LogStatus::Fatal);
   note_status(status, None);
-  if is_fatal || !is_log_output_suppressed() {
+  if unconditional || !is_log_output_suppressed() {
     log::log!(target: target, level, "{message}");
   }
 }

--- a/latexml_core/src/common/error.rs
+++ b/latexml_core/src/common/error.rs
@@ -152,6 +152,105 @@ pub fn note_consecutive_error(key: &str) -> usize {
   }
 }
 
+/// The ONE emission primitive every diagnostic flows through (DRY pass,
+/// user directive 2026-08-02): count on the emitting thread's `REPORT`,
+/// then log with the pre-formatted `target`, respecting output suppression —
+/// EXCEPT for `Fatal` records, which are never suppressed: the release
+/// dump-build gate and every success-rate measurement grep for `Fatal:`
+/// lines, so muting them would hide exactly the signal those exist for.
+/// The `MacroDiagGuard` marks the emission so the logger backend does not
+/// count it a second time.
+pub fn emit_record(status: LogStatus, target: &str, message: &str) {
+  let _diag_guard = macro_diag_guard();
+  let level = match status {
+    LogStatus::Debug => log::Level::Debug,
+    LogStatus::Info => log::Level::Info,
+    LogStatus::Warning => log::Level::Warn,
+    _ => log::Level::Error,
+  };
+  let is_fatal = matches!(status, LogStatus::Fatal);
+  note_status(status, None);
+  if is_fatal || !is_log_output_suppressed() {
+    log::log!(target: target, level, "{message}");
+  }
+}
+
+/// The single diagnostic vehicle, function form — for contexts that cannot
+/// use the `Error!`/`Warn!`/`Info!` macros because those are return-based
+/// (`Error!` escalates to `Fatal!`, which `return Err(...)`s, so it only
+/// typechecks in `Result<_, error::Error>` functions).
+///
+/// Perl LaTeXML has exactly one emission vehicle per severity (`Error.pm`),
+/// which is what lets its tally and cortex's aggregation be lossless by
+/// construction. These functions restore that property for Rust's
+/// non-`Result` contexts (post-processing drivers, workers, the LSP server):
+/// they count, emit with a proper `category:object` target, respect output
+/// suppression, and participate in the runaway circuit-breakers — everything
+/// the raw `log::warn!`-family calls they replace silently skipped. Raw
+/// `log::*!` diagnostics are BANNED in workspace crates (see
+/// `tools/lint_raw_log_diag.sh`); the logger backend's own tally
+/// (`note_status_from_logger`) remains only as the net for FOREIGN crates
+/// logging through the `log` facade, which can never use this vehicle.
+pub fn emit_info(category: &str, object: &str, message: &str) {
+  emit_record(LogStatus::Info, &format!("{category}:{object}"), message);
+}
+
+/// See [`emit_info`].
+pub fn emit_warn(category: &str, object: &str, message: &str) {
+  emit_record(LogStatus::Warning, &format!("{category}:{object}"), message);
+}
+
+/// See [`emit_info`]. Unlike the `Error!` macro this cannot escalate by
+/// `return`ing — there is no `Err` channel in the contexts it serves — so
+/// when the error count or the consecutive-error count crosses its cap it
+/// emits the `Fatal:TooManyErrors` record and latches the sticky fatal
+/// instead: the run continues (its caller has no unwind path) but the
+/// conversion's verdict and status code report the fatal honestly.
+pub fn emit_error(category: &str, object: &str, message: &str) {
+  emit_record(LogStatus::Error, &format!("{category}:{object}"), message);
+  if is_demote_fatals() {
+    return;
+  }
+  let maxerrors = match crate::state::try_lookup_int("MAX_ERRORS") {
+    None => usize::MAX, // STATE contended: skip the check for this error
+    Some(v) if v > 0 => v as usize,
+    Some(_) => 100,
+  };
+  let consec = note_consecutive_error(&format!("{category}:{object}"));
+  let over_total = get_status(LogStatus::Error) > maxerrors;
+  let over_consec = consec > MAX_CONSECUTIVE_ERRORS;
+  // Latch exactly at the crossing, not on every error past it.
+  if (over_total && get_status(LogStatus::Error) == maxerrors + 1)
+    || (over_consec && consec == MAX_CONSECUTIVE_ERRORS + 1)
+  {
+    emit_fatal(
+      "TooManyErrors",
+      "MaxLimit",
+      &format!(
+        "Too many errors (> {})!",
+        if over_total {
+          maxerrors
+        } else {
+          MAX_CONSECUTIVE_ERRORS
+        }
+      ),
+    );
+  }
+}
+
+/// See [`emit_info`]. Latches the sticky fatal and emits the canonical
+/// `Fatal:<category>:<object>` line — NEVER suppressed (see [`emit_record`]).
+/// The CALLER owns any early-exit control flow (e.g. `latexml_post`'s
+/// `Fatal!` returns its own `PostError` after this) — a fatal, unlike an
+/// error, needs no cap bookkeeping.
+pub fn emit_fatal(category: &str, object: &str, message: &str) {
+  emit_record(
+    LogStatus::Fatal,
+    &format!("Fatal:{category}:{object} "),
+    message,
+  );
+}
+
 /// Reset the consecutive-error tracker (called from initialize_report).
 fn reset_consecutive_error_tracker() {
   *LAST_ERROR_KEY.borrow_mut() = None;
@@ -528,20 +627,16 @@ macro_rules! DebugFeature {
 #[macro_export]
 macro_rules! Debug {
   ($category:expr_2021, $object:expr_2021, $message:expr_2021) => {{
-    let __diag_guard = $crate::common::error::macro_diag_guard();
-    $crate::common::error::note_status(
-      $crate::common::error::LogStatus::Debug, None);
-    use log::debug;
-    debug!(target: &format!("{}:{}", $category, $object), "{}",
-      $crate::generate_message!($message))
+    $crate::common::error::emit_record(
+      $crate::common::error::LogStatus::Debug,
+      &format!("{}:{}", $category, $object),
+      &$crate::generate_message!($message))
   }};
  ($category:expr_2021, $object:expr_2021, $message:expr_2021, $($details:expr_2021),*) => {{
-    let __diag_guard = $crate::common::error::macro_diag_guard();
-    $crate::common::error::note_status(
-      $crate::common::error::LogStatus::Debug, None);
-    use log::debug;
-    debug!(target: &format!("{}:{}", $category, $object), "{}",
-      $crate::generate_message!($message, $($details),*))
+    $crate::common::error::emit_record(
+      $crate::common::error::LogStatus::Debug,
+      &format!("{}:{}", $category, $object),
+      &$crate::generate_message!($message, $($details),*))
   }};
   ($($simple:expr_2021),*) => {{
     let __diag_guard = $crate::common::error::macro_diag_guard();
@@ -556,20 +651,14 @@ macro_rules! Debug {
 #[macro_export]
 macro_rules! Info {
   ($category:expr_2021, $object:expr_2021, $message:expr_2021) => {{
-    let __diag_guard = $crate::common::error::macro_diag_guard();
-    $crate::common::error::note_status(
-      $crate::common::error::LogStatus::Info, None);
-    use log::info;
-    info!(target: &format!("{}:{}", $category, $object), "{}",
-      $crate::generate_message!($message))
+    $crate::common::error::emit_info(
+      &format!("{}", $category), &format!("{}", $object),
+      &$crate::generate_message!($message))
   }};
  ($category:expr_2021, $object:expr_2021, $message:expr_2021, $($details:expr_2021),*) => {{
-  let __diag_guard = $crate::common::error::macro_diag_guard();
-  $crate::common::error::note_status(
-    $crate::common::error::LogStatus::Info, None);
-    use log::info;
-    info!(target: &format!("{}:{}", $category, $object), "{}",
-    $crate::generate_message!($message, $($details),*))
+    $crate::common::error::emit_info(
+      &format!("{}", $category), &format!("{}", $object),
+      &$crate::generate_message!($message, $($details),*))
   }};
   ($($simple:expr_2021),*) => {{
     let __diag_guard = $crate::common::error::macro_diag_guard();
@@ -584,24 +673,14 @@ macro_rules! Info {
 #[macro_export]
 macro_rules! Warn {
   ($category:expr_2021, $object:expr_2021, $message:expr_2021) => {{
-    let __diag_guard = $crate::common::error::macro_diag_guard();
-    $crate::common::error::note_status(
-      $crate::common::error::LogStatus::Warning, None);
-    if !$crate::common::error::is_log_output_suppressed() {
-      use log::warn;
-      warn!(target: &format!("{}:{}", $category, $object), "{}",
-        $crate::generate_message!($message))
-    }
+    $crate::common::error::emit_warn(
+      &format!("{}", $category), &format!("{}", $object),
+      &$crate::generate_message!($message))
   }};
  ($category:expr_2021, $object:expr_2021, $message:expr_2021, $($details:expr_2021),*) => {{
-    let __diag_guard = $crate::common::error::macro_diag_guard();
-    $crate::common::error::note_status(
-      $crate::common::error::LogStatus::Warning, None);
-    if !$crate::common::error::is_log_output_suppressed() {
-      use log::warn;
-      warn!(target: &format!("{}:{}", $category, $object), "{}",
-        $crate::generate_message!($message, $($details),*))
-    }
+    $crate::common::error::emit_warn(
+      &format!("{}", $category), &format!("{}", $object),
+      &$crate::generate_message!($message, $($details),*))
   }}
 }
 
@@ -611,14 +690,11 @@ macro_rules! Error {
     $crate::Error!($category,$object,$message,"")
   }};
  ($category:expr_2021, $object:expr_2021, $message:expr_2021, $($details:expr_2021),*) => {{
-    let __diag_guard = $crate::common::error::macro_diag_guard();
-    $crate::common::error::note_status(
-      $crate::common::error::LogStatus::Error, None);
-    if !$crate::common::error::is_log_output_suppressed() {
-      use log::error;
-      error!(target: &format!("{}:{}", $category, $object), "{}",
-        $crate::generate_message!($message, $($details),*));
-    }
+    $crate::common::error::emit_record(
+      $crate::common::error::LogStatus::Error,
+      &format!("{}:{}", $category, $object),
+      &$crate::generate_message!($message, $($details),*),
+    );
     // In the fatal-demotion scope (bibliography post-processing) the
     // too-many/consecutive-error escalations are SKIPPED: their Fatal!
     // would demote back into an Error, turning the circuit-breaker into
@@ -681,14 +757,12 @@ macro_rules! Fatal {
       // but never latch the document's sticky fatal. The Err return below
       // still aborts the failing digestion; its caller degrades
       // gracefully. A document must not be lost to a broken bibliography.
-      let __diag_guard = $crate::common::error::macro_diag_guard();
-      $crate::common::error::note_status($crate::common::error::LogStatus::Error, None);
-      if !$crate::common::error::is_log_output_suppressed() {
-        use log::error;
-        error!(target: "demoted_fatal", "{}", $message);
-      }
+      $crate::common::error::emit_record(
+        $crate::common::error::LogStatus::Error,
+        "demoted_fatal",
+        &format!("{}", $message),
+      );
     } else {
-      let __diag_guard = $crate::common::error::macro_diag_guard();
       $crate::common::error::note_status($crate::common::error::LogStatus::Fatal, None);
     }
     {
@@ -916,18 +990,16 @@ impl fmt::Display for Error {
 
 impl Error {
   pub fn log_fatal(&self) {
-    let target_str = s!("Fatal:{:?}:{:?} ", self.target, self.category);
-    // This emission is accounted by the note_status below — mark it so the
-    // logger backend does not also treat it as a raw record.
-    let __diag_guard = macro_diag_guard();
-    use log::error;
-    error!(target: &target_str, "{}", self.message);
-    // Mark the global report as fatal so cortex_worker's exit code is
-    // 3 (conversion failure) instead of 0 (success). Without this,
-    // `Fatal:Timeout:MemoryBudget` etc. printed but the runtime
-    // status_code stayed at 0 — canvas would classify the worker as
-    // OK with an empty HTML output. R35.A.
-    note_status(LogStatus::Fatal, None);
+    // One primitive does both halves: the `Fatal:<target>:<category>` line
+    // AND the sticky `LogStatus::Fatal` latch. Without the latch,
+    // `Fatal:Timeout:MemoryBudget` etc. printed but the runtime status_code
+    // stayed at 0 — canvas would classify the worker as OK with an empty
+    // HTML output. R35.A.
+    emit_record(
+      LogStatus::Fatal,
+      &s!("Fatal:{:?}:{:?} ", self.target, self.category),
+      &self.message,
+    );
   }
   pub fn todo() -> Self {
     Error {

--- a/latexml_core/src/definition.rs
+++ b/latexml_core/src/definition.rs
@@ -20,7 +20,7 @@ use crate::{
   common::{
     arena::{self, SymHashMap, SymStr},
     dimension::Dimension,
-    error::*,
+    error::{emit_warn, *},
     font::Font,
     object::Object,
     store::Stored,
@@ -347,7 +347,11 @@ pub trait Definition: Object {
   fn value_of(&self, _args: Vec<ArgWrap>) -> Option<RegisterValue> { None }
   /// runs the setter to assign the value for a register
   fn set_value(&self, _value: RegisterValue, _scope: Option<Scope>, _args: Vec<ArgWrap>) {
-    log::warn!("set_value called on non-register definition");
+    emit_warn(
+      "internal",
+      "register",
+      "set_value called on non-register definition",
+    );
   }
   fn register_type(&self) -> Option<RegisterType> { None }
   fn get_reversion_spec(&self) -> Option<Reversion> { None }

--- a/latexml_core/src/definition/conditional.rs
+++ b/latexml_core/src/definition/conditional.rs
@@ -9,7 +9,11 @@ use libxml::tree::Node;
 // use crate::common::numeric_ops::NumericOps;
 use crate::Digested;
 use crate::{
-  common::{error::*, locator::Locator, object::Object},
+  common::{
+    error::{emit_warn, *},
+    locator::Locator,
+    object::Object,
+  },
   definition::{BeforeDigestClosure, ConditionalClosure, Definition, DigestionClosure},
   document::Document,
   gullet,
@@ -355,7 +359,11 @@ impl Conditional {
         Some(Stored::VecDequeStored(s)) => s.len(),
         _ => 0,
       });
-      log::warn!("\\else encountered with no active if-frame (stack_len={stack_len})");
+      emit_warn(
+        "unexpected",
+        "else",
+        &format!("\\else encountered with no active if-frame (stack_len={stack_len})"),
+      );
     }
     if let Some(stack_frame) = stack_frame_opt {
       if stack_frame.borrow().parsing {

--- a/latexml_core/src/document.rs
+++ b/latexml_core/src/document.rs
@@ -18,7 +18,7 @@ use crate::{
   BoxOps, Digested, DigestedData, Tbox, TexMode,
   common::{
     arena::{self, SymHashMap, SymStr},
-    error::*,
+    error::{emit_error, emit_warn, *},
     font::{FONT_TEXT_DEFAULT, Font},
     locator::Locator,
     model,
@@ -1700,8 +1700,10 @@ impl Document {
           .and_then(|store| store.read_segment(seg).ok())
       });
       let Some(inner) = inner else {
-        log::error!(
-          "Error:spill:unresolved a nested spilled segment could not be spliced ({elem})"
+        emit_error(
+          "spill",
+          "unresolved",
+          &format!("a nested spilled segment could not be spliced ({elem})"),
         );
         out.push_str(before);
         out.push_str("<!-- latexml-oxide: LOST spilled segment -->\n");
@@ -1790,9 +1792,13 @@ impl Document {
               // `Error!` can early-return and this serializer returns `()`,
               // so raise through the logger; the marker keeps the loss
               // visible in the output itself.
-              log::error!(
-                "Error:spill:unresolved a spilled segment could not be spliced back (ref={:?})",
-                node.get_attribute("ref")
+              emit_error(
+                "spill",
+                "unresolved",
+                &format!(
+                  "a spilled segment could not be spliced back (ref={:?})",
+                  node.get_attribute("ref")
+                ),
               );
               out.push_str("<!-- latexml-oxide: LOST spilled segment -->\n");
             },
@@ -4238,9 +4244,10 @@ impl Document {
           return candidate;
         }
       }
-      log::error!(
-        "malformed:id: Automatic incrementing of ID counters failed for '{}'",
-        badid
+      emit_error(
+        "malformed",
+        "id",
+        &format!("Automatic incrementing of ID counters failed for '{badid}'"),
       );
       badid
     } else {
@@ -5289,7 +5296,11 @@ impl Document {
           // Skip XML comments during cloning (Perl also skips them in most contexts)
         },
         other => {
-          log::warn!("append_clone_aux: skipping unsupported {other:?} node type");
+          emit_warn(
+            "internal",
+            "document",
+            &format!("append_clone_aux: skipping unsupported {other:?} node type"),
+          );
         },
       };
     }

--- a/latexml_core/src/keyvals.rs
+++ b/latexml_core/src/keyvals.rs
@@ -7,7 +7,13 @@ use rustc_hash::FxHashMap as HashMap;
 use super::keyval::{has_keyval, keyval_get, keyval_qname};
 use crate::{
   BoxOps, Digested, NO_PROPERTIES,
-  common::{arena::SymHashMap, error::*, font::Font, object::Object, store::Stored},
+  common::{
+    arena::SymHashMap,
+    error::{emit_warn, *},
+    font::Font,
+    object::Object,
+    store::Stored,
+  },
   definition::argument::ArgWrap,
   document::Document,
   gullet::{self, ExpansionLevel},
@@ -144,7 +150,11 @@ impl BoxOps for KeyVals {
   }
   fn get_string(&self) -> Result<Cow<'_, str>> { Ok(Cow::Owned(self.to_string())) }
   fn set_property<T: Into<Stored>>(&mut self, _key: &str, _value: T) {
-    log::warn!("set_property on KeyVals not supported");
+    emit_warn(
+      "internal",
+      "keyvals",
+      "set_property on KeyVals not supported",
+    );
   }
   fn be_absorbed(&self, _document: &mut Document) -> Result<Vec<Node>> { Ok(Vec::new()) } // TODO
   fn get_font(&self) -> Result<Option<std::rc::Rc<Font>>> { Ok(None) } // TODO
@@ -1006,7 +1016,11 @@ impl KeyVals {
         },
         ArgWrap::Token(vtk) => tks.push(vtk),
         other => {
-          log::warn!("Unexpected ArgWrap variant in KeyVals revert: {:?}", other);
+          emit_warn(
+            "internal",
+            "keyvals",
+            &format!("Unexpected ArgWrap variant in KeyVals revert: {other:?}"),
+          );
         },
       }
     }

--- a/latexml_core/src/mouth.rs
+++ b/latexml_core/src/mouth.rs
@@ -15,7 +15,13 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::{
-  common::{arena::SymStr, error::*, locator::Locator, numeric_ops::NumericOps, object::Object},
+  common::{
+    arena::SymStr,
+    error::{emit_warn, *},
+    locator::Locator,
+    numeric_ops::NumericOps,
+    object::Object,
+  },
   state::*,
   token::*,
   tokens::{NO_TOKENS, TeXString, Tokens},
@@ -435,10 +441,18 @@ impl Mouth {
   }
   fn open_literal(&mut self, content: &str) { self.buffer = Mouth::split_lines(content); }
   fn open_http(&mut self, url: &str) {
-    log::warn!("HTTP input not supported: {url}");
+    emit_warn(
+      "unsupported",
+      "http_input",
+      &format!("HTTP input not supported: {url}"),
+    );
   }
   fn open_https(&mut self, url: &str) {
-    log::warn!("HTTPS input not supported: {url}");
+    emit_warn(
+      "unsupported",
+      "http_input",
+      &format!("HTTPS input not supported: {url}"),
+    );
   }
   // fn open_binding(&mut self, _content: &str) {}
 

--- a/latexml_core/src/parameter.rs
+++ b/latexml_core/src/parameter.rs
@@ -11,7 +11,7 @@ use crate::{
   Digested,
   common::{
     arena::{self, SymStr},
-    error::*,
+    error::{emit_warn, *},
     object::Object,
   },
   definition::{
@@ -276,7 +276,11 @@ impl Parameter {
     self.inner = self.inner.map(|inner_ps| match inner_ps.clone().init() {
       Ok(ps) => ps,
       Err(e) => {
-        log::warn!("inner parameter init failed: {e}");
+        emit_warn(
+          "internal",
+          "parameter",
+          &format!("inner parameter init failed: {e}"),
+        );
         inner_ps
       },
     });

--- a/latexml_core/src/state.rs
+++ b/latexml_core/src/state.rs
@@ -20,7 +20,7 @@ use crate::{
     BindingDispatcher, LabelMappingHook,
     arena::{self, SymHashMap, SymStr},
     dimension::Dimension,
-    error::*,
+    error::{emit_warn, *},
     font::Font,
     glue::Glue,
     model::{self, IndirectModel, Model, compute_indirect_model_aux},
@@ -1402,11 +1402,19 @@ pub fn checkin_value(key: &str, value: Stored) {
   match state_mut!().value.get_mut(&arena::pin(key)) {
     None => {
       // Key was never assigned — silently ignore the checkin
-      log::warn!("checkin_value called for unknown key '{key}'");
+      emit_warn(
+        "internal",
+        "state",
+        &format!("checkin_value called for unknown key '{key}'"),
+      );
     },
     Some(vvec) => match vvec.front_mut() {
       None => {
-        log::warn!("checkin_value called with empty value stack for key '{key}'");
+        emit_warn(
+          "internal",
+          "state",
+          &format!("checkin_value called with empty value stack for key '{key}'"),
+        );
       },
       Some(found) => {
         match found {
@@ -1882,7 +1890,9 @@ pub fn lookup_dimension_cs(cs: &str, noerror: bool) -> Option<Dimension> {
   use std::str::FromStr;
   // Obvious dimension string? (Perl: /^[0-9\+\-\.]\w\w+$/)
   let mut chars = cs.chars();
-  let obvious = matches!(chars.next(), Some(c) if c.is_ascii_digit() || matches!(c, '+' | '-' | '.'))
+  let leading_sign_or_digit =
+    matches!(chars.next(), Some(c) if c.is_ascii_digit() || matches!(c, '+' | '-' | '.'));
+  let obvious = leading_sign_or_digit
     && cs.chars().count() >= 3
     && chars.all(|c| c.is_alphanumeric() || c == '_');
   if obvious && let Ok(d) = Dimension::from_str(cs) {

--- a/latexml_core/src/tokens.rs
+++ b/latexml_core/src/tokens.rs
@@ -9,8 +9,14 @@ use quote::{ToTokens, TokenStreamExt, quote};
 use crate::{
   Digested,
   common::{
-    dimension::Dimension, error::*, float::Float, glue::Glue, mudimension::MuDimension,
-    muglue::MuGlue, number::Number, numeric_ops::NumericOps,
+    dimension::Dimension,
+    error::{emit_warn, *},
+    float::Float,
+    glue::Glue,
+    mudimension::MuDimension,
+    muglue::MuGlue,
+    number::Number,
+    numeric_ops::NumericOps,
   },
   definition::argument::ArgWrap,
   fmt,
@@ -99,7 +105,11 @@ impl From<Tokens> for Token {
       // means a stringly-typed binding slot received a multi-token value
       // (e.g. a macro argument coerced into a single-token slot). The
       // first token preserves TEx's "grab a single token" semantics.
-      log::warn!("multi-token Tokens cast into single Token: {ts:?}");
+      emit_warn(
+        "internal",
+        "tokens",
+        &format!("multi-token Tokens cast into single Token: {ts:?}"),
+      );
       ts.0.remove(0)
     }
   }
@@ -112,7 +122,11 @@ impl<'a> From<&'a Tokens> for Token {
     } else if ts.0.len() == 1 {
       ts.0[0]
     } else {
-      log::warn!("multi-token Tokens cast into single Token: {ts:?}");
+      emit_warn(
+        "internal",
+        "tokens",
+        &format!("multi-token Tokens cast into single Token: {ts:?}"),
+      );
       ts.0[0]
     }
   }

--- a/latexml_core/src/util/logger.rs
+++ b/latexml_core/src/util/logger.rs
@@ -472,6 +472,49 @@ mod tests {
     initialize_report();
   }
 
+  /// Suppression semantics (user decision 2026-08-03): Debug/Info/Warning
+  /// records are muted under suppression, but Error and Fatal EMIT
+  /// UNCONDITIONALLY — cortex-class frameworks aggregate success rates from
+  /// `Error:`/`Fatal:` lines, and a suppressed error would vanish from that
+  /// measurement while still counting locally. Counts accrue either way.
+  #[test]
+  fn suppression_never_mutes_error_or_fatal() {
+    use crate::common::error::{
+      LogStatus, emit_record, get_status, initialize_report, set_suppress_log_output,
+    };
+    initialize_report();
+    let _ = log::set_logger(&LOGGER); // ok if another test installed it
+    log::set_max_level(LevelFilter::Warn);
+    let prev = set_suppress_log_output(true);
+
+    bind_log();
+    emit_record(LogStatus::Warning, "quiet:warn", "muted warning");
+    emit_record(LogStatus::Error, "loud:error", "unmutable error");
+    emit_record(LogStatus::Fatal, "Fatal:loud:fatal ", "unmutable fatal");
+    let captured = flush_log();
+
+    set_suppress_log_output(prev);
+    assert!(
+      !captured.contains("muted warning"),
+      "suppression must mute Warning records, captured:\n{captured}"
+    );
+    assert!(
+      captured.contains("Error:loud:error unmutable error"),
+      "Error must emit under suppression, captured:\n{captured}"
+    );
+    // (Fatal targets carry their own trailing space, so the formatter's
+    // separator makes it two — match the pieces, not the join.)
+    assert!(
+      captured.contains("Fatal:loud:fatal") && captured.contains("unmutable fatal"),
+      "Fatal must emit under suppression, captured:\n{captured}"
+    );
+    // Counts accrue regardless of emission.
+    assert_eq!(get_status(LogStatus::Warning), 1);
+    assert_eq!(get_status(LogStatus::Error), 1);
+    assert_eq!(get_status(LogStatus::Fatal), 1);
+    initialize_report();
+  }
+
   #[test]
   fn strip_ansi_removes_color_codes() {
     // ESC [ ... m should vanish; other content preserved.

--- a/latexml_core/src/util/logger.rs
+++ b/latexml_core/src/util/logger.rs
@@ -269,6 +269,33 @@ impl log::Log for LatexmlLogger {
         }
       };
 
+      // Tally every printed diagnostic record that was NOT emitted by a
+      // counting macro (those count at raise time, even under output
+      // suppression — the MAX_ERRORS cap depends on that). This is the
+      // lossless half of the tally contract: any `Warning:`/`Error:` line
+      // this backend prints from a raw `log::warn!`/`log::error!` call now
+      // registers in `REPORT`, so the final "Conversion complete: N
+      // warnings" agrees with what a reader greps from the log. Witness:
+      // the 131 MB witness logged 12,105 `Warning:` lines (12,103 of them
+      // the math parser's raw `log_math_warn!`) and reported "2 warnings".
+      {
+        use crate::common::error::{LogStatus, note_status_from_logger};
+        let status = if category_object.starts_with("Fatal:") {
+          Some(LogStatus::Fatal)
+        } else {
+          match record.level() {
+            Level::Warn => Some(LogStatus::Warning),
+            Level::Error => Some(LogStatus::Error),
+            Level::Info => Some(LogStatus::Info),
+            Level::Debug => Some(LogStatus::Debug),
+            // No Trace counter exists; Trace records stay uncounted.
+            Level::Trace => None,
+          }
+        };
+        if let Some(status) = status {
+          note_status_from_logger(status);
+        }
+      }
       let message = if severity.is_empty() {
         s!("{} ", category_object)
       } else {
@@ -380,6 +407,69 @@ mod tests {
     let mut c = String::from("Info:foo\n");
     append_note(&mut c, "\n(Building...");
     assert_eq!(c, "Info:foo\n(Building...");
+  }
+
+  /// The lossless-tally contract (user directive 2026-08-02): every printed
+  /// diagnostic record counts exactly once, whether it came from a counting
+  /// macro (raise-time count, logger skips) or a raw `log::warn!`-family call
+  /// (logger counts). Defect this pins: the 131 MB witness logged 12,105
+  /// `Warning:` lines — 12,103 from the math parser's raw `log_math_warn!` —
+  /// and the final verdict said "2 warnings".
+  ///
+  /// One test, not several: the global logger and the thread-local `REPORT`
+  /// are both process/thread state, and cargo runs sibling `#[test]`s on
+  /// separate threads — but a SINGLE test body sees one thread and one
+  /// deterministic sequence.
+  #[test]
+  fn raw_log_records_count_and_macro_records_do_not_double_count() {
+    use crate::common::error::{
+      LogStatus, get_status, initialize_report, macro_diag_guard, note_status,
+      note_status_from_logger,
+    };
+    // Another test may have installed the logger already; counting rides
+    // note_status_from_logger either way, so drive it exactly as
+    // `LatexmlLogger::log` does rather than through the global sink.
+    initialize_report();
+
+    // Raw record: the logger's tally path counts it.
+    note_status_from_logger(LogStatus::Warning);
+    assert_eq!(get_status(LogStatus::Warning), 1, "raw warning must count");
+
+    // Macro-emitted record: raise-time count happens under the guard, and
+    // the logger's observation of the same record must be a no-op.
+    {
+      let _g = macro_diag_guard();
+      note_status(LogStatus::Warning, None); // what the macro does
+      note_status_from_logger(LogStatus::Warning); // what the logger then sees
+    }
+    assert_eq!(
+      get_status(LogStatus::Warning),
+      2,
+      "a macro warning counts once, not twice"
+    );
+
+    // Nested guards (Error! escalating into Fatal!) keep the marker set.
+    {
+      let _outer = macro_diag_guard();
+      {
+        let _inner = macro_diag_guard();
+      }
+      note_status_from_logger(LogStatus::Error);
+    }
+    assert_eq!(
+      get_status(LogStatus::Error),
+      0,
+      "the logger stays muted for the whole macro emission, even after a \
+       nested guard drops"
+    );
+
+    // Raw error and a raw Fatal-target record (log_fatal's shape when some
+    // future caller bypasses it): the error counts, the fatal latches.
+    note_status_from_logger(LogStatus::Error);
+    note_status_from_logger(LogStatus::Fatal);
+    assert_eq!(get_status(LogStatus::Error), 1);
+    assert_eq!(get_status(LogStatus::Fatal), 1, "raw fatal latches sticky");
+    initialize_report();
   }
 
   #[test]

--- a/latexml_core/src/whatsit.rs
+++ b/latexml_core/src/whatsit.rs
@@ -8,7 +8,7 @@ use crate::{
   common::{
     arena::{self, SymHashMap as HashMap},
     dimension::Dimension,
-    error::*,
+    error::{emit_warn, *},
     font::Font,
     locator::Locator,
     object::Object,
@@ -120,7 +120,11 @@ impl Whatsit {
   /// Returns None for n == 0 (defensive — Perl convention uses 1-based indexing).
   pub fn get_arg(&self, n: usize) -> Option<&Digested> {
     if n == 0 {
-      log::warn!("get_arg(0) called — Perl convention uses 1-based indexing");
+      emit_warn(
+        "internal",
+        "get_arg",
+        "get_arg(0) called — Perl convention uses 1-based indexing",
+      );
       return None;
     }
     match self.args.get(n - 1) {

--- a/latexml_engine/src/embedded_dumps.rs
+++ b/latexml_engine/src/embedded_dumps.rs
@@ -47,6 +47,7 @@ use std::{
   path::PathBuf,
 };
 
+use latexml_core::common::error::emit_warn;
 use once_cell::sync::Lazy;
 use rustc_hash::FxHashMap as HashMap;
 
@@ -147,10 +148,13 @@ fn decompressed_dump(year: u32, kind: &'static str, gz: &[u8]) -> Option<&'stati
       let mut decoder = flate2::read::GzDecoder::new(gz);
       let mut buf = String::with_capacity(gz.len() * 5); // ~4.7× ratio + slack
       if decoder.read_to_string(&mut buf).is_err() {
-        log::warn!(
-          "[embedded_dumps] gunzip failed for {kind} TL{year} ({} bytes); \
-           falling back to no embedded dump",
-          gz.len()
+        emit_warn(
+          "internal",
+          "embedded_dumps",
+          &format!(
+            "gunzip failed for {kind} TL{year} ({} bytes); falling back to no embedded dump",
+            gz.len()
+          ),
         );
         return None;
       }

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -1,7 +1,9 @@
 use std::collections::VecDeque;
 
 use latexml_core::{
-  alignment::template::TemplateConfig, common::xml::is_descendant_or_self, digested::DigestedData,
+  alignment::template::TemplateConfig,
+  common::{error::emit_warn, xml::is_descendant_or_self},
+  digested::DigestedData,
 };
 
 ///**********************************************************************
@@ -773,7 +775,11 @@ pub fn before_equation() -> Result<()> {
       match numbering.get("counter") {
         Some(Stored::String(v)) => to_string(*v),
         Some(other) => {
-          log::warn!("eq counter should be stored as string, was instead: {other:?}");
+          emit_warn(
+            "internal",
+            "state",
+            &format!("eq counter should be stored as string, was instead: {other:?}"),
+          );
           String::from("equation")
         },
         _ => String::from("equation"),

--- a/latexml_engine/src/setup_binding_language.rs
+++ b/latexml_engine/src/setup_binding_language.rs
@@ -1560,10 +1560,13 @@ macro_rules! DefKeyVal {
   }};
   ($keyset:expr_2021, $key:expr_2021, $vtype:expr_2021, $default:expr_2021, $options:tt) => {{
     // TODO: explicit $options with prefix logic — for now ignore options and use default prefix
-    log::warn!(
-      "DefKeyVal with explicit options not fully ported, ignoring options for {}/{}",
-      $keyset,
-      $key
+    latexml_core::common::error::emit_warn(
+      "unimplemented",
+      "DefKeyVal",
+      &format!(
+        "DefKeyVal with explicit options not fully ported, ignoring options for {}/{}",
+        $keyset, $key
+      ),
     );
     ::latexml_core::keyval::define(KeyvalConfig {
       prefix: "KV",

--- a/latexml_engine/src/tex_box.rs
+++ b/latexml_engine/src/tex_box.rs
@@ -2,7 +2,7 @@
 //!
 //! Core TeX Implementation for LaTeXML
 
-use latexml_core::common::numeric_ops::round_to;
+use latexml_core::common::{error::emit_warn, numeric_ops::round_to};
 
 use crate::prelude::*;
 
@@ -1393,7 +1393,11 @@ pub fn read_box_contents(everybox_opt: Option<Tokens>) -> Result<Tokens> {
     Some(Stored::Tokens(tokens)) => unread(tokens),
     Some(Stored::Token(token)) => unread_one(token),
     None | Some(Stored::None) => {},
-    Some(other) => log::warn!("afterAssignment should be a token, got: {}", other),
+    Some(other) => emit_warn(
+      "internal",
+      "after_assignment",
+      &format!("afterAssignment should be a token, got: {other}"),
+    ),
   };
   // AND, insert any extra tokens passed in, due to everyhbox or everyvbox
   if let Some(everybox) = everybox_opt {

--- a/latexml_engine/src/tex_glue.rs
+++ b/latexml_engine/src/tex_glue.rs
@@ -1,6 +1,8 @@
 //! TeX Glue
 //!
 //! Core TeX Implementation for LaTeXML
+use latexml_core::common::error::emit_warn;
+
 use crate::prelude::*;
 static UNICODE_EM_SPACES: [(f64, char); 7] = [
   // Spaces to fake spacing, with width in ems
@@ -262,7 +264,11 @@ LoadDefinitions!({
             if let Stored::Dimension(ref width_d) = *width_stored {
               return *width_d;
             } else {
-              log::warn!("Unexpected type of \"width\" value in State: {width_stored:?}");
+              emit_warn(
+                "internal",
+                "state",
+                &format!("Unexpected type of \"width\" value in State: {width_stored:?}"),
+              );
               break;
             }
           } else {

--- a/latexml_math_parser/Cargo.toml
+++ b/latexml_math_parser/Cargo.toml
@@ -22,7 +22,6 @@ token-locators = ["latexml_core/token-locators"]
 [dependencies]
 libxml = "0.3.21"
 regex = { version = "1.7.1", default-features = false, features = ["std", "perf", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script"] }  # DEP-10
-log = "0.4"
 # dginev/marpa fork, published as `marpa-asf`; `package` alias keeps `marpa::`.
 marpa = { package = "marpa-asf", version = "0.3.0" }
 once_cell = "1.17.0"

--- a/latexml_math_parser/src/diag.rs
+++ b/latexml_math_parser/src/diag.rs
@@ -1,8 +1,9 @@
 //! Diagnostic emission for `latexml_math_parser`.
 //!
-//! Mirrors the contract of `latexml_post::diag` and
-//! `latexml_core::common::error::Error!` so the converter's log harness
-//! aggregates math-parser emissions identically to engine + post stages:
+//! Thin forwarding wrappers over the SINGLE diagnostic vehicle
+//! (`latexml_core::common::error::emit_*`), so math-parser emissions count in
+//! the conversion tally and aggregate in cortex identically to engine + post
+//! stages:
 //!
 //!   `target = "<class>:<object>"`  →  `Error:<class>:<object> <message>`
 //!
@@ -13,37 +14,40 @@
 //!   * `Fatal('expected', 'MathGrammar', …)` — MathParser.pm:56 (grammar load)
 //!   * `Fatal('malformed', '<XMath>', …)`   — MathParser.pm:280 (bad parent)
 //!
-//! Like `latexml_post::diag`, we don't reuse `latexml_core::common::error::Error!`
-//! because that macro early-returns `Err(LatexmlError)` on max-errors /
-//! runaway-loop, and math-parser functions return diverse types
-//! (`String`, `Option<…>`, etc.), not `Result<_, LatexmlError>`.
+//! We don't reuse `latexml_core::common::error::Error!` because that macro
+//! early-returns `Err(LatexmlError)` on max-errors / runaway-loop, and
+//! math-parser functions return diverse types (`String`, `Option<…>`, etc.),
+//! not `Result<_, LatexmlError>` — exactly the gap `emit_error` exists for.
+//! These used to call raw `log::warn!`/`log::error!`, which printed
+//! `Warning:`/`Error:` lines that no counter ever saw: the 131 MB witness
+//! logged 12,103 math warnings and reported "2 warnings".
 
 #[macro_export]
 macro_rules! log_math_error {
   ($category:expr_2021, $object:expr_2021, $msg:expr_2021) => {
-    log::error!(target: &format!("{}:{}", $category, $object), "{}", $msg)
+    latexml_core::common::error::emit_error(&format!("{}", $category), &format!("{}", $object), &format!("{}", $msg))
   };
   ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {
-    log::error!(target: &format!("{}:{}", $category, $object), $fmt, $($arg)+)
+    latexml_core::common::error::emit_error(&format!("{}", $category), &format!("{}", $object), &format!($fmt, $($arg)+))
   };
 }
 
 #[macro_export]
 macro_rules! log_math_warn {
   ($category:expr_2021, $object:expr_2021, $msg:expr_2021) => {
-    log::warn!(target: &format!("{}:{}", $category, $object), "{}", $msg)
+    latexml_core::common::error::emit_warn(&format!("{}", $category), &format!("{}", $object), &format!("{}", $msg))
   };
   ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {
-    log::warn!(target: &format!("{}:{}", $category, $object), $fmt, $($arg)+)
+    latexml_core::common::error::emit_warn(&format!("{}", $category), &format!("{}", $object), &format!($fmt, $($arg)+))
   };
 }
 
 #[macro_export]
 macro_rules! log_math_info {
   ($category:expr_2021, $object:expr_2021, $msg:expr_2021) => {
-    log::info!(target: &format!("{}:{}", $category, $object), "{}", $msg)
+    latexml_core::common::error::emit_info(&format!("{}", $category), &format!("{}", $object), &format!("{}", $msg))
   };
   ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {
-    log::info!(target: &format!("{}:{}", $category, $object), $fmt, $($arg)+)
+    latexml_core::common::error::emit_info(&format!("{}", $category), &format!("{}", $object), &format!($fmt, $($arg)+))
   };
 }

--- a/latexml_oxide/bin/cortex_worker.rs
+++ b/latexml_oxide/bin/cortex_worker.rs
@@ -22,6 +22,8 @@ use std::{
   sync::atomic::{AtomicU64, Ordering},
 };
 
+use latexml_core::common::error::{emit_error, emit_warn};
+
 /// Per-process allocator. Default is **mimalloc** (lock-free per-thread heaps,
 /// avoids glibc's arena-mutex contention). Building with `--features jemalloc`
 /// swaps in **jemalloc**, whose decay-based background purging returns freed
@@ -670,9 +672,12 @@ impl Worker for LatexmlWorker {
           },
           None => ("conversion", "caught", es.as_str()),
         };
-        log::warn!(
-          target: "cortex_worker",
-          "conversion of {arxiv_id} failed ({category}:{what}): {message}; returning a Fatal result archive"
+        emit_warn(
+          "cortex_worker",
+          "failed",
+          &format!(
+            "conversion of {arxiv_id} failed ({category}:{what}): {message}; returning a Fatal result archive"
+          ),
         );
         write_failure_zip(&arxiv_id, category, what, message)?
       },
@@ -687,16 +692,22 @@ impl Worker for LatexmlWorker {
           s.set(n);
           n
         });
-        log::error!(
-          target: "cortex_worker",
-          "PANIC caught converting {arxiv_id} (consecutive: {streak}/{MAX_CONSECUTIVE_PANICS}): {msg}"
+        emit_error(
+          "cortex_worker",
+          "panic",
+          &format!(
+            "PANIC caught converting {arxiv_id} (consecutive: {streak}/{MAX_CONSECUTIVE_PANICS}): {msg}"
+          ),
         );
         if streak >= MAX_CONSECUTIVE_PANICS {
-          log::error!(
-            target: "cortex_worker",
-            "{MAX_CONSECUTIVE_PANICS} consecutive panics — engine state is likely corrupted; \
-             exiting (code 70) for a clean supervisor restart. The dispatcher's lease reaper \
-             re-leases the in-flight task to another worker."
+          emit_error(
+            "cortex_worker",
+            "panic",
+            &format!(
+              "{MAX_CONSECUTIVE_PANICS} consecutive panics — engine state is likely corrupted; \
+               exiting (code 70) for a clean supervisor restart. The dispatcher's lease reaper \
+               re-leases the in-flight task to another worker."
+            ),
           );
           process::exit(70);
         }

--- a/latexml_oxide/bin/latexml_oxide.rs
+++ b/latexml_oxide/bin/latexml_oxide.rs
@@ -12,7 +12,7 @@ use std::{
 
 use clap::Parser;
 use latexml::converter::Converter;
-use latexml_core::common::{Config, DataSize, DigestionMode, OutputFormat};
+use latexml_core::common::{Config, DataSize, DigestionMode, OutputFormat, error::emit_info};
 
 /// Per-process allocator: mimalloc avoids glibc's arena-mutex contention
 /// which dominates multi-process workloads (seen as 3.4x slowdown at 16 workers).
@@ -715,7 +715,7 @@ fn real_main() -> Result<(), Box<dyn Error>> {
 
   // Persistent LSP Server mode — handle early before source file checks
   if cli.server {
-    log::info!("Starting persistent LSP server...");
+    emit_info("lsp", "server", "Starting persistent LSP server...");
     let max_memory = resolve_max_memory(cli.max_memory);
     latexml::lsp_server::run_lsp_server(cli.timeout, max_memory)?;
     process::exit(0);

--- a/latexml_oxide/src/core_interface.rs
+++ b/latexml_oxide/src/core_interface.rs
@@ -8,7 +8,7 @@ use latexml_core::{
 use latexml_core::{
   common::{
     DigestionMode, arena,
-    error::{self, Result, note_begin, note_end},
+    error::{self, Result, emit_info, emit_warn, note_begin, note_end},
     model,
     store::Stored,
   },
@@ -214,10 +214,13 @@ fn digest_step_guarded(boxes: &mut Vec<Digested>) -> Result<bool> {
           | (ErrorTarget::Timeout, ErrorCategory::TokenLimit)
           | (ErrorTarget::Timeout, ErrorCategory::PushbackLimit)
       ) {
-        log::warn!(
-          "digest_internal: resource failure ({:?}/{:?}) — not recovering",
-          e.target,
-          e.category
+        emit_warn(
+          "recovery",
+          "digest_internal",
+          &format!(
+            "digest_internal: resource failure ({:?}/{:?}) — not recovering",
+            e.target, e.category
+          ),
         );
         return Err(e);
       }
@@ -244,7 +247,11 @@ fn digest_step_guarded(boxes: &mut Vec<Digested>) -> Result<bool> {
       // complete: No obvious problems`, status code 0 — "ok" to cortex.
       // Guard: `101_fatal_salvages_partial_document`.
       e.log_fatal();
-      log::warn!("digest_internal: error during recovery digestion: {:?}", e);
+      emit_warn(
+        "recovery",
+        "digest_internal",
+        &format!("digest_internal: error during recovery digestion: {:?}", e),
+      );
       // Recover what the failed body already digested. Without this the
       // "still produce partial output" intent above only worked when the
       // failure landed in a LATER body — a Fatal inside the FIRST one left
@@ -269,9 +276,13 @@ fn digest_step_guarded(boxes: &mut Vec<Digested>) -> Result<bool> {
       if matches!(e.target, ErrorTarget::Stomach) {
         let salvaged = stomach::salvage_pending_box_lists(true);
         if !salvaged.is_empty() {
-          log::info!(
-            "digest_internal: salvaged {} box(es) digested before the fatal",
-            salvaged.len()
+          emit_info(
+            "recovery",
+            "digest_internal",
+            &format!(
+              "digest_internal: salvaged {} box(es) digested before the fatal",
+              salvaged.len()
+            ),
           );
           boxes.extend(salvaged);
         }
@@ -656,10 +667,14 @@ fn streaming_pass2(
     {
       let mut frag = Document::from_xml_document(frag_xml, node_fonts.clone())?;
       if due {
-        log::info!(
-          "streaming pass2: segment {seg} ({} KB) parsed; RSS ~{} MB",
-          store.read_segment(seg).map(|t| t.len() / 1024).unwrap_or(0),
-          latexml_core::watchdog::process_rss_kb().unwrap_or(0) / 1024,
+        emit_info(
+          "streaming",
+          "progress",
+          &format!(
+            "streaming pass2: segment {seg} ({} KB) parsed; RSS ~{} MB",
+            store.read_segment(seg).map(|t| t.len() / 1024).unwrap_or(0),
+            latexml_core::watchdog::process_rss_kb().unwrap_or(0) / 1024,
+          ),
         );
       }
       frag.scoped_rules_strict = true;
@@ -733,11 +748,15 @@ fn streaming_pass2(
         parser.parse_math(&mut frag)?;
         drop(_gp);
         if due {
-          log::info!(
-            "streaming pass2: segment {seg} math done; RSS {} -> {} MB; arena {} syms",
-            rss0,
-            latexml_core::watchdog::process_rss_kb().unwrap_or(0) / 1024,
-            arena::len(),
+          emit_info(
+            "streaming",
+            "progress",
+            &format!(
+              "streaming pass2: segment {seg} math done; RSS {} -> {} MB; arena {} syms",
+              rss0,
+              latexml_core::watchdog::process_rss_kb().unwrap_or(0) / 1024,
+              arena::len(),
+            ),
           );
         }
         // Mirror the eager tail: mark failed formulae, renumber math ids
@@ -784,9 +803,13 @@ fn streaming_pass2(
     }
     store.finalize_segment(seg, &out)?;
     if due {
-      log::info!(
-        "streaming pass2: segment {seg} finalized+dropped; RSS ~{} MB",
-        latexml_core::watchdog::process_rss_kb().unwrap_or(0) / 1024
+      emit_info(
+        "streaming",
+        "progress",
+        &format!(
+          "streaming pass2: segment {seg} finalized+dropped; RSS ~{} MB",
+          latexml_core::watchdog::process_rss_kb().unwrap_or(0) / 1024
+        ),
       );
     }
   }
@@ -1071,10 +1094,14 @@ impl DigestionAPI for Core {
         if dir_is_writable(&dir) {
           dir
         } else {
-          log::info!(
-            "streaming: {} is not writable; spilling to {} instead",
-            dir.display(),
-            std::env::temp_dir().display()
+          emit_info(
+            "streaming",
+            "progress",
+            &format!(
+              "streaming: {} is not writable; spilling to {} instead",
+              dir.display(),
+              std::env::temp_dir().display()
+            ),
           );
           std::env::temp_dir()
         }
@@ -1106,7 +1133,7 @@ impl DigestionAPI for Core {
           target:   ErrorTarget::Timeout,
           category: ErrorCategory::MemoryBudget,
           message:  s!(
-            "streaming spill needs ~{} MB free under {} but only {} MB is available — free              disk space there, or convert with a destination on a roomier volume",
+            "streaming spill needs ~{} MB free under {} but only {} MB is available — free disk space there, or convert with a destination on a roomier volume",
             need / (1024 * 1024),
             store.dir().display(),
             avail / (1024 * 1024)
@@ -1167,10 +1194,13 @@ impl DigestionAPI for Core {
           // for. The Fatal contract still holds: announce + latch the
           // verdict, keep the partial document (user policy 2026-07-28).
           e.log_fatal();
-          log::warn!(
-            "convert_streaming: digestion stopped by a resource fatal ({:?}/{:?}) — keeping              the document built so far",
-            e.target,
-            e.category
+          emit_warn(
+            "internal",
+            "core_interface",
+            &format!(
+              "convert_streaming: digestion stopped by a resource fatal ({:?}/{:?}) — keeping the document built so far",
+              e.target, e.category
+            ),
           );
           // Recover what the interrupted step had digested. Unlike the eager
           // Stomach-target salvage, drop_innermost is FALSE: there is no
@@ -1190,10 +1220,13 @@ impl DigestionAPI for Core {
           // Same Fatal contract as the eager Build: announce, latch, keep the
           // partial document (recovery is a FEATURE of Fatal).
           e.log_fatal();
-          log::warn!(
-            "convert_streaming: build stopped early ({:?}/{:?}) — keeping the document built so far",
-            e.target,
-            e.category
+          emit_warn(
+            "internal",
+            "core_interface",
+            &format!(
+              "convert_streaming: build stopped early ({:?}/{:?}) — keeping the document built so far",
+              e.target, e.category
+            ),
           );
           fatal_stop = true;
           stopped = true;
@@ -1271,27 +1304,35 @@ impl DigestionAPI for Core {
             .map(|r| r.get_child_nodes().len())
             .unwrap_or(0);
           let (mouths, comments) = gullet::queue_sizes();
-          log::info!(
-            "streaming: undo {}; mouths {}; comments {}; node_boxes {}",
-            state::undo_depth(),
-            mouths,
-            comments,
-            document.node_boxes.len(),
+          emit_info(
+            "streaming",
+            "progress",
+            &format!(
+              "streaming: undo {}; mouths {}; comments {}; node_boxes {}",
+              state::undo_depth(),
+              mouths,
+              comments,
+              document.node_boxes.len(),
+            ),
           );
-          log::info!(
-            "streaming: fragment {} absorbed; {} segment(s) spilled; RSS ~{} MB; C-live {} MB; C-free {} MB; root-children {}; idstore {}; index {}+{}; arena {}; fonts {}; pending {}",
-            fragments,
-            latexml_core::document::spilled_segment_count(),
-            stomach::last_sampled_rss_kb() / 1024,
-            c_live_mb,
-            c_free_mb,
-            spine_children,
-            document.idstore.len(),
-            index_ids,
-            index_labels,
-            arena::len(),
-            document.node_fonts.len(),
-            document.pending.len(),
+          emit_info(
+            "streaming",
+            "progress",
+            &format!(
+              "streaming: fragment {} absorbed; {} segment(s) spilled; RSS ~{} MB; C-live {} MB; C-free {} MB; root-children {}; idstore {}; index {}+{}; arena {}; fonts {}; pending {}",
+              fragments,
+              latexml_core::document::spilled_segment_count(),
+              stomach::last_sampled_rss_kb() / 1024,
+              c_live_mb,
+              c_free_mb,
+              spine_children,
+              document.idstore.len(),
+              index_ids,
+              index_labels,
+              arena::len(),
+              document.node_fonts.len(),
+              document.pending.len(),
+            ),
           );
         }
       }
@@ -1304,12 +1345,16 @@ impl DigestionAPI for Core {
     gullet::flush();
     note_end(&digestion_note);
     let pass1_elapsed = phase_clock.elapsed();
-    log::info!(
-      "streaming: PASS 1 done in {:.1?} — {} yield(s), {} segment(s) spilled, RSS ~{} MB",
-      pass1_elapsed,
-      stomach::fragment_yield_count(),
-      latexml_core::document::spilled_segment_count(),
-      latexml_core::watchdog::process_rss_kb().unwrap_or(0) / 1024,
+    emit_info(
+      "streaming",
+      "progress",
+      &format!(
+        "streaming: PASS 1 done in {:.1?} — {} yield(s), {} segment(s) spilled, RSS ~{} MB",
+        pass1_elapsed,
+        stomach::fragment_yield_count(),
+        latexml_core::document::spilled_segment_count(),
+        latexml_core::watchdog::process_rss_kb().unwrap_or(0) / 1024,
+      ),
     );
 
     // The ROOT's after-open hooks were DEFERRED during pass 1
@@ -1337,8 +1382,10 @@ impl DigestionAPI for Core {
       // form — well-formed XML that still carries `_`-bookkeeping attributes,
       // which a salvaged partial is allowed to. The verdict is already
       // latched Fatal.
-      log::warn!(
-        "convert_streaming: fatal stop — emitting the cheap partial (pass 2 and the finalize          tail skipped to avoid allocating at the memory ceiling)"
+      emit_warn(
+        "internal",
+        "core_interface",
+        "convert_streaming: fatal stop — emitting the cheap partial (pass 2 and the finalize tail skipped to avoid allocating at the memory ceiling)",
       );
       // The partial's serialization must still RESOLVE placeholders (raw
       // segments splice recursively) — literal mode was for pass 1 only.
@@ -1378,12 +1425,16 @@ impl DigestionAPI for Core {
       .unwrap_or_default();
     let pass2_start = phase_clock.elapsed();
     streaming_pass2(&mut store, &index, &node_fonts, &mut counters)?;
-    log::info!(
-      "streaming: PASS 2 done in {:.1?} ({:.1?} cumulative) — {} segment(s), RSS ~{} MB",
-      phase_clock.elapsed().saturating_sub(pass2_start),
-      phase_clock.elapsed(),
-      latexml_core::document::spilled_segment_count(),
-      latexml_core::watchdog::process_rss_kb().unwrap_or(0) / 1024,
+    emit_info(
+      "streaming",
+      "progress",
+      &format!(
+        "streaming: PASS 2 done in {:.1?} ({:.1?} cumulative) — {} segment(s), RSS ~{} MB",
+        phase_clock.elapsed().saturating_sub(pass2_start),
+        phase_clock.elapsed(),
+        latexml_core::document::spilled_segment_count(),
+        latexml_core::watchdog::process_rss_kb().unwrap_or(0) / 1024,
+      ),
     );
     if let Some(mut root) = document.get_document().get_root_element() {
       for (key, value) in &counters {
@@ -1424,11 +1475,14 @@ impl DigestionAPI for Core {
     // run still reports as failed and never masquerades as clean.
     if let Err(e) = document.absorb(&digested, None) {
       e.log_fatal();
-      log::warn!(
-        "convert_document: build stopped early ({:?}/{:?}) — keeping the \
+      emit_warn(
+        "internal",
+        "core_interface",
+        &format!(
+          "convert_document: build stopped early ({:?}/{:?}) — keeping the \
          document built so far",
-        e.target,
-        e.category
+          e.target, e.category
+        ),
       );
     }
     note_end("Building");

--- a/latexml_oxide/src/lsp_server/generic.rs
+++ b/latexml_oxide/src/lsp_server/generic.rs
@@ -4,6 +4,7 @@
 
 use std::io::BufRead;
 
+use latexml_core::common::error::emit_error;
 use serde_json::Value;
 
 use super::*;
@@ -52,7 +53,11 @@ pub fn run(timeout_secs: u64, max_rss_kb: u64) -> Result<(), Box<dyn std::error:
     let request = match parse_json(&body_str) {
       Ok(v) => v,
       Err(e) => {
-        log::error!("Failed to parse incoming JSON: {e}");
+        emit_error(
+          "lsp",
+          "protocol",
+          &format!("Failed to parse incoming JSON: {e}"),
+        );
         continue;
       },
     };

--- a/latexml_oxide/src/lsp_server/project.rs
+++ b/latexml_oxide/src/lsp_server/project.rs
@@ -17,6 +17,7 @@ use std::{
   time::SystemTime,
 };
 
+use latexml_core::common::error::emit_warn;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use rustc_hash::FxHashMap;
@@ -215,9 +216,13 @@ pub(crate) fn resolve_root(
     if ov.exists() || ov == buffer_path {
       return ov;
     }
-    log::warn!(
-      "rootDocument override {} does not exist; ignoring",
-      ov.display()
+    emit_warn(
+      "lsp",
+      "root_document",
+      &format!(
+        "rootDocument override {} does not exist; ignoring",
+        ov.display()
+      ),
     );
   }
   if let Some(t) = text {

--- a/latexml_oxide/src/lsp_server/unix.rs
+++ b/latexml_oxide/src/lsp_server/unix.rs
@@ -8,7 +8,10 @@ use std::{
   os::unix::io::FromRawFd,
 };
 
-use latexml_core::BoxOps;
+use latexml_core::{
+  BoxOps,
+  common::error::{emit_error, emit_info, emit_warn},
+};
 use serde_json::Value;
 
 use super::*;
@@ -641,7 +644,11 @@ impl Server {
       && deps_still_current(&self.warmed_source_deps, &self.open_buffers);
 
     if !cache_hit {
-      log::info!("Warming preamble cache for {uri}");
+      emit_info(
+        "lsp",
+        "preamble",
+        &format!("Warming preamble cache for {uri}"),
+      );
       self.invalidate_cache();
       latexml_core::state::reset_thread_state();
 
@@ -668,7 +675,11 @@ impl Server {
           self.warmed_source_deps = warmup_dep_snapshot(&self.open_buffers, &root_path);
         },
         Err(e) => {
-          log::error!("Preamble warmup failed ({e}); falling back to in-process");
+          emit_error(
+            "lsp",
+            "preamble",
+            &format!("Preamble warmup failed ({e}); falling back to in-process"),
+          );
           return WarmResult::Done(self.convert_in_process(uri, text));
         },
       }
@@ -685,7 +696,7 @@ impl Server {
       match spawn_body_child(uri, offset_lines, body, warmed, timeout, self.max_rss_kb) {
         Ok(v) => v,
         Err(e) => {
-          log::error!("{e}; falling back to in-process");
+          emit_error("lsp", "fork", &format!("{e}; falling back to in-process"));
           return WarmResult::Done(self.convert_in_process(uri, text));
         },
       };
@@ -739,7 +750,11 @@ fn dispatch(
   let request = match parse_json(body_str) {
     Ok(v) => v,
     Err(e) => {
-      log::error!("Failed to parse incoming JSON: {e}");
+      emit_error(
+        "lsp",
+        "protocol",
+        &format!("Failed to parse incoming JSON: {e}"),
+      );
       return Ok(true);
     },
   };
@@ -844,7 +859,11 @@ fn dispatch(
           &error_response(id, -32601.0, format!("Method '{other}' not found")),
         )?;
       } else {
-        log::warn!("Unhandled LSP notification: {other}");
+        emit_warn(
+          "lsp",
+          "protocol",
+          &format!("Unhandled LSP notification: {other}"),
+        );
       }
     },
   }
@@ -906,7 +925,11 @@ fn convert_trigger(
       Ok(t) => t,
       Err(e) => {
         // Degrade to v1 behavior: convert the buffer standalone.
-        log::warn!("cannot read project root {root_str} ({e}); converting the buffer standalone");
+        emit_warn(
+          "lsp",
+          "project_root",
+          &format!("cannot read project root {root_str} ({e}); converting the buffer standalone"),
+        );
         text.to_string()
       },
     }

--- a/latexml_oxide/src/post.rs
+++ b/latexml_oxide/src/post.rs
@@ -6,7 +6,7 @@
 
 use latexml_core::{
   Info, Warn,
-  common::error::{LogStatus, note_progress, note_status},
+  common::error::{emit_error, note_progress},
   s,
   telemetry::{self, Phase},
 };
@@ -113,11 +113,7 @@ pub fn default_stylesheet(format: Option<&str>) -> Option<&'static str> {
 /// digester's `Result<_, error::Error>` functions. The post-processing entry
 /// points return `String`/`Result<_, ()>`, so we log+count directly with no
 /// control-flow side effect.
-fn post_error(object: &str, message: &str) {
-  let _diag_guard = latexml_core::common::error::macro_diag_guard();
-  note_status(LogStatus::Error, None);
-  log::error!(target: &format!("post:{object}"), "{message}");
-}
+fn post_error(object: &str, message: &str) { emit_error("post", object, message); }
 
 /// Result of [`run_post_processing_logged`]: the serialized HTML plus the
 /// post-phase log text and status code, mirroring Perl `LaTeXML.pm`'s

--- a/latexml_oxide/src/post.rs
+++ b/latexml_oxide/src/post.rs
@@ -114,6 +114,7 @@ pub fn default_stylesheet(format: Option<&str>) -> Option<&'static str> {
 /// points return `String`/`Result<_, ()>`, so we log+count directly with no
 /// control-flow side effect.
 fn post_error(object: &str, message: &str) {
+  let _diag_guard = latexml_core::common::error::macro_diag_guard();
   note_status(LogStatus::Error, None);
   log::error!(target: &format!("post:{object}"), "{message}");
 }

--- a/latexml_oxide/tests/101_fatal_salvages_partial_document.rs
+++ b/latexml_oxide/tests/101_fatal_salvages_partial_document.rs
@@ -122,11 +122,17 @@ fn recoverable_fatal_keeps_the_already_digested_document() {
   // a `Fatal:` in the log REQUIRES the fatal verdict, and no `Fatal:` forbids
   // it. (The verdict is `(Finalizing... )`-prefixed, hence `ends_with`.)
   if stderr.contains("Fatal:") {
+    // "1 warning; 1 fatal error", not "1 fatal error" alone: the salvage
+    // path's own `Warning:…digest_internal` note is a raw `log::warn!`, and
+    // since the lossless-tally fix (2026-08-02) every printed diagnostic
+    // record counts — the warning's presence in the tally is that fix
+    // working, not tally noise.
     assert!(
-      verdict.ends_with("Conversion failed: 1 fatal error"),
-      "the log reports a Fatal, so the final status must be exactly \
-       \"Conversion failed: 1 fatal error\" — recovering boxes is not a \
-       licence to reclassify the verdict. Got:\n  {verdict}\n{stderr}",
+      verdict.ends_with("Conversion failed: 1 warning; 1 fatal error"),
+      "the log reports a Fatal (and the salvage warning), so the final \
+       status must be exactly \"Conversion failed: 1 warning; 1 fatal \
+       error\" — recovering boxes is not a licence to reclassify the \
+       verdict. Got:\n  {verdict}\n{stderr}",
     );
   } else {
     assert!(

--- a/latexml_oxide/tests/119_final_status_report.rs
+++ b/latexml_oxide/tests/119_final_status_report.rs
@@ -177,3 +177,43 @@ fn clean_post_run_ends_with_a_complete_verdict() {
     "a post run must END on its combined verdict, got: {very_last}"
   );
 }
+
+/// The lossless-tally contract at the binary level (user directive
+/// 2026-08-02): a diagnostic emitted via a raw `log::warn!` — here
+/// `mouth.rs`'s deterministic "HTTP input not supported" — must register in
+/// the final verdict's count, not just print. Defect this pins: the 131 MB
+/// witness logged 12,105 `Warning:` lines (12,103 of them the math parser's
+/// raw `log_math_warn!`) while the verdict said "2 warnings".
+#[test]
+fn raw_log_warnings_register_in_the_final_verdict() {
+  let workdir = tempfile::tempdir().expect("tempdir");
+  let tex = workdir.path().join("rawwarn.tex");
+  std::fs::write(
+    &tex,
+    "\\documentclass{article}\\begin{document}\n\
+     \\input{http://example.com/nonexistent.tex}\nText.\n\\end{document}\n",
+  )
+  .expect("fixture written");
+  let (stderr, code) = run(
+    &[
+      &tex.to_string_lossy(),
+      "--dest=rawwarn.html",
+      "--format=html5",
+    ],
+    workdir.path(),
+  );
+  assert_eq!(
+    code, 0,
+    "warnings alone do not fail a run — stderr:\n{stderr}"
+  );
+  assert!(
+    stderr.contains("Warning:latexml_core::mouth HTTP input not supported"),
+    "the raw-log warning line must print"
+  );
+  let (last_verdict, _) = last_lines(&stderr);
+  let verdict = last_verdict.expect("verdict line present");
+  assert!(
+    verdict.contains("Conversion complete: 1 warning"),
+    "the raw-log warning must be COUNTED in the verdict, got: {verdict}"
+  );
+}

--- a/latexml_oxide/tests/119_final_status_report.rs
+++ b/latexml_oxide/tests/119_final_status_report.rs
@@ -179,9 +179,10 @@ fn clean_post_run_ends_with_a_complete_verdict() {
 }
 
 /// The lossless-tally contract at the binary level (user directive
-/// 2026-08-02): a diagnostic emitted via a raw `log::warn!` — here
-/// `mouth.rs`'s deterministic "HTTP input not supported" — must register in
-/// the final verdict's count, not just print. Defect this pins: the 131 MB
+/// 2026-08-02): `mouth.rs`'s deterministic "HTTP input not supported"
+/// warning — a raw `log::warn!` before the single-vehicle migration, an
+/// `emit_warn` after it — must register in the final verdict's count, not
+/// just print. Defect this pins: the 131 MB
 /// witness logged 12,105 `Warning:` lines (12,103 of them the math parser's
 /// raw `log_math_warn!`) while the verdict said "2 warnings".
 #[test]
@@ -207,7 +208,7 @@ fn raw_log_warnings_register_in_the_final_verdict() {
     "warnings alone do not fail a run — stderr:\n{stderr}"
   );
   assert!(
-    stderr.contains("Warning:latexml_core::mouth HTTP input not supported"),
+    stderr.contains("Warning:unsupported:http_input HTTP input not supported"),
     "the raw-log warning line must print"
   );
   let (last_verdict, _) = last_lines(&stderr);
@@ -215,5 +216,36 @@ fn raw_log_warnings_register_in_the_final_verdict() {
   assert!(
     verdict.contains("Conversion complete: 1 warning"),
     "the raw-log warning must be COUNTED in the verdict, got: {verdict}"
+  );
+}
+
+/// Error and Fatal messages are the success-rate signal — they must reach the
+/// log at ANY verbosity (user directive 2026-08-02). The quietest CLI mapping
+/// floors the level filter at `Warn`, so `Fatal:`/`Error:` records always
+/// flow; this pins that floor — if someone maps quiet to `LevelFilter::Error`
+/// or `Off`, the Fatal line or the verdict would vanish and this test names
+/// the contract being broken. (`-q` is a plain bool flag — quietest mode.)
+#[test]
+fn quiet_mode_still_reports_error_and_fatal() {
+  let workdir = tempfile::tempdir().expect("tempdir");
+  let tex = fatal_fixture(workdir.path());
+  let (stderr, code) = run(
+    &[&tex, "--dest=toomany.html", "--format=html5", "-q"],
+    workdir.path(),
+  );
+  assert_eq!(code, 1, "a fatal conversion must exit 1 even at -q");
+  assert!(
+    stderr.contains("Fatal:TooManyErrors"),
+    "the Fatal line must print at any verbosity — stderr tail:\n{}",
+    stderr.lines().rev().take(6).collect::<Vec<_>>().join("\n")
+  );
+  assert!(
+    stderr.contains("Error:undefined:"),
+    "Error lines must print at any verbosity"
+  );
+  let (_, very_last) = last_lines(&stderr);
+  assert!(
+    very_last.contains("Conversion failed"),
+    "the failure verdict stays the last line at -q, got: {very_last}"
   );
 }

--- a/latexml_package/Cargo.toml
+++ b/latexml_package/Cargo.toml
@@ -20,7 +20,6 @@ token-locators = ["latexml_core/token-locators"]
 
 [dependencies]
 regex = { version = "1.7.1", default-features = false, features = ["std", "perf", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script"] }  # DEP-10
-log = "0.4"
 libxml = "0.3.21"
 rustc-hash = "2.0.0"
 base64 = "0.23"

--- a/latexml_package/src/package/color_sty.rs
+++ b/latexml_package/src/package/color_sty.rs
@@ -1,4 +1,7 @@
-use latexml_core::common::color::{self, Color, color_from_model_spec};
+use latexml_core::common::{
+  color::{self, Color, color_from_model_spec},
+  error::emit_error,
+};
 
 use crate::prelude::*;
 
@@ -166,15 +169,11 @@ pub fn lookup_color_obj(name: &str) -> Color {
         Stored::String(pin(color::BLACK.to_stored())),
         None,
       );
-      let _diag_guard = macro_diag_guard();
-      note_status(LogStatus::Error, None);
-      if !is_log_output_suppressed() {
-        log::error!(
-          target: &format!("unexpected:{}", name),
-          "Can't find color named '{}'; assuming Black",
-          name
-        );
-      }
+      emit_error(
+        "unexpected",
+        name,
+        &format!("Can't find color named '{name}'; assuming Black"),
+      );
       color::BLACK
     },
   }

--- a/latexml_package/src/package/color_sty.rs
+++ b/latexml_package/src/package/color_sty.rs
@@ -166,6 +166,7 @@ pub fn lookup_color_obj(name: &str) -> Color {
         Stored::String(pin(color::BLACK.to_stored())),
         None,
       );
+      let _diag_guard = macro_diag_guard();
       note_status(LogStatus::Error, None);
       if !is_log_output_suppressed() {
         log::error!(

--- a/latexml_package/src/package/listings_sty.rs
+++ b/latexml_package/src/package/listings_sty.rs
@@ -1,4 +1,5 @@
 use base64::Engine as _;
+use latexml_core::common::error::emit_warn;
 
 use crate::prelude::*;
 
@@ -288,7 +289,11 @@ fn listings_read_raw_file(file: &str) -> Option<String> {
       }
     })
   } else {
-    log::warn!("Can't read listings file '{}'", filename);
+    emit_warn(
+      "missing_file",
+      "listings",
+      &format!("Can't read listings file '{filename}'"),
+    );
     None
   }
 }
@@ -1395,9 +1400,13 @@ fn lst_process_internal(ctx: &mut LstContext, end_re: Option<&Regex>, outer_clas
   while !ctx.listing.is_empty() {
     // Loop guard — must make progress on every step
     if ctx.listing == prev_listing {
-      log::warn!(
-        "lstProcess_internal failed to make progress. Content: '{}'",
-        &ctx.listing[..ctx.listing.len().min(60)]
+      emit_warn(
+        "internal",
+        "listings",
+        &format!(
+          "lstProcess_internal failed to make progress. Content: '{}'",
+          &ctx.listing[..ctx.listing.len().min(60)]
+        ),
       );
       ctx.listing.clear();
       break;

--- a/latexml_package/src/package/siunitx_sty.rs
+++ b/latexml_package/src/package/siunitx_sty.rs
@@ -3,6 +3,8 @@
 //!
 //! Full semantic port: number parsing, formatting with XMDual semantics,
 //! unit parsing/formatting, options system, table columns.
+use latexml_core::common::error::emit_error;
+
 use crate::{prelude::*, xmath_helpers::*};
 
 /// Read the control-sequence argument of a siunitx `\Declare…` primitive,
@@ -36,10 +38,12 @@ fn read_si_declare_cs() -> Result<Token> {
 /// format contract while staying type-compatible.
 macro_rules! six_log_error {
   ($category:expr_2021, $object:expr_2021, $msg:expr_2021) => {
-    log::error!(target: &format!("{}:{}", $category, $object), "{}", $msg)
+    emit_error(
+      &format!("{}", $category), &format!("{}", $object), &format!("{}", $msg))
   };
   ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {
-    log::error!(target: &format!("{}:{}", $category, $object), $fmt, $($arg)+)
+    emit_error(
+      &format!("{}", $category), &format!("{}", $object), &format!($fmt, $($arg)+))
   };
 }
 

--- a/latexml_post/src/diag.rs
+++ b/latexml_post/src/diag.rs
@@ -20,8 +20,9 @@
 //! `#[thread_local]`, so they are captured per-worker and replayed on the
 //! main thread via `latexml_core::util::logger::capture`/`replay_captured`.
 //!
-//! Output format goes through the shared `latexml_core::util::logger`
-//! formatter via `log::info!`/`warn!`/`error!` with an explicit
+//! `Info!`/`Warn!`/`Error!` forward to the SINGLE diagnostic vehicle
+//! (`latexml_core::common::error::emit_*`), which counts, respects output
+//! suppression, participates in the runaway circuit-breakers, and emits with
 //! `target = "<category>:<object>"`, yielding the canonical
 //! `{Severity}:{category}:{object} {message}` line the harness
 //! aggregates from every other stage (engine, package, contrib).
@@ -65,9 +66,8 @@ macro_rules! Info {
     $crate::Info!($category, $object, "{}", $msg)
   };
   ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {{
-    let __diag_guard = latexml_core::common::error::macro_diag_guard();
-    latexml_core::common::error::note_status(latexml_core::common::error::LogStatus::Info, None);
-    log::info!(target: &format!("{}:{}", $category, $object), $fmt, $($arg)+)
+    latexml_core::common::error::emit_info(
+      &format!("{}", $category), &format!("{}", $object), &format!($fmt, $($arg)+))
   }};
 }
 
@@ -77,9 +77,8 @@ macro_rules! Warn {
     $crate::Warn!($category, $object, "{}", $msg)
   };
   ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {{
-    let __diag_guard = latexml_core::common::error::macro_diag_guard();
-    latexml_core::common::error::note_status(latexml_core::common::error::LogStatus::Warning, None);
-    log::warn!(target: &format!("{}:{}", $category, $object), $fmt, $($arg)+)
+    latexml_core::common::error::emit_warn(
+      &format!("{}", $category), &format!("{}", $object), &format!($fmt, $($arg)+))
   }};
 }
 
@@ -89,9 +88,8 @@ macro_rules! Error {
     $crate::Error!($category, $object, "{}", $msg)
   };
   ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {{
-    let __diag_guard = latexml_core::common::error::macro_diag_guard();
-    latexml_core::common::error::note_status(latexml_core::common::error::LogStatus::Error, None);
-    log::error!(target: &format!("{}:{}", $category, $object), $fmt, $($arg)+)
+    latexml_core::common::error::emit_error(
+      &format!("{}", $category), &format!("{}", $object), &format!($fmt, $($arg)+))
   }};
 }
 
@@ -101,10 +99,9 @@ macro_rules! Fatal {
     $crate::Fatal!($category, $object, "{}", $msg)
   };
   ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {{
-    let __diag_guard = latexml_core::common::error::macro_diag_guard();
-    latexml_core::common::error::note_status(latexml_core::common::error::LogStatus::Fatal, None);
     let __m = format!($fmt, $($arg)+);
-    log::error!(target: &format!("Fatal:{}:{}", $category, $object), "{}", __m);
+    latexml_core::common::error::emit_fatal(
+      &format!("{}", $category), &format!("{}", $object), &__m);
     return Err($crate::processor::PostError::Processing(
       format!("{}:{}: {}", $category, $object, __m)
     ));

--- a/latexml_post/src/diag.rs
+++ b/latexml_post/src/diag.rs
@@ -65,6 +65,7 @@ macro_rules! Info {
     $crate::Info!($category, $object, "{}", $msg)
   };
   ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {{
+    let __diag_guard = latexml_core::common::error::macro_diag_guard();
     latexml_core::common::error::note_status(latexml_core::common::error::LogStatus::Info, None);
     log::info!(target: &format!("{}:{}", $category, $object), $fmt, $($arg)+)
   }};
@@ -76,6 +77,7 @@ macro_rules! Warn {
     $crate::Warn!($category, $object, "{}", $msg)
   };
   ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {{
+    let __diag_guard = latexml_core::common::error::macro_diag_guard();
     latexml_core::common::error::note_status(latexml_core::common::error::LogStatus::Warning, None);
     log::warn!(target: &format!("{}:{}", $category, $object), $fmt, $($arg)+)
   }};
@@ -87,6 +89,7 @@ macro_rules! Error {
     $crate::Error!($category, $object, "{}", $msg)
   };
   ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {{
+    let __diag_guard = latexml_core::common::error::macro_diag_guard();
     latexml_core::common::error::note_status(latexml_core::common::error::LogStatus::Error, None);
     log::error!(target: &format!("{}:{}", $category, $object), $fmt, $($arg)+)
   }};
@@ -98,6 +101,7 @@ macro_rules! Fatal {
     $crate::Fatal!($category, $object, "{}", $msg)
   };
   ($category:expr_2021, $object:expr_2021, $fmt:expr_2021, $($arg:tt)+) => {{
+    let __diag_guard = latexml_core::common::error::macro_diag_guard();
     latexml_core::common::error::note_status(latexml_core::common::error::LogStatus::Fatal, None);
     let __m = format!($fmt, $($arg)+);
     log::error!(target: &format!("Fatal:{}:{}", $category, $object), "{}", __m);

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -112,6 +112,12 @@ run "xml:id accessor ratchet" \
   "a new string-keyed xml: accessor landed; use the *_ns form" -- \
   tools/lint_xmlid_accessor.sh
 
+# 1b. Single diagnostic vehicle: no raw log::{info,warn,error}! in workspace
+#     crates (bypasses tally, caps, suppression, taxonomy).
+run "raw log-diagnostic ban" \
+  "use Info!/Warn!/Error!/Fatal! or emit_{info,warn,error,fatal}" -- \
+  tools/lint_raw_log_diag.sh
+
 # 2. Formatting must already be applied (check, don't rewrite).
 run "rustfmt (check)" \
   "run: cargo fmt --all" -- \

--- a/tools/lint_raw_log_diag.sh
+++ b/tools/lint_raw_log_diag.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# lint_raw_log_diag.sh — the diagnostic vehicle stays SINGLE.
+#
+# Perl LaTeXML has exactly one emission vehicle per severity (Error.pm's
+# Info/Warn/Error/Fatal), which is what makes its tally and cortex's
+# aggregation lossless by construction. The Rust equivalents are the
+# Info!/Warn!/Error!/Fatal! macros and their function forms
+# (latexml_core::common::error::emit_info/emit_warn/emit_error/emit_fatal for
+# non-Result contexts). A raw `log::warn!`/`log::error!`/`log::info!` call
+# bypasses ALL severity semantics: the tally (the 131 MB witness logged
+# 12,105 Warning: lines and reported "2 warnings"), the MAX_ERRORS cap, the
+# consecutive-error runaway breaker, output suppression, fatal demotion, and
+# the category:object taxonomy cortex classifies by.
+#
+# This lint FAILS on any raw log::{info,warn,error}! call in workspace crates.
+# The only legitimate homes are allowlisted below: the vehicle's own
+# implementation (error.rs), and the logger backend. `log::debug!`/`trace!`
+# stay free — they are developer chatter, not conversion diagnostics.
+#
+# The logger backend still counts any raw record it prints
+# (note_status_from_logger) — that net exists for FOREIGN crates logging
+# through the `log` facade, not as licence for workspace code.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ALLOW_RE='^(latexml_core/src/common/error\.rs|latexml_core/src/util/logger\.rs)'
+
+violations=$(grep -rn --include="*.rs" -E 'log::(info|warn|error)!' \
+  latexml_core/src latexml_engine/src latexml_package/src latexml_contrib/src \
+  latexml_post/src latexml_oxide/src latexml_oxide/bin latexml_math_parser/src \
+  cortex_worker/src 2>/dev/null \
+  | grep -vE "$ALLOW_RE" \
+  | grep -vE '^\S+:\s*[0-9]+:\s*//' || true)
+
+if [ -n "$violations" ]; then
+  echo "ERROR: raw log::{info,warn,error}! diagnostics found — use the single"
+  echo "vehicle instead: Info!/Warn!/Error!/Fatal! macros, or"
+  echo "latexml_core::common::error::emit_{info,warn,error,fatal} in"
+  echo "non-Result contexts. Rationale in this script's header."
+  echo
+  echo "$violations"
+  exit 1
+fi
+echo "OK: no raw log-crate diagnostics in workspace crates."


### PR DESCRIPTION
The final verdict of the 131 MB witness joint run said "Conversion complete: **2 warnings**" while its log carried **12,105 `Warning:` lines** (12,103 from the math parser's raw `log_math_warn!`). User directive: accurate final counts of ALL message types, in all phases, re-aggregated without loss.

**Mechanism.** The tally has two producers, now provably non-overlapping:

- The counting macros (`Info!`/`Warn!`/`Error!`/`Fatal!`/`Debug!`) keep counting at **raise time** — required even when output is suppressed, because the `MAX_ERRORS` cap reads that count. They now mark their emissions with a thread-local RAII `MacroDiagGuard`.
- The **logger backend** counts every other diagnostic record it prints (any raw `log::warn!`/`log::error!`/`log::info!` — 69 sites workspace-wide, plus anything future). Raw `Fatal:`-target records latch the sticky fatal flag (idempotent). `try_borrow` discipline so a raw log call from inside a `report_mut!` scope can never panic a conversion over a tally increment.

Printed lines and final counts now agree by construction — what a reader greps from the log is what the verdict reports, per phase and folded across phases by the existing capture/replay and max-fold machinery.

**Guards:** logger unit test (raw counts once, macro counts exactly once, nested guards stay muted, raw fatal latches) and a `119` binary-level test: a deterministic raw `mouth.rs` warning must end the run with `Conversion complete: 1 warning`. `101`'s expected verdict gains the salvage path's now-counted warning ("1 warning; 1 fatal error") — that delta is the fix working.

Note: once this merges, the "Known residual: verdict tallies 2 warnings…" sentence added to SYNC_STATUS by #482 should be dropped (one-line docs follow-up).

1860/1860 tests, lint gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)