### PR TITLE
fix html_feedback#6869: \widthof box widths resolve in all dimension contexts

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4186,3 +4186,44 @@ is wrong. **Upstream**: worth filing against `brucemiller/LaTeXML`.
 (`tests/cluster_regressions/siunitx_nothing_unit.tex`, via `convert_and_post_pmml_clean`) — the
 presentation MathML contains no visible `>nothing<`, the empty unit is an `<m:mphantom>`, and the
 quantity still renders.
+
+### 115. `\widthof` &friends resolve as dimensions in every dimension context, not only calc expressions
+
+**Perl** LaTeXML's `calc.sty.ltxml` defines `\widthof`/`\heightof`/`\depthof`/`\totalheightof`
+as no-op stub primitives (`DefPrimitive('\widthof','')`) and only *evaluates* them inside calc's
+own expression scanner (`readValue`, invoked by `\setlength`/`\addtolength`/`\setcounter`). But
+box- and rule-length arguments — `\makebox[⟨len⟩]`, `\rule{⟨w⟩}{⟨h⟩}`, `\hspace{⟨len⟩}`,
+`\parbox{⟨w⟩}…` — are read by the *base* dimension reader, which never routes through that
+scanner. There the non-expandable `\widthof` stops the number scan, so `\makebox[\widthof{X}][r]{Y}`
+comes out `width="0.0pt"` (Perl emits `Warning: Missing number (Dimension), treated as zero`). A
+zero-width box gives its content no advance width, so it overlaps its neighbour. Real
+pdflatex+calc gives the true width there — calc.sty L124-137 does `\let\widthof\wd` and boxes the
+argument, so `\widthof{X}` = `\wd` of a box holding X, valid *everywhere* a `<dimen>` is read.
+latexml-oxide reproduced Perl exactly (SHARED-FAILURE, both diverge from real LaTeX).
+
+**Perl behavior**: `\widthof` etc. → 0 outside a calc expression; boxed content collapses and
+overlaps. **Rust behavior**: `\widthof`/`\heightof`/`\depthof`/`\totalheightof` stay bare no-op
+primitives (so their digestion/reversion is byte-identical to Perl — `\mathmakebox[\widthof{…}]`
+parity is preserved), but the base dimension reader gains a calc-agnostic seam
+(`gullet::set_internal_dimension_fn`, consulted by `read_register_value` before it gives up with
+"Missing number"). calc installs a resolver that, when the *dimension reader* meets one of these
+tokens, digests its `{box}` argument and returns the measured width/height/depth/total-height —
+the LaTeXML analogue of calc's `\let\widthof\wd`. So they resolve in **every** dimension context
+(makebox, framebox, rule, hspace, parbox), matching real LaTeX, while digestion is untouched.
+calc's own `read_value` still intercepts them by token identity for calc expressions, so
+calc-routed widths (`tests/graphics/calc.xml`) are unchanged — only the previously-broken
+base-reader contexts change, from a wrong `0.0pt` to the measured width.
+
+**Why**: a kernel-quality gap, not a TeX-semantics change — real LaTeX+calc already makes
+`\widthof` a valid dimension in these contexts; both LaTeXML engines simply failed to. The fix
+halos across every dimension-reading construct and every calc-using paper.
+
+**Witnesses**: arXiv 2603.23669 (html_feedback#6869) — its siunitx `S`-column result tables box
+every bold value as `\makebox[\widthof{\tablenum{…}}][r]{…}`; the bold number rendered on top of
+its `± unc`. Rust `\widthof{WWWW}` now measures 41.1pt (real LaTeX: 41.1112pt).
+
+**Upstream**: worth filing against `brucemiller/LaTeXML` (same gap upstream).
+
+**Guards**: `cluster_sizing::widthof_in_base_dimension_reader::widthof_resolves_in_makebox_and_rule_length_arguments`
+— `\makebox[\widthof{WWWW}]` and `\rule{\widthof{WWWW}}{…}` widths are nonzero and agree with the
+calc-routed `\setlength\reflen{\widthof{WWWW}}` reference.

--- a/latexml_core/src/gullet.rs
+++ b/latexml_core/src/gullet.rs
@@ -2140,6 +2140,37 @@ pub fn read_value(value_type: RegisterType) -> Result<RegisterValue> {
   }
 }
 
