### PR TITLE
fix: jcappub (JCAP) papers render their full author list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
     text. The label now inherits the equation group's number (matching pdflatex's
     `\ref`), so it renders "1". Surpasses Perl, which leaks the title identically.
     Witness arXiv 2308.06222 (arXiv/html_feedback#94).
+  - **jcappub (JCAP) papers now render their full author list.** jcappub is JCAP's
+    SISSA/IOP class — the JCAP sibling of jheppub — with the same accumulating
+    `\author[affil]{name}` + `\affiliation` + `\emailAdd` frontmatter. It was
+    unbound, so each `\author` fell through to article's (which overwrites) and the
+    list collapsed to the last author, with `\affiliation`/`\emailAdd` undefined.
+    jcappub now loads the jheppub binding. Witness arXiv 2404.03569 (63 authors,
+    previously 1; arXiv/html_feedback#6884).
   - **Unsorted bibliography styles number the References in citation order.**
     `\bibliographystyle{unsrt}`/`{ieeetr}`/`{IEEEtran}` alphabetized the reference
     list, mismatching the PDF (whose figure captions bake in "[2], [3], [4]"). The

--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3473,3 +3473,18 @@ the whole title "High-temperature superconductivity induced by the Su-Schrieffer
 **surpasses** (OXIDIZED_DESIGN #120): a labelled equation row with no refnum inherits its group's
 number from a numbered sibling during Scan, so `\ref` renders "1" identically to a normal numbered
 equation. Guard: `06_cluster_regressions::cluster_eqnarray_nonumber_label_ref_is_the_number`.
+
+## 85. `\usepackage{jcappub}` truncates the author list to the last author (Rust surpasses)
+
+jcappub is JCAP's SISSA/IOP publication class — the JCAP sibling of jheppub (JHEP) — with the
+same accumulating `\author[⟨affil⟩]{⟨name⟩}` + `\affiliation[N]{…}` + `\emailAdd{…}` +
+`\keywords`/`\acknowledgments` frontmatter. Perl LaTeXML ships `jheppub.sty.ltxml` but **no**
+jcappub binding, so `\usepackage{jcappub}` reports `missing file[jcappub.sty]`, `\author` falls
+through to article's kernel `\author` (which *overwrites* on each call), and only the LAST
+`\author` survives; `\affiliation`/`\emailAdd`/`\keywords` are undefined. Same-host Perl 0.8.8 is
+byte-identical (SHARED-FAILURE: 1 author, 4 undefined macros), Perl-origin. Reported as
+arXiv/html_feedback#6884 (witness 2404.03569, a 63-author DESI paper collapsing to 1). Rust
+**surpasses**: `latexml_package::BINDINGS` routes `jcappub` to `jheppub_sty::load_definitions` (the
+sibling class's identical author API), so all authors accumulate — the same "route the sibling
+package to its bound binding" move as the biblatex variants (OXIDIZED_DESIGN #117). Guard:
+`06_cluster_regressions::cluster_jcappub_accumulates_authors`.

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -228,6 +228,33 @@ fn cluster_floatflt_pctwidth() {
     "floatflt floatingfigure width=\"0%\" — Dimension arg not read (after_digest args=None)"
   );
 }
+/// jcappub (JCAP's SISSA/IOP class) is the JCAP sibling of jheppub with the same
+/// accumulating `\author[affil]{name}` + `\affiliation` + `\emailAdd`. Unbound, its
+/// `\author`s fell through to article's (which overwrites), so only the LAST author
+/// survived and `\affiliation`/`\emailAdd`/`\keywords` were undefined. Routing
+/// jcappub to the jheppub binding accumulates every author. SHARED gap with Perl
+/// (also truncates + `missing file[jcappub.sty]`); surpass-Perl. html_feedback
+/// #6884, witness arXiv 2404.03569 (63 authors rendered, previously 1).
+#[test]
+fn cluster_jcappub_accumulates_authors() {
+  let xml = convert_to_xml("tests/cluster_regressions/jcappub_authors.tex");
+  assert_eq!(
+    xml.matches(r#"role="author""#).count(),
+    3,
+    "jcappub did not accumulate all 3 authors (routed to the jheppub binding):\n{xml}"
+  );
+  for n in ["Alpha Author", "Beta Author", "Gamma Author"] {
+    assert!(xml.contains(n), "jcappub author `{n}` missing:\n{xml}");
+  }
+  assert!(
+    xml.contains("Institute Two"),
+    "\\affiliation was undefined / not rendered:\n{xml}"
+  );
+  assert!(
+    xml.contains("alpha@example.org"),
+    "\\emailAdd was undefined / not rendered:\n{xml}"
+  );
+}
 /// Same fix for the `floatfig` package: a 4cm figure → `width="32%"`.
 #[test]
 fn cluster_floatfig_pctwidth() {

--- a/latexml_oxide/tests/cluster_regressions/jcappub_authors.tex
+++ b/latexml_oxide/tests/cluster_regressions/jcappub_authors.tex
@@ -1,0 +1,20 @@
+\documentclass[a4paper,11pt]{article}
+% jcappub is JCAP's SISSA/IOP class, the JCAP sibling of jheppub: same
+% accumulating \author[affil]{name} + \affiliation + \emailAdd machinery. Unbound,
+% each \author fell through to article's (which overwrites), so only the last
+% author survived and \affiliation/\emailAdd/\keywords were undefined.
+% html_feedback #6884, witness arXiv 2404.03569.
+\usepackage{jcappub}
+\title{A jcappub author-list test}
+\author[1]{Alpha Author,}
+\author[1,2]{Beta Author,}
+\author[2]{Gamma Author}
+\affiliation[1]{Institute One, City, Country}
+\affiliation[2]{Institute Two, City, Country}
+\emailAdd{alpha@example.org}
+\keywords{one, two}
+\abstract{A short abstract for the jcappub test.}
+\begin{document}
+\maketitle
+Body text.
+\end{document}

--- a/latexml_package/src/lib.rs
+++ b/latexml_package/src/lib.rs
@@ -143,6 +143,15 @@ pub const BINDINGS: &[(&str, &str, BindingLoader)] = &[
   ("revtex", "cls", package::revtex_cls::load_definitions),
   ("revtex4-1", "cls", package::revtex4_1_cls::load_definitions),
   ("jheppub", "sty", package::jheppub_sty::load_definitions),
+  // jcappub is JCAP's SISSA/IOP publication class — the JCAP sibling of jheppub
+  // (JHEP), with the same accumulating `\author[affil]{name}` + `\affiliation` +
+  // `\emailAdd` + `\keywords`/`\acknowledgments` frontmatter. Neither Perl nor
+  // Rust ships a jcappub binding, so its `\author`s fell through to article's
+  // (which overwrites), truncating the list to the last author, and
+  // `\affiliation`/`\emailAdd` were undefined. Route it to the jheppub binding —
+  // faithful (same author API) and surpass-Perl. html_feedback #6884, witness
+  // arXiv 2404.03569 (63 authors, previously 1).
+  ("jcappub", "sty", package::jheppub_sty::load_definitions),
   ("neurips", "sty", package::neurips_sty::load_definitions),
   (
     "neurips_2019",


### PR DESCRIPTION
**Diagnostic.** jcappub (JCAP's SISSA/IOP class) is the JCAP sibling of jheppub with
the same accumulating `\author[affil]{name}` + `\affiliation` + `\emailAdd` frontmatter,
but it was unbound. So `\author` fell through to article's kernel `\author` (which
overwrites on each call) — the list collapsed to the last author — and
`\affiliation`/`\emailAdd`/`\keywords` were undefined. Same-host Perl 0.8.8 truncates
identically (`missing file[jcappub.sty]`, 1 author) — a shared gap.

**Approach.** Register `jcappub` → `jheppub_sty::load_definitions` in
`latexml_package::BINDINGS` (the sibling class's identical author API). Surpass-Perl,
the same "route the sibling package to its bound binding" move as the biblatex variants.
KNOWN_PERL_ERRORS #84.

**Validation.** New guard `06_cluster_regressions::cluster_jcappub_accumulates_authors`
(3 `\author`s accumulate, `\affiliation`/`\emailAdd` render); full suite green;
clippy/fmt clean. Witness arXiv 2404.03569: 63 authors now render (was 1), 0 errors
(was 4).

Addresses arXiv/html_feedback#6884.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
