### PR TITLE
fix: numeric-mode natbib .bbl labels the References with [N], matching pdflatex

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3521,3 +3521,26 @@ resolves references in post-processing by design, not through `.aux`/`\r@`; emul
 reference, undefined on pdflatex's run 1 too). The rendering half of #6895 (an oversized inline
 ORCID icon) is unrelated: correct LaTeXML markup, a downstream ar5iv-css over-reach fixed in the
 `ar5iv-css` repo.
+
+## 87. Numeric-mode natbib `.bbl` mislabels authored+dated References with author-year, not `[N]` (Rust surpasses)
+
+natbib's `\NAT@wrout` (`natbib.sty.ltxml` L609-620) chooses each `\bibitem`'s reference-list label
+from `CITE_STYLE`, but its numeric branch is guarded on `$style eq 'number'` (**singular**) — a
+value `CITE_STYLE` never holds (`'numbers'`/`'super'`/`'authoryear'`). Number style is therefore
+reachable only via the empty-author/year fallback (L612). So in numeric/superscript mode, a
+pre-formatted `.bbl` entry (`thebibliography`/`\bibitem`, not the `.bib`/MakeBibliography path)
+whose `\bibitem[{Name(Year)}]{key}` label has an author AND a year keeps an author-year label
+(`Shor [1994]`) while the inline `\cite` correctly shows `[N]` — a list that disagrees with its own
+cites and with pdflatex+bibtex. Verified same-host: Perl 0.8.8 emits the identical `Shor [1994]`
+(numbers) / `Shor 1994` (super) (SHARED-FAILURE, Perl-origin). Minimal trigger:
+
+```tex
+\documentclass{article}\usepackage[numbers]{natbib}\begin{document}\cite{s}
+\begin{thebibliography}{9}\bibitem[{Shor(1994)}]{s} P. Shor.\end{thebibliography}\end{document}
+```
+
+→ reference label `Shor [1994]` in Perl and Rust; pdflatex+bibtex (apsrev4-2 / `[numbers]natbib`)
+give `[1]`. Reported as arXiv/html_feedback#4295 (witness 2410.05202, 57 entries). Rust
+**surpasses**: `\NAT@wrout` forces number style for `'numbers'`/`'super'` too, so the whole list is
+`[N]`, matching the PDF — the `authoryear` path is untouched. Full rationale + guard in
+OXIDIZED_DESIGN #121.

--- a/docs/parity/OXIDIZED_DESIGN.md
+++ b/docs/parity/OXIDIZED_DESIGN.md
@@ -18,12 +18,12 @@ This file is the **index + overview**. The detail lives in a themed family:
 > `.rs` comments reference them — so they are kept verbatim, which means three
 > quirks: (1) the numbers are **not globally unique** (the math cluster `#7–#18`
 > collides by value with divergences `#7–#18`); (2) a code-referenced number
-> resolves to the file above that owns that *topic* — most (`#1–#15`, `#19–#102`)
+> resolves to the file above that owns that *topic* — most (`#1–#15`, `#19–#121`)
 > are in DIVERGENCES, the math ones (incl. the code-referenced **`#18` = f(x)
 > "Speculative function application"**) are in MATH; (3) **`#76` is a retired
 > number** — its entry was consolidated into `#74` and the number was not
 > reused, so a gap in the sequence is expected, not a missing file. Next free
-> number: **#104**. When in doubt,
+> number: **#122**. When in doubt,
 > `grep '### N\.' docs/parity/OXIDIZED_DESIGN_*.md docs/math/OXIDIZED_DESIGN_MATH.md`.
 
 ---

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4461,3 +4461,42 @@ superconductivity induced by the Su-Schrieffer-Heeger electron-phonon coupling";
 Shared upstream bug recorded as KNOWN_PERL_ERRORS #84.
 
 **Guard**: `06_cluster_regressions::cluster_eqnarray_nonumber_label_ref_is_the_number`.
