### PR TITLE
fix(diag): robust cap latch in emit_error; post-cap divergence documented

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -3429,3 +3429,22 @@ merges onto the one line box: `<text class="ltx_verbatim" font="typewriter"
 width="345.0pt">…`. Same attributes, same semantics, one element instead of
 two; no upstream `t/` golden pins the nested form. Golden:
 `tokenize/fancyvrb.xml`.
+
+### 94. Post-processing errors cap at MAX_ERRORS; the cap latches instead of dying
+
+Perl's error cap lives in `Common/Error.pm:372` behind `$STATE &&` — and Post
+runs with `$STATE` undef, so Perl post-processing neither counts toward nor
+triggers `too_many_errors`, and a post error storm runs unbounded. Since the
+single-vehicle diagnostics rework (#484 + the cap-latch fix), Rust post
+`Error!` flows through `emit_error`, which applies the same MAX_ERRORS (100)
+and consecutive-error (500) caps as the core phase. Second divergence in the
+same seam: on crossing a cap, Perl `Fatal` **dies**; `emit_error` has no
+unwind channel (its callers return `String`/`Option`, not `Result`), so it
+emits `Fatal:TooManyErrors`, latches the sticky fatal — the run **continues**
+and keeps writing pages, but the verdict, exit code, and
+`Status:conversion:3` all report the fatal. Rationale: a partial site plus an
+honest fatal beats Perl's nothing-plus-death; the cap keeps a post storm from
+producing a million-line log. The latch is guarded by the sticky fatal (fires
+once, robust to skipped checks), and the runaway (consecutive) diagnosis is
+tested before the total cap so its message is reachable. Guards:
+`suppression_never_mutes_error_or_fatal`, `119_final_status_report`.

--- a/latexml_post/src/diag.rs
+++ b/latexml_post/src/diag.rs
@@ -6,8 +6,12 @@
 //! `latexml_post` does not need to import `latexml_core::common::error`
 //! just to emit diagnostics. The macro names deliberately shadow the
 //! identically-named macros from `latexml_core` — same shape (`(category,
-//! object, …)`), simpler implementation (no error-cap → Fatal unwinding,
-//! no location trace appended). They DO bump the shared `latexml_core`
+//! object, …)`), no location trace appended. Since the single-vehicle
+//! rework, post's `Error!` DOES participate in the MAX_ERRORS /
+//! consecutive-error caps via `emit_error` — the cap latches the sticky
+//! fatal and CONTINUES (no unwind channel here), where Perl's Post neither
+//! counts nor caps ($STATE-gated) and its Fatal dies. Deliberate
+//! divergence, recorded in OXIDIZED_DESIGN. They DO bump the shared `latexml_core`
 //! `REPORT` status counters via `note_status`, so a post-processing
 //! `Warn!`/`Error!`/`Fatal!` raises the conversion's `status_code` exactly
 //! like a core-phase one — the run's severity is the combined worst of the

--- a/tools/lint_raw_log_diag.sh
+++ b/tools/lint_raw_log_diag.sh
@@ -26,7 +26,7 @@ cd "$(dirname "$0")/.."
 
 ALLOW_RE='^(latexml_core/src/common/error\.rs|latexml_core/src/util/logger\.rs)'
 
-violations=$(grep -rn --include="*.rs" -E 'log::(info|warn|error)!' \
+violations=$(grep -rn --include="*.rs" -E '(log::(info|warn|error|log)!|^\s*use log::(info|warn|error)\b)' \
   latexml_core/src latexml_engine/src latexml_package/src latexml_contrib/src \
   latexml_post/src latexml_oxide/src latexml_oxide/bin latexml_math_parser/src \
   cortex_worker/src 2>/dev/null \


### PR DESCRIPTION
Applies review findings #1–#3 from docs/parity/CODE_REVIEW_2026-08-03.md (shipped in #487's branch): sticky-fatal-guarded cap latch (the exact-crossing check was permanently defeatable), reachable runaway diagnosis, divergence #94 (post caps + latch-and-continue vs Perl), corrected diag.rs docs, tightened lint.

1869/1869 tests, gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)