### PR TITLE
test html_feedback#6888: guard title footnote renders mark-only, not inline

### DIFF
--- a/latexml_oxide/tests/cluster_cli.rs
+++ b/latexml_oxide/tests/cluster_cli.rs
@@ -2014,4 +2014,76 @@ mod title_pubnote_pollution {
       );
     }
   }
+
+  /// arXiv/html_feedback#6888: a `\thanks` on the author / affiliation line of a
+  /// manually-formatted `\author{}` (no `\and`) becomes a loose `role='thanks'`
+  /// pubnote that the maketitle collects into the title `<h1>`. It must land
+  /// inside a **collapsible** `.ltx_pubnotes_content` block (the bundled CSS
+  /// renders only the dagger MARK and hides the content — guarded in
+  /// `latexml_post::xslt::witnessed_css_delta::title_pubnote_content_stays_collapsed`),
+  /// never as **bare inline text** in the `<h1>`, and never in the head `<title>`.
+  /// Parity: same-host Perl 0.8.8 produces the byte-identical structure. Witness
+  /// arXiv:2312.08128 (Clockwork Diffusion, Qualcomm affiliation `\thanks`).
+  #[test]
+  fn author_block_thanks_collapses_in_title_not_inline() {
+    let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+    let workdir = tempfile::tempdir().expect("tempdir");
+    let root = workdir.path();
+    let doc = "\\documentclass{article}\n\
+               \\title{Clockwork Diffusion}\n\
+               \\author{Amir Habibian\\thanks{Equal contribution} \\\\\n\
+               {Qualcomm AI Research\\thanks{Qualcomm AI Research is an initiative of \
+               Qualcomm Technologies, Inc}}}\n\
+               \\begin{document}\\maketitle Body.\\end{document}\n";
+    fs::write(root.join("doc.tex"), doc).unwrap();
+    let out = Command::new(bin)
+      .current_dir(root)
+      .arg("--format=html5")
+      .arg("--destination=out.html")
+      .arg("doc.tex")
+      .output()
+      .expect("run latexml_oxide");
+    let html = fs::read_to_string(root.join("out.html")).unwrap_or_default();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    let leak = "initiative of Qualcomm";
+    // Head <title> is clean of the footnote text.
+    let head_title = html
+      .find("<title>")
+      .and_then(|i| {
+        html[i + 7..]
+          .find("</title>")
+          .map(|j| &html[i + 7..i + 7 + j])
+      })
+      .expect("HTML must have a <head><title>");
+    assert!(
+      !head_title.contains(leak),
+      "affiliation \\thanks leaked into the head <title> (#6888);\n<title>={head_title:?}"
+    );
+
+    // Isolate the <h1> title block.
+    let h1 = html
+      .find("<h1")
+      .and_then(|i| html[i..].find("</h1>").map(|j| &html[i..i + j]))
+      .expect("HTML must have a title <h1>");
+    // The thanks IS carried in the title (a collapsible pubnotes block) …
+    assert!(
+      h1.contains("ltx_pubnotes_content") && h1.contains(leak),
+      "the title \\thanks should be present as a collapsible pubnotes block;\nh1=\n{h1}\nstderr=\n{stderr}"
+    );
+    // … but NOT as bare inline text: stripping the pubnotes block must remove it.
+    let bare = {
+      // drop everything from the pubnotes span to the end of the h1 (the pubnotes
+      // block is the trailing content of the heading here)
+      match h1.find("<span class=\"ltx_pubnotes") {
+        Some(p) => &h1[..p],
+        None => h1,
+      }
+    };
+    assert!(
+      !bare.contains(leak) && !bare.contains("Thanks"),
+      "the \\thanks text renders inline in the title <h1> outside the collapsible \
+       pubnotes block (#6888) — it must be mark-only;\nbare-h1=\n{bare}"
+    );
+  }
 }

--- a/latexml_post/src/xslt.rs
+++ b/latexml_post/src/xslt.rs
@@ -1221,4 +1221,28 @@ mod witnessed_css_delta {
        its border off-screen and scroll the whole page on a phone",
     );
   }
+
+  #[test]
+  fn title_pubnote_content_stays_collapsed() {
+    // arXiv/html_feedback#6888 (+ #6886): a title footnote (`\thanks`/`\titlenote`,
+    // role=note/thanks) stays in the `<h1>` as a `.ltx_pubnotes` block. The bundled
+    // CSS must render ONLY the dagger MARK and keep the footnote CONTENT hidden by
+    // default, so the title text is the sole rendered language — the reporter saw the
+    // footnote text rendered inline in the title (an older deployed build). Guard both
+    // halves so a re-vanilla / cleanup sweep cannot silently drop the collapse.
+    let css = bundled_latexml_css();
+    assert!(
+      css.contains(".ltx_pubnotes:before") && css.contains(r#"content:"\002020""#),
+      "the title-footnote MARK rule (.ltx_pubnotes:before dagger) is missing from \
+       LaTeXML.css (arXiv/html_feedback#6888)",
+    );
+    assert!(
+      css.contains(".ltx_pubnotes .ltx_pubnotes_content")
+        && css.contains("visibility:hidden; opacity:0"),
+      "the title-footnote CONTENT-hidden rule (.ltx_pubnotes .ltx_pubnotes_content \
+       {{ visibility:hidden }}) is missing from LaTeXML.css: the `\\thanks` text would \
+       render inline in the title instead of collapsing to the dagger \
+       (arXiv/html_feedback#6888)",
+    );
+  }
 }


### PR DESCRIPTION
**Diagnostic.** A loose author/affiliation `\thanks` (e.g. `\author{… Qualcomm AI Research\thanks{…}}`) is collected by `maketitle` into the title `<h1>` as a collapsible `.ltx_pubnotes` block. **Parity** — same-host Perl 0.8.8 produces the byte-identical structure. In the current engine both bundled LaTeXML.css and ar5iv.css render only the dagger **mark** and hide the footnote **content** (`visibility:hidden`), so the title text is the sole rendered language. The reporter's inline-text symptom is arxiv's deployed **v0.5.0**; current engine (0.7.5+) already collapses it — no code fix needed, this PR locks the behavior in.

**Approach.** Two regression guards; no production/CSS/XSLT change.

**Validation.** `cluster_cli::title_pubnote_pollution::author_block_thanks_collapses_in_title_not_inline` (structural: `\thanks` inside `.ltx_pubnotes_content`, never bare in `<h1>`; head `<title>` clean; witness arXiv:2312.08128) and `latexml_post::xslt::witnessed_css_delta::title_pubnote_content_stays_collapsed` (bundled LaTeXML.css keeps the dagger mark + content-hidden collapse). Headless-Chrome verified across all four examined witnesses (2410.20027, 2603.16021, 2509.09112, 2312.08128) under **both** stylesheets — every title mark-only, content hidden. Full suite 1968/0; clippy/fmt clean.

Ref arXiv/html_feedback#6888.

🤖 Generated with [Claude Code](https://claude.com/claude-code)