### PR TITLE
release: 0.7.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/dginev/latexml-oxide/actions/workflows/CI.yml/badge.svg)](https://github.com/dginev/latexml-oxide/actions/workflows/CI.yml)
 [![release](https://img.shields.io/github/v/release/dginev/latexml-oxide?color=orange)](https://github.com/dginev/latexml-oxide/releases)
 [![license: CC0-1.0](https://img.shields.io/badge/license-CC0--1.0-blue.svg)](LICENSE)
-![ported tests](https://img.shields.io/badge/ported%20tests-1617-32a852?style=flat)
+![ported tests](https://img.shields.io/badge/ported%20tests-1928-32a852?style=flat)
 [![arXiv](https://img.shields.io/badge/arXiv-2605.16562-b31b1b.svg)](https://arxiv.org/abs/2605.16562)
 
 latexml-oxide turns LaTeX sources into accessible web documents.
@@ -52,7 +52,7 @@ A few external tools are called as subprocesses, mainly to convert graphics file
 
 The steps below use a version variable — set it to the release you want:
 ```
-$ VERSION=0.7.4
+$ VERSION=0.7.5
 ```
 
 ### Ubuntu / Debian
@@ -128,7 +128,7 @@ Homebrew's `texlive` or MacTeX/BasicTeX — just make sure the TeX binaries are 
 shipped in a `.zip`. In PowerShell run:
 
 ```
-> $VERSION = "0.7.4"
+> $VERSION = "0.7.5"
 > curl.exe -LO "https://github.com/dginev/latexml-oxide/releases/download/$VERSION/latexml-oxide-$VERSION-x86_64-pc-windows-msvc.zip"
 > Expand-Archive "latexml-oxide-$VERSION-x86_64-pc-windows-msvc.zip" -DestinationPath .
 > .\latexml-oxide-$VERSION-x86_64-pc-windows-msvc\latexml_oxide.exe --version

--- a/latexml_oxide/Cargo.toml
+++ b/latexml_oxide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml"
-version = "0.7.5-rc6"
+version = "0.7.5"
 edition = "2024"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
 license = "CC0-1.0"


### PR DESCRIPTION
**Promote `0.7.5-rc6` → final `0.7.5`.** The rc6 draft built all 15 assets across every platform (Linux x64/arm64, macOS arm64/Intel, Windows) on the pinned `nightly-2026-07-27` with **no fat-LTO OOM** (#512); gh-pages docs green.

**Change:** top crate `0.7.5-rc6 → 0.7.5`; README ported-tests badge `1617 → 1928` and install `VERSION` samples → `0.7.5`. Subcrate versions already bumped (in `0.7.5-rc6`) for the crates.io republish.

**After merge (gated):** tag `0.7.5` → public Release + containers → Homebrew tap → crates.io (after binaries+docs gates) → deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)