+
+### 121. Numeric/superscript natbib `.bbl` labels the References with `[N]`, not author-year
+
+**Perl**'s `\NAT@wrout` (`natbib.sty.ltxml` L609-620) formats each `\bibitem`'s
+reference-list `refnum` from `CITE_STYLE`, but its numeric branch is gated on
+`$style eq 'number'` (**singular**) — a value `CITE_STYLE` never holds (it is
+`'numbers'`/`'super'`/`'authoryear'`). The only route to number style is the
+empty-author/year fallback (L612: `$style = 'number' if IsEmpty($authors) ||
+IsEmpty($year)`). So a pre-formatted numeric `.bbl` — the `thebibliography` /
+`\bibitem` path, distinct from the `.bib` / MakeBibliography path in #116 — whose
+`\bibitem[{Name(Year)}]{key}` label carries an author AND a year keeps an
+author-year label (`Shor [1994]`) even though the inline `\cite` correctly shows
+`[N]`. SHARED-FAILURE: Perl 0.8.8 emits the identical `Shor [1994]` (numbers) /
+`Shor 1994` (super), verified same-host.
+
+**Rust behavior**: `\NAT@wrout` (`natbib_sty.rs`) forces number style whenever
+`CITE_STYLE` is `'numbers'` or `'super'` (as well as the empty author/year
+fallback), so every entry's `refnum` is the bracketed entry number `[N]` (the bare
+number in super mode, whose `CITE_OPEN`/`CLOSE` are empty) — consistent with the
+inline `[N]` cites and the published PDF. `authoryear` mode is unchanged: an entry
+with an author+year keeps `Author (Year)`, and only an empty author or year falls
+back to the number.
+
+**Why**: apsrev4-2 / `[numbers]natbib` is a numeric style; pdflatex+bibtex render
+the whole reference list as `[N]`. Matching the PDF beats a partial author-year
+list that contradicts its own inline `[N]` cites, and Perl's singular-`'number'`
+guard is the defect.
+
+**Witness**: arXiv 2410.05202 (html_feedback#4295) — `revtex4-2` / apsrev4-2, 57
+entries. Before, entries with a year (`[1]` Shor(1994), `[4]` Reiher et al.(2017))
+showed an author-year label while genuinely year-less entries (`[3]` Gidney and
+Ekerå, empty `()`) already showed `[3]`; now all 57 are `[1]`…`[57]`, matching the
+PDF.
+
+**Upstream**: worth filing against `brucemiller/LaTeXML` (the singular-`'number'`
+guard mislabels every numeric-mode `.bbl` with authors+years).
+
+**Guard**: `06_cluster_bibliography::cluster_bib_natbib_bbl_numeric_refnum`
+(numbers + super go numeric; the `authoryear` control keeps `Shor (1994)`).

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -2382,6 +2382,76 @@ fn cluster_bib_revtex4_author_year_option_is_honored() {
   );
 }
 
