### PR TITLE
fix #531: pdfcol.sty no-op stub (breakable tcolorbox no longer errors)

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3365,3 +3365,23 @@ lualatex PDF draws a proper rectangle. Perl-origin, unreported upstream. Rust **
 `ltx_framed_rectangle` box (framesep→padding, framerule→border, fvextra background→background),
 dropping the raw rules and the stray line. Guard:
 `00_tokenize` `tests/tokenize/fancyvrb_frame.{tex,xml}`.
+
+## 80. `pdfcol.sty` undefined → `\pdfcolInitStack` error (Rust surpasses)
+
+Neither Perl nor Rust LaTeXML ships a `pdfcol.sty.ltxml`. `pdfcol` is a pdfTeX colour-stack
+manager pulled in transitively by tcolorbox's `breakable` library (`\tcbuselibrary{breakable}`).
+With no binding, `\pdfcolInitStack` / `\pdfcolIfStackExists` / `\pdfcolSwitchStack` /
+`\pdfcolSetCurrentColor` / `\pdfcolSetCurrent` are undefined, so a breakable coloured tcolorbox
+reports `Error:undefined:\pdfcolInitStack` and leaks the args as body text. Minimal trigger:
+
+```latex
+\documentclass{article}
+\usepackage{pdfcol}
+\begin{document}\pdfcolInitStack{main}\end{document}
+```
+
+Same-host Perl (TL2025) errors identically (`1 error; 1 undefined macro[\pdfcolInitStack]`).
+Issue #531 (reporter nasser1). Perl-origin, unreported upstream. Rust **surpasses**
+(OXIDIZED_DESIGN #112): `pdfcol_sty.rs` ports pdfcol.sty's own "disabled" fallback (all commands
+no-op, `\pdfcolIfStackExists` takes the false branch) — a PDF colour stack has no HTML output.
+Guard: `06_cluster_regressions::cluster_pdfcol_stub_no_undefined`.

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4103,3 +4103,26 @@ the golden has two `framed="rectangle" class="ltx_framed_verbatim"` boxes with t
 `border-width`/`padding`/`background` cssstyle and **zero** `<ltx:rule>` elements; plus
 `latexml_post::xslt::witnessed_css_delta::framed_verbatim_responsive_delta_stays_present`
 (the `.ltx_framed_verbatim` responsive rule stays in the bundled `LaTeXML.css`).
