### PR TITLE
fix: restore `\leavevmode` in `\hrulefill`/`\dotfill` (LaTeX kernel parity; fixes 2302.11635 float)

### DIFF
--- a/.claude/skills/canvas-triage/SKILL.md
+++ b/.claude/skills/canvas-triage/SKILL.md
@@ -1,13 +1,17 @@
 ---
 name: canvas-triage
 description: >
-  Triage a failing/suspicious arXiv paper and decide whether its errors are a
-  GENUINE Rust regression or parity with Perl LaTeXML. Use when investigating a
-  conversion error/fatal, a "Rust-only" candidate from cortex, a sandbox/canvas
-  failure, or any "is this a real bug vs. parity?" question. Pairs with
-  tools/parity_check.sh, triage_failure.sh, first_error.sh and the cortex
-  document/<id> API. Invoke for "triage this paper", "is 1234.5678 a regression",
-  "classify this failure vs Perl", "/canvas-triage".
+  Triage a failing/suspicious arXiv paper and decide whether its errors — or a
+  structural / rendering difference from LaTeX — are a GENUINE Rust regression or
+  parity with Perl LaTeXML. Use when investigating a conversion error/fatal, a
+  "Rust-only" candidate from cortex, a sandbox/canvas failure, a construct that
+  comes out malformed or laid out differently than LaTeX, or any "is this a real
+  bug vs. parity?" question. This is the classification GATE before the
+  min-repro → perl-port fix chain. Pairs with tools/parity_check.sh,
+  triage_failure.sh, first_error.sh and the cortex document/<id> API. Invoke for
+  "triage this paper", "is 1234.5678 a regression", "classify this failure vs
+  Perl", "why does this render differently from LaTeX", "is this our bug or
+  Perl's", "/canvas-triage".
 ---
 
 The output of this skill is a **classification**, not a fix. Only one verdict —

--- a/.claude/skills/min-repro/SKILL.md
+++ b/.claude/skills/min-repro/SKILL.md
@@ -2,11 +2,15 @@
 name: min-repro
 description: >
   Reduce a confirmed failing arXiv paper to a minimal, self-contained reproducer
-  (and optionally a regression-test fixture). Use after canvas-triage confirms a
-  GENUINE-RUST-ONLY failure, or whenever you need the smallest .tex that still
-  triggers a specific error/crash. Pairs with tools/bisect_repro.sh and
-  first_error.sh. Invoke for "minimize this paper", "make a reproducer for X",
-  "shrink to a failing case", "/min-repro".
+  (and optionally a regression-test fixture), AND isolate which single construct
+  or token causes it via a known-good control twin (e.g. `\vspace*` vs `\par`).
+  Use after canvas-triage confirms a GENUINE-RUST-ONLY failure, whenever you need
+  the smallest .tex that still triggers a specific error/crash, or to pinpoint the
+  culprit token behind a Rust-vs-Perl divergence and turn it into the red test.
+  Pairs with tools/bisect_repro.sh and first_error.sh. Invoke for "minimize this
+  paper", "make a reproducer for X", "shrink to a failing case", "which
+  token/construct causes X", "isolate the cause", "make a standalone repro",
+  "/min-repro".
 ---
 
 Goal: the smallest `.tex` that still emits the **canary** (the exact error
@@ -37,6 +41,20 @@ paper; `canary` optional and defaults to the first error).
 (`/usr/local/bin/latexml repro.tex`, verbose — never `--quiet`) on the same host.
 A faithful reproducer should still show the Rust-only delta; if Perl now errors
 too, the reduction changed the semantics — back off the last cut.
+
+**5 — Isolate the CAUSE with a control variable** (turns a minimal failure into a
+*diagnosis*, and often straight into the red test). Once reduced, produce a
+near-identical twin that differs by **one token** and is expected to *work* — a
+known-good control for the same operation. The delta between the failing case and
+its control pinpoints the culprit and rules out everything they share (schema,
+surrounding bindings, the harness). Witness: `\hrulefill\vspace*{4pt}` (fails,
+paragraph not closed) vs `\hrulefill\par` (works) proved the bug was the
+paragraph-terminator's *arrival*, not `\vskip`/the schema — and the pair became
+the guard (`50_structure::vspace_closes_leader_para`). Good controls: the
+explicit form of an implicit action (`\par` for `\vspace*`), a sibling macro that
+shares the machinery, or the same input one nesting level out. When the failure is
+"X doesn't happen," the control is the case where X *does* — compare their runtime
+state at the decision point (see `perl-port` §1b, "instrument the gate").
 
 ## Where the reproducer lands
 

