### PR TITLE
fix: size a faked space by the font it was digested in (streaming/eager byte-identity)

### DIFF
--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -809,37 +809,36 @@ format paths do not run the same post chain. Not yet diagnosed; check before
 trusting an `xml`-format dump as a bibliography oracle. (The `ltx:biblist`
 `fragid` gap noticed alongside it is FIXED — see the 2026-07-28 entry above.)
 
-### Streaming diverges on a fancyvrb `fontsize=` + `numbers=` Verbatim — untriaged (2026-08-04)
+### Streaming diverged on a fancyvrb `fontsize=` + `numbers=` Verbatim — ✅ FIXED 2026-08-04
 
-Under a small streaming budget the XML is **not** byte-identical to the eager
-path when a fancyvrb verbatim carries `fontsize=` **and** `numbers=` together.
-Either option alone is clean; the pair is not. Nothing package-load-related is
-involved — the minimal repro needs only `fancyvrb`:
+Under a small streaming budget the XML was **not** byte-identical to the eager
+path when a fancyvrb verbatim carried `fontsize=` **and** `numbers=` together
+(either alone was clean). Root cause was **not** package-load-related, despite
+being found while guarding #500: `tex_glue::dimension_to_spaces` renders a width
+as Unicode space glyphs and does the arithmetic in **ems**, but read the live
+`lookup_font()` from callers that are `DefConstructor`s — i.e. CONSTRUCTION
+time. The eager path builds only after the whole document is digested, so that
+is the font the document *ends* in; appending `\small` before `\end{document}`
+changes the glyph chosen for a skip pages earlier (Perl 0.8.8 too — it has the
+same read, `TeX_Glue.pool.ltxml` L44). Depending on WHEN the build ran is what
+broke byte-identity: streaming builds mid-document, read the local font, and
+emitted U+2004 where eager emitted Perl's U+2009.
 
-```tex
-\documentclass{article}
-\usepackage{fancyvrb}
-\begin{document}
-\begin{Verbatim}[fontsize=\small,numbers=left]
-alpha
-beta
-\end{Verbatim}
-\end{document}
-```
+Fixed by passing the whatsit's own digest-time font at the constructor/whatsit
+sites (`\hskip`, `\kern`, `\lx@text@intercol`, `digested_to_text`); digest-time
+callers keep the ambient read, which is already the digest font. Surpass-Perl
+divergence [OXIDIZED_DESIGN #96](parity/OXIDIZED_DESIGN_DIVERGENCES.md),
+Perl-side record [KNOWN_PERL_ERRORS #74](parity/KNOWN_PERL_ERRORS.md). Zero
+golden churn. Guards:
+`06_cluster_regressions::faked_space_is_sized_by_the_font_it_was_digested_in`
+(value) and `114_streaming_cluster_regressions::streaming_matches_eager_on_cluster_regressions`
+(eager == streaming; it caught the defect).
 
-Dropped into `latexml_oxide/tests/cluster_regressions/` it fails
-`114_streaming_cluster_regressions::streaming_matches_eager_on_cluster_regressions`
-("output diverges at byte 440"), inside the line-number box
-(`<text font="serif" fontsize="56%" width="0.0pt">1\u2003\u2009</text>`). The
-CLI cannot reach the sweep's aggressive 3-box budget (`--streaming` sizes the
-budget from `--max-memory`, and a ceiling small enough trips the RSS fuse
-first), so reproduce through `streaming_sweep::convert_with(src, Some(3), …)`
-or by running the built sweep binary — it globs the fixture dir at RUNTIME, so
-a fixture can be added/removed without a rebuild.
-
-Found while adding the #500 guard; the #500 fixtures were narrowed to
-`fontsize=` alone rather than pinning this. Unrelated to #500 (no keyval /
-xkeyval / standalone in the repro).
+**Reproduction note worth keeping:** the CLI cannot reach the sweep's aggressive
+3-box budget — `--streaming` sizes the budget from `--max-memory`, and a ceiling
+small enough trips the RSS fuse first. Drive `streaming_sweep::convert_with(src,
+Some(3), …)`, or run the built sweep binary directly: it globs its fixture dir at
+RUNTIME, so fixtures can be added or removed without a rebuild.
 
 ### A `robust` DefConstructor reverted under its munged cs — ✅ FIXED 2026-07-29
 