+
+### 112. `pdfcol.sty` is a no-op stub (PDF colour stacks have no HTML output)
+
+**Perl** LaTeXML ships no `pdfcol.sty.ltxml`. When tcolorbox's `breakable` library
+(`\tcbuselibrary{breakable}`) or a document `\RequirePackage{pdfcol}`s the package, LaTeXML
+finds no binding, and pdfcol's `\pdfcolInitStack` / `\pdfcolIfStackExists` / `\pdfcolSwitchStack`
+/ `\pdfcolSetCurrentColor` / `\pdfcolSetCurrent` are undefined → `Error:undefined:\pdfcolInitStack`
+and the args leak as body text. Issue #531 (reporter nasser1). Same-host Perl (TL2025) errors
+identically (SHARED-FAILURE).
+
+**Divergence** (surpass-Perl, SHARED-FAILURE → clean): `pdfcol_sty.rs` ports `pdfcol.sty`'s own
+`\ifpdfcolAvailable … \else … \fi` **disabled** fallback branch (`pdfcol.sty` L275-291), which
+the real package takes whenever pdfTeX's colour-stack primitives are unavailable — always the
+case for LaTeXML. Every command becomes a no-op; `\pdfcolIfStackExists#1#2#3` expands to `#3`
+(the stack is never registered, so the false branch runs); `\pdfcolErrorNoStacks` is silenced to
+`\relax` (raising a conversion error for a PDF-only capability with no HTML output would defeat
+the fix). A PDF colour stack is a page-model construct with no rendering in HTML/XML, so no
+currently-passing paper changes shape — the divergence is purely the *absence* of the shared
+error. **Upstream**: Perl LaTeXML would benefit from the same no-op binding.
+
+**Guards**: `06_cluster_regressions::cluster_pdfcol_stub_no_undefined`
+(`tests/cluster_regressions/pdfcol_stub.tex`) — the five `\pdfcol…` commands emit no `<ERROR>`
+and the body collapses to exactly `STACK-NO` (the disabled false-branch), no leaked args.

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -257,6 +257,30 @@ fn cluster_defmath_textmode_no_mode_warning() {
 /// shared diagram-macro stubs absorb them. See docs/SYNC_STATUS.md.
 #[test]
 fn cluster_feynmp_fmf() { convert_clean("tests/cluster_regressions/feynmp_fmf.tex"); }
+/// Issue #531: `pdfcol.sty` (a PDF colour-stack manager, pulled in transitively
+/// by tcolorbox's `breakable` library) had no binding, so `\pdfcolInitStack` and
+/// its four siblings raised `undefined` errors and leaked their args as text.
+/// SHARED-FAILURE (same-host Perl errors identically — neither engine shipped a
+/// pdfcol binding). LaTeXML emits no PDF colour stack, so `pdfcol_sty.rs` ports
+/// the package's own "disabled" fallback (all commands no-op; `\pdfcolIfStackExists`
+/// takes the false branch). OXIDIZED_DESIGN #112.
+#[test]
+fn cluster_pdfcol_stub_no_undefined() {
+  let xml = convert_to_xml("tests/cluster_regressions/pdfcol_stub.tex");
+  // No `undefined` ERROR nodes for any pdfcol command (`convert_to_xml` already
+  // gates 0 errors; this pins the shape). The four no-op commands emit nothing
+  // and `\pdfcolIfStackExists{main}{STACK-YES}{STACK-NO}` runs the FALSE branch
+  // (the disabled fallback: a stack is never registered), so the whole body
+  // collapses to exactly `STACK-NO` — no leaked `main`/`STACK-YES` args.
+  assert!(
+    !xml.contains("<ERROR"),
+    "pdfcol commands must no-op, not <ERROR>:\n{xml}"
+  );
+  assert!(
+    xml.contains("<p>STACK-NO</p>") && !xml.contains("STACK-YES"),
+    "\\pdfcolIfStackExists must take the false branch and siblings must no-op:\n{xml}"
+  );
+}
 /// An UNBOUND journal class (`sn-jnl`, `wlpeerj`, `sagej`, Wiley, …) falls back
 /// to the OmniBus class, whose lazy natbib autoload triggers (`\citep`/`\citet`/
 /// `\citeyear`/…) must load natbib EXACTLY ONCE and resolve to natbib's real

--- a/latexml_oxide/tests/cluster_regressions/pdfcol_stub.tex
+++ b/latexml_oxide/tests/cluster_regressions/pdfcol_stub.tex
@@ -1,0 +1,13 @@
+% Issue #531: pdfcol.sty (a PDF colour-stack package, loaded transitively by
+% tcolorbox's `breakable` library) had no binding, so \pdfcolInitStack and its
+% siblings raised `undefined` errors. LaTeXML emits no PDF colour stack, so the
+% package's own "disabled" fallback (no-ops) is the faithful HTML semantics.
+\documentclass{article}
+\usepackage{pdfcol}
+\begin{document}
+\pdfcolInitStack{main}%
+\pdfcolSwitchStack{main}%
+\pdfcolSetCurrentColor
+\pdfcolSetCurrent{main}%
+\pdfcolIfStackExists{main}{STACK-YES}{STACK-NO}
+\end{document}

--- a/latexml_package/src/lib.rs
+++ b/latexml_package/src/lib.rs
@@ -640,6 +640,7 @@ pub const BINDINGS: &[(&str, &str, BindingLoader)] = &[
     package::pdftexcmds_sty::load_definitions,
   ),
   ("pdfx", "sty", package::pdfx_sty::load_definitions),
+  ("pdfcol", "sty", package::pdfcol_sty::load_definitions),
   ("ngerman", "sty", package::ngerman_sty::load_definitions),
   ("orcidlink", "sty", package::orcidlink_sty::load_definitions),
   ("newtxmath", "sty", package::newtxmath_sty::load_definitions),

--- a/latexml_package/src/package.rs
+++ b/latexml_package/src/package.rs
@@ -332,6 +332,7 @@ pub mod overpic_sty;
 pub mod palatino_sty;
 pub mod paralist_sty;
 pub mod parskip_sty;
+pub mod pdfcol_sty;
 pub mod pdflscape_sty;
 pub mod pdfpages_sty;
 pub mod pdfsync_sty;

--- a/latexml_package/src/package/pdfcol_sty.rs
+++ b/latexml_package/src/package/pdfcol_sty.rs
@@ -1,0 +1,32 @@
+use crate::prelude::*;
+
+// pdfcol.sty — pdfTeX colour-stack manager (Heiko Oberdiek / LaTeX team). It is
+// pulled in transitively by tcolorbox's `breakable` library to keep box colours
+// consistent across a page break, and defines a handful of `\pdfcol…` commands
+// that ultimately drive pdfTeX's `\pdfcolorstack` primitive (issue #531).
+//
+// A PDF colour stack is a page-model concept with NO rendering in LaTeXML's
+// HTML/XML output, and pdfTeX's primitives are unavailable here — exactly the
+// situation the real package guards with its `\ifpdfcolAvailable … \else …`
+// switch. Perl LaTeXML ships no pdfcol.sty.ltxml either, so both engines raised
+// `undefined:\pdfcolInitStack` on breakable tcolorboxes (SHARED-FAILURE). This
+// binding ports pdfcol.sty's OWN "disabled" fallback branch (pdfcol.sty L275-291,
+// TeX Live 2025): every command becomes a no-op and `\pdfcolIfStackExists` always
+// takes its false branch (no stack is ever registered). OXIDIZED_DESIGN #112.
+#[rustfmt::skip]
+LoadDefinitions!({
+  // \def\pdfcolInitStack#1{\PDFCOL@Disabled}  — a stack is never created.
+  DefMacro!("\\pdfcolInitStack{}", "");
+  // \long\def\pdfcolIfStackExists#1#2#3{#3} — the stack never exists → false arg.
+  DefMacro!("\\pdfcolIfStackExists{}{}{}", "#3");
+  // \def\pdfcolSwitchStack#1{\PDFCOL@Disabled}
+  DefMacro!("\\pdfcolSwitchStack{}", "");
+  // \def\pdfcolSetCurrentColor{\PDFCOL@Disabled} — no argument.
+  DefMacro!("\\pdfcolSetCurrentColor", "");
+  // \def\pdfcolSetCurrent#1{\PDFCOL@Disabled}
+  DefMacro!("\\pdfcolSetCurrent{}", "");
+  // \pdfcolErrorNoStacks raises a package error in the real disabled branch; in
+  // HTML the whole feature is legitimately unavailable, so silence it (\relax)
+  // rather than surface an error for a PDF-only capability that has no output.
+  Let!("\\pdfcolErrorNoStacks", "\\relax");
+});


### PR DESCRIPTION
**Diagnostic.** `pdfcol.sty` (a pdfTeX colour-stack manager, pulled in transitively by tcolorbox's `breakable` library via `\tcbuselibrary{breakable}`) has no binding in either Perl or Rust LaTeXML, so `\pdfcolInitStack` and its four siblings raise `undefined` errors on a breakable coloured tcolorbox and leak their args as body text. Same-host Perl (TL2025) errors identically — SHARED-FAILURE.

**Approach.** Add `pdfcol_sty.rs`, a faithful port of `pdfcol.sty`'s own `\ifpdfcolAvailable…\else…\fi` *disabled* fallback branch (L275-291) — the branch the real package itself takes whenever pdfTeX's colour-stack primitives are unavailable, always the case for LaTeXML's HTML/XML output. Every command no-ops; `\pdfcolIfStackExists` takes its false branch. A PDF colour stack has no HTML rendering, so no currently-passing paper changes shape. Surpass-Perl: OXIDIZED_DESIGN #112 / KNOWN_PERL_ERRORS #80.

**Validation.** Red→green guard `06_cluster_regressions::cluster_pdfcol_stub_no_undefined`; the reporter's full tcolorbox+breakable MWE now converts "No obvious problems" (was 1 pdfcol error); full suite 1970/0; clippy/fmt/streaming-sweep clean; Perl parity re-confirmed on the MWE.

The reporter's *secondary* `\sys_if_shell:TF` error is a separate TL2026-only expl3 dump-skew (not hit by either engine on TL2025) — out of scope here.

Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)