### PR TITLE
feat #594: expose canContain, floatToElement to Rhai

### DIFF
--- a/latexml_contrib/src/script_bindings/API.md
+++ b/latexml_contrib/src/script_bindings/API.md
@@ -145,7 +145,7 @@ Called at the top level of a binding file, or from inside any body.
 
 Reached through the `document` handle a constructor body receives as its first argument — Perl's `$document->method`.
 
-25 functions, 35 calls.
+27 functions, 39 calls.
 
 | call | documentation |
 |---|---|
@@ -154,10 +154,12 @@ Reached through the `document` handle a constructor body receives as its first a
 | `absorbString(string)` | Absorb a plain string at the current insertion point. ([`Document::absorb_string`](latexml_core::document::Document::absorb_string)) |
 | `addClass(Node, string)` | Add CSS classes to a node, keeping those it already has. ([`Document::add_class`](latexml_core::document::Document::add_class)) |
 | `appendClone(Node, array)` | Append COPIES of nodes, with fresh ids. ([`Document::append_clone`](latexml_core::document::Document::append_clone)) |
+| `canContain(Node, string) -> bool`<br>`canContain(string, string) -> bool` | May an element (a node or a qname) contain a child qname? — the schema query before opening an element. ([`can_contain`](latexml_core::document::can_contain)) |
 | `closeElement(string)` | Close the deepest open element of that name. ([`Document::close_element`](latexml_core::document::Document::close_element)) |
 | `closeElementAt(Node)` | Close an element that was opened with `openElementAt`. ([`Document::close_element_at`](latexml_core::document::Document::close_element_at)) |
 | `findnode(string) -> Node?`<br>`findnode(string, Node) -> Node?` | The first node matching an XPath. ([`Document::findnode`](latexml_core::document::Document::findnode)) |
 | `findnodes(string) -> array`<br>`findnodes(string, Node) -> array` | Every node matching an XPath. ([`Document::findnodes`](latexml_core::document::Document::findnodes)) |
+| `floatToElement(string) -> Node?`<br>`floatToElement(string, bool) -> Node?` | Move the insertion point up to the nearest ancestor that can contain a qname; returns the previous point to `setNode` back to (or `()`). ([`Document::float_to_element`](latexml_core::document::Document::float_to_element)) |
 | `generateID(Node, string)` | Give a node an `xml:id`, if it has none. ([`Document::generate_id`](latexml_core::document::Document::generate_id)) |
 | `getElement() -> Node?` | The element at, or containing, the insertion point. ([`Document::get_element`](latexml_core::document::Document::get_element)) |
 | `getNode() -> Node` | The current insertion point. ([`Document::get_node`](latexml_core::document::Document::get_node)) |

--- a/latexml_contrib/src/script_bindings/api_doc.rs
+++ b/latexml_contrib/src/script_bindings/api_doc.rs
@@ -67,6 +67,7 @@ const RETURN_OVERRIDES: &[(&str, &str)] = &[
   ("LookupDefinition", "Definition?"),
   ("children", "array"),
   ("findnode", "Node?"),
+  ("floatToElement", "Node?"),
   ("firstChild", "Node?"),
   ("getElement", "Node?"),
   ("getNode", "Node"),
@@ -811,6 +812,14 @@ const DOCS: &[(&str, Doc)] = &[
     ),
   ),
   (
+    "canContain",
+    Doc::Rust(
+      "May an element (a node or a qname) contain a child qname? — the schema \
+       query before opening an element.",
+      "latexml_core::document::can_contain",
+    ),
+  ),
+  (
     "closeElement",
     Doc::Rust(
       "Close the deepest open element of that name.",
@@ -858,6 +867,14 @@ const DOCS: &[(&str, Doc)] = &[
     Doc::Rust(
       "The node's first child, or `()`.",
       "libxml::tree::Node::get_first_child",
+    ),
+  ),
+  (
+    "floatToElement",
+    Doc::Rust(
+      "Move the insertion point up to the nearest ancestor that can contain a \
+       qname; returns the previous point to `setNode` back to (or `()`).",
+      "latexml_core::document::Document::float_to_element",
     ),
   ),
   (

--- a/latexml_contrib/src/script_bindings/engine.rs
+++ b/latexml_contrib/src/script_bindings/engine.rs
@@ -1344,6 +1344,57 @@ pub(super) fn make_engine() -> Engine {
     with_doc_infallible(|doc| node_or_unit(doc.get_element()))
   });
 
+  // canContain (Perl `canContain`, Document.pm:160) — the schema query a binding
+  // asks before opening an element: may `tag` (a node OR a qname) hold a `child`
+  // qname? The motivating use (#594) is `canContain(node, "#PCDATA")` to decide
+  // whether a text-bearing wrapper (`ltx:p`) must be opened first. Read-only, so
+  // it is `with_doc_infallible` — meaningful only inside a body (where a live
+  // node handle exists); `false` outside one.
+  engine.register_fn(
+    "canContain",
+    |_d: &mut DocProxy, tag: NodeProxy, child: &str| -> bool {
+      with_doc_infallible(|_doc| latexml_core::document::can_contain(&tag.0, child))
+    },
+  );
+  engine.register_fn(
+    "canContain",
+    |_d: &mut DocProxy, tag: &str, child: &str| -> bool {
+      with_doc_infallible(|_doc| latexml_core::document::can_contain_qname(tag, child))
+    },
+  );
+
+  // floatToElement (Perl `floatToElement`, Document.pm:1052) — move the insertion
+  // point up to the nearest ancestor that can contain `qname`, and RETURN the
+  // previous insertion point (a `Node`, or `()` if none can) so the caller can
+  // `setNode(saved)` to restore it after inserting. The 2-arg form passes Perl's
+  // `$closeifpossible`: close the intervening auto-closable nodes instead of just
+  // repositioning. Mutating, so `with_doc`.
+  engine.register_fn(
+    "floatToElement",
+    |_d: &mut DocProxy, qname: &str| -> std::result::Result<Dynamic, Box<EvalAltResult>> {
+      with_doc(|doc, _props| {
+        Ok(node_or_unit(
+          doc.float_to_element(qname, false).map_err(rhai_err)?,
+        ))
+      })
+    },
+  );
+  engine.register_fn(
+    "floatToElement",
+    |_d: &mut DocProxy,
+     qname: &str,
+     closeifpossible: bool|
+     -> std::result::Result<Dynamic, Box<EvalAltResult>> {
+      with_doc(|doc, _props| {
+        Ok(node_or_unit(
+          doc
+            .float_to_element(qname, closeifpossible)
+            .map_err(rhai_err)?,
+        ))
+      })
+    },
+  );
+
   // insertElement (Perl `insertElement`, Document.pm:639) — open, absorb the
   // content, close, and hand back the node. The ELEMENT counterpart that
   // `insertXML` is named after; it was the one missing half of that pairing.

--- a/latexml_oxide/tests/30_script_bindings.rs
+++ b/latexml_oxide/tests/30_script_bindings.rs
@@ -784,6 +784,28 @@ const XMLAPI_SAMPLE: &str = r##"
       assign_global("xq:orphanmsg", "" + e);
     }
   });
