### PR TITLE
fix html_feedback#84: aa.cls loads [T1]{fontenc} (text `<`/`>` render as themselves)

### DIFF
--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -446,6 +446,29 @@ fn cluster_verb_in_index_renders_typewriter() {
     "the \\verb subentry did not compose with the `!` split; xml=\n{xml}"
   );
 }
+/// aa.cls (Astronomy & Astrophysics) does `\RequirePackage[T1]{fontenc}`
+/// (real aa.cls L154), so a literal text-mode `>`/`<` renders as itself in the
+/// PDF. Both LaTeXML engines' aa binding loaded `fontenc` WITHOUT the `[T1]`
+/// option, so the document stayed OT1 and `>` decoded as ¿ (U+00BF), `<` as ¡
+/// (U+00A1) — the arXiv HTML diverged from the arXiv PDF (html_feedback#84,
+/// arXiv:2308.06236v1 Fig 6 caption `masses > 0.1~M_\oplus`). `aa_support_sty.rs`
+/// now loads `fontenc` with `[T1]` like the real class (and like the
+/// acmart/elsarticle/moderncv bindings). Shared with Perl 0.8.8 (its aa_support
+/// dropped the same option).
+#[test]
+fn cluster_aa_class_t1_fontenc_angle_brackets() {
+  let xml = convert_to_xml("tests/cluster_regressions/aa_class_t1_fontenc.tex");
+  // The canary: no OT1 ¡/¿ decode of `<`/`>` under aa.cls's T1 encoding.
+  assert!(
+    !xml.contains('\u{00BF}') && !xml.contains('\u{00A1}'),
+    "aa.cls forces [T1]{{fontenc}}, so `>`/`<` must not decode as OT1 ¿/¡; xml=\n{xml}"
+  );
+  // …and the greater/less signs survive as themselves.
+  assert!(
+    xml.contains("masses &gt; 0.1") && xml.contains("less &lt; 0.5"),
+    "literal `>`/`<` must render as themselves under aa.cls's T1 encoding; xml=\n{xml}"
+  );
+}
 /// subcaption loaded AFTER subfigure.sty must not clobber subfigure.sty's
 /// self-contained `\subfigure[][]{}` macro with its own `{subfigure}[]{Dimension}`
 /// environment. The two have incompatible contracts: the macro consumes a

--- a/latexml_oxide/tests/cluster_regressions/aa_class_t1_fontenc.tex
+++ b/latexml_oxide/tests/cluster_regressions/aa_class_t1_fontenc.tex
@@ -1,0 +1,4 @@
+\documentclass{aa}
+\begin{document}
+Bodies with masses > 0.1 and less < 0.5 here.
+\end{document}

--- a/latexml_package/src/package/aa_support_sty.rs
+++ b/latexml_package/src/package/aa_support_sty.rs
@@ -38,7 +38,11 @@ LoadDefinitions!({
   RequirePackage!("inst_support");
   RequirePackage!("calc");
   RequirePackage!("etex");
-  RequirePackage!("fontenc");
+  // Real aa.cls L154 is `\RequirePackage[T1]{fontenc}` — the `[T1]` was dropped
+  // here (and in Perl's aa_support.sty.ltxml), leaving the document in OT1, where
+  // a literal text `<`/`>` decodes to ¡/¿ instead of itself (html_feedback#84,
+  // arXiv:2308.06236). Load T1 like the real class (as acmart/elsarticle/moderncv do).
+  RequirePackage!("fontenc", options => vec!["T1".to_string()]);
   RequirePackage!("geometry");
   RequirePackage!("setspace");
   RequirePackage!("fancyhdr");


### PR DESCRIPTION
**Diagnostic.** The aa binding loaded `fontenc` without the `[T1]` option that real aa.cls (L154, `\RequirePackage[T1]{fontenc}`) has, so aa documents stayed in OT1 — where a literal text-mode `<`/`>` decodes to ¡/¿ (U+00A1/U+00BF). That made the arXiv HTML diverge from the arXiv PDF (arXiv:2308.06236v1 Fig 6 caption `masses > 0.1`, rasterized PDF confirmed shows `>`).

**Approach.** `aa_support_sty.rs` now loads `fontenc` with `[T1]`, matching the real class and the existing acmart/elsarticle/moderncv bindings. Shared with Perl 0.8.8 (its `aa_support.sty.ltxml` dropped the same option); audited every binding `fontenc` load — aa was the only verified drop (aipproc/cjkutf8 match Perl / the OT1 default and were left untouched rather than guess an option).

**Validation.** Guard `06_cluster_regressions::cluster_aa_class_t1_fontenc_angle_brackets` (`>`/`<` render as `&gt;`/`&lt;`, no ¡/¿); witness caption re-verified; full suite 1991/0; clippy/fmt clean.

Closes arXiv/html_feedback#84