+/// A package-installed resolver for control sequences that yield an *internal
+/// dimension* by reading their own argument — e.g. calc.sty's `\widthof{box}`.
+/// Given the already-read CS token, it either consumes that CS's argument(s)
+/// from the gullet and returns the measured value (`Ok(Some(_))`), or leaves
+/// the stream untouched and declines (`Ok(None)`), in which case the caller
+/// un-reads the token. Keeps core calc-agnostic: the base dimension reader
+/// consults this seam before giving up with "Missing number", so
+/// `\makebox[\widthof{X}]` / `\rule{\widthof{X}}{…}` resolve like real LaTeX
+/// without `\widthof` having to be a register (which would change its bare
+/// digestion). See `calc_sty.rs` / OXIDIZED_DESIGN #115.
+pub type InternalDimensionFn = std::rc::Rc<dyn Fn(&Token) -> Result<Option<RegisterValue>>>;
+
+thread_local! {
+  static INTERNAL_DIMENSION_FN: RefCell<Option<InternalDimensionFn>> = const { RefCell::new(None) };
+}
+
+/// Install the internal-dimension resolver (calc.sty at load time).
+pub fn set_internal_dimension_fn(f: InternalDimensionFn) {
+  INTERNAL_DIMENSION_FN.with(|c| *c.borrow_mut() = Some(f));
+}
+
+/// Consult the installed resolver for `tok`. `Ok(None)` when none is installed
+/// or it declines; `tok` is left for the caller to un-read in that case.
+fn resolve_internal_dimension(tok: &Token) -> Result<Option<RegisterValue>> {
+  let f = INTERNAL_DIMENSION_FN.with(|c| c.borrow().clone());
+  match f {
+    Some(f) => f(tok),
+    None => Ok(None),
+  }
+}
+
 pub fn read_register_value(value_type: RegisterType) -> Result<Option<RegisterValue>> {
   read_register_value_coerce(value_type, false)
 }
@@ -2186,6 +2217,16 @@ pub fn read_register_value_coerce(
           }
         },
         _ => {
+          // calc.sty seam: `\widthof{box}` &friends yield an internal dimension
+          // by reading their own argument. Only in dimension-like contexts
+          // (calc errors "not expected here" for a Number). On decline the
+          // resolver leaves the stream untouched, so we un-read the token.
+          // OXIDIZED_DESIGN #115.
+          if value_type != RegisterType::Number
+            && let Some(rv) = resolve_internal_dimension(&token)?
+          {
+            return Ok(Some(rv));
+          }
           unread_one(token); // Unread
           Ok(None)
         },

--- a/latexml_oxide/tests/cluster_sizing.rs
+++ b/latexml_oxide/tests/cluster_sizing.rs
@@ -673,3 +673,99 @@ mod parbox_nested_math {
     );
   }
 }
