### PR TITLE
fix html_feedback#970: siunitx empty unit renders invisibly, not as "nothing"

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3410,3 +3410,15 @@ Perl-origin (Perl never fires `\everyjob`). Rust **surpasses** (OXIDIZED_DESIGN 
 `\__kernel_sys_everyjob:` at `LoadFormat('latex')` completion, faithfully emulating TeX's
 job-start `\everyjob` (tex.web §1030), so the family is defined with live values before the
 preamble. Guard: `06_cluster_regressions::cluster_everyjob_defines_l3sys_shell`.
+
+## 82. Empty-symbol siunitx unit renders as the word "nothing" (Rust surpasses)
+
+A siunitx unit declared with an empty symbol — `\DeclareSIUnit{\nothing}{\relax}`
+(arXiv/html_feedback#970, paper 2312.06275) — produces a math token with EMPTY content but
+`meaning="nothing"`. Perl `MathML.pm` `stylizeContent` falls back to the `meaning` attribute for
+empty content, so the presentation MathML is a VISIBLE `<m:mi>nothing</m:mi>` (painted red as a
+suspected error) — the literal word "nothing" appears next to every `\SI{…}{\nothing}` number,
+where the author meant no unit at all. Same-host Perl is byte-identical (SHARED-FAILURE),
+Perl-origin, unreported upstream. Rust **surpasses** (OXIDIZED_DESIGN #114): an empty
+`class="ltx_unit"` token renders as an invisible `<m:mphantom>`, never its `meaning`. Guard:
+`06_cluster_regressions::cluster_siunitx_empty_unit_renders_invisible`.

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4162,3 +4162,27 @@ filing against `brucemiller/LaTeXML`.
 probe emits `EVERYJOB-PRESENT` (was `EVERYJOB-MISSING` without the firing), and a body
 `\sys_if_shell:TF` takes the FALSE branch (`SHELL-NO`, LaTeXML has no shell). Full suite 1971/0
 confirms firing `\everyjob` on every latex conversion is output-neutral.
+
+### 114. An empty-symbol unit renders invisibly, not as its `meaning` name
+
+**Perl** LaTeXML renders a math token whose CONTENT is empty by falling back to its `meaning`
+attribute (`MathML.pm` `stylizeContent`). For a siunitx unit declared with an empty symbol —
+`\DeclareSIUnit{\nothing}{\relax}` (arXiv/html_feedback#970, paper 2312.06275) — the core emits
+an empty `<ltx:XMTok class="ltx_unit" meaning="nothing" role="ID"/>`, so the presentation MathML
+becomes a VISIBLE `<m:mi class="ltx_unit">nothing</m:mi>` (Perl even paints it red as a
+suspected error). The author intended `\SI{5}{\nothing}` to render "5" with no unit; instead the
+literal word "nothing" appears next to every number. Same-host Perl is byte-identical
+(SHARED-FAILURE).
+
+**Divergence** (surpass-Perl, user-approved 2026-08-15): in `presentation.rs::pmml_token_inner`,
+an empty-content token carrying `class="ltx_unit"` renders as an empty `<m:mphantom>` — the same
+invisible placeholder used for `meaning="absent"` — instead of falling through to the
+`meaning`→`name`→`role` text fallback. Only empty UNIT tokens are affected (a non-empty unit
+keeps its symbol; a non-unit empty token keeps the existing fallback), so no currently-passing
+paper changes shape. A unit whose symbol produces nothing is exactly the case where the fallback
+is wrong. **Upstream**: worth filing against `brucemiller/LaTeXML`.
+
+**Guards**: `06_cluster_regressions::cluster_siunitx_empty_unit_renders_invisible`
+(`tests/cluster_regressions/siunitx_nothing_unit.tex`, via `convert_and_post_pmml_clean`) — the
+presentation MathML contains no visible `>nothing<`, the empty unit is an `<m:mphantom>`, and the
+quantity still renders.

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -10,7 +10,8 @@
 
 mod cluster;
 use cluster::{
-  convert_and_post_clean, convert_clean, convert_expecting_errors, convert_log, convert_to_xml,
+  convert_and_post_clean, convert_and_post_pmml_clean, convert_clean, convert_expecting_errors,
+  convert_log, convert_to_xml,
 };
 
 #[test]
@@ -307,6 +308,27 @@ fn cluster_pdfcol_stub_no_undefined() {
   assert!(
     xml.contains("<p>STACK-NO</p>") && !xml.contains("STACK-YES"),
     "\\pdfcolIfStackExists must take the false branch and siblings must no-op:\n{xml}"
+  );
+}
+/// arXiv/html_feedback#970 (paper 2312.06275): a siunitx unit declared with an
+/// empty symbol — `\DeclareSIUnit{\nothing}{\relax}` — must render INVISIBLY, not
+/// as the literal word "nothing". The core emits an empty `<XMTok
+/// class="ltx_unit" meaning="nothing"/>`; the MathML empty-content fallback
+/// (`presentation.rs`) used the `meaning` attribute, producing `<mi
+/// class="ltx_unit">nothing</mi>` (Perl does the same, in red — SHARED-FAILURE).
+/// An empty *unit* now renders as an invisible placeholder. OXIDIZED_DESIGN #114.
+#[test]
+fn cluster_siunitx_empty_unit_renders_invisible() {
+  let post = convert_and_post_pmml_clean("tests/cluster_regressions/siunitx_nothing_unit.tex");
+  // The presentation MathML must NOT render the unit's name as visible text.
+  assert!(
+    !post.contains(">nothing<"),
+    "empty siunitx unit leaked its `meaning` as visible MathML text:\n{post}"
+  );
+  // It renders as an invisible placeholder instead, and the quantity 5 stays.
+  assert!(
+    post.contains("mphantom") && post.contains(">5<"),
+    "empty unit must be an <m:mphantom> and the quantity 5 must still render:\n{post}"
   );
 }
 /// An UNBOUND journal class (`sn-jnl`, `wlpeerj`, `sagej`, Wiley, …) falls back

--- a/latexml_oxide/tests/cluster/mod.rs
+++ b/latexml_oxide/tests/cluster/mod.rs
@@ -144,6 +144,50 @@ pub fn convert_and_post_contrib_clean(source: &str) -> String {
   out
 }
 
+/// Like [`convert_and_post_clean`] but with presentation-MathML ENABLED, so a
+/// test can assert on the generated `<m:mi>`/`<m:mo>`/… (the pmml stage the
+/// bibliography-focused `post_with` disables by default). Gates on 0 POST errors.
+pub fn convert_and_post_pmml_clean(source: &str) -> String {
+  let xml = convert_to_xml(source);
+  latexml_core::util::logger::bind_log();
+  let opts = latexml::post::PostOptions {
+    pmml:                      true,
+    cmml:                      false,
+    keep_xmath:                false,
+    stylesheet:                None,
+    destination:               None,
+    source_directory:          Some("tests/cluster_regressions"),
+    site_directory:            None,
+    search_paths:              &[],
+    nodefaultresources:        true,
+    css_files:                 &[],
+    js_files:                  &[],
+    noinvisibletimes:          false,
+    plane1:                    true,
+    hackplane1:                false,
+    mathtex:                   false,
+    navigationtoc:             None,
+    schemadocs:                false,
+    split:                     false,
+    split_xpath:               None,
+    split_naming:              None,
+    xslt_parameters:           &[],
+    graphics_svg_threshold_kb: 0,
+    graphicimages:             false,
+    timestamp:                 None,
+    icon:                      None,
+    whatsout:                  latexml_post::extract::Whatsout::default(),
+  };
+  let out = latexml::post::run_post_processing(&xml, &opts);
+  let log = latexml_core::util::logger::flush_log();
+  let n = latexml::util::test::error_count(&log);
+  assert_eq!(
+    n, 0,
+    "{source}: POST(pmml) stage logged {n} Error:<class>: markers\n{log}"
+  );
+  out
+}
+
 /// the upstream LaTeXML#2316 / arXiv-fork behavior where frontmatter
 /// (abstract/acknowledgements/bibliography) joins the navigation TOC.
 /// Like [`convert_and_post`], but returns the ANSI-free POST-stage log

--- a/latexml_oxide/tests/cluster_regressions/siunitx_nothing_unit.tex
+++ b/latexml_oxide/tests/cluster_regressions/siunitx_nothing_unit.tex
@@ -1,0 +1,12 @@
+% arXiv/html_feedback#970 (paper 2312.06275): a siunitx unit declared with an
+% empty symbol — \DeclareSIUnit{\nothing}{\relax} — must render INVISIBLY, not as
+% the literal word "nothing". The core emits an empty <XMTok class="ltx_unit"
+% meaning="nothing"/>; the MathML fallback for empty content used the `meaning`
+% attribute, producing <mi class="ltx_unit">nothing</mi> (Perl does the same, in
+% red). Now empty unit tokens render as an invisible placeholder.
+\documentclass{article}
+\usepackage{siunitx}
+\DeclareSIUnit{\nothing}{\relax}
+\begin{document}
+\SI{5}{\nothing} and \si{\nothing}.
+\end{document}

--- a/latexml_post/src/mathml/presentation.rs
+++ b/latexml_post/src/mathml/presentation.rs
@@ -1150,6 +1150,23 @@ fn pmml_token_inner(doc: &PostDocument, node: &Node, role_override: Option<&str>
 
   // Handle empty tokens
   if text.is_empty() {
+    // arXiv/html_feedback#970 (paper 2312.06275): a siunitx unit declared with an
+    // empty symbol — `\DeclareSIUnit{\nothing}{\relax}` — reaches here with empty
+    // content but `meaning`=<unit name>. The general fallback below turns that
+    // into a visible `<m:mi>nothing</m:mi>` (Perl renders the same, in red —
+    // SHARED-FAILURE). A unit whose symbol produces nothing must render
+    // INVISIBLY: emit an empty `<m:mphantom>` — the same invisible placeholder
+    // used for `absent` above — never the unit name. OXIDIZED_DESIGN #114.
+    if node
+      .get_attribute("class")
+      .is_some_and(|c| c.split_whitespace().any(|w| w == "ltx_unit"))
+    {
+      return NodeData::Element {
+        tag:        "m:mphantom".to_string(),
+        attributes: None,
+        children:   vec![],
+      };
+    }
     if let Some(default) = default_token_content(&role) {
       text = default.to_string();
     } else {


### PR DESCRIPTION
**Diagnostic.** A siunitx unit with an empty symbol — `\DeclareSIUnit{\nothing}{\relax}` (paper 2312.06275) — yields a math token with empty content but `meaning="nothing"`. `presentation.rs::pmml_token_inner` falls back to the `meaning` attribute for empty content, so the MathML becomes a visible `<m:mi class="ltx_unit">nothing</m:mi>` — the literal word "nothing" next to every number. Same-host Perl renders the same (in red) — SHARED-FAILURE.

**Approach.** An empty-content token carrying `class="ltx_unit"` now renders as an empty `<m:mphantom>` (the invisible placeholder used for `meaning="absent"`), never its meaning. Only empty UNIT tokens change, so no passing paper is affected. **Surpass-Perl** — OXIDIZED_DESIGN #114 / KNOWN_PERL_ERRORS #82 (flagged for review: this is a new documented divergence).

**Validation.** Red→green guard `06_cluster_regressions::cluster_siunitx_empty_unit_renders_invisible` (new `convert_and_post_pmml_clean` helper runs the presentation-MathML stage); reporter's MWE renders the unit invisibly; full suite 1974/0; clippy/fmt/streaming clean.

Resolves arXiv/html_feedback#970.

🤖 Generated with [Claude Code](https://claude.com/claude-code)