### PR TITLE
fix #354: `\verb` inside `\index` renders as typewriter, not an empty `<verbatim/>`

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3422,3 +3422,29 @@ where the author meant no unit at all. Same-host Perl is byte-identical (SHARED-
 Perl-origin, unreported upstream. Rust **surpasses** (OXIDIZED_DESIGN #114): an empty
 `class="ltx_unit"` token renders as an invisible `<m:mphantom>`, never its `meaning`. Guard:
 `06_cluster_regressions::cluster_siunitx_empty_unit_renders_invisible`.
+
+## 83. `\verb` inside `\index{…}` yields an empty `<verbatim/>` + `Verbatim argument lost` (Rust surpasses)
+
+`\index` is bound `SanitizedVerbatim` (`latex_constructs.pool.ltxml` L4397
+`DefMacro('\index SanitizedVerbatim', \&process_index_phrases)`), which reads the argument as
+literal text and then re-tokenizes it — collapsing a `\verb`'s raw catcode-12 body back into
+control sequences and leaving `\verb` with no mouth to scan a delimiter from. `\verb` emits an
+empty `<verbatim/>` and its body leaks out mis-tokenized (`\delta` → math-italic δ); a `|`
+delimiter additionally collides with the makeindex encap separator `process_index_phrases` splits
+on, losing everything after the first `|` into a bogus `style=` attribute and raising
+`Error:expected:delimiter Verbatim argument lost`. Minimal trigger:
+
+```latex
+\documentclass{article}\usepackage{makeidx}\makeindex
+\begin{document}
+A\index{\verb+\delta+}. B\index{\verb|\delta|}.
+\end{document}
+```
+
+Measured: pdflatex TL2025 passes the chars through (`.idx` = `\indexentry{\verb|\delta|}{1}`, index
+typesets `\delta` in typewriter). **Same-host Perl LaTeXML 0.8.8 is byte-identical** to Rust
+(SHARED-FAILURE; Perl differs only by a `key=""` on the empty phrase) — Perl-origin, split out of
+issue #347 into #354. Rust **surpasses** (OXIDIZED_DESIGN #119): `process_index_phrases` consumes
+a `\verb<D>body<D>` run atomically before the `!`/`@`/`|` split can see the delimiter, and emits
+`\@internal@text@verb`, so the body renders as `<verbatim font="typewriter">`. Guard:
+`06_cluster_regressions::cluster_verb_in_index_renders_typewriter`.

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4347,3 +4347,38 @@ Before: 2 errors, 0 bibitems. After: 0 errors, 6 rendered bibitems.
 **Guard**: `06_cluster_bibliography::amsrefs_bibsection_environment_renders`
 (`\begin{bibsection}` + `{biblist}` + `\bib` entries: References populate, entries
 convert to `<ltx:bibitem>`, no stray `<ltx:bibentry>`).
+
+### 119. `\verb` inside `\index{…}` renders as typewriter, not an empty `<verbatim/>`
+
+**Perl** LaTeXML reads `\index`'s argument `SanitizedVerbatim` (`latex_constructs.pool.ltxml`
+L4397 `DefMacro('\index SanitizedVerbatim', \&process_index_phrases)`), which re-tokenizes the
+argument string. That collapses a `\verb`'s raw catcode-12 body back into control sequences
+(`\delta`, not `\`,`d`,…) and leaves `\verb` with no mouth to scan its delimiter from, so at
+`process_index_phrases` time `\verb` emits an empty `<verbatim/>` and its body leaks out
+mis-tokenized (`\delta` → math-italic δ). A `|` delimiter additionally collides with the
+makeindex encap separator that `process_index_phrases` splits on, losing everything after the
+first `|` into a bogus `style=` attribute and raising `Error:expected:delimiter Verbatim argument
+lost`. latexml-oxide reproduced Perl 0.8.8 byte-for-byte (SHARED-FAILURE). Real pdflatex passes
+the characters through to the `.idx` and the index typesets `\delta` in typewriter (issue #354).
+
+**Perl behavior**: `\index{\verb|\delta|}` → error + empty `<indexphrase/>` (the `|` eats the
+phrase); `\index{\verb+\delta+}` → empty `<verbatim/>` + leaked math δ. **Rust behavior**:
+`process_index_phrases` (`latex_constructs.rs`) intercepts a `\verb`/`\verb*` token in its scan
+loop, consumes the whole `\verb<D>body<D>` run atomically — BEFORE the `!`/`@`/`|` split can see
+the delimiter — `untex`+`Explode!`s the body back to catcode-OTHER literals (so the digested body
+renders as typewriter text rather than re-expanding), and emits `\@internal@text@verb{star}{D}{body}`.
+Both delimiter forms and `\verb*` now render `<verbatim font="typewriter">…</verbatim>` with no
+error, and the interception composes with the `!` subentry split (`grp!\verb|sub|` → a plain `grp`
+head + a verbatim `sub` subentry).
+
+**Why**: a kernel-quality gap, not a TeX-semantics change — real LaTeX+makeindex typesets the
+`\verb` body in typewriter; both LaTeXML engines simply lost it in the sanitized re-tokenization.
+The fix is one locus (`process_index_phrases`) and halos across every `\verb`-in-`\index` paper.
+
+**Witnesses**: issue #354 (split out of #347). `\index{\verb+\delta+}`, `\index{\verb|\delta|}`,
+`\index{\verb*|a b|}`, `\index{grp!\verb|sub|}` — all render typewriter, 0 errors, where Perl 0.8.8
+errors/loses the phrase.
+
+**Upstream**: worth filing against `brucemiller/LaTeXML` (same SanitizedVerbatim/`\verb` gap).
+
+**Guards**: `06_cluster_regressions::cluster_verb_in_index_renders_typewriter`.

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -2561,6 +2561,52 @@ fn process_index_phrases(tokens: Tokens) -> Result<Tokens> {
     let tok = toks[i];
     let s = tok.with_str(|s| s.to_string());
     i += 1;
+    // #354 surpass (OXIDIZED_DESIGN #119): a `\verb`/`\verb*` inside `\index`.
+    // `\index` reads its argument `SanitizedVerbatim`, which re-tokenizes it —
+    // collapsing `\verb`'s raw body back into control sequences (`\delta`, not
+    // `\`,`d`,…) and leaving `\verb` with no mouth to scan a delimiter from. In
+    // both engines this yielded an empty `<verbatim/>` with the body leaking out
+    // mis-tokenized, and a `|` delimiter additionally collided with the makeindex
+    // encap separator handled below. Consume the whole `\verb<D>body<D>` run HERE
+    // — before the `!`/`@`/`|` split can see the delimiter — and emit
+    // `\@internal@text@verb{star}{D}{body}` so the body renders as typewriter.
+    if tok == T_CS!("\\verb") {
+      let mut starred = false;
+      if i < toks.len() && toks[i] == T_OTHER!("*") {
+        starred = true;
+        i += 1;
+      }
+      if i < toks.len() {
+        let delim = toks[i];
+        let delim_s = delim.with_str(|d| d.to_string());
+        i += 1;
+        let body_start = i;
+        while i < toks.len() && toks[i].with_str(|d| d != delim_s.as_str()) {
+          i += 1;
+        }
+        // The re-tokenized body collapsed `\verb`'s raw chars back into control
+        // sequences; `untex` + `Explode!` restores them to catcode-OTHER literals
+        // so the digested `#3` renders as typewriter text instead of re-expanding
+        // (which is exactly the `\delta`→math-δ leak this fixes).
+        let body_str = Tokens::new(toks[body_start..i].to_vec()).untex();
+        if i < toks.len() {
+          i += 1; // consume the closing delimiter
+        }
+        phrase.push(T_CS!("\\@internal@text@verb"));
+        phrase.push(T_BEGIN!());
+        if starred {
+          phrase.push(T_OTHER!("*"));
+        }
+        phrase.push(T_END!());
+        phrase.push(T_BEGIN!());
+        phrase.push(delim);
+        phrase.push(T_END!());
+        phrase.push(T_BEGIN!());
+        phrase.extend(Explode!(body_str));
+        phrase.push(T_END!());
+      }
+      continue;
+    }
     if s == "\"" && i < toks.len() {
       // Escaped character: take next token literally
       phrase.push(toks[i]);

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -398,6 +398,54 @@ fn cluster_mhchem_ce_subscripts() {
 fn cluster_theindex_nested_autoclose() {
   convert_clean("tests/cluster_regressions/theindex_nested_autoclose.tex");
 }
+/// `\verb` inside `\index{…}` must render its body as typewriter verbatim, not
+/// vanish. `\index` reads its argument `SanitizedVerbatim`, which re-tokenizes it —
+/// collapsing `\verb`'s raw body back into control sequences and leaving `\verb`
+/// with no mouth to scan a delimiter from. In BOTH engines this produced an empty
+/// `<verbatim/>` with the body leaking out mis-tokenized (`\delta` → math-italic δ),
+/// and a `|` delimiter additionally collided with makeindex's encap separator
+/// (`Error:expected:delimiter Verbatim argument lost`, phrase lost into a bogus
+/// `style=`). Rust surpasses (OXIDIZED_DESIGN #119): `process_index_phrases`
+/// consumes a `\verb<D>body<D>` run atomically — before the `!`/`@`/`|` split can
+/// see the delimiter — and emits `\@internal@text@verb`, so the body renders as
+/// typewriter. Shared with Perl LaTeXML 0.8.8; issue #354.
+#[test]
+fn cluster_verb_in_index_renders_typewriter() {
+  // convert_to_xml gates on 0 errors — the `|` form used to emit
+  // `Error:expected:delimiter Verbatim argument lost`.
+  let xml = convert_to_xml("tests/cluster_regressions/verb_in_index.tex");
+  // Four `\verb` bodies (`\verb+..+`, `\verb|..|`, `\verb*|..|`, and the
+  // `\verb|sub|` subentry), each a typewriter verbatim; `\index{plain}` and the
+  // `grp` head are plain phrases.
+  assert_eq!(
+    xml.matches(r#"<verbatim font="typewriter""#).count(),
+    4,
+    "each \\verb in \\index must render one typewriter <verbatim>; xml=\n{xml}"
+  );
+  // The body survives as literal typewriter text …
+  assert!(
+    xml.contains(r"\delta"),
+    "the \\verb body did not survive as literal text; xml=\n{xml}"
+  );
+  // … and is NOT leaked out and re-digested as a math-italic δ (U+03B4).
+  assert!(
+    !xml.contains('\u{03B4}'),
+    "the \\verb body leaked out and digested as math δ; xml=\n{xml}"
+  );
+  // The `|` delimiter must not be mistaken for the encap separator.
+  assert!(
+    !xml.contains("style=\"\u{201c}"),
+    "a \\verb `|` delimiter leaked into a bogus indexmark style=; xml=\n{xml}"
+  );
+  // `grp!\verb|sub|` composes with the `!` subentry split: a plain `grp` head and
+  // a verbatim `sub` subentry — the `\verb` `|` delimiters consumed, not split on.
+  assert!(
+    xml.contains(
+      r#"<indexphrase key="sub"><verbatim font="typewriter">sub</verbatim></indexphrase>"#
+    ),
+    "the \\verb subentry did not compose with the `!` split; xml=\n{xml}"
+  );
+}
 /// subcaption loaded AFTER subfigure.sty must not clobber subfigure.sty's
 /// self-contained `\subfigure[][]{}` macro with its own `{subfigure}[]{Dimension}`
 /// environment. The two have incompatible contracts: the macro consumes a

--- a/latexml_oxide/tests/cluster_regressions/verb_in_index.tex
+++ b/latexml_oxide/tests/cluster_regressions/verb_in_index.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+\usepackage{makeidx}\makeindex
+\begin{document}
+A\index{\verb+\delta+}. B\index{\verb|\delta|}. C\index{\verb*|a b|}. D\index{plain}.
+E\index{grp!\verb|sub|}.
+\end{document}


### PR DESCRIPTION
**Diagnostic.** `\index` reads its argument `SanitizedVerbatim`, which re-tokenizes it — collapsing a `\verb`'s raw body back into control sequences and leaving `\verb` with no mouth to scan a delimiter from (empty `<verbatim/>` + the body leaking out mis-tokenized), and a `|` delimiter additionally collided with makeindex's encap separator in `process_index_phrases` (`Error:expected:delimiter Verbatim argument lost`). Confirmed byte-identical on same-host **Perl LaTeXML 0.8.8** — SHARED-FAILURE, so this is a **surpass-perl** divergence.

**Approach.** `process_index_phrases` (`latex_constructs.rs`) now intercepts `\verb`/`\verb*` in its scan loop, consuming the whole `\verb<D>body<D>` run atomically — before the `!`/`@`/`|` split can see the delimiter — `untex`+`Explode!`s the body back to catcode-OTHER literals (so the digested body renders as typewriter, not re-expanded), and emits `\@internal@text@verb`. Documented as OXIDIZED_DESIGN #117 + KNOWN_PERL_ERRORS #83.

**Validation.** Guard `06_cluster_regressions::cluster_verb_in_index_renders_typewriter` (`\verb+…+`, `\verb|…|`, `\verb*|…|`, and `grp!\verb|sub|` subentry composition); full suite 1988/0; clippy `--workspace --all-targets` + fmt clean; Perl 0.8.8 parity re-confirmed on the witness (still errors, as expected for a surpass).

Closes #354