### PR TITLE
fix: a wrapper box merges its class onto a single block child, keeping ltx_lstlisting

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3521,3 +3521,25 @@ resolves references in post-processing by design, not through `.aux`/`\r@`; emul
 reference, undefined on pdflatex's run 1 too). The rendering half of #6895 (an oversized inline
 ORCID icon) is unrelated: correct LaTeXML markup, a downstream ar5iv-css over-reach fixed in the
 `ar5iv-css` repo.
+
+## 88. `insertBlock` overwrites a single block child's `class` with the wrapper's, not merges (Rust surpasses)
+
+When a box (minipage/parbox) is absorbed onto its content because the content is a single block the
+context can hold directly, `insertBlock` (`TeX_Box.pool.ltxml` L489-493) copies the box's attributes
+onto the child via `setAttribute` — and for `class` that **overwrites**. LaTeXML has a separate
+`addClass` (merges the space-separated set; used elsewhere in the same file at L887/892/896) but
+`insertBlock` doesn't use it. So a `lstlisting`/`minted` block that is the sole content of a
+`minipage`-in-a-`figure` becomes `<listing class="ltx_minipage">`, losing `ltx_lstlisting` and thus
+the whitespace-preserving CSS keyed on it. Verified same-host: Perl 0.8.8 emits the identical
+`class="ltx_minipage"` (SHARED-FAILURE, Perl-origin). Minimal trigger:
+
+```tex
+\documentclass{article}\usepackage{listings}\begin{document}
+\begin{figure}\begin{minipage}{0.3\textwidth}\begin{lstlisting}
+a
+\end{lstlisting}\end{minipage}\end{figure}\end{document}
+```
+
+→ `<listing class="ltx_minipage" …>` in both engines. Rust **surpasses**: `insert_block` `add_class`es
+the wrapper's class instead of overwriting, so the child keeps `ltx_lstlisting` and gains
+`ltx_minipage`. Full rationale + guard in OXIDIZED_DESIGN #122.

--- a/docs/parity/OXIDIZED_DESIGN.md
+++ b/docs/parity/OXIDIZED_DESIGN.md
@@ -9,7 +9,7 @@ This file is the **index + overview**. The detail lives in a themed family:
 
 | Theme file | What it holds |
 |---|---|
-| [OXIDIZED_DESIGN_DIVERGENCES.md](OXIDIZED_DESIGN_DIVERGENCES.md) | The numbered **Intentional Divergences from Perl** (`#1–#15`, `#17–#18`, `#19–#103`) + a brief Known-Upstream-Perl-Issues list. Code comments cite these as `OXIDIZED_DESIGN #N`. |
+| [OXIDIZED_DESIGN_DIVERGENCES.md](OXIDIZED_DESIGN_DIVERGENCES.md) | The numbered **Intentional Divergences from Perl** (`#1–#15`, `#17–#18`, `#19–#122`) + a brief Known-Upstream-Perl-Issues list. Code comments cite these as `OXIDIZED_DESIGN #N`. |
 | [OXIDIZED_DESIGN_MATH.md](../math/OXIDIZED_DESIGN_MATH.md) | Marpa math-parser design: `#16` design rules + the grammar-rule cluster `#7–#18`. |
 | [OXIDIZED_DESIGN_TYPES.md](OXIDIZED_DESIGN_TYPES.md) | Type-system improvements (behavior-neutral) + tactical internal pitfalls. |
 | [OXIDIZED_DESIGN_FUTURE_WORK.md](OXIDIZED_DESIGN_FUTURE_WORK.md) | Beyond-parity directions not yet built. |
@@ -18,12 +18,12 @@ This file is the **index + overview**. The detail lives in a themed family:
 > `.rs` comments reference them — so they are kept verbatim, which means three
 > quirks: (1) the numbers are **not globally unique** (the math cluster `#7–#18`
 > collides by value with divergences `#7–#18`); (2) a code-referenced number
-> resolves to the file above that owns that *topic* — most (`#1–#15`, `#19–#102`)
+> resolves to the file above that owns that *topic* — most (`#1–#15`, `#19–#122`)
 > are in DIVERGENCES, the math ones (incl. the code-referenced **`#18` = f(x)
 > "Speculative function application"**) are in MATH; (3) **`#76` is a retired
 > number** — its entry was consolidated into `#74` and the number was not
 > reused, so a gap in the sequence is expected, not a missing file. Next free
