### PR TITLE
feat: PushValue list family + search-path bindings for Rhai (#540)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
     `LookupNumber`/`LookupBool`/`LookupString`; and a new `LookupFloat`/`AssignFloat`
     pair (plus internal `state::lookup_float`) carries fractional values a
     `Number` would truncate (#543).
+  - **Runtime Rhai bindings gain the list-value family and search-path control.**
+    `PushValue`/`PopValue`/`UnshiftValue`/`ShiftValue` expose the Perl `@values`
+    list-op set (e.g. for `GRAPHICSPATHS`), and `PrependSearchPath`/`AppendSearchPath`
+    add an input directory — the Rust port keeps `SEARCHPATHS` in a dedicated field,
+    not the value table, so these reach file resolution where `PushValue` would not (#540).
 
 ## [0.7.5] (Rhai binding API; bibliography content recovery; wider math coverage; large-document memory; default-CSS sync; ar5iv corpus fixes)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@
     `Number` would truncate (#543).
   - **Runtime Rhai bindings gain the list-value family and search-path control.**
     `PushValue`/`PopValue`/`UnshiftValue`/`ShiftValue` expose the Perl `@values`
-    list-op set (e.g. for `GRAPHICSPATHS`), and `PrependSearchPath`/`AppendSearchPath`
-    add an input directory — the Rust port keeps `SEARCHPATHS` in a dedicated field,
-    not the value table, so these reach file resolution where `PushValue` would not (#540).
+    list-op set (e.g. for `GRAPHICSPATHS`), carrying any Rhai-representable value —
+    string/int/float/bool/`Tokens` — with the type preserved across a push/pop
+    cycle. `PrependSearchPath`/`AppendSearchPath` add an input directory: the Rust
+    port keeps `SEARCHPATHS` in a dedicated field, not the value table, so these
+    reach file resolution where `PushValue` would not (#540).
 
 ## [0.7.5] (Rhai binding API; bibliography content recovery; wider math coverage; large-document memory; default-CSS sync; ar5iv corpus fixes)
 

--- a/latexml_contrib/src/script_bindings/API.md
+++ b/latexml_contrib/src/script_bindings/API.md
@@ -35,11 +35,12 @@ closure-registered functions; only the accepted types are.
 
 Called at the top level of a binding file, or from inside any body.
 
-93 functions, 124 calls.
+99 functions, 130 calls.
 
 | call | documentation |
 |---|---|
 | `AddToCounter(string, int)` | Add a number to a counter. ([`add_to_counter`](latexml_core::binding::counter::dialect::add_to_counter)) |
+| `AppendSearchPath(string)` | Append a directory to the input search path (searched after existing paths). ([`add_search_path`](latexml_core::state::add_search_path)) |
 | `AssignBool(string, bool)`<br>`AssignBool(string, bool, string)` | Bind a key to a boolean value, with a scope. ([`assign_value`](latexml_core::state::assign_value)) |
 | `AssignCatcode(string, int)` | Set a character's category code. ([`assign_catcode`](latexml_core::state::assign_catcode)) |
 | `AssignFloat(string, float)`<br>`AssignFloat(string, float, string)` | Bind a key to a fractional (float) value, with a scope. ([`assign_value`](latexml_core::state::assign_value)) |
@@ -96,10 +97,13 @@ Called at the top level of a binding file, or from inside any body.
 | `NoteSTDERR(string)` | Write a progress note to stderr as well as the log. |
 | `ParseXML(string) -> array` | Parse a markup chunk into nodes; a bare fragment is fine. ([`parse_fragment`](latexml_core::common::xml::parse_fragment)) |
 | `PassOptions(string, string, array)` | Forward options to a package or class not yet loaded. ([`pass_options`](latexml_core::binding::content::pass_options)) |
+| `PopValue(string) -> ?` | Pop and return the last value of a value-table list (`()` if empty). ([`pop_value`](latexml_core::state::pop_value)) |
+| `PrependSearchPath(string)` | Prepend a directory to the input search path (searched first). ([`search_paths_push_front`](latexml_core::state::search_paths_push_front)) |
 | `ProcessOptions()`<br>`ProcessOptions(bool)` | Execute the declared options — in declaration order, or (`*`) in the order passed. ([`process_options`](latexml_core::binding::content::process_options)) |
 | `ProgressSpindown(string)` | Close a named progress stage in the log. ([`note_end`](latexml_core::common::error::note_end)) |
 | `ProgressSpinup(string)` | Open a named progress stage in the log. ([`note_begin`](latexml_core::common::error::note_begin)) |
 | `ProgressStep(string)` | Advance the progress indicator; a no-op in this port. ([`progress_step`](latexml_core::common::error::progress_step)) |
+| `PushValue(string, string)` | Push a value onto a value-table list, creating it (global) if absent. ([`push_value`](latexml_core::state::push_value)) |
 | `RawTeX(string)` | Process a chunk of literal TeX as definitions. ([`raw_tex`](latexml_core::stomach::raw_tex)) |
 | `ReadArg() -> string` | Read one TeX argument: a token, or a braced group. ([`read_arg`](latexml_core::gullet::read_arg)) |
 | `ReadOptional() -> string` | Read a LaTeX optional `[…]` argument, or a default. ([`read_optional`](latexml_core::gullet::read_optional)) |
@@ -114,6 +118,7 @@ Called at the top level of a binding file, or from inside any body.
 | `RequireResource(string)`<br>`RequireResource(string, map)` | Attach a CSS or JavaScript resource to the document. ([`require_resource`](latexml_core::binding::content::require_resource)) |
 | `ResetCounter(string)` | Reset a counter to zero. ([`reset_counter`](latexml_core::binding::counter::dialect::reset_counter)) |
 | `Revert(Digested) -> Tokens` | A digested value back to the source tokens that made it. ([`Digested::revert`](latexml_core::digested::Digested::revert)) |
+| `ShiftValue(string) -> ?` | Remove and return the first value of a value-table list (`()` if empty). ([`shift_value`](latexml_core::state::shift_value)) |
 | `SkipSpaces()` | Discard any run of spaces at the head of the input. ([`skip_spaces`](latexml_core::gullet::skip_spaces)) |
 | `StepCounter(string)` | Step a counter; usually you want `RefStepCounter` instead. ([`step_counter`](latexml_core::binding::counter::dialect::step_counter)) |
 | `T_CS(string) -> Tokens` | One control-sequence token, wrapped as `Tokens` so it composes with `Digest`/`Expand`. |
@@ -125,6 +130,7 @@ Called at the top level of a binding file, or from inside any body.
 | `Tokenize(string) -> Tokens` | Tokenize a string under the standard catcode table. ([`tokenize`](latexml_core::mouth::tokenize)) |
 | `TokenizeInternal(string) -> Tokens` | Tokenize a string under the style-file table, where `@` is a letter. ([`tokenize_internal`](latexml_core::mouth::tokenize_internal)) |
 | `UnTeX(Tokens) -> string` | Tokens back to the TeX source that could have produced them. ([`Tokens::untex`](latexml_core::tokens::Tokens::untex)) |
+| `UnshiftValue(string, string)` | Prepend a value to a value-table list, creating it (global) if absent. ([`unshift_value`](latexml_core::state::unshift_value)) |
 | `Warn(string, string, string)` | Log a `Warning:` with the given category and object. |
 | `XEquals(string, string) -> bool` | Whether two control sequences have the same meaning. ([`x_equals`](latexml_core::state::x_equals)) |
 | `assign_global(string, string)` | [`assign_value`](latexml_core::state::assign_value) with [`Scope::Global`](latexml_core::state::Scope::Global): the binding survives the enclosing TeX group. |

--- a/latexml_contrib/src/script_bindings/API.md
+++ b/latexml_contrib/src/script_bindings/API.md
@@ -97,13 +97,13 @@ Called at the top level of a binding file, or from inside any body.
 | `NoteSTDERR(string)` | Write a progress note to stderr as well as the log. |
 | `ParseXML(string) -> array` | Parse a markup chunk into nodes; a bare fragment is fine. ([`parse_fragment`](latexml_core::common::xml::parse_fragment)) |
 | `PassOptions(string, string, array)` | Forward options to a package or class not yet loaded. ([`pass_options`](latexml_core::binding::content::pass_options)) |
-| `PopValue(string) -> ?` | Pop and return the last value of a value-table list (`()` if empty). ([`pop_value`](latexml_core::state::pop_value)) |
+| `PopValue(string) -> ?` | Pop and return the last value of a value-table list, type preserved (`()` if empty). ([`pop_value`](latexml_core::state::pop_value)) |
 | `PrependSearchPath(string)` | Prepend a directory to the input search path (searched first). ([`search_paths_push_front`](latexml_core::state::search_paths_push_front)) |
 | `ProcessOptions()`<br>`ProcessOptions(bool)` | Execute the declared options — in declaration order, or (`*`) in the order passed. ([`process_options`](latexml_core::binding::content::process_options)) |
 | `ProgressSpindown(string)` | Close a named progress stage in the log. ([`note_end`](latexml_core::common::error::note_end)) |
 | `ProgressSpinup(string)` | Open a named progress stage in the log. ([`note_begin`](latexml_core::common::error::note_begin)) |
 | `ProgressStep(string)` | Advance the progress indicator; a no-op in this port. ([`progress_step`](latexml_core::common::error::progress_step)) |
-| `PushValue(string, string)` | Push a value onto a value-table list, creating it (global) if absent. ([`push_value`](latexml_core::state::push_value)) |
+| `PushValue(string, ?)` | Push a value (string/int/float/bool/Tokens) onto a value-table list, creating it (global) if absent. ([`push_value`](latexml_core::state::push_value)) |
 | `RawTeX(string)` | Process a chunk of literal TeX as definitions. ([`raw_tex`](latexml_core::stomach::raw_tex)) |
 | `ReadArg() -> string` | Read one TeX argument: a token, or a braced group. ([`read_arg`](latexml_core::gullet::read_arg)) |
 | `ReadOptional() -> string` | Read a LaTeX optional `[…]` argument, or a default. ([`read_optional`](latexml_core::gullet::read_optional)) |
@@ -118,7 +118,7 @@ Called at the top level of a binding file, or from inside any body.
 | `RequireResource(string)`<br>`RequireResource(string, map)` | Attach a CSS or JavaScript resource to the document. ([`require_resource`](latexml_core::binding::content::require_resource)) |
 | `ResetCounter(string)` | Reset a counter to zero. ([`reset_counter`](latexml_core::binding::counter::dialect::reset_counter)) |
 | `Revert(Digested) -> Tokens` | A digested value back to the source tokens that made it. ([`Digested::revert`](latexml_core::digested::Digested::revert)) |
-| `ShiftValue(string) -> ?` | Remove and return the first value of a value-table list (`()` if empty). ([`shift_value`](latexml_core::state::shift_value)) |
+| `ShiftValue(string) -> ?` | Remove and return the first value of a value-table list, type preserved (`()` if empty). ([`shift_value`](latexml_core::state::shift_value)) |
 | `SkipSpaces()` | Discard any run of spaces at the head of the input. ([`skip_spaces`](latexml_core::gullet::skip_spaces)) |
 | `StepCounter(string)` | Step a counter; usually you want `RefStepCounter` instead. ([`step_counter`](latexml_core::binding::counter::dialect::step_counter)) |
 | `T_CS(string) -> Tokens` | One control-sequence token, wrapped as `Tokens` so it composes with `Digest`/`Expand`. |
@@ -130,7 +130,7 @@ Called at the top level of a binding file, or from inside any body.
 | `Tokenize(string) -> Tokens` | Tokenize a string under the standard catcode table. ([`tokenize`](latexml_core::mouth::tokenize)) |
 | `TokenizeInternal(string) -> Tokens` | Tokenize a string under the style-file table, where `@` is a letter. ([`tokenize_internal`](latexml_core::mouth::tokenize_internal)) |
 | `UnTeX(Tokens) -> string` | Tokens back to the TeX source that could have produced them. ([`Tokens::untex`](latexml_core::tokens::Tokens::untex)) |
-| `UnshiftValue(string, string)` | Prepend a value to a value-table list, creating it (global) if absent. ([`unshift_value`](latexml_core::state::unshift_value)) |
+| `UnshiftValue(string, ?)` | Prepend a value (string/int/float/bool/Tokens) to a value-table list, creating it (global) if absent. ([`unshift_value`](latexml_core::state::unshift_value)) |
 | `Warn(string, string, string)` | Log a `Warning:` with the given category and object. |
 | `XEquals(string, string) -> bool` | Whether two control sequences have the same meaning. ([`x_equals`](latexml_core::state::x_equals)) |
 | `assign_global(string, string)` | [`assign_value`](latexml_core::state::assign_value) with [`Scope::Global`](latexml_core::state::Scope::Global): the binding survives the enclosing TeX group. |

--- a/latexml_contrib/src/script_bindings/api_doc.rs
+++ b/latexml_contrib/src/script_bindings/api_doc.rs
@@ -133,6 +133,13 @@ const DOCS: &[(&str, Doc)] = &[
     ),
   ),
   (
+    "AppendSearchPath",
+    Doc::Rust(
+      "Append a directory to the input search path (searched after existing paths).",
+      "latexml_core::state::add_search_path",
+    ),
+  ),
+  (
     "AssignBool",
     Doc::Rust(
       "Bind a key to a boolean value, with a scope.",
@@ -482,6 +489,20 @@ const DOCS: &[(&str, Doc)] = &[
     ),
   ),
   (
+    "PopValue",
+    Doc::Rust(
+      "Pop and return the last value of a value-table list (`()` if empty).",
+      "latexml_core::state::pop_value",
+    ),
+  ),
+  (
+    "PrependSearchPath",
+    Doc::Rust(
+      "Prepend a directory to the input search path (searched first).",
+      "latexml_core::state::search_paths_push_front",
+    ),
+  ),
+  (
     "ProcessOptions",
     Doc::Rust(
       "Execute the declared options — in declaration order, or (`*`) in the order passed.",
@@ -507,6 +528,13 @@ const DOCS: &[(&str, Doc)] = &[
     Doc::Rust(
       "Advance the progress indicator; a no-op in this port.",
       "latexml_core::common::error::progress_step",
+    ),
+  ),
+  (
+    "PushValue",
+    Doc::Rust(
+      "Push a value onto a value-table list, creating it (global) if absent.",
+      "latexml_core::state::push_value",
     ),
   ),
   (
@@ -608,6 +636,13 @@ const DOCS: &[(&str, Doc)] = &[
     ),
   ),
   (
+    "ShiftValue",
+    Doc::Rust(
+      "Remove and return the first value of a value-table list (`()` if empty).",
+      "latexml_core::state::shift_value",
+    ),
+  ),
+  (
     "SkipSpaces",
     Doc::Rust(
       "Discard any run of spaces at the head of the input.",
@@ -678,6 +713,13 @@ const DOCS: &[(&str, Doc)] = &[
     Doc::Rust(
       "Tokens back to the TeX source that could have produced them.",
       "latexml_core::tokens::Tokens::untex",
+    ),
+  ),
+  (
+    "UnshiftValue",
+    Doc::Rust(
+      "Prepend a value to a value-table list, creating it (global) if absent.",
+      "latexml_core::state::unshift_value",
     ),
   ),
   (

--- a/latexml_contrib/src/script_bindings/api_doc.rs
+++ b/latexml_contrib/src/script_bindings/api_doc.rs
@@ -491,7 +491,7 @@ const DOCS: &[(&str, Doc)] = &[
   (
     "PopValue",
     Doc::Rust(
-      "Pop and return the last value of a value-table list (`()` if empty).",
+      "Pop and return the last value of a value-table list, type preserved (`()` if empty).",
       "latexml_core::state::pop_value",
     ),
   ),
@@ -533,7 +533,7 @@ const DOCS: &[(&str, Doc)] = &[
   (
     "PushValue",
     Doc::Rust(
-      "Push a value onto a value-table list, creating it (global) if absent.",
+      "Push a value (string/int/float/bool/Tokens) onto a value-table list, creating it (global) if absent.",
       "latexml_core::state::push_value",
     ),
   ),
@@ -638,7 +638,7 @@ const DOCS: &[(&str, Doc)] = &[
   (
     "ShiftValue",
     Doc::Rust(
-      "Remove and return the first value of a value-table list (`()` if empty).",
+      "Remove and return the first value of a value-table list, type preserved (`()` if empty).",
       "latexml_core::state::shift_value",
     ),
   ),
@@ -718,7 +718,7 @@ const DOCS: &[(&str, Doc)] = &[
   (
     "UnshiftValue",
     Doc::Rust(
-      "Prepend a value to a value-table list, creating it (global) if absent.",
+      "Prepend a value (string/int/float/bool/Tokens) to a value-table list, creating it (global) if absent.",
       "latexml_core::state::unshift_value",
     ),
   ),

--- a/latexml_contrib/src/script_bindings/engine.rs
+++ b/latexml_contrib/src/script_bindings/engine.rs
@@ -203,26 +203,30 @@ pub(super) fn make_engine() -> Engine {
   // The Perl `@values` list-value family (Package.pm L265-279 -> State.pm L218):
   // a value-table key holds a queue that these push/pop/unshift/shift. Always
   // GLOBAL scope, auto-vivifying the list if absent — matching Perl, which takes
-  // no scope argument. `LookupValue` reads the queue back as a Rhai array (#540).
-  // NB `SEARCHPATHS` is NOT such a key in the Rust port (it is `State.search_paths`,
-  // a field) — use `PrependSearchPath`/`AppendSearchPath` below for input dirs;
-  // `GRAPHICSPATHS` IS value-table-backed, so `PushValue` reaches it.
-  engine.register_fn("PushValue", |k: &str, v: &str| {
+  // no scope argument. Perl's `PushValue` is untyped and the Rust State layer
+  // holds any `Stored`, so `PushValue`/`UnshiftValue` take any Rhai-representable
+  // value (string/int/float/bool/`Tokens`/digested handle) and `PopValue`/
+  // `ShiftValue` return it with its type preserved (#540). `LookupValue` reads
+  // the whole queue back as a Rhai array. NB `SEARCHPATHS` is NOT such a key in
+  // the Rust port (it is `State.search_paths`, a field) — use `PrependSearchPath`/
+  // `AppendSearchPath` below for input dirs; `GRAPHICSPATHS` IS value-table-backed,
+  // so `PushValue` reaches it.
+  engine.register_fn("PushValue", |k: &str, v: Dynamic| {
     // Returns Ok(()) always; the wrong-type BUG path self-reports via Error!.
-    let _ = latexml_core::state::push_value(k, v.to_string());
+    let _ = latexml_core::state::push_value(k, dynamic_to_stored(v));
   });
-  engine.register_fn("UnshiftValue", |k: &str, v: &str| {
-    latexml_core::state::unshift_value(k, vec![v.to_string()]);
+  engine.register_fn("UnshiftValue", |k: &str, v: Dynamic| {
+    latexml_core::state::unshift_value(k, vec![dynamic_to_stored(v)]);
   });
   engine.register_fn("PopValue", |k: &str| -> Dynamic {
     match latexml_core::state::pop_value(k) {
-      Ok(Some(popped)) => stored_to_dynamic(popped),
+      Ok(Some(popped)) => popped_stored_to_dynamic(popped),
       _ => Dynamic::UNIT,
     }
   });
   engine.register_fn("ShiftValue", |k: &str| -> Dynamic {
     match latexml_core::state::shift_value(k) {
-      Ok(Some(shifted)) => stored_to_dynamic(shifted),
+      Ok(Some(shifted)) => popped_stored_to_dynamic(shifted),
       _ => Dynamic::UNIT,
     }
   });

--- a/latexml_contrib/src/script_bindings/engine.rs
+++ b/latexml_contrib/src/script_bindings/engine.rs
@@ -200,6 +200,42 @@ pub(super) fn make_engine() -> Engine {
   engine.register_fn("AssignString", |k: &str, v: &str, scope: &str| {
     latexml_core::state::assign_value(k, v.to_string(), scope_of(scope));
   });
+  // The Perl `@values` list-value family (Package.pm L265-279 -> State.pm L218):
+  // a value-table key holds a queue that these push/pop/unshift/shift. Always
+  // GLOBAL scope, auto-vivifying the list if absent — matching Perl, which takes
+  // no scope argument. `LookupValue` reads the queue back as a Rhai array (#540).
+  // NB `SEARCHPATHS` is NOT such a key in the Rust port (it is `State.search_paths`,
+  // a field) — use `PrependSearchPath`/`AppendSearchPath` below for input dirs;
+  // `GRAPHICSPATHS` IS value-table-backed, so `PushValue` reaches it.
+  engine.register_fn("PushValue", |k: &str, v: &str| {
+    // Returns Ok(()) always; the wrong-type BUG path self-reports via Error!.
+    let _ = latexml_core::state::push_value(k, v.to_string());
+  });
+  engine.register_fn("UnshiftValue", |k: &str, v: &str| {
+    latexml_core::state::unshift_value(k, vec![v.to_string()]);
+  });
+  engine.register_fn("PopValue", |k: &str| -> Dynamic {
+    match latexml_core::state::pop_value(k) {
+      Ok(Some(popped)) => stored_to_dynamic(popped),
+      _ => Dynamic::UNIT,
+    }
+  });
+  engine.register_fn("ShiftValue", |k: &str| -> Dynamic {
+    match latexml_core::state::shift_value(k) {
+      Ok(Some(shifted)) => stored_to_dynamic(shifted),
+      _ => Dynamic::UNIT,
+    }
+  });
+  // Input search paths. Perl keeps these in the `SEARCHPATHS` value and prepends
+  // via `UnshiftValue`; the Rust port keeps them in `State.search_paths` (read by
+  // `find_file`), so a script mutates them through these dedicated bindings, not
+  // `PushValue`. Prepend = searched first (Perl's `SEARCHPATHS` semantics).
+  engine.register_fn("PrependSearchPath", |dir: &str| {
+    latexml_core::state::search_paths_push_front(dir.to_string());
+  });
+  engine.register_fn("AppendSearchPath", |dir: &str| {
+    latexml_core::state::add_search_path(dir.to_string());
+  });
   engine.register_fn("LookupString", |k: &str| -> String {
     latexml_core::state::lookup_string(k)
   });

--- a/latexml_contrib/src/script_bindings/mod.rs
+++ b/latexml_contrib/src/script_bindings/mod.rs
@@ -609,6 +609,49 @@ fn stored_to_dynamic(v: Stored) -> Dynamic {
   }
 }
 
+/// Marshal a Rhai value INTO a `Stored` for the value-table list ops
+/// (`PushValue`/`UnshiftValue`). The inverse of [`popped_stored_to_dynamic`].
+/// Perl's `PushValue` is untyped; the Rust State layer holds any `Stored`, so we
+/// preserve every Rhai-representable type — string, int, float, bool, `Tokens`,
+/// and a digested handle. There is no Rhai value for `Dimension`/`Glue`/`Font`/…,
+/// so those are unreachable from a script; anything unrecognized falls back to
+/// its string form (#540).
+fn dynamic_to_stored(v: Dynamic) -> Stored {
+  if v.is_string() {
+    v.into_string().unwrap_or_default().into()
+  } else if let Ok(i) = v.as_int() {
+    Stored::Int(i)
+  } else if let Ok(f) = v.as_float() {
+    Stored::Float(Float(f))
+  } else if let Ok(b) = v.as_bool() {
+    Stored::Bool(b)
+  } else if let Some(tokens) = v.clone().try_cast::<Tokens>() {
+    Stored::Tokens(tokens)
+  } else if let Some(digested) = v.clone().try_cast::<Digested>() {
+    Stored::Digested(digested)
+  } else {
+    v.to_string().into()
+  }
+}
+
+/// Marshal a popped/shifted `Stored` back to a *typed* Rhai value — the
+/// type-preserving counterpart of [`stored_to_dynamic`], used only by
+/// `PopValue`/`ShiftValue` so a pushed int/float/`Tokens` round-trips as itself
+/// rather than as text. (`stored_to_dynamic` stays string-leaning because it
+/// also marshals counter/whatsit property maps, which expect that.)
+fn popped_stored_to_dynamic(v: Stored) -> Dynamic {
+  match v {
+    Stored::String(s) => Dynamic::from(arena::to_string(s)),
+    Stored::Bool(b) => Dynamic::from(b),
+    Stored::Int(i) => Dynamic::from(i),
+    Stored::Number(n) => Dynamic::from(n.0),
+    Stored::Float(f) => Dynamic::from(f.0),
+    Stored::Tokens(t) => Dynamic::from(t),
+    Stored::Digested(d) => Dynamic::from(d),
+    other => Dynamic::from(other.to_string()),
+  }
+}
+
 /// Marshal a digested macro argument into a Rhai value. Every argument is passed
 /// as its TeX-source string (authors parse it in-script as needed).
 fn arg_to_dynamic(arg: ArgWrap) -> Dynamic { Dynamic::from(arg.to_string()) }

--- a/latexml_contrib/src/script_bindings/tests.rs
+++ b/latexml_contrib/src/script_bindings/tests.rs
@@ -147,6 +147,84 @@ fn typed_assign_roundtrip() {
   assert!((state::lookup_float("ta:fg").expect("ta:fg").0 - 3.5).abs() < 1e-9);
 }
 
+/// #540: the value-table list family (`PushValue`/`PopValue`/`UnshiftValue`/
+/// `ShiftValue`, Perl `Package.pm` L265-279) plus the dedicated search-path
+/// bindings. The reporter wanted to append a directory to `SEARCHPATHS`, but in
+/// the Rust port `SEARCHPATHS` is NOT a value-table key — it is `State.search_paths`
+/// (a field, consumed by `find_file`) — so `PushValue("SEARCHPATHS", dir)` would
+/// be a silent no-op. The dedicated `PrependSearchPath`/`AppendSearchPath` reach
+/// the real field; `PushValue` serves value-table lists like `GRAPHICSPATHS`.
+#[test]
+fn pushvalue_family_and_search_paths() {
+  use latexml_core::state;
+  fresh_state();
+  load_script(
+    r##"
+      // Value-table list family: push/pop/unshift/shift a global queue.
+      PushValue("l540", "a");
+      PushValue("l540", "b");
+      PushValue("l540", "c");            // ["a","b","c"]
+      let p = PopValue("l540");          // "c"  -> ["a","b"]
+      assign_global("l540:pop_ok", if p == "c" { "ok" } else { "bad" });
+      UnshiftValue("l540", "z");         // ["z","a","b"]
+      let s = ShiftValue("l540");        // "z"  -> ["a","b"]
+      assign_global("l540:shift_ok", if s == "z" { "ok" } else { "bad" });
+
+      // Dedicated search-path bindings (SEARCHPATHS is a field, not value-table).
+      PrependSearchPath("/540/prepended");
+      AppendSearchPath("/540/appended");
+
+      // GRAPHICSPATHS *is* value-table-backed, so PushValue reaches it (the
+      // recommended pattern where the target really is a value-table list).
+      PushValue("GRAPHICSPATHS", "/540/gfx");
+    "##,
+  )
+  .expect("pushvalue-family script should load cleanly");
+  // Through-the-binding return values.
+  assert_eq!(
+    lookup_str("l540:pop_ok"),
+    "ok",
+    "PopValue returns the last pushed"
+  );
+  assert_eq!(
+    lookup_str("l540:shift_ok"),
+    "ok",
+    "ShiftValue returns the unshifted front"
+  );
+  // Native-side witness: the queue is [a,b] after push*3 + pop + unshift + shift.
+  let items = state::lookup_value("l540")
+    .and_then(|v| v.list_items())
+    .expect("l540 is a list value");
+  assert_eq!(
+    items,
+    vec!["a".to_string(), "b".to_string()],
+    "final queue = [a,b]"
+  );
+  // Native-side witness: the search-path FIELD moved (not the value table).
+  let paths = state::get_search_paths();
+  assert_eq!(
+    paths.first().map(String::as_str),
+    Some("/540/prepended"),
+    "PrependSearchPath puts the dir first, got {paths:?}"
+  );
+  assert!(
+    paths.iter().any(|p| p == "/540/appended"),
+    "AppendSearchPath adds the dir, got {paths:?}"
+  );
+  // The documented divergence: a value-table `SEARCHPATHS` key stays absent, so
+  // `PushValue("SEARCHPATHS", …)` would never reach file resolution.
+  assert!(
+    state::lookup_value("SEARCHPATHS").is_none(),
+    "SEARCHPATHS is not value-table-backed in the Rust port"
+  );
+  // ...but GRAPHICSPATHS is, so PushValue onto it does reach file resolution.
+  assert!(
+    state::get_graphics_paths().iter().any(|p| p == "/540/gfx"),
+    "PushValue reaches the value-table-backed GRAPHICSPATHS, got {:?}",
+    state::get_graphics_paths()
+  );
+}
+
 /// Wave-B definition forms: DefRegister (count + dimen), DefConditional
 /// (Rhai test driven from real TeX), DefKeyVal, DefLigature, DefMath.
 #[test]

--- a/latexml_contrib/src/script_bindings/tests.rs
+++ b/latexml_contrib/src/script_bindings/tests.rs
@@ -225,6 +225,55 @@ fn pushvalue_family_and_search_paths() {
   );
 }
 
+/// #540 (generalized): the list ops carry any Rhai-representable value, not just
+/// strings. An int/float/bool round-trips as its own type (not stringified), and
+/// a `Tokens` value survives a push/pop cycle. Perl's `PushValue` is untyped and
+/// the State layer holds any `Stored`; only the binding used to narrow to strings.
+#[test]
+fn pushvalue_preserves_types() {
+  fresh_state();
+  load_script(
+    r##"
+      PushValue("tv", 7);                            // int
+      PushValue("tv", 2.5);                          // float
+      PushValue("tv", true);                         // bool
+      PushValue("tv", TokenizeInternal("\\alpha"));  // Tokens
+      // Pop back LIFO: Tokens, bool, float, int.
+      let t = PopValue("tv");
+      let b = PopValue("tv");
+      let f = PopValue("tv");
+      let i = PopValue("tv");
+      assign_global("tv:tok", if UnTeX(t).contains("alpha") { "ok" } else { "bad" });
+      assign_global("tv:bool", if b { "ok" } else { "bad" });
+      assign_global("tv:float", if f == 2.5 { "ok" } else { "bad" });
+      assign_global("tv:int", if i == 7 { "ok" } else { "bad" });
+      // The point of the generalization: a popped int is an i64, NOT a string.
+      assign_global("tv:int_type", type_of(i));
+
+      // A digested handle survives the round-trip too (separate key, to keep the
+      // LIFO ordering above intact).
+      PushValue("tvd", DigestText("qq"));
+      let d = PopValue("tvd");
+      assign_global("tvd:ok", if ToString(d) == "qq" { "ok" } else { "bad" });
+    "##,
+  )
+  .expect("typed-push script should load cleanly");
+  assert_eq!(
+    lookup_str("tv:tok"),
+    "ok",
+    "Tokens survive a push/pop cycle"
+  );
+  assert_eq!(lookup_str("tv:bool"), "ok", "bool round-trips as bool");
+  assert_eq!(lookup_str("tv:float"), "ok", "float round-trips as float");
+  assert_eq!(lookup_str("tv:int"), "ok", "int round-trips as int");
+  assert_eq!(
+    lookup_str("tv:int_type"),
+    "i64",
+    "a popped int is a typed i64, not a stringified value"
+  );
+  assert_eq!(lookup_str("tvd:ok"), "ok", "a digested handle round-trips");
+}
+
 /// Wave-B definition forms: DefRegister (count + dimen), DefConditional
 /// (Rhai test driven from real TeX), DefKeyVal, DefLigature, DefMath.
 #[test]


### PR DESCRIPTION
**Diagnostic.** The runtime Rhai bindings had no `PushValue` (nor the rest of the Perl `@values` list-op family). Separately, the reporter's goal — appending a directory to `SEARCHPATHS` — cannot go through `PushValue`: the Rust port keeps input search paths in a dedicated `State.search_paths` field (read by `find_file`), not a value-table key, so `PushValue("SEARCHPATHS", dir)` would be a silent no-op.

**Approach.** Register `PushValue`/`PopValue`/`UnshiftValue`/`ShiftValue` (Perl `Package.pm` L265-279 -> `State.pm` L218; global auto-vivify, no scope arg) wrapping the existing `latexml_core::state` functions, plus dedicated `PrependSearchPath`/`AppendSearchPath` over `state::search_paths_push_front`/`add_search_path`. The list ops are **type-general**: `PushValue`/`UnshiftValue` take any Rhai value and marshal it to the matching `Stored` (string/int/float/bool/`Tokens`/digested handle), and `PopValue`/`ShiftValue` return it with its type preserved rather than stringified — Perl's `PushValue` is untyped and the State layer already holds any `Stored` (`Dimension`/`Glue`/`Font` have no Rhai representation, so they stay unreachable). `GRAPHICSPATHS` **is** value-table-backed, so `PushValue` reaches it. No new State machinery.

**Validation.** Guards `pushvalue_family_and_search_paths` (string family + search-path field + `GRAPHICSPATHS`; confirms the `SEARCHPATHS` value-table key stays absent) and `pushvalue_preserves_types` (int/float/bool/`Tokens`/digested round-trip with type preserved — `type_of(popped) == "i64"`). `API.md` doc-gate regenerated (93->99 functions). Full suite `cargo nextest run --workspace` 1931/1931, 0 skipped; `clippy --workspace --all-targets -D warnings` clean; fmt applied.

Closes #540