--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3168,3 +3168,45 @@ as latexml-oxide issue #500, where Rust hit it on a plain
 `standalone.sty` L107's `\RequirePackage{xkeyval}`, which
 `standalone.sty.ltxml` omits. Filed upstream as
 <https://github.com/brucemiller/LaTeXML/issues/2864>.
+## 74. `DimensionToSpaces` sizes a faked space by the font the document ENDS in
+
+`TeX_Glue.pool.ltxml` L43-45:
+
+```perl
+sub DimensionToSpaces {
+  my ($dimen) = @_;
+  my $fs      = LookupValue('font')->getSize;         # 1 em
+  my $ems     = $dimen->ptValue / $fs;
+```
+
+The width is converted to **ems**, so the font supplying the em decides which
+Unicode space glyphs come out. But `DimensionToSpaces` is called from
+`DefConstructor` bodies (`\hskip` L66-79, `\kern`, `\lx@intercol`), which run
+in the CONSTRUCTION phase — after the entire document is digested. At that
+point `LookupValue('font')` is no longer the font the skip occurred in; it is
+whatever font the document happens to end in.
+
+Minimal trigger — the same file twice, differing only in a trailing `\small`
+that is nowhere near the skip:
+
+```tex
+\documentclass{article}
+\usepackage{fancyvrb}
+\begin{document}
+\begin{Verbatim}[fontsize=\small,numbers=left]
+alpha
+\end{Verbatim}
+\end{document}
+```
+
+gives `1\x{2003}\x{2009}` for the line-number skip; adding `\small` on the line
+before `\end{document}` gives `1\x{2003}\x{2004}` instead. The skip did not
+move and its width did not change — only the document's final font did.
+
+The consequence is not merely instability: because the glyph run is an
+*approximation of a fixed pt width*, measuring it in a font that will not
+render it makes the rendered spacing wrong by the font-size ratio.
+
+**Rust fixes this** by passing the whatsit's own digest-time font — see
+OXIDIZED_DESIGN #96, where the defect surfaced as an eager/streaming
+byte-identity break.

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -3484,3 +3484,45 @@ the pretense was protecting.
 **Upstream**: <https://github.com/brucemiller/LaTeXML/issues/2864>.
 
 **Guard**: `06_cluster_standalone_subfiles::keyval_internals_survive_xkeyval_preloading_it`.
