### PR TITLE
fix: author-year inline citations match the References list label

### DIFF
--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -2063,9 +2063,21 @@ fn cluster_bib_review_field_cedilla_not_welded() {
 // interleaving them with the bibref's `<ltx:bibrefphrase>` markup.
 //
 // Minimal reproductions for the class of arXiv html_feedback reports where the
-// inline citation does NOT match the list — e.g. #6276 ("citations are numbered
-// but bibliography is not"), #6302 ("reference to [number] but hard to tell
-// which one"). Expand this cluster with a new fixture per distinct reproducer.
+// inline citation does NOT match the list — the "bucket A" inline-vs-list
+// mismatch: #6276 ("citations are numbered but bibliography is not"), #6302
+// ("reference to [number] but hard to tell which one"), #6307 (inline by number,
+// bibliography by author-year), #6534 (inline `[5]`, list "name et al" with no
+// number), #6026 (list "Sensoy et al. [2018]", unclear which in-text cite maps).
+// All are the same root cause: in author-year mode the inline `\cite` fell back
+// to a bare number because the bibitem's author/year tags were never registered
+// into the CrossRef DB. Expand this cluster with a new fixture per distinct
+// reproducer.
+//
+// NOT this cluster (distinct root causes, separate work): raw citekeys leaking
+// from an un-emulated cite command (#6203/#6355/#6549/#6050), genuine
+// non-resolution `?`/`[undef]` (#6489/#6601/#6222), a missing/empty References
+// list (#6432/#6288/#6179), and reference numbering ORDER (#6294/#5930 — a
+// shared-with-Perl alphabetical-vs-citation-order gap).
 // ===========================================================================
 
 /// Tag-stripped text of each inline `<ltx:cite>` in post XML.
@@ -2163,5 +2175,40 @@ fn cluster_cite_numeric_inline_matches_reference_label() {
   assert!(
     cites.iter().all(|c| numeric_label(c).is_some()),
     "numeric inline citations should be numbers indexing the list: {cites:?}\n{x}"
+  );
+}
+
+/// The same consistency guarantee for biblatex author-year (style=apa): the fix
+/// is at the shared CrossRef/Scan layer, so a biblatex `\parencite`/`\textcite`
+/// renders the author-year label the biblatex list shows — not a bare number.
+/// The sibling `cluster_biblatex_authoryear` guards the CORE `<ltx:tag>`s; this
+/// guards the POST inline-cite fill phase. (Reuses the rich biblatex_ay/ay.tex.)
+#[test]
+fn cluster_biblatex_authoryear_inline_matches_reference_label() {
+  let x = convert_and_post_contrib_clean("tests/cluster_regressions/biblatex_ay/ay.tex");
+  // biblatex's `.bbl`-formatted list carries author-year refnum labels (not the
+  // MakeBibliography `ltx_bib_author-year` class, which this path skips).
+  assert!(
+    x.contains("Smith (2020)") && x.contains("Jones &amp; Brown (2019)"),
+    "expected author-year labels in the biblatex References list:\n{x}"
+  );
+  let cites = inline_cite_texts(&x);
+  // `\parencite{smith2020}` → "(Smith, 2020)"; `\textcite{jones2019}` →
+  // "Jones & Brown (2019)" — the author-year label, matching the list entries
+  // "Smith (2020)" / "Jones & Brown (2019)".
+  assert!(
+    cites.iter().any(|c| c.contains("(Smith, 2020)")),
+    "\\parencite should render author-year \"(Smith, 2020)\": {cites:?}\n{x}"
+  );
+  assert!(
+    cites
+      .iter()
+      .any(|c| c.contains("Jones") && c.contains("(2019)")),
+    "\\textcite should render \"Jones & Brown (2019)\": {cites:?}\n{x}"
+  );
+  // The raw citekeys must never leak into the inline text.
+  assert!(
+    !x.contains(">smith2020<") && !cites.iter().any(|c| c.contains("smith2020")),
+    "a raw biblatex citekey leaked into an inline citation:\n{x}"
   );
 }

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -2050,3 +2050,118 @@ fn cluster_bib_review_field_cedilla_not_welded() {
      (control-word-terminating space lost in the .bib field path):\n{x}"
   );
 }
