### PR TITLE
fix(cli): a conversion always writes <jobname>.latexml.log — Perl latexmlc parity

### DIFF
--- a/latexml_oxide/bin/latexml_oxide.rs
+++ b/latexml_oxide/bin/latexml_oxide.rs
@@ -822,6 +822,34 @@ fn real_main() -> Result<(), Box<dyn Error>> {
     source
   };
 
+  // Perl latexmlc parity (bin/latexmlc L103-120): ALWAYS write a conversion
+  // log — `--log` names it, otherwise `<jobname>.latexml.log` in the current
+  // directory (literal/anonymous sources fall back to plain `latexml.log`),
+  // and a pre-existing file is removed up front so the log is always this
+  // run's. The archive output packs its log into the zip instead, exactly as
+  // before. Reported missing on the 0.7.5-rc5 witness UAT (2026-08-03): a
+  // fatal scrolled away with nothing on disk to consult.
+  let cli_log: Option<String> = cli.log.clone().or_else(|| {
+    // Dump-building (`--init`) is not a conversion; no default log there.
+    if cli.init.is_some() {
+      return None;
+    }
+    let name = if source.starts_with("literal:") {
+      "latexml.log".to_string()
+    } else {
+      match Path::new(&source).file_stem().and_then(|s| s.to_str()) {
+        Some(stem) => format!("{stem}.latexml.log"),
+        None => "latexml.log".to_string(),
+      }
+    };
+    Some(name)
+  });
+  if let Some(ref lp) = cli_log
+    && Path::new(lp).is_file()
+  {
+    let _ = std::fs::remove_file(lp);
+  }
+
   // Some arXiv source archives ship a PDF mis-named with a `.tex` extension
   // (e.g. 2301.04210.tex). Perl LaTeXML detects the `%PDF-` magic and bails
   // with a single Fatal; without this guard the binary catcode-tokenizes
@@ -1340,7 +1368,7 @@ fn real_main() -> Result<(), Box<dyn Error>> {
 
     // --log: write conversion log to file (skip if already packed into
     // the ZIP by the archive output stage).
-    if let Some(ref log_path) = cli.log
+    if let Some(ref log_path) = cli_log
       && !is_archive_out
     {
       // Write the core log and the post-phase log sequentially rather than

--- a/latexml_oxide/tests/119_final_status_report.rs
+++ b/latexml_oxide/tests/119_final_status_report.rs
@@ -249,3 +249,35 @@ fn quiet_mode_still_reports_error_and_fatal() {
     "the failure verdict stays the last line at -q, got: {very_last}"
   );
 }
+
+/// Perl latexmlc parity (bin/latexmlc L103-120, reported on the rc5 witness
+/// UAT): with `--log` unset a conversion ALWAYS writes
+/// `<jobname>.latexml.log` in the working directory, ending with the
+/// canonical combined status line — so a fatal that scrolled off stderr can
+/// always be consulted on disk.
+#[test]
+fn default_latexml_log_is_written_like_perl() {
+  let workdir = tempfile::tempdir().expect("tempdir");
+  let tex = fatal_fixture(workdir.path());
+  let (_, code) = run(
+    &[&tex, "--dest=toomany.html", "--format=html5"],
+    workdir.path(),
+  );
+  assert_eq!(code, 1);
+  let log_path = workdir.path().join("toomany.latexml.log");
+  let log = std::fs::read_to_string(&log_path)
+    .unwrap_or_else(|e| panic!("default log {} must exist: {e}", log_path.display()));
+  assert!(
+    log.contains("Fatal:TooManyErrors"),
+    "the fatal must be consultable in the default log"
+  );
+  let last = log
+    .lines()
+    .rev()
+    .find(|l| !l.trim().is_empty())
+    .unwrap_or("");
+  assert_eq!(
+    last, "Status:conversion:3",
+    "default log ends with the status line"
+  );
+}


### PR DESCRIPTION
rc5 witness UAT flaw #1: no default log, so the run's Fatal had to be caught off stderr. Perl latexmlc always writes <jobname>.latexml.log (CWD, pre-existing unlinked); now mirrored exactly, with the canonical Status:conversion tail. Archive output unchanged (log packs into the zip); --init stays log-less. 1880/1880 tests, gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)