+
+  // canContain / floatToElement (Perl `canContain`/`floatToElement`, #594): the
+  // schema query + insertion-point search a binding uses to place an element
+  // where the model allows (the motivating case: patching \hrule/\vrule).
+  DefConstructor("\\xqmodel", |document| {
+    // qname/qname form — stable schema facts.
+    assign_global("xq:cc_p_text", if document.canContain("ltx:p", "#PCDATA") {"yes"} else {"no"});
+    assign_global("xq:cc_p_sec",  if document.canContain("ltx:p", "ltx:section") {"yes"} else {"no"});
+    // node form (the documented `canContain(node, "#PCDATA")` use) must agree
+    // with the qname form for that same node's tag.
+    let here = document.getNode();
+    let qn = here.qname();
+    assign_global("xq:cc_node_agrees",
+      if document.canContain(here, "#PCDATA") == document.canContain(qn, "#PCDATA") {"yes"} else {"no"});
+    // floatToElement returns the PREVIOUS insertion point to setNode back to.
+    let before = document.getNode().qname();
+    let saved = document.floatToElement("ltx:para");
+    assign_global("xq:float_kind", type_of(saved));
+    if type_of(saved) != "()" { document.setNode(saved); }
+    assign_global("xq:float_restored",
+      if document.getNode().qname() == before {"yes"} else {"no"});
+  });
 "##;
 
 fn xmlapi_dispatch(request: &str) -> Option<Result<()>> {
@@ -820,6 +842,7 @@ fn document_xml_api_matches_the_compile_time_surface() {
     "\\xqbuild{wrap}\\xqbuild{clone}\\xqbuild{replace}\\xqbuild{mover}",
     "\\xqbuild{at}\\xqbuild{orphan}",
     "\\xqfind \\xqmutate \\xqat \\xqforeign \\xqorphan ",
+    "some text \\xqmodel ",
     "\\end{document}"
   );
   let doc = latexml
@@ -939,6 +962,34 @@ fn document_xml_api_matches_the_compile_time_surface() {
     get_status(LogStatus::Fatal) == 0,
     "the XML surface escalated to Fatal: {}",
     latexml_core::common::error::get_status_message()
+  );
+
+  // ── canContain / floatToElement (#594) ──
+  assert_eq!(
+    g("xq:cc_p_text"),
+    "yes",
+    "canContain(qname, #PCDATA): ltx:p must be able to hold text"
+  );
+  assert_eq!(
+    g("xq:cc_p_sec"),
+    "no",
+    "canContain(qname, qname): ltx:p must NOT be able to hold an ltx:section"
+  );
+  assert_eq!(
+    g("xq:cc_node_agrees"),
+    "yes",
+    "canContain(node, ..) must agree with canContain(qname, ..) for that node's tag"
+  );
+  assert_eq!(
+    g("xq:float_kind"),
+    "Node",
+    "floatToElement must return the previous insertion point as a Node, got {:?}",
+    g("xq:float_kind")
+  );
+  assert_eq!(
+    g("xq:float_restored"),
+    "yes",
+    "the Node floatToElement returned must setNode back to the original point"
   );
 
   drop(latexml);


### PR DESCRIPTION
**Diagnostic.** Two `Core/Document.pm` schema/insertion-point queries had no runtime-bindings surface: `canContain` (may an element hold a child qname?) and `floatToElement` (move the insertion point to a valid ancestor). @xworld21 needs both to patch `\hrule`/`\vrule` inline-vs-block placement from a `.rhai` binding.

**Approach.** Thin 1:1 registrations over the existing core functions, following the established `DocProxy` pattern: `canContain(node|qname, qname) -> bool` (`document::can_contain`/`can_contain_qname`, Document.pm:160, read-only via `with_doc_infallible`), and `floatToElement(qname[, closeifpossible]) -> Node?` (`Document::float_to_element`, Document.pm:1052, mutating via `with_doc`) returning the previous insertion point to `setNode` back to.

**Validation.** Extended guard `document_xml_api_matches_the_compile_time_surface` (both `canContain` forms + `floatToElement` return/restore); `API.md` regenerated and `api_reference_is_up_to_date` green; full suite 1987/0; clippy `--workspace --all-targets` + rustdoc `-D warnings` clean.

Closes #594