### PR TITLE
fix(sizing): geometry-scoped SVG width + faithful tcbline segment height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [0.7.5] (Rhai binding API; bibliography content recovery; wider math coverage; large-document memory; default-CSS sync; ar5iv corpus fixes)
 
+  - **`geometry`-driven tcolorbox/tikz graphics size to the real page width, and
+    `\tcbline`-segmented boxes measure their height correctly.** Page geometry now
+    feeds the *measured SVG picture* width — never the reflowable HTML flow — so a
+    full-text-width figure keeps its PDF aspect and its panels sit side-by-side
+    instead of collapsing to 2:1; `\setkeys*` silently ignores geometry's
+    unimplemented keys. Separately, a text-mode `{...}` group that ends a paragraph
+    (as `\tcbline` does) now repacks that paragraph at digestion, so a segmented box
+    no longer over-counts its content height by a line per character.
+    (arXiv:2605.29955 Fig 1.)
   - **A conversion always writes `<jobname>.latexml.log`** — Perl `latexmlc`
     parity: with `--log` unset the log lands in the working directory
     (`latexml.log` for literal input), replacing any stale copy, and still

--- a/docs/parity/OXIDIZED_DESIGN.md
+++ b/docs/parity/OXIDIZED_DESIGN.md
@@ -9,7 +9,7 @@ This file is the **index + overview**. The detail lives in a themed family:
 
 | Theme file | What it holds |
 |---|---|
-| [OXIDIZED_DESIGN_DIVERGENCES.md](OXIDIZED_DESIGN_DIVERGENCES.md) | The numbered **Intentional Divergences from Perl** (`#1–#15`, `#17–#18`, `#19–#98`) + a brief Known-Upstream-Perl-Issues list. Code comments cite these as `OXIDIZED_DESIGN #N`. |
+| [OXIDIZED_DESIGN_DIVERGENCES.md](OXIDIZED_DESIGN_DIVERGENCES.md) | The numbered **Intentional Divergences from Perl** (`#1–#15`, `#17–#18`, `#19–#100`) + a brief Known-Upstream-Perl-Issues list. Code comments cite these as `OXIDIZED_DESIGN #N`. |
 | [OXIDIZED_DESIGN_MATH.md](../math/OXIDIZED_DESIGN_MATH.md) | Marpa math-parser design: `#16` design rules + the grammar-rule cluster `#7–#18`. |
 | [OXIDIZED_DESIGN_TYPES.md](OXIDIZED_DESIGN_TYPES.md) | Type-system improvements (behavior-neutral) + tactical internal pitfalls. |
 | [OXIDIZED_DESIGN_FUTURE_WORK.md](OXIDIZED_DESIGN_FUTURE_WORK.md) | Beyond-parity directions not yet built. |
@@ -18,7 +18,7 @@ This file is the **index + overview**. The detail lives in a themed family:
 > `.rs` comments reference them — so they are kept verbatim, which means three
 > quirks: (1) the numbers are **not globally unique** (the math cluster `#7–#18`
 > collides by value with divergences `#7–#18`); (2) a code-referenced number
-> resolves to the file above that owns that *topic* — most (`#1–#15`, `#19–#98`)
+> resolves to the file above that owns that *topic* — most (`#1–#15`, `#19–#100`)
 > are in DIVERGENCES, the math ones (incl. the code-referenced **`#18` = f(x)
 > "Speculative function application"**) are in MATH; (3) **`#76` is a retired
 > number** — its entry was consolidated into `#74` and the number was not

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -3600,3 +3600,102 @@ render unchanged (`50_structure::autoref_test`).
 idiom → `(1.1)`/`(1.2)` while a sibling `section` autoref stays `section 1`);
 `50_structure::autoref_test` (default path unchanged). Witness: ar5iv #607
 (arXiv **2607.12124**).