+
+mod widthof_in_base_dimension_reader {
+  //! html_feedback#6869 "Overlapping numbers in tables". `\makebox[\widthof{X}]`
+  //! / `\rule{\widthof{X}}{h}` read their length with the BASE gullet dimension
+  //! reader, which used to collapse the calc `\widthof` no-op to 0 — so the
+  //! boxed content had zero advance width and overlapped its neighbour. Witness
+  //! arXiv 2603.23669: its siunitx S-column result tables box every bold value
+  //! as `\makebox[\widthof{\tablenum{…}}][r]{…bold…}` and rendered the bold
+  //! number on top of its `± unc`. Both LaTeXML engines produced `width="0.0pt"`
+  //! (Perl even warns "Missing number (Dimension), treated as zero"); real
+  //! pdflatex+calc gives the true width. OXIDIZED_DESIGN #115 makes
+  //! `\widthof`&friends Dimension registers, resolvable in every dimension
+  //! context (matching real LaTeX, surpassing Perl). Guards the FIX: the widths
+  //! are nonzero and agree with the calc-routed reference `\setlength`.
+  use std::process::Command;
+
+  fn convert(body: &str) -> String {
+    let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+    let work = tempfile::tempdir().expect("tempdir");
+    let dir = work.path();
+    let tex = format!(
+      "\\documentclass{{article}}\n\\usepackage{{calc}}\n\\newlength\\reflen\n\
+       \\begin{{document}}\n{body}\n\\end{{document}}\n"
+    );
+    std::fs::write(dir.join("p.tex"), tex).unwrap();
+    let out = Command::new(bin)
+      .args(["p.tex", "--dest", "p.xml", "--nocomments"])
+      .current_dir(dir)
+      .output()
+      .expect("spawn latexml_oxide");
+    std::fs::read_to_string(dir.join("p.xml")).unwrap_or_else(|e| {
+      let stderr = String::from_utf8_lossy(&out.stderr).replace('\u{1b}', "");
+      panic!("no output: {e}\n{stderr}");
+    })
+  }
+
+  /// Parse the `pt` value of the first `width="…pt"` at/after `needle`.
+  fn width_pt_after(xml: &str, needle: &str) -> f64 {
+    let from = xml
+      .find(needle)
+      .unwrap_or_else(|| panic!("`{needle}` missing from:\n{xml}"));
+    let rest = &xml[from..];
+    let wstart = rest
+      .find("width=\"")
+      .unwrap_or_else(|| panic!("no width= after `{needle}` in:\n{xml}"))
+      + "width=\"".len();
+    let val = &rest[wstart..];
+    let end = val.find('"').expect("unterminated width attr");
+    val[..end]
+      .trim_end_matches("pt")
+      .parse::<f64>()
+      .unwrap_or_else(|_| panic!("non-numeric width `{}`", &val[..end]))
+  }
+
+  #[test]
+  fn widthof_resolves_in_makebox_and_rule_length_arguments() {
+    let xml = convert(
+      "\\setlength\\reflen{\\widthof{WWWW}}REF \\the\\reflen\\ ENDREF\n\
+       \\par\\rule{\\widthof{WWWW}}{2pt}\n\
+       \\par X\\makebox[\\widthof{WWWW}][r]{ab}Y",
+    );
+
+    // Reference: the calc-routed \widthof path (\setlength) has always worked.
+    let refw = {
+      let i = xml.find("REF ").expect("REF marker missing") + 4;
+      let rest = &xml[i..];
+      let end = rest.find("pt ENDREF").expect("ENDREF marker missing");
+      rest[..end].parse::<f64>().expect("non-numeric REF width")
+    };
+    assert!(
+      refw > 1.0,
+      "calc-routed \\widthof reference is ~zero: {refw}pt"
+    );
+
+    // The FIX: the base dimension reader now resolves \widthof too. Before
+    // OXIDIZED_DESIGN #115 both of these were width="0.0pt" (overlap).
+    let rule_w = width_pt_after(&xml, "<rule");
+    let makebox_w = width_pt_after(&xml, "<text align=\"right\"");
+    assert!(
+      rule_w > 1.0,
+      "\\rule{{\\widthof{{…}}}} width collapsed to {rule_w}pt"
+    );
+    assert!(
+      makebox_w > 1.0,
+      "\\makebox[\\widthof{{…}}] width collapsed to {makebox_w}pt (overlap bug)"
+    );
+
+    // All three measure \widthof{WWWW}, so the direct-reader widths must agree
+    // with the calc-routed reference (attribute rounding: allow 0.5pt slack).
+    assert!(
+      (rule_w - refw).abs() < 0.5 && (makebox_w - refw).abs() < 0.5,
+      "direct-reader \\widthof disagrees with calc reference: \
+       rule={rule_w}pt makebox={makebox_w}pt ref={refw}pt"
+    );
+  }
+}

--- a/latexml_package/src/package/calc_sty.rs
+++ b/latexml_package/src/package/calc_sty.rs
@@ -365,6 +365,47 @@ fn read_value(expr_type: &str) -> Result<CalcValue> {
   }
 }
 
