### PR TITLE
ci: green the lint job after dep-float drift (audit tuples + smartstring advisory)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -18,11 +18,19 @@ version = 2
 # crates are denied by default under advisories schema v2.
 yanked = "deny"
 # Add `"RUSTSEC-YYYY-NNNN"` here (with a comment justifying it) only when an
-# advisory is reviewed and accepted as not-applicable. Currently none:
-# the `cortex`-only `pericortex` dep used to drag in tempdir/ansi_term (three
-# advisories), but that was fixed at the source (cortex-peripherals 60bec10:
-# tempdir→tempfile, ansi_term→inline ANSI), so the graph is clean outright.
-ignore = []
+# advisory is reviewed and accepted as not-applicable.
+# (History: the `cortex`-only `pericortex` dep used to drag in tempdir/ansi_term
+# (three advisories), fixed at the source in cortex-peripherals 60bec10 —
+# tempdir→tempfile, ansi_term→inline ANSI — so those need no entry here.)
+ignore = [
+  # smartstring is UNMAINTAINED (repo archived 2026-05-03), not vulnerable — no
+  # CVE, just no upstream maintenance. It is rhai's `ImmutableString` backing
+  # type, a hard transitive dep of rhai 1.25.1 (the latest release), so it cannot
+  # be dropped without dropping rhai. rhai reaches the graph ONLY via the opt-in
+  # `runtime-bindings` feature; the production cortex_worker builds rhai-free, so
+  # smartstring never enters the arXiv-conversion binary. Reviewed 2026-08-12.
+  "RUSTSEC-2026-0249",
+]
 
 [licenses]
 version = 2

--- a/tools/audit_vendored_natives.py
+++ b/tools/audit_vendored_natives.py
@@ -126,12 +126,14 @@ AUDITED = {
     # ---- Build-tooling and test fixtures: native files present, NOT linked into any
     # shipped binary, so no disclosure is owed. Each verdict verified by looking at the
     # file, not at the name. Recorded so the gate stays loud on substance and quiet here.
-    "cc": ("1.4.0",
+    "cc": (("1.4.0", "1.4.2"),
         "src/detect_compiler_family.c -- a probe compiled to identify the host "
         "toolchain, never linked into our binary. The crate itself is pure Rust. "
         "Re-verified at 1.4.0: still the only non-Rust file in the crate, and still "
         "nothing but #ifdef/#pragma message lines, so it emits diagnostics and no "
-        "object code.",
+        "object code. 1.4.0 -> 1.4.2 diffed 2026-08-12: detect_compiler_family.c "
+        "byte-identical, still the only native file, license MIT OR Apache-2.0 "
+        "unchanged.",
     ),
     "walkdir": ("2.5.0",
         "compare/nftw.c -- a benchmark comparison against C's nftw(3), not built.",
@@ -217,12 +219,15 @@ AUDITED = {
         "`bundled` sqlite it is not even consulted at build time. Flagged only for "
         "its test fixtures. No code enters the shipped binary; no notice owed."
     ),
-    "libsqlite3-sys": ("0.38.1",
+    "libsqlite3-sys": (("0.38.1", "0.38.2"),
         "Bundles the SQLite amalgamation (sqlite3.c) behind rusqlite's `bundled` "
         "feature, compiled in for the ObjectDB --dbfile store. SQLite is PUBLIC "
         "DOMAIN by explicit dedication (the 'blessing' header in sqlite3.c) -- no "
         "license obligations, no notice owed; the crate's own MIT covers the "
-        "bindings. Diffed 2026-08-03 at adoption."
+        "bindings. Diffed 2026-08-03 at adoption. 0.38.1 -> 0.38.2 diffed "
+        "2026-08-12: bundled sqlite3/sqlite3.c md5-identical (SQLite 3.53.2), "
+        "license MIT unchanged; only build.rs (an MSRV cfg_select! macro + import "
+        "reorder) and metadata changed -- no native-code or link change."
     ),
     "psm": (("0.1.31", "0.1.32"),
         "Compiles its own portable stack-manipulation asm shims, and ships a prebuilt "


### PR DESCRIPTION
## Why the badge is red

The `main` CI badge went red on run [31380266001](https://github.com/dginev/latexml-oxide/actions/runs/31380266001) with **no source change**. It is **not** a nightly rustc failure — only the `lint` job failed; all test shards + miri passed, and clippy/rustdoc/cargo-machete all passed under the same nightly. The cause is dependency drift: `Cargo.lock` is gitignored, so CI resolves fresh to the latest deps each run, and cargo-deny fetches the live advisory DB. Two independent failures had accumulated:

### 1. Vendored-native audit (the actual failure on that run)
Two audited native-code crates patch-bumped, and the audit gate flags version drift by design (a bump can silently swap a vendored library or its license). Re-verified both by hand and extended their `AUDITED` tuples:

| Crate | native content at new version | license | verdict |
|---|---|---|---|
| `cc 1.4.0 → 1.4.2` | `detect_compiler_family.c` **byte-identical**, still the only native file | `MIT OR Apache-2.0` unchanged | safe |
| `libsqlite3-sys 0.38.1 → 0.38.2` | bundled `sqlite3/sqlite3.c` **md5-identical** (SQLite 3.53.2, public domain); only cosmetic `build.rs`/metadata changes | `MIT` unchanged | safe |

Gate now passes a full fresh resolution (also covers the already-tupled `ar_archive_writer 0.5.3` / `psm 0.1.32` / `stacker 0.1.25`): `OK: all 20 native-code crates in the shipped tree are audited`.

### 2. cargo-deny — the next blocker (skipped in that run, unblocks once the audit passes)
`RUSTSEC-2026-0249` flags **smartstring** as *unmaintained* (repo archived 2026-05-03) — **not vulnerable, no CVE**. It is rhai 1.25.1's `ImmutableString` backing type (latest rhai, hard transitive dep), reaching the graph only via the opt-in `runtime-bindings` feature; the production `cortex_worker` builds rhai-free, so it never enters the arXiv-conversion binary. Added to `deny.toml [advisories] ignore` with rationale.

Same class as the `cc 1.3.0 → 1.4.0` break on 2026-07-24 (`lint.sh:149`).

## Verification
- `python3 tools/audit_vendored_natives.py --verbose` → exit 0, all 20 audited.
- `cargo deny --all-features check` → `advisories ok, bans ok, licenses ok, sources ok`.
- Full `tools/lint.sh` (pre-push hook) → **all checks passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)