### PR TITLE
fix html_feedback#6886: publication metadata no longer pollutes the title <h1>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+  - **A paper's title no longer absorbs publication metadata.** Class frontmatter
+    such as acmart's `\acmConference`/`\acmDOI`/`\acmISBN` was rendered *inside*
+    the title `<h1>` (a stray dagger hover on the heading), leaking metadata into
+    the title element. Now only genuine title footnotes (`\thanks`/`\titlenote`)
+    stay on the title; publication metadata renders as a separate block after it
+    (arXiv/html_feedback#6886).
   - **A `\text{…}`-only display equation renders on one line.** `\[\text{The
     solution is not valid}\]` collapsed to one word per line: the display
     equation's content cell (`ltx_eqn_cell`) lacked the `white-space:nowrap` that

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4031,8 +4031,8 @@ ends up containing the conference/DOI/ISBN text (behind a stray `†` on the
 heading) — publication metadata leaking into the title element. Same-host Perl
 0.8.8 produces the identical structure. Not acmart-specific: IEEEtran and other
 class bindings route the same way. Issue arXiv/html_feedback#6886, witnesses
-arXiv:2410.20027 + 2603.16021 (acmart) and 2509.09112 (IEEEtran) — all three
-`<h1>` titles are clean after the fix.
+arXiv:2410.20027 + 2603.16021 + 2601.14324 (acmart) and 2509.09112 (IEEEtran) —
+all four `<h1>` (and `<head><title>`) titles are clean after the fix.
 
 **Divergence** (surpass-Perl, user-approved 2026-08-15): split the pubnotes by
 role in `maketitle`. Genuine title **footnotes** — `\thanks`, `\titlenote`/
@@ -4045,10 +4045,20 @@ a `notes` node-set; no core/XML change, and non-pubnote papers are byte-identica
 For arXiv:2410.20027 the `<h1>` is now just "Agentic Feedback Loop Modeling
 Improves Recommendation and User Simulation" (was …+"Conference: … DOI: …" + a
 stray `†`), verified with headless Chrome under ar5iv.css. The ar5iv stylesheet
-styling of the moved `ltx_pubnotes_meta` block (a visible ACM-reference footer
-rather than a lone collapsed dagger) is a follow-up in `~/git/ar5iv-css`.
+styling of the moved `ltx_pubnotes_meta` block — the inherited dagger
+hover-popup on narrow viewports, promoted to always-visible right-margin
+marginalia on wide (`>= 96rem`, sized from the real available margin so it never
+overflows) — is `dginev/ar5iv-css#45`.
 
-**Guard**: `cluster_cli::title_pubnote_pollution::title_h1_excludes_metadata_pubnotes_keeps_footnotes`
+The HTML `<head><title>` is clean of notes by construction, independent of this
+`<h1>` fix: the engine extracts every note out of `\title{}` into **sibling**
+`<pubnote>` elements (a `\thanks` nested in the title lands as a `role='thanks'`
+sibling), so the core `<title>` node — and the navigation title the head
+`<title>` derives from — carry only title text.
+
+**Guards**: `cluster_cli::title_pubnote_pollution::title_h1_excludes_metadata_pubnotes_keeps_footnotes`
 (a `\lx@add@pubnote[role=conference/doi/note]` fixture: metadata not in the `<h1>`,
 the `role=note` footnote kept in it, the metadata in an `ltx_pubnotes_meta`
-sibling after it).
+sibling after it) and `…::head_title_excludes_all_note_content` (a `\thanks` in
+`\title{}` + metadata pubnotes: the head `<title>` keeps the title text and no
+note/metadata text; verified red under a note-injecting head-title mutation).

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4029,8 +4029,10 @@ popup). Class bindings route a lot through `\lx@add@pubnote`: acmart
 `\acmJournal`/`\acmVolume`/… all to `pubnote`s. So the `<h1 class="ltx_title">`
 ends up containing the conference/DOI/ISBN text (behind a stray `†` on the
 heading) — publication metadata leaking into the title element. Same-host Perl
-0.8.8 produces the identical structure (issue arXiv/html_feedback#6886, witness
-arXiv:2410.20027 — acmart sigconf).
+0.8.8 produces the identical structure. Not acmart-specific: IEEEtran and other
+class bindings route the same way. Issue arXiv/html_feedback#6886, witnesses
+arXiv:2410.20027 + 2603.16021 (acmart) and 2509.09112 (IEEEtran) — all three
+`<h1>` titles are clean after the fix.
 
 **Divergence** (surpass-Perl, user-approved 2026-08-15): split the pubnotes by
 role in `maketitle`. Genuine title **footnotes** — `\thanks`, `\titlenote`/

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4019,3 +4019,34 @@ text without the fix). Both render on one line with it.
   above is the CI gate); self-skips unless `npm install`ed in `tests/browser` and
   run with `LATEXML_BROWSER_TESTS=1`. Verified red→green: reverting the CSS rule
   fails it at 74px-tall (pure) / 35px-overflow (mixed).