+/// Which box dimension `\widthof`/`\heightof`/`\depthof`/`\totalheightof` reports.
+#[derive(Clone, Copy)]
+enum BoxDim {
+  Width,
+  Height,
+  Depth,
+  TotalHeight,
+}
+
+/// Digest a `\widthof{…}`-family box argument and return the requested size.
+///
+/// The LaTeXML analogue of calc.sty's `\let\widthof\wd` (calc.sty L124-137):
+/// inside its expression scanner real calc typesets the argument into a box and
+/// takes `\wd`/`\ht`/`\dp` of it. Called from the base dimension reader's
+/// internal-dimension seam (installed below) so `\makebox[\widthof{X}]`,
+/// `\rule{\widthof{X}}{…}`, `\hspace{\widthof{X}}`, … — whose length is read by
+/// the base gullet dimension reader, NOT calc's own `read_value` scanner (which
+/// keeps its inline digest for `\setlength`) — resolve to the real size.
+/// Surpass-perl: OXIDIZED_DESIGN #115.
+fn measure_box_dim(toks: Tokens, kind: BoxDim) -> RegisterValue {
+  let zero = || RegisterValue::Dimension(Dimension::new(0));
+  let box_result = match digest(toks) {
+    Ok(b) => b,
+    Err(_) => return zero(),
+  };
+  match kind {
+    BoxDim::Width => box_result
+      .get_width(None)
+      .ok()
+      .flatten()
+      .unwrap_or_else(zero),
+    BoxDim::Height => box_result.get_height().unwrap_or_else(zero),
+    BoxDim::Depth => box_result.get_depth().unwrap_or_else(zero),
+    BoxDim::TotalHeight => {
+      let h = box_result.get_height().unwrap_or_else(zero);
+      let d = box_result.get_depth().unwrap_or_else(zero);
+      h.add(d)
+    },
+  }
+}
+
 LoadDefinitions!({
   // Stub primitives so they're defined but NOT expandable.
   // The expression parser recognizes these tokens and handles them.
@@ -377,6 +418,34 @@ LoadDefinitions!({
   def_primitive_noop("\\totalheightof")?;
   def_primitive_noop("\\ratio")?;
   def_primitive_noop("\\real")?;
+
+  // Resolve `\widthof`/`\heightof`/`\depthof`/`\totalheightof` to the measured
+  // box size in EVERY dimension context, not only inside a calc expression.
+  // Perl (and our own `read_value`) evaluate them only in calc's expression
+  // parser (`\setlength`), so `\makebox[\widthof{X}][r]{Y}` / `\rule{\widthof{X}}`
+  // — whose length is read by the BASE gullet dimension reader — collapse to 0
+  // (Perl even warns "Missing number (Dimension), treated as zero"), so the
+  // boxed content has no advance width and overlaps its neighbour. Real
+  // LaTeX+calc gives the true width there (calc.sty L124-137 `\let\widthof\wd`).
+  // `\widthof` stays a bare no-op primitive (above) so its digestion/reversion
+  // is unchanged (`\mathmakebox[\widthof{…}]` parity is preserved); the hook
+  // fires ONLY when the dimension reader — not digestion — meets the token.
+  // Surpass-perl: OXIDIZED_DESIGN #115. html_feedback#6869; witness 2603.23669.
+  set_internal_dimension_fn(Rc::new(|tok: &Token| {
+    let kind = if *tok == T_CS!("\\widthof") {
+      BoxDim::Width
+    } else if *tok == T_CS!("\\heightof") {
+      BoxDim::Height
+    } else if *tok == T_CS!("\\depthof") {
+      BoxDim::Depth
+    } else if *tok == T_CS!("\\totalheightof") {
+      BoxDim::TotalHeight
+    } else {
+      return Ok(None);
+    };
+    let toks = read_arg(ExpansionLevel::Off)?;
+    Ok(Some(measure_box_dim(toks, kind)))
+  }));
 
   // \setcounter{<ctr>}{<integer expression>}
   DefPrimitive!("\\setcounter{}{}", sub[(ctr, arg)] {


### PR DESCRIPTION
**Diagnostic.** In arXiv 2603.23669's siunitx result tables (and any `\makebox[\widthof{X}][r]{Y}` idiom), the boxed bold value rendered `width:0.0pt` → zero advance width → it overlapped its `± unc` sibling. Root cause is SHARED-FAILURE with Perl and diverges from real LaTeX: calc's `\widthof`/`\heightof`/`\depthof`/`\totalheightof` were only evaluated inside calc's own expression parser (`\setlength`), never in the BASE gullet dimension reader that box/rule/space length args use — so they collapsed to 0 (Perl warns "Missing number (Dimension)"). Real pdflatex+calc gives the true width (calc.sty L124-137 `\let\widthof\wd`).

**Approach.** Surpass-perl (OXIDIZED_DESIGN #115, user-approved). Add a calc-agnostic `set_internal_dimension_fn` seam that `read_register_value` consults before giving up with "Missing number"; calc installs a resolver that digests the `{box}` and returns its measured size. `\widthof` stays a bare no-op primitive, so digestion/reversion is byte-identical — `\mathmakebox[\widthof{…}]` parity is preserved. Resolves in every dimension context (makebox/framebox/rule/hspace/parbox); calc-routed widths (`tests/graphics/calc.xml`) unchanged.

**Validation.** Red→green guard `cluster_sizing::widthof_in_base_dimension_reader::widthof_resolves_in_makebox_and_rule_length_arguments`. Full suite 1976/0; clippy `-D warnings` clean; fmt. Perl 0.8.8 parity re-confirmed (both `0.0pt`); real pdflatex reference (41.11pt); witness 2603.23669 re-rendered — bold values no longer overlap. Separately noted: the `\resizebox` scale/translate that shrinks these tables is a pre-existing, unrelated rendering matter (unchanged by this PR).

Resolves arXiv/html_feedback#6869

🤖 Generated with [Claude Code](https://claude.com/claude-code)