### PR TITLE
fix: bare xml:id reads — four silently disabled passes turn on

### DIFF
--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -734,6 +734,73 @@ residuals stay here so the live worklist keeps them visible:
   still flushes `pending_comments` (gullet.rs ~L1170). Low urgency
   (`INCLUDE_COMMENTS=false` default); port at the next gullet-seam session.
 
+### `fragid` parity audit — id preservation (2026-08-04)
+
+Full Perl↔Rust comparison of the `fragid` mechanism, since `fragid` — not
+`xml:id` — is what the HTML5 XSLT's `add_id` emits the HTML `id` from, so a
+node with an `xml:id` but no `fragid` reaches HTML with **no id at all**.
+`CrossRef::fill_in_frags` (CrossRef.pm L312-324) is the assigner and is
+faithfully ported; it stamps only nodes carrying an ObjectDB `ID:` entry.
+
+**Measured end state** (same-host Perl 0.8.8, id-rich document with sections,
+labels, footnotes, equation/align, table, figure, refs): HTML id sets are
+`24 rust / 23 perl`, **zero ids present in Perl and missing here**, zero
+dangling in-page anchors in either engine; the one extra is our `abstract1`
+(we make the abstract linkable, Perl does not). Under `--splitat=section` the
+per-page sets match exactly (`S1.html` 22/22) with no broken cross-page
+anchors. Witness dirs under the session scratchpad.
+
+**Two audit claims did NOT survive checking** — do not re-chase:
+- *"Scan skips XM* descendants ⇒ hrefless `<m:share/>` in all Content MathML"*:
+  **refuted for documents.** A `$a<b<c$` document emits
+  `<share href="#p1.m1.sh1">` in BOTH engines, byte-identical. The hrefless
+  `<share/>` appears only in the standalone `latexmlmath_oxide --cmml` path —
+  where Perl's `latexmlmath` emits `href="#Ex1.m1.sh1"` pointing at **nothing**
+  (its own output has zero ids). Shared limitation, Perl's arguably worse (a
+  dangling href vs a missing one). Not a Rust-only gap.
+- *"`generate_node_id`'s fragid half is missing"*: **present and faithful**
+  (document.rs:1361-1366 vs Post.pm L1490-1492). It was merely never reached,
+  because the parent walk above it used a bare `xml:id` read that always
+  missed; the accessor sweep activated it.
+
+**Fixed here:** id-bearing markup CLONED into a generated bibliography (an
+`ltx:Math` in a `.bib` title) reached HTML with no id, because Perl's
+`Collector::rescan` (Collector.pm L97, called from MakeBibliography.pm L71/78)
+re-runs the whole Scan over the generated subtree and we have no rescan.
+MakeBibliography now registers every id-bearing node of that subtree
+(id/fragid half only, never overwriting an existing entry). Witness went
+`4 rust / 5 perl` ids → `5 / 5`. Guards:
+`06_cluster_bibliography::{bib_entry_ids_are_bib_rooted_like_perl,
+bib_entry_cloned_markup_keeps_its_id}` (both red-checked).
+
+**Still open, ranked** (each verified as real code, blast radius NOT
+re-measured except where noted):
+1. **No `Collector::rescan`.** The fix above is a bibliography-local stand-in.
+   The general wiring — re-run `Scan` from `MakeIndex`/`MakeBibliography` —
+   also restores `labels`/relations/per-type values a full Scan derives, and
+   would let the three ad-hoc registrations be deleted. Blocked on `Scan`
+   owning its `ObjectDB` by value (`scan.rs:49`), so it needs a borrow-based
+   or take/restore refactor.
+2. **`associateNode` (Post.pm L508-585) unported** — generated MathML/OpenMath
+   nodes carry no `xml:id`, so `convertedIDs` and pmml↔cmml parallel
+   cross-linking do not exist. This is also the only real caller of
+   `generate_node_id`, which currently has **zero callers**.
+3. **`in_page_id` lacks the `labelids` branch** (Scan.pm L176-184) — affects
+   `--splitnaming=label*` only; `Scan::new` takes no options to carry it.
+4. **`in_page_id` lacks the `split_from_id` fallback** (Scan.pm L191-192);
+   `PostDocument::split_from_id` exists but is read by nobody and is never set
+   on streaming pages. Anchor-naming only — links stay self-consistent.
+5. **`strip_ref_display_fragids`** (crossref.rs:131) is Rust-only and matches
+   `//ltx:ref//*[@fragid]` wholesale, so genuine id'd content inside an
+   `ltx:ref` loses its fragid too. Narrow it to ids absent from the ObjectDB.
+6. **`make_sub_collection_documents` returns `vec![]`** (collector.rs:141) —
+   `--splitindex`/`--splitbibliography` drop every entry past the first
+   initial. Note its only callers are its own unit tests, one of which is
+   named `…_currently_returns_empty`, so the accessor fix landed there is
+   inert until this is implemented.
+7. **Glossary term/description flattened to text** (make_index.rs:553-596)
+   where Perl deep-clones the phrase markup with suffix `glo`, keeping ids.
+
 ### `--format=xml` emits no `ltx:bibitem` — untriaged (2026-08-04)
 
 `--format=xml` output carries no `ltx:bibitem` elements at all, while

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -217,10 +217,18 @@ classes are singletons and the first error is often incidental.
   after which the two engines' bibliographies are byte-identical there. Guard
   `06_cluster_bibliography::cluster_bib_alpha_style_labels` (verified RED on
   the pre-fix tree: author-year classes, `Ångström` last, no suffixes).