+/// The `<tag role="refnum">` of the reference-list `<bibitem>` carrying the given
+/// `key`, from core XML.
+fn bbl_refnum(xml: &str, key: &str) -> String {
+  let needle = format!("key=\"{key}\"");
+  for chunk in xml.split("<bibitem").skip(1) {
+    if !chunk[..chunk.find('>').unwrap_or(chunk.len())].contains(&needle) {
+      continue;
+    }
+    let entry = &chunk[..chunk.find("</bibitem>").unwrap_or(chunk.len())];
+    let open = entry
+      .find(r#"<tag role="refnum">"#)
+      .unwrap_or_else(|| panic!("no refnum tag for {key}:\n{entry}"))
+      + r#"<tag role="refnum">"#.len();
+    let close = entry[open..].find("</tag>").unwrap() + open;
+    return entry[open..close].to_string();
+  }
+  panic!("no bibitem with key {key}:\n{xml}");
+}
+
+/// html_feedback#4295 (arXiv:2410.05202, revtex4-2 / apsrev4-2 numeric): a
+/// numeric-mode natbib `.bbl` (the pre-formatted `thebibliography` path, NOT the
+/// `.bib`/MakeBibliography path guarded by `cluster_bib_revtex4_family_numeric_by_default`)
+/// must label its References with the entry NUMBER `[N]` — matching the inline
+/// `[N]` cites and pdflatex+bibtex — even for entries whose `\bibitem[{Name(Year)}]`
+/// label carries an author AND a year.
+///
+/// SURPASS-PERL (OXIDIZED_DESIGN #121): Perl's `\NAT@wrout` (`natbib.sty.ltxml`
+/// L612-613) only forces number style on an EMPTY author/year — its `$style eq
+/// 'number'` guard never matches the plural `CITE_STYLE` `'numbers'`/`'super'` —
+/// so a numeric `.bbl` entry with a year keeps an author-year label. Verified
+/// same-host: Perl 0.8.8 emits `Shor [1994]` (numbers) / `Shor 1994` (super)
+/// identically, so matching the PDF is a deliberate divergence. The empty-year
+/// entry already numbered `[N]` in both engines (KNOWN_PERL_ERRORS #86 neighbour).
+#[test]
+fn cluster_bib_natbib_bbl_numeric_refnum() {
+  // numbers mode: BOTH entries are the bracketed entry number, never author-year.
+  let x = convert_to_xml("tests/cluster_regressions/natbib_bbl_numeric_refnum.tex");
+  assert_eq!(
+    bbl_refnum(&x, "shor_1994"),
+    "[1]",
+    "numbers-mode .bbl refnum must be the entry number, not an author-year label:\n{x}"
+  );
+  assert_eq!(
+    bbl_refnum(&x, "gidney_2021"),
+    "[2]",
+    "empty-year numbers-mode entry stays the entry number:\n{x}"
+  );
+
+  // super mode: bare number (empty CITE_OPEN/CLOSE), never `Shor 1994`.
+  let x = convert_to_xml("tests/cluster_regressions/natbib_bbl_super_refnum.tex");
+  assert_eq!(
+    bbl_refnum(&x, "shor_1994"),
+    "1",
+    "super-mode .bbl refnum must be the bare entry number:\n{x}"
+  );
+
+  // Control: author-year mode KEEPS the author-year label (fix is scoped).
+  let x = convert_to_xml("tests/cluster_regressions/natbib_bbl_authoryear_refnum.tex");
+  assert_eq!(
+    bbl_refnum(&x, "shor_1994"),
+    "Shor (1994)",
+    "author-year mode must keep its author-year label:\n{x}"
+  );
+  assert_eq!(
+    bbl_refnum(&x, "gidney_2021"),
+    "(2)",
+    "author-year mode empty-year entry falls back to the number:\n{x}"
+  );
+}
+
 // ===========================================================================
 // Citation-ORDER numbering for unsorted bibliography styles (html_feedback
 // #6294, IEEE `\bibliographystyle{IEEEtran}`; sibling #5930).

--- a/latexml_oxide/tests/cluster_regressions/natbib_bbl_authoryear_refnum.tex
+++ b/latexml_oxide/tests/cluster_regressions/natbib_bbl_authoryear_refnum.tex
@@ -1,0 +1,17 @@
+% Control for natbib_bbl_numeric_refnum.tex: the SAME `.bbl` entries under
+% `[authoryear]natbib` must KEEP their author-year reference-list labels
+% (`Shor (1994)`). Guards that the numeric surpass-Perl fix in \NAT@wrout is
+% scoped to numeric/super modes and does not flatten author-year mode. The
+% empty-year entry still falls back to a number in both modes.
+\documentclass{article}
+\usepackage[authoryear]{natbib}
+\begin{document}
+Cite: \cite{shor_1994,gidney_2021}.
+\begin{thebibliography}{9}
+\providecommand\citenamefont[1]{#1}
+\bibitem[{\citenamefont{Shor}(1994)}]{shor_1994}
+  P.~Shor, Polynomial-time algorithms.
+\bibitem[{\citenamefont{Gidney}\ and\ \citenamefont{Ekera}()}]{gidney_2021}
+  C.~Gidney and M.~Ekera, How to factor.
+\end{thebibliography}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/natbib_bbl_numeric_refnum.tex
+++ b/latexml_oxide/tests/cluster_regressions/natbib_bbl_numeric_refnum.tex
@@ -1,0 +1,19 @@
+% html_feedback#4295 (arXiv:2410.05202, revtex4-2 / apsrev4-2): a numeric-mode
+% natbib `.bbl` (pre-formatted `thebibliography`, not the `.bib`/MakeBibliography
+% path) whose `\bibitem[{Name(Year)}]{key}` labels carry BOTH author and year.
+% pdflatex+bibtex render the whole numeric reference list as `[N]`; LaTeXML's
+% \NAT@wrout only forced number style on an EMPTY author/year, so an entry WITH a
+% year kept an author-year label — inconsistent with the [N] inline cites and the
+% PDF. `[numbers]natbib` reproduces it without revtex.
+\documentclass{article}
+\usepackage[numbers]{natbib}
+\begin{document}
+Cite: \cite{shor_1994,gidney_2021}.
+\begin{thebibliography}{9}
+\providecommand\citenamefont[1]{#1}
+\bibitem[{\citenamefont{Shor}(1994)}]{shor_1994}
+  P.~Shor, Polynomial-time algorithms.
+\bibitem[{\citenamefont{Gidney}\ and\ \citenamefont{Ekera}()}]{gidney_2021}
+  C.~Gidney and M.~Ekera, How to factor.
+\end{thebibliography}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/natbib_bbl_super_refnum.tex
+++ b/latexml_oxide/tests/cluster_regressions/natbib_bbl_super_refnum.tex
@@ -1,0 +1,16 @@
+% Sibling of natbib_bbl_numeric_refnum.tex for `[super]` citation mode (numeric
+% superscript, empty CITE_OPEN/CLOSE): the reference-list label must be the bare
+% entry NUMBER, not `Shor 1994`. Guards that the numeric surpass-Perl fix in
+% \NAT@wrout covers 'super' as well as 'numbers'.
+\documentclass{article}
+\usepackage[super]{natbib}
+\begin{document}
+Cite: \cite{shor_1994,gidney_2021}.
+\begin{thebibliography}{9}
+\providecommand\citenamefont[1]{#1}
+\bibitem[{\citenamefont{Shor}(1994)}]{shor_1994}
+  P.~Shor, Polynomial-time algorithms.
+\bibitem[{\citenamefont{Gidney}\ and\ \citenamefont{Ekera}()}]{gidney_2021}
+  C.~Gidney and M.~Ekera, How to factor.
+\end{thebibliography}
+\end{document}

--- a/latexml_package/src/package/natbib_sty.rs
+++ b/latexml_package/src/package/natbib_sty.rs
@@ -782,8 +782,20 @@ LoadDefinitions!({
     let open = cite_open();
     let close = cite_close();
 
-    // If authors or year empty, fall back to number style
-    let use_number = !is_some_and_nonempty(&authors) || !is_some_and_nonempty(&year);
+    // If authors or year empty, fall back to number style.
+    //
+    // SURPASS-PERL (OXIDIZED_DESIGN #121): in numeric/superscript citation modes
+    // the reference-list label is the entry NUMBER `[N]`, matching pdflatex+bibtex
+    // (the apsrev4-2 / `[numbers]natbib` PDF) and the inline `[N]` cites. Perl's
+    // `\NAT@wrout` (natbib.sty.ltxml L612-613) only forces number style on an
+    // EMPTY author/year — its `$style eq 'number'` guard never matches the plural
+    // `CITE_STYLE` `'numbers'`/`'super'` — so a numeric `.bbl` entry WITH a year
+    // (e.g. `\bibitem[{Shor(1994)}]{...}`) wrongly kept an author-year label.
+    // Verified same-host: Perl 0.8.8 emits `Shor [1994]` identically, so this is
+    // a deliberate divergence. Witness html_feedback#4295 (arXiv:2410.05202).
+    let use_number = matches!(style.as_str(), "numbers" | "super")
+      || !is_some_and_nonempty(&authors)
+      || !is_some_and_nonempty(&year);
     let style = if use_number { "number" } else { &style };
 
     let refnum = if style == "number" {


### PR DESCRIPTION
**Diagnostic.** A pre-formatted numeric natbib bibliography — the `thebibliography`/`\bibitem` path, not the `.bib`/MakeBibliography path already made numeric by html_feedback#6609 — labelled its References with author-year (`Shor [1994]`) for entries carrying an author **and** a year, while the inline `\cite` correctly showed `[N]`. natbib's `\NAT@wrout` (`natbib_sty.rs`, porting `natbib.sty.ltxml` L609-620) guards its numeric branch on `$style eq 'number'` (**singular**), a value `CITE_STYLE` never holds (`'numbers'`/`'super'`/`'authoryear'`), so number style was reachable only via the empty-author/year fallback.

**Approach.** `\NAT@wrout` now forces number style for `'numbers'`/`'super'` too, so the whole list is `[N]` (bare number in super mode), consistent with the inline cites and the apsrev4-2 / `[numbers]natbib` PDF. `authoryear` mode is untouched. Surpass-Perl — Perl 0.8.8 emits the identical author-year label, verified same-host: OXIDIZED_DESIGN #121, KNOWN_PERL_ERRORS #87.

**Validation.** New guard `06_cluster_bibliography::cluster_bib_natbib_bbl_numeric_refnum` (numbers + super go numeric; the `authoryear` control keeps `Shor (1994)`); full workspace suite 2005/0; clippy + cargo doc clean. Witness arXiv:2410.05202 (html_feedback#4295): all 57 entries now `[1]`…`[57]` in core XML and rendered HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)