### PR TITLE
fix: `\mathversion{bold}` switches the math font, not the text font

### DIFF
--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -1599,10 +1599,8 @@ turns the test red and forces an update. Each says so in its own doc comment.
   base rate: 2.0% of 547 sampled papers emit any font diagnostic at all, and the
   log census is a LOWER bound because a family-map miss on a mapped encoding is
   completely silent.
-- **`\mathversion{bold}` merges the text font instead of `mathfont`** — VERIFIED
-  still-broken 2026-08-05 (`latex_constructs.pool.ltxml` L5290 vs
-  `latex_constructs.rs:10653`). Rust's `\boldmath`/`\unboldmath` get this
-  right, so `\mathversion` is the odd one out. (Same item as sweep #5 below.)
+- **`\mathversion{bold}` merges the text font instead of `mathfont`** — ✅ **FIXED
+  2026-08-05** (see sweep #5 below).
 - **`\DeclareTextCommand`/`\ProvideTextCommand` don't install the encoding-dispatch
   chain** — VERIFIED still-broken 2026-08-05 (`latex_constructs.rs:6525`/`6544`).
   Kernel accents are masked by the dump, so only package-declared text commands
@@ -1665,13 +1663,14 @@ with file:line, not established facts — re-verify before acting**:
    `Info!("ignore", …)` on the already-defined branch — matching Perl
    `latex_constructs.pool.ltxml:2677`. The def is at `latex_constructs.rs:6998`
    (`:6957` is now `\new@internalmathalphabet`).
-5. **`\mathversion{bold}` merges the text font, not `mathfont`** — VERIFIED
-   still-broken 2026-08-05 (`:5290` vs `latex_constructs.rs:10653`:
-   `"bold" => MergeFont!(forcebold => true)` merges the TEXT `font` value, where
-   Perl `AssignValue(mathfont => …merge(forcebold))`); Rust's
-   `\boldmath`/`\unboldmath` (`plain_base.rs:747`) get this right, so
-   `\mathversion` is the odd one out. Unknown versions also swallowed
-   (`_ => {}`) instead of `Error`.
+5. **`\mathversion{bold}` merges the text font, not `mathfont`** — ✅ **FIXED
+   2026-08-05** (`latex_constructs.rs:10653`). It was `MergeFont!(forcebold =>
+   true)` (merges the current TEXT `font`), so math never went bold; now it does
+   `AssignValue(mathfont => LookupValue('mathfont')->merge(forcebold => N),
+   'local')` exactly like `\boldmath`/`\unboldmath` (Perl
+   `latex_constructs.pool.ltxml` L5290-5297), and an unknown version raises
+   `Error('unexpected', …)` instead of the silent `_ => {}`. Guard
+   `06_cluster_regressions::mathversion_switches_the_mathfont_like_boldmath`.
 6. **`\DeclareTextCommand`/`\ProvideTextCommand` don't install the encoding-dispatch
    chain** — VERIFIED still-broken 2026-08-05 (`:2584`/`:2598` vs
    `latex_constructs.rs:6525`/`6544`, which bind the bare `\cs` to the raw

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -10640,7 +10640,6 @@ LoadDefinitions!({
       before_digest => { Digest!(font_toks.clone())?; });
   });
 
-  // Perl L5341-5348: \mathversion — switches between bold/normal math fonts
   // Perl L5373: \newfont{cmd}{fontname} — legacy LaTeX font command
   DefMacro!("\\newfont{}{}", "\\font#1=#2\\relax");
   // Perl L5375: \normalcolor — default no-op (overridden by color.sty)
@@ -10649,13 +10648,24 @@ LoadDefinitions!({
   // Perl L5364: \math@version default
   DefMacro!("\\math@version", "normal");
 
-  // Perl L5341-5348: \mathversion — switches between bold/normal math fonts
+  // Perl latex_constructs.pool.ltxml L5290-5297: \mathversion switches the
+  // MATHFONT — `AssignValue(mathfont => LookupValue('mathfont')->merge(forcebold
+  // => N), 'local')` — exactly as \boldmath/\unboldmath do (plain_base.rs
+  // L748-762). It was using `MergeFont!`, which merges the current *text* `font`
+  // value, so `\mathversion{bold}` never reached the math font; and an unknown
+  // version fell to `_ => {}`, silently swallowed where Perl raises
+  // `Error('unexpected', …)`. Both now match Perl. (\mathversion has no
+  // `forbidMath`, unlike \boldmath/\unboldmath — Perl doesn't either.)
   DefPrimitive!("\\mathversion{}", sub[(version)] {
-    let v = version.to_string();
-    match v.trim() {
-      "bold" => { MergeFont!(forcebold => true); },
-      "normal" => { MergeFont!(forcebold => false); },
-      _ => {},
+    let set_forcebold = |bold: bool| {
+      let mf = lookup_mathfont().unwrap_or_else(|| Rc::new(Font::math_default()));
+      let merged = mf.merge(Font { forcebold: Some(bold), ..Font::default() });
+      assign_value("mathfont", Stored::Font(Rc::new(merged)), Some(Scope::Local));
+    };
+    match version.to_string().trim() {
+      "bold" => set_forcebold(true),
+      "normal" => set_forcebold(false),
+      other => { Error!("unexpected", other, s!("Unknown math version '{other}'")); },
     }
   });
 

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -585,3 +585,38 @@ fn faked_space_is_sized_by_the_font_it_was_digested_in() {
     "the line-number skip must be sized by the line-number font:\n{xml}"
   );
 }
+
+/// `\mathversion{bold}` switches the MATH font, exactly like `\boldmath`
+/// (`plain_base.rs`) — Perl `latex_constructs.pool.ltxml` L5290-5297,
+/// `AssignValue(mathfont => LookupValue('mathfont')->merge(forcebold => N))`. It
+/// was using `MergeFont!`, which merges the current *text* `font` value, so
+/// `\mathversion{bold}` never reached the math font; and an unknown version fell
+/// to a silent `_ => {}` where Perl raises `Error('unexpected', …)`. The `{...}`
+/// groups isolate the `local` assignment so `p`/`s` stay plain math italic.
+#[test]
+fn mathversion_switches_the_mathfont_like_boldmath() {
+  let xml = convert_to_xml("tests/cluster_regressions/mathversion_bold_sets_mathfont.tex");
+  // q (grouped \mathversion{bold}) must match r (grouped \boldmath): both bold.
+  assert!(
+    xml.contains(r#"<XMTok font="bold italic" role="UNKNOWN">q</XMTok>"#),
+    "\\mathversion{{bold}} did not bold the math font — MergeFont! merges the \
+     TEXT font, leaving math un-bold:\n{xml}"
+  );
+  assert!(
+    xml.contains(r#"<XMTok font="bold italic" role="UNKNOWN">r</XMTok>"#),
+    "\\boldmath reference is not bold — the test premise is broken:\n{xml}"
+  );
+  // p and s, outside any bold group, must NOT be bold (clean local-scope reset).
+  assert!(
+    xml.contains(r#"<XMTok font="italic" role="UNKNOWN">p</XMTok>"#)
+      && xml.contains(r#"<XMTok font="italic" role="UNKNOWN">s</XMTok>"#),
+    "plain math outside the bold groups must stay italic, not bold:\n{xml}"
+  );
+
+  // An unknown version raises Error('unexpected', …) (Perl L5297); pre-fix the
+  // `_ => {}` arm swallowed it (0 errors), so "exactly 1 error" is the guard.
+  let _ = convert_expecting_errors(
+    "tests/cluster_regressions/mathversion_unknown_version_errors.tex",
+    1,
+  );
+}

--- a/latexml_oxide/tests/cluster_regressions/mathversion_bold_sets_mathfont.tex
+++ b/latexml_oxide/tests/cluster_regressions/mathversion_bold_sets_mathfont.tex
@@ -1,0 +1,16 @@
+% \mathversion{bold} must switch the MATH font (like \boldmath), not merge the
+% text font. Pre-fix it used MergeFont! (which merges the text `font` value), so
+% math never went bold. `p`/`s` stay plain math italic; grouped `q`
+% (\mathversion{bold}) and `r` (\boldmath reference) must both be bold italic.
+% The `{...}` groups isolate the `local` mathfont assignment so the reset is
+% clean. Perl latex_constructs.pool.ltxml L5290-5297 (== plain_base L612-617).
+\documentclass{article}
+\begin{document}
+Plain: $p$
+
+Grouped mathversion: {\mathversion{bold}$q$}
+
+Boldmath reference: {\boldmath$r$}
+
+After groups: $s$
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/mathversion_unknown_version_errors.tex
+++ b/latexml_oxide/tests/cluster_regressions/mathversion_unknown_version_errors.tex
@@ -1,0 +1,7 @@
+% \mathversion with an unknown version must raise Error('unexpected', …) —
+% Perl latex_constructs.pool.ltxml L5297. Pre-fix the `_ => {}` arm swallowed it
+% (0 errors, silent). Expected: exactly 1 error.
+\documentclass{article}
+\begin{document}
+$x$ \mathversion{wobble} $y$
+\end{document}


### PR DESCRIPTION
## What

`\mathversion{bold}`/`{normal}` used `MergeFont!(forcebold => …)`, which merges the current **text** `font` value — so the bold never reached the *math* font and math stayed un-bold. An unknown version also fell to a silent `_ => {}` where Perl raises `Error('unexpected', …)`.

Ported faithfully to Perl `latex_constructs.pool.ltxml` L5290-5297:

```perl
AssignValue(mathfont => LookupValue('mathfont')->merge(forcebold => N), 'local')
```

This is exactly what `\boldmath`/`\unboldmath` already do (`plain_base.rs` L748-762) — which is why those were correct and `\mathversion` was the odd one out — plus the restored `Error` arm. (`\mathversion` has no `forbidMath`; neither does Perl.)

Also removed a stray misplaced `\mathversion` comment sitting above `\newfont` with a wrong line ref.

## Verification

- **Same-host Perl 0.8.8 byte-identical** on the repro: `\mathversion{bold}$q$` and `\boldmath$r$` both `font="bold italic"`; plain `$p$`/`$s$` stay `font="italic"`.
- New guard `06_cluster_regressions::mathversion_switches_the_mathfont_like_boldmath` confirmed **RED** (fix reverted) → **GREEN**. The `{...}` groups isolate the `local` mathfont assignment so the scope reset is clean.
- The two fixtures are also swept by `114_streaming_cluster_regressions` (eager == streaming).
- Full suite **1919/1919**, clippy + fmt clean.

Also marks the item ✅ FIXED in `docs/SYNC_STATUS.md` (both the "still open" bullet and font-sweep #5), where it was de-staled to VERIFIED-still-broken in the previous PR.

## Test plan

- `cargo test -p latexml --test 06_cluster_regressions` — 36/36
- `cargo test -p latexml --test 114_streaming_cluster_regressions` — 1/1
- `cargo nextest run --workspace` — 1919/1919
- `cargo clippy --workspace --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)