### PR TITLE
test: guard acmart pubnotes stay out of the title (html_feedback#6885)

### DIFF
--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -26,6 +26,27 @@ fn frontmatter_acmart_author_optarg() {
     "acmart `[short]` optarg leaked as a bracket creator:\n{x}"
   );
 }
+/// html_feedback#6885 (arXiv:2608.07766, acmart PACMHCI): the ACM pubnotes
+/// (`\acmJournal`/`\acmVolume`/`\acmDOI`/`\ccsdesc`) must be frontmatter SIBLINGS
+/// of the title, not nested inside it. The reported "journal info appears in
+/// title" was the OLD deployed corpus binary; HEAD matches Perl 0.8.8 exactly —
+/// a clean `<title>` with the pubnotes as document children. Pins that so they
+/// cannot regress back into the title element.
+#[test]
+fn frontmatter_acmart_pubnotes_not_in_title() {
+  let x = convert_to_xml("tests/cluster_regressions/frontmatter_acmart_pubnotes_not_in_title.tex");
+  // The title is self-contained — a nested <pubnote> would break this exact close.
+  assert!(
+    x.contains("<title>The Real Title</title>"),
+    "acmart title must not absorb the journal/DOI/CCS pubnotes:\n{x}"
+  );
+  // …and the pubnotes still render, as siblings of the title.
+  assert!(
+    x.contains("role=\"journal\">PACMHCI</pubnote>")
+      && x.contains("role=\"doi\">10.1145/3710969</pubnote>"),
+    "acmart journal/DOI pubnotes missing from frontmatter:\n{x}"
+  );
+}
 /// IEEEtran `\author{\IEEEauthorblockN{…}\IEEEauthorblockA{…}\and …}`: each
 /// block is one creator; the `1\textsuperscript{st}` ordinals must not be
 /// misread as affiliation markers and drop every author. Witness 2602.05517.

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_acmart_pubnotes_not_in_title.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_acmart_pubnotes_not_in_title.tex
@@ -1,0 +1,13 @@
+\documentclass[acmsmall]{acmart}
+\setcopyright{acmlicensed}
+\acmJournal{PACMHCI}
+\acmYear{2025}\acmVolume{9}\acmNumber{2}\acmArticle{CSCW071}\acmMonth{4}\acmDOI{10.1145/3710969}
+\begin{document}
+\title[Short]{The Real Title}
+\author{Jane Doe}
+\affiliation{\institution{Uni}}
+\email{j@x.org}
+\ccsdesc[500]{Human-centered computing~Empirical studies in HCI}
+\maketitle
+Body text.
+\end{document}


### PR DESCRIPTION
**Diagnostic.** html_feedback#6885 (arXiv:2608.07766, acmart PACMHCI) reported ACM journal/volume/DOI/CCS metadata appearing *in the title*. It does not reproduce on HEAD — the pubnotes render as top-level frontmatter siblings of a clean `<title>`, so the report reflects the older deployed corpus binary (lag).

**Approach.** Empirically confirmed: re-ran a minimal acmart repro on HEAD and on Perl LaTeXML 0.8.8 — identical output, `<title>The Real Title</title>` with `<pubnote role="journal">…` as document children (parity, no divergence). Added a regression guard so the pubnotes can't slip back inside the title.

**Validation.** `frontmatter_acmart_pubnotes_not_in_title` green; full `06_cluster_frontmatter` binary 20/0; Perl-parity verified on the min-repro.

Relates to arXiv/html_feedback#6885 (cross-tracker; not auto-closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)