### PR TITLE
fix: read NOMINAL_FONT_SIZE as a float, not a truncated integer (#542)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@
   - **The `document` handle gains `insertPI`.** A `.rhai` constructor body can
     emit a processing instruction (a target, with optional attribute map) under
     the Perl name `$document->insertPI` (#537).
+  - **`NOMINAL_FONT_SIZE` is read and stored as a float, not truncated to an
+    integer.** The default-font-size reader preserves a fractional value (e.g. the
+    `11pt` class option's `10.95`), matching Perl's `DEFSIZE`, and the default is
+    now stored as a float so the assign type matches the lookup — a value assigned
+    for `11pt` round-trips instead of flooring to 10 (#542).
 
 ## [0.7.5] (Rhai binding API; bibliography content recovery; wider math coverage; large-document memory; default-CSS sync; ar5iv corpus fixes)
 

--- a/latexml_core/src/common/font.rs
+++ b/latexml_core/src/common/font.rs
@@ -45,11 +45,13 @@ static DEFCOLOR: Color = color::BLACK;
 // These are intentionally None in text_default/math_default.
 static DEFOPACITY: &str = "1";
 static DEFENCODING: &str = "OT1";
-/// Perl: sub defsize() { return $STATE->lookupValue('NOMINAL_FONT_SIZE') || 10; }
-/// Reads NOMINAL_FONT_SIZE from state, defaulting to 10.0.
+/// Perl: sub DEFSIZE() { return $STATE->lookupValue('NOMINAL_FONT_SIZE') || 10; }
+/// Reads NOMINAL_FONT_SIZE from state, defaulting to 10.0. Perl uses the value
+/// directly as a float (`Common/Font.pm:44`) — the `11pt` class option is
+/// `10.95` (LaTeX's `\@xipt`), so this must NOT truncate via `lookup_int` (#542).
 fn defsize() -> f64 {
-  let v = lookup_int("NOMINAL_FONT_SIZE");
-  if v > 0 { v as f64 } else { 10.0 }
+  let v = lookup_float("NOMINAL_FONT_SIZE").map_or(0.0, |f| f.0);
+  if v > 0.0 { v } else { 10.0 }
 }
 
 pub const TEXT_FONTS: [&str; 6] = ["cmr", "cmm", "cmsy", "cmex", "amsa", "amsb"];
@@ -2295,6 +2297,31 @@ mod tests {
   #[test]
   fn relative_font_size_half_is_50() {
     assert_eq!(relative_font_size(5.0, 10.0), "50%");
+  }
+
+  /// #542: NOMINAL_FONT_SIZE is a float, not an integer — the `11pt` class option
+  /// is `10.95` (LaTeX's `\@xipt`), which the reader must not truncate. Perl
+  /// `DEFSIZE` reads `lookupValue('NOMINAL_FONT_SIZE')` directly as a float
+  /// (`Common/Font.pm:44`); the Rust reader used to go through `lookup_int`.
+  #[test]
+  fn defsize_preserves_fractional_nominal_font_size() {
+    use crate::{
+      common::float::Float,
+      state::{State, StateOptions, assign_value, set_state},
+    };
+    set_state(State::new(StateOptions::default()));
+    // Unset → default 10.
+    assert_eq!(defsize(), 10.0, "defsize defaults to 10 when unset");
+    // 11pt → 10.95, the fractional value the old lookup_int truncated to 10.
+    assign_value("NOMINAL_FONT_SIZE", Float(10.95), None);
+    assert_eq!(
+      defsize(),
+      10.95,
+      "defsize preserves the fractional 11pt size"
+    );
+    // An integral float still reads back cleanly.
+    assign_value("NOMINAL_FONT_SIZE", Float(12.0), None);
+    assert_eq!(defsize(), 12.0, "12pt reads back as 12.0");
   }
 
   #[test]

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -2042,8 +2042,10 @@ fn maybe_promote_leading_title(document: &mut Document) -> Result<()> {
     return Ok(());
   };
   let nominal = {
-    let v = lookup_int("NOMINAL_FONT_SIZE");
-    if v > 0 { v as f64 } else { 10.0 }
+    // #542: NOMINAL_FONT_SIZE is a float (11pt = 10.95), not an int — mirror
+    // `common::font::defsize`, which reads it via lookup_float, not lookup_int.
+    let v = lookup_float("NOMINAL_FONT_SIZE").map_or(0.0, |f| f.0);
+    if v > 0.0 { v } else { 10.0 }
   };
   if title_p.get_content().trim().is_empty()
     || !descendant_has_display_font(document, &title_p, nominal)

--- a/latexml_engine/src/plain_base.rs
+++ b/latexml_engine/src/plain_base.rs
@@ -390,8 +390,13 @@ LoadDefinitions!({
   // but to change the current font used in boxes.
   // (some of these were defined on different pages? or even latex...)
 
-  // Ideally, we should set these sizes from class files
-  AssignValue!("NOMINAL_FONT_SIZE", 10);
+  // Ideally, we should set these sizes from class files.
+  // Store a Float, not an int: `defsize` reads this via `lookup_float` (#542), so
+  // keep the assign type matching the lookup type — a fractional size (11pt =
+  // 10.95) written here or by a class option then round-trips. (`lookup_float`
+  // does widen a stored Int, but `lookup_int` would NOT discover a stored Float,
+  // so the write and reader must agree.)
+  AssignValue!("NOMINAL_FONT_SIZE", Float(10.0));
 
   // Perl plain_base.pool.ltxml L371 (shadowed L369's declarative form):
   //   DefPrimitiveI('\mit', undef, sub {

--- a/latexml_package/src/package/a0poster_cls.rs
+++ b/latexml_package/src/package/a0poster_cls.rs
@@ -67,7 +67,8 @@ LoadDefinitions!({
 \else \relax
 \fi");
 
-  AssignValue!("NOMINAL_FONT_SIZE", 25);
+  // Float, not int — `defsize` reads via `lookup_float` (#542); see plain_base.
+  AssignValue!("NOMINAL_FONT_SIZE", Float(25.0));
   DefPrimitive!("\\tiny",         None, font => {size => 12 });
   DefPrimitive!("\\scriptsize",   None, font => {size => 14.4 });
   DefPrimitive!("\\footnotesize", None, font => {size => 17.28 });


### PR DESCRIPTION
**Diagnostic.** `common::font::defsize` (and a hand-inlined clone in `latexml_engine::base_utilities`) read `NOMINAL_FONT_SIZE` via `lookup_int`, truncating any fractional value — so the `11pt` class option's `10.95` (LaTeX's `\@xipt`) could never survive. Perl `DEFSIZE` reads the value directly as a float (`Common/Font.pm:44`); this is a Rust-only divergence.

**Approach.** Switch both readers to `lookup_float` (added for #543), preserving the fraction and defaulting to 10.0. Output-neutral for existing documents — every current write of `NOMINAL_FONT_SIZE` stores an integer (`Int` widens to the same float), so nothing changes until a `Float` is stored (e.g. via `AssignFloat`). The `10pt`/`11pt`/`12pt` options are no-ops in both Rust and Perl, so wiring them to emit `10.95` would be a separate beyond-Perl change — out of scope here.

**Validation.** Guard `latexml_core::common::font::tests::defsize_preserves_fractional_nominal_font_size` (RED→green: a stored `Float(10.95)` reads back as `10.95`, not `10`). Full suite `cargo nextest run --workspace` 1937/1937, 0 skipped — zero font-size/golden regressions; clippy/fmt clean.

Closes #542