### PR TITLE
fix: reduce inner \linewidth to the wrap width inside wrapfig floats

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -677,6 +677,22 @@ arXiv:2012.00499 Figure 3 (`\begin{wrapfigure}{r}{0.4\textwidth}` around a
 fit the single-line caption; now both image and caption are capped to the wrap
 width.
 
+**Extension — inner `\linewidth`:** the `@width` cap on the figure is not enough
+when the body carries its OWN intrinsic size — a `\includegraphics[width=\linewidth]`
+or `\begin{minipage}{\linewidth}` that read `\linewidth` at the full page width
+render a fixed-size box (e.g. a tikz picture serializes to `<svg width="479">`)
+that overflows the narrow float and collides with the wrapped text (`max-width:100%`
+does not rein a fixed-`width` SVG in). So `set_wrap_width` also reduces the INNER
+`\hsize`/`\columnwidth`/`\linewidth` to the wrap width (in `after_digest_begin`,
+before the body digests), exactly as real LaTeX wrapfig does (`\hsize<width>` +
+`\@parboxrestore`'s `\linewidth\hsize`) and as `{minipage}` already does here.
+`\textwidth` is left alone (the `@width` percentage is relative to the OUTER
+textwidth). Perl discards the width arg entirely, so Perl's wrapfig image renders
+full-width too (SHARED-FAILURE). Witness arXiv 2603.23669 Figure 3
+(`0.296\textwidth` wrapfigure around a 512px tikz image): the picture dropped from
+479px → 141px and the text now wraps cleanly. Guard
+`cluster_sizing::wrapfig_inner_linewidth`.
+
 ---
 
 ### 30. `\href` is `protected` (robust), unlike Perl's

--- a/latexml_oxide/tests/cluster_regressions/wrapfig_inner_linewidth.tex
+++ b/latexml_oxide/tests/cluster_regressions/wrapfig_inner_linewidth.tex
@@ -1,0 +1,13 @@
+\documentclass{article}
+\usepackage{wrapfig}
+\begin{document}
+% Control: \rule{\linewidth} outside any float renders at the full page width.
+\rule{\linewidth}{2pt}
+
+% Inside a 0.3\textwidth wrapfigure, \linewidth must be the wrap width, so this
+% rule is ~0.3 of the page. Pre-fix \linewidth stayed at the full page width, so
+% a body \includegraphics[width=\linewidth] / minipage{\linewidth} overflowed
+% the narrow float and collided with the wrapped text (arXiv 2603.23669 Fig. 3).
+\begin{wrapfigure}{r}{0.3\textwidth}\rule{\linewidth}{2pt}\end{wrapfigure}
+Some wrapped text next to the float.
+\end{document}

--- a/latexml_oxide/tests/cluster_sizing.rs
+++ b/latexml_oxide/tests/cluster_sizing.rs
@@ -769,3 +769,48 @@ mod widthof_in_base_dimension_reader {
     );
   }
 }
+
+mod wrapfig_inner_linewidth {
+  //! A `wrapfigure`'s inner `\linewidth` must be the declared wrap width, not the
+  //! full page. Witness arXiv 2603.23669 Fig. 3: a `wrapfigure{0.296\textwidth}`
+  //! whose body was `\includegraphics[width=\linewidth]` rendered the image at
+  //! the full page width (479px) inside a 29%-wide right float, so it overran and
+  //! collided with the wrapped text. Real LaTeX wrapfig sets `\hsize`/`\linewidth`
+  //! to the wrap width; Perl discards the width arg (SHARED-FAILURE). The fix
+  //! lives in `wrapfig_sty.rs::set_wrap_width` (OXIDIZED_DESIGN #29).
+  use crate::cluster::convert_to_xml;
+
+  /// Widths (pt) of every `<rule …>` in the core XML, in document order.
+  fn rule_widths(xml: &str) -> Vec<f64> {
+    xml
+      .match_indices("<rule")
+      .filter_map(|(i, _)| {
+        let rest = &xml[i..];
+        let ws = rest.find("width=\"")? + "width=\"".len();
+        let val = &rest[ws..];
+        val[..val.find('"')?]
+          .trim_end_matches("pt")
+          .parse::<f64>()
+          .ok()
+      })
+      .collect()
+  }
+
+  #[test]
+  fn wrapfigure_reduces_inner_linewidth_to_wrap_width() {
+    // One conversion, two `\rule{\linewidth}`s: a full-width control and one
+    // inside a 0.3\textwidth wrapfigure (fixture wrapfig_inner_linewidth.tex).
+    let x = convert_to_xml("tests/cluster_regressions/wrapfig_inner_linewidth.tex");
+    let widths = rule_widths(&x);
+    assert!(
+      widths.len() >= 2,
+      "expected >=2 <rule> widths, got {widths:?}:\n{x}"
+    );
+    let full = widths.iter().cloned().fold(0.0_f64, f64::max);
+    let inner = widths.iter().cloned().fold(f64::INFINITY, f64::min);
+    assert!(
+      inner > 1.0 && inner < full * 0.5,
+      "wrapfigure did not reduce inner \\linewidth: inner={inner}pt full={full}pt"
+    );
+  }
+}