+
+### 99. `geometry` sizes measured SVG graphics (not the HTML flow)
+
+**Perl** (`geometry.sty.ltxml` L27-59) makes every geometry macro a no-op —
+*"AND, in the end, they're all ignored!"* — so `\textwidth` keeps the class
+default (345pt) no matter what margins the document asks for. That is correct
+for the **reflowable HTML body**: page geometry is meaningless when the browser
+reflows the column. Rust keeps it for the flow — a `\rule{0.5\linewidth}`, a
+text minipage, `\includegraphics[width=\linewidth]` are all class-default-sized,
+byte-identical to Perl.
+
+**Rust divergence**: a *measured SVG graphic* that reads `\linewidth` — a
+`tcolorbox`, `tikzpicture`, or bare `pgfpicture` — is emitted as a fixed-size
+`<svg>` whose aspect ratio is **baked at conversion time**. Ignoring the real
+page width there makes such a box `0.495\linewidth = 0.495 × 345pt` instead of
+the `0.495 × 472pt` the PDF draws (letterpaper − the class's 2.5cm margins). The
+too-narrow interior over-wraps the content, ≈doubling the box height (aspect
+2:1 vs the PDF's ~4:1) and pushing text through the border. Witness
+**arXiv:2605.29955** Fig 1 (two side-by-side statement/proof cards). Perl has
+the same 2:1 boxes — it is a shared under-fidelity, not a Rust regression — so
+this is a beyond-Perl improvement toward the PDF, opted into by the user.
+
+**Mechanism** (`geometry_sty.rs`): parse the margin/paper keys (via `\setkeys*`,
+so the ~40 unimplemented keys are silently ignored — divergence-adjacent fix to
+`\setkeys*` in `keyval_sty.rs`), compute `\Gm@tw`/`\Gm@th`, and at
+`\AtBeginDocument` prepend an SVG-scope injector to `\tcolorbox` (the whole
+tcolorbox family funnels through it — `\newtcolorbox` envs call `\tcolorbox`),
+`\tikzpicture`, and `\pgfpicture`. The injector raises `\linewidth`/`\hsize`/
+`\columnwidth`/`\textwidth` to `\Gm@tw` **only when `\linewidth=\textwidth`**
+(top level) so a locally-reduced `\linewidth` (nesting minipage/parbox) is
+preserved, and only inside the picture's group so the surrounding HTML flow is
+never touched. Whole feature is gated on `geometry` being loaded — zero effect
+on documents that do not use it. A paper-class binding that omitted geometry as
+"visual-only" must now load it with the class's margins to benefit
+(`fairmeta_cls.rs`, which is why the boxes were 2:1 before).
+
+Because the panels become geometry-sized but the figure's float width
+(`arrange_panels`, div. #62 / WISDOM #62) is captured from `\hsize` in the HTML
+flow (345pt), the two bases would disagree and two `0.495\linewidth` boxes that
+sit side-by-side in the PDF would wrap to separate rows. `after_float`
+(`latex_constructs.rs`) therefore captures the **arrangement** float width as
+`\Gm@tw` when the float spans the full text width — the row threshold only, the
+float's HTML content stays class-default.
+
+**Known residual**: a `\ttfamily` code box (2605.29955 Fig 1 right card) can
+still poke a few px past its border — the browser's monospace is wider than
+cmtt10, forcing one extra wrap the engine did not measure. Shared with Perl
+(whose box is likewise near-overflow), orthogonal to geometry, and much reduced
+by this change (~22px → ~6px). Tracked with the foreignObject em-basis follow-up
+(WISDOM #47).
+
+**Guards**: `122_geometry_svg_sizing::geometry_sizes_svg_but_not_html_flow`
+(tcolorbox SVG widens to the geometry `\linewidth`; a sibling `\rule` stays
+class-default; the `--ltx-fo-*` em sizing survives).
+
+### 100. A text-mode `{...}` group that breaks a paragraph repacks the outer paragraph at digestion
+
+**Perl** `Core/Stomach.pm` `T_BEGIN` (`Engine/TeX_Box.pool` L30-42): a text-mode
+`{...}` flows its content FLAT into the enclosing list (`push($open);
+$stomach->digestUntil()`, no localization), so a `\par` inside the group
+`repackHorizontal`s the ENCLOSING paragraph. `computeBoxesSize` (Font.pm
+L667-682) then never sees a run of loose character boxes in a vertical list —
+every box it meets is already a packed paragraph `List`, a rule, or a vskip.
+
+**Rust** digests a text-mode `{...}` into a **localized** box-list — `tex_box.rs`
+`DefPrimitive!("{")` calls `digest_next_body`, returning the group as a `List`.
+The downstream pgf/tikz/box-capture bindings are built around that `List`
+representation, so a faithful flat `digestUntil` port is NOT viable — it regresses
+them engine-wide (the #99 tcolorbox path went 111→192pt on the experiment).
+Consequence of the localization: a `\par` INSIDE a text-mode group (e.g.
+`\tcbline@`'s `{\parskip\z@\par\nointerlineskip}`) repacks only the empty inner
+list, leaving the outer paragraph's characters LOOSE (no `mode` property).
+`computeBoxesSize` counted each loose glyph as its own vertical line — one
+`\baselineskip` per extra glyph — inflating tcolorbox/tikz SVG heights
+(`xxx\tcbline yyy` @ width=100pt measured **111.03pt** vs Perl **77.82pt**;
+arXiv:2605.29955 Fig 1).
+
+**Divergence** ("R2", `tex_box.rs` `{` primitive): reproduce Perl's END STATE
+without its flat digestion. When the `{` primitive is entered mid-paragraph
+(`MODE=horizontal`, vertical `BOUND_MODE`) and its digested body **resumed
+vertical mode** (contains a `\par` whatsit — a box whose `mode` ends in
+`vertical`), call `repack_horizontal()` after the group closes. That packs the
+outer paragraph's now-restored loose run into a `mode="horizontal"` `List` — the
+same structure Perl's flat `\par` would have produced — so `compute_boxes_size`
+runs the pure Perl one-line-per-box algorithm (no measurement-layer change) and
+lands on 77.82pt, an exact Perl match. The guard is narrow: ordinary inline
+`{...}`, math groups, and groups entered in vertical mode never satisfy both
+conditions, so only the rare `\par`-inside-a-text-group idiom is touched. (The
+box-list divergence has NO other observable symptom — the DOM absorption already
+coalesces the loose boxes into one `<ltx:p>`, verified; measurement was the sole
+consumer that didn't.)
+
+**Guard**: `123_tcbline_nointerlineskip::tcbline_box_not_over_measured`
+(`xxx\tcbline yyy` @ width=100pt sizes to < 90pt, i.e. Perl's 77.82 not the
+pre-fix 111.03). Do not confuse with #99's *known residual* (a `\ttfamily` box
+poking a few px past its border): that is the TeX-realm-vs-SVG **font impedance
+mismatch** (drawn shapes frozen at TeX-font metrics while only the foreignObject
+text reflows in the client), a structural limitation tracked with WISDOM #47 —
+orthogonal to this repack fix.

--- a/latexml_contrib/src/fairmeta_cls.rs
+++ b/latexml_contrib/src/fairmeta_cls.rs
@@ -18,8 +18,25 @@ LoadDefinitions!({
   LoadClass!("OmniBus");
   // Dependency packages the class \RequirePackage's and the paper body relies
   // on (those with bindings / user-facing commands). Purely-cosmetic layout
-  // packages (geometry, microtype, setspace, parskip, titlesec, …) are omitted
-  // — they are visual no-ops in LaTeXML and OmniBus degrades gracefully.
+  // packages (microtype, setspace, parskip, titlesec, …) are omitted — they are
+  // visual no-ops in LaTeXML and OmniBus degrades gracefully.
+  //
+  // geometry is NOT purely cosmetic: it sizes measured SVG graphics (the class
+  // draws its Figure-1 statement/proof cards as `width=0.495\linewidth`
+  // tcolorboxes). With geometry omitted, \linewidth stays at the 345pt article
+  // default instead of the class's ~472pt, so the boxes come out ~2x too tall
+  // and text runs through the border (2605.29955 Fig 1). Load it with the
+  // class's own margins (fairmeta.cls L15) so geometry_sty's SVG-scope hook
+  // sizes those boxes to match the PDF. PassOptions before the require (Perl
+  // idiom) so the option list reaches geometry's \ProcessOptions at load time.
+  pass_options("geometry", "sty", vec![
+    s!("top=2.25cm"),
+    s!("bottom=2.5cm"),
+    s!("left=2.5cm"),
+    s!("right=2.5cm"),
+    s!("columnsep=0.65cm"),
+  ])?;
+  RequirePackage!("geometry");
   RequirePackage!("amsmath");
   RequirePackage!("amssymb");
   RequirePackage!("graphicx");
@@ -39,9 +56,6 @@ LoadDefinitions!({
   // \tcbuselibrary{most} loads the enhanced/breakable/skins keys.
   pass_options("tcolorbox", "sty", vec![s!("most")])?;
   RequirePackage!("tcolorbox");
-
-  // \geometry{...} — page-geometry hint; visual-only, gobble the arg.
-  def_macro_noop("\\geometry{}")?;
 
   // Class palette (\color{metafg} is used by the abstract box).
   Digest!("\\definecolor{metablue}{HTML}{E2EFEF}")?;

--- a/latexml_core/src/common/font.rs
+++ b/latexml_core/src/common/font.rs
@@ -1529,7 +1529,11 @@ impl Font {
     // inter-line adjustment, e.g. \vskip / \hrule).
     let mut lines: Vec<[i64; 4]> = Vec::new();
     if mode_str.ends_with("vertical") {
-      // Perl: For vertical, ALL boxes are lines.
+      // Perl: For vertical, ALL boxes are lines. (Rust makes the box-list match
+      // Perl's structure BEFORE this point: a text-mode `{...}` group that
+      // breaks a paragraph repacks the outer paragraph at digestion — see
+      // `tex_box.rs` `{` primitive R2 / OXIDIZED_DESIGN #100 — so no run of loose
+      // characters ever reaches here to be mis-counted one-line-per-glyph.)
       for bx in boxes {
         if bx.has_property("isEmpty") {
           continue;

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -1863,7 +1863,29 @@ pub fn after_float(whatsit: &mut Whatsit) {
   // afterClose hook to size the per-row layout — NOT the ambient \hsize at
   // construction time, which may have been restored to an unrelated value.
   if let Ok(Some(hsize)) = lookup_register("\\hsize", Vec::new()) {
-    whatsit.set_property("floatwidth", Stored::from(hsize));
+    // geometry SVG-scope (geometry_sty / OXIDIZED_DESIGN #99): when the page
+    // geometry defined a wider text width than the class default (`\Gm@tw`) and
+    // this float spans the full text width, size the PANEL ARRANGEMENT to that
+    // width. The panels are geometry-sized SVG pictures (their `\linewidth` was
+    // raised inside the picture), so the per-row overflow threshold must be on
+    // the same basis or two `0.495\linewidth` boxes that sit side-by-side in the
+    // PDF would wrap to separate rows. Only the arrangement threshold changes —
+    // the float's HTML content keeps the class-default width.
+    let mut floatwidth = hsize.clone();
+    if let (Ok(Some(gm_tw)), Ok(Some(doctw))) = (
+      lookup_register("\\Gm@tw", Vec::new()),
+      lookup_register("\\Gm@doctw", Vec::new()),
+    ) {
+      // Full-column float only: compare against the class-default column width
+      // \Gm@doctw (captured at geometry load), not the live \textwidth — a
+      // minipage sets \textwidth=\linewidth locally, so the live compare would
+      // mis-fire inside one.
+      let (h, g, d) = (hsize.value_of(), gm_tw.clone().value_of(), doctw.value_of());
+      if h == d && g > h {
+        floatwidth = gm_tw;
+      }
+    }
+    whatsit.set_property("floatwidth", Stored::from(floatwidth));
   }
   rescue_caption_counters(&captype, whatsit);
   assign_value(

--- a/latexml_engine/src/tex_box.rs
+++ b/latexml_engine/src/tex_box.rs
@@ -359,6 +359,16 @@ LoadDefinitions!({
   // These are actually TeX primitives, but we treat them as a Whatsit so they
   // remain in the constructed tree.
   DefPrimitive!("{", {
+    // R2: were we mid-paragraph when this group opened? If so, the characters
+    // typeset so far belong to the OUTER paragraph. Perl's text-mode `{...}`
+    // flows FLAT (`digestUntil`), so a grouped `\par` repacks them; Rust
+    // localizes the group (below), hiding them from the inner `\par`. Captured
+    // BEFORE `bgroup` (the matching `}` restores mode via `egroup`).
+    let mid_para = {
+      let mode = lookup_string_from_sym(pin!("MODE"));
+      let bound = lookup_string_from_sym(pin!("BOUND_MODE"));
+      mode == "horizontal" && bound.ends_with("vertical")
+    };
     bgroup();
     let open = Tbox::new(
       pin!(""),
@@ -373,6 +383,23 @@ LoadDefinitions!({
       TexMode::Text
     });
     let body = digest_next_body(None)?;
+    // R2: if this text-mode group actually broke a paragraph (its digested body
+    // resumed vertical mode — i.e. contains a `\par` whatsit), repack the outer
+    // paragraph's now-restored loose run NOW, so the box-list matches Perl's flat
+    // digestion (packed paragraph List, not loose chars). Gated on `mid_para` and
+    // non-math, so ordinary inline `{...}` groups and math groups are untouched;
+    // fires only for the rare `\par`-inside-text-group idiom (`\tcbline@`'s
+    // `{\parskip\z@\par\nointerlineskip}`). See OXIDIZED_DESIGN #100.
+    if mid_para
+      && !lookup_bool_sym(pin!("IN_MATH"))
+      && body.iter().any(|b| {
+        b.get_property("mode")
+          .map(|m| m.to_string().ends_with("vertical"))
+          .unwrap_or(false)
+      })
+    {
+      repack_horizontal();
+    }
     let mut boxes = vec![Digested::from(open)];
     boxes.extend(body);
     let mut font = None;

--- a/latexml_oxide/tests/122_geometry_svg_sizing.rs
+++ b/latexml_oxide/tests/122_geometry_svg_sizing.rs
@@ -1,0 +1,141 @@
+//! Regression test: the `geometry` package's page layout must size **measured
+//! SVG graphics** (tcolorbox / tikz / pgf pictures) so their aspect ratio
+//! matches the PDF, while leaving the **reflowable HTML flow** untouched
+//! (OXIDIZED_DESIGN #99).
+//!
+//! LaTeXML (Perl and, faithfully, Rust) ignores `geometry` for the HTML body —
+//! page geometry is meaningless for reflowable output. But a measured picture
+//! that reads `\linewidth` (e.g. `\begin{tcolorbox}[width=0.5\linewidth]`) is
+//! emitted as a *fixed-size* SVG, so ignoring geometry there makes the box
+//! `0.5 x 345pt` (the article default) instead of the `0.5 x 472pt` the PDF uses
+//! (letterpaper minus fairmeta's 2.5cm margins). The narrow interior over-wraps
+//! the content, doubling the box height and pushing text through the border
+//! (arXiv:2605.29955, Figure 1).
+//!
+//! The fix injects the geometry-computed text width into `\linewidth` **only
+//! inside SVG-producing pictures**, never into the main HTML flow. These tests
+//! pin the contract in-process (via `convert_fixture`, no spawned binary):
+//!   1. the tcolorbox SVG widens to the geometry `\linewidth` (was 345-based),
+//!   2. a sibling `\rule{0.5\linewidth}` stays at the 345-based class default
+//!      (proof the HTML flow is NOT rescaled),
+//!   3. the SVG foreignObject `--ltx-fo-*` em sizing is preserved,
+//!   4. a `width=\linewidth` box nested in a reduced-width minipage keeps the
+//!      reduced width (the guard compares the class-default column, not the live
+//!      minipage-reduced `\textwidth`).
+//!
+//! Conditional: needs the kernel dump (so tcolorbox's expl3 loads cleanly) AND
+//! tcolorbox installed in the host TeX tree; self-skips otherwise.
+
+use latexml::util::test::{convert_fixture, dump_available, kpse_has};
+
+/// Pull the first `viewBox="minx miny W H"` width (the 3rd number) out of the
+/// serialized markup — the tcolorbox root `<svg>` is the first picture.
+fn first_viewbox_width(html: &str) -> f64 {
+  let at = html.find("viewBox=\"").expect("no viewBox in output");
+  let vb = &html[at + "viewBox=\"".len()..];
+  let vb = &vb[..vb.find('"').expect("unterminated viewBox")];
+  vb.split_whitespace()
+    .nth(2)
+    .and_then(|s| s.parse::<f64>().ok())
+    .expect("could not parse viewBox width")
+}
+
+/// Pull the first `--ltx-fo-width:<N>em` value out of the markup.
+fn fo_width_em(html: &str) -> f64 {
+  let at = html
+    .find("--ltx-fo-width:")
+    .expect("no --ltx-fo-width in SVG output");
+  let rest = &html[at + "--ltx-fo-width:".len()..];
+  let end = rest.find("em").expect("--ltx-fo-width not in em");
+  rest[..end]
+    .parse::<f64>()
+    .expect("could not parse --ltx-fo-width")
+}
+
+/// True when this environment can raw-load tcolorbox on the kernel dump.
+fn can_run() -> bool { dump_available() && kpse_has("tcolorbox.sty") }
+
+const TEX: &str = "literal:\\documentclass{article}\n\
+  \\usepackage[left=2.5cm,right=2.5cm,top=2.5cm,bottom=2.5cm]{geometry}\n\
+  \\usepackage[most]{tcolorbox}\n\
+  \\begin{document}\n\
+  \\noindent\\rule{0.5\\linewidth}{2pt}\n\
+  \n\
+  \\begin{tcolorbox}[width=0.5\\linewidth]\n\
+  Some tcolorbox content here.\n\
+  \\end{tcolorbox}\n\
+  \\end{document}\n";
+
+#[test]
+fn geometry_sizes_svg_but_not_html_flow() {
+  if !can_run() {
+    eprintln!("skipping: needs kernel dump + tcolorbox.sty in the host TeX tree");
+    return;
+  }
+  let r = convert_fixture(TEX);
+  let html = r.result.expect("conversion produced no result");
+
+  // (1) The tcolorbox SVG is sized from the geometry \linewidth (0.5 x 472pt ->
+  // ~326.6px), NOT the 345pt article default (~238.7px). letterpaper (8.5in =
+  // 614.295pt) minus left+right (2 x 2.5cm = 142.264pt) -> \textwidth 472.03pt;
+  // 0.5\linewidth = 236.02pt, emitted in px (x DPI/72.27 = x100/72.27) as ~326.6.
+  let vb_w = first_viewbox_width(&html);
+  assert!(
+    (315.0..=340.0).contains(&vb_w),
+    "tcolorbox SVG viewBox width {vb_w} is not geometry-sized (~326.6); \
+     a 345pt-default build emits ~238.7. geometry text width was not applied \
+     to the SVG picture.\n{html}",
+  );
+
+  // (2) The HTML flow is untouched: a sibling \rule{0.5\linewidth} keeps the
+  // 345-based class default (0.5 x 345 = 172.5pt). Geometry must NOT rescale
+  // the reflowable HTML body.
+  assert!(
+    html.contains("width=\"172.5pt\""),
+    "sibling \\rule{{0.5\\linewidth}} should stay at the 345-based default \
+     172.5pt (HTML flow must not be rescaled by geometry).\n{html}",
+  );
+
+  // (3) SVG box-content emulation intact: the foreignObject still carries an
+  // em-valued --ltx-fo-width, now widened by the geometry linewidth (~20.5em
+  // vs the 345-default ~14.1em).
+  let fo_em = fo_width_em(&html);
+  assert!(
+    (18.0..=22.0).contains(&fo_em),
+    "SVG foreignObject --ltx-fo-width {fo_em}em is not geometry-widened \
+     (~20.5em expected; 345-default ~14.1em). SVG content sizing regressed.\n{html}",
+  );
+}
+
+// A `width=\linewidth` tcolorbox nested in a reduced-width minipage must keep
+// the REDUCED width, not be clobbered to the full geometry width. A minipage
+// sets \textwidth=\linewidth locally, so the SVG-scope guard must compare
+// against the class-default column width, not the live \textwidth.
+const TEX_NESTED: &str = "literal:\\documentclass{article}\n\
+  \\usepackage[left=2.5cm,right=2.5cm]{geometry}\n\
+  \\usepackage[most]{tcolorbox}\n\
+  \\begin{document}\n\
+  \\begin{minipage}{0.4\\linewidth}\n\
+  \\begin{tcolorbox}[width=\\linewidth]x\\end{tcolorbox}\n\
+  \\end{minipage}\n\
+  \\end{document}\n";
+
+#[test]
+fn geometry_does_not_clobber_reduced_linewidth() {
+  if !can_run() {
+    eprintln!("skipping: needs kernel dump + tcolorbox.sty in the host TeX tree");
+    return;
+  }
+  let r = convert_fixture(TEX_NESTED);
+  let html = r.result.expect("conversion produced no result");
+
+  // 0.4 x 345pt = 138pt -> ~190.9px. If the guard mis-fired against the live
+  // (minipage-reduced) \textwidth it would jump to the full geometry width
+  // (~653px). Must stay in the reduced band.
+  let vb_w = first_viewbox_width(&html);
+  assert!(
+    (170.0..=215.0).contains(&vb_w),
+    "nested tcolorbox width {vb_w} was clobbered by geometry; a reduced \
+     \\linewidth (minipage) must be preserved (expected ~190.9px).\n{html}",
+  );
+}

--- a/latexml_oxide/tests/123_tcbline_nointerlineskip.rs
+++ b/latexml_oxide/tests/123_tcbline_nointerlineskip.rs
@@ -1,0 +1,79 @@
+//! Regression test: the height measurement of a `\tcbline`-segmented tcolorbox
+//! must not over-count the paragraph BEFORE the rule.
+//!
+//! `\tcbline` (tcolorbox's `tcbskins` segmentation, `\tcbline@`) brackets its
+//! dashed-rule picture with `{\parskip\z@\par\nointerlineskip}` on each side.
+//! The `\par` there fires INSIDE a `{...}` group. Rust digests a text-mode
+//! `{...}` into a localized box-list (a `List`), so the grouped `\par` repacks
+//! only that empty inner list — the outer paragraph's characters ("xxx") stayed
+//! LOOSE (unpacked). Perl's bare `{...}` flows flat, so its enclosing `\par`
+//! packs them; Perl never sees the loose run. `compute_boxes_size` then counted
+//! each loose glyph as its own vertical line, adding one `\baselineskip` per
+//! extra glyph: a `xxx\tcbline yyy` box measured 111.03 where Perl is 77.82.
+//! That inflated tcolorbox height and left an oversized gap after the dashed
+//! rule (arXiv:2605.29955 Figure 1, the Lean code card).
+//!
+//! Ground truth (box viewBox height, `xxx\tcbline yyy` @ width=100pt):
+//!   pdflatex 65.79 · Perl 77.82 · Rust (pre-fix) 111.03.
+//! The fix (`tex_box.rs` `{` primitive, "R2"): when a text-mode `{...}` group
+//! breaks a paragraph (its digested body resumed vertical mode via `\par`), the
+//! `{` primitive repacks the outer paragraph's loose run at DIGESTION — so the
+//! box-list matches Perl's flat-digestion structure (a packed paragraph `List`,
+//! not loose chars) and `compute_boxes_size` measures the pure Perl way. Result:
+//! 77.82, an exact Perl match. (Perl's own 12pt excess over pdflatex is a shared
+//! limitation, not this test's target.)
+//!
+//! The coalescing itself is OXIDIZED_DESIGN #100. NOTE: it does NOT address box
+//! content overflowing the drawn frame when the CLIENT browser substitutes a
+//! wider/taller monospace than cmtt10 — that is the TeX-realm-vs-SVG font
+//! impedance mismatch (shapes frozen at TeX-font metrics; only the
+//! foreignObject text reflows). That is #99's known residual / WISDOM #47.
+//!
+//! Conditional: needs the kernel dump + tcolorbox in the host TeX tree.
+
+use latexml::util::test::{convert_fixture, dump_available, kpse_has};
+
+fn first_box_viewbox_height(xml: &str) -> f64 {
+  // The tcolorbox root <svg:svg> is the first picture; its viewBox is
+  // "minx miny W H" — take H (the 4th number). Skip the nested tcbline
+  // sub-picture by taking the FIRST svg:svg (the outer box).
+  let at = xml.find("<svg:svg").expect("no <svg:svg> box in output");
+  let tag = &xml[at..xml[at..].find('>').expect("unterminated svg:svg") + at];
+  let vb = tag.split("viewBox=\"").nth(1).expect("no viewBox");
+  let vb = &vb[..vb.find('"').unwrap()];
+  vb.split_whitespace()
+    .nth(3)
+    .and_then(|s| s.parse::<f64>().ok())
+    .expect("could not parse viewBox height")
+}
+
+const TEX: &str = "literal:\\documentclass{article}\n\
+  \\usepackage[most]{tcolorbox}\n\
+  \\begin{document}\n\
+  \\begin{tcolorbox}[width=100pt]xxx\\tcbline yyy\\end{tcolorbox}\n\
+  \\end{document}\n";
+
+#[test]
+fn tcbline_box_not_over_measured() {
+  if !(dump_available() && kpse_has("tcolorbox.sty")) {
+    eprintln!("skipping: needs kernel dump + tcolorbox.sty in the host TeX tree");
+    return;
+  }
+  let r = convert_fixture(TEX);
+  let xml = r.result.expect("conversion produced no result");
+
+  let h = first_box_viewbox_height(&xml);
+  // pdflatex 65.79 / Perl 77.82 ground truth; the pre-fix Rust value is 111.03.
+  // The paragraph before the rule must pack to one line, not one-per-glyph.
+  assert!(
+    h < 90.0,
+    "\\tcbline box viewBox height {h} is over-measured (pdflatex 65.8 / Perl 77.8; \
+     pre-fix Rust 111.0) — the paragraph before the rule was not repacked at \
+     digestion, so its characters count as one vertical line each.\n{xml}",
+  );
+  // Sanity floor: it must still contain the rule + two lines (not collapse).
+  assert!(
+    h > 55.0,
+    "\\tcbline box height {h} collapsed below the rule+content floor.\n{xml}",
+  );
+}

--- a/latexml_package/src/package/geometry_sty.rs
+++ b/latexml_package/src/package/geometry_sty.rs
@@ -1,7 +1,26 @@
-//! geometry.sty — page layout (no-op in LaTeXML)
-//! Perl: geometry.sty.ltxml
+//! geometry.sty — page layout.
+//!
+//! Perl LaTeXML (`geometry.sty.ltxml`) makes every geometry macro a no-op:
+//! page geometry is meaningless for the reflowable HTML body, so `\textwidth`
+//! stays at the class default (345pt). We keep that behaviour for the HTML flow
+//! — a `\rule{0.5\linewidth}`, a text minipage, `\includegraphics[width=
+//! \linewidth]` etc. are all sized from the class default exactly as in Perl.
+//!
+//! **Divergence from Perl (OXIDIZED_DESIGN #99):** a *measured SVG graphic*
+//! that reads `\linewidth` — a `tcolorbox`, `tikzpicture`, or bare `pgfpicture`
+//! — is emitted as a fixed-size `<svg>` whose aspect ratio is baked at
+//! conversion time, so ignoring the real page width there makes the picture
+//! `0.5 x 345pt` instead of the `0.5 x 472pt` the PDF draws (letterpaper minus
+//! the document's margins). The narrow interior over-wraps the content, roughly
+//! doubling the box height and pushing text through the border
+//! (arXiv:2605.29955, Figure 1). So we DO compute the geometry text width/height
+//! and inject it into `\linewidth`/`\hsize`/`\columnwidth`/`\textwidth` — but
+//! ONLY inside SVG-producing pictures, never into the main HTML flow. The guard
+//! `\ifdim\linewidth=\textwidth` applies it only at the top level, leaving a
+//! locally-reduced `\linewidth` (nested minipage/parbox) alone.
 use crate::prelude::*;
 
+#[rustfmt::skip]
 LoadDefinitions!({
   // Dependencies — Perl L22-25
   RequirePackage!("keyval");
@@ -9,10 +28,128 @@ LoadDefinitions!({
   RequirePackage!("ifvtex");
   RequirePackage!("ifxetex");
 
-  // All geometry macros are no-ops (page layout not meaningful for XML)
-  def_macro_noop("\\geometry{}")?;
-  def_macro_noop("\\newgeometry{}")?;
-  def_macro_noop("\\restoregeometry")?;
-  def_macro_noop("\\savegeometry{}")?;
-  def_macro_noop("\\loadgeometry{}")?;
+  RawTeX!(r#"\makeatletter
+%% ---- state ---------------------------------------------------------------
+\newdimen\Gm@pw \newdimen\Gm@ph            % paper width/height
+\newdimen\Gm@l \newdimen\Gm@r              % left/right margins
+\newdimen\Gm@t \newdimen\Gm@b              % top/bottom margins
+\newdimen\Gm@tw \newdimen\Gm@th            % computed text width/height (SVG scope)
+\newdimen\Gm@doctw                         % class-default \textwidth (the full column)
+\newif\ifGm@lset \newif\ifGm@rset \newif\ifGm@tset \newif\ifGm@bset
+\newif\ifGm@twset \newif\ifGm@thset
+\Gm@pw=\paperwidth \Gm@ph=\paperheight
+\Gm@tw=\textwidth  \Gm@th=\textheight
+\Gm@doctw=\textwidth
+
+%% ---- helpers -------------------------------------------------------------
+% Split a value that is either scalar `v` or a pair `{a,b}` into \Gm@vA/\Gm@vB.
+% For a scalar, both halves are `v` (so margin=1in => all four margins 1in).
+\def\Gm@pair#1{\Gm@pair@#1,#1,\@nil}
+\def\Gm@pair@#1,#2,#3\@nil{\def\Gm@vA{#1}\def\Gm@vB{#2}}
+
+%% ---- keys (family Gm, prefix KV) -----------------------------------------
+% Paper sizes
+\define@key{Gm}{paperwidth}{\Gm@pw=#1\relax}
+\define@key{Gm}{paperheight}{\Gm@ph=#1\relax}
+\define@key{Gm}{papersize}{\Gm@pair{#1}\Gm@pw=\Gm@vA\relax\Gm@ph=\Gm@vB\relax}
+\define@key{Gm}{letterpaper}[]{\Gm@pw=8.5in\Gm@ph=11in }
+\define@key{Gm}{legalpaper}[]{\Gm@pw=8.5in\Gm@ph=14in }
+\define@key{Gm}{executivepaper}[]{\Gm@pw=7.25in\Gm@ph=10.5in }
+\define@key{Gm}{a4paper}[]{\Gm@pw=210mm\Gm@ph=297mm }
+\define@key{Gm}{a5paper}[]{\Gm@pw=148mm\Gm@ph=210mm }
+\define@key{Gm}{b5paper}[]{\Gm@pw=176mm\Gm@ph=250mm }
+\define@key{Gm}{landscape}[]{\Gm@pw=\paperheight\Gm@ph=\paperwidth}
+% Margins (each with the aliases geometry accepts)
+\define@key{Gm}{left}{\Gm@l=#1\relax\Gm@lsettrue}
+\define@key{Gm}{lmargin}{\Gm@l=#1\relax\Gm@lsettrue}
+\define@key{Gm}{inner}{\Gm@l=#1\relax\Gm@lsettrue}
+\define@key{Gm}{right}{\Gm@r=#1\relax\Gm@rsettrue}
+\define@key{Gm}{rmargin}{\Gm@r=#1\relax\Gm@rsettrue}
+\define@key{Gm}{outer}{\Gm@r=#1\relax\Gm@rsettrue}
+\define@key{Gm}{top}{\Gm@t=#1\relax\Gm@tsettrue}
+\define@key{Gm}{tmargin}{\Gm@t=#1\relax\Gm@tsettrue}
+\define@key{Gm}{bottom}{\Gm@b=#1\relax\Gm@bsettrue}
+\define@key{Gm}{bmargin}{\Gm@b=#1\relax\Gm@bsettrue}
+% margin={h,v}: h -> left+right, v -> top+bottom (scalar -> all four)
+\define@key{Gm}{margin}{\Gm@pair{#1}%
+  \Gm@l=\Gm@vA\relax\Gm@lsettrue \Gm@r=\Gm@vA\relax\Gm@rsettrue
+  \Gm@t=\Gm@vB\relax\Gm@tsettrue \Gm@b=\Gm@vB\relax\Gm@bsettrue}
+% hmargin={l,r}
+\define@key{Gm}{hmargin}{\Gm@pair{#1}%
+  \Gm@l=\Gm@vA\relax\Gm@lsettrue \Gm@r=\Gm@vB\relax\Gm@rsettrue}
+% vmargin={t,b}
+\define@key{Gm}{vmargin}{\Gm@pair{#1}%
+  \Gm@t=\Gm@vA\relax\Gm@tsettrue \Gm@b=\Gm@vB\relax\Gm@bsettrue}
+% Body dimensions given directly
+\define@key{Gm}{textwidth}{\Gm@tw=#1\relax\Gm@twsettrue}
+\define@key{Gm}{width}{\Gm@tw=#1\relax\Gm@twsettrue}
+\define@key{Gm}{totalwidth}{\Gm@tw=#1\relax\Gm@twsettrue}
+\define@key{Gm}{textheight}{\Gm@th=#1\relax\Gm@thsettrue}
+\define@key{Gm}{height}{\Gm@th=#1\relax\Gm@thsettrue}
+\define@key{Gm}{totalheight}{\Gm@th=#1\relax\Gm@thsettrue}
+% scale=s (or {sh,sv}) — fraction of the paper size
+\define@key{Gm}{scale}{\Gm@pair{#1}%
+  \Gm@tw=\Gm@vA\Gm@pw\Gm@twsettrue \Gm@th=\Gm@vB\Gm@ph\Gm@thsettrue}
+
+%% ---- recompute the text box from the collected keys ----------------------
+\def\Gm@recalc{%
+  \ifGm@twset\else
+    \ifGm@lset\ifGm@rset
+      \Gm@tw=\Gm@pw \advance\Gm@tw-\Gm@l \advance\Gm@tw-\Gm@r
+    \fi\fi
+  \fi
+  \ifGm@thset\else
+    \ifGm@tset\ifGm@bset
+      \Gm@th=\Gm@ph \advance\Gm@th-\Gm@t \advance\Gm@th-\Gm@b
+    \fi\fi
+  \fi}
+
+% \geometry{keys} — parse (ignoring unimplemented keys) and recompute.
+\def\geometry#1{\setkeys*{Gm}{#1}\Gm@recalc}
+\def\newgeometry#1{\setkeys*{Gm}{#1}\Gm@recalc}
+\let\restoregeometry\@empty
+\def\savegeometry#1{}
+\def\loadgeometry#1{}
+
+% Package options — `\usepackage[left=...,margin=...]{geometry}` — are routed
+% through the same key parser; each comma item arrives as \CurrentOption.
+\def\Gm@opt#1{\setkeys*{Gm}{#1}}
+\DeclareOption*{\expandafter\Gm@opt\expandafter{\CurrentOption}}
+\ProcessOptions*\relax
+\Gm@recalc
+
+%% ---- SVG-scope injection -------------------------------------------------
+% Applied at the start of an SVG-producing picture: raise \linewidth (and the
+% siblings measured graphics read) to the geometry text width, but ONLY when the
+% picture is at the FULL column width — compared against the class-default
+% \textwidth captured at load (\Gm@doctw), NOT the live \textwidth. A minipage
+% sets \textwidth=\linewidth locally, so `\linewidth=\textwidth` is true inside
+% one too; comparing to \Gm@doctw instead keeps a reduced \linewidth (nesting
+% minipage/parbox) untouched. Scoped to the picture's group, so the surrounding
+% HTML flow is never touched.
+\def\Gm@applysvgwidth{%
+  \ifdim\linewidth=\Gm@doctw
+    \linewidth=\Gm@tw \columnwidth=\Gm@tw \hsize=\Gm@tw \textwidth=\Gm@tw
+    \textheight=\Gm@th
+  \fi}
+
+% Install the picture hooks after all packages have loaded (tcolorbox/tikz/pgf
+% are raw-loaded and only then defined). Prepend, so the width is in force
+% before the box reads its `width=...\linewidth` key.
+\AtBeginDocument{%
+  \@ifundefined{tcolorbox}{}{%
+    \let\Gm@orig@tcolorbox\tcolorbox
+    \def\tcolorbox{\Gm@applysvgwidth\Gm@orig@tcolorbox}}%
+  \@ifundefined{tikzpicture}{}{%
+    \let\Gm@orig@tikzpicture\tikzpicture
+    \def\tikzpicture{\Gm@applysvgwidth\Gm@orig@tikzpicture}}%
+  \@ifundefined{pgfpicture}{}{%
+    \let\Gm@orig@pgfpicture\pgfpicture
+    \let\Gm@orig@endpgfpicture\endpgfpicture
+    % \pgfpicture opens its own group internally, so wrap it in an explicit
+    % group of our own to keep the width change from leaking past the picture.
+    \def\pgfpicture{\begingroup\Gm@applysvgwidth\Gm@orig@pgfpicture}%
+    \def\endpgfpicture{\Gm@orig@endpgfpicture\endgroup}}%
+}
+\makeatother"#);
 });

--- a/latexml_package/src/package/keyval_sty.rs
+++ b/latexml_package/src/package/keyval_sty.rs
@@ -23,8 +23,18 @@ LoadDefinitions!({
     })?;
   });
 
-  // \setkeys{keyset}{keyvals}
-  DefMacro!("\\setkeys{}", sub[(keyset_tks)] {
+  // \setkeys{keyset}{keyvals} and its starred form \setkeys*{keyset}{keyvals}.
+  //
+  // keyval's `\setkeys*` (and xkeyval's) silently *ignores* keys not defined in
+  // the keyset rather than raising "undefined key" — the two forms differ only
+  // in how a missing key is handled (`SkipMissing::None` = warn/error vs
+  // `SkipMissing::All` = silently drop). The keyvals themselves are read
+  // imperatively from the stream (not a macro argument), and the required
+  // keyset group is a `{}` argument grabbed *before* the sub body runs, so a
+  // leading `*` cannot be peeked here — dispatch on it in TeX with `\@ifstar`,
+  // routing to the warn/ignore variant, each of which then grabs `{keyset}` and
+  // reads the following `{keyvals}` group.
+  fn setkeys_body(keyset_tks: Tokens, skip_missing: keyvals::SkipMissing) -> Result<Tokens> {
     let keyset = do_expand(keyset_tks)?.to_string();
     let keysets: Vec<String> = keyset.split(',')
       .map(|s| s.trim().to_string())
@@ -37,10 +47,18 @@ LoadDefinitions!({
       set_all: false,
       set_internals: true,
       skip: Vec::new(),
-      skip_missing: keyvals::SkipMissing::None,
+      skip_missing,
       hook_missing: None,
     });
     keyvals.read_from(T_END!(), false)?;
     Ok(keyvals.set_keys_expansion())
+  }
+
+  DefMacro!("\\ltx@setkeys@warn{}", sub[(keyset_tks)] {
+    setkeys_body(keyset_tks, keyvals::SkipMissing::None)
   });
+  DefMacro!("\\ltx@setkeys@ignore{}", sub[(keyset_tks)] {
+    setkeys_body(keyset_tks, keyvals::SkipMissing::All)
+  });
+  RawTeX!(r"\def\setkeys{\@ifstar\ltx@setkeys@ignore\ltx@setkeys@warn}");
 });


### PR DESCRIPTION
Correctly size the tcolorbox/tikz SVG graphics of arXiv:2605.29955 Fig 1 — aspect, composition, and segment height — without touching the reflowable HTML flow.

- **geometry is SVG-scoped** (OXIDIZED_DESIGN #98): the geometry text width feeds the *measured SVG picture* width only (inside tcolorbox/tikzpicture/pgfpicture), never the HTML flow. A full-text-width figure keeps its PDF aspect and its `0.495\linewidth` panels sit side-by-side instead of collapsing to 2:1.
- **Guard on the class-default width**: the top-level hook compares `\linewidth` against the saved `\Gm@doctw`, not the live `\textwidth` (a minipage sets `textwidth=linewidth` locally and would mis-fire).
- **Panel arrangement** (`after_float`) sizes to `\Gm@tw` for full-column floats — the row threshold only; HTML content stays class-default. `fairmeta.cls` now loads geometry with its class margins instead of stubbing it as visual-only.
- **`\setkeys*`** is honored (`\@ifstar` → `SkipMissing::All`), so geometry's unimplemented keys are ignored silently.
- **`\tcbline` segment height** (OXIDIZED_DESIGN #99): a text-mode `{...}` group that ends a paragraph (as `\tcbline` does) now repacks the outer paragraph at digestion ("R2"). Previously the grouped `\par` could not repack it, leaving loose characters that `compute_boxes_size` counted one line per glyph — 111.03pt vs Perl 77.82. The trigger is narrow (mid-paragraph entry AND a `\par` in the group), so the measurement code stays the pure Perl algorithm. Exact 77.82 match.

Guards: `122_geometry_svg_sizing`, `123_tcbline_nointerlineskip`. Full suite green (1919/0); clippy `-D warnings` and `cargo doc` clean; witness 2605.29955 re-converts with 0 fatals.

Known residual (unchanged, tracked separately): a `\ttfamily` box can still poke a few px past its border — the TeX-realm-vs-SVG font impedance mismatch (WISDOM #47), orthogonal to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)