+
+### 110. Publication metadata pubnotes render outside the title `<h1>`, not inside it
+
+**Perl** `LaTeXML-structure-xhtml.xsl` `maketitle` collects **every** `ltx:pubnote`
+into a "footnote-like block" *inside* the title `<h{level}>` (a `†`-collapsed hover
+popup). Class bindings route a lot through `\lx@add@pubnote`: acmart
+(`acmart.cls.ltxml` L59-70) maps `\acmConference`/`\acmDOI`/`\acmISBN`/
+`\acmJournal`/`\acmVolume`/… all to `pubnote`s. So the `<h1 class="ltx_title">`
+ends up containing the conference/DOI/ISBN text (behind a stray `†` on the
+heading) — publication metadata leaking into the title element. Same-host Perl
+0.8.8 produces the identical structure (issue arXiv/html_feedback#6886, witness
+arXiv:2410.20027 — acmart sigconf).
+
+**Divergence** (surpass-Perl, user-approved 2026-08-15): split the pubnotes by
+role in `maketitle`. Genuine title **footnotes** — `\thanks`, `\titlenote`/
+`\subtitlenote` (`role='note'`/`'thanks'`) — stay inside the `<h1>`, matching
+author intent (a `\thanks` *is* a title footnote). Publication **metadata**
+(everything else) moves to a **sibling** `<span class="ltx_pubnotes
+ltx_pubnotes_meta">` block after the title, so the `<h1>` holds only the title
+text (and its real footnotes). The `pubnotes` XSLT template is parametrized with
+a `notes` node-set; no core/XML change, and non-pubnote papers are byte-identical.
+For arXiv:2410.20027 the `<h1>` is now just "Agentic Feedback Loop Modeling
+Improves Recommendation and User Simulation" (was …+"Conference: … DOI: …" + a
+stray `†`), verified with headless Chrome under ar5iv.css. The ar5iv stylesheet
+styling of the moved `ltx_pubnotes_meta` block (a visible ACM-reference footer
+rather than a lone collapsed dagger) is a follow-up in `~/git/ar5iv-css`.
+
+**Guard**: `cluster_cli::title_pubnote_pollution::title_h1_excludes_metadata_pubnotes_keeps_footnotes`
+(a `\lx@add@pubnote[role=conference/doi/note]` fixture: metadata not in the `<h1>`,
+the `role=note` footnote kept in it, the metadata in an `ltx_pubnotes_meta`
+sibling after it).

--- a/latexml_oxide/tests/cluster_cli.rs
+++ b/latexml_oxide/tests/cluster_cli.rs
@@ -1946,4 +1946,72 @@ mod title_pubnote_pollution {
       "metadata pubnotes must render as an ltx_pubnotes_meta block after the title;\nhtml=\n{html}"
     );
   }
+
+  /// The HTML `<head><title>` (browser tab / SEO / bookmark text) must carry
+  /// ONLY the title text — never any note content. Notes (`\thanks`, footnotes)
+  /// and publication metadata (conference/DOI) are meant to display visually in
+  /// the body only. This holds by construction: the engine extracts every note
+  /// out of `\title{}` into sibling `<pubnote>` elements, so the core `<title>`
+  /// node — and the navigation title the head `<title>` derives from — are
+  /// clean. This guard locks that in against a regression that let note text
+  /// flow back into the head title (e.g. a template switched to a
+  /// note-including flatten, or notes re-parented under `<title>`).
+  ///
+  /// A `\thanks` INSIDE `\title{}` is the strongest case: it is a note that TeX
+  /// nests within the title group, yet it must still be extracted and kept out
+  /// of the head `<title>`.
+  #[test]
+  fn head_title_excludes_all_note_content() {
+    let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+    let workdir = tempfile::tempdir().expect("tempdir");
+    let root = workdir.path();
+    // \thanks nested in the title + metadata pubnotes + a plain title footnote.
+    let doc = "\\documentclass{article}\n\
+               \\makeatletter\n\
+               \\lx@add@pubnote[role=conference]{Proc. of Something 2025}\n\
+               \\lx@add@pubnote[role=doi]{10.1/xyz}\n\
+               \\makeatother\n\
+               \\title{My Paper Title\\thanks{Secret Funding Note}}\n\
+               \\author{An Author}\n\
+               \\begin{document}\\maketitle Body.\\end{document}\n";
+    fs::write(root.join("doc.tex"), doc).unwrap();
+    let out = Command::new(bin)
+      .current_dir(root)
+      .arg("--format=html5")
+      .arg("--destination=out.html")
+      .arg("doc.tex")
+      .output()
+      .expect("run latexml_oxide");
+    let html = fs::read_to_string(root.join("out.html")).unwrap_or_default();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    // Isolate the HEAD <title>…</title> (not the body <h1 class="ltx_title">).
+    let head_title = html
+      .find("<title>")
+      .and_then(|i| {
+        html[i + 7..]
+          .find("</title>")
+          .map(|j| &html[i + 7..i + 7 + j])
+      })
+      .expect("HTML must have a <head><title>");
+
+    // The title text is present …
+    assert!(
+      head_title.contains("My Paper Title"),
+      "head <title> lost the actual title text;\n<title>={head_title:?}\nstderr=\n{stderr}"
+    );
+    // … and NONE of the note / metadata content leaked into it.
+    for leak in [
+      "Secret Funding Note",
+      "Proc. of Something",
+      "10.1/xyz",
+      "Thanks",
+    ] {
+      assert!(
+        !head_title.contains(leak),
+        "note/metadata {leak:?} leaked into the head <title> \
+         (must be body-visual only);\n<title>={head_title:?}"
+      );
+    }
+  }
 }

