### PR TITLE
fix: citation-order numbering reaches natbib/revtex (ieeetr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@
     References are now numbered by first citation — matching pdflatex+bibtex
     key-for-key — while sorted styles (`plain`/`alpha`/…) stay alphabetical.
     Surpasses Perl, which alphabetizes every style. Witness arXiv 2510.05438
-    (arXiv/html_feedback#6294).
+    (arXiv/html_feedback#6294). Now also reaches natbib/revtex papers: the
+    `\bibliographystyle` name is recorded before natbib can drop it, so a
+    revtex4-2 or `[numbers]natbib` paper with `ieeetr` is numbered by citation
+    order too (arXiv/html_feedback#5930, #6095).
   - **A biblatex `\DeclareSourcemap` block no longer breaks the conversion.**
     Source mapping is a biber pre-processing stage LaTeXML does not run;
     `\DeclareSourcemap` (and `\DeclareStyleSourcemap`) were undefined, so the

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4250,11 +4250,26 @@ list is then rendered in that same numbered order (the biblist follows
 `entry.number`, not a second `unisort`). SORTED styles (`plain`, `alpha`, `abbrv`,
 plainnat/…, and any unknown style) are unchanged — still alphabetical, identical
 to Perl. Detection is from the `bibstyle` attribute name (plus an explicit
-`sort='false'`, e.g. the bibunits `\bibstyle` path); the core `<ltx:bibliography>`
-carries no new attribute, so engine output stays byte-identical to Perl. The
-engine's `lookup_bibstyle_params` also gains `ieeetr`/`IEEEtran` → `numbers`,
-`false` (Perl's base table omits them and its class binding alphabetizes IEEEtran)
-so the real IEEE `.bst` behavior is matched.
+`sort='false'`, e.g. the bibunits `\bibstyle` path), GATED on a numeric list
+(`citestyle="numbers"`, or absent → numeric): an author-year list is always
+alphabetical by author regardless of the `.bst` sort flag. The engine's
+`lookup_bibstyle_params` also gains `ieeetr`/`IEEEtran` → `numbers`, `false`
+(Perl's base table omits them and its class binding alphabetizes IEEEtran) so the
+real IEEE `.bst` behavior is matched.
+
+**natbib/revtex arm** (html_feedback #5930/#6095): a revtex4-2 or `natbib` paper
+with `\bibliographystyle{ieeetr}` lost the style name before it reached the node —
+natbib's `[numbers]`/`nobibstyle` option does `\let\bibstyle\@gobble`, and its
+author-year `\bibstyle` has no `\bibstyle@ieeetr` preset (Perl natbib.sty.ltxml
+L85-92, which flags the loss as a known FUTURE gap). The kernel
+`\bibliographystyle` now records `BIBSTYLE` (`\lx@record@bibstyle`) BEFORE
+dispatching to the possibly-gobbled `\bibstyle`, so the name reaches the node in
+every path. It records only the name, never `CITE_STYLE` — natbib owns
+numbers-vs-author-year via its options (`plainnat` is numeric in the base table
+but author-year under natbib), and the citestyle guard above keeps author-year
+natbib lists alphabetical. `beginBibliography` still emits no `sort` attribute, so
+the core node is unchanged except for the `bibstyle` name it already ought to
+carry (`thebibliography`-based lists, which read no BIBSTYLE, are untouched).
 
 **Why**: bibtex's own guarantee is that an unsorted `.bst` leaves the References
 in citation order; IEEE figure captions bake in "[2], [3], [4]" that depend on it.
@@ -4271,10 +4286,15 @@ exact.
 **Witnesses**: arXiv 2510.05438 (html_feedback#6294) — `\documentclass{IEEEtran}`,
 `\bibliographystyle{IEEEtran}`, `\bibliography{…}`, 17 entries; oxide's numbered
 order now equals the pdflatex+bibtex `.bbl` order key-for-key (Wu2021=[1] … Shi2011=[17]).
+arXiv 2602.00643 (html_feedback#5930) — `\documentclass{revtex4-2}` +
+`\bibliographystyle{ieeetr}`, 10 entries, likewise key-for-key vs bibtex.
 
 **Upstream**: worth filing against `brucemiller/LaTeXML` (same alphabetize-everything gap).
 
 **Guards**: `06_cluster_bibliography::cluster_bib_unsrt_citation_order`
 (unsrt + IEEEtran number gamma/alpha/beta by citation order),
 `cluster_bib_plain_stays_alphabetical` (sorted styles unchanged),
-`cluster_bib_bibstyle_is_known_numeric` (engine maps IEEEtran → numeric).
+`cluster_bib_bibstyle_is_known_numeric` (engine maps IEEEtran → numeric),
+`cluster_bib_natbib_numeric_citation_order` (the natbib/revtex arm),
+`cluster_bib_natbib_numeric_sorted_stays_alphabetical` +
+`cluster_bib_natbib_authoryear_stays_alphabetical` (the unsorted + numeric gates).

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -8490,7 +8490,23 @@ LoadDefinitions!({
     }
   );
 
-  DefMacro!("\\bibliographystyle Semiverbatim", "\\bibstyle{#1}");
+  // Record the bibliographystyle name globally BEFORE dispatching to \bibstyle,
+  // so it reaches the <ltx:bibliography> node even when a package layer drops the
+  // name at \bibstyle: natbib's `nobibstyle`/`[numbers]` does
+  // `\let\bibstyle\@gobble`, and its author-year \bibstyle has no `\bibstyle@`
+  // preset for a numeric style, so `\bibstyle{ieeetr}` otherwise vanishes.
+  // MakeBibliography reads this name to number an unsorted numeric style
+  // (ieeetr/IEEEtran/unsrt) in citation order (html_feedback #5930/#6095, the
+  // natbib/revtex arm of #6294). CITE_STYLE is deliberately NOT set here —
+  // natbib owns numbers-vs-author-year via its options, and the plain-path
+  // \bibstyle DefConstructor already sets CITE_STYLE/CITE_SORT for known styles.
+  DefPrimitive!("\\lx@record@bibstyle{}", sub[(style)] {
+    assign_value("BIBSTYLE", pin(Expand!(style).to_string()), Some(Scope::Global));
+  });
+  DefMacro!(
+    "\\bibliographystyle Semiverbatim",
+    "\\lx@record@bibstyle{#1}\\bibstyle{#1}"
+  );
 
   DefConditional!("\\if@lx@inbibliography");
   // Should be an environment, but people seem to want to misuse it.

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -2433,3 +2433,88 @@ fn cluster_bib_plain_stays_alphabetical() {
      gamma=[3]), got {order:?}\n{x}"
   );
 }
+
+// ===========================================================================
+// Citation-ORDER numbering reaches the natbib/revtex arm (html_feedback
+// #5930/#6095): revtex4-2 / natbib papers with `\bibliographystyle{ieeetr}`.
+//
+// natbib drops the bibstyle name at `\bibstyle` — its `[numbers]`/`nobibstyle`
+// option does `\let\bibstyle\@gobble`, and its author-year `\bibstyle` has no
+// `\bibstyle@ieeetr` preset — so the #6294 fix (which reads the bibstyle name)
+// saw nothing. The kernel `\bibliographystyle` now records the name BEFORE
+// dispatching, so an unsorted NUMERIC natbib/revtex list is numbered in citation
+// order too. Author-year natbib lists stay alphabetical (the citestyle guard).
+// Witness arXiv 2602.00643 (revtex4-2 + ieeetr; oxide now matches bibtex .bbl
+// key-for-key across all 10 entries).
+// ===========================================================================
+
+/// The bib `key`s of the reference-list `<bibitem>`s in list order (works for
+/// numeric AND author-year lists, unlike `reference_list_order`).
+fn reference_list_keys(xml: &str) -> Vec<String> {
+  let mut out = Vec::new();
+  let mut rest = xml;
+  while let Some(s) = rest.find("<bibitem") {
+    let after = &rest[s..];
+    let end = after.find('>').unwrap_or(after.len());
+    let tag = &after[..end];
+    if let Some(i) = tag.find("key=\"") {
+      let tail = &tag[i + "key=\"".len()..];
+      out.push(tail[..tail.find('"').unwrap_or(tail.len())].to_string());
+    }
+    rest = &after[end..];
+  }
+  out
+}
+
+/// html_feedback #5930/#6095 — `[numbers]natbib` (and revtex4-2) with an unsorted
+/// numeric style numbers the References by citation order. Body cites
+/// gamma/alpha/beta, so the fixed list is gamma=[1], alpha=[2], beta=[3].
+#[test]
+fn cluster_bib_natbib_numeric_citation_order() {
+  let x = convert_and_post_clean("tests/cluster_regressions/natbib_num_ieeetr.tex");
+  let nums: Vec<u32> = inline_cite_texts(&x)
+    .iter()
+    .filter_map(|c| numeric_label(c))
+    .collect();
+  assert_eq!(
+    nums,
+    vec![1, 2, 3],
+    "[numbers]natbib+ieeetr inline cites must follow citation order: {nums:?}\n{x}"
+  );
+  assert_eq!(
+    reference_list_order(&x),
+    vec![
+      (1, "gamma".to_string()),
+      (2, "alpha".to_string()),
+      (3, "beta".to_string()),
+    ],
+    "[numbers]natbib+ieeetr References must be numbered by citation order\n{x}"
+  );
+}
+
+/// Control 1: `[numbers]natbib + plainnat` is numeric but SORTED, so it stays
+/// ALPHABETICAL — the citation-order path is gated on an UNSORTED `.bst`, not on
+/// natbib-numeric alone.
+#[test]
+fn cluster_bib_natbib_numeric_sorted_stays_alphabetical() {
+  let x = convert_and_post_clean("tests/cluster_regressions/natbib_num_plainnat.tex");
+  assert_eq!(
+    reference_list_keys(&x),
+    vec!["alpha", "beta", "gamma"],
+    "[numbers]natbib+plainnat (sorted) must stay alphabetical\n{x}"
+  );
+}
+
+/// Control 2: default natbib (AUTHOR-YEAR) + ieeetr must NOT be reordered — an
+/// author-year list is always alphabetical by author regardless of the `.bst`
+/// sort flag (the `citestyle="numbers"` guard). Guards against the natbib
+/// bibstyle-recording leaking citation-order into author-year mode.
+#[test]
+fn cluster_bib_natbib_authoryear_stays_alphabetical() {
+  let x = convert_and_post_clean("tests/cluster_regressions/natbib_ay_ieeetr.tex");
+  assert_eq!(
+    reference_list_keys(&x),
+    vec!["alpha", "beta", "gamma"],
+    "author-year natbib must stay alphabetical, not citation-ordered\n{x}"
+  );
+}

--- a/latexml_oxide/tests/cluster_regressions/natbib_ay_ieeetr.tex
+++ b/latexml_oxide/tests/cluster_regressions/natbib_ay_ieeetr.tex
@@ -1,0 +1,7 @@
+\documentclass{article}
+\usepackage{natbib}
+\begin{document}
+We first cite \cite{gamma}, then \cite{alpha}, and finally \cite{beta}.
+\bibliographystyle{ieeetr}
+\bibliography{cite_order}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/natbib_num_ieeetr.tex
+++ b/latexml_oxide/tests/cluster_regressions/natbib_num_ieeetr.tex
@@ -1,0 +1,7 @@
+\documentclass{article}
+\usepackage[numbers]{natbib}
+\begin{document}
+We first cite \cite{gamma}, then \cite{alpha}, and finally \cite{beta}.
+\bibliographystyle{ieeetr}
+\bibliography{cite_order}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/natbib_num_plainnat.tex
+++ b/latexml_oxide/tests/cluster_regressions/natbib_num_plainnat.tex
@@ -1,0 +1,7 @@
+\documentclass{article}
+\usepackage[numbers]{natbib}
+\begin{document}
+We first cite \cite{gamma}, then \cite{alpha}, and finally \cite{beta}.
+\bibliographystyle{plainnat}
+\bibliography{cite_order}
+\end{document}

--- a/latexml_post/src/make_bibliography.rs
+++ b/latexml_post/src/make_bibliography.rs
@@ -1599,12 +1599,24 @@ impl Processor for MakeBibliography {
       // explicit `sort='false'` for the bibunits `\bibstyle` path / external XML.
       // Only the non-split walk uses it; `--splitbibliography` is inherently
       // initial-major (alphabetical) and never combines with it.
-      let citation_ordered = bib.get_attribute("sort").as_deref() == Some("false")
+      //
+      // Gated on a NUMERIC list: an author-year bibliography is always ordered
+      // alphabetically by author regardless of the `.bst` sort flag, so a numeric
+      // style is a precondition. This matters for the natbib/revtex arm
+      // (#5930/#6095): natbib now records `bibstyle` even when it stays in
+      // author-year mode (no `[numbers]`), and reordering that list by citation
+      // would be wrong. An absent `citestyle` defaults to numeric (Perl L481).
+      let is_numeric = bib
+        .get_attribute("citestyle")
+        .as_deref()
+        .map(|s| s.is_empty() || s == "numbers")
+        .unwrap_or(true);
+      let unsorted_style = bib.get_attribute("sort").as_deref() == Some("false")
         || bib
           .get_attribute("bibstyle")
           .as_deref()
           .is_some_and(is_citation_order_style);
-      let cite_order = citation_ordered.then(|| citation_order(&doc));
+      let cite_order = (is_numeric && unsorted_style).then(|| citation_order(&doc));
 
       if self.split {
         // Split by initial letter


### PR DESCRIPTION
**Diagnostic.** The citation-order numbering from #591 keys on the `bibstyle` name on `<ltx:bibliography>`, but natbib **drops** that name: its `[numbers]`/`nobibstyle` option does `\let\bibstyle\@gobble`, and its author-year `\bibstyle` has no `\bibstyle@ieeetr` preset (Perl's natbib flags the loss as a known gap, natbib.sty.ltxml L85-92). So revtex4-2 / natbib papers with `\bibliographystyle{ieeetr}` still alphabetized their references — mismatching the PDF.

**Approach.** The kernel `\bibliographystyle` now records `BIBSTYLE` (`\lx@record@bibstyle`) **before** dispatching to the possibly-gobbled `\bibstyle`, so the name reaches the node in every path. It records only the name — never `CITE_STYLE` (natbib owns numbers-vs-author-year via its options; `plainnat` is numeric in the base table but author-year under natbib). A `citestyle="numbers"` guard in the post-processor keeps author-year lists alphabetical. `thebibliography`-based lists are untouched (they read no `BIBSTYLE`), so no golden churn. Surpass-Perl, extends OXIDIZED_DESIGN #116.

**Validation.** New guards `cluster_bib_natbib_numeric_citation_order`, `cluster_bib_natbib_numeric_sorted_stays_alphabetical`, `cluster_bib_natbib_authoryear_stays_alphabetical`; full suite green; clippy/fmt clean. Verified key-for-key against pdflatex+bibtex on witness arXiv 2602.00643 (revtex4-2 + ieeetr, 10 entries).

Addresses arXiv/html_feedback#5930 and arXiv/html_feedback#6095.
