### PR TITLE
feat: assign typed (non-string) values from Rhai bindings + LookupFloat/AssignFloat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [Unreleased]
+
+  - **Runtime Rhai bindings can assign typed values, not just strings.** New
+    `AssignNumber`/`AssignFloat`/`AssignBool`/`AssignString` complete the typed
+    `Assign*` family so a value written from a script reads back through
+    `LookupNumber`/`LookupBool`/`LookupString`; and a new `LookupFloat`/`AssignFloat`
+    pair (plus internal `state::lookup_float`) carries fractional values a
+    `Number` would truncate (#543).
+
 ## [0.7.5] (Rhai binding API; bibliography content recovery; wider math coverage; large-document memory; default-CSS sync; ar5iv corpus fixes)
 
   - **arXiv HTML-feedback fidelity fixes.** Title-page `\date{...}` renders bare,

--- a/latexml_contrib/src/script_bindings/API.md
+++ b/latexml_contrib/src/script_bindings/API.md
@@ -35,14 +35,18 @@ closure-registered functions; only the accepted types are.
 
 Called at the top level of a binding file, or from inside any body.
 
-88 functions, 115 calls.
+93 functions, 124 calls.
 
 | call | documentation |
 |---|---|
 | `AddToCounter(string, int)` | Add a number to a counter. ([`add_to_counter`](latexml_core::binding::counter::dialect::add_to_counter)) |
+| `AssignBool(string, bool)`<br>`AssignBool(string, bool, string)` | Bind a key to a boolean value, with a scope. ([`assign_value`](latexml_core::state::assign_value)) |
 | `AssignCatcode(string, int)` | Set a character's category code. ([`assign_catcode`](latexml_core::state::assign_catcode)) |
+| `AssignFloat(string, float)`<br>`AssignFloat(string, float, string)` | Bind a key to a fractional (float) value, with a scope. ([`assign_value`](latexml_core::state::assign_value)) |
 | `AssignMapping(string, string, string)` | Bind one key inside a named mapping. ([`assign_mapping`](latexml_core::state::assign_mapping)) |
 | `AssignMeaning(string, string)` | Make a control sequence mean a definition, or another token. ([`assign_meaning`](latexml_core::state::assign_meaning)) |
+| `AssignNumber(string, int)`<br>`AssignNumber(string, int, string)` | Bind a key to an integer (Number) value, with a scope. ([`assign_value`](latexml_core::state::assign_value)) |
+| `AssignString(string, string)`<br>`AssignString(string, string, string)` | Bind a key to a string value, with a scope (the typed twin of `AssignValue`). ([`assign_value`](latexml_core::state::assign_value)) |
 | `AssignValue(string, string)`<br>`AssignValue(string, string, string)` | Bind a key in the value table, with a scope. ([`assign_value`](latexml_core::state::assign_value)) |
 | `Command(string) -> Command` | Start a `std::process::Command` builder. A Rhai-only shim; nothing runs until `output()`. |
 | `CounterValue(string) -> int` | The current value of a counter. ([`counter_value`](latexml_core::binding::counter::dialect::counter_value)) |
@@ -79,6 +83,7 @@ Called at the top level of a binding file, or from inside any body.
 | `LookupBool(string) -> bool` | Read a value as a boolean. ([`lookup_bool`](latexml_core::state::lookup_bool)) |
 | `LookupCatcode(string) -> int` | The category code currently in force for a character. ([`lookup_catcode`](latexml_core::state::lookup_catcode)) |
 | `LookupDefinition(string) -> Definition?` | Fetch an installed definition so hooks can be pushed onto it; `()` when undefined. |
+| `LookupFloat(string) -> float` | Read a value as a fractional (float) number, keeping the fraction `LookupNumber` would truncate. ([`lookup_float`](latexml_core::state::lookup_float)) |
 | `LookupMapping(string, string) -> string` | Read one key out of a named mapping. ([`with_mapping`](latexml_core::state::with_mapping)) |
 | `LookupMeaning(string) -> string` | What a token means right now: its definition, or itself. ([`lookup_meaning`](latexml_core::state::lookup_meaning)) |
 | `LookupNumber(string) -> int` | Read a value as a number. ([`lookup_number`](latexml_core::state::lookup_number)) |

--- a/latexml_contrib/src/script_bindings/api_doc.rs
+++ b/latexml_contrib/src/script_bindings/api_doc.rs
@@ -133,10 +133,24 @@ const DOCS: &[(&str, Doc)] = &[
     ),
   ),
   (
+    "AssignBool",
+    Doc::Rust(
+      "Bind a key to a boolean value, with a scope.",
+      "latexml_core::state::assign_value",
+    ),
+  ),
+  (
     "AssignCatcode",
     Doc::Rust(
       "Set a character's category code.",
       "latexml_core::state::assign_catcode",
+    ),
+  ),
+  (
+    "AssignFloat",
+    Doc::Rust(
+      "Bind a key to a fractional (float) value, with a scope.",
+      "latexml_core::state::assign_value",
     ),
   ),
   (
@@ -151,6 +165,20 @@ const DOCS: &[(&str, Doc)] = &[
     Doc::Rust(
       "Make a control sequence mean a definition, or another token.",
       "latexml_core::state::assign_meaning",
+    ),
+  ),
+  (
+    "AssignNumber",
+    Doc::Rust(
+      "Bind a key to an integer (Number) value, with a scope.",
+      "latexml_core::state::assign_value",
+    ),
+  ),
+  (
+    "AssignString",
+    Doc::Rust(
+      "Bind a key to a string value, with a scope (the typed twin of `AssignValue`).",
+      "latexml_core::state::assign_value",
     ),
   ),
   (
@@ -367,6 +395,13 @@ const DOCS: &[(&str, Doc)] = &[
   (
     "LookupDefinition",
     Doc::Note("Fetch an installed definition so hooks can be pushed onto it; `()` when undefined."),
+  ),
+  (
+    "LookupFloat",
+    Doc::Rust(
+      "Read a value as a fractional (float) number, keeping the fraction `LookupNumber` would truncate.",
+      "latexml_core::state::lookup_float",
+    ),
   ),
   (
     "LookupMapping",
@@ -1305,6 +1340,7 @@ fn simplify_type(raw: &str) -> String {
     "alloc::string::String" => "string".into(),
     "alloc::vec::Vec<rhai::types::dynamic::Dynamic>" => "array".into(),
     "i64" => "int".into(),
+    "f64" => "float".into(),
     "rhai::types::dynamic::Dynamic" | "types::dynamic::Dynamic" => "?".into(),
     _ => {
       // A BTreeMap<SmartString, Dynamic> is Rhai's `map`; the rest just lose

--- a/latexml_contrib/src/script_bindings/engine.rs
+++ b/latexml_contrib/src/script_bindings/engine.rs
@@ -167,6 +167,39 @@ pub(super) fn make_engine() -> Engine {
   engine.register_fn("AssignValue", |k: &str, v: &str, scope: &str| {
     latexml_core::state::assign_value(k, v.to_string(), scope_of(scope));
   });
+  // Typed `Assign*` counterparts to the typed `Lookup*` readers below (#543).
+  // Before these, a binding could only ever assign a *string*, so a value
+  // written from a script was invisible to `LookupNumber`/`LookupBool`/
+  // `LookupFloat`. Each stores the matching `Stored` variant explicitly — in
+  // particular `AssignFloat` builds a `Float` (keeping the fraction) rather than
+  // an integer `Number`, which a bare `f64 -> Stored` would floor. 2-arg = TeX
+  // default scope (as `AssignValue`), 3-arg takes "local"/"global".
+  engine.register_fn("AssignNumber", |k: &str, v: i64| {
+    latexml_core::state::assign_value(k, Number(v), None);
+  });
+  engine.register_fn("AssignNumber", |k: &str, v: i64, scope: &str| {
+    latexml_core::state::assign_value(k, Number(v), scope_of(scope));
+  });
+  engine.register_fn("AssignFloat", |k: &str, v: f64| {
+    latexml_core::state::assign_value(k, Float(v), None);
+  });
+  engine.register_fn("AssignFloat", |k: &str, v: f64, scope: &str| {
+    latexml_core::state::assign_value(k, Float(v), scope_of(scope));
+  });
+  engine.register_fn("AssignBool", |k: &str, v: bool| {
+    latexml_core::state::assign_value(k, v, None);
+  });
+  engine.register_fn("AssignBool", |k: &str, v: bool, scope: &str| {
+    latexml_core::state::assign_value(k, v, scope_of(scope));
+  });
+  // Explicit string counterpart to `LookupString` (equivalent to `AssignValue`,
+  // named for a symmetric typed family).
+  engine.register_fn("AssignString", |k: &str, v: &str| {
+    latexml_core::state::assign_value(k, v.to_string(), None);
+  });
+  engine.register_fn("AssignString", |k: &str, v: &str, scope: &str| {
+    latexml_core::state::assign_value(k, v.to_string(), scope_of(scope));
+  });
   engine.register_fn("LookupString", |k: &str| -> String {
     latexml_core::state::lookup_string(k)
   });
@@ -195,6 +228,13 @@ pub(super) fn make_engine() -> Engine {
     latexml_core::state::lookup_number(k)
       .map(|n| n.0)
       .unwrap_or(0)
+  });
+  // The fractional reader `LookupNumber` can't be — a value assigned with
+  // `AssignFloat` (e.g. NOMINAL_FONT_SIZE = 10.95) reads back whole (#542/#543).
+  engine.register_fn("LookupFloat", |k: &str| -> f64 {
+    latexml_core::state::lookup_float(k)
+      .map(|f| f.0)
+      .unwrap_or(0.0)
   });
   engine.register_fn("LookupBool", |k: &str| -> bool {
     latexml_core::state::lookup_bool(k)

--- a/latexml_contrib/src/script_bindings/engine.rs
+++ b/latexml_contrib/src/script_bindings/engine.rs
@@ -229,8 +229,9 @@ pub(super) fn make_engine() -> Engine {
       .map(|n| n.0)
       .unwrap_or(0)
   });
-  // The fractional reader `LookupNumber` can't be — a value assigned with
-  // `AssignFloat` (e.g. NOMINAL_FONT_SIZE = 10.95) reads back whole (#542/#543).
+  // The fractional reader `LookupNumber` cannot be: a value assigned with
+  // `AssignFloat` (e.g. NOMINAL_FONT_SIZE = 10.95) would read back whole
+  // through `LookupNumber`, so scripts that need the fraction use this (#542/#543).
   engine.register_fn("LookupFloat", |k: &str| -> f64 {
     latexml_core::state::lookup_float(k)
       .map(|f| f.0)

--- a/latexml_contrib/src/script_bindings/mod.rs
+++ b/latexml_contrib/src/script_bindings/mod.rs
@@ -48,6 +48,7 @@ use latexml_core::{
     def_parser::parse_prototype,
     dimension::Dimension,
     error::{Error, Result},
+    float::Float,
     number::Number,
     numeric_ops::NumericOps,
     object::Object,

--- a/latexml_contrib/src/script_bindings/tests.rs
+++ b/latexml_contrib/src/script_bindings/tests.rs
@@ -89,6 +89,64 @@ fn pool_surface_state_counters_tokens() {
   assert_eq!(lookup_str("ws:kv2"), "rust", "GetKeyVals map access");
 }
 
+/// #543: typed `Assign*` counterparts to the typed `Lookup*` readers, plus the
+/// `LookupFloat`/`AssignFloat` pair. Before this, a Rhai binding could *read* a
+/// number/bool/float out of State (`LookupNumber`/`LookupBool`/`LookupFloat`)
+/// but could only ever *assign* a string — so a value written from a script was
+/// invisible to the typed readers. Round-trip each typed pair through a real
+/// script, and confirm the native-side variant really landed (not a string, and
+/// — the #542 case — a float that keeps its fraction rather than truncating).
+#[test]
+fn typed_assign_roundtrip() {
+  use latexml_core::state;
+  fresh_state();
+  load_script(
+    r##"
+      AssignNumber("ta:n", 7);
+      AssignFloat("ta:f", 10.95);
+      AssignBool("ta:b", true);
+      AssignString("ta:s", "hi");
+      // 3-arg scoped forms: global so they survive the script's own group.
+      AssignNumber("ta:ng", 42, "global");
+      AssignFloat("ta:fg", 3.5, "global");
+
+      // Round-trip each value back THROUGH the bindings (not just the Rust
+      // side). Range/equality witnesses dodge float-formatting fragility.
+      assign_global("ta:n_ok", if LookupNumber("ta:n") == 7 { "ok" } else { "bad" });
+      assign_global("ta:f_ok", if LookupFloat("ta:f") > 10.9 && LookupFloat("ta:f") < 11.0 { "ok" } else { "bad" });
+      assign_global("ta:b_ok", if LookupBool("ta:b") { "ok" } else { "bad" });
+      assign_global("ta:s_ok", if LookupString("ta:s") == "hi" { "ok" } else { "bad" });
+    "##,
+  )
+  .expect("typed-assign surface script should load cleanly");
+  // Through-the-binding round-trips.
+  assert_eq!(lookup_str("ta:n_ok"), "ok", "AssignNumber -> LookupNumber");
+  assert_eq!(
+    lookup_str("ta:f_ok"),
+    "ok",
+    "AssignFloat -> LookupFloat keeps the fraction"
+  );
+  assert_eq!(lookup_str("ta:b_ok"), "ok", "AssignBool -> LookupBool");
+  assert_eq!(lookup_str("ta:s_ok"), "ok", "AssignString -> LookupString");
+  // Native-side witnesses: the typed variant really landed, and 10.95 kept its
+  // fraction (a bare `f64 -> Stored` would floor it to 10 — issue #542).
+  assert_eq!(
+    state::lookup_number("ta:n").map(|n| n.0),
+    Some(7),
+    "ta:n is a Number(7)"
+  );
+  let f = state::lookup_float("ta:f").expect("ta:f is a Float");
+  assert!(
+    (f.0 - 10.95).abs() < 1e-9,
+    "AssignFloat stored 10.95, got {}",
+    f.0
+  );
+  assert!(state::lookup_bool("ta:b"), "ta:b is Bool(true)");
+  // 3-arg global forms survive the script's top-level group.
+  assert_eq!(state::lookup_number("ta:ng").map(|n| n.0), Some(42));
+  assert!((state::lookup_float("ta:fg").expect("ta:fg").0 - 3.5).abs() < 1e-9);
+}
+
 /// Wave-B definition forms: DefRegister (count + dimen), DefConditional
 /// (Rhai test driven from real TeX), DefKeyVal, DefLigature, DefMath.
 #[test]

--- a/latexml_core/src/common/store.rs
+++ b/latexml_core/src/common/store.rs
@@ -851,6 +851,13 @@ impl From<Cow<'_, Font>> for Stored {
 impl From<Number> for Stored {
   fn from(value: Number) -> Self { Stored::Number(value) }
 }
+// A distinct slot from `From<f64>` above, which FLOORS to an integer `Number`
+// (TeX registers are integral). A `Float` value keeps its fraction — the only
+// path that stores `Stored::Float`, so an `AssignFloat` binding must build a
+// `Float`, not lean on `f64 -> Stored`.
+impl From<Float> for Stored {
+  fn from(value: Float) -> Self { Stored::Float(value) }
+}
 impl From<Dimension> for Stored {
   fn from(value: Dimension) -> Self { Stored::Dimension(value) }
 }
@@ -1027,6 +1034,9 @@ impl<'a> From<&'a Stored> for Option<Number> {
   fn from(value: &'a Stored) -> Option<Number> {
     match value {
       Stored::Number(n) => Some(*n),
+      // A `Float` reads back as an integer `Number` by truncation, mirroring
+      // `f64 -> Stored` (floor) and how the dimension family narrows below.
+      Stored::Float(f) => Some(Number::new(f.value_of())),
       Stored::Dimension(n) => Some(Number::new(n.value_of())),
       Stored::Glue(n) => Some(Number::new(n.value_of())),
       Stored::MuDimension(n) => Some(Number::new(n.value_of())),
@@ -1035,6 +1045,22 @@ impl<'a> From<&'a Stored> for Option<Number> {
         eprintln!("TODO: auto-cast of Stored to Number attempted on {other:?}");
         None
       },
+    }
+  }
+}
+
+// The counterpart of the `Option<Number>` narrowing above, kept lenient in the
+// same spirit: a stored `Float` reads as itself, and the integral numerics
+// widen to `Float` (`Number`/`Int`), so `lookup_float` sees a value assigned
+// either way. Non-numeric variants are `None` (no eprintln — an optional typed
+// read, not a coercion error).
+impl<'a> From<&'a Stored> for Option<Float> {
+  fn from(value: &'a Stored) -> Option<Float> {
+    match value {
+      Stored::Float(f) => Some(*f),
+      Stored::Number(n) => Some(Float::new(n.value_of())),
+      Stored::Int(i) => Some(Float(*i as f64)),
+      _ => None,
     }
   }
 }

--- a/latexml_core/src/common/store.rs
+++ b/latexml_core/src/common/store.rs
@@ -1034,8 +1034,11 @@ impl<'a> From<&'a Stored> for Option<Number> {
   fn from(value: &'a Stored) -> Option<Number> {
     match value {
       Stored::Number(n) => Some(*n),
-      // A `Float` reads back as an integer `Number` by truncation, mirroring
-      // `f64 -> Stored` (floor) and how the dimension family narrows below.
+      // A `Float` narrows to an integer `Number` through `Float::value_of`
+      // (truncation toward zero, the crate's canonical Float->i64), the same
+      // `value_of` narrowing the dimension family uses just below. NB this is
+      // *not* the `floor` that `From<f64> for Stored` applies — they agree for
+      // non-negative values (the only ones stored here in practice).
       Stored::Float(f) => Some(Number::new(f.value_of())),
       Stored::Dimension(n) => Some(Number::new(n.value_of())),
       Stored::Glue(n) => Some(Number::new(n.value_of())),

--- a/latexml_core/src/state.rs
+++ b/latexml_core/src/state.rs
@@ -21,6 +21,7 @@ use crate::{
     arena::{self, SymHashMap, SymStr},
     dimension::Dimension,
     error::{emit_warn, *},
+    float::Float,
     font::Font,
     glue::Glue,
     model::{self, IndirectModel, Model, compute_indirect_model_aux},
@@ -1695,6 +1696,18 @@ pub fn assign_font(font: Rc<Font>, scope: Option<Scope>) {
 
 /// a variant of `lookup_value` that casts the value into `Number`
 pub fn lookup_number(key: &str) -> Option<Number> {
+  match state!().lookup_value(key) {
+    None | Some(Stored::None) => None,
+    Some(v) => v.into(),
+  }
+}
+/// a variant of `lookup_value` that casts the value into `Float`
+///
+/// The float counterpart of [`lookup_number`]. `Float` isn't a TeX register
+/// type (see `common::float`), but binding authors need a fractional read/write
+/// pair — e.g. `NOMINAL_FONT_SIZE` at the `11pt` class option is `10.95`, which
+/// [`lookup_number`]/[`lookup_int`] would truncate to `10` (issue #542).
+pub fn lookup_float(key: &str) -> Option<Float> {
   match state!().lookup_value(key) {
     None | Some(Stored::None) => None,
     Some(v) => v.into(),

--- a/tools/audit_vendored_natives.py
+++ b/tools/audit_vendored_natives.py
@@ -126,14 +126,16 @@ AUDITED = {
     # ---- Build-tooling and test fixtures: native files present, NOT linked into any
     # shipped binary, so no disclosure is owed. Each verdict verified by looking at the
     # file, not at the name. Recorded so the gate stays loud on substance and quiet here.
-    "cc": (("1.4.0", "1.4.2"),
+    "cc": (("1.4.0", "1.4.2", "1.4.3"),
         "src/detect_compiler_family.c -- a probe compiled to identify the host "
         "toolchain, never linked into our binary. The crate itself is pure Rust. "
         "Re-verified at 1.4.0: still the only non-Rust file in the crate, and still "
         "nothing but #ifdef/#pragma message lines, so it emits diagnostics and no "
         "object code. 1.4.0 -> 1.4.2 diffed 2026-08-12: detect_compiler_family.c "
         "byte-identical, still the only native file, license MIT OR Apache-2.0 "
-        "unchanged.",
+        "unchanged. 1.4.2 -> 1.4.3 diffed 2026-08-14: detect_compiler_family.c "
+        "byte-identical (sha 97ca4b021495), still the only native file, license "
+        "MIT OR Apache-2.0 unchanged.",
     ),
     "walkdir": ("2.5.0",
         "compare/nftw.c -- a benchmark comparison against C's nftw(3), not built.",


### PR DESCRIPTION
**Diagnostic.** The runtime Rhai binding API exposed typed readers (`LookupNumber`/`LookupBool`/`LookupString`) but only a *string* writer (`AssignValue`), so a value written from a script was invisible to the typed readers; and there was no `Float` read/write pair at all (nor an internal `state::lookup_float`).

**Approach.** Complete the typed `Assign*` family — `AssignNumber`/`AssignFloat`/`AssignBool`/`AssignString` (2- and 3-arg scoped forms, mirroring `AssignValue`) — each storing the matching `Stored` variant via the one generic `assign_value` path. `AssignFloat` builds a `Float` explicitly so it keeps its fraction (a bare `f64 -> Stored` floors to an integer `Number`). Adds `LookupFloat` + `state::lookup_float`, with `From<Float> for Stored` and `From<&Stored> for Option<Float>` so any Rust caller (e.g. the `NOMINAL_FONT_SIZE = 10.95` case, #542) can round-trip a float. The reporter's alternative — teach `try_lookup_int` to parse strings — is deliberately not taken: typed assignment is the cleaner root fix than heuristic string-parsing on a per-conditional hot path. Structural `Tokens` assignment is out of scope (this ticket is scalar non-strings).

**Validation.** New guard `latexml_contrib::script_bindings::tests::typed_assign_roundtrip` (RED->green: round-trips each typed pair through a real script and confirms the native-side variant landed, incl. 10.95 keeping its fraction). Doc-completeness gate `api_reference_is_up_to_date` regenerated (`API.md`, 88->93 functions). Full suite `cargo nextest run --workspace` 1929/1929, 0 skipped; `clippy --workspace --all-targets -D warnings` clean; fmt applied.

*Second commit (`ci:`) is orthogonal: `cc` floated 1.4.2 -> 1.4.3 (Cargo.lock is gitignored, CI re-resolves), tripping the vendored-native-code audit gate. Verified `detect_compiler_family.c` byte-identical (sha `97ca4b021495`) and license unchanged, then extended the AUDITED tuple. Needed to green the lint gate.*

Closes #543
