### PR TITLE
feat: structure lazy IEEEtran author blocks (\\[1em] + shared email), beyond Perl

### DIFF
--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -880,6 +880,13 @@ LoadDefinitions!({
   DefMacro!("\\lx@add@authors{}", sub[(stuff)] {
     let mut calls: Vec<Token> = Vec::new();
     dequeue_front_matter("ltx:creator", &[("role", "author")]);
+    // Consume any `\\[len]` / `\\*[len]` row-break optionals up front so the line
+    // splits below see a bare `\\` (KNOWN_PERL_ERRORS #75, witness 2605.23553). This
+    // also runs ahead of the tabular/minipage fallback: that fallback is a
+    // last-resort escape hatch for author markup we cannot structure, and its
+    // `<tabular>`-in-`<personname>` output is a presentational artifact we do not
+    // want in frontmatter anyway, so there is nothing to preserve by skipping it.
+    let stuff = strip_linebreak_options(stuff);
     // If too much formatting, fall back to unstructured author content
     let stuff_string = stuff.to_string();
     if stuff_string.contains("{tabular}")
@@ -889,46 +896,59 @@ LoadDefinitions!({
       calls.extend(Invocation!(T_CS!("\\lx@add@author"), vec![None, Some(stuff)]).unlist());
     } else if position_of(&stuff, &authorsup_markers()).is_some() {
       let lines = split_tokens(stuff, author_affil_splits());
-      // entries of (is_author, line)
-      let mut entries: Vec<(bool, Tokens)> = Vec::new();
+      let mut entries: Vec<(AuthorLineKind, Tokens)> = Vec::new();
       for line in lines {
         if line.is_empty() {
           continue;
         }
         match position_of(&line, &authorsup_markers()) {
           None => {
-            // No marker?
-            if let Some(last) = entries.last_mut() {
+            // A marker-less line that is purely a list of email addresses is a
+            // SHARED email line (\texttt{a@x, b@y}) covering all the authors, not
+            // a continuation of the previous affiliation — give it its own email
+            // contact so it is shown once instead of being welded into an
+            // affiliation's text (KNOWN_PERL_ERRORS #75, witness 2605.23553).
+            if line_is_email_list(&line) {
+              entries.push((AuthorLineKind::Email, line));
+            } else if let Some(last) = entries.last_mut() {
               // continues previous entry; Append
               let mut appended = last.1.clone().unlist();
               appended.extend(line.unlist());
               last.1 = Tokens::new(appended);
             } else {
-              entries.push((true, line)); // safest to assume author?
+              entries.push((AuthorLineKind::Author, line)); // safest to assume author?
             }
           },
           Some(p) if p < 8 => {
             // Close to front? assume affiliation
-            entries.push((false, line));
+            entries.push((AuthorLineKind::Affiliation, line));
           },
           Some(_) => {
             // Marker sits far from the front: an author line. Split it into the
             // individual creators it names (see split_author_line).
             for author in split_author_line(line) {
-              entries.push((true, author));
+              entries.push((AuthorLineKind::Author, author));
             }
           },
         }
       }
-      for (is_author, line) in entries {
-        if is_author {
-          let withsup = Invocation!(T_CS!("\\lx@author@withsup"), vec![Some(line)]);
-          calls.extend(
-            Invocation!(T_CS!("\\lx@add@author"), vec![None, Some(withsup)]).unlist());
-        } else {
-          let withsup = Invocation!(T_CS!("\\lx@affiliation@withsup"), vec![Some(line)]);
-          calls.extend(
-            Invocation!(T_CS!("\\lx@add@affiliation"), vec![None, Some(withsup)]).unlist());
+      for (kind, line) in entries {
+        match kind {
+          AuthorLineKind::Author => {
+            let withsup = Invocation!(T_CS!("\\lx@author@withsup"), vec![Some(line)]);
+            calls.extend(
+              Invocation!(T_CS!("\\lx@add@author"), vec![None, Some(withsup)]).unlist());
+          },
+          AuthorLineKind::Affiliation => {
+            let withsup = Invocation!(T_CS!("\\lx@affiliation@withsup"), vec![Some(line)]);
+            calls.extend(
+              Invocation!(T_CS!("\\lx@add@affiliation"), vec![None, Some(withsup)]).unlist());
+          },
+          AuthorLineKind::Email => {
+            // Same routing the no-superscript arm uses for a bare email line.
+            calls.extend(
+              Invocation!(T_CS!("\\lx@add@email"), vec![None, Some(line)]).unlist());
+          },
         }
       }
     } else {
@@ -1004,6 +1024,8 @@ LoadDefinitions!({
   DefMacro!("\\lx@add@affiliations[]{}", sub[(attr, stuff)] {
     let mut calls: Vec<Token> = Vec::new();
     dequeue_front_matter("ltx:contact", &[("role", "affiliation")]);
+    // Consume `\\[len]` row-break optionals before splitting (KNOWN_PERL_ERRORS #75).
+    let stuff = strip_linebreak_options(stuff);
     let with_sup = position_of(&stuff, &authorsup_markers()).is_some();
     for line in split_tokens(stuff, affil_splits()) {
       // Skip empty segments (e.g. a trailing \\ or a line that was wholly
@@ -3815,6 +3837,61 @@ fn affil_splits() -> Vec<SplitDelim> {
 }
 fn authorsup_markers() -> Vec<Token> { vec![T_SUPER!(), T_CS!("\\textsuperscript")] }
 
+/// Drop the optional `*` and `[<len>]` that follow a `\\` line-break token in an
+/// author/affiliation block, before the block is split into lines. The
+/// author/affiliation splitters key on the bare `\\` control sequence, so a
+/// `\\[1em]` (or `\\*[1em]`) would otherwise orphan `[1em]` at the head of the
+/// next segment — where it leaks as literal `[1em]` text AND, by pushing a
+/// following `\textsuperscript` past the author-vs-affiliation position
+/// threshold, flips a comma-bearing affiliation line into phantom author
+/// creators. Perl's own `\lx@add@authors` flags this exact gap ("matching `\\`
+/// this way fails to catch `\\[1em]`, so really should Let it") but never fixes
+/// it, so both engines garble it identically; consuming it here is a beyond-Perl
+/// improvement (KNOWN_PERL_ERRORS #75, witness arXiv:2605.23553). The `[...]` is
+/// matched only as a balanced OTHER-catcode bracket group immediately following
+/// the `\\`, so ordinary bracketed content elsewhere in a name/affiliation is
+/// untouched.
+fn strip_linebreak_options(tokens: Tokens) -> Tokens {
+  let src = tokens.unlist();
+  let n = src.len();
+  let mut out: Vec<Token> = Vec::with_capacity(n);
+  let brk = T_CS!("\\\\");
+  let mut i = 0;
+  while i < n {
+    out.push(src[i]);
+    if src[i] == brk {
+      let mut j = i + 1;
+      let mut consumed = false;
+      if j < n && src[j] == T_OTHER!("*") {
+        j += 1;
+        consumed = true;
+      }
+      if j < n && src[j] == T_OTHER!("[") {
+        let mut k = j + 1;
+        let mut depth = 1usize;
+        while k < n && depth > 0 {
+          if src[k] == T_OTHER!("[") {
+            depth += 1;
+          } else if src[k] == T_OTHER!("]") {
+            depth -= 1;
+          }
+          k += 1;
+        }
+        if depth == 0 {
+          j = k;
+          consumed = true;
+        }
+      }
+      if consumed {
+        i = j;
+        continue;
+      }
+    }
+    i += 1;
+  }
+  Tokens::new(out)
+}
+
 /// Does this token list *begin* with a NUMERIC affiliation superscript mark
 /// (`$^{1}…` / `$^1…` / `\textsuperscript{1}…`)? This is the signature of the
 /// arXiv "`\thanks` abuse" idiom (affiliations smuggled into an author
@@ -3899,6 +3976,38 @@ fn line_is_email(line: &Tokens) -> bool {
   }
   let v = visible.trim();
   !v.is_empty() && v.contains('@') && !v.chars().any(|c| c.is_whitespace())
+}
+
+/// A marker-less line that is *purely* a list of email addresses — a shared
+/// `\texttt{a@x, b@y,}` / `\email{...}` line covering all authors. Like
+/// [`line_is_email`] but tolerates a comma-separated list (and the trailing
+/// comma authors often leave): every non-empty comma item must itself carry '@'.
+/// A prose affiliation line ("Dept. of Foo, University of Pisa, Italy") has no
+/// '@' and is rejected, so this never misclassifies an address as an email.
+fn line_is_email_list(line: &Tokens) -> bool {
+  let mut visible = String::new();
+  for t in line.unlist_ref() {
+    if t.code == Catcode::LETTER || t.code == Catcode::OTHER {
+      t.with_str(|s| visible.push_str(s));
+    } else if t.code == Catcode::SPACE {
+      visible.push(' ');
+    }
+  }
+  let v = visible.trim();
+  v.contains('@')
+    && v
+      .split(',')
+      .map(str::trim)
+      .filter(|p| !p.is_empty())
+      .all(|p| p.contains('@') && !p.chars().any(char::is_whitespace))
+}
+
+/// Line role within a superscript-labeled author block (see `\lx@add@authors`).
+#[derive(Clone, Copy, PartialEq)]
+enum AuthorLineKind {
+  Author,
+  Affiliation,
+  Email,
 }
 
 /// Converts tokens to a string in the fashion of \message and others

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -61,6 +61,53 @@ fn frontmatter_ieee_membership_no_phantom() {
     "IEEEmembership leaked as a phantom creator:\n{x}"
   );
 }
+/// IEEEtran lazy single-`\author` block with `\\[1em]` row breaks (witness
+/// 2605.23553, arXiv/html_feedback; KNOWN_PERL_ERRORS #75). The optional-length
+/// `[1em]` on `\\` must be consumed, not leak as literal `[1em]` text; and its
+/// removal keeps the following `\textsuperscript` at the front of the
+/// affiliation line so the comma-bearing address is NOT reclassified into
+/// phantom "University of Pisa"/"Italy" author creators. Beyond-Perl: Perl 0.8.8
+/// garbles this identically (its own `\lx@add@authors` flags the gap).
+#[test]
+fn frontmatter_ieee_linebreak_optarg() {
+  let x = convert_to_xml("tests/cluster_regressions/frontmatter_ieee_linebreak_optarg.tex");
+  // The `\\[1em]` length must not leak as literal text anywhere.
+  assert!(
+    !x.contains("[1em]"),
+    "\\\\[1em] optional length leaked as text:\n{x}"
+  );
+  // The three authors are clean personnames.
+  assert!(
+    x.contains("<personname>Alice Smith")
+      && x.contains("<personname>Bob Jones")
+      && x.contains("<personname>Carol White"),
+    "IEEE lazy-block authors missing/unstructured:\n{x}"
+  );
+  // The affiliation lines stay affiliations, not comma-split into phantom authors.
+  assert!(
+    !x.contains("<personname>University of Pisa")
+      && !x.contains("<personname>Italy")
+      && !x.contains("<personname>University of Padua"),
+    "affiliation address commas mis-split into phantom authors:\n{x}"
+  );
+  // The affiliation content still survives (attached as affiliation contacts).
+  assert!(
+    x.contains("University of Pisa") && x.contains("University of Padua"),
+    "affiliation content dropped:\n{x}"
+  );
+  // The shared \texttt{} email line becomes its own email contact, shown once —
+  // not welded into an affiliation's text.
+  assert!(
+    x.contains("role=\"email\"") && x.contains("alice@unipi.it"),
+    "shared email line not routed to an email contact:\n{x}"
+  );
+  // The email must not be glued onto an affiliation's content (the pre-fix bug
+  // was `…Padua, Italy<text font=\"typewriter\">alice@…` inside role=affiliation).
+  assert!(
+    !x.contains("Italy<text"),
+    "email welded into affiliation text instead of its own contact:\n{x}"
+  );
+}
 /// Modern Interspeech.cls `\name[affiliation={1,*}]{First}{Last}` (2-arg): the
 /// author renders as "First Last"; the `[affiliation=…]` optarg must not leak a
 /// `[` creator or `\name`. Interspeech2024 resolves here by version-stripping.

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_ieee_linebreak_optarg.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_ieee_linebreak_optarg.tex
@@ -1,0 +1,24 @@
+\documentclass[12pt,onecolumn]{IEEEtran}
+\begin{document}
+% IEEEtran lazy single-\author block (witness 2605.23553): superscript-labeled
+% author names, then superscript-labeled affiliation lines, separated by
+% \\[1em] row breaks. The optional-length `[1em]` on `\\` must be consumed (not
+% leak as literal text), and its presence must not push a following
+% \textsuperscript past the author/affiliation position threshold and turn a
+% comma-bearing affiliation line into phantom "University of Pisa"/"Italy"
+% authors.
+\author{
+Alice Smith\textsuperscript{1,2}, Bob Jones\textsuperscript{3}, \\
+Carol White\textsuperscript{1} \\[1em]
+
+\textsuperscript{1}Dept. of Foo, University of Pisa, Italy \\
+\textsuperscript{2}Naval Centre, La Spezia, Italy \\
+\textsuperscript{3}Dept. of Bar, University of Padua, Italy \\[1em]
+
+\texttt{alice@unipi.it, bob@unipd.it,}\\
+\texttt{carol@unipi.it}
+}
+\title{T}
+\maketitle
+Body.
+\end{document}

--- a/tools/audit_vendored_natives.py
+++ b/tools/audit_vendored_natives.py
@@ -126,14 +126,16 @@ AUDITED = {
     # ---- Build-tooling and test fixtures: native files present, NOT linked into any
     # shipped binary, so no disclosure is owed. Each verdict verified by looking at the
     # file, not at the name. Recorded so the gate stays loud on substance and quiet here.
-    "cc": (("1.4.0", "1.4.2"),
+    "cc": (("1.4.0", "1.4.2", "1.4.3"),
         "src/detect_compiler_family.c -- a probe compiled to identify the host "
         "toolchain, never linked into our binary. The crate itself is pure Rust. "
         "Re-verified at 1.4.0: still the only non-Rust file in the crate, and still "
         "nothing but #ifdef/#pragma message lines, so it emits diagnostics and no "
         "object code. 1.4.0 -> 1.4.2 diffed 2026-08-12: detect_compiler_family.c "
         "byte-identical, still the only native file, license MIT OR Apache-2.0 "
-        "unchanged.",
+        "unchanged. 1.4.2 -> 1.4.3 diffed 2026-08-14: detect_compiler_family.c "
+        "md5-identical, still the only native file, license unchanged (only the "
+        "find-msvc-tools build-dep bumped 0.1.10 -> 0.1.11).",
     ),
     "walkdir": ("2.5.0",
         "compare/nftw.c -- a benchmark comparison against C's nftw(3), not built.",


### PR DESCRIPTION
**Diagnostic.** A single `\author{}` block that lists superscript-labeled names, then superscript-labeled affiliation lines, then a shared `\texttt{}` email line, separated by `\\[1em]` row breaks (IEEEtran idiom, witness arXiv:2605.23553) was garbled *identically by both engines*: `[1em]` leaked as text; the `[1em]` shoved a following `\textsuperscript` past the author/affiliation position threshold so comma-bearing addresses became phantom "University of Pisa"/"Italy" authors; and the shared email was welded into an affiliation's text. Perl's own `\lx@add@authors` flags the `\\` gap ("really should Let it") but never fixes it — this is a **beyond-Perl** improvement.

**Approach** (shared `\lx@add@authors` / `\lx@add@affiliations`, `base_utilities.rs`):
- `strip_linebreak_options` — consume the optional `*`/`[len]` after a `\\` row-break token before the block is split, so the line splitters see a bare `\\` (no leak; superscripts stay at line front, restoring correct author↔affiliation matching).
- `line_is_email_list` + a 3-way line kind — a marker-less line that is *purely* a list of `@`-addresses becomes its own `role=email` contact (shown once) instead of being appended to the previous affiliation.

The no-superscript arm (witness 2606.00315) and the `\IEEEauthorblock*` path are untouched.

**Validation.** Witness now yields 3 clean authors, affiliations matched by superscript (Alice→1,2; Bob→3; Carol→1), no `[1em]`, emails as `role=email`. Guard `frontmatter_ieee_linebreak_optarg`; full suite 1929/0; clippy/fmt clean; 2606.00315 re-converted unchanged.

Documented as KNOWN_PERL_ERRORS #75 (the parity gap) by #545; after both land, that entry should flip to "Rust fixes this". Independent of #545 (touches different files); the shared `ci:` commit greens the cc-1.4.3 dep-float on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)