### PR TITLE
fix: fvextra no longer strips fancyvrb `Verbatim`'s ltx_verbatim class (issue 502)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,10 @@
     keep their own row, indentation and spacing (the binding's per-line
     `ltx_verbatim` class had been dropped in porting), and the bundled CSS
     replaces vanilla's `nowrap` — which collapsed a plain `{verbatim}` block
-    to a single line — with true `pre` whitespace (issue 431).
+    to a single line — with true `pre` whitespace (issue 431). Loading
+    `fvextra` no longer strips that class: fvextra redefines
+    `\FancyVerbFormatLine` after requiring fancyvrb, so its hook is now
+    re-installed over the redefinition (issue 502).
   - **A stale or empty stylesheet in the output directory is overwritten** instead
     of leaving the page unstyled.
   - **Split output (`--splitat`) styles every page** and carries the document date

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -44,6 +44,23 @@ fn cluster_cmidrule_cline_let() {
 fn cluster_fvextra_breakanywhere() {
   convert_clean("tests/cluster_regressions/fvextra_breakanywhere.tex");
 }
+/// fvextra loaded after fancyvrb must NOT strip the `ltx_verbatim` css class
+/// from `Verbatim` lines. `fancyvrb_sty.rs` installs the class by wrapping
+/// `\FancyVerbFormatLine` (`\lx@add@cssclass{ltx_verbatim}…`); fvextra.sty L2249
+/// then `\def\FancyVerbFormatLine#1{#1}` overwrites that wrapper, so every line
+/// loaded after fvextra lost `class="ltx_verbatim"` (and its `white-space:pre`)
+/// — the verbatim collapsed to ordinary typewriter text, silently, 0 errors.
+/// `fvextra_sty.rs` re-installs the hook over fvextra's redefinition. Witness:
+/// issue #502 (fancyvrb + fvextra; pre-fix 0 `ltx_verbatim`, post-fix one per line).
+#[test]
+fn cluster_fvextra_preserves_ltx_verbatim() {
+  let xml = convert_to_xml("tests/cluster_regressions/fvextra_ltx_verbatim.tex");
+  assert!(
+    xml.contains(r#"class="ltx_verbatim""#),
+    "fvextra clobbered the ltx_verbatim class — its `\\def\\FancyVerbFormatLine` \
+     overwrote the fancyvrb hook, so verbatim lines lose white-space:pre:\n{xml}"
+  );
+}
 /// An unbound class (->OmniBus) whose `.bbl` `\bibitem[\protect\citeauthoryear…]`
 /// side-loads natbib must not leave a body `\citep` looping. The side-load runs
 /// inside the `thebibliography` group, so natbib's `\citep` would be popped on

--- a/latexml_oxide/tests/cluster_regressions/fvextra_ltx_verbatim.tex
+++ b/latexml_oxide/tests/cluster_regressions/fvextra_ltx_verbatim.tex
@@ -1,0 +1,14 @@
+\documentclass[12pt]{book}
+\usepackage{fancyvrb}
+\usepackage{fvextra}
+\begin{document}
+\begin{Verbatim}
+TEST 1  ABC
+TEST 2
+
+TEST 3
+
+for i in range(10):
+    print(i)
+\end{Verbatim}
+\end{document}

--- a/latexml_package/src/package/fancyvrb_sty.rs
+++ b/latexml_package/src/package/fancyvrb_sty.rs
@@ -7,8 +7,10 @@ LoadDefinitions!({
 
   // Perl fancyvrb.sty.ltxml L22-25: hack internals to add css class ltx_verbatim
   // to every typeset source line (fancyvrb applies \FancyVerbFormatLine per line
-  // for all Verbatim variants; fvextra/minted raw-load the real .sty whose
-  // \RequirePackage{fancyvrb} routes through this binding, so they inherit it).
+  // for all Verbatim variants). NOTE: a package that redefines
+  // \FancyVerbFormatLine after requiring fancyvrb overwrites this hook — fvextra
+  // (L2249 `\def\FancyVerbFormatLine#1{#1}`) does exactly that, so fvextra_sty.rs
+  // re-installs the hook over its redefinition (issue #502).
   Let!("\\lx@save@FancyVerbFormatLine", "\\FancyVerbFormatLine");
   DefMacro!("\\FancyVerbFormatLine{}",
     "\\lx@add@cssclass{ltx_verbatim}\\lx@save@FancyVerbFormatLine{#1}");

--- a/latexml_package/src/package/fvextra_sty.rs
+++ b/latexml_package/src/package/fvextra_sty.rs
@@ -33,4 +33,16 @@ LoadDefinitions!({
   InputDefinitions!("fvextra", noltxml => true, extension => Some(Cow::Borrowed("sty")));
 
   RawTeX!(r"\let\FV@Break\relax");
+
+  // fvextra L2249 `\def\FancyVerbFormatLine#1{#1}` OVERWRITES the ltx_verbatim
+  // css-class hook that fancyvrb_sty.rs installs on `\FancyVerbFormatLine` (via
+  // `\lx@add@cssclass{ltx_verbatim}`). fvextra runs its `\def` AFTER
+  // `\RequirePackage{fancyvrb}`, so a Verbatim loaded once fvextra is present
+  // lost `class="ltx_verbatim"` — and with it `white-space:pre` — collapsing to
+  // ordinary typewriter text (issue #502). Re-install the hook over fvextra's
+  // redefinition (with the scanner relaxed above, `\FancyVerbFormatLine` is
+  // just the per-line formatter, so wrapping it is safe).
+  Let!("\\lx@save@FancyVerbFormatLine", "\\FancyVerbFormatLine");
+  DefMacro!("\\FancyVerbFormatLine{}",
+    "\\lx@add@cssclass{ltx_verbatim}\\lx@save@FancyVerbFormatLine{#1}");
 });


### PR DESCRIPTION
## Problem (issue 502)

Loading `fvextra` silently strips verbatim formatting from `fancyvrb`'s `Verbatim`: line breaks and whitespace collapse to ordinary typewriter text, with **0 errors** in the log. Removing `\usepackage{fvextra}` restores it.

## Root cause

`fancyvrb_sty.rs` carries the per-line `ltx_verbatim` class (which supplies `white-space:pre`) by wrapping `\FancyVerbFormatLine`. **fvextra.sty L2249 `\def\FancyVerbFormatLine#1{#1}`** runs *after* its own `\RequirePackage{fancyvrb}` and overwrites that wrapper — so every `Verbatim` line loaded once fvextra is present loses the class.

## Fix

Re-install the hook in `fvextra_sty.rs` after fvextra's raw-load (its break scanner is already relaxed there, so `\FancyVerbFormatLine` is just the per-line formatter). Genuine Rust-only divergence — Perl LaTeXML ships no `fvextra.sty.ltxml`, so it never loads the clobbering `\def`; **same-host Perl 0.8.8 keeps the class (7/7 lines)** and our post-fix output now matches it. Robust to load order (fvextra with or without an explicit `fancyvrb`).

## Guard

`06_cluster_regressions::cluster_fvextra_preserves_ltx_verbatim` (red pre-fix: 0 `ltx_verbatim`; green post-fix: one per line). Full suite 1920/0, clippy + rustdoc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)