### PR TITLE
release: 0.7.5-rc6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [0.7.5] (Rhai binding API; bibliography content recovery; wider math coverage; large-document memory; default-CSS sync; ar5iv corpus fixes)
 
+  - **arXiv HTML-feedback fidelity fixes.** Title-page `\date{...}` renders bare,
+    without the surrounding parentheses (arXiv html_feedback 1934); `\parbox`/`\mbox`
+    math nested inside math converts to presentation MathML instead of garbled raw
+    content-MathML (arXiv html_feedback 6847); and Springer-Nature `sn-jnl.cls`
+    author affiliations attach to their authors instead of floating off as an
+    orphaned note (arXiv html_feedback 534).
   - **`geometry`-driven tcolorbox/tikz graphics size to the real page width, and
     `\tcbline`-segmented boxes measure their height correctly.** Page geometry now
     feeds the *measured SVG picture* width — never the reflowable HTML flow — so a

--- a/latexml_codegen/Cargo.toml
+++ b/latexml_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml_codegen"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "CC0-1.0"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
@@ -37,4 +37,4 @@ glob = "0.3"
 # codegen path uses only the binding AST and never resolves TeX files. The
 # runtime `latexml_core` (linked into the binary) keeps kpathsea via its
 # default feature; resolver v2 keeps the two builds separate.
-latexml_core = { path = "../latexml_core", version = "0.4.0", default-features = false, features = ["codegen"] }
+latexml_core = { path = "../latexml_core", version = "0.5.0", default-features = false, features = ["codegen"] }

--- a/latexml_contrib/Cargo.toml
+++ b/latexml_contrib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml_contrib"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "CC0-1.0"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
@@ -31,10 +31,10 @@ token-locators = ["latexml_core/token-locators"]
 runtime-bindings = ["dep:rhai", "dep:log"]
 
 [dependencies]
