### PR TITLE
feat(diag): memory Fatals report what the document needs; disk staging loses the scary wording

### DIFF
--- a/latexml_core/src/document.rs
+++ b/latexml_core/src/document.rs
@@ -1703,10 +1703,10 @@ impl Document {
         emit_error(
           "spill",
           "unresolved",
-          &format!("a nested spilled segment could not be spliced ({elem})"),
+          &format!("a nested disk-staged segment could not be spliced back ({elem})"),
         );
         out.push_str(before);
-        out.push_str("<!-- latexml-oxide: LOST spilled segment -->\n");
+        out.push_str("<!-- latexml-oxide: LOST staged segment -->\n");
         rest = &from[elem_end..];
         continue;
       };
@@ -1796,11 +1796,11 @@ impl Document {
                 "spill",
                 "unresolved",
                 &format!(
-                  "a spilled segment could not be spliced back (ref={:?})",
+                  "a disk-staged segment could not be spliced back (ref={:?})",
                   node.get_attribute("ref")
                 ),
               );
-              out.push_str("<!-- latexml-oxide: LOST spilled segment -->\n");
+              out.push_str("<!-- latexml-oxide: LOST staged segment -->\n");
             },
           }
           return;
@@ -3461,7 +3461,7 @@ impl Document {
         "malformed",
         "id",
         s!(
-          "Duplicated attribute xml:id. Using id='{}' on <{}> id='{}' already set on a spilled fragment",
+          "Duplicated attribute xml:id. Using id='{}' on <{}> id='{}' already set on a disk-staged fragment",
           new_id,
           arena::to_string(get_node_qname(node)),
           id
@@ -3899,7 +3899,7 @@ impl Document {
         let spill_error = |details: String| Error {
           target:   ErrorTarget::Document,
           category: ErrorCategory::Libxml,
-          message:  s!("spill: {}", details),
+          message:  s!("segment staging: {}", details),
         };
         let mut placeholder = Node::new(SPILL_PLACEHOLDER, None, &self.document)
           .map_err(|()| spill_error(s!("cannot create the placeholder node")))?;

--- a/latexml_core/src/stomach.rs
+++ b/latexml_core/src/stomach.rs
@@ -339,13 +339,26 @@ pub fn check_timeout() -> Result<()> {
               let bt = std::backtrace::Backtrace::force_capture();
               eprintln!("{bt}");
             }
+            // The actionable half of the message is a KNOWN NEED, not an
+            // anomaly: a document's peak scales with macro expansion and math
+            // density (the 131 MB witness needs ~23 GB resident just to
+            // stream through core), so the honest advice is "raise the
+            // ceiling", plus the derived flag value so the user knows which
+            // number they are raising — the cap here is the 75% fuse, not
+            // the `--max-memory` figure they typed. The latch lets the
+            // binary's end-of-run report add the kernel-tracked peak
+            // (`watchdog::peak_memory_report`, emitted only when this fired).
+            crate::watchdog::note_memory_fatal();
             fatal!(
               Timeout,
               MemoryBudget,
               format!(
-                "Memory budget exceeded: RSS {} MB > cap {} MB",
+                "Memory budget exceeded: RSS {} MB > cap {} MB (the cooperative fuse at 75% of \
+                 --max-memory={}). This document needs a larger ceiling: rerun with a higher \
+                 --max-memory on a machine with enough free RAM.",
                 rss_bytes / 1_000_000,
-                cap / 1_000_000
+                cap / 1_000_000,
+                (cap * 4).div_ceil(3 * 1024 * 1024),
               )
             );
           }

--- a/latexml_core/src/watchdog.rs
+++ b/latexml_core/src/watchdog.rs
@@ -127,6 +127,91 @@ pub fn process_rss_kb() -> Option<u64> {
 #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
 pub fn process_rss_kb() -> Option<u64> { None }
 
+/// Kernel-tracked PEAK resident set of this process in KiB (`VmHWM`), or `None`
+/// if it can't be determined. Unlike [`process_rss_kb`]'s point-in-time sample,
+/// this is the true high-water mark over the whole process lifetime — no
+/// sampling cadence can miss a spike — which makes it the honest basis for the
+/// end-of-run "this document needed N" report ([`peak_memory_report`]).
+#[cfg(target_os = "linux")]
+pub fn process_peak_rss_kb() -> Option<u64> {
+  let status = std::fs::read_to_string("/proc/self/status").ok()?;
+  for line in status.lines() {
+    if let Some(rest) = line.strip_prefix("VmHWM:") {
+      return rest.split_whitespace().next()?.parse::<u64>().ok();
+    }
+  }
+  None
+}
+
+/// macOS: `getrusage(RUSAGE_SELF)`; `ru_maxrss` is in BYTES on Darwin.
+#[cfg(target_os = "macos")]
+pub fn process_peak_rss_kb() -> Option<u64> {
+  let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
+  // SAFETY: getrusage fills the zeroed struct we own; a nonzero return is
+  // handled below.
+  if unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage) } == 0 {
+    return Some(usage.ru_maxrss as u64 / 1024);
+  }
+  None
+}
+
+/// Windows: `PeakWorkingSetSize` from the same `GetProcessMemoryInfo` call that
+/// backs [`process_rss_kb`].
+#[cfg(windows)]
+pub fn process_peak_rss_kb() -> Option<u64> {
+  use windows_sys::Win32::System::{
+    ProcessStatus::{K32GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS},
+    Threading::GetCurrentProcess,
+  };
+  let mut counters: PROCESS_MEMORY_COUNTERS = unsafe { std::mem::zeroed() };
+  counters.cb = size_of::<PROCESS_MEMORY_COUNTERS>() as u32;
+  // SAFETY: `counters` is a correctly sized, zeroed struct with `cb` set, as the
+  // API requires; `GetCurrentProcess` returns a pseudo-handle needing no close.
+  if unsafe { K32GetProcessMemoryInfo(GetCurrentProcess(), &mut counters, counters.cb) } != 0 {
+    return Some(counters.PeakWorkingSetSize as u64 / 1024);
+  }
+  None
+}
+
+/// Other platforms: no peak available — the report line is simply omitted.
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+pub fn process_peak_rss_kb() -> Option<u64> { None }
+
+/// Latched by the cooperative memory fuse when it raises its
+/// `Timeout:MemoryBudget` Fatal (`stomach::check_timeout`), read at end of run
+/// by [`peak_memory_report`]. An `AtomicBool` static, not a thread-local: the
+/// fuse fires on the conversion thread while the binary's end-of-run reporting
+/// runs on the main thread.
+static MEMORY_FATAL_SEEN: AtomicBool = AtomicBool::new(false);
+
+/// Record that a memory-budget Fatal fired, so the end-of-run report knows
+/// memory was actually the problem.
+pub fn note_memory_fatal() { MEMORY_FATAL_SEEN.store(true, Ordering::Relaxed); }
+
+/// The end-of-run memory report — emitted ONLY when a memory-budget Fatal
+/// fired during the run (user directive 2026-08-03: alert when needed, stay
+/// quiet on clean runs). `None` otherwise, or when no peak is measurable.
+///
+/// It reports the kernel-tracked peak and says the document needs MORE — never
+/// a specific sufficient figure, because none is knowable from a truncated
+/// run: the fuse clamped the peak at 75% of the ceiling, and the streaming
+/// spill watermark itself derives from the ceiling, so the true requirement
+/// can only be found by rerunning higher. A document's need scales with macro
+/// expansion and math density, not source bytes (the 131 MB math-dense
+/// witness needs ~23 GB resident just to stream through core), so this
+/// measured figure is the only honest lower bound there is.
+pub fn peak_memory_report() -> Option<String> {
+  if !MEMORY_FATAL_SEEN.load(Ordering::Relaxed) {
+    return None;
+  }
+  let peak_kb = process_peak_rss_kb()?;
+  Some(format!(
+    "peak memory {} MB was not enough: this document needs a higher --max-memory ceiling \
+     (0 disables the limit) and enough free RAM",
+    peak_kb / 1024,
+  ))
+}
+
 /// Total physical RAM on this machine in bytes, or `None` if it cannot be
 /// determined.
 ///
@@ -517,7 +602,9 @@ impl Watchdog {
           return;
         }
         eprintln!(
-          "Fatal:oom:rss latexml-oxide: resident memory {}MB exceeded the {}MB ceiling — exiting process",
+          "Fatal:oom:rss latexml-oxide: resident memory {}MB exceeded the {}MB ceiling — exiting \
+           process. This document needs a larger ceiling: rerun with a higher --max-memory on a \
+           machine with enough free RAM.",
           rss / 1024,
           max_rss_kb / 1024
         );

--- a/latexml_math_parser/src/parser.rs
+++ b/latexml_math_parser/src/parser.rs
@@ -31,6 +31,25 @@ use crate::{
   util::{filter_hints, node_to_grammar_lexemes_from},
 };
 
+thread_local! {
+  /// Conversion-wide ordinal behind the `[N]` math-progress markers.
+  /// Deliberately NOT a `MathParser` field: streaming pass 2 builds a fresh
+  /// parser per staged fragment, and a per-instance counter restarted the
+  /// bracket sequence at `[1]` in every fragment. Thread-local like the rest
+  /// of the engine state (core runs one conversion per thread); reset once
+  /// per conversion by [`reset_conversion_notices`] (called from
+  /// `core_interface::initialize_singletons`), so a pooled `--server` /
+  /// test-harness thread does not inherit the previous document's count.
+  static FORMULA_ORDINAL: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// Advance and return the conversion-wide formula ordinal (1-based).
+fn next_formula_ordinal() -> usize {
+  let n = FORMULA_ORDINAL.get() + 1;
+  FORMULA_ORDINAL.set(n);
+  n
+}
+
 /// Fallback table for formulas the Marpa grammar cannot yet parse.
 /// Maps tex attribute → text attribute for known test formulas.
 /// TODO: Remove entries as grammar coverage improves.
@@ -261,7 +280,10 @@ thread_local! {
 /// begins on a thread that already ran one (the persistent `cortex_worker`
 /// converts many documents per process), or the second document silently
 /// loses notices the first one emitted.
-pub fn reset_conversion_notices() { LOSTNODES_NOOP_REPORTED.set(false); }
+pub fn reset_conversion_notices() {
+  LOSTNODES_NOOP_REPORTED.set(false);
+  FORMULA_ORDINAL.set(0);
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 // `Accepted(XM)` is the hot/common variant; boxing it to equalize variant
@@ -425,7 +447,6 @@ pub struct MathParser {
   maybe_functions:           SymHashMap<usize>,
   /// XMath nodes that failed to parse (stored as hashable IDs for post-parse class marking)
   pub failed_xmath_ids:      Vec<usize>,
-  n_parsed:                  usize,
   /// Grammar tree count from the last successful parse (for \ltx@count@parses)
   pub last_parsetrees_count: usize,
   /// Hashes of the distinct formula token streams that have already emitted an `ambiguous_math` /
@@ -462,7 +483,6 @@ impl Default for MathParser {
       // punctuation: HashMap::default(),
       // lostnodes: HashMap::default(),
       // idrefs: Vec::new(),
-      n_parsed: 0,
       last_parsetrees_count: 0,
       warned_formulas: HashSet::new(),
       suppress_unparsed_warning: false,
@@ -1076,7 +1096,6 @@ impl MathParser {
     self.unknowns = SymHashMap::default();
     self.maybe_functions = SymHashMap::default();
     self.failed_xmath_ids = Vec::new();
-    self.n_parsed = 0;
   }
   // our %EXCLUDED_PRETTYNAME_ATTRIBUTES = (fontsize => 1, opacity => 1);
 
@@ -1245,9 +1264,13 @@ impl MathParser {
         Some(mut result) => {
           *self.passed.entry_sym(tag).or_insert(0) += 1;
           if tag == pin!("ltx:XMath") {
-            // Replace the content of XMath with parsed result
-            self.n_parsed += 1;
-            note_progress(&s!("[{}]", self.n_parsed));
+            // Replace the content of XMath with parsed result. The `[N]`
+            // progress markers count CONVERSION-wide, not per parser
+            // instance: streaming pass 2 builds a fresh `MathParser` per
+            // staged fragment, and a per-instance counter restarted the
+            // bracket sequence at `[1]` in every fragment — useless for
+            // judging global progress on a 500k-formula document.
+            note_progress(&s!("[{}]", next_formula_ordinal()));
             // Unrecord the old content's ids BEFORE the copy below, so the
             // copy's freshly recorded entries (same id strings) survive.
             for el_node in element_nodes(&node) {

--- a/latexml_oxide/bin/latexml_oxide.rs
+++ b/latexml_oxide/bin/latexml_oxide.rs
@@ -1340,14 +1340,22 @@ fn real_main() -> Result<(), Box<dyn Error>> {
           let source_date_epoch = std::env::var("SOURCE_DATE_EPOCH")
             .ok()
             .and_then(|s| s.trim().parse::<u64>().ok());
+          // Emitted only after a memory-budget Fatal (`peak_memory_report`
+          // is `None` otherwise): the measured peak rides just above the
+          // status tail so the packed log records what the article needed —
+          // see the identical placement in the `--log` file write below.
+          let peak_log = latexml_core::watchdog::peak_memory_report()
+            .map(|body| format!("Info:memory:peak {body}\n"))
+            .unwrap_or_default();
           latexml_post::pack::pack_archive(&latexml_post::pack::PackOptions {
             zip_path: &zip_dest,
             html_filename: &html_name,
             html: &output,
             log_filename: Some(&log_name),
             log: &format!(
-              "{}\n{}",
+              "{}\n{}{}",
               assemble_conversion_log(&response.log, &post_log).trim_end(),
+              peak_log,
               combined_status_line
             ),
             status: &combined_status_line,
@@ -1385,9 +1393,19 @@ fn real_main() -> Result<(), Box<dyn Error>> {
           latexml_core::common::error::get_status_code().max(phase_status_max)
         )
       );
+      // Emitted only after a memory-budget Fatal: the kernel-tracked peak,
+      // recorded in the log as the honest lower bound on what THIS article
+      // needs — a figure the user has no other way to learn.
+      let peak_line = latexml_core::watchdog::peak_memory_report()
+        .map(|body| format!("\nInfo:memory:peak {body}"))
+        .unwrap_or_default();
       if post_log.is_empty() {
         latexml_post::writer::write_output_segments(
-          &[response.log.trim_end_matches('\n'), &status_line],
+          &[
+            response.log.trim_end_matches('\n'),
+            &peak_line,
+            &status_line,
+          ],
           Some(log_path),
         )?;
       } else {
@@ -1396,6 +1414,7 @@ fn real_main() -> Result<(), Box<dyn Error>> {
             response.log.trim_end_matches('\n'),
             "\n",
             post_log.trim_end_matches('\n'),
+            &peak_line,
             &status_line,
           ],
           Some(log_path),
@@ -1415,6 +1434,13 @@ fn real_main() -> Result<(), Box<dyn Error>> {
   // is scoped to the conversion branch. Match bin/latexml's exit(1) exactly;
   // status_code 2 ("errors but recoverable") stays a 0 exit, as in Perl.
   let final_status_code = latexml_core::common::error::get_status_code().max(phase_status_max);
+  // The stderr copy of the peak-memory report — present only when a
+  // memory-budget Fatal fired, so clean runs stay quiet. Info-level: `-q`
+  // mutes it, the log file above keeps it regardless. Placed before the
+  // verdict so the verdict stays the run's final word (101/119 guards).
+  if let Some(body) = latexml_core::watchdog::peak_memory_report() {
+    emit_info("memory", "peak", &body);
+  }
   // The end-of-run verdict: the LAST line of a conversion names the COMBINED
   // core+post outcome. The core prints its own verdict when it finishes, but
   // on a post-processing run thousands of per-page lines follow it — a

--- a/latexml_oxide/src/core_interface.rs
+++ b/latexml_oxide/src/core_interface.rs
@@ -661,7 +661,7 @@ fn streaming_pass2(
       .map_err(|e| Error {
         target:   ErrorTarget::Internal,
         category: ErrorCategory::Libxml,
-        message:  s!("cannot re-parse spilled segment {seg}: {e}"),
+        message:  s!("cannot re-parse staged segment {seg}: {e}"),
       })?;
     let mut out = String::new();
     {
@@ -1319,7 +1319,7 @@ impl DigestionAPI for Core {
             "streaming",
             "progress",
             &format!(
-              "streaming: fragment {} absorbed; {} segment(s) spilled; RSS ~{} MB; C-live {} MB; C-free {} MB; root-children {}; idstore {}; index {}+{}; arena {}; fonts {}; pending {}",
+              "streaming: fragment {} absorbed; {} segment(s) staged to disk; RSS ~{} MB; C-live {} MB; C-free {} MB; root-children {}; idstore {}; index {}+{}; arena {}; fonts {}; pending {}",
               fragments,
               latexml_core::document::spilled_segment_count(),
               stomach::last_sampled_rss_kb() / 1024,
@@ -1349,7 +1349,7 @@ impl DigestionAPI for Core {
       "streaming",
       "progress",
       &format!(
-        "streaming: PASS 1 done in {:.1?} — {} yield(s), {} segment(s) spilled, RSS ~{} MB",
+        "streaming: PASS 1 done in {:.1?} — {} yield(s), {} segment(s) staged to disk, RSS ~{} MB",
         pass1_elapsed,
         stomach::fragment_yield_count(),
         latexml_core::document::spilled_segment_count(),

--- a/latexml_oxide/src/post.rs
+++ b/latexml_oxide/src/post.rs
@@ -421,10 +421,7 @@ fn try_streaming_front(
     };
     for d in processed {
       if root_unnamed && let Err(e) = std::fs::write(&page.path, d.to_xml_string()) {
-        post_error(
-          "post",
-          &format!("cannot refresh a streamed page spill: {e}"),
-        );
+        post_error("post", &format!("cannot refresh a disk-staged page: {e}"));
         telemetry::phase_exit();
         return Err(());
       }
@@ -492,7 +489,7 @@ fn run_post_processing_impl(input: PostInput, opts: &PostOptions) -> String {
             "post",
             "spill",
             format!(
-              "oversized handoff ({} bytes) spilled to {}",
+              "oversized handoff ({} bytes) staged to {}",
               xml.len(),
               path.display()
             )
@@ -505,7 +502,7 @@ fn run_post_processing_impl(input: PostInput, opts: &PostOptions) -> String {
           latexml_core::Info!(
             "post",
             "spill",
-            format!("could not spill an oversized handoff ({e}); parsing from memory")
+            format!("could not stage an oversized handoff to disk ({e}); parsing from memory")
           );
           PostInput::Xml(xml)
         },
@@ -609,7 +606,7 @@ fn run_post_processing_inner(input: PostInput, opts: &PostOptions) -> String {
     Err(e) => {
       post_error(
         "post",
-        &format!("cannot create the page spill directory: {e}"),
+        &format!("cannot create the page staging directory: {e}"),
       );
       return fallback();
     },
@@ -822,7 +819,7 @@ fn run_post_processing_inner(input: PostInput, opts: &PostOptions) -> String {
     for (i, d) in docs.drain(..).enumerate() {
       let path = page_spill.path().join(format!("page-{i:07}.xml"));
       if let Err(e) = std::fs::write(&path, d.to_xml_string()) {
-        post_error("post", &format!("cannot spill page {i}: {e}"));
+        post_error("post", &format!("cannot stage page {i} to disk: {e}"));
         return fallback();
       }
       let (needs_index, needs_bib) = page_placeholder_probes(&d);
@@ -1075,7 +1072,7 @@ fn run_post_processing_inner(input: PostInput, opts: &PostOptions) -> String {
       );
       let path_str = path.to_string_lossy().into_owned();
       let mut page = PostDocument::new_from_file(&path_str, opts.clone()).map_err(|e| {
-        post_error("post", &format!("cannot re-read a spilled page: {e}"));
+        post_error("post", &format!("cannot re-read a disk-staged page: {e}"));
       })?;
       page.destination = dest.clone();
       page.destination_directory = dest_dir.clone();
@@ -1093,7 +1090,7 @@ fn run_post_processing_inner(input: PostInput, opts: &PostOptions) -> String {
       // MakeBibliography fill placeholders in place and return the same page.
       for d in processed.iter().take(1) {
         if let Err(e) = std::fs::write(path, d.to_xml_string()) {
-          post_error("post", &format!("cannot re-spill a page: {e}"));
+          post_error("post", &format!("cannot re-stage a page to disk: {e}"));
           return Err(());
         }
       }
@@ -1373,7 +1370,7 @@ pub(crate) fn render_spilled_page(
       d
     },
     Err(e) => {
-      post_error("post", &format!("cannot re-read a spilled page: {e}"));
+      post_error("post", &format!("cannot re-read a disk-staged page: {e}"));
       return Err(());
     },
   };

--- a/latexml_post/src/scan.rs
+++ b/latexml_post/src/scan.rs
@@ -18,11 +18,17 @@ use crate::{
 ///
 /// Port of `LaTeXML::Post::Scan`.
 pub struct Scan {
-  name:    String,
+  name:             String,
   /// Reference to the shared ObjectDB.
-  pub db:  ObjectDB,
+  pub db:           ObjectDB,
   /// Root document id for the current scan.
-  page_id: Option<String>,
+  page_id:          Option<String>,
+  /// Object-count threshold at which the next `Scan: DBStatus:` line is due —
+  /// the line logs when the count PASSES a power of two, not per page. A
+  /// per-page line (Perl's verbosity-gated `NoteProgressDetailed`) wrote
+  /// 115k+ near-identical lines on a book-scale split; exponential backoff
+  /// keeps the growth curve visible in ~20 lines (user directive 2026-08-03).
+  db_status_due_at: usize,
 }
 
 /// Collected properties for a scanned element, ready for DB registration.
@@ -45,6 +51,7 @@ impl Scan {
       name: "Scan".to_string(),
       db,
       page_id: None,
+      db_status_due_at: 1,
     }
   }
 
@@ -903,7 +910,12 @@ impl Processor for Scan {
       }
     }
 
-    Info!("scan", "db_status", "Scan: DBStatus: {}", self.db.status());
+    // Exponential backoff: log only when the object count passes the next
+    // power of two (see the `db_status_due_at` field docs).
+    if self.db.len() >= self.db_status_due_at {
+      Info!("scan", "db_status", "Scan: DBStatus: {}", self.db.status());
+      self.db_status_due_at = (self.db.len() + 1).next_power_of_two();
+    }
     Ok(vec![doc])
   }
 }

--- a/latexml_post/src/stream_split.rs
+++ b/latexml_post/src/stream_split.rs
@@ -423,7 +423,7 @@ impl Splitter {
       Warn!(
         "split",
         "stream",
-        "{} appeared after the first page was written; already-spilled pages do not carry it",
+        "{} appeared after the first page was written; already-staged pages do not carry it",
         what
       );
     }
@@ -1591,8 +1591,12 @@ fn patch_spill_root_tag(
   value: &str,
   before_appended_class: bool,
 ) -> Result<(), String> {
-  let content = std::fs::read_to_string(file)
-    .map_err(|e| format!("cannot read spill {} for patching: {e}", file.display()))?;
+  let content = std::fs::read_to_string(file).map_err(|e| {
+    format!(
+      "cannot read staged page {} for patching: {e}",
+      file.display()
+    )
+  })?;
   // Locate the root element: the first `<` not opening a PI or comment.
   let mut pos = 0;
   let root_start = loop {


### PR DESCRIPTION
Two UAT-driven diagnostics improvements from the 131 MB witness runs.

## A memory Fatal now tells the user what the document needs

At \`--max-memory=26000\` the witness died with the bare \`Memory budget exceeded: RSS 19947 MB > cap 20447 MB\` — no hint that the cap is the 75% fuse of a flag the user can raise, nor that a ~23 GB core floor is a *known need* of a document this size, not an anomaly.

- The cooperative-fuse Fatal (\`Timeout:MemoryBudget\`) now names the fuse fraction and the \`--max-memory\` figure it derives from, and advises rerunning with a higher ceiling. The watchdog hard-kill line carries the same advice.
- **Only after such a Fatal** (clean runs stay quiet — reviewer directive), the end of the run adds \`Info:memory:peak\` with the kernel-tracked peak RSS (Linux \`VmHWM\`, macOS \`getrusage\`, Windows \`PeakWorkingSetSize\`): the honest lower bound on what THIS article needs. Emitted to stderr and recorded just above the log's \`Status:conversion:N\` tail (plain \`--log\` and archive-packed logs both).
- No "sufficient" figure is claimed: the fuse clamps the peak and the spill watermark itself derives from the ceiling, so the true requirement is only found by rerunning higher.

## "spilled" → "staged to disk"

\`459,579 segment(s) spilled\` reads as an accident, but writing segments/pages to disk when the document does not fit RAM is exactly what the streaming design intends. User-facing log/error text now says "staged to disk" / "disk-staged"; internal identifiers (\`spill_dir\`, \`render_spilled_page\`, \`spill_watermark_bytes\`, \`.latexml-spill-*\` temp dirs) keep their names. No test or tool asserted on the old wording.

Gates: 1880/1880 nextest, clippy \`-D warnings\`, rustdoc — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)