-  **Found, not fixed:** a Rust `<ltx:biblist>` has `xml:id` but no `fragid`, and
-  `add_id` emits the HTML `id` from `@fragid` only, so Perl's `<ul id="bib.L1">`
-  is a bare `<ul>` here. Pre-existing; the XSLT is byte-identical between the
-  engines, so the cause is whatever assigns `fragid` to a post-created node.
+  **Found, then fixed 2026-08-04:** a Rust `<ltx:biblist>` had `xml:id` but no
+  `fragid`, and `add_id` emits the HTML `id` from `@fragid` only, so Perl's
+  `<ul id="bib.L1">` was a bare `<ul>` here. The `fragid` assigner is
+  `CrossRef::fill_in_frags` ("Any nodes with an ID will get a fragid",
+  CrossRef.pm L312-324) — faithfully ported — which stamps only nodes that have
+  an `ID:<id>` ObjectDB entry. Perl's Scan runs AFTER MakeBibliography and
+  registers every id'd node; our port hand-registers the *bibitems* at that
+  seam (because Perl's Scan is what registers them) but never the enclosing
+  list, so the list alone had no entry. MakeBibliography now registers each
+  `ltx:biblist` too. Output `<ul id="bib.L1" class="ltx_biblist">` is
+  byte-identical to same-host Perl. Guard:
+  `06_cluster_bibliography::bib_entry_ids_are_bib_rooted_like_perl`.
 
 - **2026-07-27 — the `unexpected:fi` fatal cluster: `\meaning` of a
   `\chardef` token returned the internal class name.** GENUINE-RUST-ONLY,
@@ -726,19 +734,13 @@ residuals stay here so the live worklist keeps them visible:
   still flushes `pending_comments` (gullet.rs ~L1170). Low urgency
   (`INCLUDE_COMMENTS=false` default); port at the next gullet-seam session.
 
-### `ltx:biblist` loses its `xml:id` between post and HTML — OPEN (2026-08-04)
+### `--format=xml` emits no `ltx:bibitem` — untriaged (2026-08-04)
 
-Perl emits `<ul id="bib.L1" class="ltx_biblist">`; we emit the `<ul>` with no
-id. Not an id-minting bug: `make_bib_list` sets it (make_bibliography.rs:886)
-and it IS present in our post XML (`<biblist xml:id="bib.L1">`, seen in
-`06_cluster_bibliography::bib_entry_ids_are_bib_rooted_like_perl`'s output), so
-it is dropped on the XSLT side. Bibitem anchors themselves match Perl exactly
-(`bib.bibN`) since the `n_bibliographies` fix below.
-
-Sibling observation, untriaged: `--format=xml` output carries no `ltx:bibitem`
-elements at all, while `--format=html5` renders the bibliography — so the two
-format paths run different post chains. Check before trusting an `xml`-format
-dump as a bibliography oracle.
+`--format=xml` output carries no `ltx:bibitem` elements at all, while
+`--format=html5` on the same source renders the bibliography — so the two
+format paths do not run the same post chain. Not yet diagnosed; check before
+trusting an `xml`-format dump as a bibliography oracle. (The `ltx:biblist`
+`fragid` gap noticed alongside it is FIXED — see the 2026-07-28 entry above.)
 
 ### A `robust` DefConstructor reverted under its munged cs — ✅ FIXED 2026-07-29
 

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -726,6 +726,23 @@ residuals stay here so the live worklist keeps them visible:
   still flushes `pending_comments` (gullet.rs ~L1170). Low urgency
   (`INCLUDE_COMMENTS=false` default); port at the next gullet-seam session.
 
+### Bibliography anchor-id residuals (2026-08-04, exposed by the xml:id bare-read sweep)
+
+The sweep made `formatBibEntry`'s id scheme faithful (Perl MakeBibliography.pm
+L407-415: `s/^bib//`, prepend bibid — previously the NS-blind read forced every
+bibitem onto the `.bibN` numbering fallback). Two upstream-of-that-site parity
+gaps became visible on a plain BibTeX doc (`\bibliography{b}`, `\cite`):
+
+- **Bibitem anchor prefix**: ours `biba.bibN`, Perl `bib.bibN`. Our recursive
+  `.bib` session mints bibentry ids under a root prefix `a` where Perl's
+  subdocument yields `bib.bibN`-shaped ids. Links stay self-consistent
+  (`href="#biba.bib1"` ↔ `id="biba.bib1"`) — only the anchor spelling differs.
+- **`<ul class="ltx_biblist">` misses its id** (Perl: `bib.L1`).
+  `make_bib_list` sets one (make_bibliography.rs:886) but it does not survive
+  to HTML.
+
+Both live in the bibliography session's id minting, not the accessor layer.
+
 ### A `robust` DefConstructor reverted under its munged cs — ✅ FIXED 2026-07-29
 
 Rust wrote `tex="x+\text{see \ref {sec:one}}"` where Perl writes

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -726,22 +726,21 @@ residuals stay here so the live worklist keeps them visible:
   still flushes `pending_comments` (gullet.rs ~L1170). Low urgency
   (`INCLUDE_COMMENTS=false` default); port at the next gullet-seam session.
 
-### Bibliography anchor-id residuals (2026-08-04, exposed by the xml:id bare-read sweep)
+### `ltx:biblist` loses its `xml:id` between post and HTML — OPEN (2026-08-04)
 
-The sweep made `formatBibEntry`'s id scheme faithful (Perl MakeBibliography.pm
-L407-415: `s/^bib//`, prepend bibid — previously the NS-blind read forced every
-bibitem onto the `.bibN` numbering fallback). Two upstream-of-that-site parity
-gaps became visible on a plain BibTeX doc (`\bibliography{b}`, `\cite`):
+Perl emits `<ul id="bib.L1" class="ltx_biblist">`; we emit the `<ul>` with no
+id. Not an id-minting bug: `make_bib_list` sets it (make_bibliography.rs:886)
+and it IS present in our post XML (`<biblist xml:id="bib.L1">`, seen in
+`06_cluster_bibliography::bib_entry_ids_are_bib_rooted_like_perl`'s output), so
+it is dropped on the XSLT side. Bibitem anchors themselves match Perl exactly
+(`bib.bibN`) since the `n_bibliographies` fix below.
 
-- **Bibitem anchor prefix**: ours `biba.bibN`, Perl `bib.bibN`. Our recursive
-  `.bib` session mints bibentry ids under a root prefix `a` where Perl's
-  subdocument yields `bib.bibN`-shaped ids. Links stay self-consistent
-  (`href="#biba.bib1"` ↔ `id="biba.bib1"`) — only the anchor spelling differs.
-- **`<ul class="ltx_biblist">` misses its id** (Perl: `bib.L1`).
-  `make_bib_list` sets one (make_bibliography.rs:886) but it does not survive
-  to HTML.
+Sibling observation, untriaged: `--format=xml` output carries no `ltx:bibitem`
+elements at all, while `--format=html5` renders the bibliography — so the two
+format paths run different post chains. Check before trusting an `xml`-format
+dump as a bibliography oracle.
 
-Both live in the bibliography session's id minting, not the accessor layer.
+### A `robust` DefConstructor reverted under its munged cs — ✅ FIXED 2026-07-29
 
 ### A `robust` DefConstructor reverted under its munged cs — ✅ FIXED 2026-07-29
 

--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3077,3 +3077,38 @@ bundled-CSS local delta (OXIDIZED_DESIGN divergence #93). Note Perl's
 fancyvrb binding itself is fine (`fancyvrb.sty.ltxml` adds the per-line
 `ltx_verbatim` class); the Rust port of that binding had dropped the hack
 and now carries it.
+
+## 72. `seealsoPartition_aux` keys its attribute hash on attribute NODES — the styling attributes it means to copy are lost
+
+`Post/MakeIndex.pm` L445, re-wrapping a `\see`/`\seealso` phrase's styling
+element around each partitioned sub-chunk:
+
+```perl
+my $attr = { map { ($_ => $ch->getAttribute($_)) } $ch->attributes };
+push(@result, map { [$$_[0], [$tag, $attr, cdr($_)]] } seealsoPartition_aux($doc, $ch));
+```
+
+`$ch->attributes` yields attribute **nodes**, not names. Used as hash keys they
+stringify to their serialized form, and `getAttribute($node)` then looks up an
+attribute by that same junk string and finds nothing. So `%$attr` is a hash of
+unusable keys mapped to `undef` — the `ltx:text`/`ltx:emph` wrapper is rebuilt
+with none of the attributes the line is written to preserve (`font`, `class`,
+…). The intended read is `$_->nodeName` (or `getQName`), as the sibling
+`mergeAttributes` (`Post.pm` L1303-1305) does correctly.
+
+Measured (same-host `XML::LibXML`):
+
+```perl
+my $doc = XML::LibXML->load_xml(string => q{<r><t role="x" font="bold" xml:id="i1">hi</t></r>});
+my ($ch) = $doc->documentElement->childNodes;
+my $attr = { map { ($_ => $ch->getAttribute($_)) } $ch->attributes };
+#   [ font="bold"]  => (undef)
+#   [ role="x"]     => (undef)
+#   [ xml:id="i1"]  => (undef)
+```
+
+Low impact — it only degrades styling inside a see/seealso phrase, and only
+when that phrase is itself styled. **Rust implements the intent instead**
+(`make_index.rs::seealso_partition_aux` copies the real attributes), minus the
+id attributes: the wrapper is cloned once per sub-chunk, so copying `xml:id`
+would mint duplicate ids — which Perl's bug incidentally also avoids.

--- a/latexml_core/src/document.rs
+++ b/latexml_core/src/document.rs
@@ -3936,16 +3936,20 @@ impl Document {
     Ok(runs_spilled)
   }
 
-  /// A node's `xml:id` in EITHER attribute form. Nodes CONSTRUCTED by the
-  /// builder carry a plain attribute literally named `"xml:id"`
-  /// (`set_attribute` does not namespace it), while nodes PARSED from XML
-  /// carry the namespaced form — so a namespace-only read silently misses
-  /// every constructed node. Witness (131 MB book, 2026-08-01): spill-time
-  /// indexing registered 865 of 23,654 spilled labels, gutting the fragment
-  /// index for `label:`/`id:`-scoped rewrites and spilled-id dedup — with no
-  /// error anywhere, because a missing id is indistinguishable from an
-  /// id-less node. The same trap, in the parsed direction, is
-  /// `latexml_post::document::get_xml_id`.
+  /// A node's `xml:id`, namespace-aware with a defensive plain-name fallback.
+  ///
+  /// MECHANISM CORRECTION (2026-08-04, empirically probed against libxml
+  /// 0.3.21): `set_attribute("xml:id", …)` DOES namespace the attribute
+  /// (`xmlSetProp` resolves the predefined `xml` prefix), so builder-
+  /// CONSTRUCTED nodes and PARSED nodes both store the namespaced form and
+  /// `get_attribute_ns("id", XML_NS)` reads both; no code path in this
+  /// workspace produces a literal-named "xml:id" attribute. The earlier
+  /// claim here that constructed nodes carry the plain form does not
+  /// reproduce. The 131 MB-book witness (2026-08-01: spill-time indexing
+  /// registered 865 of 23,654 labels) was fixed by the commit that added
+  /// this helper, but the missing-id mechanism was misattributed; the bare
+  /// fallback is kept as belt (it is dead under the probed model, and
+  /// harmless).
   pub(crate) fn node_xml_id_any_form(node: &Node) -> Option<String> {
     node
       .get_attribute_ns("id", XML_NS)
@@ -4525,21 +4529,17 @@ impl Document {
     let c_name = with_node_qname(&content, |n| n.to_string());
     let p_name = with_node_qname(&presentation, |n| n.to_string());
 
-    // Case 1: Quick fix — merge two tokens
+    // Case 1: Quick fix — merge two tokens (Perl compactXMDual L1588-1593).
+    // Perl has NO id cleanup here: mergeAttributes deliberately TRANSFERS the
+    // content/dual xml:id onto the surviving presentation token (unRecordID +
+    // recordID, L1308-1313), keeping refs to that id resolvable. A former
+    // Rust-only "remove the leaked content id" block contradicted that — and
+    // was dead anyway (its bare has/get/remove_attribute("xml:id") calls
+    // always missed the namespaced attribute).
     if c_name == "ltx:XMTok" && p_name == "ltx:XMTok" {
       let mut pres = presentation;
-      let pres_had_id = pres.has_attribute("xml:id");
       self.merge_attributes(&content, &mut pres, Some(&CONTENT_TRANSFER))?;
       self.merge_attributes(&dual, &mut pres, Some(&DUAL_TRANSFER))?;
-      // If presentation didn't originally have an xml:id and the dual doesn't either,
-      // remove the content's xml:id that leaked through merge_attributes
-      if !pres_had_id
-        && !dual.has_attribute("xml:id")
-        && let Some(id) = pres.get_attribute("xml:id")
-      {
-        self.unrecord_id(&id);
-        let _ = pres.remove_attribute("xml:id");
-      }
       // Unlink presentation from dual before replacing, since presentation is a child of dual
       pres.unlink();
       self.replace_node(dual, vec![pres])?;

--- a/latexml_core/src/rewrite.rs
+++ b/latexml_core/src/rewrite.rs
@@ -251,6 +251,23 @@ impl Rewrite {
         pattern,
       };
     }
+    // Perl Rewrite.pm L288-297: a `label` clause COMPILES to a select on the
+    // labeled node's xml:id (via getLabelID) — it has no runtime behavior.
+    // `scope => "label:<label>"` compiles through the identical getLabelID
+    // path (L300-302), so delegate to that branch below. (The former runtime
+    // Label arm instead tried to RECORD the current node's id under the
+    // label — not Perl semantics, and dead anyway: its bare
+    // get_attribute("xml:id") read always returned None.)
+    if op == RewriteOperator::Label
+      && let RewritePattern::String(label_str) = &pattern
+    {
+      let as_scope = RewriteClause {
+        compiled: false,
+        op:       RewriteOperator::Scope,
+        pattern:  RewritePattern::String(format!("label:{label_str}")),
+      };
+      return self.compile_clause(document, as_scope);
+    }
     // scope => 'label:...' compiles to select with xpath via label ID resolution
     // Perl: $op = 'select'; $pattern = ["descendant-or-self::*[@xml:id='<id>']", 1];
     if op == RewriteOperator::Scope
@@ -679,14 +696,9 @@ impl Rewrite {
           }
         },
         Label => {
-          // Label clause stores the label on the node. Perl: $$self{label} usage.
-          // Typically compiled away in compile_clause, but if it reaches here, record it.
-          if let RewritePattern::String(label_str) = pattern {
-            let id = tree.get_attribute("xml:id").unwrap_or_default();
-            if !id.is_empty() {
-              document.rewrite_labels.insert(label_str.clone(), id);
-            }
-          }
+          // Unreachable once compiled: compile_clause lowers Label to a
+          // Select via the scope "label:…" path (Perl Rewrite.pm L288-297 —
+          // a label clause has NO runtime behavior). Defensive pass-through.
           self.apply_clause(document, tree, nmatched, clauses)?;
         },
         Trace => {

--- a/latexml_core/src/rewrite.rs
+++ b/latexml_core/src/rewrite.rs
@@ -1217,3 +1217,73 @@ fn mark_seen_rec(node: &Node) {
     }
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::document::Document;
+
+  /// A `label` clause must COMPILE AWAY into a Select on the labeled node's
+  /// `xml:id` — Perl `Rewrite.pm::compileClause` L288-297:
+  /// `$op = 'select'; $pattern = ["descendant-or-self::*[\@xml:id='" .
+  ///  $self->getLabelID($pattern) . "']", 1];`
+  ///
+  /// It has no runtime behavior in Perl. The former Rust runtime arm instead
+  /// tried to RECORD the current node's id under the label — not Perl
+  /// semantics, and dead anyway (its bare `get_attribute("xml:id")` read
+  /// always returned None). `label => …` is reachable only from the Rhai
+  /// `DefRewrite(#{label: …})` option bag, so this unit test is its only
+  /// coverage.
+  #[test]
+  fn label_clause_compiles_to_a_select_on_the_labeled_id() {
+    let mut document = Document::new();
+    document
+      .rewrite_labels
+      .insert("LABEL:eq.one".to_string(), "S1.E2".to_string());
+
+    let mut rule = Rewrite::new("text", RewriteOptions {
+      label: Some("eq.one".to_string()),
+      ..RewriteOptions::default()
+    });
+    assert!(
+      matches!(
+        rule.clauses.first().map(|c| c.op),
+        Some(RewriteOperator::Label)
+      ),
+      "a label option must start life as a Label clause"
+    );
+    rule.compile_clauses(&mut document);
+
+    match rule.clauses.first() {
+      Some(RewriteClause {
+        op: RewriteOperator::Select,
+        pattern: RewritePattern::String(xpath),
+        ..
+      }) => assert_eq!(xpath, "descendant-or-self::*[@xml:id='S1.E2']"),
+      other => panic!("label must lower to a Select on the labeled id, got {other:?}"),
+    }
+    // Perl sets the select count to 1 in the same breath (L297's trailing `1`).
+    assert_eq!(rule.options.select_count, Some(1));
+  }
+
+  /// An UNKNOWN label falls through to `Ignore`, so the remaining clauses
+  /// still apply to the current tree — preserving the pre-lowering behavior
+  /// on a miss (Perl errors and yields an empty-id xpath, which selects
+  /// nothing; the strict streaming path mirrors that with an empty NodeList).
+  #[test]
+  fn unknown_label_falls_through_to_ignore() {
+    let mut document = Document::new();
+    let mut rule = Rewrite::new("text", RewriteOptions {
+      label: Some("nope".to_string()),
+      ..RewriteOptions::default()
+    });
+    rule.compile_clauses(&mut document);
+    assert!(
+      matches!(
+        rule.clauses.first().map(|c| c.op),
+        Some(RewriteOperator::Ignore)
+      ),
+      "an unresolvable label must not silently restrict the rule"
+    );
+  }
+}

--- a/latexml_core/src/sxml/fragment_index.rs
+++ b/latexml_core/src/sxml/fragment_index.rs
@@ -226,16 +226,20 @@ mod tests {
     assert!(result.is_err(), "unknown record kinds must fail loudly");
   }
 
-  /// Both `xml:id` attribute forms must be readable at spill-indexing time:
-  /// parsed nodes carry the namespaced attribute, CONSTRUCTED nodes carry a
-  /// plain attribute literally named "xml:id". The namespace-only read
-  /// registered 865 of 23,654 spilled labels on the 131 MB witness — no
-  /// error anywhere, the fragment index just went missing.
+  /// `xml:id` must be readable at spill-indexing time however the node was
+  /// produced. MECHANISM CORRECTION (2026-08-04, probed against libxml
+  /// 0.3.21): BOTH construction paths store the attribute NAMESPACED —
+  /// `set_attribute("xml:id", …)` resolves the predefined `xml` prefix via
+  /// `xmlSetProp`, exactly like parsing does — so this test's two branches
+  /// both exercise `node_xml_id_any_form`'s `get_attribute_ns` arm, and its
+  /// bare-read fallback is defensive dead code. (The comment that previously
+  /// claimed constructed nodes carry a plain-named attribute does not
+  /// reproduce; see `node_xml_id_any_form`'s doc.)
   #[test]
   fn xml_id_readable_in_both_attribute_forms() {
     use libxml::{parser::Parser, tree::Node};
 
-    // Parsed form: xml:id arrives namespaced.
+    // Parsed: xml:id arrives namespaced.
     let parsed = Parser::default()
       .parse_string(r#"<r xmlns="urn:x"><s xml:id="parsed.id"/></r>"#)
       .expect("parse");
@@ -249,17 +253,21 @@ mod tests {
       "namespaced form must read"
     );
 
-    // Constructed form: set_attribute stores a plain "xml:id" attribute.
+    // Constructed: set_attribute ALSO stores the namespaced form.
     let built = Parser::default().parse_string("<r/>").expect("parse shell");
     let mut root = built.get_root_element().expect("root");
     let mut child = Node::new("s", None, &built).expect("node");
     child.set_attribute("xml:id", "built.id").expect("attr");
     root.add_child(&mut child).expect("attach");
     assert_eq!(
+      child.get_attribute_ns("id", "http://www.w3.org/XML/1998/namespace"),
+      Some("built.id".to_string()),
+      "set_attribute must namespace xml:id (probed libxml 0.3.21 behavior)"
+    );
+    assert_eq!(
       crate::document::Document::node_xml_id_any_form(&child).as_deref(),
       Some("built.id"),
-      "the plain constructed form must read too — a namespace-only read \
-       silently misses every builder-constructed node"
+      "constructed form must read through the helper too"
     );
   }
 }

--- a/latexml_engine/src/math_common.rs
+++ b/latexml_engine/src/math_common.rs
@@ -642,7 +642,9 @@ LoadDefinitions!({
         string_map!("role" => "ENCLOSE", "enclose" => "updiagonalstrike",
         "meaning" => "not", "_box" => not_node.to_hashable()), None)?;
       if let Some(id) = not_node.get_attribute_ns("id",XML_NS) {
-        not_node.remove_attribute("xml:id")?;
+        // NS-aware remove (the bare form was a silent no-op — masked only
+        // because the rewrite discards not_node after this closure).
+        not_node.remove_attribute_ns("id", XML_NS)?;
         document.unrecord_id(&id);
         document.set_attribute(&mut strike, "xml:id", &id)?;
       }

--- a/latexml_math_parser/src/parser.rs
+++ b/latexml_math_parser/src/parser.rs
@@ -990,7 +990,10 @@ impl MathParser {
       if !SCRIPT_RE.is_match(&role) {
         continue;
       }
-      let appid = match app.get_attribute("xml:id") {
+      // NS-aware read: xml:id is stored namespaced (local "id" in XML_NS);
+      // the bare get_attribute("xml:id") form always returns None, which
+      // silently disabled this whole pass (every iteration bailed here).
+      let appid = match app.get_attribute_ns("id", XML_NS) {
         Some(id) => id,
         None => continue,
       };
@@ -1005,22 +1008,39 @@ impl MathParser {
         Some(child) => child,
         None => continue,
       };
-      // Ensure the script has an xml:id so we can create XMRef to it
-      if script.get_attribute("xml:id").is_none() {
-        let _ = document.generate_id(&mut script, "");
-      }
-      let script_id = match script.get_attribute("xml:id") {
-        Some(id) => id,
-        None => continue,
+      // Perl builds the replacement ref via `createXMRefs` (Package.pm
+      // L1544-1575), which for an XMRef child clones the ref's target
+      // instead of creating a ref-to-a-ref; mirror that branch. (The
+      // XMHint branch — clone the ephemeral hint without id — is not
+      // mirrored: a hint as the sole script child does not occur in the
+      // XM stream this pass sees.)
+      let script_id = if script.get_name() == "XMRef" {
+        match script.get_attribute("idref") {
+          Some(idref) => idref,
+          None => continue,
+        }
+      } else {
+        // Ensure the script has an xml:id so we can create XMRef to it
+        if script.get_attribute_ns("id", XML_NS).is_none() {
+          let _ = document.generate_id(&mut script, "");
+        }
+        match script.get_attribute_ns("id", XML_NS) {
+          Some(id) => id,
+          None => continue,
+        }
       };
-      // Unregister the app's id and remove the attribute
+      // Unregister the app's id and remove the attribute (NS-aware —
+      // the bare remove_attribute("xml:id") is a silent no-op)
       document.unrecord_id(&appid);
-      let _ = app.remove_attribute("xml:id");
-      // Collect app attributes (except xml:id, which we already removed)
+      let _ = app.remove_attribute_ns("id", XML_NS);
+      // Collect app attributes (except the id, which we already removed).
+      // get_attributes() reports xml:id under its LOCAL name "id", so
+      // filter both spellings — copying the old id onto every replacement
+      // XMApp would mint duplicate ids the moment this pass fires.
       let attrs: Vec<(String, String)> = app
         .get_attributes()
         .into_iter()
-        .filter(|(name, _)| name != "xml:id")
+        .filter(|(name, _)| name != "xml:id" && name != "id")
         .collect();
       let ns = app.get_namespace();
       // Replace each ref with an XMApp containing an XMRef to the script
@@ -1321,9 +1341,9 @@ impl MathParser {
             // //   $attr{font} = $font->specialize($content); } }
             // // } else {
             attr.remove("_font");
-            // TODO: See the namespaced attribute issue for libxml's wrapper:
-            //  https://github.com/KWARC/rust-libxml/issues/104
-            // until then, HACK ids.
+            // get_attributes() reports xml:id under its LOCAL name "id";
+            // re-key it as "xml:id" so document.set_attribute (which
+            // namespaces that spelling) re-installs it correctly below.
             let newid = attr.remove("id");
             if let Some(ref nid) = newid {
               attr.insert(String::from("xml:id"), nid.to_owned());
@@ -1337,9 +1357,11 @@ impl MathParser {
                 continue;
               }
               if key == "xml:id" {
-                // Since we're moving the id...bookkeeping
+                // Since we're moving the id...bookkeeping. NS-aware remove
+                // (the node is replaced and freed just below, so this is
+                // hygiene, not behavior — but the bare form was a no-op).
                 document.unrecord_id(&value);
-                node.remove_attribute("xml:id")?;
+                node.remove_attribute_ns("id", XML_NS)?;
               }
               // TODO: is the array/XM case still relevant?
               // if ($isarr) { $$result[1]{$key} = $value; } else {
@@ -1752,7 +1774,10 @@ impl MathParser {
         let mut pre_replacement_ids: Vec<String> = Vec::new();
         for child_el in element_nodes(mathnode) {
           for descendant in document.findnodes("descendant-or-self::*[@xml:id]", Some(&child_el)) {
-            if let Some(id) = descendant.get_attribute("xml:id") {
+            // NS-aware read — the bare get_attribute("xml:id") form always
+            // returned None here, leaving the snapshot empty and the
+            // orphan-detection loop below permanently disabled.
+            if let Some(id) = descendant.get_attribute_ns("id", XML_NS) {
               pre_replacement_ids.push(id);
             }
           }

--- a/latexml_math_parser/src/util.rs
+++ b/latexml_math_parser/src/util.rs
@@ -514,11 +514,16 @@ pub fn create_xmrefs(args: &mut [&mut XM], ctxt: ActionContext) -> Result<Vec<XM
         // idref so a content branch never points at a presentation-side
         // reference. Without this branch the ref-to-a-ref shape reaches
         // the output (Perl's whole golden corpus has zero of them).
-        if node.get_name() == "XMRef"
-          && let Some(idref) = node.get_attribute("idref")
-        {
+        if node.get_name() == "XMRef" {
+          // Carry BOTH spellings, as Perl does — `_xmkey` is the deferred
+          // form used before ids exist, `idref` the resolved one, and either
+          // may be absent. Taking this branch unconditionally matters: on a
+          // key-only XMRef, falling through would mint an xml:id ON the ref
+          // and reference THAT, which is the ref-to-a-ref this branch exists
+          // to prevent.
           refs.push(XM::Ref(XProps {
-            id: Some(Cow::Owned(idref)),
+            id: node.get_attribute("idref").map(Cow::Owned),
+            xmkey: node.get_attribute("_xmkey").map(Cow::Owned),
             ..XProps::default()
           }));
           continue;

--- a/latexml_math_parser/src/util.rs
+++ b/latexml_math_parser/src/util.rs
@@ -509,7 +509,10 @@ pub fn create_xmrefs(args: &mut [&mut XM], ctxt: ActionContext) -> Result<Vec<XM
           },
         };
 
-        match node.get_attribute("xml:id") {
+        // NS-aware read (xml:id = local "id" in XML_NS; the bare
+        // get_attribute("xml:id") form always returns None, which sent
+        // every node — id or not — through the generate_id branch).
+        match node.get_attribute_ns("id", latexml_core::common::xml::XML_NS) {
           //  already has id, so refer to it.
           Some(id) => refs.push(XM::Ref(XProps {
             id: Some(Cow::Owned(id)),
@@ -518,11 +521,7 @@ pub fn create_xmrefs(args: &mut [&mut XM], ctxt: ActionContext) -> Result<Vec<XM
           None => {
             // Generate xml:id for this node so we can reference it
             document.generate_id(&mut node.clone(), "")?;
-            let generated_id = node
-              .get_attribute("xml:id")
-              .or_else(|| node.get_attribute_ns("id", "http://www.w3.org/XML/1998/namespace"))
-              .or_else(|| node.get_attribute("id"));
-            if let Some(id) = generated_id {
+            if let Some(id) = node.get_attribute_ns("id", latexml_core::common::xml::XML_NS) {
               refs.push(XM::Ref(XProps {
                 id: Some(Cow::Owned(id)),
                 ..XProps::default()

--- a/latexml_math_parser/src/util.rs
+++ b/latexml_math_parser/src/util.rs
@@ -509,6 +509,21 @@ pub fn create_xmrefs(args: &mut [&mut XM], ctxt: ActionContext) -> Result<Vec<XM
           },
         };
 
+        // Perl `createXMRefs` (Package.pm L1557-1561): "clone an XMRef
+        // rather than create an XMRef to an XMRef" — reuse the target's
+        // idref so a content branch never points at a presentation-side
+        // reference. Without this branch the ref-to-a-ref shape reaches
+        // the output (Perl's whole golden corpus has zero of them).
+        if node.get_name() == "XMRef"
+          && let Some(idref) = node.get_attribute("idref")
+        {
+          refs.push(XM::Ref(XProps {
+            id: Some(Cow::Owned(idref)),
+            ..XProps::default()
+          }));
+          continue;
+        }
+
         // NS-aware read (xml:id = local "id" in XML_NS; the bare
         // get_attribute("xml:id") form always returns None, which sent
         // every node — id or not — through the generate_id branch).

--- a/latexml_oxide/src/bib_session.rs
+++ b/latexml_oxide/src/bib_session.rs
@@ -224,11 +224,35 @@ fn convert(request: &BibConversionRequest) -> Option<PostDocument> {
     // thread-local State the outer document uses, so leaving it installed
     // would leak into any later `.bib` in this process.
     latexml_engine::pre_bibtex::set_wanted_keys(request.wanted_keys.clone());
+    // Hide the OUTER document's bibliography count for the duration of the
+    // recursive digestion — the one value reusing the live State would
+    // otherwise leak (see the module docs for why the State is shared).
+    // `{bibtex@bibliography}` runs `begin_bibliography_clean`, which does
+    // `n_bibliographies += 1` and names the session's ids
+    // `<docid>bib<radix_alpha(n-1)>` (latex_constructs.rs:2392-2398). Perl
+    // builds a FRESH State per `.bib` (MakeBibliography.pm:181-215), so its
+    // inner session always sees 0 and mints `bib.bibN`; sharing ours made the
+    // FIRST `.bib` of a one-bibliography document mint `biba.bibN` — the
+    // second slot of the multi-bibliography sequence. Post then strips `^bib`
+    // and re-prepends the OUTER bibid (MakeBibliography.pm:407-415), which is
+    // exactly why the inner ids must be `bib`-rooted regardless of which
+    // bibliography they end up in.
+    let outer_n_bibliographies = latexml_core::state::lookup_int("n_bibliographies");
+    latexml_core::state::assign_value(
+      "n_bibliographies",
+      0,
+      Some(latexml_core::state::Scope::Global),
+    );
     let digested = core.digest_file(source.clone(), DigestionOptions {
       mode: Some(DigestionMode::BibTeX),
       noinitialize: Some(true),
       ..DigestionOptions::default()
     });
+    latexml_core::state::assign_value(
+      "n_bibliographies",
+      outer_n_bibliographies,
+      Some(latexml_core::state::Scope::Global),
+    );
     latexml_engine::pre_bibtex::clear_wanted_keys();
     let digested = digested?;
     let document = core.convert_document(digested)?;

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -1945,4 +1945,18 @@ fn bib_entry_ids_are_bib_rooted_like_perl() {
       "missing bibitem anchor {id}"
     );
   }
+
+  // The enclosing biblist needs a `fragid` as well as an `xml:id`: the HTML5
+  // XSLT's `add_id` emits the HTML `id` from `@fragid` ALONE, and `fragid` is
+  // stamped by `CrossRef::fill_in_frags` only for nodes carrying an ObjectDB
+  // `ID:` entry. Without MakeBibliography registering the list, Perl's
+  // `<ul id="bib.L1" class="ltx_biblist">` came out here as a bare `<ul>`.
+  assert!(
+    x.contains(r#"xml:id="bib.L1""#),
+    "biblist must keep its xml:id"
+  );
+  assert!(
+    x.contains(r#"fragid="bib.L1""#),
+    "biblist must receive a fragid, or the HTML <ul> loses its id entirely"
+  );
 }

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -1902,3 +1902,47 @@ fn bib_biblatex_autoloads_under_an_unbound_class() {
     "the autoloaded entries did not render their titles:\n{x}"
   );
 }
+
+/// The recursive `.bib` session must mint `bib`-rooted entry ids, so a
+/// single-bibliography document's anchors come out `bib.bibN` — byte-identical
+/// to same-host Perl (`<li id="bib.bib1">`).
+///
+/// Perl builds a FRESH State per `.bib` (`MakeBibliography.pm` L181-215), so
+/// its inner session always sees `n_bibliographies == 0` and names ids
+/// `bib<radix_alpha(0)>` = `bib`. We deliberately SHARE the live State
+/// (`bib_session.rs` module docs — the enhancement Perl's own comment asks
+/// for), which leaked the outer document's count into
+/// `begin_bibliography_clean` (`latex_constructs.rs:2392-2398`): the inner
+/// session saw 1, minted `biba`, and every anchor came out `biba.bibN` — the
+/// SECOND slot of the multi-bibliography sequence, on a document with one
+/// bibliography. `bib_session::convert` now hides that count for the duration
+/// of the recursive digestion.
+///
+/// Post then strips `^bib` and re-prepends the OUTER bibliography's id
+/// (`MakeBibliography.pm` L407-415), which is why the inner ids must be
+/// `bib`-rooted whichever bibliography they land in — `structure/crazybib`
+/// covers the multi-bibliography sequence (`bib` / `biba` / `bibb`).
+#[test]
+fn bib_entry_ids_are_bib_rooted_like_perl() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_abstract_percent.tex");
+  assert!(
+    x.contains(r#"xml:id="bib.bib1""#),
+    "first bibitem must be bib.bib1 (Perl parity), got ids: {:?}",
+    x.match_indices("xml:id=\"bib")
+      .map(|(i, _)| x[i..(i + 24).min(x.len())].to_string())
+      .take(6)
+      .collect::<Vec<_>>()
+  );
+  assert!(
+    !x.contains(r#"xml:id="biba."#),
+    "no entry may use the SECOND bibliography's prefix in a one-bibliography document"
+  );
+  // The citation links must agree with the anchors they point at.
+  for n in 1..=4 {
+    let id = format!("bib.bib{n}");
+    assert!(
+      x.contains(&format!(r#"xml:id="{id}""#)),
+      "missing bibitem anchor {id}"
+    );
+  }
+}

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -1960,3 +1960,46 @@ fn bib_entry_ids_are_bib_rooted_like_perl() {
     "biblist must receive a fragid, or the HTML <ul> loses its id entirely"
   );
 }
+
+/// Id-bearing markup CLONED INTO a bibliography entry (here `$E=mc^2$` in a
+/// title) must keep an id all the way to HTML.
+///
+/// Perl's `Collector::rescan` (Collector.pm L97, called from
+/// MakeBibliography.pm L71/L78) re-runs the whole Scan over the generated
+/// bibliography, so such nodes get an ObjectDB entry — which is the
+/// precondition `CrossRef::fill_in_frags` needs before it stamps `fragid`,
+/// and the HTML5 XSLT emits the HTML `id` from `@fragid` alone. This port has
+/// no rescan, so the cloned `ltx:Math` reached HTML with no id at all
+/// (measured against same-host Perl 0.8.8, which emits `bib.bib1.m1a`).
+/// MakeBibliography now registers every id-bearing node of the generated
+/// subtree.
+///
+/// The id NAME is allowed to differ from Perl's: Perl's trailing `a` is a
+/// `uniquifyID` artifact of cloning while the source bibentry still carried
+/// the same id, which it then deletes. What must hold is that the node keeps
+/// an id and that nothing dangles.
+#[test]
+fn bib_entry_cloned_markup_keeps_its_id() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_title_math.tex");
+  let math_ids: Vec<&str> = x
+    .match_indices("<Math")
+    .filter_map(|(i, _)| {
+      let tail = &x[i..(i + 200).min(x.len())];
+      tail
+        .find("xml:id=\"")
+        .map(|j| &tail[j + 8..])
+        .and_then(|s| s.find('"').map(|e| &s[..e]))
+    })
+    .collect();
+  assert!(
+    math_ids.iter().any(|id| id.starts_with("bib.")),
+    "the math cloned into the bib title must keep a bib-rooted xml:id, got {math_ids:?}"
+  );
+  // …and the fragid that turns it into an HTML id.
+  for id in math_ids.iter().filter(|i| i.starts_with("bib.")) {
+    assert!(
+      x.contains(&format!(r#"fragid="{id}""#)),
+      "cloned bib markup {id} must receive a fragid"
+    );
+  }
+}

--- a/latexml_oxide/tests/107_cleanup_scripts_xmlid.rs
+++ b/latexml_oxide/tests/107_cleanup_scripts_xmlid.rs
@@ -1,0 +1,156 @@
+//! Guard for the re-enabled `cleanup_scripts` pass — the port of Perl
+//! `MathParser.pm:cleanupScripts` (L106-126).
+//!
+//! The pass was silently dead: its bare `get_attribute("xml:id")` reads always
+//! returned `None` (xml:id is stored namespaced — local `id` in the XML
+//! namespace), so every iteration bailed at the `appid` read and no XMRef was
+//! ever redirected. This test drives it against a crafted XMath fragment in a
+//! fully-initialized session (the schema model gates both `generate_id` and
+//! the attribute copy of the replacement build, so a bare `Document` is not a
+//! faithful environment — role= would be dropped and namespaces misresolved).
+//!
+//! Covers the `createXMRefs` branches the pass exercises (Perl `Package.pm`
+//! L1544-1575): a script child that already has an id ("refer to it"), a
+//! script child with NO id (gets one via `generate_id`), and an XMRef child
+//! (its idref is cloned — never a ref-to-a-ref).
+
+mod cluster;
+
+use latexml_core::{common::xml::XML_NS, document::Document};
+use latexml_math_parser::MathParser;
+
+#[test]
+fn cleanup_scripts_redirects_script_xmapp_refs() {
+  // A tiny conversion first: initializes the session singletons, the schema
+  // model, and namespace registration that the pass's replacement build
+  // depends on. The output itself is irrelevant here. (The cluster helpers
+  // take a file path, so stage the doc in a tempdir.)
+  let boot = tempfile::tempdir().expect("tempdir");
+  let boot_tex = boot.path().join("boot.tex");
+  std::fs::write(
+    &boot_tex,
+    "\\documentclass{article}\n\\begin{document}\n$x$\n\\end{document}\n",
+  )
+  .expect("write boot.tex");
+  cluster::convert_clean(boot_tex.to_str().expect("utf8 path"));
+
+  // NOTE: no whitespace inside the XMApps — the pass takes `firstChild`
+  // verbatim (as Perl does; XMath trees carry no indentation text nodes),
+  // so a pretty-printed fixture would hand it a text node.
+  let xml_doc = libxml::parser::Parser::default()
+    .parse_string(
+      r#"<?xml version="1.0"?>
+<XMath xmlns="http://dlmf.nist.gov/LaTeXML" xml:id="m1"><XMDual><XMRef idref="m1.app1"/><XMApp xml:id="m1.app1" role="POSTSUBSCRIPT"><XMTok xml:id="m1.x1">b</XMTok></XMApp></XMDual><XMDual><XMRef idref="m1.app2"/><XMApp xml:id="m1.app2" role="POSTSUPERSCRIPT"><XMRef idref="m1.tok9"/></XMApp></XMDual><XMDual><XMRef idref="m1.app3"/><XMApp xml:id="m1.app3" role="FLOATSUPERSCRIPT"><XMTok>c</XMTok></XMApp></XMDual><XMTok xml:id="m1.tok9">d</XMTok></XMath>"#,
+    )
+    .expect("parse fixture");
+  let mut document = Document::from_xml_document(xml_doc, Default::default()).expect("wrap");
+  let mut parser = MathParser::default();
+  parser.cleanup_scripts(&mut document).expect("cleanup");
+
+  // Every script XMApp lost its id (NS-aware remove + unrecord)…
+  for app_id in ["m1.app1", "m1.app2", "m1.app3"] {
+    assert!(
+      document
+        .findnodes(&format!("//*[@xml:id='{app_id}']"), None)
+        .is_empty(),
+      "{app_id} must lose its xml:id"
+    );
+    assert!(document.lookup_id(app_id).is_none());
+    // …so nothing may still reference it.
+    assert!(
+      document
+        .findnodes(&format!("//*[@idref='{app_id}']"), None)
+        .is_empty(),
+      "no ref to the stripped {app_id} may survive"
+    );
+  }
+
+  // Branch 1 (script child already carrying an id — Perl createXMRefs
+  // L1563-1565 "already has id, so refer to it"): the dual's ref slot became
+  // an XMApp (attrs copied from app1) wrapping an XMRef to the XMTok itself.
+  assert_eq!(
+    document
+      .findnodes(
+        "//*[local-name()='XMApp' and @role='POSTSUBSCRIPT']/*[local-name()='XMRef' and @idref='m1.x1']",
+        None
+      )
+      .len(),
+    1,
+    "exactly one replacement XMApp[XMRef -> already-id'd script tok] expected"
+  );
+
+  // Branch 2 (XMRef script child): the replacement clones the idref —
+  // original + replacement both point at m1.tok9 directly, and no XMRef
+  // acquired an xml:id of its own (no ref-to-a-ref).
+  assert_eq!(
+    document
+      .findnodes(
+        "//*[local-name()='XMApp' and @role='POSTSUPERSCRIPT']/*[local-name()='XMRef' and @idref='m1.tok9']",
+        None
+      )
+      .len(),
+    2,
+    "original app2 and its replacement must both ref m1.tok9 directly"
+  );
+  assert!(
+    document
+      .findnodes("//*[local-name()='XMRef' and @xml:id]", None)
+      .is_empty(),
+    "no XMRef may be given an xml:id (ref-to-a-ref)"
+  );
+
+  // Branch 3 (id-less script child): generate_id gave the XMTok an id, the
+  // replacement refs it, and the id is recorded in the idstore.
+  let tok3 = document
+    .findnodes(
+      "//*[local-name()='XMApp' and @role='FLOATSUPERSCRIPT']/*[local-name()='XMTok']",
+      None,
+    )
+    .into_iter()
+    .next()
+    .expect("original app3 still holds its XMTok");
+  let tok3_id = tok3
+    .get_attribute_ns("id", XML_NS)
+    .expect("id-less script content must receive a generated xml:id");
+  assert!(
+    document.lookup_id(&tok3_id).is_some(),
+    "generated script id must be recorded in the idstore"
+  );
+  assert_eq!(
+    document
+      .findnodes(
+        &format!(
+          "//*[local-name()='XMApp' and @role='FLOATSUPERSCRIPT']/*[local-name()='XMRef' and @idref='{tok3_id}']"
+        ),
+        None
+      )
+      .len(),
+    1,
+    "replacement must ref the generated script id"
+  );
+
+  // The replacement XMApps live in the LaTeXML namespace (the build sets the
+  // namespace from the original app; a bare environment misresolved this).
+  for repl in document.findnodes("//*[local-name()='XMApp' and @role]", None) {
+    assert_eq!(
+      repl.get_namespace().map(|ns| ns.get_href()).as_deref(),
+      Some("http://dlmf.nist.gov/LaTeXML"),
+      "replacement XMApp must stay in the ltx namespace"
+    );
+  }
+
+  // Duplicate-id guard: the attrs copy must not mint a second xml:id
+  // (get_attributes() reports xml:id under its LOCAL name "id" — copying it
+  // onto every replacement would duplicate ids the moment the pass fires).
+  let all_ids: Vec<String> = document
+    .findnodes("//*[@xml:id]", None)
+    .into_iter()
+    .filter_map(|n| n.get_attribute_ns("id", XML_NS))
+    .collect();
+  let unique: std::collections::HashSet<&String> = all_ids.iter().collect();
+  assert_eq!(
+    all_ids.len(),
+    unique.len(),
+    "duplicate xml:id minted: {all_ids:?}"
+  );
+}

--- a/latexml_oxide/tests/ams/mathtools.xml
+++ b/latexml_oxide/tests/ams/mathtools.xml
@@ -4487,113 +4487,106 @@ Then a switch of tag forms.</p>
     <title><tag close=" ">9</tag>Multlines</title>
     <para xml:id="S9.p1">
       <equation>
-        <Math mode="display" tex="p(x)=3x^{6}+14x^{5}y+590x^{4}y^{2}+19x^{3}y^{3}\\&#10;-12x^{2}y^{4}-12xy^{5}+2y^{6}-a^{3}b^{3}" text="p@(delimited-@([])) = (((3 * x ^ 6 + 14 * x ^ 5 * y + 590 * x ^ 4 * y ^ 2 + 19 * x ^ 3 * y ^ 3) - 12 * x ^ 2 * y ^ 4 - 12 * x * y ^ 5) + 2 * y ^ 6) - a ^ 3 * b ^ 3" xml:id="S9.p1.m1">
+        <Math mode="display" tex="p(x)=3x^{6}+14x^{5}y+590x^{4}y^{2}+19x^{3}y^{3}\\&#10;-12x^{2}y^{4}-12xy^{5}+2y^{6}-a^{3}b^{3}" text="p@(delimited-@(x)) = (((3 * x ^ 6 + 14 * x ^ 5 * y + 590 * x ^ 4 * y ^ 2 + 19 * x ^ 3 * y ^ 3) - 12 * x ^ 2 * y ^ 4 - 12 * x * y ^ 5) + 2 * y ^ 6) - a ^ 3 * b ^ 3" xml:id="S9.p1.m1">
           <XMath>
             <XMDual>
               <XMApp>
-                <XMRef idref="S9.p1.m1.2"/>
+                <XMRef idref="S9.p1.m1.1"/>
                 <XMApp>
-                  <XMRef idref="S9.p1.m1.3"/>
-                  <XMDual>
-                    <XMApp>
-                      <XMTok meaning="delimited-"/>
-                      <XMRef idref="S9.p1.m1.1"/>
-                    </XMApp>
-                    <XMWrap>
-                      <XMRef idref="S9.p1.m1.4"/>
-                      <XMRef idref="S9.p1.m1.5" xml:id="S9.p1.m1.1"/>
-                      <XMRef idref="S9.p1.m1.6"/>
-                    </XMWrap>
-                  </XMDual>
+                  <XMRef idref="S9.p1.m1.2"/>
+                  <XMApp>
+                    <XMTok meaning="delimited-"/>
+                    <XMRef idref="S9.p1.m1.4"/>
+                  </XMApp>
                 </XMApp>
                 <XMApp>
-                  <XMRef idref="S9.p1.m1.25"/>
+                  <XMRef idref="S9.p1.m1.24"/>
                   <XMApp>
-                    <XMRef idref="S9.p1.m1.26"/>
+                    <XMRef idref="S9.p1.m1.25"/>
                     <XMApp>
-                      <XMRef idref="S9.p1.m1.27"/>
+                      <XMRef idref="S9.p1.m1.26"/>
                       <XMApp>
-                        <XMRef idref="S9.p1.m1.7"/>
+                        <XMRef idref="S9.p1.m1.6"/>
                         <XMApp>
                           <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                          <XMRef idref="S9.p1.m1.8"/>
+                          <XMRef idref="S9.p1.m1.7"/>
                           <XMApp>
                             <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                            <XMRef idref="S9.p1.m1.8"/>
                             <XMRef idref="S9.p1.m1.9"/>
-                            <XMRef idref="S9.p1.m1.10"/>
                           </XMApp>
                         </XMApp>
                         <XMApp>
                           <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                          <XMRef idref="S9.p1.m1.11"/>
+                          <XMRef idref="S9.p1.m1.10"/>
                           <XMApp>
                             <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                            <XMRef idref="S9.p1.m1.11"/>
                             <XMRef idref="S9.p1.m1.12"/>
-                            <XMRef idref="S9.p1.m1.13"/>
                           </XMApp>
+                          <XMRef idref="S9.p1.m1.13"/>
+                        </XMApp>
+                        <XMApp>
+                          <XMTok meaning="times" role="MULOP">⁢</XMTok>
                           <XMRef idref="S9.p1.m1.14"/>
-                        </XMApp>
-                        <XMApp>
-                          <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                          <XMRef idref="S9.p1.m1.15"/>
                           <XMApp>
                             <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                            <XMRef idref="S9.p1.m1.15"/>
                             <XMRef idref="S9.p1.m1.16"/>
-                            <XMRef idref="S9.p1.m1.17"/>
                           </XMApp>
                           <XMApp>
                             <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                            <XMRef idref="S9.p1.m1.17"/>
                             <XMRef idref="S9.p1.m1.18"/>
-                            <XMRef idref="S9.p1.m1.19"/>
                           </XMApp>
                         </XMApp>
                         <XMApp>
                           <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                          <XMRef idref="S9.p1.m1.20"/>
+                          <XMRef idref="S9.p1.m1.19"/>
                           <XMApp>
                             <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                            <XMRef idref="S9.p1.m1.20"/>
                             <XMRef idref="S9.p1.m1.21"/>
-                            <XMRef idref="S9.p1.m1.22"/>
                           </XMApp>
                           <XMApp>
                             <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                            <XMRef idref="S9.p1.m1.22"/>
                             <XMRef idref="S9.p1.m1.23"/>
-                            <XMRef idref="S9.p1.m1.24"/>
                           </XMApp>
                         </XMApp>
                       </XMApp>
                       <XMApp>
                         <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                        <XMRef idref="S9.p1.m1.28"/>
+                        <XMRef idref="S9.p1.m1.27"/>
                         <XMApp>
                           <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                          <XMRef idref="S9.p1.m1.28"/>
                           <XMRef idref="S9.p1.m1.29"/>
-                          <XMRef idref="S9.p1.m1.30"/>
                         </XMApp>
                         <XMApp>
                           <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                          <XMRef idref="S9.p1.m1.30"/>
                           <XMRef idref="S9.p1.m1.31"/>
-                          <XMRef idref="S9.p1.m1.32"/>
                         </XMApp>
                       </XMApp>
                       <XMApp>
                         <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                        <XMRef idref="S9.p1.m1.32"/>
                         <XMRef idref="S9.p1.m1.33"/>
-                        <XMRef idref="S9.p1.m1.34"/>
                         <XMApp>
                           <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                          <XMRef idref="S9.p1.m1.34"/>
                           <XMRef idref="S9.p1.m1.35"/>
-                          <XMRef idref="S9.p1.m1.36"/>
                         </XMApp>
                       </XMApp>
                     </XMApp>
                     <XMApp>
                       <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                      <XMRef idref="S9.p1.m1.37"/>
+                      <XMRef idref="S9.p1.m1.36"/>
                       <XMApp>
                         <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                        <XMRef idref="S9.p1.m1.37"/>
                         <XMRef idref="S9.p1.m1.38"/>
-                        <XMRef idref="S9.p1.m1.39"/>
                       </XMApp>
                     </XMApp>
                   </XMApp>
@@ -4601,13 +4594,13 @@ Then a switch of tag forms.</p>
                     <XMTok meaning="times" role="MULOP">⁢</XMTok>
                     <XMApp>
                       <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                      <XMRef idref="S9.p1.m1.39"/>
                       <XMRef idref="S9.p1.m1.40"/>
-                      <XMRef idref="S9.p1.m1.41"/>
                     </XMApp>
                     <XMApp>
                       <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                      <XMRef idref="S9.p1.m1.41"/>
                       <XMRef idref="S9.p1.m1.42"/>
-                      <XMRef idref="S9.p1.m1.43"/>
                     </XMApp>
                   </XMApp>
                 </XMApp>
@@ -4616,62 +4609,62 @@ Then a switch of tag forms.</p>
                 <XMRow>
                   <XMCell align="left">
                     <XMApp>
-                      <XMTok meaning="equals" role="RELOP" xml:id="S9.p1.m1.2">=</XMTok>
+                      <XMTok meaning="equals" role="RELOP" xml:id="S9.p1.m1.1">=</XMTok>
                       <XMApp>
-                        <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.3">p</XMTok>
+                        <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.2">p</XMTok>
                         <XMWrap>
-                          <XMTok role="OPEN" stretchy="false" xml:id="S9.p1.m1.4">(</XMTok>
-                          <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.5">x</XMTok>
-                          <XMTok role="CLOSE" stretchy="false" xml:id="S9.p1.m1.6">)</XMTok>
+                          <XMTok role="OPEN" stretchy="false">(</XMTok>
+                          <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.4">x</XMTok>
+                          <XMTok role="CLOSE" stretchy="false">)</XMTok>
                         </XMWrap>
                       </XMApp>
                       <XMApp>
-                        <XMTok meaning="plus" role="ADDOP" xml:id="S9.p1.m1.7">+</XMTok>
+                        <XMTok meaning="plus" role="ADDOP" xml:id="S9.p1.m1.6">+</XMTok>
                         <XMApp>
                           <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                          <XMTok meaning="3" role="NUMBER" xml:id="S9.p1.m1.8">3</XMTok>
+                          <XMTok meaning="3" role="NUMBER" xml:id="S9.p1.m1.7">3</XMTok>
                           <XMApp>
                             <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.9">x</XMTok>
-                            <XMTok fontsize="70%" meaning="6" role="NUMBER" xml:id="S9.p1.m1.10">6</XMTok>
+                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.8">x</XMTok>
+                            <XMTok fontsize="70%" meaning="6" role="NUMBER" xml:id="S9.p1.m1.9">6</XMTok>
                           </XMApp>
                         </XMApp>
                         <XMApp>
                           <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                          <XMTok meaning="14" role="NUMBER" xml:id="S9.p1.m1.11">14</XMTok>
+                          <XMTok meaning="14" role="NUMBER" xml:id="S9.p1.m1.10">14</XMTok>
                           <XMApp>
                             <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.12">x</XMTok>
-                            <XMTok fontsize="70%" meaning="5" role="NUMBER" xml:id="S9.p1.m1.13">5</XMTok>
+                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.11">x</XMTok>
+                            <XMTok fontsize="70%" meaning="5" role="NUMBER" xml:id="S9.p1.m1.12">5</XMTok>
                           </XMApp>
-                          <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.14">y</XMTok>
+                          <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.13">y</XMTok>
                         </XMApp>
                         <XMApp>
                           <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                          <XMTok meaning="590" role="NUMBER" xml:id="S9.p1.m1.15">590</XMTok>
+                          <XMTok meaning="590" role="NUMBER" xml:id="S9.p1.m1.14">590</XMTok>
                           <XMApp>
                             <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.16">x</XMTok>
-                            <XMTok fontsize="70%" meaning="4" role="NUMBER" xml:id="S9.p1.m1.17">4</XMTok>
+                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.15">x</XMTok>
+                            <XMTok fontsize="70%" meaning="4" role="NUMBER" xml:id="S9.p1.m1.16">4</XMTok>
                           </XMApp>
                           <XMApp>
                             <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.18">y</XMTok>
-                            <XMTok fontsize="70%" meaning="2" role="NUMBER" xml:id="S9.p1.m1.19">2</XMTok>
+                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.17">y</XMTok>
+                            <XMTok fontsize="70%" meaning="2" role="NUMBER" xml:id="S9.p1.m1.18">2</XMTok>
                           </XMApp>
                         </XMApp>
                         <XMApp>
                           <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                          <XMTok meaning="19" role="NUMBER" xml:id="S9.p1.m1.20">19</XMTok>
+                          <XMTok meaning="19" role="NUMBER" xml:id="S9.p1.m1.19">19</XMTok>
                           <XMApp>
                             <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.21">x</XMTok>
-                            <XMTok fontsize="70%" meaning="3" role="NUMBER" xml:id="S9.p1.m1.22">3</XMTok>
+                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.20">x</XMTok>
+                            <XMTok fontsize="70%" meaning="3" role="NUMBER" xml:id="S9.p1.m1.21">3</XMTok>
                           </XMApp>
                           <XMApp>
                             <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.23">y</XMTok>
-                            <XMTok fontsize="70%" meaning="3" role="NUMBER" xml:id="S9.p1.m1.24">3</XMTok>
+                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.22">y</XMTok>
+                            <XMTok fontsize="70%" meaning="3" role="NUMBER" xml:id="S9.p1.m1.23">3</XMTok>
                           </XMApp>
                         </XMApp>
                       </XMApp>
@@ -4681,46 +4674,46 @@ Then a switch of tag forms.</p>
                 <XMRow>
                   <XMCell align="right">
                     <XMApp>
-                      <XMTok meaning="minus" role="ADDOP" xml:id="S9.p1.m1.25">-</XMTok>
+                      <XMTok meaning="minus" role="ADDOP" xml:id="S9.p1.m1.24">-</XMTok>
                       <XMApp>
-                        <XMTok meaning="plus" role="ADDOP" xml:id="S9.p1.m1.26">+</XMTok>
+                        <XMTok meaning="plus" role="ADDOP" xml:id="S9.p1.m1.25">+</XMTok>
                         <XMApp>
                           <XMTok meaning="minus" role="ADDOP">-</XMTok>
                           <XMApp>
-                            <XMTok meaning="minus" role="ADDOP" xml:id="S9.p1.m1.27">-</XMTok>
+                            <XMTok meaning="minus" role="ADDOP" xml:id="S9.p1.m1.26">-</XMTok>
                             <XMApp>
                               <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                              <XMTok meaning="12" role="NUMBER" xml:id="S9.p1.m1.28">12</XMTok>
+                              <XMTok meaning="12" role="NUMBER" xml:id="S9.p1.m1.27">12</XMTok>
                               <XMApp>
                                 <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                                <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.29">x</XMTok>
-                                <XMTok fontsize="70%" meaning="2" role="NUMBER" xml:id="S9.p1.m1.30">2</XMTok>
+                                <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.28">x</XMTok>
+                                <XMTok fontsize="70%" meaning="2" role="NUMBER" xml:id="S9.p1.m1.29">2</XMTok>
                               </XMApp>
                               <XMApp>
                                 <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                                <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.31">y</XMTok>
-                                <XMTok fontsize="70%" meaning="4" role="NUMBER" xml:id="S9.p1.m1.32">4</XMTok>
+                                <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.30">y</XMTok>
+                                <XMTok fontsize="70%" meaning="4" role="NUMBER" xml:id="S9.p1.m1.31">4</XMTok>
                               </XMApp>
                             </XMApp>
                           </XMApp>
                           <XMApp>
                             <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                            <XMTok meaning="12" role="NUMBER" xml:id="S9.p1.m1.33">12</XMTok>
-                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.34">x</XMTok>
+                            <XMTok meaning="12" role="NUMBER" xml:id="S9.p1.m1.32">12</XMTok>
+                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.33">x</XMTok>
                             <XMApp>
                               <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                              <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.35">y</XMTok>
-                              <XMTok fontsize="70%" meaning="5" role="NUMBER" xml:id="S9.p1.m1.36">5</XMTok>
+                              <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.34">y</XMTok>
+                              <XMTok fontsize="70%" meaning="5" role="NUMBER" xml:id="S9.p1.m1.35">5</XMTok>
                             </XMApp>
                           </XMApp>
                         </XMApp>
                         <XMApp>
                           <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                          <XMTok meaning="2" role="NUMBER" xml:id="S9.p1.m1.37">2</XMTok>
+                          <XMTok meaning="2" role="NUMBER" xml:id="S9.p1.m1.36">2</XMTok>
                           <XMApp>
                             <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.38">y</XMTok>
-                            <XMTok fontsize="70%" meaning="6" role="NUMBER" xml:id="S9.p1.m1.39">6</XMTok>
+                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.37">y</XMTok>
+                            <XMTok fontsize="70%" meaning="6" role="NUMBER" xml:id="S9.p1.m1.38">6</XMTok>
                           </XMApp>
                         </XMApp>
                       </XMApp>
@@ -4728,13 +4721,13 @@ Then a switch of tag forms.</p>
                         <XMTok meaning="times" role="MULOP">⁢</XMTok>
                         <XMApp>
                           <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                          <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.40">a</XMTok>
-                          <XMTok fontsize="70%" meaning="3" role="NUMBER" xml:id="S9.p1.m1.41">3</XMTok>
+                          <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.39">a</XMTok>
+                          <XMTok fontsize="70%" meaning="3" role="NUMBER" xml:id="S9.p1.m1.40">3</XMTok>
                         </XMApp>
                         <XMApp>
                           <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                          <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.42">b</XMTok>
-                          <XMTok fontsize="70%" meaning="3" role="NUMBER" xml:id="S9.p1.m1.43">3</XMTok>
+                          <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.41">b</XMTok>
+                          <XMTok fontsize="70%" meaning="3" role="NUMBER" xml:id="S9.p1.m1.42">3</XMTok>
                         </XMApp>
                       </XMApp>
                     </XMApp>

--- a/latexml_oxide/tests/ams/mathtools.xml
+++ b/latexml_oxide/tests/ams/mathtools.xml
@@ -4487,112 +4487,191 @@ Then a switch of tag forms.</p>
     <title><tag close=" ">9</tag>Multlines</title>
     <para xml:id="S9.p1">
       <equation>
-        <Math mode="display" tex="p(x)=3x^{6}+14x^{5}y+590x^{4}y^{2}+19x^{3}y^{3}\\&#10;-12x^{2}y^{4}-12xy^{5}+2y^{6}-a^{3}b^{3}" text="p@(@x@)@=@3@x@[]@+@14@x@[]@y@[]@590@x@[]@y@[]@[]@19@x@[]@y@[]@-@12@x@[]@y@[]@-@12@x@y@[]@+@2@y@[]@-@a@[]@b@[]" xml:id="S9.p1.m1">
+        <Math mode="display" tex="p(x)=3x^{6}+14x^{5}y+590x^{4}y^{2}+19x^{3}y^{3}\\&#10;-12x^{2}y^{4}-12xy^{5}+2y^{6}-a^{3}b^{3}" text="p@(delimited-@([])) = (((3 * x ^ 6 + 14 * x ^ 5 * y + 590 * x ^ 4 * y ^ 2 + 19 * x ^ 3 * y ^ 3) - 12 * x ^ 2 * y ^ 4 - 12 * x * y ^ 5) + 2 * y ^ 6) - a ^ 3 * b ^ 3" xml:id="S9.p1.m1">
           <XMath>
             <XMDual>
-              <XMWrap rule="Anything,">
+              <XMApp>
                 <XMRef idref="S9.p1.m1.2"/>
-                <XMRef idref="S9.p1.m1.3"/>
-                <XMRef idref="S9.p1.m1.4"/>
-                <XMRef idref="S9.p1.m1.5"/>
-                <XMRef idref="S9.p1.m1.1"/>
-                <XMRef idref="S9.p1.m1.7"/>
-                <XMRef idref="S9.p1.m1.8"/>
-                <XMRef idref="S9.p1.m1.8"/>
-                <XMRef idref="S9.p1.m1.6"/>
-                <XMRef idref="S9.p1.m1.9"/>
-                <XMRef idref="S9.p1.m1.10"/>
-                <XMRef idref="S9.p1.m1.12"/>
-                <XMRef idref="S9.p1.m1.11"/>
-                <XMRef idref="S9.p1.m1.14"/>
-                <XMRef idref="S9.p1.m1.12"/>
-                <XMRef idref="S9.p1.m1.13"/>
-                <XMRef idref="S9.p1.m1.17"/>
-                <XMRef idref="S9.p1.m1.14"/>
-                <XMRef idref="S9.p1.m1.19"/>
-                <XMRef idref="S9.p1.m1.20"/>
-                <XMRef idref="S9.p1.m1.15"/>
-                <XMRef idref="S9.p1.m1.16"/>
-                <XMRef idref="S9.p1.m1.23"/>
-                <XMRef idref="S9.p1.m1.17"/>
-                <XMRef idref="S9.p1.m1.25"/>
-                <XMRef idref="S9.p1.m1.21"/>
-                <XMRef idref="S9.p1.m1.22"/>
-                <XMRef idref="S9.p1.m1.23"/>
-                <XMRef idref="S9.p1.m1.29"/>
-                <XMRef idref="S9.p1.m1.24"/>
-                <XMRef idref="S9.p1.m1.31"/>
-                <XMRef idref="S9.p1.m1.20"/>
-                <XMRef idref="S9.p1.m1.25"/>
-                <XMRef idref="S9.p1.m1.26"/>
-                <XMRef idref="S9.p1.m1.27"/>
-                <XMRef idref="S9.p1.m1.19"/>
-                <XMRef idref="S9.p1.m1.28"/>
-                <XMRef idref="S9.p1.m1.29"/>
-                <XMRef idref="S9.p1.m1.18"/>
-                <XMRef idref="S9.p1.m1.30"/>
-                <XMRef idref="S9.p1.m1.31"/>
-              </XMWrap>
+                <XMApp>
+                  <XMRef idref="S9.p1.m1.3"/>
+                  <XMDual>
+                    <XMApp>
+                      <XMTok meaning="delimited-"/>
+                      <XMRef idref="S9.p1.m1.1"/>
+                    </XMApp>
+                    <XMWrap>
+                      <XMRef idref="S9.p1.m1.4"/>
+                      <XMRef idref="S9.p1.m1.5" xml:id="S9.p1.m1.1"/>
+                      <XMRef idref="S9.p1.m1.6"/>
+                    </XMWrap>
+                  </XMDual>
+                </XMApp>
+                <XMApp>
+                  <XMRef idref="S9.p1.m1.25"/>
+                  <XMApp>
+                    <XMRef idref="S9.p1.m1.26"/>
+                    <XMApp>
+                      <XMRef idref="S9.p1.m1.27"/>
+                      <XMApp>
+                        <XMRef idref="S9.p1.m1.7"/>
+                        <XMApp>
+                          <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                          <XMRef idref="S9.p1.m1.8"/>
+                          <XMApp>
+                            <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                            <XMRef idref="S9.p1.m1.9"/>
+                            <XMRef idref="S9.p1.m1.10"/>
+                          </XMApp>
+                        </XMApp>
+                        <XMApp>
+                          <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                          <XMRef idref="S9.p1.m1.11"/>
+                          <XMApp>
+                            <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                            <XMRef idref="S9.p1.m1.12"/>
+                            <XMRef idref="S9.p1.m1.13"/>
+                          </XMApp>
+                          <XMRef idref="S9.p1.m1.14"/>
+                        </XMApp>
+                        <XMApp>
+                          <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                          <XMRef idref="S9.p1.m1.15"/>
+                          <XMApp>
+                            <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                            <XMRef idref="S9.p1.m1.16"/>
+                            <XMRef idref="S9.p1.m1.17"/>
+                          </XMApp>
+                          <XMApp>
+                            <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                            <XMRef idref="S9.p1.m1.18"/>
+                            <XMRef idref="S9.p1.m1.19"/>
+                          </XMApp>
+                        </XMApp>
+                        <XMApp>
+                          <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                          <XMRef idref="S9.p1.m1.20"/>
+                          <XMApp>
+                            <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                            <XMRef idref="S9.p1.m1.21"/>
+                            <XMRef idref="S9.p1.m1.22"/>
+                          </XMApp>
+                          <XMApp>
+                            <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                            <XMRef idref="S9.p1.m1.23"/>
+                            <XMRef idref="S9.p1.m1.24"/>
+                          </XMApp>
+                        </XMApp>
+                      </XMApp>
+                      <XMApp>
+                        <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                        <XMRef idref="S9.p1.m1.28"/>
+                        <XMApp>
+                          <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                          <XMRef idref="S9.p1.m1.29"/>
+                          <XMRef idref="S9.p1.m1.30"/>
+                        </XMApp>
+                        <XMApp>
+                          <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                          <XMRef idref="S9.p1.m1.31"/>
+                          <XMRef idref="S9.p1.m1.32"/>
+                        </XMApp>
+                      </XMApp>
+                      <XMApp>
+                        <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                        <XMRef idref="S9.p1.m1.33"/>
+                        <XMRef idref="S9.p1.m1.34"/>
+                        <XMApp>
+                          <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                          <XMRef idref="S9.p1.m1.35"/>
+                          <XMRef idref="S9.p1.m1.36"/>
+                        </XMApp>
+                      </XMApp>
+                    </XMApp>
+                    <XMApp>
+                      <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                      <XMRef idref="S9.p1.m1.37"/>
+                      <XMApp>
+                        <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                        <XMRef idref="S9.p1.m1.38"/>
+                        <XMRef idref="S9.p1.m1.39"/>
+                      </XMApp>
+                    </XMApp>
+                  </XMApp>
+                  <XMApp>
+                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                    <XMApp>
+                      <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                      <XMRef idref="S9.p1.m1.40"/>
+                      <XMRef idref="S9.p1.m1.41"/>
+                    </XMApp>
+                    <XMApp>
+                      <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                      <XMRef idref="S9.p1.m1.42"/>
+                      <XMRef idref="S9.p1.m1.43"/>
+                    </XMApp>
+                  </XMApp>
+                </XMApp>
+              </XMApp>
               <XMArray name="multline">
                 <XMRow>
                   <XMCell align="left">
                     <XMApp>
-                      <XMTok meaning="equals" role="RELOP" xml:id="S9.p1.m1.1">=</XMTok>
+                      <XMTok meaning="equals" role="RELOP" xml:id="S9.p1.m1.2">=</XMTok>
                       <XMApp>
-                        <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.2">p</XMTok>
+                        <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.3">p</XMTok>
                         <XMWrap>
-                          <XMTok role="OPEN" stretchy="false" xml:id="S9.p1.m1.3">(</XMTok>
-                          <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.4">x</XMTok>
-                          <XMTok role="CLOSE" stretchy="false" xml:id="S9.p1.m1.5">)</XMTok>
+                          <XMTok role="OPEN" stretchy="false" xml:id="S9.p1.m1.4">(</XMTok>
+                          <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.5">x</XMTok>
+                          <XMTok role="CLOSE" stretchy="false" xml:id="S9.p1.m1.6">)</XMTok>
                         </XMWrap>
                       </XMApp>
                       <XMApp>
-                        <XMTok meaning="plus" role="ADDOP" xml:id="S9.p1.m1.6">+</XMTok>
+                        <XMTok meaning="plus" role="ADDOP" xml:id="S9.p1.m1.7">+</XMTok>
                         <XMApp>
                           <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                          <XMTok meaning="3" role="NUMBER" xml:id="S9.p1.m1.7">3</XMTok>
+                          <XMTok meaning="3" role="NUMBER" xml:id="S9.p1.m1.8">3</XMTok>
                           <XMApp>
                             <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.8">x</XMTok>
-                            <XMTok fontsize="70%" meaning="6" role="NUMBER">6</XMTok>
+                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.9">x</XMTok>
+                            <XMTok fontsize="70%" meaning="6" role="NUMBER" xml:id="S9.p1.m1.10">6</XMTok>
                           </XMApp>
                         </XMApp>
                         <XMApp>
                           <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                          <XMTok meaning="14" role="NUMBER" xml:id="S9.p1.m1.9">14</XMTok>
+                          <XMTok meaning="14" role="NUMBER" xml:id="S9.p1.m1.11">14</XMTok>
                           <XMApp>
                             <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.10">x</XMTok>
-                            <XMTok fontsize="70%" meaning="5" role="NUMBER">5</XMTok>
+                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.12">x</XMTok>
+                            <XMTok fontsize="70%" meaning="5" role="NUMBER" xml:id="S9.p1.m1.13">5</XMTok>
                           </XMApp>
-                          <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.11">y</XMTok>
+                          <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.14">y</XMTok>
                         </XMApp>
                         <XMApp>
                           <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                          <XMTok meaning="590" role="NUMBER" xml:id="S9.p1.m1.12">590</XMTok>
-                          <XMApp>
-                            <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.13">x</XMTok>
-                            <XMTok fontsize="70%" meaning="4" role="NUMBER">4</XMTok>
-                          </XMApp>
-                          <XMApp>
-                            <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.14">y</XMTok>
-                            <XMTok fontsize="70%" meaning="2" role="NUMBER">2</XMTok>
-                          </XMApp>
-                        </XMApp>
-                        <XMApp>
-                          <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                          <XMTok meaning="19" role="NUMBER" xml:id="S9.p1.m1.15">19</XMTok>
+                          <XMTok meaning="590" role="NUMBER" xml:id="S9.p1.m1.15">590</XMTok>
                           <XMApp>
                             <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
                             <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.16">x</XMTok>
-                            <XMTok fontsize="70%" meaning="3" role="NUMBER">3</XMTok>
+                            <XMTok fontsize="70%" meaning="4" role="NUMBER" xml:id="S9.p1.m1.17">4</XMTok>
                           </XMApp>
                           <XMApp>
                             <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.17">y</XMTok>
-                            <XMTok fontsize="70%" meaning="3" role="NUMBER">3</XMTok>
+                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.18">y</XMTok>
+                            <XMTok fontsize="70%" meaning="2" role="NUMBER" xml:id="S9.p1.m1.19">2</XMTok>
+                          </XMApp>
+                        </XMApp>
+                        <XMApp>
+                          <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                          <XMTok meaning="19" role="NUMBER" xml:id="S9.p1.m1.20">19</XMTok>
+                          <XMApp>
+                            <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.21">x</XMTok>
+                            <XMTok fontsize="70%" meaning="3" role="NUMBER" xml:id="S9.p1.m1.22">3</XMTok>
+                          </XMApp>
+                          <XMApp>
+                            <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
+                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.23">y</XMTok>
+                            <XMTok fontsize="70%" meaning="3" role="NUMBER" xml:id="S9.p1.m1.24">3</XMTok>
                           </XMApp>
                         </XMApp>
                       </XMApp>
@@ -4602,46 +4681,46 @@ Then a switch of tag forms.</p>
                 <XMRow>
                   <XMCell align="right">
                     <XMApp>
-                      <XMTok meaning="minus" role="ADDOP" xml:id="S9.p1.m1.18">-</XMTok>
+                      <XMTok meaning="minus" role="ADDOP" xml:id="S9.p1.m1.25">-</XMTok>
                       <XMApp>
-                        <XMTok meaning="plus" role="ADDOP" xml:id="S9.p1.m1.19">+</XMTok>
+                        <XMTok meaning="plus" role="ADDOP" xml:id="S9.p1.m1.26">+</XMTok>
                         <XMApp>
-                          <XMTok meaning="minus" role="ADDOP" xml:id="S9.p1.m1.20">-</XMTok>
+                          <XMTok meaning="minus" role="ADDOP">-</XMTok>
                           <XMApp>
-                            <XMTok meaning="minus" role="ADDOP" xml:id="S9.p1.m1.21">-</XMTok>
+                            <XMTok meaning="minus" role="ADDOP" xml:id="S9.p1.m1.27">-</XMTok>
                             <XMApp>
                               <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                              <XMTok meaning="12" role="NUMBER" xml:id="S9.p1.m1.22">12</XMTok>
+                              <XMTok meaning="12" role="NUMBER" xml:id="S9.p1.m1.28">12</XMTok>
                               <XMApp>
                                 <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                                <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.23">x</XMTok>
-                                <XMTok fontsize="70%" meaning="2" role="NUMBER">2</XMTok>
+                                <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.29">x</XMTok>
+                                <XMTok fontsize="70%" meaning="2" role="NUMBER" xml:id="S9.p1.m1.30">2</XMTok>
                               </XMApp>
                               <XMApp>
                                 <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                                <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.24">y</XMTok>
-                                <XMTok fontsize="70%" meaning="4" role="NUMBER">4</XMTok>
+                                <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.31">y</XMTok>
+                                <XMTok fontsize="70%" meaning="4" role="NUMBER" xml:id="S9.p1.m1.32">4</XMTok>
                               </XMApp>
                             </XMApp>
                           </XMApp>
                           <XMApp>
                             <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                            <XMTok meaning="12" role="NUMBER" xml:id="S9.p1.m1.25">12</XMTok>
-                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.26">x</XMTok>
+                            <XMTok meaning="12" role="NUMBER" xml:id="S9.p1.m1.33">12</XMTok>
+                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.34">x</XMTok>
                             <XMApp>
                               <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                              <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.27">y</XMTok>
-                              <XMTok fontsize="70%" meaning="5" role="NUMBER">5</XMTok>
+                              <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.35">y</XMTok>
+                              <XMTok fontsize="70%" meaning="5" role="NUMBER" xml:id="S9.p1.m1.36">5</XMTok>
                             </XMApp>
                           </XMApp>
                         </XMApp>
                         <XMApp>
                           <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                          <XMTok meaning="2" role="NUMBER" xml:id="S9.p1.m1.28">2</XMTok>
+                          <XMTok meaning="2" role="NUMBER" xml:id="S9.p1.m1.37">2</XMTok>
                           <XMApp>
                             <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.29">y</XMTok>
-                            <XMTok fontsize="70%" meaning="6" role="NUMBER">6</XMTok>
+                            <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.38">y</XMTok>
+                            <XMTok fontsize="70%" meaning="6" role="NUMBER" xml:id="S9.p1.m1.39">6</XMTok>
                           </XMApp>
                         </XMApp>
                       </XMApp>
@@ -4649,13 +4728,13 @@ Then a switch of tag forms.</p>
                         <XMTok meaning="times" role="MULOP">⁢</XMTok>
                         <XMApp>
                           <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                          <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.30">a</XMTok>
-                          <XMTok fontsize="70%" meaning="3" role="NUMBER">3</XMTok>
+                          <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.40">a</XMTok>
+                          <XMTok fontsize="70%" meaning="3" role="NUMBER" xml:id="S9.p1.m1.41">3</XMTok>
                         </XMApp>
                         <XMApp>
                           <XMTok role="SUPERSCRIPTOP" scriptpos="post5"/>
-                          <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.31">b</XMTok>
-                          <XMTok fontsize="70%" meaning="3" role="NUMBER">3</XMTok>
+                          <XMTok font="italic" role="UNKNOWN" xml:id="S9.p1.m1.42">b</XMTok>
+                          <XMTok fontsize="70%" meaning="3" role="NUMBER" xml:id="S9.p1.m1.43">3</XMTok>
                         </XMApp>
                       </XMApp>
                     </XMApp>

--- a/latexml_oxide/tests/cluster_regressions/bib_title_math.bib
+++ b/latexml_oxide/tests/cluster_regressions/bib_title_math.bib
@@ -1,0 +1,6 @@
+@article{mathy,
+  author = "A Author",
+  title = "On $E=mc^2$ and \emph{emphasis}",
+  journal = "J",
+  year = 2020
+}

--- a/latexml_oxide/tests/cluster_regressions/bib_title_math.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_title_math.tex
@@ -1,0 +1,10 @@
+% Guard for id preservation through the bibliography clone path: the math and
+% the emphasis in the .bib title are id-bearing markup CLONED into the
+% generated bibliography, and must keep an id (and hence a fragid) in HTML.
+% Perl gets this from Collector::rescan; see bib_entry_cloned_markup_keeps_its_id.
+\documentclass{article}
+\begin{document}
+Cite \cite{mathy}.
+\bibliographystyle{plain}
+\bibliography{bib_title_math}
+\end{document}

--- a/latexml_post/src/collector.rs
+++ b/latexml_post/src/collector.rs
@@ -11,7 +11,7 @@ use libxml::tree::Node;
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
-  document::{NodeData, PostDocument},
+  document::{NodeData, PostDocument, get_xml_id},
   processor::{ProcessResult, Processor},
 };
 
@@ -69,7 +69,9 @@ pub fn make_sub_collection_documents(
   let _root_tag = doc
     .get_qname(root)
     .unwrap_or_else(|| "ltx:index".to_string());
-  let root_id = root.get_attribute("xml:id").unwrap_or_default();
+  // NS-aware read — the bare form always returned None, so every
+  // sub-collection page id was built from an EMPTY root id (".B"-style).
+  let root_id = get_xml_id(root).unwrap_or_default();
 
   // Build (id, initial) pairs for each sub-collection
   let ids: Vec<(String, &str)> = initials

--- a/latexml_post/src/document.rs
+++ b/latexml_post/src/document.rs
@@ -1324,11 +1324,13 @@ impl PostDocument {
       return Some(id);
     }
 
-    // Find the closest parent with an ID
+    // Find the closest parent with an ID (NS-aware — the bare read always
+    // missed, so generated ids silently lost their parent prefix, e.g.
+    // "fn1" instead of "S2.fn1")
     let mut parent_node = node.get_parent();
     let mut pid = String::new();
     while let Some(ref p) = parent_node {
-      if let Some(id) = p.get_attribute("xml:id") {
+      if let Some(id) = get_xml_id(p) {
         pid = id;
         break;
       }
@@ -1661,7 +1663,9 @@ impl PostDocument {
     for node in nodes {
       if node.get_type() == Some(NodeType::ElementNode) {
         for idd in self.findnodes_at("descendant-or-self::*[@xml:id]", Some(node)) {
-          if let Some(id) = idd.get_attribute("xml:id") {
+          // NS-aware read — the bare form always returned None, so no id
+          // was ever marked reusable and generate_node_id skipped reuse.
+          if let Some(id) = get_xml_id(&idd) {
             self.idcache_reusable.insert(id, true);
           }
         }

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -1690,6 +1690,26 @@ impl Processor for MakeBibliography {
       }
     }
 
+    // Register the enclosing `ltx:biblist` too — Perl's Scan runs AFTER
+    // MakeBibliography and registers EVERY id'd node, which is what lets
+    // `CrossRef::fill_in_frags` ("Any nodes with an ID will get a fragid",
+    // CrossRef.pm L312-324) stamp `fragid` on it. This port registers the
+    // bibitems by hand at this seam but never the list, so the list alone
+    // reached HTML with no `id` — the XSLT's `add_id` emits the HTML `id`
+    // from `@fragid` only, so Perl's `<ul id="bib.L1">` was a bare `<ul>`
+    // here (SYNC_STATUS "Found, not fixed", 2026-07-28).
+    for list_node in doc.findnodes("//ltx:biblist") {
+      let Some(list_id) = crate::document::get_xml_id(&list_node) else {
+        continue;
+      };
+      let location = doc.site_relative_destination().unwrap_or_default();
+      self.db.register(&format!("ID:{}", list_id), vec![
+        ("type", crate::object_db::Value::from("ltx:biblist")),
+        ("location", crate::object_db::Value::from(location.as_str())),
+        ("fragid", crate::object_db::Value::from(list_id.as_str())),
+      ]);
+    }
+
     // Remove any remaining bibentry elements (they've been converted to bibitems)
     let bibentries = doc.findnodes("//ltx:bibentry");
     if !bibentries.is_empty() {

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -1690,23 +1690,46 @@ impl Processor for MakeBibliography {
       }
     }
 
-    // Register the enclosing `ltx:biblist` too — Perl's Scan runs AFTER
-    // MakeBibliography and registers EVERY id'd node, which is what lets
-    // `CrossRef::fill_in_frags` ("Any nodes with an ID will get a fragid",
-    // CrossRef.pm L312-324) stamp `fragid` on it. This port registers the
-    // bibitems by hand at this seam but never the list, so the list alone
-    // reached HTML with no `id` — the XSLT's `add_id` emits the HTML `id`
-    // from `@fragid` only, so Perl's `<ul id="bib.L1">` was a bare `<ul>`
-    // here (SYNC_STATUS "Found, not fixed", 2026-07-28).
-    for list_node in doc.findnodes("//ltx:biblist") {
-      let Some(list_id) = crate::document::get_xml_id(&list_node) else {
+    // Stand in for Perl's rescan of the generated subtree.
+    //
+    // Perl `Collector::rescan` (Collector.pm L97) re-runs the WHOLE Scan over
+    // the post-MakeBibliography document (called at MakeBibliography.pm L71,
+    // L78), so every id-bearing node in the generated bibliography — the
+    // enclosing `ltx:biblist`, and any id'd markup CLONED IN from a bibentry
+    // (an `ltx:Math` in a title, a styled `ltx:text`, …) — lands in the
+    // ObjectDB. That entry is what `CrossRef::fill_in_frags` ("Any nodes with
+    // an ID will get a fragid", CrossRef.pm L312-324) needs before it will
+    // stamp `fragid`, and the HTML5 XSLT's `add_id` emits the HTML `id` from
+    // `@fragid` ALONE. So an unregistered node reaches HTML with NO id.
+    //
+    // This port hand-registers the bibitems just above (Perl's Scan is what
+    // registers them there) but nothing else, so both classes were lost:
+    // Perl's `<ul id="bib.L1">` was a bare `<ul>` here, and a `$…$` inside a
+    // bib title lost the `bib.bib1.m1a` id Perl emits (measured on same-host
+    // 0.8.8). Registering the whole generated subtree covers both.
+    //
+    // Deliberately narrower than Perl's rescan: this restores the id/fragid
+    // half only. It does NOT re-derive `labels`, relations or the richer
+    // per-type values a full Scan would, and it never overwrites an entry
+    // that already exists — the bibitem registrations above (which carry
+    // `type`/`number`) win. Wiring a real `Collector::rescan` is tracked in
+    // SYNC_STATUS.
+    let location = doc.site_relative_destination().unwrap_or_default();
+    for node in doc.findnodes("//ltx:bibliography//*[@xml:id]") {
+      let Some(id) = crate::document::get_xml_id(&node) else {
         continue;
       };
-      let location = doc.site_relative_destination().unwrap_or_default();
-      self.db.register(&format!("ID:{}", list_id), vec![
-        ("type", crate::object_db::Value::from("ltx:biblist")),
+      let key = format!("ID:{}", id);
+      if self.db.lookup(&key).is_some() {
+        continue; // already registered (bibitems, and anything Scan saw)
+      }
+      let qname = doc
+        .get_qname(&node)
+        .unwrap_or_else(|| "ltx:text".to_string());
+      self.db.register(&key, vec![
+        ("type", crate::object_db::Value::from(qname.as_str())),
         ("location", crate::object_db::Value::from(location.as_str())),
-        ("fragid", crate::object_db::Value::from(list_id.as_str())),
+        ("fragid", crate::object_db::Value::from(id.as_str())),
       ]);
     }
 

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -899,8 +899,10 @@ impl MakeBibliography {
     style: &CitationStyle,
   ) -> NodeData {
     // ID generation: match Perl's $id =~ s/^bib//; $id = $bibid . $id;
+    // (MakeBibliography.pm L407-415; NS-aware read — the bare form always
+    // returned None, so every bibitem fell to the .bibN numbering fallback)
     let id = if let Some(ref bibentry) = entry.bibentry {
-      let orig_id = bibentry.get_attribute("xml:id").unwrap_or_default();
+      let orig_id = crate::document::get_xml_id(bibentry).unwrap_or_default();
       if orig_id.is_empty() {
         // No xml:id on bibentry (e.g. from raw .bib parsing) — use number
         format!("{}.bib{}", bib_id, entry.number)
@@ -1555,12 +1557,15 @@ impl Processor for MakeBibliography {
         continue;
       }
 
-      let bib_id = bib
-        .get_attribute("xml:id")
+      // Perl MakeBibliography.pm L393-394: bib's id, else the document
+      // element's id, else the literal 'bib'. NS-aware reads — the bare
+      // forms always fell through to the literal.
+      let bib_id = crate::document::get_xml_id(bib)
         .or_else(|| {
           doc
             .get_document_element()
-            .and_then(|r| r.get_attribute("xml:id"))
+            .as_ref()
+            .and_then(crate::document::get_xml_id)
         })
         .unwrap_or_else(|| "bib".to_string());
 
@@ -1649,9 +1654,9 @@ impl Processor for MakeBibliography {
         .unwrap_or_else(|| "bibliography".to_string());
       for entry in entries.values() {
         let cited_key = entry.cited_key.as_deref().unwrap_or(&entry.bib_key);
-        // Compute the same ID as format_bib_entry
+        // Compute the same ID as format_bib_entry (NS-aware, same as there)
         let bibitem_id = if let Some(ref bibentry) = entry.bibentry {
-          let orig_id = bibentry.get_attribute("xml:id").unwrap_or_default();
+          let orig_id = crate::document::get_xml_id(bibentry).unwrap_or_default();
           if orig_id.is_empty() {
             format!("{}.bib{}", bib_id, entry.number)
           } else {

--- a/latexml_post/src/make_index.rs
+++ b/latexml_post/src/make_index.rs
@@ -984,7 +984,15 @@ fn seealso_partition_aux(node: &Node) -> Vec<SeeChunk> {
         if name == "text" || name == "emph" {
           // Recurse, re-wrapping each sub-chunk in the styling element
           // so delimiters can split styled phrases (Perl does the same).
-          let attrs: HashMap<String, String> = ch.get_properties().into_iter().collect();
+          // Drop the source node's id ("id" is how get_properties()
+          // reports xml:id): the styling wrapper is CLONED once per
+          // sub-chunk, and copying the id onto every clone would mint
+          // schema-invalid duplicate xml:ids.
+          let attrs: HashMap<String, String> = ch
+            .get_properties()
+            .into_iter()
+            .filter(|(k, _)| k != "id" && k != "xml:id" && k != "fragid")
+            .collect();
           for sub in seealso_partition_aux(&ch) {
             result.push(SeeChunk {
               key: sub.key,

--- a/latexml_post/src/make_index.rs
+++ b/latexml_post/src/make_index.rs
@@ -987,11 +987,23 @@ fn seealso_partition_aux(node: &Node) -> Vec<SeeChunk> {
           // Drop the source node's id ("id" is how get_properties()
           // reports xml:id): the styling wrapper is CLONED once per
           // sub-chunk, and copying the id onto every clone would mint
-          // schema-invalid duplicate xml:ids.
+          // schema-invalid duplicate xml:ids. The namespace probe keeps a
+          // GENUINE plain `id` attribute (model-granted on a few bib
+          // elements) from being dropped along with it.
+          //
+          // Perl copies the attributes here — or means to: its
+          // `map { ($_ => $ch->getAttribute($_)) } $ch->attributes`
+          // (MakeIndex.pm L445) keys the hash on attribute NODES, which
+          // stringify to ` role="x"`-style junk with undef values, so it
+          // copies nothing usable. We implement the intent, minus the ids.
+          // KNOWN_PERL_ERRORS #72.
+          let ch_has_xml_id = ch
+            .get_attribute_ns("id", latexml_core::common::xml::XML_NS)
+            .is_some();
           let attrs: HashMap<String, String> = ch
             .get_properties()
             .into_iter()
-            .filter(|(k, _)| k != "id" && k != "xml:id" && k != "fragid")
+            .filter(|(k, _)| k != "xml:id" && k != "fragid" && !(k == "id" && ch_has_xml_id))
             .collect();
           for sub in seealso_partition_aux(&ch) {
             result.push(SeeChunk {

--- a/latexml_post/src/mathml/mod.rs
+++ b/latexml_post/src/mathml/mod.rs
@@ -1257,10 +1257,16 @@ pub fn rebuild_text_subtree_with_doc(
       // which this helper does not receive — drop both here rather
       // than forge a wrong id. NOTE: get_attributes() reports xml:id
       // under its LOCAL name "id", so that spelling must be skipped
-      // too — it used to leak through as a plain id= duplicate.
+      // too — it used to leak through as a plain id= duplicate. The
+      // namespace probe keeps a GENUINE plain `id` (the model grants
+      // one to `ltx:bib-identifier`/`ltx:bib-review`, carrying a
+      // DOI/ISSN) from being dropped along with it.
+      let has_xml_id = node
+        .get_attribute_ns("id", latexml_core::common::xml::XML_NS)
+        .is_some();
       let mut attrs: HashMap<String, String> = HashMap::default();
       for (k, v) in node.get_attributes() {
-        if k.starts_with('_') || k == "xml:id" || k == "id" || k == "fragid" {
+        if k.starts_with('_') || k == "xml:id" || k == "fragid" || (k == "id" && has_xml_id) {
           continue;
         }
         attrs.insert(k, v);

--- a/latexml_post/src/mathml/mod.rs
+++ b/latexml_post/src/mathml/mod.rs
@@ -1255,10 +1255,12 @@ pub fn rebuild_text_subtree_with_doc(
       // Matches Perl convertXMTextContent (Post.pm L479-483); the
       // `fragid → xml:id` remap requires the MathProcessor's IDSuffix
       // which this helper does not receive — drop both here rather
-      // than forge a wrong id.
+      // than forge a wrong id. NOTE: get_attributes() reports xml:id
+      // under its LOCAL name "id", so that spelling must be skipped
+      // too — it used to leak through as a plain id= duplicate.
       let mut attrs: HashMap<String, String> = HashMap::default();
       for (k, v) in node.get_attributes() {
-        if k.starts_with('_') || k == "xml:id" || k == "fragid" {
+        if k.starts_with('_') || k == "xml:id" || k == "id" || k == "fragid" {
           continue;
         }
         attrs.insert(k, v);

--- a/latexml_post/src/writer.rs
+++ b/latexml_post/src/writer.rs
@@ -23,7 +23,7 @@ use std::{
 use libxml::tree::{Node, SaveOptions};
 
 use crate::{
-  document::PostDocument,
+  document::{PostDocument, get_xml_id},
   processor::{PostError, ProcessResult, Processor},
 };
 
@@ -147,10 +147,14 @@ impl Processor for Writer {
       doc.get_document_mut().remove_internal_subset();
     }
 
-    // Remove TEMPORARY_DOCUMENT_ID if present (Perl Writer.pm L41-42)
-    if let Some(id) = root.get_attribute("xml:id") {
+    // Remove TEMPORARY_DOCUMENT_ID if present (Perl Writer.pm L41-42).
+    // NS-aware forms: the bare get/remove_attribute("xml:id") pair silently
+    // no-opped, so this last-chance strip never fired (the split path
+    // removes the temp id earlier via core_interface, but this writer-side
+    // guard is the one Perl relies on).
+    if let Some(id) = get_xml_id(&root) {
       if id == "TEMPORARY_DOCUMENT_ID" {
-        let _ = root.remove_attribute("xml:id");
+        let _ = root.remove_attribute_ns("id", latexml_core::common::xml::XML_NS);
       }
     }
 

--- a/tools/lint_xmlid_accessor.sh
+++ b/tools/lint_xmlid_accessor.sh
@@ -9,10 +9,11 @@
 # Full analysis: docs/archive/XMLID_ACCESSOR_AUDIT_2026-06-08.md.
 #
 # This lint FAILS when a NEW `*_{attribute,property}("xml:...")` read/has/remove
-# accessor appears (one not in the checked-in baseline). The 53 pre-existing
-# sites are baselined (most are masked by `.or_else(get_property("id"))` or a
-# paired `_ns` call — see the audit); we ratchet so no NEW footgun lands without
-# review, without churning the working masked sites.
+# accessor appears (one not in the checked-in baseline). The remaining baselined
+# sites are masked by `.or_else(get_property("id"))` or a paired `_ns` call —
+# see the audit; the load-bearing bare reads were migrated in the 2026-08-04
+# sweep. We ratchet so no NEW footgun lands without review, without churning
+# the working masked sites.
 #
 # Usage:
 #   tools/lint_xmlid_accessor.sh           # check; exit 1 on a new violation

--- a/tools/xmlid_lint_baseline.txt
+++ b/tools/xmlid_lint_baseline.txt
@@ -1,15 +1,10 @@
 latexml_core/src/document.rs	&& !current.has_attribute("xml:id")
-latexml_core/src/document.rs	&& !dual.has_attribute("xml:id")
-latexml_core/src/document.rs	&& let Some(id) = pres.get_attribute("xml:id")
 latexml_core/src/document.rs	.or_else(|| node.get_attribute("xml:id"))
 latexml_core/src/document.rs	if let Some(id) = node.get_attribute("xml:id") {
-latexml_core/src/document.rs	let _ = pres.remove_attribute("xml:id");
 latexml_core/src/document.rs	let _ = tok.remove_attribute("xml:id");
-latexml_core/src/document.rs	let pres_had_id = pres.has_attribute("xml:id");
 latexml_core/src/document.rs	let to_has_id = to.has_attribute("xml:id")
 latexml_core/src/rewrite.rs	.get_property("xml:id")
 latexml_core/src/rewrite.rs	.get_property("xml:id")
-latexml_core/src/rewrite.rs	let id = tree.get_attribute("xml:id").unwrap_or_default();
 latexml_core/src/rewrite.rs	|| n.get_attribute("xml:id").as_deref() == Some(&target_id)
 latexml_engine/src/base_xmath.rs	.get_attribute("xml:id")
 latexml_engine/src/base_xmath.rs	.or_else(|| eq.get_attribute("xml:id"))
@@ -20,32 +15,14 @@ latexml_engine/src/base_xmath.rs	with(qname, |qstr| qstr.starts_with("ltx:XM")) 
 latexml_engine/src/latex_constructs.rs	.get_attribute("xml:id")
 latexml_engine/src/latex_constructs.rs	float.remove_attribute("xml:id").ok();
 latexml_engine/src/latex_constructs.rs	if node.has_attribute("labels") && !node.has_attribute("xml:id") {
-latexml_engine/src/math_common.rs	not_node.remove_attribute("xml:id")?;
 latexml_math_parser/src/data.rs	if child.get_attribute("xml:id").as_deref() == Some(id) {
 latexml_math_parser/src/parser.rs	.get_attribute("xml:id")
 latexml_math_parser/src/parser.rs	.get_attribute("xml:id")
-latexml_math_parser/src/parser.rs	if let Some(id) = descendant.get_attribute("xml:id") {
-latexml_math_parser/src/parser.rs	if script.get_attribute("xml:id").is_none() {
-latexml_math_parser/src/parser.rs	let _ = app.remove_attribute("xml:id");
-latexml_math_parser/src/parser.rs	let appid = match app.get_attribute("xml:id") {
-latexml_math_parser/src/parser.rs	let script_id = match script.get_attribute("xml:id") {
-latexml_math_parser/src/parser.rs	node.remove_attribute("xml:id")?;
-latexml_math_parser/src/util.rs	.get_attribute("xml:id")
-latexml_math_parser/src/util.rs	match node.get_attribute("xml:id") {
 latexml_oxide/src/core_interface.rs	.or_else(|| p.get_attribute("xml:id"))
 latexml_oxide/src/core_interface.rs	let _ = node.remove_attribute("xml:id");
 latexml_oxide/src/core_interface.rs	let _ = node.remove_attribute("xml:id");
 latexml_package/src/package/amsmath_sty.rs	.or_else(|| node.get_attribute("xml:id"))
 latexml_package/src/package/latexml_sty/declare.rs	.get_property("xml:id")
-latexml_post/src/collector.rs	let root_id = root.get_attribute("xml:id").unwrap_or_default();
 latexml_post/src/document.rs	.or_else(|| node.get_attribute("xml:id"))
-latexml_post/src/document.rs	if let Some(id) = idd.get_attribute("xml:id") {
-latexml_post/src/document.rs	if let Some(id) = p.get_attribute("xml:id") {
-latexml_post/src/make_bibliography.rs	.and_then(|r| r.get_attribute("xml:id"))
-latexml_post/src/make_bibliography.rs	.get_attribute("xml:id")
-latexml_post/src/make_bibliography.rs	let orig_id = bibentry.get_attribute("xml:id").unwrap_or_default();
-latexml_post/src/make_bibliography.rs	let orig_id = bibentry.get_attribute("xml:id").unwrap_or_default();
 latexml_post/src/mathml/content.rs	.get_attribute("xml:id")
 latexml_post/src/scan.rs	.get_attribute("xml:id")
-latexml_post/src/writer.rs	if let Some(id) = root.get_attribute("xml:id") {
-latexml_post/src/writer.rs	let _ = root.remove_attribute("xml:id");


### PR DESCRIPTION
**Diagnostic.** libxml stores `xml:id` namespaced (local `id` in the XML namespace), so every bare `get/has/remove_attribute("xml:id")` silently returns None/no-ops — in BOTH construction paths (probed against libxml 0.3.21: `set_attribute("xml:id")` namespaces too; no plain-form producer exists, correcting two comments that claimed otherwise). 20+ sites carried such reads; four were whole passes silently disabled: `cleanup_scripts` (MathParser cleanupScripts), the LOSTNODES orphan pre-snapshot, post `generateNodeID`'s parent prefix, and preremove id-reuse (whose consumer is `uniquify_id`, mirroring Perl `uniquifyID` line for line).

**Approach.** Per-site, Perl-diffed (per `docs/archive/XMLID_ACCESSOR_AUDIT_2026-06-08.md` — masked no-ops can be load-bearing; `rewrite.rs:1242` deliberately untouched): load-bearing reads → ns-aware forms; Rewrite `Label` clauses now COMPILE to a Select (Perl Rewrite.pm L288-297) instead of a dead not-Perl runtime record; `compact_xmdual`'s dead anti-Perl "remove leaked id" block deleted (Perl transfers that id, L1308-1313); mathml text-copy + make_index re-wrap stop leaking `xml:id` as duplicate plain `id=`; `formatBibEntry` regains Perl's id scheme (MakeBibliography.pm L407-415). Ratchet baseline 51 → 28 (survivors are masked fallback arms, kept per the audit's anti-churn rule).

**Two defects the sweep exposed** (second commit, each with a red-checked guard):

- `create_xmrefs` lacked Perl's XMRef branch (Package.pm L1557-1561, "clone an XMRef rather than create an XMRef to an XMRef"), so a content branch could reference a contentless presentation XMRef. Once `cleanup_scripts` began parsing the mathtools witness, that shape reached a golden — the only ref-to-a-ref in our corpus, against zero anywhere in Perl's. It was a content defect, not cosmetic: the formula's text form read `p@(delimited-@([]))` — `[]` being an **elided argument** — and is now `p@(delimited-@(x))`.
- The recursive `.bib` session shares the live State (a deliberate surpass-Perl choice), which leaked `n_bibliographies` into `begin_bibliography_clean`: the inner session saw 1, minted the SECOND bibliography's prefix, and a one-bibliography document's anchors came out `biba.bibN`. Perl uses a fresh State per `.bib` (MakeBibliography.pm L181-215) and always mints `bib`-rooted ids, which its `s/^bib//` + re-prepend contract depends on. Now `bib.bibN`, byte-identical to same-host Perl. Caught because the sweep made `formatBibEntry` faithful, turning an accidentally-Perl-matching fallback into a visible divergence.

**Validation.** Guards `cleanup_scripts_redirects_script_xmapp_refs` and `bib_entry_ids_are_bib_rooted_like_perl` (both red-checked against the unfixed code). Full suite **1882/1882**; clippy/fmt/xmlid-lint green.

One golden re-blessed — `tests/ams/mathtools.xml`, exactly **1 of its 175** formulas: it had pinned that formula in FAILED-parse form, and it now parses (unparsed wraps 1 → 0; Perl's own golden still has 4 in this document). Correcting an earlier claim in this PR: its `text=` does **not** match Perl's — we read `p(x)` as function application, Perl as `p * x`. That is a pre-existing math-parser divergence, invisible while the formula failed to parse, and arguably the better reading for a polynomial.

Corpus check over all 579 fixtures: the newly-live LOSTNODES **unlink** branch fires **zero** times and leaves zero dangling refs — blast radius nil, but it is therefore also **uncovered** by the suite; its correctness rests on the Perl diff, not on a test. Residuals recorded in `SYNC_STATUS.md`: `ltx:biblist` loses its `bib.L1` id on the XSLT side (it IS present in our post XML), and `--format=xml` emits no `ltx:bibitem` at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