-latexml_core = {path = "../latexml_core", version = "0.4.0"}
-latexml_codegen = {path = "../latexml_codegen", version = "0.4.0"}
-latexml_engine = {path = "../latexml_engine", version = "0.5.0"}
-latexml_package = {path = "../latexml_package", version = "0.5.0"}
+latexml_core = {path = "../latexml_core", version = "0.5.0"}
+latexml_codegen = {path = "../latexml_codegen", version = "0.4.1"}
+latexml_engine = {path = "../latexml_engine", version = "0.6.0"}
+latexml_package = {path = "../latexml_package", version = "0.6.0"}
 rustc-hash = "2.0.0"
 libxml = "0.3.21"
 regex = { version = "1.7.1", default-features = false, features = ["std", "perf", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script"] }

--- a/latexml_core/Cargo.toml
+++ b/latexml_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml_core"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "CC0-1.0"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]

--- a/latexml_engine/Cargo.toml
+++ b/latexml_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml_engine"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 license = "CC0-1.0"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
@@ -36,5 +36,5 @@ rustc-hash = "2.0.0"
 # Runtime gunzip of the embedded dumps from `build.rs` (DEP-12).
 # Same flate2 instance the binary already pulls via zip/tar.
 flate2 = "1"
-latexml_codegen = { path = "../latexml_codegen", version = "0.4.0" }
-latexml_core = { path = "../latexml_core", version = "0.4.0" }
+latexml_codegen = { path = "../latexml_codegen", version = "0.4.1" }
+latexml_core = { path = "../latexml_core", version = "0.5.0" }

--- a/latexml_math_parser/Cargo.toml
+++ b/latexml_math_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml_math_parser"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
 edition = "2024"
 license = "CC0-1.0"
@@ -26,6 +26,6 @@ regex = { version = "1.7.1", default-features = false, features = ["std", "perf"
 marpa = { package = "marpa-asf", version = "0.3.0" }
 once_cell = "1.17.0"
 rustc-hash = "2.0.0"
-latexml_core = { path = "../latexml_core", version = "0.4.0" }
+latexml_core = { path = "../latexml_core", version = "0.5.0" }
 # stack-growth guard now goes through latexml_core::stack_guard (one configurable
 # home for the maybe_grow params); no direct stacker dependency needed here.

--- a/latexml_oxide/Cargo.toml
+++ b/latexml_oxide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml"
-version = "0.7.5-rc5"
+version = "0.7.5-rc6"
 edition = "2024"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
 license = "CC0-1.0"

--- a/latexml_oxide/Cargo.toml
+++ b/latexml_oxide/Cargo.toml
@@ -157,13 +157,13 @@ regex = { version = "1.7.1", default-features = false, features = ["std", "perf"
 glob = { version = "0.3", optional = true }
 phf = { version = "0.14.0", features = ["macros"], optional = true }
 rustc-hash = "2.0.0"
-latexml_codegen = {path = "../latexml_codegen", version = "0.4.0"}
-latexml_core = {path = "../latexml_core", version = "0.4.0"}
-latexml_engine = {path = "../latexml_engine", version = "0.5.0"}
-latexml_package = {path = "../latexml_package", version = "0.5.0"}
-latexml_contrib = {path = "../latexml_contrib", version = "0.3.0"}
-latexml_math_parser = {path = "../latexml_math_parser", version = "0.3.0"}
-latexml_post = {path = "../latexml_post", version = "0.3.0"}
+latexml_codegen = {path = "../latexml_codegen", version = "0.4.1"}
+latexml_core = {path = "../latexml_core", version = "0.5.0"}
+latexml_engine = {path = "../latexml_engine", version = "0.6.0"}
+latexml_package = {path = "../latexml_package", version = "0.6.0"}
+latexml_contrib = {path = "../latexml_contrib", version = "0.4.0"}
+latexml_math_parser = {path = "../latexml_math_parser", version = "0.4.0"}
+latexml_post = {path = "../latexml_post", version = "0.4.0"}
 pericortex = { version = "0.2.8", optional = true }
 hostname = { version = "0.4", optional = true }
 # Replaces glibc malloc. glibc's per-arena mutex is a hard scaling bottleneck

--- a/latexml_package/Cargo.toml
+++ b/latexml_package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml_package"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 license = "CC0-1.0"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
@@ -23,7 +23,7 @@ regex = { version = "1.7.1", default-features = false, features = ["std", "perf"
 libxml = "0.3.21"
 rustc-hash = "2.0.0"
 base64 = "0.23"
-latexml_codegen = { path = "../latexml_codegen", version = "0.4.0" }
-latexml_core = { path = "../latexml_core", version = "0.4.0" }
+latexml_codegen = { path = "../latexml_codegen", version = "0.4.1" }
+latexml_core = { path = "../latexml_core", version = "0.5.0" }
 winnow = "1.0"
-latexml_engine = { path = "../latexml_engine", version = "0.5.0" }
+latexml_engine = { path = "../latexml_engine", version = "0.6.0" }

--- a/latexml_post/Cargo.toml
+++ b/latexml_post/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml_post"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "CC0-1.0"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
@@ -52,7 +52,7 @@ which = "8"
 # a raw `.bib` is now converted by the injected recursive BibTeX session, which
 # lives in `latexml_oxide` because it needs the model loader. This crate is back
 # to depending on `latexml_core` alone.
-latexml_core = {path = "../latexml_core", version = "0.4.0"}
+latexml_core = {path = "../latexml_core", version = "0.5.0"}
 rusqlite = { version = "0.40.1", features = ["bundled"] }
 serde_json = "1.0.151"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,10 +1,11 @@
-# Floating nightly, deliberately (2026-07-03): we track the latest nightly
-# everywhere — dev, CI, and dependent workspaces (ar5iv-editor) — so fmt/
-# clippy/codegen drift surfaces immediately instead of at release time.
-# (The project requires nightly — latexml_core uses #![feature(thread_local)];
-# see CLAUDE.md.) If release-day reproducibility is ever needed again, pin a
-# dated nightly here and CI follows automatically (workflows run plain
-# `cargo`, resolved through this file).
+# Pinned nightly for the 0.7.5-rc6 release (2026-08-06). Nightlies in the window
+# (2026-07-27, 2026-08-04] regressed fat-LTO rustc RSS to >200 GB and OOM-kill the
+# `maxperf` release build (issue #512); nightly-2026-07-27 is the last-known-good
+# (5.3 GB fat-LTO). CI and the tag-triggered release both resolve their toolchain
+# through this file (the 0.7.0 release used the same dated-pin mechanism), so this
+# freezes every leg on the good nightly. Revert to floating `channel = "nightly"`
+# once a fixed nightly lands and #512 closes. (The project requires nightly —
+# latexml_core uses #![feature(thread_local)]; see CLAUDE.md.)
 [toolchain]
-channel = "nightly"
+channel = "nightly-2026-07-27"
 components = ["rustfmt", "clippy", "rust-src"]


### PR DESCRIPTION
**Version.** `latexml_oxide` `0.7.5-rc5` → `0.7.5-rc6`; CHANGELOG gains the rc6 window (arXiv html_feedback fidelity fixes: date parens 1934 #519, nested-math 6847 #518, sn-jnl affiliations 534 #521 — all merged).

**Toolchain pin (issue #512).** `rust-toolchain.toml` pinned to `nightly-2026-07-27` — the last-known-good fat-LTO nightly (5.3 GB). Nightlies in (2026-07-27, 2026-08-04] regressed fat-LTO rustc RSS to >200 GB and OOM-kill the `maxperf` release build. Same dated-pin mechanism the 0.7.0 release used; CI + the tag-triggered release both resolve their toolchain through this file. Revert once a fixed nightly lands.

**Validation.** This PR's CI is the end-to-end check that the pin resolves correctly and the workspace is green on it. Merged-main full suite before this PR: 1928/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)