### PR TITLE
fix: amsrefs `{bibsection}` environment renders its References

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
     `\bibliographystyle` name is recorded before natbib can drop it, so a
     revtex4-2 or `[numbers]natbib` paper with `ieeetr` is numbered by citation
     order too (arXiv/html_feedback#5930, #6095).
+  - **amsrefs papers that open with `\begin{bibsection}` now render their
+    References.** `bibsection` is amsrefs' real section-heading wrapper around
+    `{biblist}` (with `bibdiv` defined as it), but only `bibdiv`/`biblist` were
+    bound, so `\begin{bibsection}` was an undefined environment — the reference
+    list floated into a paragraph and vanished, every `\cite` left dangling. The
+    environment is now bound like `bibdiv`, titled from its optional heading
+    (default "References"). Witness arXiv 2405.18501 (arXiv/html_feedback#1393).
   - **A biblatex `\DeclareSourcemap` block no longer breaks the conversion.**
     Source mapping is a biber pre-processing stage LaTeXML does not run;
     `\DeclareSourcemap` (and `\DeclareStyleSourcemap`) were undefined, so the

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4314,3 +4314,36 @@ arXiv 2602.00643 (html_feedback#5930) — `\documentclass{revtex4-2}` +
 `cluster_bib_natbib_numeric_citation_order` (the natbib/revtex arm),
 `cluster_bib_natbib_numeric_sorted_stays_alphabetical` +
 `cluster_bib_natbib_authoryear_stays_alphabetical` (the unsorted + numeric gates).
+
+### 118. amsrefs `{bibsection}` is a bound environment
+
+**Perl** LaTeXML's `amsrefs.sty.ltxml` binds `{bibdiv}` and `{biblist}` but not
+`{bibsection}`. In the real `amsrefs.sty` (L1251/L1265) it is the other way round:
+`{bibsection}[⟨heading⟩]` is the primitive section-heading wrapper around
+`{biblist}`, and `{bibdiv}` is *defined as* `{bibsection}` in article mode
+(`\newenvironment{bibdiv}{\bibsection}{\endbibsection}`). So an amsrefs paper that
+opens its references with `\begin{bibsection}` directly — common in AMS templates
+— hit `Environment {bibsection} is not defined`: the `<ltx:biblist>` then floated
+in an `<ltx:p>` (schema-invalid) and the **entire References list was lost**, with
+every `\cite` left dangling. latexml-oxide reproduced this (SHARED gap — Perl
+errors identically).
+
+**Rust behavior**: `latexml_package::amsrefs_sty` binds `{bibsection}[Default:\refname]`
+to the **same** `<ltx:bibliography>` container and digest hooks as `{bibdiv}`, with
+the optional argument as the `<ltx:title>` (default `\refname` → "References",
+which is also `begin_bibliography_clean`'s own fallback, so a no-argument
+`\begin{bibsection}` and `\begin{bibdiv}` render identically). The entries digest
+into `<ltx:bibentry>` and MakeBibliography converts them to `<ltx:bibitem>` exactly
+as the `bibdiv` path already did.
+
+**Why**: matching the published PDF — whose bibliography is present — beats an empty
+References list, and `bibsection` is a real, load-bearing amsrefs environment, so
+binding it is a faithful port of the package Perl's incomplete `.ltxml` omitted.
+
+**Witness**: arXiv 2405.18501 (html_feedback #1393) — `\documentclass{amsart}`,
+`\usepackage[numeric]{amsrefs}`, references in `\begin{bibsection}\begin{biblist}`.
+Before: 2 errors, 0 bibitems. After: 0 errors, 6 rendered bibitems.
+
+**Guard**: `06_cluster_bibliography::amsrefs_bibsection_environment_renders`
+(`\begin{bibsection}` + `{biblist}` + `\bib` entries: References populate, entries
+convert to `<ltx:bibitem>`, no stray `<ltx:bibentry>`).

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -761,6 +761,35 @@ fn amsrefs_inline_bibliography_is_not_dropped() {
      children were flattened to plain text:\n{x}"
   );
 }
+
+/// amsrefs papers commonly open their references with `\begin{bibsection}`
+/// rather than `\begin{bibdiv}` — in real `amsrefs.sty` (L1251/L1265) `bibdiv`
+/// IS `bibsection` in article mode, the section-heading wrapper around
+/// `{biblist}`. Perl (and, before this, the Rust port) bound only `bibdiv`, so
+/// `\begin{bibsection}` was an undefined environment: the `<ltx:biblist>`
+/// floated in an `<ltx:p>` (schema-invalid) and the entire References list was
+/// lost. The environment now renders the same `<ltx:bibliography>` container as
+/// `bibdiv`, titled from its optional arg (default `\refname`). Shared gap with
+/// Perl, faithful port of the real `.sty`. html_feedback #1393, witness arXiv
+/// 2405.18501 (`\documentclass{amsart}`, `\usepackage[numeric]{amsrefs}`).
+#[test]
+fn amsrefs_bibsection_environment_renders() {
+  let x = convert_and_post("tests/cluster_regressions/amsrefs_bibsection.tex");
+  assert!(
+    x.contains("<bibitem"),
+    "\\begin{{bibsection}} produced no References (environment undefined?):\n{x}"
+  );
+  assert!(
+    !x.contains("<bibentry"),
+    "an ltx:bibentry survived unconverted from the bibsection list:\n{x}"
+  );
+  for needle in ["References", "Chakerian", "Gruber", "Convex"] {
+    assert!(
+      x.contains(needle),
+      "bibsection entry content `{needle}` missing:\n{x}"
+    );
+  }
+}
 /// Loading `bibunits` — even without ever opening a `bibunit` environment —
 /// made EVERY citation dangle. `\cite` runs bibunits' `\lx@bibunits@resetglobal`,
 /// stamping `CITE_UNIT=bu0`, so the bibref asks for `BIBLABEL:bu0:<key>`; the

--- a/latexml_oxide/tests/cluster_regressions/amsrefs_bibsection.tex
+++ b/latexml_oxide/tests/cluster_regressions/amsrefs_bibsection.tex
@@ -1,0 +1,23 @@
+\documentclass{amsart}
+\usepackage[numeric]{amsrefs}
+\begin{document}
+See \cite{CG} and \cite{G}.
+% amsrefs papers open the references with \begin{bibsection} (= \bibdiv in
+% article mode). Without the environment the biblist floats in an <ltx:p> and
+% the whole References list is lost. html_feedback #1393, witness 2405.18501.
+\begin{bibsection}
+\begin{biblist}
+\bib{CG}{article}{
+  author={Chakerian, G. D.},
+  title={Convex bodies of constant width},
+  journal={J. Math},
+  date={1983},
+}
+\bib{G}{book}{
+  author={Gruber, P. M.},
+  title={Convex and discrete geometry},
+  date={2007},
+}
+\end{biblist}
+\end{bibsection}
+\end{document}

--- a/latexml_package/src/package/amsrefs_sty.rs
+++ b/latexml_package/src/package/amsrefs_sty.rs
@@ -79,6 +79,33 @@ LoadDefinitions!({
       Let!("\\par", "\\relax");
     });
 
+  // {bibsection}[heading] — real amsrefs.sty L1251. amsrefs defines `bibdiv`
+  // AS `bibsection` in article mode (`\newenvironment{bibdiv}{\bibsection}
+  // {\endbibsection}`, L1265): `bibsection` is the section-heading wrapper
+  // around `{biblist}`, its optional arg the heading (default `\refname`).
+  // Perl amsrefs.sty.ltxml binds only `bibdiv`/`biblist`, so a paper that opens
+  // its references with `\begin{bibsection}` directly hit `Environment
+  // {bibsection} is not defined` and lost the whole References list (the
+  // `<ltx:biblist>` then floated in an `<ltx:p>`). Shared gap with Perl; this is
+  // a faithful port of the real `.sty`. Same `<ltx:bibliography>` container and
+  // hooks as `bibdiv`; the optional arg is the title (begin_bibliography_clean
+  // also defaults an absent title to `\refname`, matching `[\refname]`).
+  // html_feedback #1393, witness arXiv 2405.18501 (`\documentclass{amsart}`,
+  // `\usepackage[numeric]{amsrefs}`, 6 `\bib` entries).
+  DefEnvironment!("{bibsection}[Default:\\refname]",
+    "<ltx:bibliography xml:id='#id' \
+     bibstyle='#bibstyle' citestyle='#citestyle' sort='#sort'>\
+     <ltx:title font='#titlefont' _force_font='true'>#1</ltx:title>\
+     #body\
+     </ltx:bibliography>",
+    before_digest => {
+      engine::latex_constructs::before_digest_bibliography()?;
+    },
+    after_digest_begin => sub[whatsit] {
+      engine::latex_constructs::begin_bibliography_clean(whatsit)?;
+      Let!("\\par", "\\relax");
+    });
+
   // {biblist} environment
   DefEnvironment!("{biblist}", "<ltx:biblist>#body</ltx:biblist>");
 


### PR DESCRIPTION
**Diagnostic.** `amsrefs.sty.ltxml` binds `{bibdiv}`/`{biblist}` but not
`{bibsection}` — yet in the real `amsrefs.sty` `bibsection` is the primitive
section-heading wrapper and `bibdiv` is *defined as* it. So an amsrefs paper that
opens its references with `\begin{bibsection}` (common in AMS templates) hit an
undefined environment: `<ltx:biblist>` floated into an `<ltx:p>` and the whole
References list was lost, every `\cite` dangling.

**Approach.** Bind `{bibsection}[Default:\refname]` in `amsrefs_sty` to the same
`<ltx:bibliography>` container and digest hooks as `{bibdiv}`, with the optional
arg as the title (default `\refname`, which is also `begin_bibliography_clean`'s
own fallback — so `\begin{bibsection}` and `\begin{bibdiv}` render identically).
Faithful port of the real `.sty`; shared gap with Perl (which errors the same),
recorded as OXIDIZED_DESIGN #118.

**Validation.** New guard `06_cluster_bibliography::amsrefs_bibsection_environment_renders`
(entries populate, convert to `<ltx:bibitem>`, no stray `<ltx:bibentry>`); bibliography
binary 54/54; full suite green; clippy/fmt clean. Verified on witness arXiv 2405.18501:
2 errors / 0 bibitems → 0 errors / 6 rendered bibitems.

Addresses arXiv/html_feedback#1393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