+### 96. A faked space is sized by the font it was DIGESTED in, not the ambient one
+
+`tex_glue::dimension_to_spaces` renders a width as a run of Unicode space
+glyphs, and it does the arithmetic in **ems** — so which font supplies the em
+decides the answer completely.
+
+**Perl behavior**: `TeX_Glue.pool.ltxml` L44 reads the live
+`LookupValue('font')`. In a `DefConstructor` that is the font at CONSTRUCTION
+time, and Perl builds only after the whole document is digested — so it is
+whatever font the document *ends* in. Appending `\small` before
+`\end{document}` changes the glyph chosen for a skip that occurred pages
+earlier (verified same-host on the witness below: `U+2009` → `U+2004`).
+
+**Rust behavior**: the constructor and whatsit call sites (`\hskip`, `\kern`,
+`\lx@text@intercol`, `digested_to_text`) pass the whatsit's own
+`props["font"]` / `get_font()`. Digest-time callers (`\hspace`, `\hglue`, the
+tabskip Tbox) keep the ambient read, where `lookup_font()` already IS the
+digest font. One site keeps the ambient read for lack of an alternative:
+`cleanup_math`'s `<ltx:XMHint>` records only `width`, never a font.
+
+**Why**: the ambient read made the output depend on WHEN the build ran, which
+broke the eager/streaming byte-identity invariant outright — streaming builds
+mid-document, so it read the local font and emitted `U+2004` where the eager
+path emitted Perl's `U+2009`. There is no way to make streaming reproduce
+"the font the document will end in"; the only deterministic choice is the
+font the skip actually occurred in. That is also the *correct* one: the glyph
+run is an approximation of a fixed pt width, and it is only a good
+approximation when measured in the font that will render those glyphs.
+
+**Witness**: `latexml_oxide/tests/cluster_regressions/fancyvrb_fontsize_numbers.tex`
+— a `numbers=left` line-number skip, digested in the number's `56%` font,
+inside a `fontsize=\small` verbatim, inside a default-size document: three
+distinct sizes, so every candidate font gives a different answer. Rust emits
+`1␣␣␣` (`U+2003 U+2003 U+2004`); Perl emits `1␣␣` (`U+2003 U+2009`).
+
+**Cost**: zero golden churn — the full suite was 1885/1885 with no fixture
+updates, so no existing test exercised a skip whose digest font differed from
+the document's final font.
+
+**Guards**: `06_cluster_regressions::faked_space_is_sized_by_the_font_it_was_digested_in`
+pins the value; `114_streaming_cluster_regressions::streaming_matches_eager_on_cluster_regressions`
+pins eager == streaming (it is what caught the defect).

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -1543,7 +1543,12 @@ pub fn digested_to_text(d: &Digested) -> Result<String> {
       let w = w.borrow();
       match w.get_property("width").as_deref() {
         Some(Stored::Dimension(width)) => {
-          out.push_str(&super::tex_glue::dimension_to_spaces(*width));
+          // The whatsit's OWN font — see tex_glue::dimension_to_spaces.
+          let font = w.get_font()?;
+          out.push_str(&super::tex_glue::dimension_to_spaces(
+            *width,
+            font.as_deref(),
+          ));
         },
         _ => {
           out.push_str(&w.get_string()?);
@@ -3262,7 +3267,13 @@ pub fn cleanup_math(document: &mut Document, mathnode: Node) -> Result<()> {
             }
           });
           if let Some(dim) = dim_opt {
-            let spaces = super::tex_glue::dimension_to_spaces(dim);
+            // No font to thread: this runs over an already-built
+            // `<ltx:XMHint>`, which records only `width` — the digest font is
+            // not on the element. Keeps the ambient read (and with it the
+            // WHEN-dependence described in tex_glue::dimension_to_spaces);
+            // reachable only for math hints, which the streaming sweep has
+            // never caught diverging.
+            let spaces = super::tex_glue::dimension_to_spaces(dim, None);
             if !spaces.is_empty()
               && let Ok(text_node) = Node::new_text(&spaces, &document.document)
             {
@@ -4075,9 +4086,13 @@ fn either_case_token(token: Token, is_upper: bool) -> Token {
 /// caller, dropping the math-mode space marker between `^{...}` and a
 /// following `'` — surfacing as the false `unexpected:double-superscript`
 /// in hep-th9601176 (`\Si^{\mu\nu}\hs{0.25}'(p)`).
+///
+/// Both callers (`\hglue`, `\hspace`) are `DefPrimitive`s, i.e. DIGEST time,
+/// where `lookup_font()` already IS the font in effect — so the ambient read
+/// is the right one and no font is threaded through.
 pub fn dimension_to_spaces<T: NumericOps>(dimen: T) -> Cow<'static, str> {
   let dim = Dimension::new(dimen.value_of());
-  Cow::Owned(super::tex_glue::dimension_to_spaces(dim))
+  Cow::Owned(super::tex_glue::dimension_to_spaces(dim, None))
 }
 
 pub fn aligning_environment(

--- a/latexml_engine/src/tex_glue.rs
+++ b/latexml_engine/src/tex_glue.rs
@@ -28,9 +28,32 @@ static REVERT_SKIPS: [(f64, &str); 6] = [
   (2.000, "\\qquad"),     // double em
 ];
 
-/// String of spacing chars with width roughly equivalent to $dimen
-pub(crate) fn dimension_to_spaces(dimen: Dimension) -> String {
-  let fs = lookup_font().unwrap().get_size().unwrap_or(1.0); // 1 em
+/// String of spacing chars with width roughly equivalent to $dimen.
+///
+/// `font` is the font the skip was DIGESTED in — pass `Some` wherever it is
+/// known, i.e. from every CONSTRUCTOR (`props["font"]`) and from any whatsit
+/// (`get_font`). It matters because the width is expressed in **ems**, so the
+/// glyph chosen depends entirely on which font supplies the em.
+///
+/// Perl `TeX_Glue.pool.ltxml` L44 reads the *live* `LookupValue('font')` here
+/// instead. In a constructor that is the font at CONSTRUCTION time — i.e. the
+/// one the document happens to end in, since Perl builds only after the whole
+/// document is digested. Appending `\small` before `\end{document}` therefore
+/// changes the space glyph chosen for a skip that occurred pages earlier. Rust
+/// diverges deliberately (OXIDIZED_DESIGN #96): the ambient global made the
+/// result depend on WHEN the build ran, which broke the eager/streaming
+/// byte-identity invariant outright — streaming builds mid-document, so it read
+/// the local font and produced U+2004 where the eager path produced Perl's
+/// U+2009 (guard `streaming_matches_eager_on_cluster_regressions`, fixture
+/// `fancyvrb_fontsize_numbers.tex`).
+///
+/// `None` keeps the old ambient read, and is correct for the DIGEST-time
+/// callers, where `lookup_font()` already IS the digest font.
+pub(crate) fn dimension_to_spaces(dimen: Dimension, font: Option<&Font>) -> String {
+  let fs = match font {
+    Some(f) => f.get_size().unwrap_or(1.0),
+    None => lookup_font().unwrap().get_size().unwrap_or(1.0), // 1 em
+  };
   let mut ems = dimen.pt_value(None) / fs;
   let mut s = String::default();
   for (w, space_char) in UNICODE_EM_SPACES.into_iter().rev() {
@@ -117,7 +140,12 @@ LoadDefinitions!({
       // Without this branch, `\qquad` after `,` lost its `rpadding="20.0pt"`.
       document.insert_element("ltx:XMHint", Vec::new(), Some(map!("width" => length.to_attribute())))?;
     } else {
-      let spaces = dimension_to_spaces(length);
+      // The whatsit's OWN font, not the ambient one — see dimension_to_spaces.
+      let font = match props.get("font") {
+        Some(Stored::Font(f)) => Some(Rc::clone(f)),
+        _ => None,
+      };
+      let spaces = dimension_to_spaces(length, font.as_deref());
       document.absorb_string(&spaces, &SymHashMap::default())?;
     }
   },

--- a/latexml_engine/src/tex_kern.rs
+++ b/latexml_engine/src/tex_kern.rs
@@ -50,7 +50,12 @@ LoadDefinitions!({
       // Add space to document
       // Use the precise Unicode space mapping from tex_glue (matching Perl's TeX_Glue algorithm),
       // not the simple threshold version from base_functions.
-      let spaces = super::tex_glue::dimension_to_spaces(length);
+      // The whatsit's OWN font — see tex_glue::dimension_to_spaces.
+      let font = match props.get("font") {
+        Some(Stored::Font(f)) => Some(Rc::clone(f)),
+        _ => None,
+      };
+      let spaces = super::tex_glue::dimension_to_spaces(length, font.as_deref());
       document.absorb_string(&spaces, &SymHashMap::default())?;
     }
   },

--- a/latexml_engine/src/tex_tables.rs
+++ b/latexml_engine/src/tex_tables.rs
@@ -437,7 +437,12 @@ LoadDefinitions!({
     if let Some(width) = props.get("width") {
       let dim: Option<Dimension> = width.into();
       if let Some(d) = dim {
-        let s = crate::tex_glue::dimension_to_spaces(d);
+        // The whatsit's OWN font — see tex_glue::dimension_to_spaces.
+        let font = match props.get("font") {
+          Some(Stored::Font(f)) => Some(Rc::clone(f)),
+          _ => None,
+        };
+        let s = crate::tex_glue::dimension_to_spaces(d, font.as_deref());
         if !s.is_empty() {
           document.absorb_string(&s, &SymHashMap::default())?;
         }
@@ -1150,7 +1155,9 @@ pub fn extract_alignment_column(
     && skip.value_of() != 0
   {
     let dim = Dimension::new(skip.value_of());
-    let spaces = crate::tex_glue::dimension_to_spaces(dim);
+    // DIGEST time: `lookup_font()` already IS this box's font (it is the very
+    // font the Tbox below is built with), so the ambient read is correct here.
+    let spaces = crate::tex_glue::dimension_to_spaces(dim, None);
     if !spaces.is_empty() {
       let tbox = Tbox {
         text: pin(&spaces),

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -546,3 +546,42 @@ fn cluster_rdfa_math_subject() {
     assert!(x.contains(attr), "missing RDFa attribute {attr}:\n{x}");
   }
 }
+
+/// A faked space's glyph run must be sized by the font the skip was DIGESTED
+/// in, not by whatever font happens to be current when the document is BUILT.
+///
+/// `tex_glue::dimension_to_spaces` expresses a width in **ems** and picks
+/// Unicode space glyphs to match, so the answer depends entirely on which font
+/// supplies the em. Perl `TeX_Glue.pool.ltxml` L44 reads the live
+/// `LookupValue('font')` — inside a constructor that is the font at CONSTRUCTION
+/// time, i.e. whatever the document ends in, since Perl builds only after the
+/// whole document is digested. Appending `\small` before `\end{document}`
+/// therefore changes the glyph chosen for a skip that occurred pages earlier.
+///
+/// That ambient read made the result depend on WHEN the build ran, which broke
+/// the eager/streaming byte-identity invariant outright: streaming builds
+/// mid-document, so it read the local font. Rust now uses the whatsit's own
+/// font (OXIDIZED_DESIGN #96, KNOWN_PERL_ERRORS #74) — deterministic, and the
+/// glyph run finally approximates the true pt width in the font that actually
+/// renders it.
+///
+/// The witness is fancyvrb's line number: the `numbers=left` skip is digested
+/// inside the NUMBER's font (`fontsize="56%"`), while `fontsize=\small` makes
+/// the surrounding verbatim differ from both that and the document default —
+/// three distinct sizes, so every candidate font gives a different answer.
+/// `06_cluster_regressions` fixtures are also swept by
+/// `114_streaming_cluster_regressions`, which is what pins eager == streaming;
+/// this test pins the VALUE, so a future "match Perl here" cannot quietly
+/// restore the ambient read while keeping the sweep green.
+#[test]
+fn faked_space_is_sized_by_the_font_it_was_digested_in() {
+  let xml = convert_to_xml("tests/cluster_regressions/fancyvrb_fontsize_numbers.tex");
+  // Two em-quads + a three-per-em, measured in the 56% line-number font.
+  // Perl 0.8.8 emits `1\u{2003}\u{2009}` here — one em-quad + a thin space,
+  // measured in the document's FINAL font, which is not the font that renders
+  // these glyphs. The divergence is intentional; see the doc comment.
+  assert!(
+    xml.contains("1\u{2003}\u{2003}\u{2004}</text>"),
+    "the line-number skip must be sized by the line-number font:\n{xml}"
+  );
+}

--- a/latexml_oxide/tests/cluster_regressions/fancyvrb_fontsize_numbers.tex
+++ b/latexml_oxide/tests/cluster_regressions/fancyvrb_fontsize_numbers.tex
@@ -1,0 +1,8 @@
+\documentclass{article}
+\usepackage{fancyvrb}
+\begin{document}
+\begin{Verbatim}[fontsize=\small,numbers=left]
+alpha
+beta
+\end{Verbatim}
+\end{document}


### PR DESCRIPTION
**Diagnostic.** `tex_glue::dimension_to_spaces` renders a width as Unicode space glyphs and does the arithmetic in **ems**, but read the live `lookup_font()` (as Perl `TeX_Glue.pool.ltxml` L44 does) from callers that are `DefConstructor`s — i.e. construction time. The eager path builds after all digestion, so that is the font the document *ends* in: appending `\small` before `\end{document}` changes the glyph chosen for a skip pages earlier. Depending on *when* the build ran broke eager/streaming byte-identity — streaming builds mid-document and emitted `U+2004` where eager emitted `U+2009`.

**Approach.** Constructor and whatsit sites (`\hskip`, `\kern`, `\lx@text@intercol`, `digested_to_text`) pass the whatsit's own font; digest-time sites (`\hspace`, `\hglue`, tabskip) keep the ambient read, where `lookup_font()` already *is* the digest font. Also the correct choice, not just the deterministic one: the glyph run approximates a fixed pt width, which only works measured in the font that renders it. Surpass-Perl divergence OXIDIZED_DESIGN #96, Perl-side record KNOWN_PERL_ERRORS #74; the `SYNC_STATUS.md` row #503 filed as untriaged is updated to FIXED here.

**Validation.** Guards `06_cluster_regressions::faked_space_is_sized_by_the_font_it_was_digested_in` (pins the value) and `114_streaming_cluster_regressions::streaming_matches_eager_on_cluster_regressions` (pins eager == streaming; it caught the defect). Rebased on merged #503: full suite **1887/1887, 0 failed** with **zero golden churn** — no existing fixture exercised a skip whose digest font differed from the document's final font. Clippy `-D warnings` clean; fmt applied; Perl 0.8.8 re-checked same-host on the witness and on the `\small`-at-the-end variant that demonstrates the WHEN-dependence.

Found while guarding #500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)