--- a/latexml_oxide/tests/cluster_cli.rs
+++ b/latexml_oxide/tests/cluster_cli.rs
@@ -1882,3 +1882,68 @@ mod browser_render_display_math {
     }
   }
 }
+
+mod title_pubnote_pollution {
+  //! arXiv/html_feedback#6886: publication METADATA pubnotes (conference, DOI,
+  //! ISBN, journal, …) were nested inside the title `<h1 class="ltx_title">`,
+  //! leaking frontmatter into the title (a stray dagger on the heading + the
+  //! metadata living in the title DOM). Vanilla LaTeXML's `maketitle` "collects
+  //! ALL pubnotes into the title"; we diverge (OXIDIZED_DESIGN) — only genuine
+  //! title FOOTNOTES (`\thanks`, `\titlenote` ⇒ role note/thanks) stay in the
+  //! `<h1>`; metadata pubnotes move to a sibling `ltx_pubnotes_meta` block.
+  //!
+  //! Deterministic without acmart: `\lx@add@pubnote[role=…]` is the exact API
+  //! acmart maps `\acmConference`/`\acmDOI`/… onto.
+
+  use std::{fs, process::Command};
+
+  const DOC: &str = "\\documentclass{article}\n\
+                     \\makeatletter\n\
+                     \\lx@add@pubnote[role=conference]{Proc. of Something 2025}\n\
+                     \\lx@add@pubnote[role=doi]{10.1/xyz}\n\
+                     \\lx@add@pubnote[role=note]{A title footnote.}\n\
+                     \\makeatother\n\
+                     \\title{My Paper Title}\n\
+                     \\author{An Author}\n\
+                     \\begin{document}\\maketitle Body.\\end{document}\n";
+
+  #[test]
+  fn title_h1_excludes_metadata_pubnotes_keeps_footnotes() {
+    let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+    let workdir = tempfile::tempdir().expect("tempdir");
+    let root = workdir.path();
+    fs::write(root.join("doc.tex"), DOC).unwrap();
+    let out = Command::new(bin)
+      .current_dir(root)
+      .arg("--format=html5")
+      .arg("--destination=out.html")
+      .arg("doc.tex")
+      .output()
+      .expect("run latexml_oxide");
+    let html = fs::read_to_string(root.join("out.html")).unwrap_or_default();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    let h1 = html
+      .find("<h1")
+      .and_then(|i| html[i..].find("</h1>").map(|j| &html[i..i + j]))
+      .unwrap_or("");
+
+    // The metadata (conference/DOI) must NOT pollute the title heading …
+    assert!(
+      !h1.contains("Proc. of Something") && !h1.contains("10.1/xyz"),
+      "publication metadata leaked into the <h1> title (#6886);\nh1=\n{h1}\nstderr=\n{stderr}"
+    );
+    // … but a genuine title footnote (\thanks/\titlenote ⇒ role=note) stays in it.
+    assert!(
+      h1.contains("A title footnote"),
+      "the role=note title footnote should remain on the title;\nh1=\n{h1}"
+    );
+    // The metadata moves to a sibling `ltx_pubnotes_meta` block AFTER the <h1>.
+    let (h1_close, meta) = (html.find("</h1>"), html.find("ltx_pubnotes_meta"));
+    assert!(
+      matches!((h1_close, meta), (Some(h), Some(m)) if m > h)
+        && html.contains("Proc. of Something"),
+      "metadata pubnotes must render as an ltx_pubnotes_meta block after the title;\nhtml=\n{html}"
+    );
+  }
+}

