### PR TITLE
feat: faithfully emulate \everyjob so l3sys system constants are defined (#531 secondary)

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3385,3 +3385,28 @@ Issue #531 (reporter nasser1). Perl-origin, unreported upstream. Rust **surpasse
 (OXIDIZED_DESIGN #112): `pdfcol_sty.rs` ports pdfcol.sty's own "disabled" fallback (all commands
 no-op, `\pdfcolIfStackExists` takes the false branch) — a PDF colour stack has no HTML output.
 Guard: `06_cluster_regressions::cluster_pdfcol_stub_no_undefined`.
+
+## 81. `\sys_if_shell:TF` undefined on a newer texmf expl3.sty (Perl never fires `\everyjob`)
+
+Neither Perl nor Rust LaTeXML fired TeX's `\everyjob` at job start. l3sys defers its *system*
+constants — `\c_sys_shell_escape_int`, the `\sys_if_shell:*` conditional families, the
+`\c_sys_{minute,…,year}_int` date/time ints — into `\__sys_everyjob:n { … }`
+(`expl3-code.tex` L8131-8217), i.e. into `\g__sys_everyjob_tl`, run by `\__kernel_sys_everyjob:`
+at job start. With `\everyjob` never fired, those constants stay undefined on the
+dump/short-circuit path (where a texmf `expl3.sty` newer than the embedded dump skips
+`\input expl3-code.tex`). A `expl3.sty` dated ≥ 2026-03-20 then USES `\sys_if_shell:TF` in its
+support-file/shell-escape check → `Error:undefined:\sys_if_shell:TF` on a breakable coloured
+`tcolorbox` (issue #531 secondary; reporter's TL2026 dump 2026-01-19 vs texmf 2026-03-20).
+Minimal trigger (needs the version skew, reproduced in `texlive-docker:2026` with l3kernel
+2026-07-20 over a 2026-01-19 dump):
+
+```latex
+\documentclass{article}\usepackage{expl3}
+\ExplSyntaxOn \sys_if_shell:TF{}{} \ExplSyntaxOff
+\begin{document}x\end{document}
+```
+
+Perl-origin (Perl never fires `\everyjob`). Rust **surpasses** (OXIDIZED_DESIGN #113): fire
+`\__kernel_sys_everyjob:` at `LoadFormat('latex')` completion, faithfully emulating TeX's
+job-start `\everyjob` (tex.web §1030), so the family is defined with live values before the
+preamble. Guard: `06_cluster_regressions::cluster_everyjob_defines_l3sys_shell`.

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4126,3 +4126,39 @@ error. **Upstream**: Perl LaTeXML would benefit from the same no-op binding.
 **Guards**: `06_cluster_regressions::cluster_pdfcol_stub_no_undefined`
 (`tests/cluster_regressions/pdfcol_stub.tex`) — the five `\pdfcol…` commands emit no `<ERROR>`
 and the body collapses to exactly `STACK-NO` (the disabled false-branch), no leaked args.
+
+### 113. `\everyjob` is fired at job start (l3sys system constants get defined)
+
+**Perl** LaTeXML never fires TeX's `\everyjob` token list. Real TeX inserts `\everyjob` at
+`main_control` start — right after the format is loaded, before the first token of the main
+input (`tex.web` §1030: `if every_job<>null then begin_token_list(every_job,every_job_text)`).
+LaTeX's `\everyjob` contains `\__kernel_sys_everyjob:`, which runs `\g__sys_everyjob_tl` to
+define the l3sys *system* constants — `\c_sys_shell_escape_int`, the `\sys_if_shell:*` /
+`\sys_if_shell_unrestricted:*` / `\sys_if_shell_restricted:*` conditional families, and the
+`\c_sys_{minute,hour,day,month,year}_int` date/time ints. l3sys defers ALL of these into
+`\__sys_everyjob:n { … }` blocks (`expl3-code.tex` L8131-8217), i.e. into `\g__sys_everyjob_tl`,
+precisely so they are (re)computed at each job start. Because Perl (and, pre-fix, Rust) never
+fires the hook, those constants are undefined on the dump/short-circuit path — a texmf
+`expl3.sty` NEWER than the embedded dump takes the `\ifx\csname tex_let:D\endcsname\relax`-false
+branch and skips `\input expl3-code.tex`, relying on the format to have run everyjob. That newer
+`expl3.sty` then USES `\sys_if_shell:TF` in its support-file/shell-escape check →
+`Error:undefined:\sys_if_shell:TF`. Issue #531 secondary (reporter nasser1; TL2026 dump
+2026-01-19 vs texmf 2026-03-20). Reproduced in `ghcr.io/tkw1536/texlive-docker:2026` with
+l3kernel 2026-07-20 overlaid on the 2026-01-19 dump.
+
+**Divergence** (surpass-Perl, user-approved 2026-08-15): fire `\__kernel_sys_everyjob:` at the
+completion of `LoadFormat('latex')` (`latex.rs`) — the faithful equivalent of TeX's job-start
+`\everyjob` insertion, since our LaTeX "format" is exactly that pool block. The constants are
+then defined with LIVE values on every conversion, before the document preamble runs. The
+`INI_MODE` early return in the same block means the firing is SKIPPED during dump-build, so the
+date/time ints are never frozen into the dump (only `\g__sys_everyjob_tl` — the deferred
+*recipe* — is dumped, which is correct). Guarded on `\__kernel_sys_everyjob:` existing (present
+via the latex dump or the raw-base path; absent for plain/math dumps, a clean no-op). This is a
+genuine TeX-semantics improvement Perl LaTeXML would also benefit from. **Upstream**: worth
+filing against `brucemiller/LaTeXML`.
+
+**Guards**: `06_cluster_regressions::cluster_everyjob_defines_l3sys_shell`
+(`tests/cluster_regressions/everyjob_sys_shell.tex`) — a preamble `\@ifundefined{sys_if_shell:TF}`
+probe emits `EVERYJOB-PRESENT` (was `EVERYJOB-MISSING` without the firing), and a body
+`\sys_if_shell:TF` takes the FALSE branch (`SHELL-NO`, LaTeXML has no shell). Full suite 1971/0
+confirms firing `\everyjob` on every latex conversion is output-neutral.

--- a/latexml_engine/src/latex.rs
+++ b/latexml_engine/src/latex.rs
@@ -161,4 +161,25 @@ LoadDefinitions!({
       s!("deferred aliases: {} applied, {} skipped", applied, skipped)
     );
   }
+
+  // Faithful `\everyjob` emulation (beyond Perl). TeX inserts `\everyjob`'s
+  // token list at `main_control` start — right after the format is loaded
+  // (tex.web §1030). Our LaTeX "format" is this `LoadFormat('latex')` block, so
+  // fire the l3sys job-start hook now, before the document preamble runs. l3sys
+  // defers `\c_sys_shell_escape_int`, `\sys_if_shell:*` and the date/time ints
+  // into `\__sys_everyjob:n { … }` (expl3-code.tex L8197-8217), i.e. into
+  // `\g__sys_everyjob_tl`, which `\__kernel_sys_everyjob:` runs at job start.
+  // Perl LaTeXML never fires `\everyjob`, so on the dump/short-circuit path (a
+  // texmf expl3.sty NEWER than the embedded dump skips `\input expl3-code.tex`)
+  // those constants stay undefined — issue #531 secondary: the newer expl3.sty
+  // USES `\sys_if_shell:TF` in its support-file/shell-escape check →
+  // `Error:undefined:\sys_if_shell:TF` (reporter nasser1, TL2026 dump 2026-01-19
+  // vs texmf 2026-03-20). Firing here gives LIVE values every conversion; the
+  // `INI_MODE` early return above means it does NOT run during dump-build, so
+  // the date/time constants are never frozen into the dump. Guarded on the hook
+  // existing (the latex dump / raw base defines it; a `\csname` fires it whether
+  // or not `:`/`_` are catcode-letters, since the name is built char-by-char).
+  if lookup_meaning(&T_CS!("\\__kernel_sys_everyjob:")).is_some() {
+    let _ = raw_tex(r"\csname __kernel_sys_everyjob:\endcsname");
+  }
 });

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -257,6 +257,34 @@ fn cluster_defmath_textmode_no_mode_warning() {
 /// shared diagram-macro stubs absorb them. See docs/SYNC_STATUS.md.
 #[test]
 fn cluster_feynmp_fmf() { convert_clean("tests/cluster_regressions/feynmp_fmf.tex"); }
+/// Issue #531 (secondary): faithful `\everyjob` emulation (beyond Perl). l3sys
+/// defers `\sys_if_shell:*` / `\c_sys_shell_escape_int` / date-time ints into
+/// `\g__sys_everyjob_tl`, which `\__kernel_sys_everyjob:` runs at job start via
+/// `\everyjob`. Perl LaTeXML never fires `\everyjob`, so those constants were
+/// undefined until a package loaded expl3 — and NEVER on the dump/short-circuit
+/// path a texmf expl3.sty newer than the embedded dump takes (it skips `\input
+/// expl3-code.tex`), where the newer expl3.sty USES `\sys_if_shell:TF` in its
+/// support-file check → `Error:undefined:\sys_if_shell:TF` (reporter's TL2026
+/// case; reproduced in the `texlive-docker:2026` container with l3kernel
+/// 2026-07-20 over a 2026-01-19 dump). `latex.rs` now fires
+/// `\__kernel_sys_everyjob:` at `LoadFormat('latex')` completion, so the family
+/// is defined with LIVE values before the preamble. The fixture PROBES
+/// `\sys_if_shell:TF` in the preamble (before any `\usepackage`) — RED
+/// (`EVERYJOB-MISSING`) without the fix, GREEN (`EVERYJOB-PRESENT`) with it —
+/// then uses it (LaTeXML has no shell → FALSE branch). OXIDIZED_DESIGN #113.
+#[test]
+fn cluster_everyjob_defines_l3sys_shell() {
+  let xml = convert_to_xml("tests/cluster_regressions/everyjob_sys_shell.tex");
+  assert!(
+    xml.contains("EVERYJOB-PRESENT") && !xml.contains("EVERYJOB-MISSING"),
+    "\\everyjob must fire at LoadFormat so \\sys_if_shell:TF is defined in the \
+     preamble:\n{xml}"
+  );
+  assert!(
+    xml.contains("SHELL-NO") && !xml.contains("SHELL-YES"),
+    "\\sys_if_shell:TF must take the FALSE branch (LaTeXML has no shell):\n{xml}"
+  );
+}
 /// Issue #531: `pdfcol.sty` (a PDF colour-stack manager, pulled in transitively
 /// by tcolorbox's `breakable` library) had no binding, so `\pdfcolInitStack` and
 /// its four siblings raised `undefined` errors and leaked their args as text.

--- a/latexml_oxide/tests/cluster_regressions/everyjob_sys_shell.tex
+++ b/latexml_oxide/tests/cluster_regressions/everyjob_sys_shell.tex
@@ -1,0 +1,20 @@
+% Issue #531 (secondary): faithful \everyjob emulation. l3sys defers
+% \sys_if_shell:TF (and the other system constants) into \g__sys_everyjob_tl,
+% run by \__kernel_sys_everyjob: at job start via \everyjob. Perl LaTeXML never
+% fires \everyjob, so \sys_if_shell:TF was undefined in the PREAMBLE (before any
+% package loads expl3) — the exact window a newer texmf expl3.sty uses it in its
+% support-file check on the dump/short-circuit path. We now fire it at
+% LoadFormat('latex'), so the probe below sees it DEFINED. The document then uses
+% it: LaTeXML has no shell, so it takes the FALSE branch.
+\documentclass{article}
+\makeatletter
+\@ifundefined{sys_if_shell:TF}%
+  {\def\everyjobstatus{EVERYJOB-MISSING}}%
+  {\def\everyjobstatus{EVERYJOB-PRESENT}}
+\makeatother
+\begin{document}
+\everyjobstatus
+\ExplSyntaxOn
+\sys_if_shell:TF{ SHELL-YES }{ SHELL-NO }
+\ExplSyntaxOff
+\end{document}


### PR DESCRIPTION
**Diagnostic.** l3sys defers its system constants — `\c_sys_shell_escape_int`, the `\sys_if_shell:*` conditional families, the `\c_sys_{minute,…,year}_int` date/time ints — into `\__sys_everyjob:n{…}` → `\g__sys_everyjob_tl`, run by `\__kernel_sys_everyjob:` at job start via TeX's `\everyjob` (tex.web §1030). Perl LaTeXML (and, pre-fix, Rust) never fires `\everyjob`, so those stay undefined on the dump/short-circuit path: a texmf `expl3.sty` newer than the embedded dump skips `\input expl3-code.tex` and then USES `\sys_if_shell:TF` in its support-file check → `Error:undefined:\sys_if_shell:TF` (issue #531 secondary; reporter's TL2026 dump 2026-01-19 vs texmf 2026-03-20, reproduced in `texlive-docker:2026` with l3kernel 2026-07-20 over the 2026-01-19 dump).

**Approach.** Fire `\__kernel_sys_everyjob:` at `LoadFormat('latex')` completion (`latex.rs`) — the faithful equivalent of TeX inserting `\everyjob` right after the format loads. LIVE values every conversion; `INI_MODE`-guarded so dump-build never freezes the date/time ints (only `\g__sys_everyjob_tl`, the deferred recipe, is dumped). Surpass-Perl: OXIDIZED_DESIGN #113 / KNOWN_PERL_ERRORS #81.

**Validation.** Red→green guard `06_cluster_regressions::cluster_everyjob_defines_l3sys_shell` (preamble probe `EVERYJOB-PRESENT`, body `\sys_if_shell:TF` → false branch); reporter's full tcolorbox+breakable MWE converts "No obvious problems" in the TL2026 container (was `1 error [\sys_if_shell:TF]`); full suite 1971/0 (firing `\everyjob` on every latex conversion is output-neutral); clippy/fmt clean.

Follow-up to #531 (the pdfcol part merged in #579); resolves its secondary `\sys_if_shell:TF` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)