### PR TITLE
fix: dedup LLNCS \inst affiliations cited by multiple authors of one creator

### DIFF
--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -2335,12 +2335,16 @@ fn relocate_annotations(document: &mut Document) -> Result<()> {
     if target.get_attribute("role").unwrap_or_default() == "pending" {
       continue;
     }
-    for label in target
-      .get_attribute("_annotations")
-      .unwrap_or_default()
-      .split(',')
-    {
-      if label.is_empty() {
+    // Dedup labels PER TARGET: a creator that cites the same annotation label
+    // from several of its authors (LLNCS `\author{A\inst{1} B\inst{2,1}}` — both
+    // A and B cite institution 1) must receive that affiliation ONCE, not once
+    // per citing author. Each duplicate label would otherwise push `target`
+    // again, and the pending note gets cloned into it per push. Witness arXiv
+    // 2603.23669: two-author creators rendered "Mila … Mila … McGill … McGill".
+    let annotations = target.get_attribute("_annotations").unwrap_or_default();
+    let mut seen: HashSet<&str> = HashSet::default();
+    for label in annotations.split(',') {
+      if label.is_empty() || !seen.insert(label) {
         continue;
       }
       labeltable

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -459,3 +459,25 @@ fn frontmatter_sn_jnl_numbered_affil() {
     "sn-jnl numbered affiliation leaked as an orphaned top-level note:\n{x}"
   );
 }
+
+/// A single creator whose authors cite the same institution via different
+/// `\inst` lists (`Alice\inst{1}` + `Bob\inst{2,1}`, both citing institution 1)
+/// must receive that affiliation ONCE, not once per citing author. The dedup
+/// lives in `relocate_annotations` (base_utilities.rs): duplicate labels within
+/// a creator's `_annotations` previously cloned the affiliation contact per
+/// citation. Witness arXiv 2603.23669 (html_feedback frontmatter report): the
+/// two-author creators rendered "Mila … Mila … McGill … McGill".
+#[test]
+fn frontmatter_inst_affiliation_dedup() {
+  let x = convert_to_xml("tests/cluster_regressions/frontmatter_inst_affiliation_dedup.tex");
+  let mila = x.matches(">Mila Institute").count();
+  assert_eq!(
+    mila, 1,
+    "affiliation cited by two authors was not deduped (got {mila}× Mila Institute):\n{x}"
+  );
+  // Both distinct institutions still present, as structured affiliation contacts.
+  assert!(
+    x.contains(">Uni Montreal") && x.contains("role=\"affiliation\""),
+    "the second (distinct) affiliation was dropped:\n{x}"
+  );
+}

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_inst_affiliation_dedup.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_inst_affiliation_dedup.tex
@@ -1,0 +1,11 @@
+\documentclass{llncs}
+\begin{document}
+\title{Affiliation dedup}
+% Two authors in ONE creator (\quad-separated, no \and/\\ split), both citing
+% institution 1. \inst{1} + \inst{2,1} => the creator references affiliation
+% label 1 twice; the deduped affiliation must appear ONCE, not per-citation.
+% Reduced from arXiv 2603.23669 (html_feedback frontmatter report).
+\author{Alice\inst{1} \quad Bob\inst{2,1}}
+\institute{\textsuperscript{1}Mila Institute \quad \textsuperscript{2}Uni Montreal}
+\maketitle
+\end{document}


### PR DESCRIPTION
**Diagnostic.** LLNCS frontmatter affiliations were not deduplicated (witness arXiv 2603.23669): a creator whose authors cite the same institution via different `\inst` lists (`Alice\inst{1}` + `Bob\inst{2,1}`, both citing institution 1) received that affiliation once *per citing author*, rendering "Mila … Mila … McGill … McGill" under the authors.

**Approach.** `relocate_annotations` (base_utilities.rs) built its label→target table from each creator's `_annotations`, which carries a label once per citation; a duplicate label pushed the target again and the pending affiliation note was cloned into it per push. Dedup the labels **per target** — a creator never wants the same affiliation twice. General correctness fix (all classes using the annotation mechanism).

**Validation.** Guard `06_cluster_frontmatter::frontmatter_inst_affiliation_dedup` (single creator, two authors citing institution 1 → affiliation appears once). Full suite **1983/0** unchanged — no existing golden relied on the duplication. clippy `-D warnings` clean; witness re-rendered under ar5iv (each institution now appears once per author group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)