--- a/latexml_oxide/tests/complex/figure_mixed_content.xml
+++ b/latexml_oxide/tests/complex/figure_mixed_content.xml
@@ -100,7 +100,7 @@
     <p>Testing <ref labelref="LABEL:array:subfig1"/> and <ref labelref="LABEL:array:subfig2"/> inside <ref labelref="LABEL:array:fig"/>.</p>
     <pagination role="newpage"/>
   </para>
-  <figure align="center" class="ltx_minipage" float="right" framed="top" inlist="loa" placement="H" vattach="middle" width="345.0pt" xml:id="alg1">
+  <figure align="center" class="ltx_minipage" float="right" framed="top" inlist="loa" placement="H" vattach="middle" width="120.8pt" xml:id="alg1">
     <tags>
       <tag><text font="bold">Algorithm 1</text></tag>
       <tag role="refnum">1</tag>

--- a/latexml_package/src/package/wrapfig_sty.rs
+++ b/latexml_package/src/package/wrapfig_sty.rs
@@ -83,6 +83,22 @@ fn set_wrap_width(whatsit: &mut Whatsit) {
   if v == 0 {
     return;
   }
+  // Cap the float's INNER line width to the declared wrap width, so a body
+  // `\includegraphics[width=\linewidth]` / `\rule{\linewidth}` / nested box is
+  // sized to the float and not to the full page. Real LaTeX wrapfig does this
+  // (`\hsize<width>` then `\@parboxrestore`'s `\linewidth\hsize`); Perl's
+  // binding discards the width arg entirely, so its wrapfig image renders at the
+  // full page width and overflows the narrow float, colliding with the wrapped
+  // text (SHARED-FAILURE). Witness arXiv 2603.23669 Fig. 3: a 0.296\textwidth
+  // wrapfigure whose 512px tikz image overran the 29% float. `\textwidth` is
+  // left alone (the @width percentage below is relative to the OUTER textwidth,
+  // and wrapfig itself never rescales \textwidth). Runs in after_digest_begin,
+  // before the body digests, so the reduced \linewidth reaches the image.
+  // OXIDIZED_DESIGN #29 (extends the width-emission divergence).
+  let rv: RegisterValue = Dimension::new(v).into();
+  let _ = assign_register("\\hsize", rv.clone(), None, Vec::new());
+  let _ = assign_register("\\columnwidth", rv.clone(), None, Vec::new());
+  let _ = assign_register("\\linewidth", rv, None, Vec::new());
   let Some(tw) = lookup_dimension("\\textwidth") else {
     return;
   };


### PR DESCRIPTION
**Diagnostic.** A `wrapfigure`'s body read `\linewidth` at the full page width, so an `\includegraphics[width=\linewidth]` / `minipage{\linewidth}` rendered a fixed-size box that overflowed the narrow float and collided with the wrapped text (witness arXiv 2603.23669 Fig. 3: a `0.296\textwidth` wrapfigure whose 512px tikz image overran the 29% right float; the figure `@width` cap alone can't rein a fixed-`width` SVG in). Perl discards the wrap-width arg, so its wrapfig image is full-width too — SHARED-FAILURE; real LaTeX wrapfig sets `\hsize`/`\linewidth` to the wrap width.

**Approach.** Extend `set_wrap_width` (OXIDIZED_DESIGN #29) to also reduce the inner `\hsize`/`\columnwidth`/`\linewidth` to the declared wrap width in `after_digest_begin`, before the body digests — exactly as `{minipage}` already does. `\textwidth` is left alone (the figure `@width` % is relative to the outer textwidth).

**Validation.** Guard `cluster_sizing::wrapfig_inner_linewidth` (via the in-process `convert_to_xml` API + committed fixture — no subprocess/tempfiles). `figure_mixed_content` golden re-blessed: a `minipage{\linewidth}` in a `0.35\textwidth` wrapfigure now sizes to 120.8pt, not 345.0pt. Full suite **1983/0**; clippy `-D warnings` clean. Witness re-rendered under ar5iv: picture 479px→141px, text wraps cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)