### PR TITLE
fix html_feedback#6614: short author names in ACL \author blocks stay authors

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -1380,6 +1380,19 @@ are unchanged; an empty `\\`-leading name list keeps a single empty author so it
 affiliations are not dropped. `author_affil_splits()` already carried the comment
 "NO comma in affiliations!!!"; this extends that discipline to the no-marker arm.
 
+**(c) Short author names in a marker-labeled line.** The marker-labeled arm
+classifies each `\quad`/`\\`-split line as author vs affiliation by where its
+superscript sits. The original proxy — a marker within the first 8 tokens ⇒
+affiliation ("¹CMU") — misread a **short author name** whose trailing mark landed
+under the threshold: "Min Xu" is 7 tokens, so `Min Xu\textsuperscript{1}` was
+demoted to an affiliation and the author lost (witness arXiv:2606.08234,
+html_feedback#6614). Replaced by the length-independent signal
+`name_precedes_marker`: a line reads "Name\textsuperscript{n}" (letter text
+before the marker ⇒ author, split into creators) or "\textsuperscript{n}Affil"
+(the marker leads the line ⇒ affiliation). Here Rust surpasses Perl, which keeps
+the four authors but ALSO emits the affiliation line itself as phantom author
+creators.
+
 **Scope/limits:**
 - The `*` equal-contribution suffix on a combined author mark (`$^{1*}$`) still
   labels `affiliation:1*`, so it does not yet match a plain `affiliation:1`

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -919,15 +919,19 @@ LoadDefinitions!({
               entries.push((AuthorLineKind::Author, line)); // safest to assume author?
             }
           },
-          Some(p) if p < 8 => {
-            // Close to front? assume affiliation
-            entries.push((AuthorLineKind::Affiliation, line));
-          },
-          Some(_) => {
-            // Marker sits far from the front: an author line. Split it into the
-            // individual creators it names (see split_author_line).
-            for author in split_author_line(line) {
-              entries.push((AuthorLineKind::Author, author));
+          Some(p) => {
+            // "\textsuperscript{n}Affil" (the marker LEADS the line) → an
+            // affiliation; "Name\textsuperscript{n}" (a name precedes the
+            // marker) → an author line, split into the individual creators it
+            // names (see split_author_line). The old `p < 8` token-count proxy
+            // misread short author names like "Min Xu" (html_feedback#6614) —
+            // key on name-before-marker, which is length-independent.
+            if name_precedes_marker(&line, p) {
+              for author in split_author_line(line) {
+                entries.push((AuthorLineKind::Author, author));
+              }
+            } else {
+              entries.push((AuthorLineKind::Affiliation, line));
             }
           },
         }
@@ -3842,6 +3846,22 @@ fn affil_splits() -> Vec<SplitDelim> {
   ]
 }
 fn authorsup_markers() -> Vec<Token> { vec![T_SUPER!(), T_CS!("\\textsuperscript")] }
+
+/// In a superscript-labeled author block, decide whether a line reads
+/// "Name\textsuperscript{n}" (an author — name TEXT precedes the marker) or
+/// "\textsuperscript{n}Affil" (an affiliation — the marker LEADS the line).
+/// Returns true iff a letter token precedes the first marker at `marker_pos`
+/// (1-based, from `position_of`). Replaces an earlier `position < 8`
+/// token-count proxy that misread short author names: "Min Xu" is 7 tokens, so
+/// its trailing `\textsuperscript{1}` fell under the threshold and the author
+/// was reclassified as an affiliation (html_feedback#6614, arXiv:2606.08234).
+/// Keying on "is there a name before the marker" is length-independent.
+/// OXIDIZED_DESIGN #52.
+fn name_precedes_marker(line: &Tokens, marker_pos: usize) -> bool {
+  line.unlist_ref()[..marker_pos.saturating_sub(1)]
+    .iter()
+    .any(|t| t.code == Catcode::LETTER)
+}
 
 /// Drop the optional `*` and `[<len>]` that follow a `\\` line-break token in an
 /// author/affiliation block, before the block is split into lines. The

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -47,6 +47,43 @@ fn frontmatter_acmart_pubnotes_not_in_title() {
     "acmart journal/DOI pubnotes missing from frontmatter:\n{x}"
   );
 }
