### PR TITLE
fix #593: Note/NoteLog/NoteSTDERR write to the right stream(s)

### DIFF
--- a/latexml_contrib/src/script_bindings/API.md
+++ b/latexml_contrib/src/script_bindings/API.md
@@ -35,7 +35,7 @@ closure-registered functions; only the accepted types are.
 
 Called at the top level of a binding file, or from inside any body.
 
-101 functions, 134 calls.
+102 functions, 135 calls.
 
 | call | documentation |
 |---|---|
@@ -95,8 +95,9 @@ Called at the top level of a binding file, or from inside any body.
 | `LookupValue(string) -> ?` | Read a value, whatever type it was stored as. ([`lookup_value`](latexml_core::state::lookup_value)) |
 | `MergeFont(map)` | Merge font attributes into the current font, group-locally. ([`merge_font`](latexml_core::binding::content::merge_font)) |
 | `NewCounter(string)`<br>`NewCounter(string, string)` | Declare a new counter. ([`new_counter`](latexml_core::binding::counter::dialect::new_counter)) |
+| `Note(string)` | Write a progress note to both the conversion log and stderr. |
 | `NoteLog(string)` | Write a progress note to the conversion log only. |
-| `NoteSTDERR(string)` | Write a progress note to stderr as well as the log. |
+| `NoteSTDERR(string)` | Write a progress note to stderr only. |
 | `ParseXML(string) -> array` | Parse a markup chunk into nodes; a bare fragment is fine. ([`parse_fragment`](latexml_core::common::xml::parse_fragment)) |
 | `PassOptions(string, string, array)` | Forward options to a package or class not yet loaded. ([`pass_options`](latexml_core::binding::content::pass_options)) |
 | `PopValue(string) -> ?` | Pop and return the last value of a value-table list, type preserved (`()` if empty). ([`pop_value`](latexml_core::state::pop_value)) |

--- a/latexml_contrib/src/script_bindings/api_doc.rs
+++ b/latexml_contrib/src/script_bindings/api_doc.rs
@@ -481,12 +481,16 @@ const DOCS: &[(&str, Doc)] = &[
     ),
   ),
   (
+    "Note",
+    Doc::Note("Write a progress note to both the conversion log and stderr."),
+  ),
+  (
     "NoteLog",
     Doc::Note("Write a progress note to the conversion log only."),
   ),
   (
     "NoteSTDERR",
-    Doc::Note("Write a progress note to stderr as well as the log."),
+    Doc::Note("Write a progress note to stderr only."),
   ),
   (
     "ParseXML",

--- a/latexml_contrib/src/script_bindings/engine.rs
+++ b/latexml_contrib/src/script_bindings/engine.rs
@@ -453,10 +453,16 @@ pub(super) fn make_engine() -> Engine {
       res.map_err(rhai_err)
     },
   );
