### PR TITLE
feat(post): process-parallel page rendering — N workers over the spilled pages

### DIFF
--- a/docs/math/MATH_PARSER_AND_ASF.md
+++ b/docs/math/MATH_PARSER_AND_ASF.md
@@ -475,3 +475,33 @@ Final acceptance numbers:
 | Ambiguity hotspots research | [`docs/archive/MATH_AMBIGUITY_AUDIT_2026-05-21.md`](../archive/MATH_AMBIGUITY_AUDIT_2026-05-21.md) |
 | marpa-side perf doc | [`~/git/marpa/docs/ASF_PERFORMANCE_FINDINGS.md`](https://github.com/dginev/marpa/blob/master/docs/ASF_PERFORMANCE_FINDINGS.md) |
 | Pre-flight ambiguity oracle | `Parser::ambiguity_metric(tokens)` and `Bocage::ambiguity_metric()` |
+
+## Parallel math parsing — DEFERRED (user decision 2026-08-03), spike plan recorded
+
+Not on the critical path: cortex saturates cores across papers, so per-paper
+math parallelism is fleet-neutral — it pays only on the single-huge-document
+showcase (witness: 1289 s of core = 50.6% — would drop to ~160 s at 8
+workers). Do NOT implement without running this spike first.
+
+**The one maintainable shape** (any State-sharing approach is a settled
+dead-end): a frozen-phase formula pipeline. The conversion thread extracts
+each formula into an owned Send job (plain strings + role enums — NO arena
+ids, NO libxml nodes); long-lived parser threads each own their OWN grammar +
+arena + scratch (one thread-local world per worker, no Mutex); owned ASTs
+reintegrate in submission order on the conversion thread (determinism +
+ambiguity-dedup stay serial; diagnostics fold via capture/replay_captured).
+
+**Spike gates (~1 day, both must pass or deep-defer permanently):**
+1. Confirm State is effectively frozen during the math-parse phase: Perl
+   parses math post-digestion over the built document; verify our per-segment
+   pass-2 parse reads no LIVE State mid-parse (roles are assigned at
+   digestion). A live read anywhere = fail.
+2. Enumerate the semantics rules' State reads: must be a short, stable list
+   snapshotable into a compile-enforced job struct. Open-ended = fail.
+   Mechanical sub-check: vendored libmarpa 8.6.2 globals-free for independent
+   per-thread grammar instances (designed reentrant; one grammar per worker
+   sidesteps shared-grammar questions).
+
+**If gates pass**: opt-in LATEXML_MATH_PARSE_JOBS + a permanent canary mode
+that runs both paths and diffs ASTs (the parity guard no test suite would
+otherwise provide). Record either outcome here.

--- a/docs/performance/STREAMING_POST_DESIGN_2026-07-06.md
+++ b/docs/performance/STREAMING_POST_DESIGN_2026-07-06.md
@@ -333,6 +333,14 @@ wall. Audit conclusions (file:line verified 2026-08-02) that fix the design:
   Telemetry-record wiring gap noted: its own warnings/errors/db_objects/
   output_bytes fields read 0 despite the 12,094-warning verdict — the JSON
   record snapshots before the fold; small follow-up.
+* **MEASURED (PR #490, 2026-08-03): 8 render workers take the witness post
+  pass 37:31 → 12:17 wall (3.05×)** — all 115,519 pages, exit 0, clean
+  verdict/status fold, parent peak RSS 3.0 GB (rendering left the parent
+  process; the whole fleet ran inside a 28 GB cgroup). The remaining 12:17
+  is dominated by the still-serial prologue (split scan + index/bib sweeps
+  + db save + spawn) plus ~6 min of parallel render — matching the ~5-8 min
+  prediction from the phase shares. Byte-parity: sampled pages identical to
+  the serial baseline; the mid-scale harness pins it systematically.
 * **Rejected:** making ObjectDB Send + thread pool with serial XSLT (cap
   ~2.5×, large refactor for a small ceiling); hoisting XSLT to the main
   thread with worker-produced DOM strings (still serializes the 60% share).

--- a/latexml_oxide/Cargo.toml
+++ b/latexml_oxide/Cargo.toml
@@ -183,6 +183,7 @@ dhat = { version = "0.3", optional = true }
 # retain-the-high-water default — the property a persistent conversion worker
 # needs. Used for the mimalloc-vs-jemalloc A/B and the recommended harness build.
 tikv-jemallocator = { version = "0.7", optional = true }
+serde = { version = "1.0.229", features = ["derive"] }
 
 [dev-dependencies]
 # Line-diff engine for tests/90_latexmlpost.rs's golden comparison — the

--- a/latexml_oxide/bin/latexml_oxide.rs
+++ b/latexml_oxide/bin/latexml_oxide.rs
@@ -615,6 +615,15 @@ fn projected_source_bytes(source: &str) -> u64 {
 fn main() -> Result<(), Box<dyn Error>> {
   set_alloc_error_hook(custom_alloc_error_hook);
 
+  // Hidden page-render worker mode (streaming-post design §6): a parent
+  // conversion doing process-parallel page rendering re-invokes this very
+  // binary with `LATEXML_RENDER_WORKER` pointing at a page-range manifest.
+  // Dispatched before ANY CLI handling so the worker path can never drift
+  // into a normal conversion; it exits with its own status protocol.
+  if let Ok(manifest) = std::env::var("LATEXML_RENDER_WORKER") {
+    process::exit(latexml::render_workers::worker_main(&manifest));
+  }
+
   // Run all work on a worker thread with a 256 MB stack so deeply
   // nested math trees don't overflow the OS-default 8 MB main-thread
   // stack during finalize/post-processing. See cortex_worker.rs for

--- a/latexml_oxide/src/lib.rs
+++ b/latexml_oxide/src/lib.rs
@@ -13,6 +13,7 @@ pub mod ini_tex;
 pub mod lsp_server;
 pub mod main_tex;
 pub mod post;
+pub mod render_workers;
 pub mod util;
 
 /// Load the embedded LaTeXML schema (compile-time) into the runtime

--- a/latexml_oxide/src/post.rs
+++ b/latexml_oxide/src/post.rs
@@ -20,6 +20,25 @@ use once_cell::sync::Lazy;
 // Process-once cached env var (see WISDOM #56 — getenv hot-path race).
 static POST_AUDIT: Lazy<bool> = Lazy::new(|| std::env::var("LATEXML_POST_AUDIT").is_ok());
 
+/// Start an audit timer when `LATEXML_POST_AUDIT` is set. Module-level (not a
+/// closure) so [`render_spilled_page`] — shared by the serial driver and the
+/// parallel render worker — can use the identical instrumentation.
+fn audit_start(name: &str) -> Option<(String, std::time::Instant)> {
+  if *POST_AUDIT {
+    Some((name.to_string(), std::time::Instant::now()))
+  } else {
+    None
+  }
+}
+
+/// Report an audit timer started by [`audit_start`] (no-op when audit is off).
+fn audit_end(started: Option<(String, std::time::Instant)>) {
+  if let Some((name, t0)) = started {
+    let ms = t0.elapsed().as_millis();
+    Info!("audit", "phase", s!("{} took {}ms", name, ms));
+  }
+}
+
 /// Options for the post-processing pipeline.
 pub struct PostOptions<'a> {
   pub pmml:                      bool,
@@ -547,21 +566,6 @@ fn run_post_processing_inner(input: PostInput, opts: &PostOptions) -> String {
   if let Some(site_dir) = site_directory {
     doc_opts.site_directory = Some(site_dir.to_string());
   }
-  let audit = *POST_AUDIT;
-  let audit_start = |name: &str| -> Option<(String, std::time::Instant)> {
-    if audit {
-      Some((name.to_string(), std::time::Instant::now()))
-    } else {
-      None
-    }
-  };
-  let audit_end = |started: Option<(String, std::time::Instant)>| {
-    if let Some((name, t0)) = started {
-      let ms = t0.elapsed().as_millis();
-      Info!("audit", "phase", s!("{} took {}ms", name, ms));
-    }
-  };
-
   // `raw_xml` holds the in-memory serialization — `Some` only for `Xml` input.
   // `File` input streams from disk and never holds it, so `raw_xml` is `None`
   // and the three raw-string features (empty-doc substitution, SVG extraction,
@@ -876,13 +880,13 @@ fn run_post_processing_inner(input: PostInput, opts: &PostOptions) -> String {
   // Phase 5: Graphics (Perl `graphicimages!` → `dographics`, default on).
   // `--nographicimages` skips the phase wholesale, leaving the raw
   // `<ltx:graphics>` references in the output untouched.
-  let mut graphics_proc = graphicimages.then(|| {
+  let graphics_proc = graphicimages.then(|| {
     latexml_post::graphics::Graphics::new(None, true)
       .with_svg_threshold_kb(graphics_svg_threshold_kb)
   });
 
   // Phase 3: MathML + XSLT
-  let mut post = latexml_post::Post::new();
+  let post = latexml_post::Post::new();
   let mut processors: Vec<Box<dyn Processor>> = Vec::new();
 
   // `intent_literal` was computed up-front (before Split consumed `doc`).
@@ -919,6 +923,11 @@ fn run_post_processing_inner(input: PostInput, opts: &PostOptions) -> String {
         .with_plane1(plane1, hackplane1),
     ));
   }
+  // Clones of the fully-resolved XSLT inputs for the parallel-render worker
+  // manifest — `XSLT::new` consumes the real map/vec below, and by the time
+  // the pass-B driver decides between serial and parallel they are gone.
+  let mut manifest_xslt_params: Vec<(String, String)> = Vec::new();
+  let mut manifest_searchpaths: Vec<String> = Vec::new();
   if let Some(xsl_path) = stylesheet {
     let mut searchpaths = vec![".".to_string()];
     if let Ok(exe) = std::env::current_exe()
@@ -1000,6 +1009,11 @@ fn run_post_processing_inner(input: PostInput, opts: &PostOptions) -> String {
         xslt_params.insert(key.to_string(), format!("\"{}\"", value));
       }
     }
+    manifest_xslt_params = xslt_params
+      .iter()
+      .map(|(k, v)| (k.clone(), v.clone()))
+      .collect();
+    manifest_searchpaths = searchpaths.clone();
     match latexml_post::xslt::XSLT::new(
       xsl_path,
       xslt_params,
@@ -1036,18 +1050,8 @@ fn run_post_processing_inner(input: PostInput, opts: &PostOptions) -> String {
   // Failure semantics change deliberately: pages that finish are already on
   // disk, so a later failure leaves a partial site rather than nothing. That
   // matches how a resource Fatal already keeps partial core output.
-  let run_page_phase = |doc: PostDocument,
-                        proc: &mut dyn Processor,
-                        label: &'static str|
-   -> Result<Vec<PostDocument>, ()> {
-    let nodes = proc.to_process(&doc);
-    if nodes.is_empty() {
-      return Ok(vec![doc]);
-    }
-    proc.process(doc, nodes).map_err(|e| {
-      post_error(label, &format!("{label} failed: {e}"));
-    })
-  };
+  // (The per-page pipeline itself lives in `render_spilled_page`, shared with
+  // the process-parallel worker in `crate::render_workers`.)
 
   // The ObjectDB is a BATON: MakeIndex, MakeBibliography and CrossRef each take
   // it by value in turn, so they cannot be alive simultaneously. Each therefore
@@ -1119,7 +1123,90 @@ fn run_post_processing_inner(input: PostInput, opts: &PostOptions) -> String {
   if bib_result.is_err() {
     return fallback();
   }
-  let mut crossref = build_crossref(bibmaker.db);
+  // ---- Parallel pass B: process-level page-range workers (design §6) ------
+  //
+  // Env-gated (`LATEXML_RENDER_JOBS`, default 1 = the serial path below,
+  // unchanged), and only past a minimum page count — below it the db save +
+  // child spawn overhead beats the win. The ObjectDB is COMPLETE here (Scan,
+  // MakeIndex and MakeBibliography have all run), so it is saved once as a
+  // SQLite file and each worker attaches it readonly; the workers run the
+  // identical `render_spilled_page` pipeline over contiguous page ranges and
+  // the parent folds their diagnostics deterministically, in chunk order.
+  let render_jobs = crate::render_workers::render_jobs();
+  if render_jobs > 1 && spilled_pages.len() >= crate::render_workers::MIN_PAGES_FOR_PARALLEL {
+    let page_jobs: Vec<crate::render_workers::PageJob> = spilled_pages
+      .iter()
+      .map(|p| crate::render_workers::PageJob {
+        path:                  p.path.clone(),
+        destination:           p.destination.clone(),
+        destination_directory: p.destination_directory.clone(),
+      })
+      .collect();
+    let manifest = crate::render_workers::RenderManifest {
+      // Filled in by `parallel_render` once the db is saved.
+      dbfile: std::path::PathBuf::new(),
+      navigation_toc: navigationtoc.map(String::from),
+      graphicimages,
+      graphics_svg_threshold_kb,
+      pmml,
+      cmml,
+      keep_xmath,
+      invisible_times: !noinvisibletimes,
+      plane1,
+      hackplane1,
+      mathtex,
+      intent_literal,
+      stylesheet: stylesheet.map(String::from),
+      xslt_params: manifest_xslt_params,
+      nodefaultresources,
+      searchpaths: manifest_searchpaths,
+      is_html_out,
+      svg_fragments: svg_fragments.clone(),
+      schemadocs,
+      whatsout: whatsout.as_cli().to_string(),
+      page_opts: (&page_opts).into(),
+      pages: Vec::new(),
+    };
+    let t_pages = audit_start("render_pages");
+    let outcome = crate::render_workers::parallel_render(
+      manifest,
+      page_jobs,
+      render_jobs,
+      page_spill.path(),
+      &bibmaker.db,
+    );
+    audit_end(t_pages);
+    if let Some(result) = outcome {
+      Info!(
+        "post",
+        "parallel-render",
+        s!(
+          "parallel render finished: {} of {} page(s) written",
+          result.pages_rendered,
+          spilled_pages.len()
+        )
+      );
+      drop(page_spill);
+      return result.main_output.unwrap_or_else(fallback);
+    }
+    // Setup failed BEFORE any worker spawned (already reported): fall through
+    // to the serial render — the spilled pages are untouched on disk.
+  }
+
+  let crossref = build_crossref(bibmaker.db);
+  let ctx = PageRenderCtx {
+    page_opts: page_opts.clone(),
+    is_html_out,
+    svg_fragments,
+    schemadocs,
+    whatsout,
+  };
+  let mut procs = PageProcessors {
+    crossref,
+    graphics: graphics_proc,
+    post,
+    processors,
+  };
 
   let mut main_output: Option<String> = None;
   let t_pages = audit_start("render_pages");
@@ -1197,77 +1284,11 @@ fn run_post_processing_inner(input: PostInput, opts: &PostOptions) -> String {
         mi.fordblks / (1024 * 1024)
       );
     }
-    let path_str = path.to_string_lossy().into_owned();
-    let page = match PostDocument::new_from_file(&path_str, page_opts.clone()) {
-      Ok(mut d) => {
-        d.destination = dest;
-        d.destination_directory = dest_dir;
-        d
-      },
-      Err(e) => {
-        post_error("post", &format!("cannot re-read a spilled page: {e}"));
-        return fallback();
-      },
-    };
-    // Free the spill as soon as it is parsed: for a 40k-page document the
-    // spill area is the size of the core XML, and it need not outlive its page.
-    let _ = std::fs::remove_file(&path);
-
-    // CrossRef resolves this page's references out of the completed ObjectDB,
-    // and its navigation/TOC work reads the DB rather than sibling pages — so
-    // it is page-local once pass A has finished.
-    telemetry::phase_enter(Phase::Crossref);
-    let t_xref = audit_start("CrossRef");
-    let xref = run_page_phase(page, &mut crossref, "CrossRef");
-    audit_end(t_xref);
-    telemetry::phase_exit();
-    let mut staged = match xref {
-      Ok(out) => out,
+    let outputs = match render_spilled_page(&path, &mut procs, &ctx, dest, dest_dir) {
+      Ok(o) => o,
       Err(()) => return fallback(),
     };
-    if let Some(gfx) = graphics_proc.as_mut() {
-      telemetry::phase_enter(Phase::Graphics);
-      let t_gfx = audit_start("Graphics");
-      let mut next = Vec::with_capacity(staged.len());
-      let mut failed = false;
-      for d in staged.drain(..) {
-        match run_page_phase(d, gfx, "Graphics") {
-          Ok(out) => next.extend(out),
-          Err(()) => {
-            failed = true;
-            break;
-          },
-        }
-      }
-      audit_end(t_gfx);
-      telemetry::phase_exit();
-      if failed {
-        return fallback();
-      }
-      staged = next;
-    }
-
-    let rendered = match post.process_chain(staged, &mut processors) {
-      Ok(r) => r,
-      Err(e) => {
-        post_error("convert", &format!("Post-processing failed: {e}"));
-        return fallback();
-      },
-    };
-
-    for doc in rendered {
-      let dest = doc.get_destination().map(String::from);
-      let output = latexml_post::extract::serialize_whatsout(&doc, whatsout);
-      let output = if is_html_out {
-        finalize_html5(output, &svg_fragments)
-      } else {
-        output
-      };
-      let output = if schemadocs && is_html_out {
-        latexml_post::schema_docs::process_page(&output)
-      } else {
-        output
-      };
+    for (dest, output) in outputs {
       if let Some(path) = dest.as_deref() {
         if let Some(parent) = std::path::Path::new(path).parent()
           && !parent.as_os_str().is_empty()
@@ -1282,13 +1303,141 @@ fn run_post_processing_inner(input: PostInput, opts: &PostOptions) -> String {
       if main_output.is_none() {
         main_output = Some(output);
       }
-      // `doc` drops here — the whole point.
     }
   }
   audit_end(t_pages);
   drop(page_spill);
 
   main_output.unwrap_or_else(fallback)
+}
+
+/// The per-page processor set for pass B — everything [`render_spilled_page`]
+/// mutates. Bundled so the serial driver and the process-parallel worker
+/// ([`crate::render_workers`]) share ONE pipeline implementation and cannot
+/// drift.
+pub(crate) struct PageProcessors {
+  pub(crate) crossref:   latexml_post::crossref::CrossRef,
+  pub(crate) graphics:   Option<latexml_post::graphics::Graphics>,
+  pub(crate) post:       latexml_post::Post,
+  pub(crate) processors: Vec<Box<dyn Processor>>,
+}
+
+/// The read-only per-run context for pass B page rendering, shared by every
+/// page of one conversion (serial driver or one parallel worker).
+pub(crate) struct PageRenderCtx {
+  /// Clone-source for each page's `PostDocument` parse — carries the same
+  /// searchpaths/site-directory the pass-A parse used.
+  pub(crate) page_opts:     PostDocumentOptions,
+  pub(crate) is_html_out:   bool,
+  pub(crate) svg_fragments: Vec<(String, String)>,
+  pub(crate) schemadocs:    bool,
+  pub(crate) whatsout:      latexml_post::extract::Whatsout,
+}
+
+/// Run one page-local phase (CrossRef / Graphics) over one page, mirroring
+/// `run_phase` for a single document. Failures are reported via [`post_error`].
+fn run_page_phase(
+  doc: PostDocument,
+  proc: &mut dyn Processor,
+  label: &'static str,
+) -> Result<Vec<PostDocument>, ()> {
+  let nodes = proc.to_process(&doc);
+  if nodes.is_empty() {
+    return Ok(vec![doc]);
+  }
+  proc.process(doc, nodes).map_err(|e| {
+    post_error(label, &format!("{label} failed: {e}"));
+  })
+}
+
+/// The pass-B per-page pipeline: parse one spilled page (deleting the spill
+/// file as soon as it is parsed), run CrossRef → Graphics → MathML/XSLT, and
+/// return the finalized `(destination, output)` pairs for the caller to write.
+/// Exactly the body the serial render loop ran in place before the
+/// process-parallel split — phase order, telemetry and audit calls included —
+/// so the serial path stays byte-identical (guard:
+/// `118_streaming_split_parity`). `Err(())` means the failure was already
+/// reported via [`post_error`] (or a phase's own diagnostics).
+pub(crate) fn render_spilled_page(
+  path: &std::path::Path,
+  procs: &mut PageProcessors,
+  ctx: &PageRenderCtx,
+  destination: Option<String>,
+  destination_directory: Option<String>,
+) -> Result<Vec<(Option<String>, String)>, ()> {
+  let path_str = path.to_string_lossy().into_owned();
+  let page = match PostDocument::new_from_file(&path_str, ctx.page_opts.clone()) {
+    Ok(mut d) => {
+      d.destination = destination;
+      d.destination_directory = destination_directory;
+      d
+    },
+    Err(e) => {
+      post_error("post", &format!("cannot re-read a spilled page: {e}"));
+      return Err(());
+    },
+  };
+  // Free the spill as soon as it is parsed: for a 40k-page document the
+  // spill area is the size of the core XML, and it need not outlive its page.
+  let _ = std::fs::remove_file(path);
+
+  // CrossRef resolves this page's references out of the completed ObjectDB,
+  // and its navigation/TOC work reads the DB rather than sibling pages — so
+  // it is page-local once pass A has finished.
+  telemetry::phase_enter(Phase::Crossref);
+  let t_xref = audit_start("CrossRef");
+  let xref = run_page_phase(page, &mut procs.crossref, "CrossRef");
+  audit_end(t_xref);
+  telemetry::phase_exit();
+  let mut staged = xref?;
+  if let Some(gfx) = procs.graphics.as_mut() {
+    telemetry::phase_enter(Phase::Graphics);
+    let t_gfx = audit_start("Graphics");
+    let mut next = Vec::with_capacity(staged.len());
+    let mut failed = false;
+    for d in staged.drain(..) {
+      match run_page_phase(d, gfx, "Graphics") {
+        Ok(out) => next.extend(out),
+        Err(()) => {
+          failed = true;
+          break;
+        },
+      }
+    }
+    audit_end(t_gfx);
+    telemetry::phase_exit();
+    if failed {
+      return Err(());
+    }
+    staged = next;
+  }
+
+  let rendered = match procs.post.process_chain(staged, &mut procs.processors) {
+    Ok(r) => r,
+    Err(e) => {
+      post_error("convert", &format!("Post-processing failed: {e}"));
+      return Err(());
+    },
+  };
+
+  let mut outputs = Vec::with_capacity(rendered.len());
+  for doc in rendered {
+    let dest = doc.get_destination().map(String::from);
+    let output = latexml_post::extract::serialize_whatsout(&doc, ctx.whatsout);
+    let output = if ctx.is_html_out {
+      finalize_html5(output, &ctx.svg_fragments)
+    } else {
+      output
+    };
+    let output = if ctx.schemadocs && ctx.is_html_out {
+      latexml_post::schema_docs::process_page(&output)
+    } else {
+      output
+    };
+    outputs.push((dest, output));
+    // `doc` drops here — the whole point.
+  }
+  Ok(outputs)
 }
 
 /// One page spilled between the post pipeline's two passes: where its XML

--- a/latexml_oxide/src/render_workers.rs
+++ b/latexml_oxide/src/render_workers.rs
@@ -1,0 +1,694 @@
+//! Process-parallel page rendering for pass B of the post pipeline
+//! (`docs/performance/STREAMING_POST_DESIGN_2026-07-06.md` §6).
+//!
+//! In-process page threads are blocked twice (`ObjectDB` is `!Send`;
+//! libxslt serializes every transform behind a process-wide lock), so the
+//! chosen shape is **process-level page-range workers**: the parent saves the
+//! completed ObjectDB as a SQLite file, partitions the spilled pages into
+//! contiguous chunks, and re-invokes its own binary once per chunk with
+//! `LATEXML_RENDER_WORKER=<manifest.json>`. Each child attaches the db
+//! readonly (WAL — N readers share one page cache via mmap), runs the SAME
+//! per-page pipeline as the serial driver
+//! (`crate::post::render_spilled_page`), and reports its diagnostic tally
+//! as trailing `Status:` lines on stderr. The parent folds child logs and
+//! counts deterministically, in chunk order, into its own `LOG_BUFFER` /
+//! `REPORT` — so the combined verdict and the persisted `--log` stay lossless
+//! (canvas signal-integrity rule: a child that dies without a status line is
+//! folded as FATAL, never as success).
+//!
+//! Env knob: `LATEXML_RENDER_JOBS` (usize). Default 1 = the serial path,
+//! byte-identical to before this module existed.
+
+use std::path::{Path, PathBuf};
+
+use latexml_core::{
+  Info,
+  common::error::{
+    LogStatus, ReportCounts, emit_error, emit_fatal, get_status_code, note_status,
+    snapshot_report_counts,
+  },
+  s,
+  util::logger::{CapturedDiagnostics, replay_captured},
+};
+use latexml_post::object_db::{DbAttachOptions, ObjectDB};
+use serde::{Deserialize, Serialize};
+
+/// Fewer spilled pages than this and the db save + child spawn overhead beats
+/// the parallel win — the serial path is taken regardless of the jobs knob.
+pub(crate) const MIN_PAGES_FOR_PARALLEL: usize = 64;
+
+/// The `LATEXML_RENDER_JOBS` knob: how many page-render worker processes pass
+/// B may spawn. Default (and any unparsable value) is 1 = serial. Read once
+/// per conversion, so no hot-path caching is needed.
+pub(crate) fn render_jobs() -> usize {
+  std::env::var("LATEXML_RENDER_JOBS")
+    .ok()
+    .and_then(|v| v.parse::<usize>().ok())
+    .filter(|&n| n >= 1)
+    .unwrap_or(1)
+}
+
+/// The serializable subset of `PostDocumentOptions` a worker needs to
+/// reconstruct the page parse — ALL of its fields, since even `destination`
+/// (later overridden per page) feeds the site-directory fallback inside
+/// `PostDocument::new`.
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct PageOpts {
+  pub destination:           Option<String>,
+  pub destination_directory: Option<String>,
+  pub site_directory:        Option<String>,
+  pub source:                Option<String>,
+  pub source_directory:      Option<String>,
+  pub searchpaths:           Option<Vec<String>>,
+  pub validate:              bool,
+  pub nocache:               bool,
+}
+
+impl From<&latexml_post::document::PostDocumentOptions> for PageOpts {
+  fn from(o: &latexml_post::document::PostDocumentOptions) -> Self {
+    PageOpts {
+      destination:           o.destination.clone(),
+      destination_directory: o.destination_directory.clone(),
+      site_directory:        o.site_directory.clone(),
+      source:                o.source.clone(),
+      source_directory:      o.source_directory.clone(),
+      searchpaths:           o.searchpaths.clone(),
+      validate:              o.validate,
+      nocache:               o.nocache,
+    }
+  }
+}
+
+impl From<PageOpts> for latexml_post::document::PostDocumentOptions {
+  fn from(o: PageOpts) -> Self {
+    latexml_post::document::PostDocumentOptions {
+      destination:           o.destination,
+      destination_directory: o.destination_directory,
+      site_directory:        o.site_directory,
+      source:                o.source,
+      source_directory:      o.source_directory,
+      searchpaths:           o.searchpaths,
+      validate:              o.validate,
+      nocache:               o.nocache,
+    }
+  }
+}
+
+/// One spilled page for a worker to render: the spill path plus the metadata
+/// that does not survive the XML round-trip (mirrors `post::SpilledPage`
+/// minus the parent-only placeholder flags).
+#[derive(Serialize, Deserialize, Clone)]
+pub struct PageJob {
+  pub path:                  PathBuf,
+  pub destination:           Option<String>,
+  pub destination_directory: Option<String>,
+}
+
+/// Everything a page-render worker needs to rebuild the pass-B processor set
+/// exactly as the parent would have, plus its page range. Written as
+/// `render-manifest-{i}.json` beside the saved `render.db`.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct RenderManifest {
+  /// The saved ObjectDB (SQLite, attached readonly by each worker).
+  pub dbfile:                    PathBuf,
+  pub navigation_toc:            Option<String>,
+  pub graphicimages:             bool,
+  pub graphics_svg_threshold_kb: u32,
+  pub pmml:                      bool,
+  pub cmml:                      bool,
+  pub keep_xmath:                bool,
+  /// Already-inverted from the CLI's `noinvisibletimes`.
+  pub invisible_times:           bool,
+  pub plane1:                    bool,
+  pub hackplane1:                bool,
+  pub mathtex:                   bool,
+  pub intent_literal:            bool,
+  pub stylesheet:                Option<String>,
+  /// The fully-resolved XSLT parameter map (CSS/JS/LATEXML_VERSION/user
+  /// overrides), captured after the parent computed it.
+  pub xslt_params:               Vec<(String, String)>,
+  pub nodefaultresources:        bool,
+  /// The resolved stylesheet/resource search paths the parent's `XSLT::new`
+  /// received.
+  pub searchpaths:               Vec<String>,
+  pub is_html_out:               bool,
+  pub svg_fragments:             Vec<(String, String)>,
+  pub schemadocs:                bool,
+  /// [`latexml_post::extract::Whatsout`] as its canonical CLI tag
+  /// (`as_cli`/`from_cli` round-trip).
+  pub whatsout:                  String,
+  pub page_opts:                 PageOpts,
+  pub pages:                     Vec<PageJob>,
+}
+
+/// The parent-side result of a parallel render in which workers were actually
+/// spawned (successfully or not — failures are already folded as diagnostics).
+pub(crate) struct ParallelResult {
+  /// The first page's finalized output, read back from its destination file —
+  /// the same content the serial driver would have returned as `main_output`.
+  pub(crate) main_output:    Option<String>,
+  /// Total pages written, summed from the workers' `Status:pages:` lines.
+  pub(crate) pages_rendered: usize,
+}
+
+/// Remove the per-run handoff artifacts (db + WAL sidecars + manifests).
+/// Best-effort: they live in the page-spill tempdir, which is removed wholesale
+/// when the parent drops it, so a failure here only delays the cleanup.
+fn cleanup_handoff(dbfile: &Path, manifests: &[PathBuf]) {
+  let _ = std::fs::remove_file(dbfile);
+  for suffix in ["-wal", "-shm"] {
+    let mut side = dbfile.as_os_str().to_owned();
+    side.push(suffix);
+    let _ = std::fs::remove_file(PathBuf::from(side));
+  }
+  for m in manifests {
+    let _ = std::fs::remove_file(m);
+  }
+}
+
+/// Strip ANSI `ESC[...m` color sequences (same logic as the logger's private
+/// helper). Child stderr is a pipe, so the TTY-gated logger should emit none —
+/// this is belt-and-suspenders for the log fold (signal-integrity rule).
+fn strip_ansi(s: &str) -> String {
+  let mut result = String::with_capacity(s.len());
+  let mut in_escape = false;
+  for c in s.chars() {
+    if in_escape {
+      if c == 'm' {
+        in_escape = false;
+      }
+    } else if c == '\u{1b}' {
+      in_escape = true;
+    } else {
+      result.push(c);
+    }
+  }
+  result
+}
+
+/// A worker's stderr, parsed: the trailing `Status:` lines are consumed into
+/// structured fields and everything else is the log text to forward + fold.
+struct ChildReport {
+  log:    String,
+  counts: Option<ReportCounts>,
+  status: Option<usize>,
+  pages:  usize,
+}
+
+fn parse_child_report(stderr_text: &str) -> ChildReport {
+  let mut log = String::new();
+  let mut counts = None;
+  let mut status = None;
+  let mut pages = 0usize;
+  for line in stderr_text.lines() {
+    if let Some(rest) = line.strip_prefix("Status:counts:") {
+      let mut it = rest.split(',').map(|v| v.trim().parse::<usize>().ok());
+      let (d, i, w, e, f) = (
+        it.next().flatten(),
+        it.next().flatten(),
+        it.next().flatten(),
+        it.next().flatten(),
+        it.next().flatten(),
+      );
+      if let (Some(debug), Some(info), Some(warning), Some(error), Some(fatal)) = (d, i, w, e, f) {
+        counts = Some(ReportCounts {
+          debug,
+          info,
+          warning,
+          error,
+          fatal: fatal > 0,
+        });
+      }
+    } else if let Some(rest) = line.strip_prefix("Status:conversion:") {
+      status = rest.trim().parse::<usize>().ok();
+    } else if let Some(rest) = line.strip_prefix("Status:pages:") {
+      pages = rest.trim().parse::<usize>().unwrap_or(0);
+    } else {
+      log.push_str(line);
+      log.push('\n');
+    }
+  }
+  ChildReport { log, counts, status, pages }
+}
+
+/// One spawned (or spawn-failed) worker awaiting its fold.
+enum Pending {
+  /// The drain thread owns the child and returns its full `Output`; the pid
+  /// is kept so a parent-side timeout can kill the fleet.
+  Spawned(
+    std::thread::JoinHandle<std::io::Result<std::process::Output>>,
+    u32,
+  ),
+  Failed(String),
+}
+
+/// Spawn `jobs` page-range workers over `pages` and fold their results.
+///
+/// Returns `None` when setup failed BEFORE any child was spawned (reported at
+/// Info severity) — the caller falls back to the serial render, which is still
+/// fully correct since the spilled pages are untouched. Once children run
+/// there is no fallback: a worker that fails, dies, or omits its status line
+/// is folded as an Error + FATAL status (fail toward flagging, never silent
+/// success).
+pub(crate) fn parallel_render(
+  mut manifest: RenderManifest,
+  pages: Vec<PageJob>,
+  jobs: usize,
+  spill_dir: &Path,
+  db: &ObjectDB,
+) -> Option<ParallelResult> {
+  let total_pages = pages.len();
+  let exe = match std::env::current_exe() {
+    Ok(e) => e,
+    Err(e) => {
+      Info!(
+        "post",
+        "parallel-render",
+        s!("parallel render disabled (current_exe: {})", e)
+      );
+      return None;
+    },
+  };
+  let dbfile = spill_dir.join("render.db");
+  if let Err(e) = db.save_as(&dbfile) {
+    Info!(
+      "post",
+      "parallel-render",
+      s!("parallel render disabled (db save: {})", e)
+    );
+    return None;
+  }
+  manifest.dbfile = dbfile.clone();
+
+  // Contiguous chunks preserve page order: worker 0 owns the first pages, so
+  // the fold below (and the first page's main-output read) is deterministic.
+  let jobs = jobs.min(total_pages);
+  let chunk_size = total_pages.div_ceil(jobs);
+  let first_destination = pages.first().and_then(|p| p.destination.clone());
+  let mut manifest_paths: Vec<PathBuf> = Vec::with_capacity(jobs);
+  for (i, chunk) in pages.chunks(chunk_size).enumerate() {
+    let mut m = manifest.clone();
+    m.pages = chunk.to_vec();
+    let mpath = spill_dir.join(format!("render-manifest-{i}.json"));
+    let write_result = serde_json::to_string(&m)
+      .map_err(|e| e.to_string())
+      .and_then(|json| std::fs::write(&mpath, json).map_err(|e| e.to_string()));
+    if let Err(e) = write_result {
+      Info!(
+        "post",
+        "parallel-render",
+        s!("parallel render disabled (manifest write: {})", e)
+      );
+      cleanup_handoff(&dbfile, &manifest_paths);
+      return None;
+    }
+    manifest_paths.push(mpath);
+  }
+
+  // Parent-side deadline check before committing to the spawn (the workers
+  // carry no deadline of their own; the parent polls between waits below and
+  // kills the fleet on a breach).
+  if let Err(e) = latexml_core::stomach::check_timeout() {
+    e.log_fatal();
+    cleanup_handoff(&dbfile, &manifest_paths);
+    return Some(ParallelResult {
+      main_output:    None,
+      pages_rendered: 0,
+    });
+  }
+
+  // The engagement marker (also what the parity test asserts on — without it
+  // a silently-ignored jobs knob would let the test pass vacuously serial).
+  Info!(
+    "post",
+    "parallel-render",
+    s!(
+      "parallel page render engaged: {} worker(s) over {} pages",
+      manifest_paths.len(),
+      total_pages
+    )
+  );
+
+  let mut pending: Vec<Pending> = Vec::with_capacity(manifest_paths.len());
+  for mpath in &manifest_paths {
+    let spawned = std::process::Command::new(&exe)
+      .env("LATEXML_RENDER_WORKER", mpath)
+      .stdin(std::process::Stdio::null())
+      .stdout(std::process::Stdio::piped())
+      .stderr(std::process::Stdio::piped())
+      .spawn();
+    match spawned {
+      Ok(child) => {
+        let pid = child.id();
+        // Each child gets a drain thread calling `wait_with_output` — piped
+        // stderr MUST be consumed while the parent polls, or a chatty child
+        // blocks on a full pipe and the poll below never sees it exit.
+        let handle = std::thread::Builder::new()
+          .name(format!("render-worker-drain-{pid}"))
+          .spawn(move || child.wait_with_output());
+        match handle {
+          Ok(h) => pending.push(Pending::Spawned(h, pid)),
+          Err(e) => pending.push(Pending::Failed(format!("drain thread spawn failed: {e}"))),
+        }
+      },
+      Err(e) => pending.push(Pending::Failed(format!("worker spawn failed: {e}"))),
+    }
+  }
+
+  // Poll (rather than block) so the parent's cooperative timeout keeps
+  // running between waits; on a breach, kill the fleet so the join below
+  // returns promptly instead of riding out the children.
+  loop {
+    let all_done = pending
+      .iter()
+      .all(|p| !matches!(p, Pending::Spawned(h, _) if !h.is_finished()));
+    if all_done {
+      break;
+    }
+    if let Err(e) = latexml_core::stomach::check_timeout() {
+      e.log_fatal();
+      #[cfg(unix)]
+      for p in &pending {
+        if let Pending::Spawned(h, pid) = p
+          && !h.is_finished()
+        {
+          // SAFETY: plain kill(2) on a child pid this process spawned.
+          unsafe {
+            libc::kill(*pid as i32, libc::SIGKILL);
+          }
+        }
+      }
+      break;
+    }
+    std::thread::sleep(std::time::Duration::from_millis(100));
+  }
+
+  // Fold IN CHUNK ORDER (deterministic log/tally, mirroring the graphics
+  // worker fold): forward each child's stderr, replay its log + counts into
+  // the parent LOG_BUFFER/REPORT, and flag anything that did not report.
+  let mut pages_rendered = 0usize;
+  for (i, p) in pending.into_iter().enumerate() {
+    match p {
+      Pending::Failed(e) => {
+        emit_error("post", "render_worker", &format!("worker {i}: {e}"));
+        note_status(LogStatus::Fatal, None);
+      },
+      Pending::Spawned(handle, _) => match handle.join() {
+        Err(_) => {
+          emit_error(
+            "post",
+            "render_worker",
+            &format!("worker {i}: drain thread panicked"),
+          );
+          note_status(LogStatus::Fatal, None);
+        },
+        Ok(Err(e)) => {
+          emit_error(
+            "post",
+            "render_worker",
+            &format!("worker {i}: wait failed: {e}"),
+          );
+          note_status(LogStatus::Fatal, None);
+        },
+        Ok(Ok(output)) => {
+          let stderr_text = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+          let report = parse_child_report(&stderr_text);
+          if !report.log.is_empty() {
+            // The child's stderr was piped, so nothing reached the live
+            // stderr yet — forward it now, then fold the same text + counts
+            // into the captured log and the REPORT tally.
+            eprint!("{}", report.log);
+          }
+          replay_captured(CapturedDiagnostics {
+            log:    report.log,
+            counts: report.counts.unwrap_or_default(),
+          });
+          pages_rendered += report.pages;
+          match report.status {
+            None => {
+              // No status line = the child died before its final report (or
+              // never got that far). Fail toward flagging: this chunk's pages
+              // cannot be assumed rendered.
+              emit_error(
+                "post",
+                "render_worker",
+                &format!(
+                  "worker {i} exited (code {:?}) without a Status:conversion line",
+                  output.status.code()
+                ),
+              );
+              note_status(LogStatus::Fatal, None);
+            },
+            Some(s) if s >= 3 && !report.counts.is_some_and(|c| c.fatal) => {
+              // The child declared fatal but its counts line didn't carry the
+              // flag (or was missing) — max-fold the declared status anyway.
+              note_status(LogStatus::Fatal, None);
+            },
+            Some(_) => {},
+          }
+        },
+      },
+    }
+  }
+
+  // The serial driver returns the first page's finalized output as
+  // `main_output`; here that page is already on disk (written by worker 0),
+  // so read it back. A missing/unreadable file leaves `None` and the caller's
+  // fallback applies — the diagnostics above already flagged the failure.
+  let main_output = first_destination.and_then(|d| std::fs::read_to_string(&d).ok());
+  cleanup_handoff(&dbfile, &manifest_paths);
+  Some(ParallelResult { main_output, pages_rendered })
+}
+
+/// Print the worker's canonical trailing status report (the LAST lines on
+/// stderr): `Status:pages:`, then `Status:counts:`, then `Status:conversion:`
+/// — the parent parses them positionally-independently by prefix. Returns the
+/// process exit code (0 below fatal, 1 at fatal).
+fn print_status_report(pages: usize) -> i32 {
+  let c = snapshot_report_counts();
+  let status = get_status_code();
+  eprintln!("Status:pages:{pages}");
+  eprintln!(
+    "Status:counts:{},{},{},{},{}",
+    c.debug,
+    c.info,
+    c.warning,
+    c.error,
+    usize::from(c.fatal)
+  );
+  eprintln!("Status:conversion:{status}");
+  if status < 3 { 0 } else { 1 }
+}
+
+/// Entry point of the hidden worker mode (`LATEXML_RENDER_WORKER=<manifest>`),
+/// dispatched from the binary's `main` before any CLI handling. Renders the
+/// manifest's page range and ALWAYS ends its stderr with the status report —
+/// even when the manifest cannot be read — so the parent never mistakes a
+/// broken worker for a clean one.
+pub fn worker_main(manifest_path: &str) -> i32 {
+  latexml_core::util::logger::init(log::LevelFilter::Info).ok();
+  let manifest: RenderManifest = match std::fs::read_to_string(manifest_path)
+    .map_err(|e| e.to_string())
+    .and_then(|s| serde_json::from_str(&s).map_err(|e| e.to_string()))
+  {
+    Ok(m) => m,
+    Err(e) => {
+      emit_fatal(
+        "post",
+        "render_worker",
+        &format!("cannot read the render manifest {manifest_path}: {e}"),
+      );
+      return print_status_report(0);
+    },
+  };
+  // Mirror `api.rs::on_worker`: a 256 MiB-stack thread for deeply nested
+  // math, and an explicit engine reset before the thread exits (the
+  // `#[thread_local]` roots do not Drop on a bare thread exit).
+  std::thread::Builder::new()
+    .stack_size(256 * 1024 * 1024)
+    .spawn(move || {
+      let pages = render_manifest_pages(manifest);
+      let code = print_status_report(pages);
+      latexml_core::reset_thread_engine();
+      code
+    })
+    .expect("spawn render worker thread")
+    .join()
+    .expect("render worker thread panicked")
+}
+
+/// Rebuild the pass-B processor set from the manifest — the EXACT construction
+/// the parent's `run_post_processing_inner` performs (same MathML
+/// primary/secondary parallel model, same XSLT wiring, same error paths) —
+/// then render every page in the manifest's range through the shared
+/// [`crate::post::render_spilled_page`]. Returns the number of pages written.
+fn render_manifest_pages(m: RenderManifest) -> usize {
+  use latexml_post::{
+    crossref::{CrossRef, UrlStyle},
+    processor::Processor,
+  };
+  let db = match ObjectDB::attach(&m.dbfile, DbAttachOptions {
+    readonly: true,
+    clean:    false,
+  }) {
+    Ok(db) => db,
+    Err(e) => {
+      emit_fatal(
+        "post",
+        "render_worker",
+        &format!("cannot attach the render db {}: {e}", m.dbfile.display()),
+      );
+      return 0;
+    },
+  };
+  let mut crossref = CrossRef::new(db, UrlStyle::File, true);
+  if let Some(navtoc) = m.navigation_toc.as_deref() {
+    crossref.set_navigation_toc(navtoc);
+  }
+  let graphics = m.graphicimages.then(|| {
+    latexml_post::graphics::Graphics::new(None, true)
+      .with_svg_threshold_kb(m.graphics_svg_threshold_kb)
+  });
+  let post = latexml_post::Post::new();
+  let mut processors: Vec<Box<dyn Processor>> = Vec::new();
+  if m.pmml {
+    let mut presentation = latexml_post::mathml::MathML::new_presentation()
+      .with_keep_xmath(m.keep_xmath)
+      .with_invisible_times(m.invisible_times)
+      .with_plane1(m.plane1, m.hackplane1)
+      .with_mathtex(m.mathtex)
+      .with_intent_literal(m.intent_literal);
+    if m.cmml {
+      presentation = presentation.with_secondaries(vec![Box::new(
+        latexml_post::mathml::MathML::new_content()
+          .with_keep_xmath(m.keep_xmath)
+          .with_invisible_times(m.invisible_times)
+          .with_plane1(m.plane1, m.hackplane1)
+          .secondary(),
+      )]);
+    }
+    processors.push(Box::new(presentation));
+  } else if m.cmml {
+    processors.push(Box::new(
+      latexml_post::mathml::MathML::new_content()
+        .with_keep_xmath(m.keep_xmath)
+        .with_invisible_times(m.invisible_times)
+        .with_plane1(m.plane1, m.hackplane1),
+    ));
+  }
+  if let Some(xsl_path) = m.stylesheet.as_deref() {
+    let params: rustc_hash::FxHashMap<String, String> = m.xslt_params.iter().cloned().collect();
+    match latexml_post::xslt::XSLT::new(
+      xsl_path,
+      params,
+      m.nodefaultresources,
+      None,
+      m.searchpaths.clone(),
+    ) {
+      Ok(xslt) => processors.push(Box::new(xslt)),
+      Err(e) => emit_error("post", "xslt", &format!("XSLT error: {e}")),
+    }
+  }
+  let ctx = crate::post::PageRenderCtx {
+    page_opts:     m.page_opts.clone().into(),
+    is_html_out:   m.is_html_out,
+    svg_fragments: m.svg_fragments.clone(),
+    schemadocs:    m.schemadocs,
+    whatsout:      latexml_post::extract::Whatsout::from_cli(&m.whatsout).unwrap_or_default(),
+  };
+  let mut procs = crate::post::PageProcessors {
+    crossref,
+    graphics,
+    post,
+    processors,
+  };
+  let mut pages_written = 0usize;
+  for job in &m.pages {
+    // Same OS give-back cadence as the serial render loop: each page cycles a
+    // DOM + XSLT result through the C heap, and a chunk can be tens of
+    // thousands of pages.
+    if pages_written > 0 && pages_written.is_multiple_of(512) {
+      #[cfg(target_os = "linux")]
+      unsafe {
+        libc::malloc_trim(0);
+      }
+      #[cfg(not(feature = "dhat-heap"))]
+      unsafe {
+        libmimalloc_sys::mi_collect(true);
+      }
+    }
+    match crate::post::render_spilled_page(
+      &job.path,
+      &mut procs,
+      &ctx,
+      job.destination.clone(),
+      job.destination_directory.clone(),
+    ) {
+      Ok(outputs) => {
+        for (dest, output) in outputs {
+          if let Some(path) = dest.as_deref() {
+            if let Some(parent) = Path::new(path).parent()
+              && !parent.as_os_str().is_empty()
+            {
+              let _ = std::fs::create_dir_all(parent);
+            }
+            pages_written += 1;
+            if let Err(e) = std::fs::write(path, &output) {
+              emit_error(
+                "post",
+                "write",
+                &format!("failed to write page {path}: {e}"),
+              );
+            }
+          }
+        }
+      },
+      // Already reported inside the pipeline; mirror the serial driver's
+      // abort-on-page-failure (the parent flags the shortfall through the
+      // folded error + the fatal-bearing status this worker will report).
+      Err(()) => break,
+    }
+  }
+  pages_written
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn child_report_parses_status_lines_and_keeps_log() {
+    let stderr_text = "Warning:post:x something odd\nInfo:post:y fine\nStatus:pages:41\nStatus:counts:0,2,1,3,1\nStatus:conversion:3\n";
+    let r = parse_child_report(stderr_text);
+    assert_eq!(r.pages, 41);
+    assert_eq!(r.status, Some(3));
+    let c = r.counts.expect("counts parsed");
+    assert_eq!((c.debug, c.info, c.warning, c.error), (0, 2, 1, 3));
+    assert!(c.fatal);
+    assert!(r.log.contains("something odd"));
+    assert!(
+      !r.log.contains("Status:"),
+      "status lines must not leak into the folded log"
+    );
+  }
+
+  #[test]
+  fn child_report_without_status_is_flagged_as_none() {
+    let r = parse_child_report("Error:post:z boom\n");
+    assert_eq!(r.status, None);
+    assert!(r.counts.is_none());
+    assert_eq!(r.pages, 0);
+  }
+
+  #[test]
+  fn ansi_is_stripped_from_child_stderr() {
+    assert_eq!(strip_ansi("\u{1b}[31mError:\u{1b}[0m x"), "Error: x");
+  }
+
+  #[test]
+  fn render_jobs_defaults_to_serial() {
+    // NOTE: does not set the env var (process-global); only checks the parse
+    // fallback contract via the default branch.
+    assert!(render_jobs() >= 1);
+  }
+}

--- a/latexml_oxide/tests/120_midscale_streaming.rs
+++ b/latexml_oxide/tests/120_midscale_streaming.rs
@@ -122,3 +122,135 @@ fn midscale_streams_splits_and_reports_faithfully() {
     "expected >150 split pages (40 sections x 5 subsections), got {pages}"
   );
 }
+
+/// Sorted basenames of the split `*.html` pages in `dir`.
+fn html_pages(dir: &Path) -> Vec<String> {
+  let mut pages: Vec<String> = std::fs::read_dir(dir)
+    .expect("readdir")
+    .filter_map(|e| e.ok())
+    .map(|e| e.file_name().to_string_lossy().into_owned())
+    .filter(|n| n.ends_with(".html"))
+    .collect();
+  pages.sort();
+  pages
+}
+
+/// Run the midscale conversion in `workdir`; `render_jobs` engages the
+/// process-parallel page renderer. Same args both ways — the ONLY variable is
+/// the jobs knob.
+fn run_midscale(workdir: &Path, render_jobs: Option<&str>) -> std::process::Output {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  let tex = generate_midscale(workdir);
+  let mut cmd = Command::new(bin);
+  cmd
+    .args([
+      &tex,
+      "--dest=midscale.html",
+      "--format=html5",
+      "--splitat=subsection",
+      "--log=midscale.log",
+      "--timeout=1200",
+    ])
+    .env("LATEXML_POST_STREAM_SPLIT", "1")
+    // The serial baseline must really be serial, whatever the ambient env.
+    .env_remove("LATEXML_RENDER_JOBS")
+    .current_dir(workdir);
+  if let Some(jobs) = render_jobs {
+    cmd.env("LATEXML_RENDER_JOBS", jobs);
+  }
+  cmd.output().expect("spawn latexml_oxide")
+}
+
+/// The process-parallel page renderer (LATEXML_RENDER_JOBS) must be an
+/// invisible optimization: same page set, byte-identical pages, and a
+/// lossless diagnostic fold — the anchored CORE warning survives as the
+/// parent's combined verdict and canonical trailing status line.
+#[test]
+fn midscale_parallel_render_matches_serial() {
+  let serial_dir = tempfile::tempdir().expect("tempdir");
+  let parallel_dir = tempfile::tempdir().expect("tempdir");
+
+  let serial = run_midscale(serial_dir.path(), None);
+  let parallel = run_midscale(parallel_dir.path(), Some("3"));
+  let serial_stderr = String::from_utf8_lossy(&serial.stderr);
+  let parallel_stderr = String::from_utf8_lossy(&parallel.stderr);
+
+  assert_eq!(
+    serial.status.code(),
+    Some(0),
+    "serial run must succeed — stderr tail:\n{}",
+    serial_stderr
+      .lines()
+      .rev()
+      .take(12)
+      .collect::<Vec<_>>()
+      .join("\n")
+  );
+  assert_eq!(
+    parallel.status.code(),
+    Some(0),
+    "parallel run must succeed — stderr tail:\n{}",
+    parallel_stderr
+      .lines()
+      .rev()
+      .take(12)
+      .collect::<Vec<_>>()
+      .join("\n")
+  );
+
+  // The parallel path must actually engage — otherwise this test would pass
+  // vacuously as serial-vs-serial (canvas signal-integrity rule).
+  assert!(
+    parallel_stderr.contains("parallel page render engaged"),
+    "the parallel worker path must engage under LATEXML_RENDER_JOBS=3"
+  );
+
+  // Same set of split pages…
+  let serial_pages = html_pages(serial_dir.path());
+  let parallel_pages = html_pages(parallel_dir.path());
+  assert!(
+    serial_pages.len() > 150,
+    "expected >150 split pages, got {}",
+    serial_pages.len()
+  );
+  assert_eq!(
+    serial_pages, parallel_pages,
+    "serial and parallel runs must produce the same page set"
+  );
+
+  // …and byte-identical content for a spread of sample pages: first, last,
+  // and three interior picks across the sorted order.
+  let n = serial_pages.len();
+  for idx in [0, n / 4, n / 2, 3 * n / 4, n - 1] {
+    let name = &serial_pages[idx];
+    let a = std::fs::read(serial_dir.path().join(name)).expect("serial page read");
+    let b = std::fs::read(parallel_dir.path().join(name)).expect("parallel page read");
+    assert!(
+      a == b,
+      "page {name} must be byte-identical between serial and parallel renders"
+    );
+  }
+
+  // The diagnostic fold is lossless: the one anchored CORE warning (raised in
+  // the parent, not a worker) still drives the combined verdict…
+  let last = parallel_stderr
+    .lines()
+    .rev()
+    .find(|l| !l.trim().is_empty())
+    .unwrap_or("");
+  assert!(
+    last.contains("Conversion complete: 1 warning"),
+    "parallel run must keep the anchored 1-warning verdict as the final line, got: {last}"
+  );
+  // …and the persisted log still ENDS with the canonical combined status.
+  let log = std::fs::read_to_string(parallel_dir.path().join("midscale.log")).expect("log written");
+  let log_last = log
+    .lines()
+    .rev()
+    .find(|l| !l.trim().is_empty())
+    .unwrap_or("");
+  assert_eq!(
+    log_last, "Status:conversion:1",
+    "the parallel run's log must end with the canonical combined status"
+  );
+}

--- a/latexml_oxide/tests/120_midscale_streaming.rs
+++ b/latexml_oxide/tests/120_midscale_streaming.rs
@@ -1,0 +1,124 @@
+//! Mid-scale end-to-end harness (review 2026-08-03 recommendation): the
+//! witness-class guarantees — auto-streaming core, streaming post-split,
+//! combined verdict, lossless tally, canonical status line — were proven
+//! only by an 84-minute manual run on a 131 MB book. This generates a
+//! math-dense, sectioned document big enough to force BOTH streaming paths
+//! under a small memory ceiling, and pins all of those contracts in one
+//! CI-runnable conversion. It is deliberately the harness the parallel
+//! page-render work will be reviewed against.
+
+use std::{path::Path, process::Command};
+
+/// ~1 MB of sectioned, math-dense LaTeX: 40 sections x 5 subsections, each
+/// with prose filler and formulas. One deterministic warning (the raw
+/// http-input site) anchors the tally cross-check.
+fn generate_midscale(dir: &Path) -> String {
+  let mut tex = String::with_capacity(1 << 20);
+  tex.push_str("\\documentclass{article}\\usepackage{amsmath}\\begin{document}\n");
+  tex.push_str("\\input{http://example.com/warn-anchor.tex}\n");
+  for s in 0..40 {
+    tex.push_str(&format!("\\section{{Generated section {s}}}\n"));
+    for ss in 0..5 {
+      tex.push_str(&format!("\\subsection{{Topic {s}.{ss}}}\n"));
+      let para = format!(
+        "\\label{{sec:{s}-{ss}}} As shown in \\ref{{sec:0-0}}, the filler \
+         prose of block {s}.{ss} continues with enough ordinary text to give \
+         each page body real weight beyond its mathematics. "
+      );
+      tex.push_str(&para.repeat(18));
+      for f in 0..6 {
+        tex.push_str(&format!(
+          "\\begin{{equation}}\\alpha_{{{s}}} = \\sum_{{i=0}}^{{{f}}} \
+           \\frac{{x_i^{{{ss}}}}}{{1 + \\sin(\\beta_{{{f}}} t)}}\\end{{equation}}\n"
+        ));
+      }
+    }
+  }
+  tex.push_str("\\end{document}\n");
+  let path = dir.join("midscale.tex");
+  std::fs::write(&path, &tex).expect("fixture written");
+  assert!(
+    tex.len() > 700_000,
+    "fixture must be mid-scale, got {} bytes",
+    tex.len()
+  );
+  path.to_string_lossy().into_owned()
+}
+
+#[test]
+fn midscale_streams_splits_and_reports_faithfully() {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  let workdir = tempfile::tempdir().expect("tempdir");
+  let tex = generate_midscale(workdir.path());
+
+  let output = Command::new(bin)
+    .args([
+      &tex,
+      "--dest=midscale.html",
+      "--format=html5",
+      "--splitat=subsection",
+      // Small ceiling: the ~1900 B/source-byte projection exceeds the fuse,
+      // so core auto-streams — the witness path, at CI scale.
+      "--max-memory=1200",
+      "--log=midscale.log",
+      "--timeout=1200",
+    ])
+    // Force the streaming post-split despite the sub-GiB handoff.
+    .env("LATEXML_POST_STREAM_SPLIT", "1")
+    .current_dir(workdir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+  let stderr = String::from_utf8_lossy(&output.stderr);
+
+  assert_eq!(
+    output.status.code(),
+    Some(0),
+    "mid-scale conversion must succeed — stderr tail:\n{}",
+    stderr.lines().rev().take(12).collect::<Vec<_>>().join("\n")
+  );
+
+  // The combined verdict is the run's last line, and the tally is LOSSLESS:
+  // exactly the one anchored warning, in both the verdict and the log grep.
+  let last = stderr
+    .lines()
+    .rev()
+    .find(|l| !l.trim().is_empty())
+    .unwrap_or("");
+  assert!(
+    last.contains("Conversion complete: 1 warning"),
+    "expected the anchored 1-warning verdict as the final line, got: {last}"
+  );
+  let log = std::fs::read_to_string(workdir.path().join("midscale.log")).expect("log written");
+  let warning_lines = log.lines().filter(|l| l.starts_with("Warning:")).count();
+  assert_eq!(
+    warning_lines, 1,
+    "the log must carry exactly the anchored warning (tally agreement)"
+  );
+  let log_last = log
+    .lines()
+    .rev()
+    .find(|l| !l.trim().is_empty())
+    .unwrap_or("");
+  assert_eq!(
+    log_last, "Status:conversion:1",
+    "the log must END with the canonical combined status"
+  );
+
+  // Streaming actually engaged, and the split produced the site.
+  assert!(
+    stderr.contains("streaming"),
+    "core auto-streaming must engage under the small ceiling"
+  );
+  let pages = std::fs::read_dir(workdir.path())
+    .expect("readdir")
+    .filter(|e| {
+      e.as_ref()
+        .map(|e| e.file_name().to_string_lossy().ends_with(".html"))
+        .unwrap_or(false)
+    })
+    .count();
+  assert!(
+    pages > 150,
+    "expected >150 split pages (40 sections x 5 subsections), got {pages}"
+  );
+}

--- a/latexml_post/src/extract.rs
+++ b/latexml_post/src/extract.rs
@@ -68,6 +68,18 @@ impl Whatsout {
     }
   }
 
+  /// The canonical CLI tag for this variant — round-trips through
+  /// [`Whatsout::from_cli`]. Used to serialize the mode across a process
+  /// boundary (the parallel page-render worker manifest).
+  pub fn as_cli(self) -> &'static str {
+    match self {
+      Whatsout::Document => "document",
+      Whatsout::Fragment => "fragment",
+      Whatsout::Math => "math",
+      Whatsout::Archive => "archive",
+    }
+  }
+
   /// Whether this mode bundles the output into a zip archive (Perl
   /// `pack_collection` `whatsout =~ /^archive/`). The binary's output
   /// stage branches on this to call [`crate::pack::pack_archive`].
@@ -455,5 +467,21 @@ mod tests {
       node.get_attribute("typeof").as_deref(),
       Some("ScholarlyArticle")
     );
+  }
+
+  #[test]
+  fn whatsout_cli_tag_round_trips() {
+    for w in [
+      Whatsout::Document,
+      Whatsout::Fragment,
+      Whatsout::Math,
+      Whatsout::Archive,
+    ] {
+      assert_eq!(
+        Whatsout::from_cli(w.as_cli()),
+        Some(w),
+        "as_cli must round-trip through from_cli for {w:?}"
+      );
+    }
   }
 }

--- a/latexml_post/src/object_db.rs
+++ b/latexml_post/src/object_db.rs
@@ -578,6 +578,52 @@ impl ObjectDB {
     Ok(db)
   }
 
+  /// Persist this IN-MEMORY db as a fresh dbfile (the parallel-render
+  /// handoff: the parent scans/sweeps in memory, saves once, and each worker
+  /// attaches the file readonly). Unlike [`ObjectDB::finish`] this does not
+  /// consume the attachment state — the db stays usable in memory, and any
+  /// existing file at `path` is replaced.
+  pub fn save_as(&self, path: &std::path::Path) -> Result<usize, String> {
+    if path.exists() {
+      std::fs::remove_file(path).map_err(|e| format!("cannot replace {}: {e}", path.display()))?;
+    }
+    let mut conn = rusqlite::Connection::open(path)
+      .map_err(|e| format!("cannot create dbfile {}: {e}", path.display()))?;
+    let _ = conn.query_row("PRAGMA journal_mode = WAL", [], |_| Ok(()));
+    conn
+      .execute_batch(&format!(
+        "PRAGMA user_version = {DBFILE_FORMAT_VERSION};
+         CREATE TABLE meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+         CREATE TABLE entries(key TEXT PRIMARY KEY, props TEXT NOT NULL);"
+      ))
+      .map_err(|e| format!("cannot initialize {}: {e}", path.display()))?;
+    let tx = conn
+      .transaction()
+      .map_err(|e| format!("cannot begin save_as transaction: {e}"))?;
+    let mut stored = 0usize;
+    for (key, entry) in &self.objects {
+      let map: serde_json::Map<String, serde_json::Value> = entry
+        .values
+        .iter()
+        .map(|(k, v)| (k.clone(), value_to_json_with(self.xml_holder.as_ref(), v)))
+        .collect();
+      tx.execute(
+        "INSERT INTO entries(key, props) VALUES (?1, ?2)",
+        rusqlite::params![key, serde_json::Value::Object(map).to_string()],
+      )
+      .map_err(|e| format!("cannot store entry {key}: {e}"))?;
+      stored += 1;
+    }
+    tx.execute(
+      "INSERT INTO meta(key, value) VALUES ('latexml_version', ?1)",
+      rusqlite::params![env!("CARGO_PKG_VERSION")],
+    )
+    .map_err(|e| format!("cannot store meta: {e}"))?;
+    tx.commit()
+      .map_err(|e| format!("cannot commit save_as: {e}"))?;
+    Ok(stored)
+  }
+
   /// Write back changed entries and detach — Perl `ObjectDB::finish`.
   /// Returns how many entries were stored. Idempotent: a second call (or a
   /// call on a never-attached DB) stores nothing.


### PR DESCRIPTION
Roadmap gap 3 (STREAMING_POST_DESIGN §6), on the reviewed foundation: ObjectDB SQLite handoff (#487) + the mid-scale harness (first commit of this branch).

- `LATEXML_RENDER_JOBS=N` (default 1 = serial, byte-identical — `118` guards) spawns N workers over contiguous page chunks; each attaches the db readonly and renders through the same extracted `render_spilled_page` as the serial loop.
- Worker/parent status contract: `Status:pages`/`Status:counts`/`Status:conversion` terminal lines, chunk-order fold via `replay_captured`, severity max-fold, missing-status/dead-child → Fatal (fail toward flagging), parent timeout SIGKILLs the fleet.
- Guard: `midscale_parallel_render_matches_serial` — identical page sets, byte-identical sampled pages, lossless tally in the parallel verdict.

Witness measurement (render ≈31 min serial → target ~5–8 min at 8 workers) to follow in this PR before merge.

1877/1877 tests, all gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)