-> number: **#104**. When in doubt,
+> number: **#123**. When in doubt,
 > `grep '### N\.' docs/parity/OXIDIZED_DESIGN_*.md docs/math/OXIDIZED_DESIGN_MATH.md`.
 
 ---

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4461,3 +4461,54 @@ superconductivity induced by the Su-Schrieffer-Heeger electron-phonon coupling";
 Shared upstream bug recorded as KNOWN_PERL_ERRORS #84.
 
 **Guard**: `06_cluster_regressions::cluster_eqnarray_nonumber_label_ref_is_the_number`.
+
+### 122. A wrapper box merges its `class` onto a single block child, not overwrites it
+
+**Perl**'s `insertBlock` (`TeX_Box.pool.ltxml` L489-493) absorbs a box (minipage,
+parbox, …) onto its content when that content is a single block the context can
+hold directly: it copies the box's attributes onto the child and unwraps the
+wrapper. For `class` it uses `setAttribute(class => …)`, which **overwrites**.
+LaTeXML has a separate `addClass` (used elsewhere in the same file, L887/892/896)
+that merges the space-separated set — but `insertBlock` doesn't use it. So a
+`lstlisting` (or a `minted` block, which routes through the same listings display)
+that is the **sole** content of a `minipage` becomes `<listing class="ltx_minipage">`,
+**losing `ltx_lstlisting`** — and with it the whitespace-preserving CSS keyed on
+that class, so its indentation collapses. latexml-oxide reproduced this exactly
+(SHARED-FAILURE, verified same-host: Perl 0.8.8 also emits `class="ltx_minipage"`).
+
+**Rust behavior**: `insert_block` (`base_utilities.rs`) treats `class` as the
+space-separated set it is — it `add_class`es the wrapper's class onto the child
+instead of overwriting, so the child keeps its own semantic class and *gains* the
+wrapper's: `<listing class="ltx_lstlisting ltx_minipage" vattach="…" width="…">`.
+Every other absorbed attribute (`width`, `vattach`, …) is still `set_attribute`d as
+before; only `class` merges. This is the same `addClass`-vs-`setAttribute`
+distinction LaTeXML already draws, applied at the one site that forgot it.
+
+**Why**: the child's class carries its rendering contract (`ltx_lstlisting` →
+`white-space` handling for code); a wrapper that borrows the child's element must
+not erase it. pdflatex shows the code indented; keeping `ltx_lstlisting` is what
+preserves that in HTML.
+
+**Scope note**: this is the *single-minipage-in-a-float* path. A float with
+*multiple* side-by-side minipages takes the flex-figure layout, where the minipage
+is a separate `ltx_figure_panel` wrapper and the listing already keeps its class —
+so this fix and that path are independent. (The whitespace loss reported for the
+flex path in html_feedback#6632, arXiv:2605.03143, was a *separate*, CSS-only
+cause: arXiv's deployed `arxiv-html-papers-theme` layer sets a bare
+`.ltx_listingline{white-space:normal}` that overrides ar5iv's `nowrap` by
+cascade-layer order — not an engine issue.)
+
+**Witness**: arXiv:2605.03143 (a single `\begin{minipage}…\begin{minted}` in a
+`figure`); before, `<listing class="ltx_minipage">`, after,
+`<listing class="ltx_lstlisting ltx_minipage">`.
+
+**Upstream**: worth filing against `brucemiller/LaTeXML` (`insertBlock` should
+`addClass`, not `setAttribute`, for the `class` key).
+
+**Connected behavior**: the same merge preserves any absorbed block's own class,
+not just listings — e.g. an algorithm float (`ltx_float_algorithm`) that is a
+minipage panel now keeps `ltx_float_algorithm` alongside `ltx_minipage` instead of
+being clobbered to bare `ltx_minipage` (golden `tests/complex/figure_mixed_content.xml`).
+
+**Guard**: `cluster_sizing::listing_in_minipage_keeps_class::listing_sole_content_of_minipage_keeps_lstlisting_class`;
+the `80_complex::figure_mixed_content_test` golden pins the algorithm-float case.

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -3156,8 +3156,23 @@ pub fn insert_block(
     {
       // IF: Single node, allowed in context & accepts attributes
       // THEN: Add attributes and unwrap the single node
+      //
+      // SURPASS-PERL (OXIDIZED_DESIGN #122): `class` MERGES, it does not
+      // overwrite. Perl's insertBlock (`TeX_Box.pool.ltxml` L492) uses
+      // `setAttribute(class => …)`, so a wrapper's class (e.g. minipage's
+      // `ltx_minipage`) clobbered the single child's own class — a `lstlisting`
+      // that is the sole content of a `minipage`-in-`figure` became
+      // `class="ltx_minipage"`, losing `ltx_lstlisting` and thus the
+      // whitespace-preserving CSS, so its indentation collapsed
+      // (html_feedback#6632, arXiv:2605.03143). LaTeXML already distinguishes
+      // `addClass` from `setAttribute`; merging the child's class with the
+      // wrapper's keeps both (`ltx_lstlisting ltx_minipage`).
       for (k, v) in block_attr.iter() {
-        document.set_attribute(&mut nodes[0], k, v)?;
+        if k == "class" {
+          document.add_class(&mut nodes[0], v)?;
+        } else {
+          document.set_attribute(&mut nodes[0], k, v)?;
+        }
       }
       document.unwrap_nodes(container)?;
       return Ok(nodes);

--- a/latexml_oxide/tests/cluster_regressions/listing_in_minipage_keeps_class.tex
+++ b/latexml_oxide/tests/cluster_regressions/listing_in_minipage_keeps_class.tex
@@ -1,0 +1,29 @@
+% html_feedback#4295... no — html_feedback#6632 (arXiv:2605.03143): code in a
+% figure/minipage lost its indentation and newlines. Root cause: when a
+% `lstlisting` (or a `minted` block, which routes through the same listings
+% display) is the SOLE content of a `minipage`, insert_block absorbs the minipage
+% onto the single child and OVERWRITES its `class` — `ltx_lstlisting` becomes
+% `ltx_minipage`, so the whitespace-preserving CSS keyed on `.ltx_lstlisting`
+% stops applying and the leading-space indentation collapses. The listing must
+% keep `ltx_lstlisting` and merely GAIN `ltx_minipage` (+ width/vattach).
+\documentclass{article}
+\usepackage{listings}
+\begin{document}
+Control (not boxed):
+\begin{lstlisting}
+let f () =
+  send(x)
+  if a
+\end{lstlisting}
+
+Inside a minipage in a figure (the paper's structure: figure > minipage > code):
+\begin{figure}
+\begin{minipage}{0.3\textwidth}
+\begin{lstlisting}
+let f () =
+  send(x)
+  if a
+\end{lstlisting}
+\end{minipage}
+\end{figure}
+\end{document}

--- a/latexml_oxide/tests/cluster_sizing.rs
+++ b/latexml_oxide/tests/cluster_sizing.rs
@@ -790,3 +790,63 @@ mod wrapfig_inner_linewidth {
     );
   }
 }
+
+/// html_feedback#6632 (arXiv:2605.03143): code in a figure/minipage lost its
+/// indentation and newlines. When a `lstlisting` (or a `minted` block, which
+/// routes through the same listings display) is the SOLE content of a `minipage`,
+/// `insert_block` (`base_utilities.rs`) absorbs the minipage onto the single child
+/// and set the child's attributes — but `setAttribute("class", …)` OVERWROTE the
+/// child's `ltx_lstlisting` with `ltx_minipage`, so the whitespace-preserving CSS
+/// keyed on `.ltx_lstlisting` stopped applying (leading-space indentation
+/// collapsed). Fix: the `class` key MERGES (`add_class`) like LaTeXML's own
+/// `addClass`, so the listing keeps `ltx_lstlisting` AND gains `ltx_minipage`.
+///
+/// SURPASS-PERL (OXIDIZED_DESIGN #122): Perl's `insertBlock` (`TeX_Box.pool.ltxml`
+/// L492) uses `setAttribute(class => …)`, which overwrites — verified same-host,
+/// Perl 0.8.8 also emits `<listing class="ltx_minipage">` (SHARED-FAILURE). The
+/// merged class matches the PDF's rendered, indented code.
+mod listing_in_minipage_keeps_class {
+  use crate::cluster::convert_to_xml;
+
+  /// The `class` attribute of the `<listing>` element whose base64 `data` starts
+  /// with `data_prefix` (distinguishes the boxed copy from the control — same
+  /// source, same data).
+  fn listing_class(xml: &str, which: usize) -> String {
+    let opens: Vec<&str> = xml
+      .match_indices("<listing ")
+      .map(|(i, _)| {
+        let tag = &xml[i..];
+        &tag[..tag.find('>').unwrap_or(tag.len())]
+      })
+      .collect();
+    let tag = opens
+      .get(which)
+      .unwrap_or_else(|| panic!("fewer than {} <listing> elements:\n{xml}", which + 1));
+    let ci = tag
+      .find("class=\"")
+      .unwrap_or_else(|| panic!("no class on <listing>: {tag}"))
+      + "class=\"".len();
+    tag[ci..][..tag[ci..].find('"').unwrap()].to_string()
+  }
+
+  #[test]
+  fn listing_sole_content_of_minipage_keeps_lstlisting_class() {
+    let xml = convert_to_xml("tests/cluster_regressions/listing_in_minipage_keeps_class.tex");
+
+    // Control: the un-boxed listing has always carried its own class.
+    assert_eq!(
+      listing_class(&xml, 0),
+      "ltx_lstlisting",
+      "control listing lost its class:\n{xml}"
+    );
+
+    // The FIX: the minipage-absorbed listing keeps `ltx_lstlisting` (for the
+    // whitespace CSS) and GAINS `ltx_minipage` (for the sizing) — not one or the
+    // other. `add_class` sorts, so the merged value is `ltx_lstlisting ltx_minipage`.
+    assert_eq!(
+      listing_class(&xml, 1),
+      "ltx_lstlisting ltx_minipage",
+      "listing inside a minipage must keep ltx_lstlisting AND gain ltx_minipage:\n{xml}"
+    );
+  }
+}

--- a/latexml_oxide/tests/complex/figure_mixed_content.xml
+++ b/latexml_oxide/tests/complex/figure_mixed_content.xml
@@ -100,7 +100,7 @@
     <p>Testing <ref labelref="LABEL:array:subfig1"/> and <ref labelref="LABEL:array:subfig2"/> inside <ref labelref="LABEL:array:fig"/>.</p>
     <pagination role="newpage"/>
   </para>
-  <figure align="center" class="ltx_minipage" float="right" framed="top" inlist="loa" placement="H" vattach="middle" width="120.8pt" xml:id="alg1">
+  <figure align="center" class="ltx_float_algorithm ltx_minipage" float="right" framed="top" inlist="loa" placement="H" vattach="middle" width="120.8pt" xml:id="alg1">
     <tags>
       <tag><text font="bold">Algorithm 1</text></tag>
       <tag role="refnum">1</tag>
@@ -454,7 +454,7 @@
     </figure>
     <pagination role="newpage"/>
     <figure placement="tb" xml:id="S0.SS0.SSS0.Px1.fig3">
-      <float class="ltx_figure_panel ltx_minipage" framed="top" inlist="loa" labels="LABEL:alg:main" placement="H" vattach="middle" width="193.2pt" xml:id="alg2">
+      <float class="ltx_figure_panel ltx_float_algorithm ltx_minipage" framed="top" inlist="loa" labels="LABEL:alg:main" placement="H" vattach="middle" width="193.2pt" xml:id="alg2">
         <tags>
           <tag><text font="bold">Algorithm 2</text></tag>
           <tag role="refnum">2</tag>


### PR DESCRIPTION
**Diagnostic.** When `insert_block` (`base_utilities.rs`) absorbs a minipage/parbox onto its single block child, it set the child's attributes via `setAttribute` — and for `class` that overwrote. So a `lstlisting`/`minted` that is the sole content of a `minipage`-in-a-`figure` became `class="ltx_minipage"`, losing `ltx_lstlisting` and its whitespace-preserving CSS.

**Approach.** Merge the `class` key (`add_class`, as LaTeXML's own `addClass` does) instead of overwriting, so the child keeps its class and gains the wrapper's (`ltx_lstlisting ltx_minipage`); other attributes still `set_attribute` as before. Surpass-Perl (Perl 0.8.8 overwrites identically, verified same-host): OXIDIZED_DESIGN #122, KNOWN_PERL_ERRORS #88.

**Validation.** Red→green guard `cluster_sizing::listing_in_minipage_keeps_class::listing_sole_content_of_minipage_keeps_lstlisting_class`; the same merge preserves `ltx_float_algorithm` on an algorithm-float panel (golden `80_complex::figure_mixed_content`); full suite 2005/0; clippy + cargo doc clean.

Found while investigating html_feedback#6632; note that the reporter's *rendered* whitespace loss was a **separate, CSS-only** cause — arXiv's deployed `arxiv-html-papers-theme` layer resets `.ltx_listingline`/`.ltx_text` to `white-space:normal`, overriding ar5iv by cascade-layer order (fixed in `ar5iv-css`), not this engine path. This PR is the independent engine-side class-merge correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)