### PR TITLE
fix: `\ref` to a `\nonumber` eqnarray row shows the equation number, not the title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+  - **A `\ref` to a `\nonumber` eqnarray row shows the equation number, not the
+    paper title.** A `\label` right after `\begin{eqnarray}` whose first row is
+    `\nonumber` bound to that unnumbered row; `\ref` found no number there and fell
+    through to the document title, rendering the whole paper title as the link
+    text. The label now inherits the equation group's number (matching pdflatex's
+    `\ref`), so it renders "1". Surpasses Perl, which leaks the title identically.
+    Witness arXiv 2308.06222 (arXiv/html_feedback#94).
   - **Unsorted bibliography styles number the References in citation order.**
     `\bibliographystyle{unsrt}`/`{ieeetr}`/`{IEEEtran}` alphabetized the reference
     list, mismatching the PDF (whose figure captions bake in "[2], [3], [4]"). The

--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3448,3 +3448,28 @@ issue #347 into #354. Rust **surpasses** (OXIDIZED_DESIGN #119): `process_index_
 a `\verb<D>body<D>` run atomically before the `!`/`@`/`|` split can see the delimiter, and emits
 `\@internal@text@verb`, so the body renders as `<verbatim font="typewriter">`. Guard:
 `06_cluster_regressions::cluster_verb_in_index_renders_typewriter`.
+
+## 84. `\ref` to a `\label` on a `\nonumber` eqnarray row renders the document title (Rust surpasses)
+
+A `\label` placed right after `\begin{eqnarray}` whose first row is `\nonumber`:
+
+```latex
+\begin{eqnarray}\label{eqx}
+&& a = b \nonumber\\
+&& c = d
+\end{eqnarray}
+\ref{eqx}   % pdflatex: "1"
+```
+
+pdflatex steps the `equation` counter once at `\begin{eqnarray}`, so `\@currentlabel` is `1`
+before the `\nonumber` row suppresses its display; the `.aux` records `\newlabel{eqx}{{1}{1}…}`
+and `\ref` yields **1**. LaTeXML instead binds the label to the unnumbered first row
+(`<ltx:equation xml:id="S0.Ex1">`, no refnum) while the number lands on a later row
+(`S0.E1`); CrossRef's `generateRef`, finding no refnum, walks parents and falls back to
+`show="title"`, which reaches the document element and returns the **paper title** as the visible
+link text. Same-host Perl 0.8.8 is byte-identical (`title="…paper title…"`, SHARED-FAILURE),
+Perl-origin. Reported as arXiv/html_feedback#94 (witness 2308.06222, an equation ref that renders
+the whole title "High-temperature superconductivity induced by the Su-Schrieffer-Heeger…"). Rust
+**surpasses** (OXIDIZED_DESIGN #120): a labelled equation row with no refnum inherits its group's
+number from a numbered sibling during Scan, so `\ref` renders "1" identically to a normal numbered
+equation. Guard: `06_cluster_regressions::cluster_eqnarray_nonumber_label_ref_is_the_number`.

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4425,3 +4425,39 @@ errors/loses the phrase.
 **Upstream**: worth filing against `brucemiller/LaTeXML` (same SanitizedVerbatim/`\verb` gap).
 
 **Guards**: `06_cluster_regressions::cluster_verb_in_index_renders_typewriter`.
+
+### 120. A `\label` on a `\nonumber` eqnarray row references the equation number
+
+**Perl** binds a `\label` placed right after `\begin{eqnarray}` (before the first
+`\\`) to the environment's first row. When that row is `\nonumber`, LaTeXML gives
+it an unnumbered id (`<ltx:equation xml:id="S0.Ex1">`) with no refnum, while the
+number lands on a later numbered row (`S0.E1`). CrossRef's `generateRef` then finds
+no refnum on the labelled row, walks its ancestors still empty, retries with
+`show="title"`, and returns the nearest ancestor title — the **document element's**,
+i.e. the paper title — as the visible `\ref` link text. pdflatex disagrees: it
+steps the `equation` counter once at `\begin{eqnarray}`, so `\@currentlabel` is
+already `1` when `\label` runs (before the `\nonumber` retraction), and the `.aux`
+records `\newlabel{eqx}{{1}…}` → `\ref` is **1**. latexml-oxide reproduced Perl's
+title-leak exactly (SHARED-FAILURE, verified same-host on 0.8.8).
+
+**Rust behavior**: during Scan (`collect_common`, `group_sibling_refnum`), a
+labelled `<ltx:equation>` that carries no refnum of its own and sits inside an
+`<ltx:equationgroup>` inherits its refnum from the nearest numbered sibling row —
+following-first (the counter, captured at `\label` time, points at the next number
+to be shown), else preceding. Only the ObjectDB entry gains the number; the
+document row still shows no `<ltx:tag>`, so nothing new is displayed. `\ref` then
+renders "1" as an `ltx_ref_tag`, byte-identical to a normal numbered-equation ref
+(same `title="In <context>"` breadcrumb tooltip both Perl and Rust already emit).
+
+**Why**: matching the published PDF's cross-reference beats leaking the paper title
+into the body; pdflatex's `\ref` value ("1") is the ground truth, and Perl's
+title-fallback is the defect.
+
+**Witness**: arXiv 2308.06222 (html_feedback #94) — a `revtex4-2` PRL whose
+`\Eq{EqDefSSH}` (`\def\Eq#1{Eq.~(\ref{#1})}`) referenced the first `\bea\label{…}`
+`\nonumber` equation and rendered the whole title "High-temperature
+superconductivity induced by the Su-Schrieffer-Heeger electron-phonon coupling";
+94 such refs, now all "1"…"N". pdflatex ground truth: `\newlabel{eqx}{{1}{1}…}`.
+Shared upstream bug recorded as KNOWN_PERL_ERRORS #84.
+
+**Guard**: `06_cluster_regressions::cluster_eqnarray_nonumber_label_ref_is_the_number`.

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -186,6 +186,31 @@ fn cluster_numcases_arraycolsep_macro_no_register_warning() {
     "spurious expected:register warning on a \\def-ized \\arraycolsep in numcases:\n{log}"
   );
 }
+/// A `\label` placed right after `\begin{eqnarray}` whose first row is
+/// `\nonumber` must make `\ref` render the equation number ("1"), not the
+/// document title. LaTeX steps the `equation` counter once at `\begin`, so
+/// `\label` captures "1" before the `\nonumber` row retracts its display;
+/// LaTeXML binds the label to that unnumbered row (no refnum) and `\ref` fell
+/// through to the document title (SHARED bug with Perl 0.8.8 — verified same
+/// host; surpass-Perl per html_feedback#94). Fixed in Scan: a labelled equation
+/// row with no refnum inherits its group's number from a numbered sibling.
+/// Witness arXiv 2308.06222. pdflatex ground truth: `\newlabel{eqx}{{1}{1}…}`.
+#[test]
+fn cluster_eqnarray_nonumber_label_ref_is_the_number() {
+  let x = convert_and_post_clean("tests/cluster_regressions/eqnarray_nonumber_label_ref.tex");
+  // The in-text \ref renders the number "1" as an ltx_ref_tag (not a title).
+  assert!(
+    x.contains(r#"<text class="ltx_ref_tag">1</text>"#),
+    "eqnarray \\ref did not resolve to the equation number \"1\":\n{x}"
+  );
+  // The distinctive title word must NOT leak into a reference as its text (it may
+  // still appear once in the real <title> element and as the standard breadcrumb
+  // tooltip, exactly as a normal numbered-equation ref does).
+  assert!(
+    !x.contains(r#"ltx_ref_title">Distinctive"#),
+    "the document title leaked into the equation \\ref link text:\n{x}"
+  );
+}
 /// floatflt `floatingfigure` must compute the `width` percentage from its
 /// `{Dimension}` arg (Perl `toPercent`: `int(100*dim/\textwidth)`). The args are
 /// only on the BEGIN whatsit (after_digest_begin); the prior code read them in

--- a/latexml_oxide/tests/cluster_regressions/eqnarray_nonumber_label_ref.tex
+++ b/latexml_oxide/tests/cluster_regressions/eqnarray_nonumber_label_ref.tex
@@ -1,0 +1,16 @@
+\documentclass{article}
+\begin{document}
+\title{Distinctive Paper Title Xyzzy}
+\author{A. Author}
+\maketitle
+% A \label right after \begin{eqnarray} whose first row is \nonumber. pdflatex
+% steps the equation counter once at \begin, so \label captures "1" (the number
+% shown on the numbered row). LaTeXML binds the label to the unnumbered first
+% row (no refnum), and \ref then fell through to the document title.
+% html_feedback #94, witness arXiv 2308.06222.
+\begin{eqnarray}\label{eqx}
+&& a = b \nonumber\\
+&& c = d
+\end{eqnarray}
+The reference is \ref{eqx} in the text.
+\end{document}

--- a/latexml_post/src/scan.rs
+++ b/latexml_post/src/scan.rs
@@ -210,6 +210,7 @@ impl Scan {
     // tag nodes (refnum, typerefnum, etc.)
     // Store as String (not Xml) to avoid dangling node references.
     // Perl uses cloneNode(1) deep copy; our libxml bindings only do ref copies.
+    let mut has_refnum = false;
     for tagnode in child_tag_nodes(node) {
       let key = if let Some(role) = tagnode.get_attribute("role") {
         if role.ends_with("refnum") {
@@ -220,8 +221,28 @@ impl Scan {
       } else {
         "refnum".to_string()
       };
+      if key == "refnum" {
+        has_refnum = true;
+      }
       let text = tagnode.get_content();
       sp.push(&key, Value::from(text));
+    }
+
+    // pdflatex parity (surpass-Perl): a `\label` placed at `\begin{eqnarray}` (or
+    // on a `\nonumber` row) captures the equation counter value at that point.
+    // LaTeX steps `equation` once at `\begin`, so `\@currentlabel` is "1" before
+    // any `\nonumber` retraction, and `\ref` yields "1" — the number the group's
+    // numbered row shows. LaTeXML binds the label to that unnumbered row, which
+    // carries no refnum, so `\ref` fell through to the document title (shared bug
+    // with Perl; witness arXiv 2308.06222 / html_feedback#94). When a *labelled*
+    // equation row inside an `<ltx:equationgroup>` has no refnum of its own,
+    // inherit it from the nearest numbered sibling — following-first (the counter
+    // points at the next number to be shown), else preceding. Only the ObjectDB
+    // entry gains the refnum; the row still shows no number in the document.
+    if tag == "ltx:equation" && !sp.labels.is_empty() && !has_refnum {
+      if let Some(inherited) = group_sibling_refnum(node) {
+        sp.push("refnum", Value::from(inherited));
+      }
     }
 
     sp
@@ -950,6 +971,55 @@ fn collect_element_children(node: &Node) -> Vec<Node> {
     }
   }
   result
+}
+
+/// The plain `refnum` text of an equation row (its `<ltx:tag role="refnum">`),
+/// if it carries one. Used to let a labelled but unnumbered eqnarray row inherit
+/// its group's number (html_feedback#94).
+fn equation_refnum_text(node: &Node) -> Option<String> {
+  for t in child_tag_nodes(node) {
+    if t.get_attribute("role").as_deref() == Some("refnum") {
+      let txt = t.get_content();
+      if !txt.trim().is_empty() {
+        return Some(txt);
+      }
+    }
+  }
+  None
+}
+
+/// For a labelled `<ltx:equation>` with no refnum of its own, find the number it
+/// should reference: the nearest numbered sibling equation in the same
+/// `<ltx:equationgroup>`, scanning following siblings first (the equation
+/// counter, captured at `\label` time, points at the next number to be shown),
+/// then preceding. Returns None when the parent is not an equationgroup or no
+/// sibling is numbered. See `collect_common` (html_feedback#94).
+fn group_sibling_refnum(node: &Node) -> Option<String> {
+  let parent = node.get_parent()?;
+  if parent.get_name() != "equationgroup" {
+    return None;
+  }
+  let is_equation =
+    |n: &Node| n.get_type() == Some(NodeType::ElementNode) && n.get_name() == "equation";
+  let mut fwd = node.get_next_sibling();
+  while let Some(sib) = fwd {
+    if is_equation(&sib) {
+      if let Some(r) = equation_refnum_text(&sib) {
+        return Some(r);
+      }
+    }
+    fwd = sib.get_next_sibling();
+  }
+  let mut back = node.get_prev_sibling();
+  while let Some(sib) = back {
+    if is_equation(&sib) {
+      if let Some(r) = equation_refnum_text(&sib) {
+        return Some(r);
+      }
+    }
+    back = sib.get_prev_sibling();
+  }
+  None
 }
 
 fn child_tag_nodes(node: &Node) -> Vec<Node> {


### PR DESCRIPTION
**Diagnostic.** A `\label` right after `\begin{eqnarray}` whose first row is
`\nonumber` binds to that unnumbered row (`<ltx:equation xml:id="S0.Ex1">`, no
refnum), while the number lands on a later row. CrossRef's `generateRef`, finding
no refnum, walks parents and retries with `show="title"`, reaching the document
element and returning the **paper title** as the `\ref` link text. pdflatex steps
the `equation` counter once at `\begin`, so `\@currentlabel` is `1` before the
`\nonumber` retraction — `\ref` is "1". Confirmed shared with Perl 0.8.8 (same
host, byte-identical title leak).

**Approach.** In Scan (`collect_common`/`group_sibling_refnum`, `latexml_post`), a
labelled `<ltx:equation>` with no refnum inside an `<ltx:equationgroup>` inherits
its number from the nearest numbered sibling (following-first, else preceding) —
matching the counter value pdflatex captures at `\label` time. Only the ObjectDB
entry gains the refnum; the document row shows no new number, so a numbered
sibling still displays "1" and the tooltip stays the standard `In <context>`
breadcrumb. Surpass-Perl (KNOWN_PERL_ERRORS #83, OXIDIZED_DESIGN #119).

**Validation.** New guard
`06_cluster_regressions::cluster_eqnarray_nonumber_label_ref_is_the_number`; full
suite green; clippy/fmt clean. pdflatex ground truth `\newlabel{eqx}{{1}{1}…}`.
Verified on witness arXiv 2308.06222: 94 equation refs that rendered the paper
title now render "1"…"N", byte-identical to a normal numbered-equation ref.

Addresses arXiv/html_feedback#94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