-  // Notes + progress reporting (Perl `NoteSTDERR`/`NoteLog`, `ProgressStep`,
-  // `ProgressSpinup`/`ProgressSpindown`).
-  engine.register_fn("NoteSTDERR", |msg: &str| {
+  // Notes + progress reporting (Perl `Note`/`NoteSTDERR`/`NoteLog`, `ProgressStep`,
+  // `ProgressSpinup`/`ProgressSpindown`). Matching Perl `Common/Error.pm`: `Note`
+  // writes to BOTH the log and stderr, `NoteSTDERR` to stderr only, `NoteLog` to
+  // the log only. (#593: NoteLog/NoteSTDERR previously reached neither the log —
+  // both macros only wrote stderr — nor the right stream.)
+  engine.register_fn("Note", |msg: &str| {
     latexml_core::Note!(msg);
+  });
+  engine.register_fn("NoteSTDERR", |msg: &str| {
+    latexml_core::NoteSTDERR!(msg);
   });
   engine.register_fn("NoteLog", |msg: &str| {
     latexml_core::NoteLog!(msg);

--- a/latexml_contrib/src/script_bindings/tests.rs
+++ b/latexml_contrib/src/script_bindings/tests.rs
@@ -656,12 +656,20 @@ fn lookup_value_on_list_returns_rhai_array() {
 /// #319: the diagnostics surface beyond `Warn`/`Error` — `Info`, the
 /// `Note`/`Progress` family (side-effecting, must load and run cleanly), and
 /// `Fatal` (must abort the script, mirroring Perl `Fatal` which dies).
+///
+/// #593: also guards the log routing. Matching Perl `Common/Error.pm`, `Note`
+/// writes to BOTH the log and stderr, `NoteLog` to the log only, and
+/// `NoteSTDERR` to stderr only — previously `NoteLog`/`NoteSTDERR` reached the
+/// log from neither (both macros wrote stderr and were level-gated off).
 #[test]
 fn diagnostics_surface_info_notes_progress_and_fatal() {
   fresh_state();
+  // Capture the log buffer to prove routing (the log write is not stderr-gated).
+  latexml_core::util::logger::bind_log();
   load_script(
     r#"
     Info("test", "obj", "an info message");
+    Note("a both note");
     NoteSTDERR("a stderr note");
     NoteLog("a log note");
     ProgressSpinup("stage");
@@ -670,6 +678,19 @@ fn diagnostics_surface_info_notes_progress_and_fatal() {
     "#,
   )
   .expect("non-fatal diagnostics must load and run cleanly");
+  let log = latexml_core::util::logger::flush_log();
+  assert!(
+    log.contains("a log note"),
+    "NoteLog did not reach the log:\n{log}"
+  );
+  assert!(
+    log.contains("a both note"),
+    "Note did not reach the log:\n{log}"
+  );
+  assert!(
+    !log.contains("a stderr note"),
+    "NoteSTDERR leaked into the log (it must be stderr only):\n{log}"
+  );
   let fatal = load_script(r#"Fatal("internal", "obj", "boom");"#);
   assert!(fatal.is_err(), "Fatal must abort the script, got {fatal:?}");
   // Clear the run tally so the raised fatal doesn't leak into sibling tests.

--- a/latexml_core/src/common/error.rs
+++ b/latexml_core/src/common/error.rs
@@ -857,24 +857,39 @@ macro_rules! generate_message {
   };
 }
 
+/// Progress note to BOTH the log and stderr — Perl `Note` (`_printline`): the LOG
+/// always (if a buffer is bound, ANSI-stripped), STDERR only when the verbosity
+/// admits it (`$USE_STDERR && $VERBOSITY>=0` ≈ `max_level >= Info`).
 #[macro_export]
 macro_rules! Note {
-  ($input:expr_2021) => {
+  ($input:expr_2021) => {{
+    let msg = $input;
+    $crate::util::logger::note_to_log(&msg.to_string());
     if !$crate::common::error::is_log_output_suppressed()
       && log::max_level() >= log::LevelFilter::Info
     {
-      let msg = $input;
       $crate::println_stderr!("{msg}");
       $crate::util::logger::mark_stderr_at_line_start();
     }
-  };
+  }};
 }
 
+/// Progress note to the LOG only — Perl `NoteLog` (`print $LOG … if $LOG`). Always
+/// written to the bound log buffer (the log is the verbose record), never stderr.
 #[macro_export]
 macro_rules! NoteLog {
   ($input:expr_2021) => {
+    $crate::util::logger::note_to_log(&($input).to_string());
+  };
+}
+
+/// Progress note to STDERR only — Perl `NoteSTDERR` (`if $USE_STDERR &&
+/// $VERBOSITY>=0`). Never touches the log.
+#[macro_export]
+macro_rules! NoteSTDERR {
+  ($input:expr_2021) => {
     if !$crate::common::error::is_log_output_suppressed()
-      && log::max_level() >= log::LevelFilter::Debug
+      && log::max_level() >= log::LevelFilter::Info
     {
       let msg = $input;
       $crate::println_stderr!("{msg}");

--- a/latexml_core/src/util/logger.rs
+++ b/latexml_core/src/util/logger.rs
@@ -81,6 +81,32 @@ pub fn bind_log() { *LOG_BUFFER.borrow_mut() = Some(String::new()); }
 /// Flush and return the captured log output, stopping capture (Perl: flush_log).
 pub fn flush_log() -> String { LOG_BUFFER.borrow_mut().take().unwrap_or_default() }
 
+/// Append a progress note to the captured log (`.latexml.log`) only — the LOG
+/// half of Perl `Note`/`NoteLog` (`Common/Error.pm`: `print $LOG _freshline($LOG),
+/// strip_ansi($message), "\n" if $LOG`). ANSI is stripped and the note lands on
+/// its own fresh line with a single trailing newline, so CorTeX's line-anchored
+/// parser and the `.latexml.log` stay clean (mirrors the diagnostic-record
+/// freshline path below). No-op when no buffer is bound or output is suppressed —
+/// unlike a `log::info!` record it is NOT gated on the stderr verbosity, because
+/// the log is the verbose record (Perl writes it regardless of `$VERBOSITY`).
+pub fn note_to_log(msg: &str) {
+  if crate::common::error::is_log_output_suppressed() {
+    return;
+  }
+  if let Ok(mut buf) = LOG_BUFFER.try_borrow_mut()
+    && let Some(ref mut log) = *buf
+  {
+    let clean = strip_ansi(msg);
+    if !log.is_empty() && !log.ends_with('\n') {
+      log.push('\n');
+    }
+    log.push_str(&clean);
+    if !log.ends_with('\n') {
+      log.push('\n');
+    }
+  }
+}
+
 /// Diagnostics captured from a worker thread by [`capture`], for the main thread
 /// to fold back in via [`replay_captured`]. Carries both the already-formatted
 /// log text AND the `REPORT` count deltas — `LOG_BUFFER` and `REPORT` are BOTH


### PR DESCRIPTION
**Diagnostic.** The `Note!`/`NoteLog!` macros (behind Rhai `NoteLog`/`NoteSTDERR` and engine `\typeout`/`\wlog`/`\show`/the converter identity+verdict) both only called `println_stderr!` — stderr, never the log — and were gated off at default verbosity, so nothing reached `.latexml.log`. Routing also didn't match Perl.

**Approach.** Match Perl `Common/Error.pm`: `Note` = both log+stderr (`_printline`), `NoteLog` = log only/always (`print $LOG … if $LOG`), `NoteSTDERR` = stderr only (verbosity≥0). Add `logger::note_to_log` (append to the bound LOG_BUFFER, ANSI-stripped, fresh-lined, not stderr-gated); rewire `Note!`/`NoteLog!` + new `NoteSTDERR!`; Rhai gains a `Note` fn and routes `NoteSTDERR` to the stderr-only macro. Engine progress notes (identity, `(Loading …)`, `\typeout`, "Conversion complete") now reach the log too, as Perl does.

**Validation.** Guard `script_bindings::tests::diagnostics_surface_info_notes_progress_and_fatal` captures the log and asserts Note/NoteLog land there while NoteSTDERR does not. API.md regenerated (+`Note`, corrected `NoteSTDERR`). Full suite **1986/0**; runtime-bindings **28/0**; clippy/fmt clean.

Closes #593