+
+// ===========================================================================
+// Citation ⇄ reference label CONSISTENCY cluster.
+//
+// BibTeX's core guarantee: the label of an inline citation matches the label
+// printed next to that entry in the References list, in whatever style the
+// bibliography uses (numeric `[N]`, or author-year `Author (Year)`). Perl
+// LaTeXML's CrossRef fill phase (`make_bibcite`) honors this by reading the
+// bibitem's author/year tags from the ObjectDB (populated by Scan's
+// `bibitem_handler`, re-run over the generated bibliography by `rescan`) and
+// interleaving them with the bibref's `<ltx:bibrefphrase>` markup.
+//
+// Minimal reproductions for the class of arXiv html_feedback reports where the
+// inline citation does NOT match the list — e.g. #6276 ("citations are numbered
+// but bibliography is not"), #6302 ("reference to [number] but hard to tell
+// which one"). Expand this cluster with a new fixture per distinct reproducer.
+// ===========================================================================
+
+/// Tag-stripped text of each inline `<ltx:cite>` in post XML.
+fn inline_cite_texts(xml: &str) -> Vec<String> {
+  let mut out = Vec::new();
+  let mut rest = xml;
+  while let Some(s) = rest.find("<cite") {
+    let after = &rest[s..];
+    let Some(e) = after.find("</cite>") else {
+      break;
+    };
+    let seg = &after[..e];
+    let mut txt = String::new();
+    let mut in_tag = false;
+    for c in seg.chars() {
+      match c {
+        '<' => in_tag = true,
+        '>' => in_tag = false,
+        _ if !in_tag => txt.push(c),
+        _ => {},
+      }
+    }
+    out.push(txt.trim().to_string());
+    rest = &after[e + "</cite>".len()..];
+  }
+  out
+}
+
+/// A purely numeric citation label (`2` or `[2]`) — the numeric style. In
+/// author-year mode an inline cite that reduces to this is the bug: it can no
+/// longer be matched to the `Author (Year)` label the References list shows.
+fn numeric_label(s: &str) -> Option<u32> {
+  let t = s
+    .trim()
+    .trim_start_matches('[')
+    .trim_end_matches(']')
+    .trim();
+  if t.is_empty() { None } else { t.parse().ok() }
+}
+
+/// html_feedback #6276/#6302 — natbib AUTHOR-YEAR mode: the inline `\cite`/
+/// `\citet`/`\citep` must render the author-year label the References list
+/// shows, NOT a bare number.
+///
+/// The bug was GENUINE-RUST-ONLY: MakeBibliography registered only the bibitem
+/// `number` into the CrossRef DB — never `authors`/`year` — so
+/// `crossref::fill_in_bibrefs` fell back to the number for a `show="Authors …"`
+/// bibref (inline `2` vs the list's `Beta (2002)`). Perl 0.8.8 renders
+/// `Beta (2002)` inline. Fix: the rescan registers the bibitem's tags via the
+/// shared `bibitem_tag_props`, and `fill_in_bibrefs` interleaves author/year
+/// with the `<ltx:bibrefphrase>` children (`Beta (2002)` for `\citet`,
+/// `(Beta, 2002)` for `\citep`), matching Perl `CrossRef::make_bibcite`.
+#[test]
+fn cluster_cite_authoryear_inline_matches_reference_label() {
+  let x = convert_and_post_clean("tests/cluster_regressions/cite_labels_authoryear.tex");
+  assert!(
+    x.contains("ltx_bib_author-year"),
+    "expected an author-year References list:\n{x}"
+  );
+  let cites = inline_cite_texts(&x);
+  assert!(!cites.is_empty(), "no inline citations were rendered:\n{x}");
+  // Every author-year inline cite carries the AUTHOR NAME (matching the list) —
+  // none collapses to a bare/bracketed number.
+  assert!(
+    cites.iter().all(|c| numeric_label(c).is_none()),
+    "an author-year inline citation rendered as a bare number, mismatching the \
+     References list label: {cites:?}\n{x}"
+  );
+  // \citet{beta} → "Beta (2002)"; \citep{beta} → "(Beta, 2002)".
+  assert!(
+    cites
+      .iter()
+      .any(|c| c.contains("Beta") && c.contains("(2002)")),
+    "\\citet should render \"Beta (2002)\": {cites:?}\n{x}"
+  );
+  assert!(
+    cites.iter().any(|c| c.contains("(Beta, 2002)")),
+    "\\citep should render \"(Beta, 2002)\": {cites:?}\n{x}"
+  );
+}
+
+/// Control + regression guard for the numeric path: numeric natbib mode is
+/// already consistent (inline `[N]` indexes the numbered list), and the
+/// author-year fix must not disturb it.
+#[test]
+fn cluster_cite_numeric_inline_matches_reference_label() {
+  let x = convert_and_post_clean("tests/cluster_regressions/cite_labels_numeric.tex");
+  assert!(
+    !x.contains("ltx_bib_author-year"),
+    "numeric mode must not produce an author-year list:\n{x}"
+  );
+  let cites = inline_cite_texts(&x);
+  assert!(!cites.is_empty(), "no inline citations were rendered:\n{x}");
+  // Each inline numeric cite is the entry number (bracketed) indexing the list.
+  assert!(
+    cites.iter().all(|c| numeric_label(c).is_some()),
+    "numeric inline citations should be numbers indexing the list: {cites:?}\n{x}"
+  );
+}

