### PR TITLE
fix: unsorted bibliography styles number References in citation order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+  - **Unsorted bibliography styles number the References in citation order.**
+    `\bibliographystyle{unsrt}`/`{ieeetr}`/`{IEEEtran}` alphabetized the reference
+    list, mismatching the PDF (whose figure captions bake in "[2], [3], [4]"). The
+    References are now numbered by first citation — matching pdflatex+bibtex
+    key-for-key — while sorted styles (`plain`/`alpha`/…) stay alphabetical.
+    Surpasses Perl, which alphabetizes every style. Witness arXiv 2510.05438
+    (arXiv/html_feedback#6294).
   - **A biblatex `\DeclareSourcemap` block no longer breaks the conversion.**
     Source mapping is a biber pre-processing stage LaTeXML does not run;
     `\DeclareSourcemap` (and `\DeclareStyleSourcemap`) were undefined, so the

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4227,3 +4227,54 @@ its `± unc`. Rust `\widthof{WWWW}` now measures 41.1pt (real LaTeX: 41.1112pt).
 **Guards**: `cluster_sizing::widthof_in_base_dimension_reader::widthof_resolves_in_makebox_and_rule_length_arguments`
 — `\makebox[\widthof{WWWW}]` and `\rule{\widthof{WWWW}}{…}` widths are nonzero and agree with the
 calc-routed `\setlength\reflen{\widthof{WWWW}}` reference.
+
+### 116. Unsorted bibliography styles number the References in citation order, not alphabetically
+
+**Perl** LaTeXML's `MakeBibliography.pm` **always** `unisort`s the cited entries
+(`getBibEntries` L357, `makeBibliographyList` L398) and assigns `[N]` in that
+alphabetical order (`++$NUMBER`, L418) — regardless of the `\bibliographystyle`.
+It reads the style's `sort` flag into `%STYLE` (L57) but never uses it, and even
+maps `IEEEtran → sort='true'` (`IEEEtran.cls.ltxml` L331). So a paper with
+`\bibliographystyle{unsrt}`/`{ieeetr}`/`{IEEEtran}` — whose `.bst` is UNSORTED —
+gets an alphabetized list, mismatching the published PDF. latexml-oxide
+reproduced this exactly (SHARED-FAILURE: both engines alphabetize where
+pdflatex+bibtex number by first citation).
+
+**Perl behavior**: every `\bibliographystyle` alphabetizes the References; the
+inline `[N]` cites index that alphabetical list. **Rust behavior**: for an
+UNSORTED style (bibtex's `sort='false'`: `unsrt`, `unsrtnat`, `ieeetr`,
+`IEEEtran`) MakeBibliography numbers the entries by **first citation appearance**
+— the document order of the inline `<ltx:bibref>`s (`citation_order`,
+`make_bibliography.rs`), which is exactly bibtex's `\citation`-record order. The
+list is then rendered in that same numbered order (the biblist follows
+`entry.number`, not a second `unisort`). SORTED styles (`plain`, `alpha`, `abbrv`,
+plainnat/…, and any unknown style) are unchanged — still alphabetical, identical
+to Perl. Detection is from the `bibstyle` attribute name (plus an explicit
+`sort='false'`, e.g. the bibunits `\bibstyle` path); the core `<ltx:bibliography>`
+carries no new attribute, so engine output stays byte-identical to Perl. The
+engine's `lookup_bibstyle_params` also gains `ieeetr`/`IEEEtran` → `numbers`,
+`false` (Perl's base table omits them and its class binding alphabetizes IEEEtran)
+so the real IEEE `.bst` behavior is matched.
+
+**Why**: bibtex's own guarantee is that an unsorted `.bst` leaves the References
+in citation order; IEEE figure captions bake in "[2], [3], [4]" that depend on it.
+Matching pdflatex+bibtex is the ground truth (html_feedback #6294 asked for
+exactly this), and Perl's alphabetization is the defect.
+
+**Residual** (shared with Perl, out of scope): `\nocite{key}` is deferred to
+end-of-document in both engines (`\nocite`→`@at@end@document`), so a mid-document
+`\nocite`'d entry lands after the cited ones rather than at bibtex's `\nocite`
+position; and `\nocite{*}` entries (no citation position) fall to the end in
+`unisort` order rather than `.bib`-file order. The reported `\cite`-order case is
+exact.
+
+**Witnesses**: arXiv 2510.05438 (html_feedback#6294) — `\documentclass{IEEEtran}`,
+`\bibliographystyle{IEEEtran}`, `\bibliography{…}`, 17 entries; oxide's numbered
+order now equals the pdflatex+bibtex `.bbl` order key-for-key (Wu2021=[1] … Shi2011=[17]).
+
+**Upstream**: worth filing against `brucemiller/LaTeXML` (same alphabetize-everything gap).
+
+**Guards**: `06_cluster_bibliography::cluster_bib_unsrt_citation_order`
+(unsrt + IEEEtran number gamma/alpha/beta by citation order),
+`cluster_bib_plain_stays_alphabetical` (sorted styles unchanged),
+`cluster_bib_bibstyle_is_known_numeric` (engine maps IEEEtran → numeric).

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -2445,12 +2445,22 @@ pub fn begin_bibliography_clean(whatsit: &mut Whatsit) -> Result<()> {
   if let Some(cs) = lookup_value("CITE_STYLE") {
     whatsit.set_property("citestyle", cs);
   }
+  // NB: Perl's `beginBibliography` does NOT populate `#sort` here (only the
+  // `\bibstyle` DefConstructor sets the `sort` attribute, and only on a
+  // bibliography node that already exists — the bibunits path). We match that:
+  // the main `<ltx:bibliography>` carries `bibstyle`/`citestyle` but no `sort`,
+  // byte-identical to Perl. MakeBibliography derives citation-order numbering
+  // from the `bibstyle` name (html_feedback #6294), so no `sort` attribute is
+  // needed on the core node.
   // And prepare for the likely nonsense that appears within bibliographies
   ResetCounter!("enumiv");
   Ok(())
 }
 
 // Perl: $BIBSTYLES hash — maps bib style names to (citestyle, sort) pairs
+// (latex_constructs.pool.ltxml L3953-3961). `sort => 'false'` is bibtex's own
+// "leave in citation order" flag; MakeBibliography honors it (html_feedback
+// #6294) to number the References the way the `.bst` — and the PDF — do.
 fn lookup_bibstyle_params(style: &str) -> Option<(&'static str, &'static str)> {
   match style {
     "plain" => Some(("numbers", "true")),
@@ -2461,6 +2471,13 @@ fn lookup_bibstyle_params(style: &str) -> Option<(&'static str, &'static str)> {
     "unsrtnat" => Some(("numbers", "false")),
     "alphanat" => Some(("AY", "true")),
     "abbrvnat" => Some(("numbers", "true")),
+    // Surpass-Perl: the real `ieeetr.bst`/`IEEEtran.bst` are UNSORTED (number by
+    // first citation). Perl's base table omits them and `IEEEtran.cls.ltxml`
+    // L331 even maps `IEEEtran → sort='true'` — both alphabetize, contradicting
+    // the `.bst` and the published PDF. Map them to citation order to match the
+    // ground-truth PDF (witness arXiv 2510.05438). See OXIDIZED_DESIGN.
+    "ieeetr" => Some(("numbers", "false")),
+    "IEEEtran" => Some(("numbers", "false")),
     _ => None,
   }
 }

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -2090,11 +2090,16 @@ fn cluster_biblatex_declaresourcemap_is_a_noop() {
 // into the CrossRef DB. Expand this cluster with a new fixture per distinct
 // reproducer.
 //
+// Reference numbering ORDER for citation-order styles (`unsrt`/`IEEEtran`,
+// #6294/#5930) is a sibling cluster guarded just below
+// (`cluster_bib_*_citation_order`): those styles number by first-citation
+// appearance, not alphabetically — a deliberate surpass-Perl (Perl always
+// alphabetizes, OXIDIZED_DESIGN divergence).
+//
 // NOT this cluster (distinct root causes, separate work): raw citekeys leaking
 // from an un-emulated cite command (#6203/#6355/#6549/#6050), genuine
 // non-resolution `?`/`[undef]` (#6489/#6601/#6222), a missing/empty References
-// list (#6432/#6288/#6179), and reference numbering ORDER (#6294/#5930 — a
-// shared-with-Perl alphabetical-vs-citation-order gap).
+// list (#6432/#6288/#6179).
 // ===========================================================================
 
 /// Tag-stripped text of each inline `<ltx:cite>` in post XML.
@@ -2281,5 +2286,150 @@ fn cluster_bib_revtex4_author_year_option_is_honored() {
   assert!(
     core.contains(r#"citestyle="authoryear""#),
     "\\documentclass[author-year]{{revtex4-1}} must render author-year:\n{core}"
+  );
+}
+
+// ===========================================================================
+// Citation-ORDER numbering for unsorted bibliography styles (html_feedback
+// #6294, IEEE `\bibliographystyle{IEEEtran}`; sibling #5930).
+//
+// bibtex's own guarantee: an UNSORTED `.bst` (`unsrt`, `unsrtnat`, `ieeetr`,
+// `IEEEtran`) numbers the References in the order entries are first cited, NOT
+// alphabetically. LaTeXML's MakeBibliography always `unisort`s — so a paper
+// whose figure captions hard-code "[2], [3], [4]" (baked into the PDF) gets a
+// mismatched, alphabetized list. Both Perl AND oxide alphabetize here, so this
+// is a deliberate surpass-Perl: oxide honors the `sort='false'` flag
+// (OXIDIZED_DESIGN divergence). Perl even maps `IEEEtran`→`sort='true'`
+// (IEEEtran.cls.ltxml L331), itself unfaithful to `IEEEtran.bst`; oxide maps
+// `IEEEtran`/`ieeetr`→`sort='false'` to match the real `.bst` and the PDF.
+//
+// Witness arXiv 2510.05438 (`\documentclass{IEEEtran}`,
+// `\bibliographystyle{IEEEtran}`, `\bibliography{...}`, 17 entries).
+// ===========================================================================
+
+/// `(refnum, key)` of each reference-list `<bibitem>`, in list order, from
+/// post-processed ltx XML — enough to prove WHICH bib key received `[1]`.
+fn reference_list_order(xml: &str) -> Vec<(u32, String)> {
+  let mut out = Vec::new();
+  let mut rest = xml;
+  while let Some(s) = rest.find("<bibitem") {
+    let after = &rest[s..];
+    let end = after.find("</bibitem>").unwrap_or(after.len());
+    let seg = &after[..end];
+    let key = seg
+      .find("key=\"")
+      .map(|i| {
+        let tail = &seg[i + "key=\"".len()..];
+        tail[..tail.find('"').unwrap_or(tail.len())].to_string()
+      })
+      .unwrap_or_default();
+    // Content of the `role="refnum"` tag (the `>` after `role="refnum"` closes
+    // the opening `<tag …>`; attributes never contain `>`, so this is robust to
+    // attribute order).
+    let refnum = seg
+      .find("role=\"refnum\"")
+      .and_then(|i| seg[i..].find('>').map(|j| &seg[i + j + 1..]))
+      .and_then(|tail| tail.find('<').map(|k| &tail[..k]))
+      .and_then(numeric_label);
+    if let Some(n) = refnum {
+      out.push((n, key));
+    }
+    rest = &after[end..];
+  }
+  out
+}
+
+/// html_feedback #6294 — `\bibliographystyle{unsrt}` and `{IEEEtran}` number the
+/// References list by CITATION ORDER, and the inline `[N]` cites index that
+/// order. Body cites in the order gamma, alpha, beta, so the fixed list is
+/// gamma=[1], alpha=[2], beta=[3] (alphabetical would be alpha/beta/gamma).
+#[test]
+fn cluster_bib_unsrt_citation_order() {
+  for tex in ["cite_order_unsrt.tex", "cite_order_ieeetran.tex"] {
+    let x = convert_and_post_clean(&format!("tests/cluster_regressions/{tex}"));
+    // Inline cites in reading order (gamma, alpha, beta) read [1], [2], [3].
+    let nums: Vec<u32> = inline_cite_texts(&x)
+      .iter()
+      .filter_map(|c| numeric_label(c))
+      .collect();
+    assert_eq!(
+      nums,
+      vec![1, 2, 3],
+      "{tex}: inline citations must follow citation order (gamma=1, alpha=2, \
+       beta=3), got {nums:?}\n{x}"
+    );
+    // The References list itself is ordered gamma, alpha, beta — the first-cited
+    // entry (Gamma) is [1] and appears first.
+    let order = reference_list_order(&x);
+    assert_eq!(
+      order.len(),
+      3,
+      "{tex}: expected 3 reference entries, got {order:?}\n{x}"
+    );
+    assert_eq!(
+      order,
+      vec![
+        (1, "gamma".to_string()),
+        (2, "alpha".to_string()),
+        (3, "beta".to_string()),
+      ],
+      "{tex}: the References list must be numbered by citation order \
+       (gamma=[1], alpha=[2], beta=[3]), got {order:?}\n{x}"
+    );
+  }
+}
+
+/// The engine half of the fix: `\bibliographystyle{IEEEtran}` (and `{unsrt}`)
+/// reach the core `<ltx:bibliography>` as `bibstyle="…"` + `citestyle="numbers"`
+/// — the signals the post-processor keys on. `IEEEtran` in particular must be
+/// KNOWN (it maps to numeric+unsorted); before the fix it was an "unknown
+/// bibstyle". Core output carries no `sort` attribute (byte-identical to Perl,
+/// which never emits it on the main node — the post derives order from bibstyle).
+#[test]
+fn cluster_bib_bibstyle_is_known_numeric() {
+  for (tex, bibstyle) in [
+    ("cite_order_unsrt.tex", "unsrt"),
+    ("cite_order_ieeetran.tex", "IEEEtran"),
+    ("cite_order_plain.tex", "plain"),
+  ] {
+    let core = convert_to_xml(&format!("tests/cluster_regressions/{tex}"));
+    assert!(
+      core.contains(&format!(r#"bibstyle="{bibstyle}""#)),
+      "{tex}: expected bibstyle=\"{bibstyle}\" on ltx:bibliography:\n{core}"
+    );
+    assert!(
+      core.contains(r#"citestyle="numbers""#),
+      "{tex}: expected citestyle=\"numbers\":\n{core}"
+    );
+  }
+}
+
+/// Control: a SORTED style (`plain`) must stay ALPHABETICAL — the citation-order
+/// path must not leak into the default. Body cites gamma, alpha, beta, so the
+/// list stays alpha=[1], beta=[2], gamma=[3] and the inline cites read
+/// [3], [1], [2].
+#[test]
+fn cluster_bib_plain_stays_alphabetical() {
+  let x = convert_and_post_clean("tests/cluster_regressions/cite_order_plain.tex");
+  let nums: Vec<u32> = inline_cite_texts(&x)
+    .iter()
+    .filter_map(|c| numeric_label(c))
+    .collect();
+  assert_eq!(
+    nums,
+    vec![3, 1, 2],
+    "plain must stay alphabetical (alpha=1, beta=2, gamma=3), so inline cites \
+     gamma/alpha/beta read [3],[1],[2], got {nums:?}\n{x}"
+  );
+  let order = reference_list_order(&x);
+  assert_eq!(
+    order,
+    vec![
+      (1, "alpha".to_string()),
+      (2, "beta".to_string()),
+      (3, "gamma".to_string()),
+    ],
+    "plain: the References list must stay ALPHABETICAL (alpha=[1], beta=[2], \
+     gamma=[3]), got {order:?}\n{x}"
   );
 }

--- a/latexml_oxide/tests/cluster_regressions/cite_order.bib
+++ b/latexml_oxide/tests/cluster_regressions/cite_order.bib
@@ -1,0 +1,18 @@
+@article{gamma,
+  author = {Gamma, Grace},
+  title = {On the third letter},
+  journal = {Journal of Ordering},
+  year = {2021},
+}
+@article{alpha,
+  author = {Alpha, Alice},
+  title = {On the first letter},
+  journal = {Journal of Ordering},
+  year = {2019},
+}
+@article{beta,
+  author = {Beta, Bob},
+  title = {On the second letter},
+  journal = {Journal of Ordering},
+  year = {2020},
+}

--- a/latexml_oxide/tests/cluster_regressions/cite_order_ieeetran.tex
+++ b/latexml_oxide/tests/cluster_regressions/cite_order_ieeetran.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+\begin{document}
+We first cite \cite{gamma}, then \cite{alpha}, and finally \cite{beta}.
+\bibliographystyle{IEEEtran}
+\bibliography{cite_order}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/cite_order_plain.tex
+++ b/latexml_oxide/tests/cluster_regressions/cite_order_plain.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+\begin{document}
+We first cite \cite{gamma}, then \cite{alpha}, and finally \cite{beta}.
+\bibliographystyle{plain}
+\bibliography{cite_order}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/cite_order_unsrt.tex
+++ b/latexml_oxide/tests/cluster_regressions/cite_order_unsrt.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+\begin{document}
+We first cite \cite{gamma}, then \cite{alpha}, and finally \cite{beta}.
+\bibliographystyle{unsrt}
+\bibliography{cite_order}
+\end{document}

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -872,12 +872,16 @@ impl MakeBibliography {
       format!("{}.L1", bib_id)
     };
 
-    // Perl L398 `$doc->unisort(keys %$entries)`.
-    let mut sorted_keys: Vec<String> = entries.keys().cloned().collect();
-    unisort(&mut sorted_keys);
-    let items: Vec<NodeData> = sorted_keys
+    // Order the rendered list by the number already assigned in `process`. Perl
+    // re-`unisort`s here (L398), but the number was likewise assigned in
+    // `unisort` order, so for a sorted style the result is identical; for a
+    // citation-order style (`sort='false'`, html_feedback #6294) the number
+    // carries the citation order and the list must follow it, not re-alphabetize.
+    // Keying on the number makes "list order == numbering order" an invariant.
+    let mut ordered: Vec<&BibEntryData> = entries.values().collect();
+    ordered.sort_by_key(|e| e.number);
+    let items: Vec<NodeData> = ordered
       .iter()
-      .filter_map(|key| entries.get(key))
       .map(|entry| self.format_bib_entry(doc, bib_id, entry, style))
       .collect();
 
@@ -1586,6 +1590,22 @@ impl Processor for MakeBibliography {
       // the walk it counts.
       let mut number = 0u32;
 
+      // Citation-order numbering for an UNSORTED style: the References are
+      // numbered by first citation, not alphabetically — matching the `.bst` and
+      // the published PDF (html_feedback #6294). Perl always `unisort`s (it reads
+      // the sort flag into `%STYLE` but ignores it), so this is a deliberate
+      // surpass-Perl. Detected from the `bibstyle` NAME — the reliable signal on
+      // the main node (Perl's `beginBibliography` never emits `sort`) — plus an
+      // explicit `sort='false'` for the bibunits `\bibstyle` path / external XML.
+      // Only the non-split walk uses it; `--splitbibliography` is inherently
+      // initial-major (alphabetical) and never combines with it.
+      let citation_ordered = bib.get_attribute("sort").as_deref() == Some("false")
+        || bib
+          .get_attribute("bibstyle")
+          .as_deref()
+          .is_some_and(is_citation_order_style);
+      let cite_order = citation_ordered.then(|| citation_order(&doc));
+
       if self.split {
         // Split by initial letter
         let mut by_initial: HashMap<String, Vec<String>> = HashMap::default();
@@ -1625,8 +1645,7 @@ impl Processor for MakeBibliography {
           doc.add_nodes(&mut bib_mut, &[biblist]);
         }
       } else {
-        let mut sorted_keys: Vec<String> = entries.keys().cloned().collect();
-        unisort(&mut sorted_keys);
+        let sorted_keys = order_entry_keys(&entries, cite_order.as_ref());
         for key in &sorted_keys {
           debug_assert!(entries.contains_key(key), "sorted key {key} left entries");
           if let Some(entry) = entries.get_mut(key) {
@@ -2949,6 +2968,83 @@ fn format_links(doc: &PostDocument, nodes: &[Node]) -> Vec<NodeData> {
 /// map.
 fn unisort(keys: &mut [String]) {
   keys.sort_by_cached_key(|k| (collation_primary_key(k), k.clone()));
+}
+
+/// Whether a `\bibliographystyle` produces an UNSORTED (citation-order)
+/// bibliography — bibtex's `sort='false'` styles. Kept in sync with the
+/// engine's `lookup_bibstyle_params` (`latex_constructs.rs`): the two live in
+/// different crates, but both encode the same small, stable bibtex fact.
+/// `unsrt`/`unsrtnat` are the base-table unsorted styles; `ieeetr`/`IEEEtran`
+/// are the surpass-Perl additions matching the real IEEE `.bst` + PDF.
+fn is_citation_order_style(bibstyle: &str) -> bool {
+  matches!(bibstyle, "unsrt" | "unsrtnat" | "ieeetr" | "IEEEtran")
+}
+
+/// First-citation order of bib keys (lowercased) → 0-based rank, read from the
+/// document's inline `<ltx:bibref>`s in reading order.
+///
+/// This is bibtex's `\citation`-record order for `\cite`: an UNSORTED `.bst`
+/// (`unsrt`/`unsrtnat`/`ieeetr`/`IEEEtran`) numbers the References by it. bibrefs
+/// INSIDE the bibliography (a `\bibitem` crossref, the "Cited by" back-links)
+/// are excluded via `not(ancestor::ltx:bibliography)` so only real in-text
+/// citations count. Verified key-for-key against pdflatex+bibtex on witness
+/// arXiv 2510.05438.
+///
+/// `\nocite` emits its bibref too, but BOTH engines defer it to end-of-document
+/// (`\nocite`→`@at@end@document`), so a mid-document `\nocite` ranks after the
+/// cited entries rather than at bibtex's `\nocite` position — a documented
+/// shared-Perl residual (OXIDIZED_DESIGN #116), not exact bibtex parity.
+fn citation_order(doc: &PostDocument) -> HashMap<String, usize> {
+  let mut order: HashMap<String, usize> = HashMap::default();
+  let mut next = 0usize;
+  for node in doc.findnodes("//ltx:bibref[not(ancestor::ltx:bibliography)]") {
+    let Some(refs) = node.get_attribute("bibrefs") else {
+      continue;
+    };
+    for key in refs.split(',') {
+      let k = key.trim().to_lowercase();
+      if k.is_empty() {
+        continue;
+      }
+      order.entry(k).or_insert_with(|| {
+        let i = next;
+        next += 1;
+        i
+      });
+    }
+  }
+  order
+}
+
+/// The order to number entries in. With `cite_order = Some(..)` (a `sort='false'`
+/// style) cited entries come first in first-citation order, and any entry not
+/// directly cited — pulled in transitively (a crossref) or via `\nocite{*}` —
+/// falls to the end in the usual `unisort` (alphabetical) order, since it has no
+/// citation position. Otherwise plain `unisort` (Perl's always-alphabetical).
+fn order_entry_keys(
+  entries: &HashMap<String, BibEntryData>,
+  cite_order: Option<&HashMap<String, usize>>,
+) -> Vec<String> {
+  match cite_order {
+    Some(order) => {
+      let mut cited: Vec<(usize, String)> = Vec::new();
+      let mut uncited: Vec<String> = Vec::new();
+      for (sort_key, entry) in entries {
+        match order.get(&entry.bib_key.to_lowercase()) {
+          Some(&idx) => cited.push((idx, sort_key.clone())),
+          None => uncited.push(sort_key.clone()),
+        }
+      }
+      cited.sort_by_key(|(idx, _)| *idx);
+      unisort(&mut uncited);
+      cited.into_iter().map(|(_, k)| k).chain(uncited).collect()
+    },
+    None => {
+      let mut keys: Vec<String> = entries.keys().cloned().collect();
+      unisort(&mut keys);
+      keys
+    },
+  }
 }
 
 /// The primary-level collation weight of a sort-key: NFD, combining marks


### PR DESCRIPTION
**Diagnostic.** `MakeBibliography` always `unisort`s the cited entries and numbers `[N]` in that alphabetical order, ignoring the `\bibliographystyle` — so `unsrt`/`ieeetr`/`IEEEtran` (bibtex's *unsorted* styles) got an alphabetized list that mismatches the PDF, whose figure captions bake in "[2], [3], [4]". Both Perl and oxide share this; Perl even maps `IEEEtran → sort='true'`.

**Approach.** For an unsorted style the References are now numbered by **first citation appearance** — the document order of the inline `<ltx:bibref>`s, which is exactly bibtex's `\citation`-record order — and the list follows that numbering. Detection is from the `bibstyle` name (Perl's `beginBibliography` never emits `sort`, so core output stays byte-identical); the engine's `lookup_bibstyle_params` gains `ieeetr`/`IEEEtran → numbers, false` to match the real `.bst`. Sorted styles (`plain`/`alpha`/…) are unchanged. A deliberate surpass-Perl (OXIDIZED_DESIGN #116); ground truth is pdflatex+bibtex.

**Validation.** New guards `cluster_bib_unsrt_citation_order`, `cluster_bib_plain_stays_alphabetical`, `cluster_bib_bibstyle_is_known_numeric`; full suite green; clippy/fmt clean. Verified key-for-key against pdflatex+bibtex on witness arXiv 2510.05438 (17 entries) and 79 inline cites consistent with the list.

Addresses arXiv/html_feedback#6294.
