### PR TITLE
test: guard construction-time live-state reads against streaming divergence

### DIFF
--- a/docs/parity/WISDOM.md
+++ b/docs/parity/WISDOM.md
@@ -2960,3 +2960,39 @@ the spill intermediates carried 51.2 % indentation that pass 2 re-parsed into
 ~40 M text nodes and deleted (`spill_flat` now skips both halves; the deleted
 `strip_indentation_whitespace` also orphaned every node it unlinked, the #79
 trap).
+
+## 82. Streaming byte-identity is a MECHANICAL ORACLE for construction-time live-state reads — and the audited class is contained to one fixed site
+
+A `DefConstructor` body runs at CONSTRUCTION (XML-build) time, not digest time.
+The eager path builds after the whole document is digested (so a live
+`lookup_font()`/`lookup_value()` there sees the document's FINAL state); the
+streaming path builds mid-document (sees LOCAL state). **So any constructor-body
+read of mutable STATE that shapes output diverges eager-vs-streaming, and the
+`114_streaming_*::streaming_matches_eager_on_*` sweep catches it — but ONLY where
+a fixture exercises the construct.** #504 (`tex_glue::dimension_to_spaces` sizing
+a faked space off the live font, [OXIDIZED_DESIGN #96]) was found only after a
+fixture was added; the mechanism was blind to it until then. Fixture coverage is
+the gap, not the sweep.
+
+**Audit method (reusable).** Two complementary passes:
+- *Static:* classify every `lookup_font()`/`lookup_value()` call by enclosing
+  scope — a `sub[document, …]` constructor body is a suspect; `properties`/
+  `sizer`/`after_digest`/`getter` closures and `DefPrimitive` bodies are
+  digest-time (live font is CORRECT there); free helper fns need per-caller
+  classification (the dangerous shape is a helper reading live font that is
+  CALLED FROM a constructor — exactly `dimension_to_spaces`). A ~40-line Python
+  walk-back-to-nearest-header script does this in one pass.
+- *Dynamic:* a probe battery — each construction-time-sensitive construct
+  (spacing, `\rule`, `\phantom`, fills, math spacing, `p{}` intercol, `\kern`)
+  followed by a font-size shift (the #504 witness pattern) — run through the
+  sweep, which reports the first diverging byte.
+
+**Finding (2026-08-04).** Of 85 `lookup_font()` sites, ZERO are output-shaping
+reads in a constructor body (the one flagged was a `properties` closure false
+positive). Every other read is digest-time-correct: unit resolution
+(`em_value`/`mu_to_pt`/`convert_unit`), font decode (`decode`/`merge_font`/
+`font_decode`), and colour helpers all inside `DefPrimitive`/`properties`
+bodies. #504's `dimension_to_spaces` was the SOLE instance. Guard:
+`114_streaming_cluster_regressions` over
+`tests/cluster_regressions/streaming_construction_time_spacing.tex` (one fixture
+covering the whole class) + `faked_space_is_sized_by_the_font_it_was_digested_in`.

--- a/latexml_oxide/tests/cluster_regressions/streaming_construction_time_spacing.tex
+++ b/latexml_oxide/tests/cluster_regressions/streaming_construction_time_spacing.tex
@@ -1,0 +1,19 @@
+\documentclass{article}
+\begin{document}
+% text spacing (dimension_to_spaces path — the #504 case, generalized)
+A\hspace{20pt}B \hskip 15pt C \quad D\,E\;F \kern 4pt G
+% a rule and phantoms whose size derives from the current font
+X\rule{2ex}{1ex}Y \hphantom{WWW} \phantom{Z}
+% fill leaders
+one\hfill two\dotfill three\hrulefill four
+% a font shift BEFORE more spacing, so a construction-time read would see it
+{\large L\quad L\hspace{1em}L} M\,M
+% math-mode spacing (→ XMHint width)
+$a\quad b\,c\;d\qquad e$
+% paragraph column + intercol spacing, then a trailing font shift
+\begin{tabular}{p{3cm}l}
+p\quad col & r\hspace{1em}col \\
+\end{tabular}
+\small
+Trailing text after the whole document has shifted to \verb|\small|.
+\end{document}


### PR DESCRIPTION
**Diagnostic.** Follow-up audit of the #504 class: a `DefConstructor` body reading *live* state (font/mode/…) at construction time diverges eager-vs-streaming, because eager builds after full digestion while streaming builds mid-document. The question this PR answers: was `dimension_to_spaces` the only such site, or are there siblings?

**Approach.** Two independent passes (method recorded in WISDOM #82):
- *Static* — of 85 `lookup_font()` sites, **zero** are output-shaping reads in a constructor body (the one flagged was a `properties` closure false-positive). Every other read is digest-time-correct: unit resolution, font decode, and the colour helpers all inside `DefPrimitive`/`properties` bodies. #504's `dimension_to_spaces` was the sole instance.
- *Dynamic* — a probe battery (spacing, `\rule`, `\phantom`, fills, math spacing, `p{}` intercol, `\kern`, each followed by a font shift — the #504 witness pattern) is byte-identical eager-vs-streaming.

Lands the durable half: one consolidated fixture `streaming_construction_time_spacing.tex` so the `114_streaming_cluster_regressions` sweep permanently guards the whole class — fixture coverage being the exact gap that let #504 slip through until a fixture existed.

**Validation.** Full suite **1887/1887**, no code change (the audit found no siblings to fix). Test + docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)