--- a/latexml_post/resources/XSLT/LaTeXML-structure-xhtml.xsl
+++ b/latexml_post/resources/XSLT/LaTeXML-structure-xhtml.xsl
@@ -449,13 +449,33 @@
       <xsl:apply-templates>
         <xsl:with-param name="context" select="$innercontext"/>
       </xsl:apply-templates>
-      <!-- collect all pubnotes into a footnote-like block -->
-      <xsl:if test="parent::*/ltx:pubnote">
+      <!-- Only genuine title FOOTNOTES (\thanks, \titlenote/\subtitlenote →
+           role note/thanks) belong INSIDE the <h1>. Publication METADATA
+           (conference, DOI, ISBN, journal, volume, …) does not — nesting it in
+           the title element leaks frontmatter into the title (a stray dagger on
+           the heading + the metadata living in the <h1> DOM). See
+           arXiv/html_feedback#6886; divergence from vanilla LaTeXML's
+           "collect ALL pubnotes into the title" (OXIDIZED_DESIGN). -->
+      <xsl:variable name="titlenotes"
+                    select="parent::*/ltx:pubnote[@role='note' or @role='thanks']"/>
+      <xsl:if test="$titlenotes">
       <xsl:call-template name="pubnotes">
         <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="notes" select="$titlenotes"/>
       </xsl:call-template>
       </xsl:if>
     </xsl:element>
+    <!-- Publication metadata pubnotes as a SIBLING block after the title. -->
+    <xsl:variable name="metanotes"
+                  select="parent::*/ltx:pubnote[not(@role='note' or @role='thanks')]"/>
+    <xsl:if test="$metanotes">
+      <xsl:text>&#x0A;</xsl:text>
+      <xsl:call-template name="pubnotes">
+        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="notes" select="$metanotes"/>
+        <xsl:with-param name="extra_class" select="'ltx_pubnotes_meta'"/>
+      </xsl:call-template>
+    </xsl:if>
     <!-- include parent's subtitle, author & date (if any)-->
     <xsl:apply-templates select="../ltx:subtitle" mode="intitle">
       <xsl:with-param name="context" select="$context"/>
@@ -482,11 +502,21 @@
 
   <xsl:template name="pubnotes">
     <xsl:param name="context"/>
+    <!-- Which pubnotes to render (a node-set); default = all, for callers that
+         do not split them. `extra_class` distinguishes the metadata block that
+         maketitle now emits OUTSIDE the title from the in-title footnote block. -->
+    <xsl:param name="notes" select="parent::*/ltx:pubnote"/>
+    <xsl:param name="extra_class" select="''"/>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:attribute name="class">ltx_pubnotes</xsl:attribute>
+      <xsl:attribute name="class">
+        <xsl:text>ltx_pubnotes</xsl:text>
+        <xsl:if test="$extra_class != ''">
+          <xsl:value-of select="concat(' ',$extra_class)"/>
+        </xsl:if>
+      </xsl:attribute>
       <xsl:element name="span" namespace="{$html_ns}">
         <xsl:attribute name="class">ltx_pubnotes_content</xsl:attribute>
-        <xsl:apply-templates select="parent::*/ltx:pubnote" mode="intitle">
+        <xsl:apply-templates select="$notes" mode="intitle">
           <xsl:with-param name="context" select="$context"/>
         </xsl:apply-templates>
       </xsl:element>


### PR DESCRIPTION
**Diagnostic.** acmart maps `\acmConference`/`\acmDOI`/`\acmISBN`/… to `\lx@add@pubnote`, and the shared `maketitle` XSLT collects **every** pubnote into the title `<h1>` (a `†`-collapsed hover) — so the conference/DOI/ISBN text lives in the title element, with a stray `†` on the heading. Same-host Perl 0.8.8 is identical (witness arXiv:2410.20027).

**Approach.** Surpass-Perl (user-approved): split pubnotes by role in `maketitle` — genuine title footnotes (`\thanks`/`\titlenote` ⇒ role note/thanks) stay in the `<h1>`; publication metadata moves to a sibling `ltx_pubnotes_meta` block after it. XSLT-only, non-pubnote papers byte-identical (zero golden churn). OXIDIZED_DESIGN #110.

**Validation.** Guard `cluster_cli::title_pubnote_pollution::title_h1_excludes_metadata_pubnotes_keeps_footnotes`; full suite 1963/0; clippy/fmt clean; `<h1>` verified clean under ar5iv.css with headless Chrome. (ar5iv.css styling of the moved block is a follow-up in `~/git/ar5iv-css`.)

Closes arXiv/html_feedback#6886