### PR TITLE
feat: expose AtBeginDocument/AtEndDocument to Rhai bindings (#539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
     cycle. `PrependSearchPath`/`AppendSearchPath` add an input directory: the Rust
     port keeps `SEARCHPATHS` in a dedicated field, not the value table, so these
     reach file resolution where `PushValue` would not (#540).
+  - **Runtime Rhai bindings expose the document hooks.** `AtBeginDocument`/
+    `AtEndDocument` (TeX source or a `Tokens` body) queue work onto the
+    `@at@begin@document`/`@at@end@document` lists the engine runs at
+    `\begin{document}`/`\end{document}`, mirroring Perl `Package.pm` (#539).
 
 ## [0.7.5] (Rhai binding API; bibliography content recovery; wider math coverage; large-document memory; default-CSS sync; ar5iv corpus fixes)
 

--- a/latexml_contrib/src/script_bindings/API.md
+++ b/latexml_contrib/src/script_bindings/API.md
@@ -35,7 +35,7 @@ closure-registered functions; only the accepted types are.
 
 Called at the top level of a binding file, or from inside any body.
 
-99 functions, 130 calls.
+101 functions, 134 calls.
 
 | call | documentation |
 |---|---|
@@ -49,6 +49,8 @@ Called at the top level of a binding file, or from inside any body.
 | `AssignNumber(string, int)`<br>`AssignNumber(string, int, string)` | Bind a key to an integer (Number) value, with a scope. ([`assign_value`](latexml_core::state::assign_value)) |
 | `AssignString(string, string)`<br>`AssignString(string, string, string)` | Bind a key to a string value, with a scope (the typed twin of `AssignValue`). ([`assign_value`](latexml_core::state::assign_value)) |
 | `AssignValue(string, string)`<br>`AssignValue(string, string, string)` | Bind a key in the value table, with a scope. ([`assign_value`](latexml_core::state::assign_value)) |
+| `AtBeginDocument(Tokens)`<br>`AtBeginDocument(string)` | Queue TeX source (or a Tokens value) to run at `\begin{document}`. ([`push_value`](latexml_core::state::push_value)) |
+| `AtEndDocument(Tokens)`<br>`AtEndDocument(string)` | Queue TeX source (or a Tokens value) to run at `\end{document}`. ([`push_value`](latexml_core::state::push_value)) |
 | `Command(string) -> Command` | Start a `std::process::Command` builder. A Rhai-only shim; nothing runs until `output()`. |
 | `CounterValue(string) -> int` | The current value of a counter. ([`counter_value`](latexml_core::binding::counter::dialect::counter_value)) |
 | `DeclareOption(Fn)`<br>`DeclareOption(string, Fn)`<br>`DeclareOption(string, string)` | Declare a class/package option: named with a body, or the bare-closure form for the default handler (Perl `DeclareOption(undef, sub {...})`). |

--- a/latexml_contrib/src/script_bindings/api_doc.rs
+++ b/latexml_contrib/src/script_bindings/api_doc.rs
@@ -196,6 +196,20 @@ const DOCS: &[(&str, Doc)] = &[
     ),
   ),
   (
+    "AtBeginDocument",
+    Doc::Rust(
+      "Queue TeX source (or a Tokens value) to run at `\\begin{document}`.",
+      "latexml_core::state::push_value",
+    ),
+  ),
+  (
+    "AtEndDocument",
+    Doc::Rust(
+      "Queue TeX source (or a Tokens value) to run at `\\end{document}`.",
+      "latexml_core::state::push_value",
+    ),
+  ),
+  (
     "Command",
     Doc::Note(
       "Start a `std::process::Command` builder. A Rhai-only shim; nothing runs until `output()`.",

--- a/latexml_contrib/src/script_bindings/engine.rs
+++ b/latexml_contrib/src/script_bindings/engine.rs
@@ -328,6 +328,47 @@ pub(super) fn make_engine() -> Engine {
       latexml_core::stomach::raw_tex(text).map_err(rhai_err)
     },
   );
+  // Document-lifecycle hooks (Perl `Package.pm` `AtBeginDocument`/`AtEndDocument`,
+  // L2815/L2830). Each pushes a Tokens body onto the value-table list the engine
+  // digests at `\begin{document}`/`\end{document}` — mirroring the native macros
+  // in `latex_constructs.rs` (which `push_value` onto `@at@begin@document`/
+  // `@at@end@document`). Accept TeX source (via `TokenizeInternal`, so `@` is a
+  // letter as Perl's string path does) or a `Tokens` value (#539). The Perl
+  // CODE-ref form is not exposed; a script can `DefMacro` a CS and hook that.
+  // `AtEndOfPackage`/`AtEndOfClass`/`AtBeginDvi` are TeX-macro-level (`AddToMacro`
+  // / no-op), reachable via `RawTeX`.
+  engine.register_fn(
+    "AtBeginDocument",
+    |text: &str| -> std::result::Result<(), Box<EvalAltResult>> {
+      latexml_core::state::push_value(
+        "@at@begin@document",
+        mouth::tokenize_internal(TeXString::assembled(text.to_string())),
+      )
+      .map_err(rhai_err)
+    },
+  );
+  engine.register_fn(
+    "AtBeginDocument",
+    |tokens: Tokens| -> std::result::Result<(), Box<EvalAltResult>> {
+      latexml_core::state::push_value("@at@begin@document", tokens).map_err(rhai_err)
+    },
+  );
+  engine.register_fn(
+    "AtEndDocument",
+    |text: &str| -> std::result::Result<(), Box<EvalAltResult>> {
+      latexml_core::state::push_value(
+        "@at@end@document",
+        mouth::tokenize_internal(TeXString::assembled(text.to_string())),
+      )
+      .map_err(rhai_err)
+    },
+  );
+  engine.register_fn(
+    "AtEndDocument",
+    |tokens: Tokens| -> std::result::Result<(), Box<EvalAltResult>> {
+      latexml_core::state::push_value("@at@end@document", tokens).map_err(rhai_err)
+    },
+  );
   engine.register_fn(
     "TeX",
     |text: &str| -> std::result::Result<(), Box<EvalAltResult>> {

--- a/latexml_contrib/src/script_bindings/tests.rs
+++ b/latexml_contrib/src/script_bindings/tests.rs
@@ -274,6 +274,44 @@ fn pushvalue_preserves_types() {
   assert_eq!(lookup_str("tvd:ok"), "ok", "a digested handle round-trips");
 }
 
+/// #539: LaTeX document hooks exposed to Rhai. `AtBeginDocument`/`AtEndDocument`
+/// push a Tokens body onto the `@at@begin@document`/`@at@end@document` value-table
+/// lists (Perl `Package.pm` L2815/L2830; native macro `latex_constructs.rs:3368`),
+/// which the engine digests at `\begin{document}`/`\end{document}`. Both a
+/// TeX-source string and a `Tokens` value are accepted.
+#[test]
+fn document_hooks_at_begin_end() {
+  use latexml_core::state;
+  fresh_state();
+  load_script(
+    r##"
+      AtBeginDocument("\\def\\hookbegin{B}");
+      AtBeginDocument(TokenizeInternal("\\relax"));  // Tokens overload
+      AtEndDocument("\\def\\hookend{E}");
+    "##,
+  )
+  .expect("document-hooks script should load cleanly");
+  // The hooks landed on the value-table keys the engine consumes at \begin/\end.
+  let begin = state::lookup_tokens("@at@begin@document")
+    .expect("@at@begin@document hook list exists")
+    .to_string();
+  assert!(
+    begin.contains("hookbegin"),
+    "AtBeginDocument pushed the string body, got: {begin}"
+  );
+  assert!(
+    begin.contains("relax"),
+    "AtBeginDocument Tokens overload pushed too, got: {begin}"
+  );
+  let end = state::lookup_tokens("@at@end@document")
+    .expect("@at@end@document hook list exists")
+    .to_string();
+  assert!(
+    end.contains("hookend"),
+    "AtEndDocument pushed the body, got: {end}"
+  );
+}
+
 /// Wave-B definition forms: DefRegister (count + dimen), DefConditional
 /// (Rhai test driven from real TeX), DefKeyVal, DefLigature, DefMath.
 #[test]


### PR DESCRIPTION
**Diagnostic.** The runtime Rhai bindings had no `AtBeginDocument`/`AtEndDocument`, so a `.rhai` binding couldn't queue work for `\begin{document}`/`\end{document}`.

**Approach.** Register `AtBeginDocument`/`AtEndDocument` (a TeX-source `&str` via `TokenizeInternal`, or a `Tokens` value) wrapping `state::push_value` onto `@at@begin@document`/`@at@end@document` — the exact value-table lists the engine digests at document begin/end, mirroring the native macros (`latex_constructs.rs`) and Perl `Package.pm` L2815/L2830. The Perl CODE-ref form, and the TeX-macro-level `AtEndOfPackage`/`AtEndOfClass`/`AtBeginDvi` (`AddToMacro`/no-op, reachable via `RawTeX`), are out of scope.

**Validation.** Guard `latexml_contrib::script_bindings::tests::document_hooks_at_begin_end` (both input forms land on the right keys, read back via `lookup_tokens`). `API.md` doc-gate regenerated (99→101 functions). Full suite `cargo nextest run --workspace` 1932/1932, 0 skipped; `clippy --workspace --all-targets -D warnings` clean; fmt applied.

Closes #539