--- a/.claude/skills/perl-port/SKILL.md
+++ b/.claude/skills/perl-port/SKILL.md
@@ -1,12 +1,19 @@
 ---
 name: perl-port
 description: >
-  Faithfully translate or fix a LaTeXML binding (macro / primitive / constructor
-  / column type / package) from the Perl source to Rust. Use whenever you write
-  or change engine/package code that mirrors Perl LaTeXML — porting a new .pool
-  entry, binding a package, or aligning a definition to Perl semantics. Enforces
-  "read the Perl source first" and the divergence policy. Invoke for "port \foo",
-  "translate this .pool entry", "bind package X", "make Y match Perl",
+  Faithfully translate, fix, or ROOT-CAUSE a LaTeXML binding (macro / primitive /
+  constructor / column type / package) from the Perl source to Rust — including
+  why an existing binding still diverges from Perl or real LaTeX when it already
+  looks faithful to the `.pool` (LaTeXML's `.pool`/`.ltxml` is a reimplementation
+  that sometimes SIMPLIFIES the kernel — check `latex.ltx`/`<pkg>.sty` and
+  `tex.web`, not just LaTeXML). Use whenever you write, change, or debug
+  engine/package code that mirrors Perl LaTeXML — porting a `.pool` entry, binding
+  a package, aligning a definition to Perl semantics, or chasing a structural /
+  mode / paragraph-break divergence to its root. Enforces "read the Perl (and
+  kernel) source first" and the divergence policy. Invoke for "port \foo",
+  "translate this .pool entry", "bind package X", "make Y match Perl", "why does
+  Rust differ from Perl on \foo", "this construct is malformed / renders wrong vs
+  LaTeX", "a primitive isn't firing", "root-cause this parity divergence",
   "/perl-port".
 ---
 
@@ -24,10 +31,37 @@ description: >
 | Core machinery (Mouth/Gullet/Stomach/Document/State) | `LaTeXML/lib/LaTeXML/Core/*.pm` |
 | The `Def*` API itself | `LaTeXML/lib/LaTeXML/Package.pm` |
 | TeX ground truth (when Perl is itself emulating TeX) | `background/tex.web`, `background/texbook.tex` |
+| **Real LaTeX / package source** — LaTeXML's `.pool`/`.ltxml` is a *reimplementation*, occasionally **simplified** | `kpsewhich latex.ltx` (kernel) · `kpsewhich <pkg>.sty` — the actual `\def`s |
 
 Quote the Perl line range in a comment next to the Rust port (the codebase does
 this consistently, e.g. `// Perl L2734-2752`) so the next reader can diff against
 the source.
