### PR TITLE
fix(sizing): unify the graphicx algebra; fix angle-order, rotation, and PDF object-stream sizing

### DIFF
--- a/latexml_core/Cargo.toml
+++ b/latexml_core/Cargo.toml
@@ -50,6 +50,10 @@ codegen = ["dep:proc-macro2", "dep:quote"]
 token-locators = []
 
 [dependencies]
+# Inflating PDF object streams to reach a page box (`util::image`). Already a
+# direct dependency of latexml_engine / latexml_post / latexml_oxide, so this
+# adds no crate to the tree.
+flate2 = "1"
 once_cell = "1.17.0"
 # Trimmed regex unicode features — see DEP-10 note in
 # latexml_codegen/Cargo.toml. Same set across the workspace.

--- a/latexml_core/src/util/image.rs
+++ b/latexml_core/src/util/image.rs
@@ -234,9 +234,17 @@ pub fn to_bp(x: &str) -> f64 {
 
 /// Compile a graphicx option string into the transformation sequence.
 ///
-/// Port of Perl `image_graphicx_parse` (`Util/Image.pm` L142-196). The order
-/// matters and is Perl's: rotation comes **before** scaling when no sizing
-/// option was given at all (`$rotfirst`), and after it otherwise.
+/// Port of Perl `image_graphicx_parse` (`Util/Image.pm` L142-196). Key order
+/// matters and is Perl's, in two ways:
+///
+/// * A rotation is applied **before** scaling when no sizing option preceded
+///   the `angle` in the source string, and after it otherwise. Perl decides
+///   this the instant it parses `angle` (`$rotfirst = !($width || $height ||
+///   $xscale || $yscale)`, L168), from the keys seen *so far* — so
+///   `angle=90,width=100pt` rotates then scales, while `width=100pt,angle=90`
+///   scales then rotates. graphicx really behaves this way and pdflatex agrees:
+///   the first is ~100x200, the second ~50x100 for a 200x100 source. We capture
+///   `rot_first` at the same point, not from the final key set.
 ///
 /// `pc` differs from Perl by design: Perl's table has `pc => 12/72.27`, which
 /// is 12 *TeX pt* expressed in bp only if you also drop the pt→bp step — a pica
@@ -248,6 +256,9 @@ pub fn parse_graphicx_options(options: &str) -> Vec<GraphicxOp> {
   let (mut xscale, mut yscale) = (None, None);
   let (mut aspect, mut angle, mut page) = (false, 0.0f64, None);
   let (mut viewport, mut is_trim) = (None, false);
+  // Set the instant `angle` is parsed, from the sizing keys seen so far — NOT
+  // recomputed from the final key set. Perl `image_graphicx_parse` L168.
+  let mut rot_first = false;
   for opt in options.split(',') {
     let opt = opt.trim();
     if opt.is_empty() {
@@ -275,7 +286,10 @@ pub fn parse_graphicx_options(options: &str) -> Vec<GraphicxOp> {
       },
       "xscale" => xscale = val.parse::<f64>().ok(),
       "yscale" => yscale = val.parse::<f64>().ok(),
-      "angle" => angle = val.parse::<f64>().unwrap_or(0.0),
+      "angle" => {
+        angle = val.parse::<f64>().unwrap_or(0.0);
+        rot_first = width.is_none() && height.is_none() && xscale.is_none() && yscale.is_none();
+      },
       "keepaspectratio" => aspect = val != "false",
       "page" => page = val.parse::<u32>().ok(),
       "viewport" => {
@@ -289,8 +303,6 @@ pub fn parse_graphicx_options(options: &str) -> Vec<GraphicxOp> {
       _ => {},
     }
   }
-  // Perl L168: rotation precedes scaling only when nothing sizes the image.
-  let rot_first = width.is_none() && height.is_none() && xscale.is_none() && yscale.is_none();
 
   let mut ops = Vec::new();
   if let Some(p) = page {
@@ -1407,6 +1419,47 @@ mod sizing_characterization_tests {
     // keeps whatever the pixel reader gave it.
     let png = fixture("n.png", &png_header(200, 100));
     assert_eq!(natural_size_pt(&png), None);
+  }
+
+  /// The compiled op *sequence* depends on where `angle` sits relative to the
+  /// sizing keys — the ordering graphicx and pdflatex both honour. Pinned at the
+  /// parse layer so the rule is guarded without a rasterizer: `angle` before a
+  /// sizing key rotates first, after it rotates last, and a rotation with no
+  /// sizing key at all rotates first.
+  #[test]
+  fn parse_orders_rotation_by_key_position() {
+    use GraphicxOp::*;
+    let w100 = ScaleTo {
+      w:           Some(to_bp("100pt")),
+      h:           None,
+      keep_aspect: true,
+    };
+    assert_eq!(
+      parse_graphicx_options("angle=90,width=100pt"),
+      vec![Rotate(90.0), w100.clone()],
+      "angle first -> rotate then scale"
+    );
+    assert_eq!(
+      parse_graphicx_options("width=100pt,angle=90"),
+      vec![w100, Rotate(90.0)],
+      "width first -> scale then rotate"
+    );
+    assert_eq!(
+      parse_graphicx_options("angle=90"),
+      vec![Rotate(90.0)],
+      "no sizing key -> rotate first (trivially)"
+    );
+    // scale is a sizing key too, so it flips the order the same way.
+    assert_eq!(
+      parse_graphicx_options("angle=90,scale=2")[0],
+      Rotate(90.0),
+      "angle before scale -> rotate first"
+    );
+    assert_eq!(
+      parse_graphicx_options("scale=2,angle=90")[1],
+      Rotate(90.0),
+      "angle after scale -> rotate last"
+    );
   }
 
   // ── layer 3a: the pt-space algebra (fallback branch) ──────────────────

--- a/latexml_core/src/util/image.rs
+++ b/latexml_core/src/util/image.rs
@@ -160,6 +160,279 @@ pub fn image_candidates(path: &str) -> String {
   candidates.join(",")
 }
 
+/// One graphicx transformation, as compiled from the option string.
+///
+/// Port of the `@transform` list Perl `image_graphicx_parse` builds
+/// (`Util/Image.pm` L142-196). Lengths are in **bp**, the unit `to_bp` yields,
+/// and angles in degrees counter-clockwise, as graphicx states them.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GraphicxOp {
+  /// `page=N` — which page of a multi-page source to take.
+  Page(u32),
+  /// `trim=l b r t` — amounts to remove from each edge.
+  Trim {
+    l: f64,
+    b: f64,
+    r: f64,
+    t: f64,
+  },
+  /// `viewport=llx lly urx ury` — an absolute box (Perl's `clip` op).
+  Clip {
+    l: f64,
+    b: f64,
+    r: f64,
+    t: f64,
+  },
+  /// `angle=N`, counter-clockwise.
+  Rotate(f64),
+  Reflect,
+  /// `scale=`/`xscale=`/`yscale=`.
+  Scale {
+    x: f64,
+    y: f64,
+  },
+  /// `width=`/`height=`/`totalheight=`. A dimension left `None` is derived
+  /// from the other through the aspect ratio; Perl spells that as a 999999
+  /// sentinel with `keep_aspect` forced on (L188-189).
+  ScaleTo {
+    w:           Option<f64>,
+    h:           Option<f64>,
+    keep_aspect: bool,
+  },
+}
+
+/// A TeX/graphicx length in **bp**. Port of Perl `to_bp` + `%BP_conversions`
+/// (`Util/Image.pm` L198-210), including its `true`-prefix strip (`truept`) and
+/// its "unknown unit counts as bp" fallback. A value that is not a length at
+/// all yields 1, exactly as Perl's `else { return 1 }` does.
+pub fn to_bp(x: &str) -> f64 {
+  let x = x.trim();
+  let split = x
+    .find(|c: char| !c.is_ascii_digit() && c != '.' && c != '+' && c != '-')
+    .unwrap_or(x.len());
+  let (num, unit) = x.split_at(split);
+  let Ok(v) = num.parse::<f64>() else {
+    return 1.0;
+  };
+  let unit = unit.trim().strip_prefix("true").unwrap_or(unit.trim());
+  let factor = match unit {
+    "" | "bp" => 1.0,
+    "pt" => 72.0 / 72.27,
+    "pc" => 12.0 * 72.0 / 72.27,
+    "in" => 72.0,
+    "cm" => 72.0 / 2.54,
+    "mm" => 72.0 / 25.4,
+    "dd" => (72.0 / 72.27) * (1238.0 / 1157.0),
+    "cc" => 12.0 * (72.0 / 72.27) * (1238.0 / 1157.0),
+    "sp" => 72.0 / 72.27 / 65536.0,
+    // Perl: `($u && $BP_conversions{$u}) || 1` — an unrecognised unit falls
+    // back to a factor of 1, i.e. the number is taken as bp.
+    _ => 1.0,
+  };
+  v * factor
+}
+
+/// Compile a graphicx option string into the transformation sequence.
+///
+/// Port of Perl `image_graphicx_parse` (`Util/Image.pm` L142-196). The order
+/// matters and is Perl's: rotation comes **before** scaling when no sizing
+/// option was given at all (`$rotfirst`), and after it otherwise.
+///
+/// `pc` differs from Perl by design: Perl's table has `pc => 12/72.27`, which
+/// is 12 *TeX pt* expressed in bp only if you also drop the pt→bp step — a pica
+/// is 12 pt, so the factor is `12 * 72/72.27`. Perl's value makes a 1pc box
+/// 0.166bp instead of 11.955bp. Ours is the correct one; no test in the corpus
+/// exercised `pc`.
+pub fn parse_graphicx_options(options: &str) -> Vec<GraphicxOp> {
+  let (mut width, mut height) = (None, None);
+  let (mut xscale, mut yscale) = (None, None);
+  let (mut aspect, mut angle, mut page) = (false, 0.0f64, None);
+  let (mut viewport, mut is_trim) = (None, false);
+  for opt in options.split(',') {
+    let opt = opt.trim();
+    if opt.is_empty() {
+      continue;
+    }
+    let (key, val) = match opt.split_once('=') {
+      Some((k, v)) => (k.trim(), v.trim()),
+      None => (opt, ""),
+    };
+    let box4 = |v: &str| {
+      let n: Vec<f64> = v.split_whitespace().map(to_bp).collect();
+      if n.len() == 4 {
+        Some((n[0], n[1], n[2], n[3]))
+      } else {
+        None
+      }
+    };
+    match key {
+      "width" => width = Some(to_bp(val)),
+      "height" | "totalheight" => height = Some(to_bp(val)),
+      "scale" => {
+        let s = val.parse::<f64>().ok();
+        xscale = s;
+        yscale = s;
+      },
+      "xscale" => xscale = val.parse::<f64>().ok(),
+      "yscale" => yscale = val.parse::<f64>().ok(),
+      "angle" => angle = val.parse::<f64>().unwrap_or(0.0),
+      "keepaspectratio" => aspect = val != "false",
+      "page" => page = val.parse::<u32>().ok(),
+      "viewport" => {
+        viewport = box4(val);
+        is_trim = false;
+      },
+      "trim" => {
+        viewport = box4(val);
+        is_trim = true;
+      },
+      _ => {},
+    }
+  }
+  // Perl L168: rotation precedes scaling only when nothing sizes the image.
+  let rot_first = width.is_none() && height.is_none() && xscale.is_none() && yscale.is_none();
+
+  let mut ops = Vec::new();
+  if let Some(p) = page {
+    ops.push(GraphicxOp::Page(p));
+  }
+  if let Some((a, b, c, d)) = viewport {
+    ops.push(if is_trim {
+      GraphicxOp::Trim { l: a, b, r: c, t: d }
+    } else {
+      GraphicxOp::Clip { l: a, b, r: c, t: d }
+    });
+  }
+  if rot_first && angle != 0.0 {
+    ops.push(GraphicxOp::Rotate(angle));
+  }
+  match (width, height, xscale, yscale) {
+    // Perl L187-189: a single dimension forces aspect preservation, whatever
+    // `keepaspectratio` said.
+    (Some(w), Some(h), ..) => ops.push(GraphicxOp::ScaleTo {
+      w:           Some(w),
+      h:           Some(h),
+      keep_aspect: aspect,
+    }),
+    (Some(w), None, ..) => ops.push(GraphicxOp::ScaleTo {
+      w:           Some(w),
+      h:           None,
+      keep_aspect: true,
+    }),
+    (None, Some(h), ..) => ops.push(GraphicxOp::ScaleTo {
+      w:           None,
+      h:           Some(h),
+      keep_aspect: true,
+    }),
+    (None, None, Some(x), Some(y)) => ops.push(GraphicxOp::Scale { x, y }),
+    (None, None, Some(x), None) => ops.push(GraphicxOp::Scale { x, y: 1.0 }),
+    (None, None, None, Some(y)) => ops.push(GraphicxOp::Scale { x: 1.0, y }),
+    (None, None, None, None) => {},
+  }
+  if !rot_first && angle != 0.0 {
+    ops.push(GraphicxOp::Rotate(angle));
+  }
+  ops
+}
+
+/// Apply a compiled transformation sequence to a natural size.
+///
+/// Port of Perl `image_graphicx_size` (`Util/Image.pm` L221-256), generalised
+/// over the output unit so the engine and the post-processor share one algebra:
+///
+/// * `units_per_bp` scales a bp-valued option into the caller's unit —
+///   `DPI/72.27` for device pixels (Perl's `$dppt`), `72.27/72` for TeX pt.
+/// * `quantize` applies Perl's `ceil` at each sizing step. True in pixel space,
+///   where a fractional device pixel is meaningless; false in pt space, where
+///   rounding the box to 1/100 inch would be a needless loss of precision.
+///
+/// `Page` is a selector, not a geometric transform, so it is skipped here —
+/// callers read it out separately.
+pub fn apply_graphicx_ops(
+  mut w: f64,
+  mut h: f64,
+  ops: &[GraphicxOp],
+  units_per_bp: f64,
+  quantize: bool,
+) -> (f64, f64) {
+  let round = |v: f64| if quantize { v.ceil() } else { v };
+  for op in ops {
+    match *op {
+      GraphicxOp::Page(_) | GraphicxOp::Reflect => {},
+      GraphicxOp::Scale { x, y } => {
+        w = round(w * x);
+        h = round(h * y);
+      },
+      GraphicxOp::ScaleTo { w: rw, h: rh, keep_aspect } => {
+        let (tw, th) = (rw.map(|v| v * units_per_bp), rh.map(|v| v * units_per_bp));
+        match (tw, th) {
+          (Some(tw), Some(th)) if keep_aspect => {
+            // Perl L234 `return unless $w && $h` — a degenerate natural size
+            // carries no aspect ratio to preserve, and Perl abandons the whole
+            // computation rather than guess. The sizer then reports 0.
+            if w <= 0.0 || h <= 0.0 {
+              return (0.0, 0.0);
+            }
+            // Perl L233-236: honour the less extreme request, so the result
+            // fits inside the requested box.
+            if tw / w < th / h {
+              h = h * tw / w;
+              w = tw;
+            } else {
+              w = w * th / h;
+              h = th;
+            }
+            w = round(w);
+            h = round(h);
+          },
+          (Some(tw), Some(th)) => {
+            w = round(tw);
+            h = round(th);
+          },
+          // A single dimension always preserves aspect (Perl compiles it as a
+          // scale-to with a 999999 sentinel and `keep_aspect` forced on), so
+          // the same degenerate-size bail applies.
+          (Some(tw), None) => {
+            if w <= 0.0 || h <= 0.0 {
+              return (0.0, 0.0);
+            }
+            h = round(h * tw / w);
+            w = round(tw);
+          },
+          (None, Some(th)) => {
+            if w <= 0.0 || h <= 0.0 {
+              return (0.0, 0.0);
+            }
+            w = round(w * th / h);
+            h = round(th);
+          },
+          (None, None) => {},
+        }
+      },
+      GraphicxOp::Rotate(deg) => {
+        // Perl L239-242: `$rad = -$a1 * pi/180`, then the axis-aligned bounding
+        // box of the rotated rectangle. Not quantized — Perl does not ceil here.
+        let rad = -deg * std::f64::consts::PI / 180.0;
+        let (s, c) = (rad.sin(), rad.cos());
+        let (nw, nh) = ((w * c).abs() + (h * s).abs(), (w * s).abs() + (h * c).abs());
+        w = nw;
+        h = nh;
+      },
+      GraphicxOp::Trim { l, b, r, t } => {
+        // Perl L248-250: shrink by the trimmed edges.
+        w = round(w - (l + r) * units_per_bp);
+        h = round(h - (t + b) * units_per_bp);
+      },
+      GraphicxOp::Clip { l, b, r, t } => {
+        // Perl L252-253: the viewport box IS the new extent.
+        w = round((r - l) * units_per_bp);
+        h = round((t - b) * units_per_bp);
+      },
+    }
+  }
+  (w.max(0.0), h.max(0.0))
+}
+
 /// Perl: `image_graphicx_sizer($whatsit)` (Util::Image L259-272).
 ///
 /// Reads image dimensions from `candidates`, applies the `options` string
@@ -260,89 +533,15 @@ pub fn image_graphicx_sizer(whatsit: &mut Whatsit) {
 
   // Apply graphicx options (height, width, scale, keepaspectratio)
   // Perl: image_graphicx_size applies parsed transformations
-  let dppt = dpi / 72.27; // dots per point
-  let mut w = img_w;
-  let mut h = img_h;
-
-  // Parse options string for simple cases
-  // Perl: image_graphicx_parse uses to_bp() to convert dimensions to big points (1/72 inch)
-  let mut req_w: Option<f64> = None; // in bp (big points)
-  let mut req_h: Option<f64> = None; // in bp
-  let mut keep_ratio = false;
-  let mut scale: Option<f64> = None;
-
-  for opt in options.split(',') {
-    let opt = opt.trim();
-    if let Some(val) = opt.strip_prefix("width=") {
-      if let Ok(dim) = <Dimension as std::str::FromStr>::from_str(val.trim()) {
-        // to_bp: convert pt to bp (1bp = 1/72 inch, 1pt = 1/72.27 inch)
-        req_w = Some(dim.value_of() as f64 / 65536.0 * 72.0 / 72.27);
-      }
-    } else if let Some(val) = opt.strip_prefix("height=") {
-      if let Ok(dim) = <Dimension as std::str::FromStr>::from_str(val.trim()) {
-        req_h = Some(dim.value_of() as f64 / 65536.0 * 72.0 / 72.27);
-      }
-    } else if let Some(val) = opt.strip_prefix("totalheight=") {
-      if let Ok(dim) = <Dimension as std::str::FromStr>::from_str(val.trim()) {
-        req_h = Some(dim.value_of() as f64 / 65536.0 * 72.0 / 72.27);
-      }
-    } else if opt.starts_with("keepaspectratio") {
-      keep_ratio = true;
-    } else if let Some(val) = opt.strip_prefix("scale=") {
-      scale = val.trim().parse::<f64>().ok();
-    }
-  }
-
-  // Apply transformations (matching Perl image_graphicx_size logic)
-  if let Some(s) = scale {
-    w = (w * s).ceil();
-    h = (h * s).ceil();
-  }
-  if req_w.is_some() || req_h.is_some() {
-    let target_w = req_w.map(|rw| rw * dppt);
-    let target_h = req_h.map(|rh| rh * dppt);
-    if keep_ratio {
-      match (target_w, target_h) {
-        (Some(tw), Some(th)) => {
-          // Both specified with keepaspectratio: use the more restrictive
-          if w > 0.0 && h > 0.0 {
-            if tw / w < th / h {
-              let th2 = h * tw / w;
-              w = tw;
-              h = th2;
-            } else {
-              let tw2 = w * th / h;
-              w = tw2;
-              h = th;
-            }
-          }
-        },
-        (Some(tw), None) => {
-          if w > 0.0 {
-            h = h * tw / w;
-            w = tw;
-          }
-        },
-        (None, Some(th)) => {
-          if h > 0.0 {
-            w = w * th / h;
-            h = th;
-          }
-        },
-        (None, None) => {},
-      }
-    } else {
-      if let Some(tw) = target_w {
-        w = tw;
-      }
-      if let Some(th) = target_h {
-        h = th;
-      }
-    }
-  }
-  // Perl: ceil pixel dimensions after applying transforms
-  w = w.ceil();
-  h = h.ceil();
+  // Perl `image_graphicx_size` (Util/Image.pm L221-256) works in device pixels
+  // with `$dppt = DPI/72.27`, and derives the box from it at L271.
+  let (w, h) = apply_graphicx_ops(
+    img_w,
+    img_h,
+    &parse_graphicx_options(&options),
+    dpi / 72.27,
+    true,
+  );
 
   // Convert pixel dimensions back to points, then to scaled points (sp)
   let width_pt = w * 72.27 / dpi;
@@ -507,47 +706,17 @@ fn pt_to_dim(pt: f64) -> Dimension { Dimension::new((pt * 65536.0).round() as i6
 /// `\the\wd` under pdflatex: an explicit `width=` sets the box width outright,
 /// the natural size only supplying the missing dimension via the aspect ratio.
 fn graphicx_box_pt(nw: f64, nh: f64, options: &str) -> (Dimension, Dimension) {
-  let dim_pt = |v: &str| {
-    <Dimension as std::str::FromStr>::from_str(v.trim())
-      .ok()
-      .map(|d| d.value_of() as f64 / 65536.0)
-  };
-  let (mut w_opt, mut h_opt, mut scale, mut keep) = (None, None, None, false);
-  for opt in options.split(',') {
-    let opt = opt.trim();
-    if let Some(v) = opt.strip_prefix("width=") {
-      w_opt = dim_pt(v);
-    } else if let Some(v) = opt.strip_prefix("height=") {
-      h_opt = dim_pt(v);
-    } else if let Some(v) = opt.strip_prefix("totalheight=") {
-      h_opt = dim_pt(v);
-    } else if let Some(v) = opt.strip_prefix("scale=") {
-      scale = v.trim().parse::<f64>().ok();
-    } else if opt.starts_with("keepaspectratio") {
-      keep = true;
-    }
-  }
-  let (bw, bh) = match (w_opt, h_opt) {
-    (Some(w), Some(h)) => {
-      // Both requested: `keepaspectratio` fits within the box, dropping the more
-      // extreme request (Perl `image_graphicx_size` scale-to, a3 branch).
-      if keep && nw > 0.0 && nh > 0.0 {
-        if w / nw < h / nh {
-          (w, nh * w / nw)
-        } else {
-          (nw * h / nh, h)
-        }
-      } else {
-        (w, h)
-      }
-    },
-    (Some(w), None) => (w, if nw > 0.0 { nh * w / nw } else { 0.0 }),
-    (None, Some(h)) => (if nh > 0.0 { nw * h / nh } else { 0.0 }, h),
-    (None, None) => match scale {
-      Some(s) => (nw * s, nh * s),
-      None => (nw, nh),
-    },
-  };
+  // The same algebra as the pixel branch, in pt and without quantization:
+  // options arrive in bp, and 1bp = 72.27/72 pt. Rounding a typeset box to a
+  // whole device pixel — which is what the pixel branch's `ceil` amounts to —
+  // would throw away four digits of a TeX dimension for nothing.
+  let (bw, bh) = apply_graphicx_ops(
+    nw,
+    nh,
+    &parse_graphicx_options(options),
+    72.27 / 72.0,
+    false,
+  );
   (pt_to_dim(bw), pt_to_dim(bh))
 }
 
@@ -1193,9 +1362,11 @@ mod sizing_characterization_tests {
     );
     // Units other than pt parse through `Dimension::from_str`.
     near(case("width=1in"), (72.27, 36.135), "in parses");
-    // A degenerate natural size cannot supply the missing dimension.
+    // A degenerate natural size carries no aspect ratio, and a lone `width=`
+    // always wants one — Perl abandons the computation rather than guess
+    // (`Util/Image.pm` L234), reporting nothing, i.e. a zero box.
     let (w, h) = graphicx_box_pt(0.0, 0.0, "width=100pt");
-    near((pt(w), pt(h)), (100.0, 0.0), "zero natural height");
+    near((pt(w), pt(h)), (0.0, 0.0), "zero natural height");
   }
 
   // ── layer 3b: the px-space algebra, and the whole seam ────────────────
@@ -1230,15 +1401,17 @@ mod sizing_characterization_tests {
   ///   `graphicx_box_pt` fallback. They answer `width=100pt` differently:
   ///   99.7326 vs 100.0, because the px branch quantizes the box to a whole
   ///   device pixel (100pt -> 99.6265bp -> 137.848 px -> ceil 138 -> 99.7326pt).
-  /// * **They also disagree on aspect.** Bare `width=100pt` leaves the height
-  ///   at its natural value on the px branch (72.27) but scales it on the pt
-  ///   branch (50.0). Real documents rarely see this: `graphicx_sty` injects
-  ///   `keepaspectratio=true` for a single-dimension request, which is the row
-  ///   above it. It is pinned because it is a live divergence, not because it
-  ///   is reachable from ordinary LaTeX.
-  /// * **`angle=` never affects the box** on either branch — neither algebra
-  ///   implements the rotate op, so a rotated figure reserves its unrotated
-  ///   width. pdflatex swaps the dimensions.
+  /// * **A single dimension always preserves aspect**, on both branches, as
+  ///   Perl does by compiling `width=` alone into a scale-to with a 999999
+  ///   sentinel and `keep_aspect` forced on (`Util/Image.pm` L188-189). Until
+  ///   2026-08-04 the px branch left the height at its natural value; the
+  ///   `keepaspectratio=true` that `graphicx_sty` injects had been hiding it
+  ///   from ordinary LaTeX.
+  /// * **`angle=` rotates the reserved box** (Perl L238-242). Until 2026-08-04
+  ///   neither branch implemented the op, so a sideways figure reserved its
+  ///   unrotated width — a Rust-only gap, since Perl has always rotated:
+  ///   measured `angle=90` on the PNG gives Perl 72.27 x 144.54, and that is
+  ///   now what this matrix pins.
   /// * **The last-resort branch** (unreadable page box) honours an explicit
   ///   `width=`/`height=` and reports 0 for the dimension not asked for.
   #[test]
@@ -1258,20 +1431,20 @@ mod sizing_characterization_tests {
       // px-space branch: raster pixels, and an EPS BoundingBox read as pixels.
       ("png", "",                                 144.5400,  72.2700),
       ("png", "width=100pt,keepaspectratio=true",  99.7326,  49.8663),
-      ("png", "width=100pt",                       99.7326,  72.2700),
+      ("png", "width=100pt",                       99.7326,  49.8663),
       ("png", "scale=0.5",                         72.2700,  36.1350),
       ("png", "height=25pt,keepaspectratio=true",  49.8663,  25.2945),
       ("png", "width=100pt,height=80pt",           99.7326,  80.2197),
       ("png", "width=1in,keepaspectratio=true",    72.2700,  36.1350),
-      ("png", "angle=90",                         144.5400,  72.2700),
+      ("png", "angle=90",                          72.2700, 144.5400),
       ("eps", "",                                 144.5400,  72.2700),
       ("eps", "width=100pt,keepaspectratio=true",  99.7326,  49.8663),
-      ("eps", "width=100pt",                       99.7326,  72.2700),
+      ("eps", "width=100pt",                       99.7326,  49.8663),
       ("eps", "scale=0.5",                         72.2700,  36.1350),
       ("eps", "height=25pt,keepaspectratio=true",  49.8663,  25.2945),
       ("eps", "width=100pt,height=80pt",           99.7326,  80.2197),
       ("eps", "width=1in,keepaspectratio=true",    72.2700,  36.1350),
-      ("eps", "angle=90",                         144.5400,  72.2700),
+      ("eps", "angle=90",                          72.2700, 144.5400),
       // pt-space branch: the `natural_size_pt` fallback, no quantization.
       ("pdf", "",                                 200.7500, 100.3750),
       ("pdf", "width=100pt,keepaspectratio=true", 100.0000,  50.0000),
@@ -1280,7 +1453,7 @@ mod sizing_characterization_tests {
       ("pdf", "height=25pt,keepaspectratio=true",  50.0000,  25.0000),
       ("pdf", "width=100pt,height=80pt",          100.0000,  80.0000),
       ("pdf", "width=1in,keepaspectratio=true",    72.2700,  36.1350),
-      ("pdf", "angle=90",                         200.7500, 100.3750),
+      ("pdf", "angle=90",                         100.3750, 200.7500),
       ("svg", "",                                 150.5625,  75.2812),
       ("svg", "width=100pt,keepaspectratio=true", 100.0000,  50.0000),
       ("svg", "width=100pt",                      100.0000,  50.0000),
@@ -1288,7 +1461,7 @@ mod sizing_characterization_tests {
       ("svg", "height=25pt,keepaspectratio=true",  50.0000,  25.0000),
       ("svg", "width=100pt,height=80pt",          100.0000,  80.0000),
       ("svg", "width=1in,keepaspectratio=true",    72.2700,  36.1350),
-      ("svg", "angle=90",                         150.5625,  75.2812),
+      ("svg", "angle=90",                          75.2812, 150.5625),
       // last resort: nothing measurable, only an explicit request is honoured.
       ("objstm", "",                                0.0000,   0.0000),
       ("objstm", "width=100pt,keepaspectratio=true", 100.0000, 0.0000),
@@ -1300,6 +1473,10 @@ mod sizing_characterization_tests {
       ("objstm", "angle=90",                         0.0000,   0.0000),
     ];
 
+    // Report EVERY divergence, not just the first: when this matrix moves it is
+    // usually because a shared rule changed, and the whole delta is the useful
+    // signal.
+    let mut deltas = Vec::new();
     for (src, opts, want_w, want_h) in matrix {
       let path = match *src {
         "png" => &png,
@@ -1311,10 +1488,18 @@ mod sizing_characterization_tests {
       let (w, h) = sizer_pt(path, opts);
       // 1e-3 pt is ~1/70000 inch: far tighter than any behaviour change, loose
       // enough to survive `Dimension`'s fixed-point round trip.
-      assert!(
-        (w - want_w).abs() < 1e-3 && (h - want_h).abs() < 1e-3,
-        "{src} [{opts}]: got ({w:.4}, {h:.4}), pinned ({want_w:.4}, {want_h:.4})"
-      );
+      if (w - want_w).abs() >= 1e-3 || (h - want_h).abs() >= 1e-3 {
+        deltas.push(format!(
+          "  {src:<7} [{opts}]\n      pinned ({want_w:.4}, {want_h:.4})  got ({w:.4}, {h:.4})"
+        ));
+      }
     }
+    assert!(
+      deltas.is_empty(),
+      "{} of {} pinned rows moved:\n{}",
+      deltas.len(),
+      matrix.len(),
+      deltas.join("\n")
+    );
   }
 }

--- a/latexml_core/src/util/image.rs
+++ b/latexml_core/src/util/image.rs
@@ -970,3 +970,351 @@ mod svg_geometry_tests {
     }
   }
 }
+
+/// Characterization tests for the engine-side image sizing pipeline.
+///
+/// **These pin behaviour, not correctness.** Several of the numbers below are
+/// known to disagree with pdflatex — an EPS BoundingBox is read as pixels, a
+/// PNG is assumed to be 100 dpi, an SVG 96 dpi, and a box is quantized to whole
+/// device pixels. They are recorded exactly as they are today so that the
+/// planned unification of the sizing pipeline (one probe, one resolution
+/// policy, one graphicx algebra) has to declare every change it makes instead
+/// of drifting silently. When a value here changes, that is a decision, and the
+/// comment above it says which way the current number leans.
+///
+/// Measured references, same 200x100 figure in each format, `\the\wd0` with no
+/// graphicx options, recorded 2026-08-04:
+///
+/// | source              | pdflatex   | Perl LaTeXML | here       |
+/// |---------------------|------------|--------------|------------|
+/// | PNG 200x100 px      | 200.7495pt | 144.54pt     | 144.54pt   |
+/// | EPS BBox 200x100 bp | -          | (no sizer)   | 144.54pt   |
+/// | PDF 200x100 bp      | 200.7495pt | (no sizer)   | 200.75pt   |
+/// | SVG viewBox 200x100 | -          | (no sizer)   | 150.5625pt |
+#[cfg(test)]
+mod sizing_characterization_tests {
+  use super::*;
+
+  fn fixture(name: &str, bytes: &[u8]) -> PathBuf {
+    let path = std::env::temp_dir().join(format!("lxsize-{}-{name}", std::process::id()));
+    std::fs::write(&path, bytes).expect("write fixture");
+    path
+  }
+
+  /// A PNG header with the given IHDR dimensions. `read_image_dimensions` reads
+  /// a fixed 32-byte prefix and takes bytes 16..24 as width/height, so an
+  /// honest signature + IHDR is the whole contract; no CRC is consulted.
+  fn png_header(w: u32, h: u32) -> Vec<u8> {
+    let mut v = vec![0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
+    v.extend_from_slice(&13u32.to_be_bytes());
+    v.extend_from_slice(b"IHDR");
+    v.extend_from_slice(&w.to_be_bytes());
+    v.extend_from_slice(&h.to_be_bytes());
+    v.extend_from_slice(&[0x08, 0x02, 0x00, 0x00, 0x00]);
+    v.extend_from_slice(&[0u8; 16]); // pad past the 32-byte read_exact
+    v
+  }
+
+  /// A JPEG with a single SOF0 frame header. The reader scans markers for
+  /// 0xC0..=0xCF (minus DHT/JPG/DAC) and takes height then width, big-endian.
+  fn jpeg_header(w: u16, h: u16) -> Vec<u8> {
+    let mut v = vec![0xFF, 0xD8, 0xFF, 0xC0, 0x00, 0x11, 0x08];
+    v.extend_from_slice(&h.to_be_bytes());
+    v.extend_from_slice(&w.to_be_bytes());
+    v.extend_from_slice(&[0x03, 0x01, 0x22, 0x00, 0x02, 0x11, 0x01, 0x03, 0x11, 0x01]);
+    v.extend_from_slice(&[0xFF, 0xD9]);
+    v.extend_from_slice(&[0u8; 16]);
+    v
+  }
+
+  // ── layer 1: what each format probe returns, and in which unit ────────
+
+  /// PNG and JPEG report true device pixels; EPS reports **bp** through the
+  /// same `(u32, u32)` channel. Nothing in the type distinguishes them, which
+  /// is the defect the unification is meant to remove — pinned here so the
+  /// removal is visible.
+  #[test]
+  fn read_image_dimensions_returns_pixels_for_raster_and_bp_for_eps() {
+    let png = fixture("dims.png", &png_header(200, 100));
+    assert_eq!(read_image_dimensions(&png), Some((200, 100)), "PNG IHDR px");
+
+    let jpg = fixture("dims.jpg", &jpeg_header(640, 480));
+    assert_eq!(read_image_dimensions(&jpg), Some((640, 480)), "JPEG SOF px");
+
+    // 200 x 100 **bp**, handed back as if it were 200 x 100 pixels.
+    let eps = fixture(
+      "dims.eps",
+      b"%!PS-Adobe-3.0 EPSF-3.0\n%%BoundingBox: 0 0 200 100\n%%EndComments\n",
+    );
+    assert_eq!(
+      read_image_dimensions(&eps),
+      Some((200, 100)),
+      "EPS bp-as-px"
+    );
+
+    // HiResBoundingBox wins over BoundingBox when both are present.
+    let hires = fixture(
+      "hires.eps",
+      b"%!PS-Adobe-3.0 EPSF-3.0\n%%BoundingBox: 0 0 200 100\n\
+        %%HiResBoundingBox: 0 0 199.5 99.4\n%%EndComments\n",
+    );
+    assert_eq!(
+      read_image_dimensions(&hires),
+      Some((200, 99)),
+      "HiRes wins, rounded"
+    );
+
+    // Formats this reader does not know stay `None` — that is what routes a
+    // PDF or an SVG to the `natural_size_pt` fallback.
+    let pdf = fixture(
+      "dims1.pdf",
+      b"%PDF-1.4\n1 0 obj\n<< /MediaBox [0 0 200 100] >>\nendobj\n",
+    );
+    assert_eq!(
+      read_image_dimensions(&pdf),
+      None,
+      "PDF is not this reader's job"
+    );
+  }
+
+  /// The PDF page box: CropBox is pdfTeX's default and wins over MediaBox; a
+  /// box that is not visible in the plaintext bytes yields `None`.
+  ///
+  /// That last case is not hypothetical. Across 14 real PDFs in this repo, 5
+  /// returned `None` here, correlating exactly with `ObjStm` (object-stream)
+  /// compression — the default for `%PDF-1.5` and later, which is what modern
+  /// pdflatex emits. Those figures reach the engine with a 0x0 natural box.
+  #[test]
+  fn read_pdf_page_box_prefers_cropbox_and_gives_up_on_compressed_objects() {
+    let media = fixture("m.pdf", b"%PDF-1.4\n<< /MediaBox [0 0 200 100] >>\n");
+    assert_eq!(read_pdf_page_box(&media), Some((200.0, 100.0)));
+
+    let both = fixture(
+      "b.pdf",
+      b"%PDF-1.4\n<< /MediaBox [0 0 612 792] /CropBox [0 0 200 100] >>\n",
+    );
+    assert_eq!(
+      read_pdf_page_box(&both),
+      Some((200.0, 100.0)),
+      "CropBox wins"
+    );
+
+    // Non-zero origin: the box is the extent, not the corner.
+    let offset = fixture("o.pdf", b"%PDF-1.4\n<< /MediaBox [10 20 210 120] >>\n");
+    assert_eq!(read_pdf_page_box(&offset), Some((200.0, 100.0)));
+
+    // No plaintext box — the object-stream case.
+    let hidden = fixture(
+      "h.pdf",
+      b"%PDF-1.5\n<< /Type /ObjStm /N 12 >>\nstream\n...\n",
+    );
+    assert_eq!(read_pdf_page_box(&hidden), None);
+  }
+
+  /// `natural_size_pt` is the only place a file-read number is actually
+  /// converted from its own unit into TeX pt — and it uses a different
+  /// resolution per format: PDF at 72 (bp), SVG at 96 (CSS px).
+  #[test]
+  fn natural_size_pt_uses_72_for_pdf_and_96_for_svg() {
+    let pdf = fixture("n.pdf", b"%PDF-1.4\n<< /MediaBox [0 0 200 100] >>\n");
+    let (w, h) = natural_size_pt(&pdf).expect("pdf box");
+    assert!((w - 200.0 * 72.27 / 72.0).abs() < 1e-9, "w = {w}"); // 200.75
+    assert!((h - 100.0 * 72.27 / 72.0).abs() < 1e-9, "h = {h}");
+
+    let svg = fixture("n.svg", br#"<svg viewBox="0 0 200 100"><rect/></svg>"#);
+    let (w, h) = natural_size_pt(&svg).expect("svg viewport");
+    assert!((w - 200.0 * 72.27 / 96.0).abs() < 1e-9, "w = {w}"); // 150.5625
+    assert!((h - 100.0 * 72.27 / 96.0).abs() < 1e-9, "h = {h}");
+
+    // A raster file has no page box and no SVG root: `None`, so the caller
+    // keeps whatever the pixel reader gave it.
+    let png = fixture("n.png", &png_header(200, 100));
+    assert_eq!(natural_size_pt(&png), None);
+  }
+
+  // ── layer 3a: the pt-space algebra (fallback branch) ──────────────────
+
+  /// `graphicx_box_pt` works in pt throughout and never quantizes, so an
+  /// explicit `width=100pt` comes out as exactly 100pt. Compare
+  /// `sizer_quantizes_the_box_to_whole_device_pixels` below, which is the
+  /// px-space algebra answering the *same* request with 99.7326pt.
+  #[test]
+  fn graphicx_box_pt_table() {
+    let pt = |d: Dimension| d.value_of() as f64 / 65536.0;
+    let case = |opts: &str| {
+      let (w, h) = graphicx_box_pt(200.0, 100.0, opts);
+      (pt(w), pt(h))
+    };
+    let near = |got: (f64, f64), want: (f64, f64), label: &str| {
+      assert!(
+        (got.0 - want.0).abs() < 1e-3 && (got.1 - want.1).abs() < 1e-3,
+        "{label}: got {got:?}, want {want:?}"
+      );
+    };
+    near(case(""), (200.0, 100.0), "no options = natural size");
+    near(
+      case("width=100pt"),
+      (100.0, 50.0),
+      "width= drives height by aspect",
+    );
+    near(
+      case("height=25pt"),
+      (50.0, 25.0),
+      "height= drives width by aspect",
+    );
+    near(
+      case("totalheight=25pt"),
+      (50.0, 25.0),
+      "totalheight aliases height",
+    );
+    near(case("scale=0.5"), (100.0, 50.0), "scale=");
+    near(
+      case("width=100pt,height=80pt"),
+      (100.0, 80.0),
+      "both, no keepaspect",
+    );
+    // keepaspectratio drops the more extreme request and fits inside the box.
+    near(
+      case("width=100pt,height=80pt,keepaspectratio"),
+      (100.0, 50.0),
+      "keepaspectratio fits width",
+    );
+    near(
+      case("width=400pt,height=80pt,keepaspectratio"),
+      (160.0, 80.0),
+      "keepaspectratio fits height",
+    );
+    // An explicit width wins over scale (scale is only consulted when neither
+    // width nor height is given).
+    near(
+      case("scale=2,width=100pt"),
+      (100.0, 50.0),
+      "width beats scale",
+    );
+    // Units other than pt parse through `Dimension::from_str`.
+    near(case("width=1in"), (72.27, 36.135), "in parses");
+    // A degenerate natural size cannot supply the missing dimension.
+    let (w, h) = graphicx_box_pt(0.0, 0.0, "width=100pt");
+    near((pt(w), pt(h)), (100.0, 0.0), "zero natural height");
+  }
+
+  // ── layer 3b: the px-space algebra, and the whole seam ────────────────
+
+  /// Drive the real entry point, `image_graphicx_sizer`, with an absolute
+  /// candidate path so no `SOURCEDIRECTORY` is needed. Returns cached
+  /// (width, height) in pt.
+  fn sizer_pt(path: &Path, options: &str) -> (f64, f64) {
+    let mut w = Whatsit::default();
+    w.set_property("candidates", path.to_string_lossy().to_string());
+    w.set_property("options", options.to_string());
+    image_graphicx_sizer(&mut w);
+    let get = |k: &str| match w.get_property(k).map(|c| c.into_owned()) {
+      Some(Stored::Dimension(d)) => d.value_of() as f64 / 65536.0,
+      other => panic!("{k} was {other:?}"),
+    };
+    (get("cached_width"), get("cached_height"))
+  }
+
+  /// **The whole engine-side seam, as one matrix.** Same 200x100 figure in
+  /// four containers, eight option strings, `cached_width`/`cached_height` in
+  /// pt. This is the table the unified pipeline has to reproduce, row by row,
+  /// or explicitly change.
+  ///
+  /// What each surprising row records:
+  ///
+  /// * **Four resolutions.** With no options the same figure is 144.54pt as a
+  ///   PNG or EPS (100 dpi), 200.75pt as a PDF (72 dpi, i.e. bp), 150.5625pt as
+  ///   an SVG (96 dpi, CSS px), and 0 as a PDF whose page box sits in an object
+  ///   stream. pdflatex says 200.7495pt for the PNG and the PDF alike.
+  /// * **Two algebras.** PNG/EPS take the px-space branch, PDF/SVG the pt-space
+  ///   `graphicx_box_pt` fallback. They answer `width=100pt` differently:
+  ///   99.7326 vs 100.0, because the px branch quantizes the box to a whole
+  ///   device pixel (100pt -> 99.6265bp -> 137.848 px -> ceil 138 -> 99.7326pt).
+  /// * **They also disagree on aspect.** Bare `width=100pt` leaves the height
+  ///   at its natural value on the px branch (72.27) but scales it on the pt
+  ///   branch (50.0). Real documents rarely see this: `graphicx_sty` injects
+  ///   `keepaspectratio=true` for a single-dimension request, which is the row
+  ///   above it. It is pinned because it is a live divergence, not because it
+  ///   is reachable from ordinary LaTeX.
+  /// * **`angle=` never affects the box** on either branch — neither algebra
+  ///   implements the rotate op, so a rotated figure reserves its unrotated
+  ///   width. pdflatex swaps the dimensions.
+  /// * **The last-resort branch** (unreadable page box) honours an explicit
+  ///   `width=`/`height=` and reports 0 for the dimension not asked for.
+  #[test]
+  fn sizer_matrix_across_formats_and_options() {
+    let png = fixture("m.png", &png_header(200, 100));
+    let eps = fixture(
+      "m.eps",
+      b"%!PS-Adobe-3.0 EPSF-3.0\n%%BoundingBox: 0 0 200 100\n",
+    );
+    let pdf = fixture("m.pdf", b"%PDF-1.4\n<< /MediaBox [0 0 200 100] >>\n");
+    let svg = fixture("m.svg", br#"<svg viewBox="0 0 200 100"><rect/></svg>"#);
+    let objstm = fixture("m2.pdf", b"%PDF-1.5\n<< /Type /ObjStm >>\nstream\n..\n");
+
+    // (source, options, expected width pt, expected height pt)
+    #[rustfmt::skip]
+    let matrix: &[(&str, &str, f64, f64)] = &[
+      // px-space branch: raster pixels, and an EPS BoundingBox read as pixels.
+      ("png", "",                                 144.5400,  72.2700),
+      ("png", "width=100pt,keepaspectratio=true",  99.7326,  49.8663),
+      ("png", "width=100pt",                       99.7326,  72.2700),
+      ("png", "scale=0.5",                         72.2700,  36.1350),
+      ("png", "height=25pt,keepaspectratio=true",  49.8663,  25.2945),
+      ("png", "width=100pt,height=80pt",           99.7326,  80.2197),
+      ("png", "width=1in,keepaspectratio=true",    72.2700,  36.1350),
+      ("png", "angle=90",                         144.5400,  72.2700),
+      ("eps", "",                                 144.5400,  72.2700),
+      ("eps", "width=100pt,keepaspectratio=true",  99.7326,  49.8663),
+      ("eps", "width=100pt",                       99.7326,  72.2700),
+      ("eps", "scale=0.5",                         72.2700,  36.1350),
+      ("eps", "height=25pt,keepaspectratio=true",  49.8663,  25.2945),
+      ("eps", "width=100pt,height=80pt",           99.7326,  80.2197),
+      ("eps", "width=1in,keepaspectratio=true",    72.2700,  36.1350),
+      ("eps", "angle=90",                         144.5400,  72.2700),
+      // pt-space branch: the `natural_size_pt` fallback, no quantization.
+      ("pdf", "",                                 200.7500, 100.3750),
+      ("pdf", "width=100pt,keepaspectratio=true", 100.0000,  50.0000),
+      ("pdf", "width=100pt",                      100.0000,  50.0000),
+      ("pdf", "scale=0.5",                        100.3750,  50.1875),
+      ("pdf", "height=25pt,keepaspectratio=true",  50.0000,  25.0000),
+      ("pdf", "width=100pt,height=80pt",          100.0000,  80.0000),
+      ("pdf", "width=1in,keepaspectratio=true",    72.2700,  36.1350),
+      ("pdf", "angle=90",                         200.7500, 100.3750),
+      ("svg", "",                                 150.5625,  75.2812),
+      ("svg", "width=100pt,keepaspectratio=true", 100.0000,  50.0000),
+      ("svg", "width=100pt",                      100.0000,  50.0000),
+      ("svg", "scale=0.5",                         75.2812,  37.6406),
+      ("svg", "height=25pt,keepaspectratio=true",  50.0000,  25.0000),
+      ("svg", "width=100pt,height=80pt",          100.0000,  80.0000),
+      ("svg", "width=1in,keepaspectratio=true",    72.2700,  36.1350),
+      ("svg", "angle=90",                         150.5625,  75.2812),
+      // last resort: nothing measurable, only an explicit request is honoured.
+      ("objstm", "",                                0.0000,   0.0000),
+      ("objstm", "width=100pt,keepaspectratio=true", 100.0000, 0.0000),
+      ("objstm", "width=100pt",                    100.0000,   0.0000),
+      ("objstm", "scale=0.5",                        0.0000,   0.0000),
+      ("objstm", "height=25pt,keepaspectratio=true", 0.0000,  25.0000),
+      ("objstm", "width=100pt,height=80pt",        100.0000,  80.0000),
+      ("objstm", "width=1in,keepaspectratio=true",  72.2700,   0.0000),
+      ("objstm", "angle=90",                         0.0000,   0.0000),
+    ];
+
+    for (src, opts, want_w, want_h) in matrix {
+      let path = match *src {
+        "png" => &png,
+        "eps" => &eps,
+        "pdf" => &pdf,
+        "svg" => &svg,
+        _ => &objstm,
+      };
+      let (w, h) = sizer_pt(path, opts);
+      // 1e-3 pt is ~1/70000 inch: far tighter than any behaviour change, loose
+      // enough to survive `Dimension`'s fixed-point round trip.
+      assert!(
+        (w - want_w).abs() < 1e-3 && (h - want_h).abs() < 1e-3,
+        "{src} [{opts}]: got ({w:.4}, {h:.4}), pinned ({want_w:.4}, {want_h:.4})"
+      );
+    }
+  }
+}

--- a/latexml_core/src/util/image.rs
+++ b/latexml_core/src/util/image.rs
@@ -722,18 +722,96 @@ fn graphicx_box_pt(nw: f64, nh: f64, options: &str) -> (Dimension, Dimension) {
 
 /// Read a PDF's page box (width, height) in bp — CropBox (pdfTeX's default),
 /// else MediaBox. Pure Rust, no external tool (this is what pdfTeX's built-in
-/// reader does). Shared with `LaTeXML::Post::Graphics`. `None` when neither box
-/// appears as raw bytes (e.g. compressed into an object stream).
+/// reader does). Shared with `LaTeXML::Post::Graphics`.
+///
+/// Looks in the raw bytes first, then inside object streams. `%PDF-1.5` and
+/// later — everything current pdflatex emits — may put the page tree in a
+/// `/Type /ObjStm` stream, where the box tokens do not appear as raw bytes at
+/// all: measured over 14 real PDFs in this repo, 5 were unreadable without this
+/// second pass, and `ObjStm` presence predicted it exactly.
+///
+/// **First box wins**, in file order, as the raw-byte scan has always done. A
+/// correct answer for page N would mean resolving the page tree through the
+/// xref stream; for the figures `\includegraphics` pulls in, which are
+/// single-page, the first box is the page's own (or the `/Pages` node's, which
+/// it inherits).
 pub fn read_pdf_page_box(path: &Path) -> Option<(f64, f64)> {
   let bytes = std::fs::read(path).ok()?;
-  // Fast-fail before the (whole-file) UTF-8 conversion: modern PDFs often
-  // compress the page dictionary into an object stream, so the box tokens never
-  // appear as raw bytes.
-  if byte_find(&bytes, b"/CropBox").is_none() && byte_find(&bytes, b"/MediaBox").is_none() {
-    return None;
+  if byte_find(&bytes, b"/CropBox").is_some() || byte_find(&bytes, b"/MediaBox").is_some() {
+    let content = String::from_utf8_lossy(&bytes);
+    if let Some(box_) =
+      parse_pdf_box(&content, "/CropBox").or_else(|| parse_pdf_box(&content, "/MediaBox"))
+    {
+      return Some(box_);
+    }
   }
-  let content = String::from_utf8_lossy(&bytes);
-  parse_pdf_box(&content, "/CropBox").or_else(|| parse_pdf_box(&content, "/MediaBox"))
+  let inflated = inflate_object_streams(&bytes)?;
+  parse_pdf_box(&inflated, "/CropBox").or_else(|| parse_pdf_box(&inflated, "/MediaBox"))
+}
+
+/// Concatenate the inflated contents of every `/Type /ObjStm` in `bytes`.
+///
+/// Deliberately not a PDF parser: it finds object-stream dictionaries, takes the
+/// `stream`…`endstream` payload that follows each, and inflates it. That is
+/// enough to expose the page dictionary, and it stops well short of xref-stream
+/// parsing and object resolution — which is what a real page-N lookup would
+/// need, and is not what a figure's natural size is worth.
+///
+/// Only `/FlateDecode` streams are attempted (the only filter pdflatex, Ghost-
+/// script, Cairo or matplotlib use for object streams), and only the first
+/// [`MAX_OBJSTM_SCAN`] of them, so a pathological file cannot turn a size probe
+/// into an unbounded decompression.
+fn inflate_object_streams(bytes: &[u8]) -> Option<String> {
+  use std::io::Read;
+
+  /// Enough for any real document; a figure PDF has one or two.
+  const MAX_OBJSTM_SCAN: usize = 64;
+  /// Per-stream inflate ceiling, so a zip bomb cannot be handed to us as a
+  /// figure. A page dictionary is a few hundred bytes.
+  const MAX_INFLATED: u64 = 8 << 20;
+
+  let mut out = String::new();
+  let mut from = 0;
+  let mut seen = 0;
+  while seen < MAX_OBJSTM_SCAN {
+    let Some(hit) = byte_find(&bytes[from..], b"/ObjStm") else {
+      break;
+    };
+    let at = from + hit;
+    from = at + b"/ObjStm".len();
+    seen += 1;
+    // The dictionary ends at `stream`, optionally followed by CR, then LF.
+    let Some(rel) = byte_find(&bytes[at..], b"stream") else {
+      continue;
+    };
+    let dict = &bytes[at..at + rel];
+    if byte_find(dict, b"/FlateDecode").is_none() {
+      continue;
+    }
+    let mut start = at + rel + b"stream".len();
+    if bytes.get(start) == Some(&b'\r') {
+      start += 1;
+    }
+    if bytes.get(start) == Some(&b'\n') {
+      start += 1;
+    }
+    let end = byte_find(&bytes[start..], b"endstream").map_or(bytes.len(), |e| start + e);
+    let mut buf = Vec::new();
+    if flate2::read::ZlibDecoder::new(&bytes[start..end])
+      .take(MAX_INFLATED)
+      .read_to_end(&mut buf)
+      .is_err()
+      && buf.is_empty()
+    {
+      // A truncated or mis-delimited stream still yields the bytes decoded
+      // before the error, and the page dictionary sits at the front — so an
+      // error is only fatal when nothing at all came out.
+      continue;
+    }
+    out.push_str(&String::from_utf8_lossy(&buf));
+    out.push('\n');
+  }
+  (!out.is_empty()).then_some(out)
 }
 
 /// Parse `TOKEN [ llx lly urx ury ]` from PDF content, returning `(w, h)`.
@@ -1170,6 +1248,21 @@ mod sizing_characterization_tests {
     path
   }
 
+  /// A minimal `%PDF-1.5` whose only object is a Flate-compressed object stream
+  /// carrying `payload` — the shape pdflatex emits for a page tree since 1.5.
+  fn objstm_pdf(payload: &[u8]) -> Vec<u8> {
+    use std::io::Write;
+    let mut enc = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+    enc.write_all(payload).expect("deflate");
+    let body = enc.finish().expect("finish");
+    let mut pdf = Vec::from(
+      &b"%PDF-1.5\n1 0 obj\n<< /Type /ObjStm /N 1 /First 4 /Filter /FlateDecode >>\nstream\n"[..],
+    );
+    pdf.extend_from_slice(&body);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+    pdf
+  }
+
   /// A PNG header with the given IHDR dimensions. `read_image_dimensions` reads
   /// a fixed 32-byte prefix and takes bytes 16..24 as width/height, so an
   /// honest signature + IHDR is the whole contract; no CRC is consulted.
@@ -1246,15 +1339,16 @@ mod sizing_characterization_tests {
     );
   }
 
-  /// The PDF page box: CropBox is pdfTeX's default and wins over MediaBox; a
-  /// box that is not visible in the plaintext bytes yields `None`.
+  /// The PDF page box: CropBox is pdfTeX's default and wins over MediaBox, and
+  /// a box compressed into an object stream is inflated and read.
   ///
   /// That last case is not hypothetical. Across 14 real PDFs in this repo, 5
-  /// returned `None` here, correlating exactly with `ObjStm` (object-stream)
-  /// compression — the default for `%PDF-1.5` and later, which is what modern
-  /// pdflatex emits. Those figures reach the engine with a 0x0 natural box.
+  /// returned `None` before the object-stream pass, correlating exactly with
+  /// `ObjStm` — the default for `%PDF-1.5` and later, which is what modern
+  /// pdflatex emits — and those figures reached the engine with a 0x0 natural
+  /// box. All 14 now match `pdfinfo` exactly.
   #[test]
-  fn read_pdf_page_box_prefers_cropbox_and_gives_up_on_compressed_objects() {
+  fn read_pdf_page_box_prefers_cropbox_and_reaches_into_object_streams() {
     let media = fixture("m.pdf", b"%PDF-1.4\n<< /MediaBox [0 0 200 100] >>\n");
     assert_eq!(read_pdf_page_box(&media), Some((200.0, 100.0)));
 
@@ -1272,12 +1366,26 @@ mod sizing_characterization_tests {
     let offset = fixture("o.pdf", b"%PDF-1.4\n<< /MediaBox [10 20 210 120] >>\n");
     assert_eq!(read_pdf_page_box(&offset), Some((200.0, 100.0)));
 
-    // No plaintext box — the object-stream case.
-    let hidden = fixture(
+    // A real object stream: the box exists only as deflated bytes.
+    let objstm = fixture(
       "h.pdf",
-      b"%PDF-1.5\n<< /Type /ObjStm /N 12 >>\nstream\n...\n",
+      &objstm_pdf(b"5 0 << /Type /Page /MediaBox [0 0 200 100] >>"),
     );
-    assert_eq!(read_pdf_page_box(&hidden), None);
+    assert_eq!(read_pdf_page_box(&objstm), Some((200.0, 100.0)));
+
+    // A CropBox inside the stream still wins over a MediaBox beside it.
+    let cropped = fixture(
+      "hc.pdf",
+      &objstm_pdf(b"5 0 << /MediaBox [0 0 612 792] /CropBox [0 0 200 100] >>"),
+    );
+    assert_eq!(read_pdf_page_box(&cropped), Some((200.0, 100.0)));
+
+    // Nothing readable anywhere: an object stream we cannot inflate.
+    let opaque = fixture(
+      "ho.pdf",
+      b"%PDF-1.5\n<< /Type /ObjStm /N 12 /Filter /FlateDecode >>\nstream\nnot-zlib\nendstream\n",
+    );
+    assert_eq!(read_pdf_page_box(&opaque), None);
   }
 
   /// `natural_size_pt` is the only place a file-read number is actually

--- a/latexml_oxide/tests/121_image_sizing_characterization.rs
+++ b/latexml_oxide/tests/121_image_sizing_characterization.rs
@@ -26,9 +26,12 @@
 //! (L271) — which is why an unscaled raster typesets 28% smaller than pdflatex
 //! makes it.
 //!
-//! The PDF-with-object-streams row is not a contrived case: `%PDF-1.5` and
-//! later put the page tree in a compressed object stream by default, which our
-//! byte-level reader cannot see, and the figure then reserves no space at all.
+//! A fifth row covers a PDF whose page tree lives in a compressed object
+//! stream — the `%PDF-1.5` default, so most figures pdflatex produces. The
+//! byte-level reader could not see it and the figure reserved no space at all;
+//! since 2026-08-04 the stream is inflated and the row matches the plain PDF.
+//! Measured over 14 real PDFs in this repo: 5 failed that way before, all 14
+//! match `pdfinfo` now.
 
 use std::{path::Path, process::Command};
 
@@ -44,6 +47,21 @@ fn png_header(w: u32, h: u32) -> Vec<u8> {
   v.extend_from_slice(&[0x08, 0x02, 0x00, 0x00, 0x00]);
   v.extend_from_slice(&[0u8; 16]);
   v
+}
+
+/// A minimal `%PDF-1.5` whose only object is a Flate-compressed object stream
+/// carrying `payload` — the shape pdflatex has emitted by default since PDF 1.5.
+fn objstm_pdf(payload: &[u8]) -> Vec<u8> {
+  use std::io::Write;
+  let mut enc = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+  enc.write_all(payload).expect("deflate");
+  let body = enc.finish().expect("finish");
+  let mut pdf = Vec::from(
+    &b"%PDF-1.5\n1 0 obj\n<< /Type /ObjStm /N 1 /First 4 /Filter /FlateDecode >>\nstream\n"[..],
+  );
+  pdf.extend_from_slice(&body);
+  pdf.extend_from_slice(b"\nendstream\nendobj\n");
+  pdf
 }
 
 /// Convert `doc` and return the body text, with the `\the\wd`/`\the\ht` probes
@@ -65,12 +83,11 @@ fn sizes(probes: &[(&str, &str)]) -> String {
     "%PDF-1.4\n1 0 obj\n<< /Type /Page /MediaBox [0 0 200 100] >>\nendobj\n",
   )
   .unwrap();
-  // A page tree hidden in an object stream, as pdflatex emits by default for
-  // PDF 1.5+. Nothing here is readable as plaintext `/MediaBox`.
+  // A page tree inside a real Flate-compressed object stream, as pdflatex emits
+  // by default for PDF 1.5+. The box appears nowhere in the plaintext bytes.
   std::fs::write(
     dir.join("objstm.pdf"),
-    "%PDF-1.5\n1 0 obj\n<< /Type /ObjStm /N 8 /First 52 /Filter /FlateDecode >>\nstream\n\
-     (compressed payload; no plaintext page box)\nendstream\nendobj\n",
+    objstm_pdf(b"5 0 << /Type /Page /MediaBox [0 0 200 100] >>"),
   )
   .unwrap();
   std::fs::write(
@@ -134,8 +151,13 @@ fn natural_box_size_differs_per_source_format() {
   assert_eq!(row(&xml, 2), "200.75pt 100.375pt", "PDF");
   // 200 viewBox user units read as CSS px: 200 * 72.27/96.
   assert_eq!(row(&xml, 3), "150.5625pt 75.28125pt", "SVG");
-  // Page box unreadable — the figure reserves nothing.
-  assert_eq!(row(&xml, 4), "0.0pt 0.0pt", "PDF with object streams");
+  // Same 200 bp box, reachable only by inflating the object stream. Until
+  // 2026-08-04 this row read "0.0pt 0.0pt" — the figure reserved nothing.
+  assert_eq!(
+    row(&xml, 4),
+    "200.75pt 100.375pt",
+    "PDF with object streams"
+  );
 }
 
 /// With an explicit `width=`, the two sizing algebras still disagree — the

--- a/latexml_oxide/tests/121_image_sizing_characterization.rs
+++ b/latexml_oxide/tests/121_image_sizing_characterization.rs
@@ -193,3 +193,38 @@ fn an_explicit_width_is_quantized_on_the_raster_branch_only() {
     "PNG angle=45 — the rotated bounding box, Perl parity"
   );
 }
+
+/// graphicx applies a rotation before or after scaling depending on whether the
+/// `angle` key precedes the sizing key in the source string, and Perl replicates
+/// it (`image_graphicx_parse` sets `$rotfirst` from the keys seen up to `angle`,
+/// L168). This is not a quirk to smooth over: pdflatex behaves the same way, so
+/// getting it wrong reserves visibly wrong space for every rotated-and-sized
+/// figure. All four rows were verified against Perl 0.8.8 on the same input;
+/// three match to the digit.
+#[test]
+fn rotation_order_depends_on_key_order_like_perl_and_pdflatex() {
+  let xml = sizes(&[
+    ("fig.png", "angle=90,width=100pt"),
+    ("fig.png", "width=100pt,angle=90"),
+    ("fig.png", "scale=0.5,angle=90"),
+    ("fig.png", "angle=90,scale=0.5"),
+  ]);
+  // angle first: rotate 200x100 -> 100x200, then width=100pt scales it (aspect
+  // preserved) -> ~100x200pt. Perl: 99.7326 x 199.4652, exact.
+  assert_eq!(row(&xml, 0), "99.7326pt 199.4652pt", "angle then width");
+  // width first: scale to 100pt (-> ~138x69 px), then rotate -> swapped.
+  // Perl: 49.8663 x 99.7326, exact.
+  assert_eq!(row(&xml, 1), "49.8663pt 99.7326pt", "width then angle");
+  // Uniform scale commutes with rotation; both orders agree with Perl exactly.
+  assert_eq!(row(&xml, 2), "36.135pt 72.27pt", "scale then angle");
+  // angle then scale: rotate-then-scale. Width matches Perl (36.8577); the
+  // height is the one intentional sub-pixel divergence. Perl's truncated pi
+  // (3.1415926) leaves a ~2.7e-6 residual on the 200px edge that its ceil
+  // rounds UP to 101 px (72.9927pt); Rust's real pi keeps it at 100 px
+  // (72.27pt), the geometrically correct, pdflatex-consistent value.
+  assert_eq!(
+    row(&xml, 3),
+    "36.8577pt 72.27pt",
+    "angle then scale — real pi, not Perl's 72.9927"
+  );
+}

--- a/latexml_oxide/tests/121_image_sizing_characterization.rs
+++ b/latexml_oxide/tests/121_image_sizing_characterization.rs
@@ -1,0 +1,167 @@
+//! End-to-end characterization of `\includegraphics` box sizing, one row per
+//! source format.
+//!
+//! **This pins behaviour, not correctness**, and it is the durable half of the
+//! image-sizing characterization suite: it names no internal function, so it
+//! survives a refactor of the sizing pipeline untouched and will report exactly
+//! which format's typeset size moved.
+//!
+//! The same 200x100 figure is saved as PNG, EPS, PDF and SVG and included with
+//! no graphicx options. Four containers, four answers, because the resolution
+//! used to turn a source measurement into a TeX dimension is chosen per format
+//! rather than once:
+//!
+//! | source              | pdflatex   | Perl LaTeXML | here       | implied dpi |
+//! |---------------------|------------|--------------|------------|-------------|
+//! | PNG 200x100 px      | 200.7495pt | 144.54pt     | 144.54pt   | 100         |
+//! | EPS BBox 200x100 bp | (n/a)      | (no sizer)   | 144.54pt   | 100, on bp  |
+//! | PDF 200x100 bp      | 200.7495pt | (no sizer)   | 200.75pt   | 72          |
+//! | SVG viewBox 200x100 | (n/a)      | (no sizer)   | 150.5625pt | 96          |
+//!
+//! The pdflatex and Perl columns were measured on the same fixtures on
+//! 2026-08-04 (Perl 0.8.8 lacks Image::Magick on this host, so it can only size
+//! what `Image::Size` reads — hence "no sizer" for EPS/PDF/SVG; the PNG row is
+//! exact parity with us). Perl's own convention is the 100 dpi one:
+//! `Util/Image.pm:37 our $DPI = 100`, with the box derived as `w * 72.27 / $DPI`
+//! (L271) — which is why an unscaled raster typesets 28% smaller than pdflatex
+//! makes it.
+//!
+//! The PDF-with-object-streams row is not a contrived case: `%PDF-1.5` and
+//! later put the page tree in a compressed object stream by default, which our
+//! byte-level reader cannot see, and the figure then reserves no space at all.
+
+use std::{path::Path, process::Command};
+
+/// A PNG header with the given IHDR dimensions — signature, length, `IHDR`,
+/// width, height, then the bit-depth/colour bytes. No CRC and no image data:
+/// every reader in the workspace takes the dimensions from this prefix.
+fn png_header(w: u32, h: u32) -> Vec<u8> {
+  let mut v = vec![0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
+  v.extend_from_slice(&13u32.to_be_bytes());
+  v.extend_from_slice(b"IHDR");
+  v.extend_from_slice(&w.to_be_bytes());
+  v.extend_from_slice(&h.to_be_bytes());
+  v.extend_from_slice(&[0x08, 0x02, 0x00, 0x00, 0x00]);
+  v.extend_from_slice(&[0u8; 16]);
+  v
+}
+
+/// Convert `doc` and return the body text, with the `\the\wd`/`\the\ht` probes
+/// left in place for the caller to match on.
+fn sizes(probes: &[(&str, &str)]) -> String {
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+  let work = tempfile::tempdir().expect("tempdir");
+  let dir = work.path();
+
+  std::fs::write(dir.join("fig.png"), png_header(200, 100)).unwrap();
+  std::fs::write(
+    dir.join("fig.eps"),
+    "%!PS-Adobe-3.0 EPSF-3.0\n%%BoundingBox: 0 0 200 100\n%%EndComments\n",
+  )
+  .unwrap();
+  std::fs::write(
+    dir.join("fig.pdf"),
+    "%PDF-1.4\n1 0 obj\n<< /Type /Page /MediaBox [0 0 200 100] >>\nendobj\n",
+  )
+  .unwrap();
+  // A page tree hidden in an object stream, as pdflatex emits by default for
+  // PDF 1.5+. Nothing here is readable as plaintext `/MediaBox`.
+  std::fs::write(
+    dir.join("objstm.pdf"),
+    "%PDF-1.5\n1 0 obj\n<< /Type /ObjStm /N 8 /First 52 /Filter /FlateDecode >>\nstream\n\
+     (compressed payload; no plaintext page box)\nendstream\nendobj\n",
+  )
+  .unwrap();
+  std::fs::write(
+    dir.join("fig.svg"),
+    r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100"><rect/></svg>"#,
+  )
+  .unwrap();
+
+  let mut tex = String::from(
+    "\\documentclass{article}\n\\usepackage{graphicx}\n\
+     \\newcommand\\probe[3]{\\par\\noindent PROBE #3 \
+     \\setbox0\\hbox{\\includegraphics[#2]{#1}}\\the\\wd0\\ \\the\\ht0\\ END\\par}\n\
+     \\begin{document}\n",
+  );
+  for (i, (file, opts)) in probes.iter().enumerate() {
+    tex.push_str(&format!("\\probe{{{file}}}{{{opts}}}{{{i}}}\n"));
+  }
+  tex.push_str("\\end{document}\n");
+  std::fs::write(dir.join("p.tex"), tex).unwrap();
+
+  let out = Command::new(bin)
+    .args(["p.tex", "--dest", "p.xml", "--nocomments"])
+    .current_dir(dir)
+    .output()
+    .expect("spawn latexml_oxide");
+  std::fs::read_to_string(dir.join("p.xml")).unwrap_or_else(|e| {
+    let stderr = String::from_utf8_lossy(&out.stderr).replace('\u{1b}', "");
+    panic!("no output: {e}\n{stderr}");
+  })
+}
+
+/// The probe text for row `i`, whitespace-collapsed.
+fn row(xml: &str, i: usize) -> String {
+  let marker = format!("PROBE {i} ");
+  let start = xml
+    .find(&marker)
+    .unwrap_or_else(|| panic!("row {i} missing from:\n{xml}"))
+    + marker.len();
+  let rest = &xml[start..];
+  let end = rest
+    .find(" END")
+    .unwrap_or_else(|| panic!("row {i} unterminated"));
+  rest[..end].split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[test]
+fn natural_box_size_differs_per_source_format() {
+  let xml = sizes(&[
+    ("fig.png", ""),
+    ("fig.eps", ""),
+    ("fig.pdf", ""),
+    ("fig.svg", ""),
+    ("objstm.pdf", ""),
+  ]);
+  // 200 px read as 100 dpi.
+  assert_eq!(row(&xml, 0), "144.54pt 72.27pt", "PNG");
+  // 200 bp read as if it were 200 px, then as 100 dpi — the BoundingBox unit
+  // is discarded on the way in.
+  assert_eq!(row(&xml, 1), "144.54pt 72.27pt", "EPS");
+  // 200 bp converted honestly: 200 * 72.27/72. Exact pdflatex parity.
+  assert_eq!(row(&xml, 2), "200.75pt 100.375pt", "PDF");
+  // 200 viewBox user units read as CSS px: 200 * 72.27/96.
+  assert_eq!(row(&xml, 3), "150.5625pt 75.28125pt", "SVG");
+  // Page box unreadable — the figure reserves nothing.
+  assert_eq!(row(&xml, 4), "0.0pt 0.0pt", "PDF with object streams");
+}
+
+/// With an explicit `width=`, the two sizing algebras still disagree — the
+/// raster branch quantizes the box to a whole device pixel at DPI 100
+/// (100pt -> 99.6265bp -> 137.85 px -> ceil 138 -> 99.7326pt) while the page-box
+/// branch stays in pt and returns the request unchanged. pdflatex: 100.0pt for
+/// both. Perl agrees with us exactly on the PNG row (99.7326pt / 49.8663pt).
+#[test]
+fn an_explicit_width_is_quantized_on_the_raster_branch_only() {
+  let xml = sizes(&[
+    ("fig.png", "width=100pt"),
+    ("fig.pdf", "width=100pt"),
+    ("fig.svg", "width=100pt"),
+    ("fig.png", "scale=0.5"),
+    // `angle=` never affects the reserved box on either branch: neither
+    // algebra implements a rotate op, so a sideways figure still reserves its
+    // unrotated width. pdflatex swaps the two dimensions.
+    ("fig.png", "angle=90"),
+  ]);
+  assert_eq!(row(&xml, 0), "99.7326pt 49.8663pt", "PNG width=100pt");
+  assert_eq!(row(&xml, 1), "100.0pt 50.0pt", "PDF width=100pt");
+  assert_eq!(row(&xml, 2), "100.0pt 50.0pt", "SVG width=100pt");
+  assert_eq!(row(&xml, 3), "72.27pt 36.135pt", "PNG scale=0.5");
+  assert_eq!(
+    row(&xml, 4),
+    "144.54pt 72.27pt",
+    "PNG angle=90 — box unrotated"
+  );
+}

--- a/latexml_oxide/tests/121_image_sizing_characterization.rs
+++ b/latexml_oxide/tests/121_image_sizing_characterization.rs
@@ -150,10 +150,11 @@ fn an_explicit_width_is_quantized_on_the_raster_branch_only() {
     ("fig.pdf", "width=100pt"),
     ("fig.svg", "width=100pt"),
     ("fig.png", "scale=0.5"),
-    // `angle=` never affects the reserved box on either branch: neither
-    // algebra implements a rotate op, so a sideways figure still reserves its
-    // unrotated width. pdflatex swaps the two dimensions.
+    // `angle=` rotates the reserved box, as Perl has always done
+    // (`Util/Image.pm` L238-242) and we did not until 2026-08-04. Perl on
+    // these exact inputs: 72.27pt x 144.54pt, and 153.30782pt square at 45.
     ("fig.png", "angle=90"),
+    ("fig.png", "angle=45"),
   ]);
   assert_eq!(row(&xml, 0), "99.7326pt 49.8663pt", "PNG width=100pt");
   assert_eq!(row(&xml, 1), "100.0pt 50.0pt", "PDF width=100pt");
@@ -161,7 +162,12 @@ fn an_explicit_width_is_quantized_on_the_raster_branch_only() {
   assert_eq!(row(&xml, 3), "72.27pt 36.135pt", "PNG scale=0.5");
   assert_eq!(
     row(&xml, 4),
-    "144.54pt 72.27pt",
-    "PNG angle=90 — box unrotated"
+    "72.27pt 144.54pt",
+    "PNG angle=90 — Perl parity"
+  );
+  assert_eq!(
+    row(&xml, 5),
+    "153.30782pt 153.30782pt",
+    "PNG angle=45 — the rotated bounding box, Perl parity"
   );
 }

--- a/latexml_post/src/graphics.rs
+++ b/latexml_post/src/graphics.rs
@@ -645,10 +645,11 @@ impl Graphics {
   ///   It also silently ignored every unit that was not `pt`/`px`.
   /// * **Rotation is the true bounding box**, not a 90/270 axis swap. That
   ///   matches what `convert -rotate` actually writes to disk for an oblique
-  ///   angle. Witness for the rotation mattering at all: 1303.5091 Figs 5-7,
-  ///   `[angle=90,scale=0.75]`, which rendered upside-down before any of it —
-  ///   still correct here, since Perl orders a rotation after the scaling
-  ///   whenever a sizing option is present.
+  ///   angle. It is ordered relative to scaling by key order, as Perl and
+  ///   graphicx do — see `parse_graphicx_options`. Witness for the rotation
+  ///   mattering at all: 1303.5091 Figs 5-7, `[angle=90,scale=0.75]`, which
+  ///   rendered upside-down before any of it — still correct here: a uniform
+  ///   scale commutes with a rotation, so its order does not change the box.
   ///
   /// Witness for the width-only path: astro-ph0005397 Fig 11 (sfh_burst), where
   /// feeding the unscaled raw height back through displayed square sources as

--- a/latexml_post/src/graphics.rs
+++ b/latexml_post/src/graphics.rs
@@ -627,107 +627,42 @@ impl Graphics {
     None
   }
 
-  /// Parse graphicx options and apply transforms to image dimensions.
-  /// Port of Perl's `getTransform` + `image_graphicx_trivial`.
+  /// Apply the graphicx options to a measured pixel size.
   ///
-  /// Handles: scale=N, width=Npt, height=Npt, keepaspectratio, angle=N.
+  /// Delegates to the shared algebra in `latexml_core::util::image` — the port
+  /// of Perl `image_graphicx_size` (`Util/Image.pm` L221-256) — so the pixel
+  /// count written into the HTML and the box the engine reserved come from one
+  /// implementation. Pixel space, hence `DPI/72.27` per bp and Perl's `ceil` at
+  /// each step.
+  ///
+  /// Two behaviours changed when this stopped being its own implementation, both
+  /// toward Perl:
+  ///
+  /// * **Option values now go through `to_bp` first.** The local parser stripped
+  ///   a `pt` suffix and used the number as-is, skipping Perl's pt->bp step, so
+  ///   every explicit size came out up to one pixel wider than the engine's box
+  ///   for the same request (`width=100pt`: 139 px here vs 138 in the engine).
+  ///   It also silently ignored every unit that was not `pt`/`px`.
+  /// * **Rotation is the true bounding box**, not a 90/270 axis swap. That
+  ///   matches what `convert -rotate` actually writes to disk for an oblique
+  ///   angle. Witness for the rotation mattering at all: 1303.5091 Figs 5-7,
+  ///   `[angle=90,scale=0.75]`, which rendered upside-down before any of it —
+  ///   still correct here, since Perl orders a rotation after the scaling
+  ///   whenever a sizing option is present.
+  ///
+  /// Witness for the width-only path: astro-ph0005397 Fig 11 (sfh_burst), where
+  /// feeding the unscaled raw height back through displayed square sources as
+  /// 4:1 ribbons.
   fn apply_graphicx_transforms(raw_w: u32, raw_h: u32, options: &str, dpi: u32) -> (u32, u32) {
-    let dppt = dpi as f64 / 72.27; // dots per point
-
-    // angle=N — for axis-aligned rotations (90, -90, 180, 270, ...),
-    // swap width/height so the HTML's imagewidth/imageheight attrs
-    // match the rotated physical image. Driver: 1303.5091 Figs 5-7
-    // use `[angle=90,scale=0.75]` and rendered upside-down without
-    // this swap.
-    let angle = Self::parse_angle_option(options).unwrap_or(0.0);
-    let rot_mod = ((angle.rem_euclid(360.0) + 0.5).floor() as i32 % 360 + 360) % 360;
-    let (mut w, mut h) = if rot_mod == 90 || rot_mod == 270 {
-      (raw_h as f64, raw_w as f64)
-    } else {
-      (raw_w as f64, raw_h as f64)
-    };
-
-    // Parse options as key=value pairs
-    let mut scale: Option<f64> = None;
-    let mut target_width: Option<f64> = None;
-    let mut target_height: Option<f64> = None;
-    let mut keep_aspect = false;
-
-    for opt in options.split(',') {
-      let opt = opt.trim();
-      if let Some((key, val)) = opt.split_once('=') {
-        let key = key.trim();
-        let val = val.trim();
-        match key {
-          "scale" => {
-            scale = val.parse::<f64>().ok();
-          },
-          "width" => {
-            // Parse dimension: "345.0pt" or "345pt" or bare number
-            let val = val.trim_end_matches("pt").trim_end_matches("px");
-            target_width = val.parse::<f64>().ok();
-          },
-          "height" => {
-            let val = val.trim_end_matches("pt").trim_end_matches("px");
-            target_height = val.parse::<f64>().ok();
-          },
-          "keepaspectratio" => {
-            keep_aspect = val == "true" || val == "1" || val.is_empty();
-          },
-          _ => {},
-        }
-      } else if opt == "keepaspectratio" {
-        keep_aspect = true;
-      }
-    }
-
-    // Apply transforms (matching Perl's image_graphicx_trivial).
-    //
-    // graphicx semantics (texbook L182 of graphics.dtx):
-    //   * scale=S         — both dims × S
-    //   * width=W only    — preserve aspect: height auto-scales by W/raw_w
-    //   * height=H only   — preserve aspect: width auto-scales by H/raw_h
-    //   * width=W height=H (no keepaspectratio) — stretch independently
-    //   * +keepaspectratio — use the more constraining dimension
-    //
-    // Earlier Rust port did `th = target_height.unwrap_or(h / dppt)` in the
-    // width-only path, which fed the unscaled raw height back through and
-    // emitted `width=W height=raw_pixels` — visibly wrong (square sources
-    // displayed as 4:1 ribbons; witness astro-ph0005397 Fig 11 sfh_burst).
-    if let Some(s) = scale {
-      w *= s;
-      h *= s;
-    } else {
-      match (target_width, target_height) {
-        (Some(tw), Some(th)) if keep_aspect => {
-          let scale_w = tw / (w / dppt);
-          let scale_h = th / (h / dppt);
-          let s = scale_w.min(scale_h);
-          w = (w / dppt * s * dppt).ceil();
-          h = (h / dppt * s * dppt).ceil();
-        },
-        (Some(tw), Some(th)) => {
-          w = (tw * dppt).ceil();
-          h = (th * dppt).ceil();
-        },
-        (Some(tw), None) => {
-          // width-only: auto-scale height proportionally.
-          let s = tw / (w / dppt);
-          w = (tw * dppt).ceil();
-          h = (h * s).ceil();
-        },
-        (None, Some(th)) => {
-          // height-only: auto-scale width proportionally.
-          let s = th / (h / dppt);
-          h = (th * dppt).ceil();
-          w = (w * s).ceil();
-        },
-        (None, None) => {
-          // No dimension hints — keep raw pixel size.
-        },
-      }
-    }
-
+    let ops = latexml_core::util::image::parse_graphicx_options(options);
+    let (w, h) = latexml_core::util::image::apply_graphicx_ops(
+      raw_w as f64,
+      raw_h as f64,
+      &ops,
+      dpi as f64 / 72.27,
+      true,
+    );
+    // An image attribute of 0 is useless to a browser; keep at least one pixel.
     (w.max(1.0) as u32, h.max(1.0) as u32)
   }
 
@@ -3005,39 +2940,56 @@ endobj
   /// `image_graphicx_sizer`; the two disagree, and the disagreements are
   /// recorded here so the planned unification has to resolve them deliberately.
   ///
-  /// Source is 200x100 px throughout, DPI 100. What the surprising rows record:
+  /// Source is 200x100 px throughout, DPI 100. Notes on individual rows:
   ///
-  /// * `width=100pt` -> 139 px. 100pt = 99.6265bp; x 100/72.27 = 137.85;
-  ///   but the engine's px branch ceils to 138. The extra pixel is the
-  ///   post pass converting via a slightly different expression.
-  /// * `angle=90` **does** swap the box here (100x200) while the engine leaves
-  ///   it at 200x100 — the engine implements no rotate op at all.
-  /// * `width=1in` and `width=2cm` are **ignored** (200x100 unchanged): the
-  ///   value parser only strips a `pt`/`px` suffix. This is unreachable from
-  ///   ordinary LaTeX — `graphicx_sty` normalizes every dimension to pt before
-  ///   it reaches the `options` attribute (`width=2cm` arrives as
-  ///   `width=56.9055pt`, verified) — so it is defensive behaviour, pinned to
-  ///   stay honest about what the parser actually accepts.
-  /// * The `width=137.9979pt` row is issue 498's own witness: 191 px.
+  /// * `width=100pt` -> 138 px: 100pt = 99.6265bp, x 100/72.27 = 137.85, ceil.
+  ///   Until 2026-08-04 this read 139, because the local parser skipped Perl's
+  ///   pt->bp step and multiplied the raw 100 — so the HTML pixel count and the
+  ///   engine's reserved box disagreed by a pixel on every explicit size.
+  /// * `width=1in` / `width=2cm` are honoured since the same date; the local
+  ///   parser only knew `pt` and `px` and silently dropped anything else. This
+  ///   is unreachable from ordinary LaTeX either way — `graphicx_sty`
+  ///   normalizes to pt first (`width=2cm` arrives as `width=56.9055pt`,
+  ///   verified) — so it is defensive behaviour, pinned to stay honest about
+  ///   what the parser accepts.
+  /// * `angle=90` swaps the box, and now does so via the true rotated bounding
+  ///   box rather than a 90/270 special case, which is also what
+  ///   `convert -rotate` writes for an oblique angle.
+  /// * The `width=137.9979pt` row is issue 498's own witness: 191 px, unmoved
+  ///   by any of the above.
   #[test]
   fn apply_graphicx_transforms_matrix() {
     #[rustfmt::skip]
     let matrix: &[(&str, u32, u32)] = &[
       ("",                                     200, 100),
-      ("width=100pt",                          139,  70),
-      ("width=100pt,keepaspectratio=true",     139,  70),
+      ("width=100pt",                          138,  69),
+      ("width=100pt,keepaspectratio=true",     138,  69),
       ("scale=0.5",                            100,  50),
-      ("height=25pt,keepaspectratio=true",      70,  35),
-      ("width=100pt,height=80pt",              139, 111),
-      ("width=1in,keepaspectratio=true",       200, 100), // unit dropped
-      ("width=2cm",                            200, 100), // unit dropped
-      ("angle=90",                             100, 200), // engine does NOT do this
+      ("height=25pt,keepaspectratio=true",      69,  35),
+      ("width=100pt,height=80pt",              138, 111),
+      ("width=1in,keepaspectratio=true",       100,  50), // 1in at DPI 100
+      ("width=2cm",                             79,  40), // 2cm = 0.787in
+      ("angle=90",                             100, 200),
       ("width=137.9979pt,keepaspectratio=true", 191,  96), // issue 498 witness
     ];
+    // Report every divergence at once: when this matrix moves it is normally
+    // because a shared rule changed, and the whole delta is the signal.
+    let mut deltas = Vec::new();
     for (opts, want_w, want_h) in matrix {
       let got = Graphics::apply_graphicx_transforms(200, 100, opts, 100);
-      assert_eq!(got, (*want_w, *want_h), "options {opts:?}");
+      if got != (*want_w, *want_h) {
+        deltas.push(format!(
+          "  [{opts}] pinned ({want_w}, {want_h})  got {got:?}"
+        ));
+      }
     }
+    assert!(
+      deltas.is_empty(),
+      "{} of {} pinned rows moved:\n{}",
+      deltas.len(),
+      matrix.len(),
+      deltas.join("\n")
+    );
   }
 
   /// `parse_angle_option`'s doc claims it normalizes to {0,90,180,270} when

--- a/latexml_post/src/graphics.rs
+++ b/latexml_post/src/graphics.rs
@@ -2997,6 +2997,180 @@ endobj
     );
   }
 
+  /// Characterization matrix for the post-side graphicx algebra.
+  ///
+  /// **Pins behaviour, not correctness.** `apply_graphicx_transforms` works in
+  /// device pixels at the effective DPI (100 unless a `<?latexml DPI=?>` PI
+  /// says otherwise) and is a *separate* implementation from the engine's
+  /// `image_graphicx_sizer`; the two disagree, and the disagreements are
+  /// recorded here so the planned unification has to resolve them deliberately.
+  ///
+  /// Source is 200x100 px throughout, DPI 100. What the surprising rows record:
+  ///
+  /// * `width=100pt` -> 139 px. 100pt = 99.6265bp; x 100/72.27 = 137.85;
+  ///   but the engine's px branch ceils to 138. The extra pixel is the
+  ///   post pass converting via a slightly different expression.
+  /// * `angle=90` **does** swap the box here (100x200) while the engine leaves
+  ///   it at 200x100 — the engine implements no rotate op at all.
+  /// * `width=1in` and `width=2cm` are **ignored** (200x100 unchanged): the
+  ///   value parser only strips a `pt`/`px` suffix. This is unreachable from
+  ///   ordinary LaTeX — `graphicx_sty` normalizes every dimension to pt before
+  ///   it reaches the `options` attribute (`width=2cm` arrives as
+  ///   `width=56.9055pt`, verified) — so it is defensive behaviour, pinned to
+  ///   stay honest about what the parser actually accepts.
+  /// * The `width=137.9979pt` row is issue 498's own witness: 191 px.
+  #[test]
+  fn apply_graphicx_transforms_matrix() {
+    #[rustfmt::skip]
+    let matrix: &[(&str, u32, u32)] = &[
+      ("",                                     200, 100),
+      ("width=100pt",                          139,  70),
+      ("width=100pt,keepaspectratio=true",     139,  70),
+      ("scale=0.5",                            100,  50),
+      ("height=25pt,keepaspectratio=true",      70,  35),
+      ("width=100pt,height=80pt",              139, 111),
+      ("width=1in,keepaspectratio=true",       200, 100), // unit dropped
+      ("width=2cm",                            200, 100), // unit dropped
+      ("angle=90",                             100, 200), // engine does NOT do this
+      ("width=137.9979pt,keepaspectratio=true", 191,  96), // issue 498 witness
+    ];
+    for (opts, want_w, want_h) in matrix {
+      let got = Graphics::apply_graphicx_transforms(200, 100, opts, 100);
+      assert_eq!(got, (*want_w, *want_h), "options {opts:?}");
+    }
+  }
+
+  /// `parse_angle_option`'s doc claims it normalizes to {0,90,180,270} when
+  /// within 5 degrees. It does not — every value comes back raw. Pinned as it
+  /// behaves; the doc comment is the thing that is wrong.
+  #[test]
+  fn parse_angle_option_returns_the_raw_angle() {
+    for (opts, want) in [
+      ("angle=90", Some(90.0)),
+      ("angle=-90", Some(-90.0)),
+      ("angle=88", Some(88.0)), // NOT snapped to 90
+      ("angle=45", Some(45.0)),
+      ("angle=180", Some(180.0)),
+      ("angle=0.2", Some(0.2)), // below the 0.5 threshold callers apply
+      ("angle=272", Some(272.0)),
+      ("", None),
+      ("width=100pt", None),
+    ] {
+      assert_eq!(Graphics::parse_angle_option(opts), want, "options {opts:?}");
+    }
+  }
+
+  /// Which reader a source reaches, and what it can measure. EPS answers
+  /// `None` here: the post raster reader is the `imagesize` crate, which has no
+  /// PostScript support, so an EPS is never sized on the trivial-copy path — it
+  /// always goes through `Plan::Convert` and is measured from the produced PNG.
+  #[test]
+  fn read_source_dimensions_dispatch_matrix() {
+    let tmp = TempDir::new("post_dispatch");
+    let svg = tmp.join("a.svg");
+    std::fs::write(&svg, r#"<svg viewBox="0 0 200 100"><rect/></svg>"#).unwrap();
+    let svg_upper = tmp.join("B.SVG");
+    std::fs::write(&svg_upper, r#"<svg viewBox="0 0 60 40"><rect/></svg>"#).unwrap();
+    let png = tmp.join("c.png");
+    std::fs::write(&png, ONE_PIXEL_PNG).unwrap();
+    let eps = tmp.join("d.eps");
+    std::fs::write(
+      &eps,
+      "%!PS-Adobe-3.0 EPSF-3.0\n%%BoundingBox: 0 0 200 100\n",
+    )
+    .unwrap();
+
+    let dims = |p: &Path| Graphics::read_source_dimensions(p.to_str().unwrap());
+    assert_eq!(dims(&svg), Some((200, 100)), "svg via viewBox");
+    assert_eq!(
+      dims(&svg_upper),
+      Some((60, 40)),
+      "extension match is case-insensitive"
+    );
+    assert_eq!(dims(&png), Some((1, 1)), "png via imagesize");
+    assert_eq!(dims(&eps), None, "EPS is unmeasurable here, by design");
+  }
+
+  /// The three `%%BoundingBox` shapes the PS reader accepts. Values are bp; the
+  /// two-value form returns the extent, the full form the raw corners.
+  #[test]
+  fn postscript_bounding_box_forms() {
+    let tmp = TempDir::new("post_psbbox");
+    let offset = tmp.join("o.eps");
+    std::fs::write(
+      &offset,
+      "%!PS-Adobe-3.0 EPSF-3.0\n%%BoundingBox: 10 20 210 120\n",
+    )
+    .unwrap();
+    assert_eq!(
+      read_postscript_bounding_box(offset.to_str().unwrap()),
+      Some((200.0, 100.0)),
+      "extent, not corners"
+    );
+    assert_eq!(
+      read_postscript_bounding_box_full(offset.to_str().unwrap()),
+      Some((10.0, 20.0, 200.0, 100.0)),
+      "full form is (llx, lly, width, height) — NOT (llx,lly,urx,ury)"
+    );
+    // The deferred `(atend)` form: the real numbers appear later in the file.
+    let atend = tmp.join("a.eps");
+    std::fs::write(
+      &atend,
+      "%!PS-Adobe-3.0 EPSF-3.0\n%%BoundingBox: (atend)\nstuff\n%%BoundingBox: 0 0 300 150\n",
+    )
+    .unwrap();
+    assert_eq!(
+      read_postscript_bounding_box(atend.to_str().unwrap()),
+      Some((300.0, 150.0))
+    );
+  }
+
+  /// Rasterization density is a *quality* knob, independent of the sizing DPI:
+  /// `DEFAULT_RASTER_DENSITY` (120) unless the source's own box is large enough
+  /// that rendering at 120 would exceed `MAX_RASTER_DIMENSION_PX`.
+  #[test]
+  fn raster_density_is_capped_by_source_box_size() {
+    let tmp = TempDir::new("post_density");
+    let small = tmp.join("s.eps");
+    std::fs::write(
+      &small,
+      "%!PS-Adobe-3.0 EPSF-3.0\n%%BoundingBox: 0 0 200 100\n",
+    )
+    .unwrap();
+    assert_eq!(
+      Graphics::raster_density_for_source(small.to_str().unwrap()),
+      120
+    );
+
+    let pdf = tmp.join("s.pdf");
+    std::fs::write(&pdf, "%PDF-1.4\n<< /MediaBox [0 0 200 100] >>\n").unwrap();
+    assert_eq!(
+      Graphics::raster_density_for_source(pdf.to_str().unwrap()),
+      120
+    );
+
+    // No measurable box (a raster source) — the default stands.
+    let png = tmp.join("s.png");
+    std::fs::write(&png, ONE_PIXEL_PNG).unwrap();
+    assert_eq!(
+      Graphics::raster_density_for_source(png.to_str().unwrap()),
+      120
+    );
+
+    // A 2000bp-wide source at 120 dpi would be 3333 px, over the 2048 cap, so
+    // the density drops to floor(2048 * 72 / 2000) = 73.
+    let big = tmp.join("b.eps");
+    std::fs::write(
+      &big,
+      "%!PS-Adobe-3.0 EPSF-3.0\n%%BoundingBox: 0 0 2000 1000\n",
+    )
+    .unwrap();
+    assert_eq!(
+      Graphics::raster_density_for_source(big.to_str().unwrap()),
+      73
+    );
+  }
+
   /// Smallest valid PNG: 1×1, 8-bit RGB. `imagesize` reads its IHDR, so the
   /// sizing half of `Plan::Copy` succeeds and no `expected:image` warn fires.
   const ONE_PIXEL_PNG: &[u8] = &[

--- a/latexml_post/tests/integration.rs
+++ b/latexml_post/tests/integration.rs
@@ -501,13 +501,12 @@ fn test_svg_source_sized_and_aspect_classed() {
       Some("191"),
       "{id}: imagewidth must be the option-scaled width, not missing/intrinsic"
     );
-    // Heights auto-scale by each source's aspect ratio:
-    //   g1: ceil(805 × 137.9979/(634·72.27/100)) = 243
-    //   g2: ceil(80 × 137.9979/(62·72.27/100)) = 247
-    // (Perl-with-ImageMagick lands within a pixel — 242/246 — via its
-    // pt→bp detour in image_graphicx_trivial; the port's accepted
-    // transform math ceils once, one px above, for every Copy source.)
-    let want_h = if id == "g1" { "243" } else { "247" };
+    // Heights auto-scale by each source's aspect ratio. These are
+    // Perl-with-ImageMagick's own numbers: since 2026-08-04 the post pass
+    // shares the engine's algebra, which includes Perl's pt→bp step in
+    // `image_graphicx_trivial`, so the one-pixel divergence this test used to
+    // record (243/247) is gone.
+    let want_h = if id == "g1" { "242" } else { "246" };
     assert_eq!(
       node.get_attribute("imageheight").as_deref(),
       Some(want_h),


### PR DESCRIPTION
Follow-up to #499 (issue #498). Characterizes the image-sizing pipeline, then unifies it — one graphicx algebra shared by the engine and the post pass, ported faithfully from Perl `Util/Image.pm`, with three sizing bugs fixed along the way. Every behaviour change is verified against Perl 0.8.8 and pdflatex, and pinned by a characterization test.

**Characterize first, then change.** A 40-row engine matrix + end-to-end tests pin what sizing does *today* across PNG/EPS/PDF/SVG × options, so every later change had to declare itself. Recorded, not silently kept: four per-format resolutions (100/100-on-bp/72/96 dpi) and pixel quantization — the residue of a not-yet-done probe/policy unification, left as characterized behaviour, not fixed here.

**One graphicx algebra.** The option string was parsed in four places and applied by two divergent implementations. Both are now the port of Perl `image_graphicx_parse` + `image_graphicx_size` (`GraphicxOp`, `parse_graphicx_options`, `to_bp`, `apply_graphicx_ops`), shared over an output-unit + quantize parameter so the engine's pt box and the post pass's HTML pixel count agree by construction. `trim`/`clip`/`viewport`/`page` are compiled for the first time.

**Three sizing fixes, each toward Perl/pdflatex parity:**
- **`angle=` now rotates the reserved box** (Perl `Util/Image.pm` L238-242); it never did, so rotated figures reserved their unrotated width.
- **Key order decides rotate-before-vs-after-scale**, as graphicx and pdflatex do: `angle=90,width=100pt` is ~100×200, `width=100pt,angle=90` is ~50×100. The port had collapsed this; now captured at angle-parse time like Perl.
- **A PDF page box compressed into a `/Type /ObjStm` stream is now read** (the `%PDF-1.5`+ pdflatex default) — 5 of 14 repo PDFs read a 0×0 box before; all 14 match `pdfinfo` now.

**One intentional divergence:** real `PI` vs Perl's truncated `3.1415926`, which leaves a spurious +1px on some rotated-then-scaled edges. Rust keeps the geometrically correct, pdflatex-consistent value. Pinned with the reason.

**Guards:** `sizing_characterization_tests::*` (6, incl. the 40-row seam matrix), `graphics::tests::*` (5), `121_image_sizing_characterization` (3 end-to-end, naming no internal function so they survive future refactors). Full suite 1914/1914; clippy `-D warnings` + rustdoc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)