### PR TITLE
feat: expose document.insertPI to Rhai bindings (#537)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
     `AtEndDocument` (TeX source or a `Tokens` body) queue work onto the
     `@at@begin@document`/`@at@end@document` lists the engine runs at
     `\begin{document}`/`\end{document}`, mirroring Perl `Package.pm` (#539).
+  - **The `document` handle gains `insertPI`.** A `.rhai` constructor body can
+    emit a processing instruction (a target, with optional attribute map) under
+    the Perl name `$document->insertPI` (#537).
 
 ## [0.7.5] (Rhai binding API; bibliography content recovery; wider math coverage; large-document memory; default-CSS sync; ar5iv corpus fixes)
 

--- a/latexml_contrib/src/script_bindings/API.md
+++ b/latexml_contrib/src/script_bindings/API.md
@@ -145,7 +145,7 @@ Called at the top level of a binding file, or from inside any body.
 
 Reached through the `document` handle a constructor body receives as its first argument — Perl's `$document->method`.
 
-24 functions, 33 calls.
+25 functions, 35 calls.
 
 | call | documentation |
 |---|---|
@@ -162,6 +162,7 @@ Reached through the `document` handle a constructor body receives as its first a
 | `getElement() -> Node?` | The element at, or containing, the insertion point. ([`Document::get_element`](latexml_core::document::Document::get_element)) |
 | `getNode() -> Node` | The current insertion point. ([`Document::get_node`](latexml_core::document::Document::get_node)) |
 | `insertElement(string) -> Node`<br>`insertElement(string, Digested) -> Node`<br>`insertElement(string, Digested, map) -> Node`<br>`insertElement(string, map) -> Node` | Open, absorb and close in one step; returns the new element. ([`Document::insert_element`](latexml_core::document::Document::insert_element)) |
+| `insertPI(string)`<br>`insertPI(string, map)` | Insert a processing instruction: a target, with optional attributes. ([`Document::insert_pi`](latexml_core::document::Document::insert_pi)) |
 | `insertXML(Node)`<br>`insertXML(array)`<br>`insertXML(string)` | Splice ALREADY-PARSED nodes in at the insertion point. ([`Document::insert_nodes`](latexml_core::document::Document::insert_nodes)) |
 | `maybeCloseElement(string)` | Close an element if it is open and closeable; otherwise do nothing. ([`Document::maybe_close_element`](latexml_core::document::Document::maybe_close_element)) |
 | `openElement(string)` | Open an element and make it the insertion point. ([`Document::open_element`](latexml_core::document::Document::open_element)) |

--- a/latexml_contrib/src/script_bindings/api_doc.rs
+++ b/latexml_contrib/src/script_bindings/api_doc.rs
@@ -903,6 +903,13 @@ const DOCS: &[(&str, Doc)] = &[
     ),
   ),
   (
+    "insertPI",
+    Doc::Rust(
+      "Insert a processing instruction: a target, with optional attributes.",
+      "latexml_core::document::Document::insert_pi",
+    ),
+  ),
+  (
     "insertXML",
     Doc::Rust(
       "Splice ALREADY-PARSED nodes in at the insertion point.",

--- a/latexml_contrib/src/script_bindings/engine.rs
+++ b/latexml_contrib/src/script_bindings/engine.rs
@@ -1402,6 +1402,27 @@ pub(super) fn make_engine() -> Engine {
       })
     },
   );
+  // insertPI (Perl `insertPI`, Document.pm:703) — insert a `<?op attr=".."?>`
+  // processing instruction: a bare target, or a target + attribute map (#537).
+  engine.register_fn(
+    "insertPI",
+    |_d: &mut DocProxy, op: &str| -> std::result::Result<(), Box<EvalAltResult>> {
+      with_doc(|doc, _props| {
+        doc.insert_pi(op, None).map_err(rhai_err)?;
+        Ok(())
+      })
+    },
+  );
+  engine.register_fn(
+    "insertPI",
+    |_d: &mut DocProxy, op: &str, attrib: Map| -> std::result::Result<(), Box<EvalAltResult>> {
+      let attrib = attribute_map(attrib);
+      with_doc(|doc, _props| {
+        doc.insert_pi(op, Some(attrib)).map_err(rhai_err)?;
+        Ok(())
+      })
+    },
+  );
 
   // openElementAt/closeElementAt (Perl Document.pm:1830-1884) — build at an
   // explicit node instead of the current insertion point.

--- a/latexml_oxide/tests/30_script_bindings.rs
+++ b/latexml_oxide/tests/30_script_bindings.rs
@@ -102,6 +102,13 @@ const SAMPLE: &str = r##"
   // Processing-instruction template (the class/package PI dialect shape).
   DefConstructor("\\mypi{}", "<?mypi data=\"#1\"?>");
 
+  // The imperative `document.insertPI` method (#537), vs \mypi's template form.
+  // Exercises both overloads: bare target, and target + attribute map.
+  DefConstructor("\\rhpi", |document| {
+    document.insertPI("rhpibare");
+    document.insertPI("rhpi", #{ data: "imperative" });
+  });
+
   // Environment, template form — a 1:1 port of latex_base's {quote}
   // (latex_constructs.rs L5019): the template's #body hole receives the
   // digested environment body.
@@ -310,7 +317,7 @@ fn script_binding_macro_and_constructor_convert() {
     "\\begin{biop}{Ada}Idiom\\end{biop} \\begin{rbox}Boxed\\end{rbox} ",
     "\\begin{rproof}QED-body\\end{rproof} \\numbered{NUM} \\rcite*[pre][post]{k1,k2} ",
     "\\gsbox{2}{3}{SCL} \\kvprobe[lang=rust]{KVB} \\sized{SZ} \\racc{o} $a := b$ $c!!$ \\gread[x]{y} \\rwvictim{OLD} ",
-    "\\rhrawhtml \\rhfragment ",
+    "\\rhrawhtml \\rhfragment \\rhpi ",
     "\\endreferences \\setx{hello}\\end{document}"
   );
   let doc = latexml
@@ -414,6 +421,15 @@ fn script_binding_macro_and_constructor_convert() {
   assert!(
     xml.contains("<?mypi") && xml.contains("data=\"d1\""),
     "PI template (\\mypi) did not emit; xml=\n{xml}"
+  );
+  // document.insertPI method (#537), both overloads: bare target + target/attrs.
+  assert!(
+    xml.contains("<?rhpi") && xml.contains("data=\"imperative\""),
+    "document.insertPI(target, attrs) did not emit its PI; xml=\n{xml}"
+  );
+  assert!(
+    xml.contains("<?rhpibare"),
+    "document.insertPI(target) bare form did not emit its PI; xml=\n{xml}"
   );
   // DefEnvironment, template form ({quote} port): #body lands inside the element.
   assert!(


### PR DESCRIPTION
**Diagnostic.** The `document` handle exposed `insertElement`/`insertXML`/etc. to `.rhai` bindings but not `insert_pi`, so a runtime binding couldn't emit a processing instruction the way a compile-time constructor's `<?op ..?>` template can.

**Approach.** Register `insertPI` on the `DocProxy` (bare target, or target + attribute `Map` → `attribute_map`) wrapping the existing `Document::insert_pi`, under the Perl name `$document->insertPI` (`Core/Document.pm:703`) — mirroring the `insertElement` proxy registration.

**Validation.** Extended guard `latexml::30_script_bindings::script_binding_macro_and_constructor_convert`: a `.rhai` constructor calls both `document.insertPI("rhpibare")` and `document.insertPI("rhpi", #{data:..})` through a real conversion and asserts both PIs emit with zero errors. `API.md` doc-gate regenerated (`insertPI` under `document` methods). Full suite `cargo nextest run --workspace` 1936/1936, 0 skipped; clippy/fmt clean.

Closes #537