+
+### 1b — When a faithful-looking binding still diverges from Perl
+
+Two techniques that repeatedly cut a multi-hour dig to minutes (witness: the
+`\hrulefill\vspace*` float bug, arXiv 2302.11635, [OXIDIZED_DESIGN #97] /
+WISDOM #38):
+
+- **Diff the LaTeXML binding against the REAL kernel def early.** `Perl is ground
+  truth` has one exception: LaTeXML's `.pool`/`.sty.ltxml` sometimes *simplifies*
+  the kernel macro (drops a `\leavevmode`, `\kern\z@`, `\relax`, a mode switch…).
+  Perl may still be correct because its core machinery *compensates* for the
+  omission; Rust's may not, so Rust diverges while its binding looks byte-faithful
+  to the `.pool`. When Perl behaves right and Rust wrong on a construct whose
+  binding you've already confirmed matches the `.pool`, run `kpsewhich latex.ltx`
+  (or `<pkg>.sty`) and grep the real `\def` — a token LaTeXML dropped is a prime
+  suspect. Restoring the kernel definition is *more* faithful (record it in
+  `OXIDIZED_DESIGN.md`), and it fixes the root instead of the symptom.
+- **A mode/state-gated primitive that "doesn't fire" → suspect the UPSTREAM
+  setter, not the primitive.** Instrument the *gate itself* (an env-gated
+  `eprintln!` of the condition inputs — e.g. `MODE`/`BOUND_MODE` at the
+  `if mode=="horizontal"` check). If the gate is correctly false, the binding is
+  faithful and the bug is whatever *should* have set that state earlier
+  (`\leavevmode`/`enterHorizontal` here). Don't keep re-reading the primitive that
+  didn't fire — it's the victim, not the culprit. `background/tex.web` states the
+  real gate (e.g. `hmode+vskip: head_for_vmode` — `\vskip` ends a paragraph only
+  *in horizontal mode*), which tells you which state must be true upstream.
 
 ## 2 — Find the Rust home: `docs/parity/ORGANIZATION.md`
 

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -3526,3 +3526,34 @@ the document's final font.
 **Guards**: `06_cluster_regressions::faked_space_is_sized_by_the_font_it_was_digested_in`
 pins the value; `114_streaming_cluster_regressions::streaming_matches_eager_on_cluster_regressions`
 pins eager == streaming (it is what caught the defect).
+
+### 97. `\hrulefill`/`\dotfill` restore the LaTeX kernel's `\leavevmode`
+
+**Perl** (`plain_constructs.pool.ltxml` L86-87): `\hrulefill` → `\leaders\hrule\hfill`,
+`\dotfill` → `\leaders\hbox{.}\hfill` — dropping the leading `\leavevmode` and
+trailing `\kern\z@` of the real LaTeX kernel (`latex.ltx` L643-644:
+`\def\hrulefill{\leavevmode\leaders\hrule\hfill\kern\z@}`).
+
+**Rust** uses the kernel definitions verbatim (with `\leavevmode\…\kern\z@`).
+
+**Why**: `\hrule` is a vertical-mode command and the fill leader is horizontal,
+so LaTeX enters horizontal mode FIRST (`\leavevmode` starts the paragraph). Only
+then does a following `\vskip`/`\vspace*` fire TeX's `head_for_vmode` (tex.web
+L21160 `hmode+vskip: head_for_vmode`) — the internal `\par` that ends the
+paragraph. Perl gets away without the `\leavevmode` because `\hfill`'s
+`enterHorizontal` (an `inplace` MODE assignment) persists past `\leaders` (a
+`bounded` constructor); Rust's `bounded` reverts it, so after `\hrulefill` the
+mode was `internal_vertical`, `leaveHorizontal` never fired, the leader's
+`<ltx:p>` never closed, and the next float panel merged into it — a
+schema-invalid `<caption>`-in-`<block>` (arXiv **2302.11635**), and, more
+generally, a *silent* paragraph-merge in any float with `\hrulefill\vspace*`
+between rows. Restoring the kernel definition fixes the root faithfully; where
+`\hrulefill` is used mid-line (already horizontal) the `\leavevmode` is a no-op,
+so output is byte-identical to Perl.
+
+**Cost**: no golden churn — the `\leavevmode` only bites in vertical contexts,
+where it makes Rust match BOTH Perl's output and the LaTeX kernel. 2302.11635:
+4 errors → 0, 10 `<figure>` / 0 `<block>` (Perl-identical structure).
+
+**Guards**: `50_structure::vspace_closes_leader_para_test` (the `\vspace*` vs
+`\par` control pair). Cross-ref WISDOM #38.

--- a/docs/parity/WISDOM.md
+++ b/docs/parity/WISDOM.md
@@ -1007,23 +1007,35 @@ proper path to parity is:
 Verify fix against `moderncv/cs_cv.tex` + any other `\vspace`-using
 regression tests before landing. Without step 1, step 2 breaks moderncv.
 
-**Update (2026-08-05, issue #508):** `\vspace` is now the faithful DefMacro
-form (`latex_constructs.rs:9241`, `'\vskip #2\relax'`), but step 1 is still
-open — Rust's `\vskip` does **not** fire the vertical break that leaves
-horizontal mode and closes an open `<ltx:p>`. **Witness: arXiv 2302.11635**
-(IEEEtran transmag `figure*`, `\hrulefill\vspace*{4pt}` between minipage rows).
-Perl's `\vspace*` closes the `<p>` so the following captioned minipages become
-separate `<ltx:figure>`s (0 errors); Rust keeps them inside the `<p>`, so
-`insert_block` renames the capture to a plain `<ltx:block>` and the enclosed
-`<ltx:caption>`/`<ltx:toccaption>` are malformed there (4 `malformed:` errors —
-the same class Perl emits on the reduced, `\vspace`-less construct). Minimal
-repro: a `figure` with `\hrulefill\vspace*{4pt}` and two captioned minipages;
-Perl 0 with `\vspace*`, 4 without. Until step 1 lands, 2302.11635 shows these 4
-errors. A prior `Tag('ltx:block', auto_close=>true)` band-aid **masked** them by
-letting the caption escape the block, but that broke an author's explicit
-`<ltx:block>` wrapper on any body `\par` (#508) and produced reordered,
-non-Perl-faithful output; it was removed. See the note in
-`latex_constructs.rs` just after the `ltx:bibblock` Tags.
+**Update (2026-08-05):** `\vspace` is now the faithful DefMacro form
+(`latex_constructs.rs:9241`, `'\vskip #2\relax'`).
+
+**RESOLVED (2026-08-05) — the "step 1" diagnosis above was WRONG.** `\vskip`'s
+`leaveHorizontal` binding is *faithful*; the bug was upstream. **Witness: arXiv
+2302.11635** (IEEEtran `figure*`, `\hrulefill\vspace*{4pt}` between minipage
+rows): the captioned minipages after the `\vspace*` came out inside the leader's
+`<ltx:p>` as a schema-invalid `<caption>`-in-`<block>` (4 `malformed:` errors),
+where Perl makes them separate `<ltx:figure>`s (0 errors). Root cause: **Rust
+was `internal_vertical`, not `horizontal`, at the `\vskip`** — so
+`leaveHorizontal` *correctly* declined to fire (`hmode+vskip: head_for_vmode` is
+gated on horizontal mode, tex.web L21160). The real defect was that
+**LaTeXML's `\hrulefill` dropped the LaTeX kernel's leading `\leavevmode`**
+(latex.ltx L643); `\hrule` is a vertical-mode command, so without `\leavevmode`
+nothing enters horizontal mode. Perl survived because `\hfill`'s
+`enterHorizontal` (`inplace`) persists past `\leaders` (a `bounded`
+constructor); Rust's `bounded` reverts it (isolated: bare `\hfill` *does*
+persist; `\leaders`-wrapped does not). Fix: restore the kernel definition —
+`\hrulefill` → `\leavevmode\leaders\hrule\hfill\kern\z@` (and `\dotfill`
+likewise), `plain_constructs.rs`, [OXIDIZED_DESIGN #97](OXIDIZED_DESIGN_DIVERGENCES.md).
+2302.11635: 4 errors → 0, 10 `<figure>`/0 `<block>` (Perl-identical). The old
+note's feared moderncv landmine never fired — the fix doesn't touch `\vskip`, so
+`82_moderncv::cs_cv_test` stays green. Guard:
+`50_structure::vspace_closes_leader_para_test` (`\vspace*` vs `\par` control).
+
+Method takeaway (durable): when a mode-gated primitive "doesn't fire," suspect
+the UPSTREAM mode-setter, not the primitive. And check the **real LaTeX kernel
+definition** (latex.ltx) — LaTeXML's `.pool` macros are sometimes simplified
+(dropped `\leavevmode`/`\kern\z@`), and the port should follow the kernel.
 
 ## 40. `\#`/`\&`/`\%`/`\$` Def*-kind mismatch is intentional mode-split
 

--- a/latexml_engine/src/plain_constructs.rs
+++ b/latexml_engine/src/plain_constructs.rs
@@ -171,8 +171,20 @@ LoadDefinitions!({
 
   //======================================================================
   // Perl: plain_constructs.pool.ltxml L86-91
-  DefMacro!("\\hrulefill", "\\leaders\\hrule\\hfill");
-  DefMacro!("\\dotfill", "\\leaders\\hbox{.}\\hfill");
+  // Faithful to the real LaTeX kernel (latex.ltx L643/L644), NOT Perl's
+  // `plain_constructs.pool.ltxml` L86-87 which drops the leading `\leavevmode`
+  // and trailing `\kern\z@`. The `\leavevmode` is load-bearing: `\hrule` is a
+  // vertical-mode command and the fill leader is horizontal, so LaTeX enters
+  // horizontal mode FIRST (starts the paragraph). Only then does a following
+  // `\vskip`/`\vspace*` fire TeX's `head_for_vmode` (tex.web L21160:
+  // `hmode+vskip: head_for_vmode`) — the `\par` that ends the paragraph. Perl
+  // gets away without it because `\hfill`'s `enterHorizontal` persists past
+  // `\leaders` (a `bounded` constructor); Rust's does not, so the paragraph
+  // never closed and a following float panel merged into the leader's `<p>`
+  // (arXiv 2302.11635, WISDOM #38). Restoring the kernel definition fixes the
+  // root, faithfully. Divergence recorded in OXIDIZED_DESIGN.
+  DefMacro!("\\hrulefill", "\\leavevmode\\leaders\\hrule\\hfill\\kern\\z@");
+  DefMacro!("\\dotfill", "\\leavevmode\\leaders\\hbox{.}\\hfill\\kern\\z@");
   DefMath!("\\leftarrowfill", None, "\u{2190}", role => "ARROW", stretchy => true);
   DefMath!("\\rightarrowfill", None, "\u{2192}", role => "ARROW", stretchy => true);
   DefMath!("\\upbracefill", None, "\u{23DF}", role => "ARROW", stretchy => true);

--- a/latexml_oxide/tests/structure/vspace_closes_leader_para.tex
+++ b/latexml_oxide/tests/structure/vspace_closes_leader_para.tex
@@ -1,0 +1,20 @@
+% Regression fixture (branch fix-vskip-leavehorizontal-par).
+% Invariant: `\vspace*`/`\vskip` in a vertical container must END the current
+% paragraph, exactly like an explicit `\par` — via the internal `\par` that
+% `leaveHorizontal` injects. fig1 (\vspace*) MUST come out identical to fig2
+% (\par): the leader closes its own <p>, a <break/> follows, and the trailing
+% text is a SEPARATE <p>. The bug merges the leader and "Second" into one <p>
+% (the injected \par is sequenced ahead of the leader <p>'s materialization, so
+% its close no-ops). Witness: arXiv 2302.11635, where the un-closed <p> traps a
+% captioned minipage as a schema-invalid <caption>-in-<block>. See WISDOM #38.
+\documentclass{article}
+\begin{document}
+\begin{figure}
+\hrulefill\vspace*{4pt}
+Second
+\end{figure}
+\begin{figure}
+\hrulefill\par
+Third
+\end{figure}
+\end{document}

--- a/latexml_oxide/tests/structure/vspace_closes_leader_para.xml
+++ b/latexml_oxide/tests/structure/vspace_closes_leader_para.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <figure xml:id="fig1">
+    <p class="ltx_figure_panel"><text class="ltx_leader"><rule height="1px" width="100%"/></text></p>
+    <break class="ltx_break"/>
+    <p class="ltx_figure_panel">Second</p>
+  </figure>
+  <figure xml:id="fig2">
+    <p class="ltx_figure_panel"><text class="ltx_leader"><rule height="1px" width="100%"/></text></p>
+    <break class="ltx_break"/>
+    <p class="ltx_figure_panel">Third</p>
+  </figure>
+</document>


### PR DESCRIPTION
**Diagnostic.** LaTeXML's `\hrulefill` (`\leaders\hrule\hfill`) drops the LaTeX kernel's leading `\leavevmode` (latex.ltx L643). `\hrule` is a vertical-mode command, so without `\leavevmode` nothing enters horizontal mode — and a following `\vspace*`→`\vskip` then can't fire TeX's `head_for_vmode` (tex.web L21160 `hmode+vskip`), the `\par` that ends the paragraph. So the leader's `<ltx:p>` never closed and the next float panel merged into it: a schema-invalid `<caption>`-in-`<block>` (arXiv 2302.11635), and, more subtly, a *silent* paragraph-merge in any `\hrulefill\vspace*` float.

**Approach.** Restore the kernel definitions verbatim — `\hrulefill`/`\dotfill` → `\leavevmode…\kern\z@`. `\vskip`/`leaveHorizontal` were faithful all along; Perl survives the dropped `\leavevmode` because `\hfill`'s `enterHorizontal` persists past `\leaders` (a `bounded` constructor) where Rust's reverts — so the port follows the kernel, not the simplified `.pool` macro. Divergence recorded as OXIDIZED_DESIGN #97; WISDOM #38 corrected + resolved. (Also folds in the troubleshooting-skill updates distilled from this dig.)

**Validation.** Red→green guard `50_structure::vspace_closes_leader_para_test` (`\vspace*` vs a `\par` control, isolating the cause); full suite **1916/0** incl. `82_moderncv::cs_cv_test` (the WISDOM #38 landmine — never fired, `\vskip` untouched); 2302.11635 **4→0 errors, 10 `<figure>`/0 `<block>`, Perl-identical**; mid-line `\hrulefill`/`\dotfill` byte-identical to Perl. Resolves the one documented caveat of #509.

🤖 Generated with [Claude Code](https://claude.com/claude-code)