--- a/latexml_oxide/tests/cluster_regressions/cite_labels.bib
+++ b/latexml_oxide/tests/cluster_regressions/cite_labels.bib
@@ -1,0 +1,2 @@
+@article{alpha, author = {Alpha, Anne}, title = {On alpha}, journal = {J. Alpha}, volume={1}, pages={1}, year = {2001}}
+@article{beta,  author = {Beta, Bob},   title = {On beta},  journal = {J. Beta},  volume={2}, pages={2}, year = {2002}}

--- a/latexml_oxide/tests/cluster_regressions/cite_labels_authoryear.tex
+++ b/latexml_oxide/tests/cluster_regressions/cite_labels_authoryear.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+\usepackage{natbib}
+\begin{document}
+citet \citet{beta}; citep \citep{beta}; cite \cite{alpha}.
+\bibliography{cite_labels}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/cite_labels_numeric.tex
+++ b/latexml_oxide/tests/cluster_regressions/cite_labels_numeric.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+\usepackage[numbers]{natbib}
+\begin{document}
+cite \cite{beta}; cite \cite{alpha}.
+\bibliography{cite_labels}
+\end{document}

--- a/latexml_post/src/crossref.rs
+++ b/latexml_post/src/crossref.rs
@@ -176,6 +176,84 @@ pub struct CrossRef {
   child_pages:    RefCell<HashMap<String, Rc<ChildPages>>>,
 }
 
