### PR TITLE
fix #6870: \centering in a redefined \abstractname stays out of the abstract heading

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3521,3 +3521,28 @@ resolves references in post-processing by design, not through `.aux`/`\r@`; emul
 reference, undefined on pdflatex's run 1 too). The rendering half of #6895 (an oversized inline
 ORCID icon) is unrelated: correct LaTeXML markup, a downstream ar5iv-css over-reach fixed in the
 `ar5iv-css` repo.
+
+## 87. `\centering` in a redefined `\abstractname` leaks as literal text into the abstract heading (Rust surpasses)
+
+`\renewcommand{\abstractname}{\centering {\large Abstract}}` (arXiv/html_feedback#6870, paper
+2312.14226, aistats2024) makes the abstract heading render the literal text `\centeringAbstract`.
+LaTeXML extracts the heading via `getFrontmatterName` → `DigestText(\lx@abstract@name)`, and
+`\lx@abstract@name` is `\format@title@abstract{\abstractname}` with `\format@title@abstract` the
+identity hook `#1` (`latex_constructs.pool.ltxml` L1146-1148). `\centering` is a `DefConstructor`
+(L1237); digesting it into the text-only `name=` attribute serializes its **reversion** back as
+`\centering`. Both engines emit `<ltx:abstract name="\centeringAbstract">` and the XSLT renders
+`<h6 class="ltx_title ltx_title_abstract">\centeringAbstract</h6>`. **Same-host Perl LaTeXML 0.8.8
+is byte-identical** (core XML and post-processed HTML) — SHARED-FAILURE, Perl-origin (upstream
+filing pending, owned by maintainer). Minimal trigger:
+
+```latex
+\documentclass{article}
+\renewcommand{\abstractname}{\centering {\large Abstract}}
+\begin{document}\begin{abstract}Text.\end{abstract}\end{document}
+```
+
+Rust **surpasses** (OXIDIZED_DESIGN #121): the `\format@title@abstract` hook neutralizes alignment
+declarations during name extraction (`{\let\centering\relax\let\raggedright\relax\let\raggedleft\relax#1}`),
+mirroring LaTeXML's own `titlepage` `Let('\centering','\relax')` precedent (L1168), so the name is
+the clean label "Abstract". Font-size/series primitives (`\large`, `\bfseries`) never leaked. Guard:
+`06_cluster_frontmatter::frontmatter_abstract_centering_name`.

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4474,3 +4474,33 @@ superconductivity induced by the Su-Schrieffer-Heeger electron-phonon coupling";
 Shared upstream bug recorded as KNOWN_PERL_ERRORS #84.
 
 **Guard**: `06_cluster_regressions::cluster_eqnarray_nonumber_label_ref_is_the_number`.
+
+### 121. Alignment declarations in `\abstractname` are stripped from the abstract's `name`
+
+**Perl** extracts the abstract heading via `getFrontmatterName` → `DigestText(\lx@abstract@name)`,
+and `\lx@abstract@name` is `\format@title@abstract{\abstractname}` with `\format@title@abstract`
+defined as the identity hook `#1` (`latex_constructs.pool.ltxml` L1146-1148). When a document
+redefines `\renewcommand{\abstractname}{\centering {\large Abstract}}`, digesting the name runs
+`\centering` — a `DefConstructor` (L1237) — whose **reversion** serializes back as the literal
+text `\centering` when the digested box is flattened into the text-only `name=` attribute. So both
+engines emit `<ltx:abstract name="\centeringAbstract">`, and the XSLT renders `<h6
+class="ltx_title ltx_title_abstract">\centeringAbstract</h6>` (SHARED-FAILURE, verified same-host
+on Perl 0.8.8: identical core XML and identical post-processed HTML). Font-size/series primitives
+(`\large`, `\bfseries`) already produce no text leak — only the alignment *constructors* do.
+
+**Rust behavior**: the `\format@title@abstract` hook — designed for exactly this ("# Redefine")
+and used only during abstract-name extraction — neutralizes the alignment declarations inside a
+group: `{\let\centering\relax\let\raggedright\relax\let\raggedleft\relax#1}`. The name digests to
+the clean label `<ltx:abstract name="Abstract">`.
+
+**Why**: the `name` is a plain-text label; an alignment declaration has no textual content and
+must not leak its reversion into it. The fix mirrors LaTeXML's own `titlepage` precedent, which
+does `Let('\centering', '\relax')` (L1168) for the same reason — alignment declarations should not
+fire while frontmatter is being captured. It halos across every paper that decorates
+`\abstractname` with `\centering`/`\raggedright`/`\raggedleft`, at one designated hook rather than
+per-paper. Perl would benefit identically (upstream filing pending, owned by maintainer).
+
+**Witness**: arXiv 2312.14226 (html_feedback #6870, aistats2024 class) — abstract heading rendered
+`\centeringAbstract`; now "Abstract". Shared upstream bug recorded as KNOWN_PERL_ERRORS #87.
+
+**Guard**: `06_cluster_frontmatter::frontmatter_abstract_centering_name`.

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -5133,7 +5133,18 @@ LoadDefinitions!({
     "\\format@title@abstract{\\abstractname}"
   ); // Redefine
   DefMacro!("\\abstractname", "Abstract");
-  def_macro_identity("\\format@title@abstract{}")?;
+  // Perl: `\format@title@abstract{}` -> `#1` (identity). SURPASS (html_feedback#6870,
+  // OXIDIZED_DESIGN_DIVERGENCES #121): this hook is the designated place to format the
+  // abstract heading, whose extracted `name=` is a plain-text label. When users write
+  // `\renewcommand{\abstractname}{\centering {\large Abstract}}`, digesting the name
+  // leaks `\centering`'s constructor reversion as literal text (`\centeringAbstract`);
+  // Perl leaks it identically. Neutralize alignment declarations inside a group during
+  // name extraction, mirroring the `titlepage` `Let('\centering','\relax')` precedent.
+  // Font-size/series primitives (`\large`, `\bfseries`) already produce no text leak.
+  DefMacro!(
+    "\\format@title@abstract{}",
+    "{\\let\\centering\\relax\\let\\raggedright\\relax\\let\\raggedleft\\relax#1}"
+  );
 
   // Hmm, titlepage is likely to be hairy, low-level markup,
   // without even title, author, etc, specified as such!

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -84,6 +84,25 @@ fn frontmatter_acl_quad_authors_short_name() {
     "\\\\[5pt] optional length leaked as text:\n{x}"
   );
 }
+/// html_feedback#6870 (arXiv:2312.14226, aistats2024): `\renewcommand{\abstractname}
+/// {\centering {\large Abstract}}` — the abstract heading must read "Abstract", not
+/// leak the alignment declaration as literal text `\centeringAbstract`. Both Perl and
+/// Rust digested `\centering`'s constructor reversion into the `name=` string; the
+/// designated hook `\format@title@abstract` now neutralizes alignment declarations
+/// during name extraction (mirrors the `titlepage` `Let('\centering','\relax')`
+/// precedent). Surpass-Perl divergence — see OXIDIZED_DESIGN_DIVERGENCES #121.
+#[test]
+fn frontmatter_abstract_centering_name() {
+  let x = convert_to_xml("tests/cluster_regressions/frontmatter_abstract_centering_name.tex");
+  assert!(
+    x.contains("name=\"Abstract\""),
+    "abstract name must be the clean text \"Abstract\":\n{x}"
+  );
+  assert!(
+    !x.contains("\\centering"),
+    "alignment declaration leaked as literal text into the abstract name:\n{x}"
+  );
+}
 /// IEEEtran `\author{\IEEEauthorblockN{…}\IEEEauthorblockA{…}\and …}`: each
 /// block is one creator; the `1\textsuperscript{st}` ordinals must not be
 /// misread as affiliation markers and drop every author. Witness 2602.05517.

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_abstract_centering_name.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_abstract_centering_name.tex
@@ -1,0 +1,7 @@
+\documentclass{article}
+\renewcommand{\abstractname}{\centering {\large Abstract}}
+\begin{document}
+\begin{abstract}
+Large language models can produce long, coherent passages of text.
+\end{abstract}
+\end{document}


### PR DESCRIPTION
**Diagnostic.** `\renewcommand{\abstractname}{\centering {\large Abstract}}` (arXiv 2312.14226) made the abstract heading render literal `\centeringAbstract`: `getFrontmatterName` digests `\lx@abstract@name` into the text-only `name=` attribute, and `\centering` — a `DefConstructor` — serializes its reversion back as text. Same-host Perl 0.8.8 leaks identically (SHARED-FAILURE, core XML + HTML byte-identical).

**Approach.** Surpass-Perl. The designated identity hook `\format@title@abstract` (Perl `#1`) now neutralizes alignment declarations during name extraction — `{\let\centering\relax\let\raggedright\relax\let\raggedleft\relax#1}` — mirroring LaTeXML's own `titlepage` `Let('\centering','\relax')` precedent. Documented as OXIDIZED_DESIGN_DIVERGENCES #121 / KNOWN_PERL_ERRORS #87 (upstream filing owned by maintainer).

**Validation.** Guard `06_cluster_frontmatter::frontmatter_abstract_centering_name` (red→green); witness 2312.14226 `name="\centeringAbstract"` → `name="Abstract"`, zero errors; full suite 2006/0; clippy + fmt clean.

Closes #6870

🤖 Generated with [Claude Code](https://claude.com/claude-code)