+/// html_feedback#6614 (arXiv:2606.08234, ACL): a `\author{Name\quad Name… \\
+/// \textsuperscript{n}Affil}` block must keep SHORT author names as authors, not
+/// reclassify them as affiliations. "Min Xu" (7 tokens) tripped the old `p < 8`
+/// superscript-position proxy and was demoted to an `Affiliation:`; the
+/// length-independent name-before-marker rule keeps all four authors while the
+/// marker-led affiliation lines stay affiliations.
+#[test]
+fn frontmatter_acl_quad_authors_short_name() {
+  let x = convert_to_xml("tests/cluster_regressions/frontmatter_acl_quad_authors.tex");
+  // All four authors survive as personnames — including the short "Min Xu".
+  for name in [
+    "Tanush Swaminathan",
+    "Runmin Jiang",
+    "Letian Zhang",
+    "Min Xu",
+  ] {
+    assert!(
+      x.contains(&format!("<personname>{name}")),
+      "author {name} missing as a personname:\n{x}"
+    );
+  }
+  // "Min Xu" must NOT be demoted to an affiliation (the reported canary).
+  assert!(
+    !x.contains("role=\"affiliation\">Min Xu"),
+    "short author Min Xu misclassified as an affiliation:\n{x}"
+  );
+  // The marker-led affiliation lines still render as affiliations.
+  assert!(
+    x.contains("Carnegie Mellon University") && x.contains("Allen Institute"),
+    "affiliations dropped:\n{x}"
+  );
+  // The `\\[5pt]` optional length must not leak as literal text.
+  assert!(
+    !x.contains("[5pt]"),
+    "\\\\[5pt] optional length leaked as text:\n{x}"
+  );
+}
 /// IEEEtran `\author{\IEEEauthorblockN{…}\IEEEauthorblockA{…}\and …}`: each
 /// block is one creator; the `1\textsuperscript{st}` ordinals must not be
 /// misread as affiliation markers and drop every author. Witness 2602.05517.

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_acl_quad_authors.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_acl_quad_authors.tex
@@ -1,0 +1,13 @@
+\documentclass{article}
+\begin{document}
+\author{
+  Tanush Swaminathan\textsuperscript{1,2} \quad
+  Runmin Jiang\textsuperscript{1} \quad
+  Letian Zhang\textsuperscript{1} \quad
+  Min Xu\textsuperscript{1} \\[5pt]
+  \textsuperscript{1}Carnegie Mellon University \quad
+  \textsuperscript{2}Allen Institute
+}
+\title{T}
+\maketitle
+\end{document}


### PR DESCRIPTION
**Diagnostic.** `\lx@add@authors` (`base_utilities.rs`) classified each `\quad`/`\\`-split line of a superscript-labeled author block by marker position, using a "marker within the first 8 tokens ⇒ affiliation" proxy. That misreads a **short author name**: `Min Xu` is 7 tokens, so `Min Xu\textsuperscript{1}` fell under the threshold and was demoted to an `Affiliation:` — the author lost, the block rendered as 3 creators with affiliations repeated (arXiv:2606.08234).

**Approach.** Replace the token-count proxy with `name_precedes_marker` — length-independent: letter text before the marker ⇒ author (`Name^{n}`), marker leading the line ⇒ affiliation (`^{n}Affil`). Refines OXIDIZED_DESIGN #52; Rust now *surpasses* Perl, which keeps the four authors but also emits the affiliation line as phantom author creators.

**Validation.** red→green guard `frontmatter_acl_quad_authors_short_name`; **all 20 existing frontmatter witnesses still green** (21/21); full suite **2004/0**; clippy/fmt clean; witness 2606.08234 → 4 creators, Min Xu preserved as a personname.

Scope: fixes the author-block (frontmatter) part of the report; the figure-centering/appendix complaints are separate (tikz/pgfplots parity) and not addressed here. Relates to arXiv/html_feedback#6614 (cross-tracker; not auto-closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)