+/// Render a natbib bibref `show` format into its visible label by interleaving
+/// the resolved `authors`/`year`/`number`/`refnum` values with the bibref's
+/// `<ltx:bibrefphrase>` children (`Phrase1`, `Phrase2`, …) and any literal
+/// characters. `\citet`/`\cite` use `show="Authors Phrase1YearPhrase2"` (phrases
+/// `(` / `)` → "Beta (2002)"); `\citep` uses `show="AuthorsPhrase1Year"` (phrase
+/// `, ` → "Beta, 2002", the surrounding macro adding the outer parens). Mirrors
+/// Perl `CrossRef.pm` `make_bibcite`'s show walk.
+///
+/// Returns `(label, resolved_ay)`: `resolved_ay` is true iff an `Authors`/
+/// `Fullauthors`/`Year` token resolved to a non-empty value, so the caller can
+/// fall back to the bare number for entries that carry no author-year metadata.
+fn render_bibref_show(
+  show: &str,
+  authors: Option<&str>,
+  fullauthors: Option<&str>,
+  year: Option<&str>,
+  number: Option<&str>,
+  refnum: Option<&str>,
+  phrases: &[String],
+) -> (String, bool) {
+  let lower = show.to_ascii_lowercase();
+  let lb = lower.as_bytes();
+  let mut out = String::new();
+  let mut resolved_ay = false;
+  let mut i = 0;
+  while i < show.len() {
+    // Phrase token: "phrase" + digits → the Nth <ltx:bibrefphrase> child.
+    if lb[i..].starts_with(b"phrase") {
+      let ds = i + "phrase".len();
+      let mut j = ds;
+      while j < lb.len() && lb[j].is_ascii_digit() {
+        j += 1;
+      }
+      if j > ds {
+        if let Ok(n) = show[ds..j].parse::<usize>() {
+          if n >= 1 && n <= phrases.len() {
+            out.push_str(&phrases[n - 1]);
+          }
+        }
+        i = j;
+        continue;
+      }
+    }
+    // Value keyword (fullauthors before authors — distinct first letters, so
+    // order is not load-bearing, but keep the longest name first for clarity).
+    let mut matched = false;
+    for (kw, val, is_ay) in [
+      ("fullauthors", fullauthors.or(authors), true),
+      ("authors", authors, true),
+      ("year", year, true),
+      ("number", number, false),
+      ("refnum", refnum, false),
+    ] {
+      if lb[i..].starts_with(kw.as_bytes()) {
+        if let Some(v) = val {
+          if !v.is_empty() {
+            out.push_str(v);
+            if is_ay {
+              resolved_ay = true;
+            }
+          }
+        }
+        i += kw.len();
+        matched = true;
+        break;
+      }
+    }
+    if matched {
+      continue;
+    }
+    // Literal character.
+    let ch = show[i..].chars().next().unwrap();
+    out.push(ch);
+    i += ch.len_utf8();
+  }
+  (out, resolved_ay)
+}
+
 impl CrossRef {
   pub fn new(db: ObjectDB, url_style: UrlStyle, number_sections: bool) -> Self {
     CrossRef {
@@ -1443,49 +1521,60 @@ impl CrossRef {
           // Perl: use 'number' field for numeric citations (bare number without brackets).
           // The 'refnum' field includes brackets like "[13]", causing double brackets [[13]].
           let entry = self.db.lookup(&format!("ID:{}", id));
+          // Pull the entry's citation metadata into owned strings (ends the
+          // `entry` borrow before we touch `doc`/`bibref` below).
+          let get = |k: &str| {
+            entry
+              .and_then(|e| e.get_value(k))
+              .map(|v| v.to_string())
+              .map(|s| s.trim().to_string())
+              .filter(|s| !s.is_empty())
+          };
+          let authors = get("authors");
+          let fullauthors = get("fullauthors");
+          let keytag = get("keytag");
+          let year = get("year");
+          let typetag = get("typetag");
+          let number = get("number");
+          let refnum = get("refnum");
+          let number_or_refnum = || {
+            number
+              .clone()
+              .or_else(|| refnum.clone())
+              .unwrap_or_else(|| key.to_string())
+          };
           let display = if want_authoryear {
-            let authors = entry
-              .and_then(|e| {
-                e.get_value("authors")
-                  .or_else(|| e.get_value("fullauthors"))
-                  .or_else(|| e.get_value("keytag"))
-              })
-              .map(|v| v.to_string())
-              .map(|s| s.trim().to_string())
-              .filter(|s| !s.is_empty());
-            let year = entry
-              .and_then(|e| e.get_value("year").or_else(|| e.get_value("typetag")))
-              .map(|v| v.to_string())
-              .map(|s| s.trim().to_string())
-              .filter(|s| !s.is_empty());
-            match (authors, year) {
-              (Some(a), Some(y)) => {
-                // `Phrase1`/`Phrase2` in the show string mark where
-                // open/close paren or yyseparator usually go in Perl's
-                // bibrefphrase markup. We collapse to a simple
-                // "Authors Year" form: `\citep` (AuthorsPhrase1Year)
-                // becomes "Author Year" inside the surrounding
-                // parens emitted by the citemacro; `\citet`
-                // (Authors Phrase1YearPhrase2) becomes "Author Year"
-                // with the macro adding the year-parens. Good enough
-                // for visual parity with the PDF in the common case.
-                format!("{} {}", a, y)
-              },
-              (Some(a), None) => a,
-              (None, Some(y)) => y,
-              (None, None) => {
-                // No author/year metadata → fall back to refnum.
-                entry
-                  .and_then(|e| e.get_value("number").or_else(|| e.get_value("refnum")))
-                  .map(|v| v.to_string())
-                  .unwrap_or_else(|| key.to_string())
-              },
+            // The `<ltx:bibrefphrase>` children supply Phrase1/Phrase2 (the
+            // `(`/`)` for \citet, the `, ` for \citep). Interleave them with the
+            // authors/year per the `show` format — Perl CrossRef.pm make_bibcite.
+            let phrases: Vec<String> = crate::document::element_children(bibref)
+              .iter()
+              .filter(|c| doc.get_qname(c).as_deref() == Some("ltx:bibrefphrase"))
+              .map(|c| c.get_content())
+              .collect();
+            let a = authors
+              .as_deref()
+              .or(fullauthors.as_deref())
+              .or(keytag.as_deref());
+            let y = year.as_deref().or(typetag.as_deref());
+            let (text, resolved) = render_bibref_show(
+              &show,
+              a,
+              fullauthors.as_deref(),
+              y,
+              number.as_deref(),
+              refnum.as_deref(),
+              &phrases,
+            );
+            // No author/year metadata (e.g. an entry with only a number) → fall
+            // back to the bare number so the inline label still resolves.
+            if resolved && !text.trim().is_empty() {
+              text
+            } else {
+              number_or_refnum()
             }
           } else {
-            entry
-              .and_then(|e| e.get_value("number").or_else(|| e.get_value("refnum")))
-              .map(|v| v.to_string())
-              .unwrap_or_else(|| key.to_string())
+            number_or_refnum()
           };
           refs.push(NodeData::Element {
             tag:        "ltx:ref".to_string(),

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -1676,7 +1676,10 @@ impl Processor for MakeBibliography {
           )]);
         }
 
-        // Register ID:{id} with type, location, and number for CrossRef URL generation
+        // Register ID:{id} with type, location, and number for CrossRef URL
+        // generation. The author-year metadata (`authors`/`year`/`refnum`/…) the
+        // fill phase needs is registered by the rescan below, read from the
+        // bibitem's own `<ltx:tag>` children — see the rescan comment.
         let location = doc.site_relative_destination().unwrap_or_default();
         self.db.register(&format!("ID:{}", bibitem_id), vec![
           ("type", crate::object_db::Value::from("ltx:bibitem")),
@@ -1720,17 +1723,36 @@ impl Processor for MakeBibliography {
         continue;
       };
       let key = format!("ID:{}", id);
-      if self.db.lookup(&key).is_some() {
-        continue; // already registered (bibitems, and anything Scan saw)
-      }
       let qname = doc
         .get_qname(&node)
         .unwrap_or_else(|| "ltx:text".to_string());
-      self.db.register(&key, vec![
-        ("type", crate::object_db::Value::from(qname.as_str())),
-        ("location", crate::object_db::Value::from(location.as_str())),
-        ("fragid", crate::object_db::Value::from(id.as_str())),
-      ]);
+      if qname == "ltx:bibitem" {
+        // Faithful to Perl's rescan (MakeBibliography.pm L78 re-runs Scan, whose
+        // `bibitem_handler` reads the bibitem's `<ltx:tag role="…">` children
+        // into the DB): augment this bibitem's already-registered ID entry with
+        // its author-year metadata, read from its OWN generated tags via the
+        // handler oxide's Scan also uses. CrossRef's fill phase (make_bibcite /
+        // `fill_in_bibrefs`) then renders an author-year inline citation matching
+        // the References list; without these values it fell back to the bare
+        // number (`\cite{beta}` → `2` vs the list's `Beta (2002)`).
+        // html_feedback #6276/#6302 (inline-vs-list label mismatch).
+        let props = crate::scan::bibitem_tag_props(&doc, &node);
+        if !props.is_empty() {
+          let entry = self.db.register(&key, vec![]);
+          for (k, v) in props {
+            entry.set_value(&k, v);
+          }
+        }
+      } else if self.db.lookup(&key).is_none() {
+        // A non-bibitem id-bearing node (an ltx:Math in a title, a styled
+        // ltx:text, …) cloned into the generated bibliography: register its
+        // id/fragid so CrossRef can stamp it (Perl's rescan covers these too).
+        self.db.register(&key, vec![
+          ("type", crate::object_db::Value::from(qname.as_str())),
+          ("location", crate::object_db::Value::from(location.as_str())),
+          ("fragid", crate::object_db::Value::from(id.as_str())),
+        ]);
+      }
     }
 
     // Remove any remaining bibentry elements (they've been converted to bibitems)

--- a/latexml_post/src/scan.rs
+++ b/latexml_post/src/scan.rs
@@ -513,26 +513,7 @@ impl Scan {
       props.push(("fragid".to_string(), Value::from(fragid)));
     }
 
-    for role in &[
-      "authors",
-      "fullauthors",
-      "year",
-      "number",
-      "refnum",
-      "title",
-      "key",
-      "bibtype",
-    ] {
-      let xpath = format!("ltx:tags/ltx:tag[@role='{}']", role);
-      if let Some(tagnode) = doc.findnode_at(&xpath, node) {
-        let prop_name = match *role {
-          "key" => "keytag",
-          "bibtype" => "typetag",
-          _ => role,
-        };
-        props.push((prop_name.to_string(), Value::from(tagnode.get_content())));
-      }
-    }
+    props.extend(bibitem_tag_props(doc, node));
 
     let db_key = format!("ID:{}", id);
     let entry = self.db.register(&db_key, vec![]);
@@ -922,6 +903,40 @@ impl Processor for Scan {
 
 // ======================================================================
 // Helpers
+
+/// Read a `<ltx:bibitem>`'s `<ltx:tags>/<ltx:tag role="…">` children into the
+/// ObjectDB props CrossRef's fill phase (`make_bibcite`) reads: `authors`,
+/// `fullauthors`, `year`, `number`, `refnum`, `title`, plus `keytag` (role
+/// `key`) and `typetag` (role `bibtype`). Port of Perl `Scan::bibitem_handler`
+/// (Scan.pm L475-483). Shared by [`Scan::bibitem_handler`] (the initial scan of
+/// authored `\bibitem`s) and `MakeBibliography`'s rescan of the bibitems it
+/// generates from `.bib`/`.bbl` — the same values, from whichever pass first
+/// produced the formatted entry, so an author-year inline citation resolves to
+/// the SAME author-year label the References list shows.
+pub fn bibitem_tag_props(doc: &PostDocument, node: &Node) -> Vec<(String, Value)> {
+  let mut props = Vec::new();
+  for role in &[
+    "authors",
+    "fullauthors",
+    "year",
+    "number",
+    "refnum",
+    "title",
+    "key",
+    "bibtype",
+  ] {
+    let xpath = format!("ltx:tags/ltx:tag[@role='{}']", role);
+    if let Some(tagnode) = doc.findnode_at(&xpath, node) {
+      let prop_name = match *role {
+        "key" => "keytag",
+        "bibtype" => "typetag",
+        _ => *role,
+      };
+      props.push((prop_name.to_string(), Value::from(tagnode.get_content())));
+    }
+  }
+  props
+}
 
 fn collect_element_children(node: &Node) -> Vec<Node> {
   let mut result = Vec::new();

--- a/latexml_post/src/scan.rs
+++ b/latexml_post/src/scan.rs
@@ -908,7 +908,7 @@ impl Processor for Scan {
 /// ObjectDB props CrossRef's fill phase (`make_bibcite`) reads: `authors`,
 /// `fullauthors`, `year`, `number`, `refnum`, `title`, plus `keytag` (role
 /// `key`) and `typetag` (role `bibtype`). Port of Perl `Scan::bibitem_handler`
-/// (Scan.pm L475-483). Shared by [`Scan::bibitem_handler`] (the initial scan of
+/// (Scan.pm L475-483). Shared by `Scan::bibitem_handler` (the initial scan of
 /// authored `\bibitem`s) and `MakeBibliography`'s rescan of the bibitems it
 /// generates from `.bib`/`.bbl` — the same values, from whichever pass first
 /// produced the formatted entry, so an author-year inline citation resolves to


### PR DESCRIPTION
**Diagnostic.** An inline `\cite`/`\citet`/`\citep` in natbib/biblatex author-year mode rendered a bare NUMBER while the References list showed the author-year label (`Beta (2002)`) — the reader could not connect a citation to its entry. Root cause: `MakeBibliography` registered only the bibitem `number` into the CrossRef ObjectDB, never `authors`/`year`, so `crossref::fill_in_bibrefs` fell back to the number for a `show="Authors …"` bibref. GENUINE-RUST-ONLY (same-host Perl 0.8.8 renders `Beta (2002)`).

**Approach.** Faithful to Perl's CrossRef fill-phase model. Scan's bibitem tag-reading is extracted to a shared `bibitem_tag_props`; `MakeBibliography`'s rescan of the generated bibliography registers the bibitem's own `<ltx:tag role="…">` children (authors/year/refnum/keytag/typetag), exactly as Perl's `Scan::bibitem_handler` does when `rescan` re-runs Scan (MakeBibliography.pm L78). `fill_in_bibrefs` renders the `show` format by interleaving the resolved author/year with the bibref's `<ltx:bibrefphrase>` children (a new `render_bibref_show`, mirroring Perl `CrossRef::make_bibcite`): `\citet` → `Beta (2002)`, `\citep` → `(Beta, 2002)`; an authorless entry still falls back to the number.

**Validation.** Byte-identical to Perl on the natbib repro; benefits biblatex (style=apa). Consistent across eager, streaming, AND split post-processing (bibliography on a separate page — the shared ObjectDB baton carries the tags cross-chunk). Red→green consistency cluster: `cluster_cite_authoryear_/numeric_/biblatex_authoryear_inline_matches_reference_label`. Full suite 1978/0; clippy `-D warnings` + fmt + rustdoc clean.

Addresses the arXiv html_feedback inline-vs-list label reports arXiv/html_feedback#6276, arXiv/html_feedback#6302, arXiv/html_feedback#6307, arXiv/html_feedback#6534, arXiv/html_feedback#6026. Distinct buckets (raw keys, non-resolution, missing list, numbering order) are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)