### PR TITLE
fix: biblatex \DeclareSourcemap is a no-op, not a fatal cascade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+  - **A biblatex `\DeclareSourcemap` block no longer breaks the conversion.**
+    Source mapping is a biber pre-processing stage LaTeXML does not run;
+    `\DeclareSourcemap` (and `\DeclareStyleSourcemap`) were undefined, so the
+    nested `\maps`/`\map`/`\step`/`\regexp` ran as undefined control sequences
+    and cascaded into fatal math-mode errors that dropped the whole bibliography.
+    They now gobble the rule argument as a no-op (arXiv/html_feedback#6720).
+
   - **A paper's title no longer absorbs publication metadata.** Class frontmatter
     such as acmart's `\acmConference`/`\acmDOI`/`\acmISBN` was rendered *inside*
     the title `<h1>` (a stray dagger hover on the heading), leaking metadata into

--- a/latexml_contrib/src/biblatex_sty.rs
+++ b/latexml_contrib/src/biblatex_sty.rs
@@ -1847,6 +1847,16 @@ LoadDefinitions!({
   DefMacro!("\\xref{}", "\\ref{#1}");
   def_macro_noop("\\fakeset{}")?;
 
+  // biblatex source-mapping API (a biber pre-processing stage LaTeXML does not
+  // run): gobble the whole rule argument WITHOUT expanding it, so the nested
+  // `\maps`/`\map`/`\step`/`\regexp` etc. never reach the stomach as undefined
+  // control sequences. Undefined `\DeclareSourcemap` let those inner tokens run
+  // and cascade into math-mode/`\fi` errors, breaking the whole conversion
+  // (arXiv:2607.03177, html_feedback #6720). `\DeclareStyleSourcemap` is the
+  // style-file sibling.
+  def_macro_noop("\\DeclareSourcemap{}")?;
+  def_macro_noop("\\DeclareStyleSourcemap{}")?;
+
   // Perl L429-434: language API (no-ops)
   def_macro_noop("\\DeclareLanguageMapping{}{}")?;
   def_macro_noop("\\DeclareLanguageMappingSuffix{}")?;

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -2050,3 +2050,20 @@ fn cluster_bib_review_field_cedilla_not_welded() {
      (control-word-terminating space lost in the .bib field path):\n{x}"
   );
 }
+
+/// html_feedback #6720 (arXiv:2607.03177): a biblatex `\DeclareSourcemap`
+/// preamble block (a biber source-mapping stage LaTeXML does not run) must not
+/// break the conversion. `\DeclareSourcemap` was undefined, so its nested
+/// `\maps`/`\map`/`\step`/`\regexp` reached the stomach as undefined control
+/// sequences and cascaded into math-mode/`\fi` fatals. It (and its
+/// `\DeclareStyleSourcemap` sibling) now gobble the rule argument as a no-op;
+/// the 0-error gate below catches any regression of that cascade.
+#[test]
+fn cluster_biblatex_declaresourcemap_is_a_noop() {
+  let x = convert_to_xml_contrib_clean("tests/cluster_regressions/biblatex_declaresourcemap.tex");
+  // The document body survives — the citation and its bibresource are intact.
+  assert!(
+    x.contains(r#"bibrefs="beta""#),
+    "the \\cite survived the sourcemap preamble:\n{x}"
+  );
+}

--- a/latexml_oxide/tests/cluster_regressions/biblatex_declaresourcemap.bib
+++ b/latexml_oxide/tests/cluster_regressions/biblatex_declaresourcemap.bib
@@ -1,0 +1,1 @@
+@article{beta, author = {Beta, Bob}, title = {On beta}, journal = {J. Beta}, volume={2}, pages={2}, year = {2002}}

--- a/latexml_oxide/tests/cluster_regressions/biblatex_declaresourcemap.tex
+++ b/latexml_oxide/tests/cluster_regressions/biblatex_declaresourcemap.tex
@@ -1,0 +1,19 @@
+% html_feedback #6720 (arXiv:2607.03177): a biblatex `\DeclareSourcemap`
+% preamble block (a biber source-mapping stage LaTeXML does not run) left
+% `\DeclareSourcemap` undefined, so its nested `\maps`/`\map`/`\step`/`\regexp`
+% reached the stomach as undefined control sequences and cascaded into
+% math-mode / `\fi` errors that broke the whole conversion. The command (and its
+% `\DeclareStyleSourcemap` sibling) now gobble the rule argument as a no-op.
+\documentclass{article}
+\usepackage[backend=biber]{biblatex}
+\DeclareSourcemap{
+  \maps[datatype=bibtex]{
+    \map{\step[fieldset=abstract, null]}
+    \map[overwrite]{\step[fieldsource=doi, match=\regexp{^(.+)$}, replace=\regexp{$1}]}
+  }
+}
+\addbibresource{biblatex_declaresourcemap}
+\begin{document}
+Cite \cite{beta}.
+\printbibliography
+\end{document}


### PR DESCRIPTION
**Diagnostic.** biblatex `\DeclareSourcemap` configures a biber source-mapping pre-processing stage LaTeXML does not run. The command was undefined, so its nested `\maps`/`\map`/`\step`/`\regexp` reached the stomach as undefined control sequences and cascaded into math-mode/`\fi` fatals — dropping the entire bibliography (witness arXiv:2607.03177: 46 errors, no References list).

**Approach.** Define `\DeclareSourcemap`/`\DeclareStyleSourcemap` as no-ops that gobble the rule argument (unexpanded), so the nested tokens never run. biblatex is contrib-only (no Perl `.ltxml` to mirror); ignoring the source map is the right LaTeXML behavior since it's a biber-side transformation.

**Validation.** Witness 2607.03177 now converts with **0 errors and a 50-entry References list**. Guard `cluster_biblatex_declaresourcemap_is_a_noop` (0-error gate, red pre-fix). Full suite 1976/0; clippy/fmt clean.

Reported as arXiv/html_feedback#6720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)