### PR TITLE
fix: biblatex style packages (biblatex-chicago, …) render their bibliography

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@
     list floated into a paragraph and vanished, every `\cite` left dangling. The
     environment is now bound like `bibdiv`, titled from its optional heading
     (default "References"). Witness arXiv 2405.18501 (arXiv/html_feedback#1393).
+  - **biblatex style packages (`biblatex-chicago`, `-apa`, `-ieee`, …) now render
+    their bibliography.** A `\usepackage{biblatex-chicago}` variant never loaded
+    the biblatex binding, so its preamble `\DeclareFieldFormat`/`\renewbibmacro`
+    customization was undefined and the biber `.bbl` — guarded on
+    `\ver@biblatex.sty` — emptied the whole References list. Variant names now
+    route to the biblatex binding (as each `.sty` really does via
+    `\RequirePackage{biblatex}`), and the binding marks `\ver@biblatex.sty` so the
+    `.bbl` renders. Witness arXiv 2605.11180 (arXiv/html_feedback#6601).
   - **A biblatex `\DeclareSourcemap` block no longer breaks the conversion.**
     Source mapping is a biber pre-processing stage LaTeXML does not run;
     `\DeclareSourcemap` (and `\DeclareStyleSourcemap`) were undefined, so the

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4315,6 +4315,49 @@ arXiv 2602.00643 (html_feedback#5930) — `\documentclass{revtex4-2}` +
 `cluster_bib_natbib_numeric_sorted_stays_alphabetical` +
 `cluster_bib_natbib_authoryear_stays_alphabetical` (the unsorted + numeric gates).
 
+### 117. biblatex style/variant packages load the native biblatex binding
+
+**Perl** LaTeXML ships **no** `biblatex.sty.ltxml` at all — biblatex is
+unsupported upstream. latexml-oxide's `latexml_contrib/src/biblatex_sty.rs` is a
+surpass-Perl native binding (see #62), reached when the document `\usepackage`s
+**`biblatex`** or fires the `\addbibresource`/`\printbibliography` autoload. But
+the biblatex ecosystem ships dozens of **style/variant** packages —
+`biblatex-chicago`, `biblatex-apa`, `biblatex-ieee`, `biblatex-nature`,
+`biblatex-science`, `biblatex-phys`, `biblatex-chem`, … — each of which in
+reality does `\RequirePackage{biblatex}` and then only *configures* it. Their
+configuration commands (`\DeclareFieldFormat`, `\DeclareFieldAlias`,
+`\renewbibmacro`, …) run in the **preamble**, before any `\addbibresource`. With
+no binding for the variant name, those commands were undefined the moment they
+were used, and — separately — every biber-generated `.bbl` opens with the guard
+`\@ifundefined{ver@biblatex.sty}{\@latex@error{Missing 'biblatex' package}…
+\aftergroup\endinput}{}`, so the `.bbl` `\endinput`ed itself and the **entire
+References list came out empty** (0 bibitems, a flood of preamble
+`Error:undefined:`s).
+
+**Rust behavior**: (1) `latexml_contrib::dispatch` routes any `biblatex-<style>.sty`
+name to the biblatex binding — reproducing the `\RequirePackage{biblatex}` the
+variant's real `.sty` performs. (2) The biblatex binding itself now sets
+`\ver@biblatex.sty` (mirroring biblatex.sty's own `\ProvidesPackage{biblatex}`),
+so the biber `.bbl` guard passes no matter how biblatex was loaded — including
+the variant path, where the package machinery would otherwise only set
+`\ver@biblatex-chicago.sty`. The variant's preamble customization commands
+resolve (as the biblatex binding's no-op/gobble stubs), and the `.bbl` renders
+its entries.
+
+**Why**: matching the published PDF, whose bibliography is present, beats an
+empty References list; and the variant packages genuinely reduce to
+`biblatex` + configuration, so routing them there is faithful to what the real
+`.sty` does. Perl produces nothing here, so this is purely additive.
+
+**Witness**: arXiv 2605.11180 (html_feedback #6601) —
+`\usepackage[authordate,backend=biber]{biblatex-chicago}` via a `biblatex-aer.tex`
+helper full of `\DeclareFieldFormat`/`\renewbibmacro`; biber `.bbl` format 3.3.
+Before: 13 errors, 0 bibitems. After: 0 errors, 56 rendered bibitems.
+
+**Guard**: `06_cluster_bibliography::cluster_bib_biblatex_variant_loads_and_renders`
+(`\usepackage{biblatex-chicago}` + preamble `\DeclareFieldFormat` + biber `.bbl`:
+customization does not leak/error and the References populate).
+
 ### 118. amsrefs `{bibsection}` is a bound environment
 
 **Perl** LaTeXML's `amsrefs.sty.ltxml` binds `{bibdiv}` and `{biblist}` but not

--- a/latexml_contrib/src/biblatex_sty.rs
+++ b/latexml_contrib/src/biblatex_sty.rs
@@ -719,6 +719,26 @@ LoadDefinitions!({
   Info!("bibliography", "biblatex",
     "biblatex.sty is provided by a native binding, not interpreted raw.");
 
+  // Mark biblatex as provided, exactly as the real biblatex.sty's
+  // `\ProvidesPackage{biblatex}[…]` does (latex_constructs `\ProvidesPackage`
+  // → `\ver@biblatex.sty`). Every biber-generated `.bbl` opens with the guard
+  //   \@ifundefined{ver@biblatex.sty}{\@latex@error{Missing 'biblatex' package}
+  //     …\aftergroup\endinput}{}
+  // so without `\ver@biblatex.sty` the `.bbl` `\endinput`s itself and the whole
+  // References list is empty. The normal `\usepackage{biblatex}` path gets this
+  // marker under the requested name from the package machinery, but a biblatex
+  // *variant* (`\usepackage{biblatex-chicago}`, routed here by
+  // `latexml_contrib::dispatch`'s `biblatex-*` fallback) would otherwise only
+  // set `\ver@biblatex-chicago.sty`, leaving the guard's `\ver@biblatex.sty`
+  // undefined. Setting it in the binding itself covers every load path.
+  // Witness arXiv 2605.11180 (html_feedback #6601): biber `.bbl` format 3.3,
+  // empty References before this marker.
+  {
+    let ver_cs = T_CS!("\\ver@biblatex.sty");
+    DefMacro!(ver_cs, None, "2023/03/05 v3.19 Sophisticated Bibliographies (PK/MW)",
+      scope => Some(Scope::Global));
+  }
+
   // Perl option processing: maxbibnames, style/citestyle keyvals, ignore
   // the rest. Perl wires these through DefKeyVal `code` callbacks; here we
   // register the keys for keyset parity and read the raw package-option

--- a/latexml_contrib/src/lib.rs
+++ b/latexml_contrib/src/lib.rs
@@ -627,6 +627,29 @@ pub fn dispatch(filename: &str) -> Option<Result<()>> {
       })
     })
     .map(|(_, _, loader)| loader())
+    // biblatex style/variant packages (`biblatex-chicago`, `biblatex-apa`,
+    // `biblatex-ieee`, `biblatex-nature`, `biblatex-science`, `biblatex-mla`,
+    // `biblatex-phys`, `biblatex-chem`, …) each begin their real `.sty` with
+    // `\RequirePackage{biblatex}` and then only *configure* it; the
+    // configuration commands (`\DeclareFieldFormat`, `\renewbibmacro`, …) run
+    // in the preamble. Without a binding for the variant name, that
+    // `\RequirePackage{biblatex}` never happens, so those commands are
+    // undefined the moment they are used — before the `\addbibresource`
+    // autoload trigger fires — and the whole bibliography collapses (0
+    // bibitems). Route every `biblatex-<style>.sty` to the biblatex binding,
+    // reproducing the `\RequirePackage{biblatex}` the variant would have done.
+    // Perl LaTeXML ships no biblatex binding at all, so this is surpass-Perl,
+    // consistent with the existing biblatex contrib. Witness arXiv 2605.11180
+    // (`\usepackage[authordate,backend=biber]{biblatex-chicago}` via
+    // `biblatex-aer.tex`; html_feedback #6601): `\DeclareFieldFormat`
+    // undefined, empty References, before this fallback.
+    .or_else(|| {
+      let lower = base_only.to_ascii_lowercase();
+      (ext.eq_ignore_ascii_case("sty")
+        && lower.len() > "biblatex-".len()
+        && lower.starts_with("biblatex-"))
+      .then(biblatex_sty::load_definitions)
+    })
 }
 
 /// All registered (name, extension) pairs for this crate's BINDINGS.

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -641,6 +641,36 @@ fn cluster_biblatex_authoryear() {
     "numeric doc must not get author-year tags:\n{x}"
   );
 }
+
+/// A biblatex *style/variant* package — `biblatex-chicago` here, but the whole
+/// `biblatex-<style>` family (`-apa`/`-ieee`/`-nature`/`-science`/`-phys`/…) —
+/// must load the biblatex binding, because each such `.sty` in reality does
+/// `\RequirePackage{biblatex}` and then only configures it. Its configuration
+/// commands (`\DeclareFieldFormat`, `\DeclareFieldAlias`) run in the preamble,
+/// so if the variant name is unbound they are undefined at use, and every biber
+/// `.bbl` `\endinput`s itself at its `\@ifundefined{ver@biblatex.sty}` guard —
+/// emptying the References list outright. html_feedback #6601, witness arXiv
+/// 2605.11180 (`\usepackage[authordate,backend=biber]{biblatex-chicago}` via
+/// `biblatex-aer.tex`): 13 errors and 0 bibitems before the fix, 0 errors and a
+/// full bibliography after. Guards both halves: the preamble `\DeclareFieldFormat`
+/// does not leak/error, and the `.bbl` renders its entries.
+#[test]
+fn cluster_bib_biblatex_variant_loads_and_renders() {
+  let x = convert_to_xml_contrib("tests/cluster_regressions/biblatex_ay/chicago.tex");
+  assert!(
+    !x.contains("DeclareFieldFormat"),
+    "preamble \\DeclareFieldFormat leaked raw / errored (biblatex-chicago did not load biblatex):\n{x}"
+  );
+  assert!(
+    x.contains(r#"<bibitem key="smith2020""#),
+    "biblatex-chicago produced no References (biber .bbl guard emptied the list):\n{x}"
+  );
+  assert!(
+    x.contains("Smith"),
+    "biblatex-chicago bibitem missing its author text:\n{x}"
+  );
+}
+
 /// apacite spells its citation pre-note in ANGLE brackets:
 /// `\cite<pre-note>[post-note]{key-list}` (apacite.sty L259-311 dispatch
 /// `\@ifnextchar< {\@cite} {\@cite<>}`, L313-327 `\def\@cite<#1>`). Without that

--- a/latexml_oxide/tests/cluster_regressions/biblatex_ay/chicago.bbl
+++ b/latexml_oxide/tests/cluster_regressions/biblatex_ay/chicago.bbl
@@ -1,0 +1,97 @@
+% $ biblatex auxiliary file $
+% $ biblatex bbl format version 3.2 $
+% Do not modify the above lines!
+\begingroup
+\makeatletter
+\@ifundefined{ver@biblatex.sty}
+  {\@latex@error
+     {Missing 'biblatex' package}
+     {The bibliography requires the 'biblatex' package.}
+      \aftergroup\endinput}
+  {}
+\endgroup
+
+\refsection{0}
+  \datalist[entry]{nyt/global//global/global}
+    \entry{smith2020}{article}{}
+      \name{author}{1}{}{%
+        {{un=0,uniquepart=base,hash=3f8a2b}{%
+           family={Smith},
+           familyi={S\bibinitperiod},
+           given={John},
+           giveni={J\bibinitperiod}}}%
+      }
+      \strng{namehash}{3f8a2b}
+      \strng{fullhash}{3f8a2b}
+      \field{sortinit}{S}
+      \field{labelnamesource}{author}
+      \field{labeltitlesource}{title}
+      \field{journaltitle}{Journal of Testing}
+      \field{title}{A study of things}
+      \field{volume}{12}
+      \field{year}{2020}
+      \field{pages}{1\bibrangedash 20}
+    \endentry
+    \entry{jones2019}{article}{}
+      \name{author}{2}{}{%
+        {{un=0,uniquepart=base,hash=a1b2c3}{%
+           family={Jones},
+           familyi={J\bibinitperiod},
+           given={Alice},
+           giveni={A\bibinitperiod}}}%
+        {{un=0,uniquepart=base,hash=d4e5f6}{%
+           family={Brown},
+           familyi={B\bibinitperiod},
+           given={Bob},
+           giveni={B\bibinitperiod}}}%
+      }
+      \strng{namehash}{a1b2c3d4e5f6}
+      \field{sortinit}{J}
+      \field{journaltitle}{Review of Examples}
+      \field{title}{On examples \& counterexamples}
+      \field{year}{2019}
+    \endentry
+    \entry{trio2021}{book}{}
+      \name{author}{3}{}{%
+        {{un=0,uniquepart=base,hash=111111}{%
+           family={Adams},
+           familyi={A\bibinitperiod},
+           given={Carol},
+           giveni={C\bibinitperiod}}}%
+        {{un=0,uniquepart=base,hash=222222}{%
+           family={Baker},
+           familyi={B\bibinitperiod},
+           given={Dan},
+           giveni={D\bibinitperiod}}}%
+        {{un=0,uniquepart=base,hash=333333}{%
+           family={Clark},
+           familyi={C\bibinitperiod},
+           given={Eve},
+           giveni={E\bibinitperiod}}}%
+      }
+      \strng{namehash}{112233}
+      \field{sortinit}{A}
+      \field{title}{The trio book}
+      \field{year}{2021}
+      \list{publisher}{1}{%
+        {Simon \& Schuster}%
+      }
+    \endentry
+    \entry{vandenberg2018}{article}{}
+      \name{author}{1}{}{%
+        {{un=0,uniquepart=base,hash=444444}{%
+           family={Berg},
+           familyi={B\bibinitperiod},
+           given={Pieter},
+           giveni={P\bibinitperiod},
+           prefix={van den},
+           prefixi={v\bibinitperiod\bibinitdelim d\bibinitperiod}}}%
+      }
+      \strng{namehash}{444444}
+      \field{sortinit}{B}
+      \field{journaltitle}{Dutch Journal}
+      \field{title}{Prefixed names}
+      \field{year}{2018}
+    \endentry
+  \enddatalist
+\endrefsection

--- a/latexml_oxide/tests/cluster_regressions/biblatex_ay/chicago.tex
+++ b/latexml_oxide/tests/cluster_regressions/biblatex_ay/chicago.tex
@@ -1,0 +1,15 @@
+\documentclass{article}
+% biblatex *variant* package (a whole family: biblatex-chicago / -apa / -ieee /
+% -nature / ...). Each does \RequirePackage{biblatex} then configures it, so its
+% configuration commands (\DeclareFieldFormat, ...) run in the preamble. Without
+% routing the variant name to the biblatex binding these are undefined the
+% moment they are used, and the biber .bbl's \ver@biblatex.sty guard empties the
+% References. html_feedback #6601, witness arXiv 2605.11180.
+\usepackage[authordate,backend=biber]{biblatex-chicago}
+\DeclareFieldFormat{citehyperref}{#1}
+\DeclareFieldAlias{bibhyperref}{noformat}
+\addbibresource{refs.bib}
+\begin{document}
+Cite: \cite{smith2020} and \parencite{jones2019}.
+\printbibliography
+\end{document}


### PR DESCRIPTION
**Diagnostic.** `\usepackage{biblatex-chicago}` (and the whole `biblatex-<style>`
family) never loaded the native biblatex binding: the autoload triggers are
`\addbibresource`/`\printbibliography`, but the variant's preamble customization
(`\DeclareFieldFormat`, `\renewbibmacro`, …, run via an `\input`ed helper) fires
first, so those commands were undefined. Separately, every biber `.bbl` guards on
`\@ifundefined{ver@biblatex.sty}` and `\endinput`s itself when it is unset — which
it was on any path that did not load biblatex under its own name. Net: 13 preamble
errors and an empty References list.

**Approach.** Two faithful mirrors of what the real `.sty` does: (1)
`latexml_contrib::dispatch` routes any `biblatex-<style>.sty` name to the biblatex
binding — the `\RequirePackage{biblatex}` every variant performs; (2) the biblatex
binding sets `\ver@biblatex.sty` itself — biblatex.sty's own
`\ProvidesPackage{biblatex}` — so the `.bbl` guard passes on every load path
(plain or variant). Perl ships no biblatex binding at all, so this is
surpass-Perl, extending the existing biblatex contrib (OXIDIZED_DESIGN #62/#117).

**Validation.** New guard `06_cluster_bibliography::cluster_bib_biblatex_variant_loads_and_renders`
(`\usepackage{biblatex-chicago}` + preamble `\DeclareFieldFormat` + biber `.bbl`:
customization does not leak/error and the References populate); full suite green;
clippy/fmt clean. Verified on witness arXiv 2605.11180: 13 errors / 0 bibitems →
0 errors / 56 rendered bibitems, no raw-key leaks.

Addresses arXiv/html_feedback#6601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
