### PR TITLE
fix #61: unwrap whole-name bold so author lines render coherently

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3608,3 +3608,24 @@ Same-host Perl 0.8.8 drops it identically (SHARED-FAILURE, Perl-origin). Minimal
 accumulated content in a title-neutralized group before relaxing it, so the figure renders and the
 reference resolves to "Fig. 1". Guard:
 `06_cluster_frontmatter::frontmatter_maketitle_injected_figure_survives`.
+## 88. Partially-bold author block renders incoherently (Rust surpasses)
+
+`neurips_2023` (and similar classes) bold the *whole* author block with a block-level `\bf` in
+their `\@maketitle` tabular — pure PDF layout LaTeXML does not emulate, since it captures semantic
+creators from `\author`. A paper (arXiv 2308.06262, html_feedback#61) that `\textbf`s only its
+second author line and relies on that class `\bf` for the first then renders incoherently: the
+first line plain, the second bold. **Same-host Perl LaTeXML 0.8.8 is byte-identical** — both emit
+`<ltx:personname><ltx:text font="bold">Name</ltx:text></ltx:personname>` on the `\textbf` lines and
+a bare `<ltx:personname>Name</ltx:personname>` on the rest (SHARED-FAILURE, Perl-origin, upstream
+filing pending, owned by maintainer). Minimal trigger (plain `article`, no neurips needed):
+
+```latex
+\documentclass{article}\title{T}
+\author{Alpha One \\ \textbf{Beta Two}}
+\begin{document}\maketitle\end{document}
+```
+
+Rust **surpasses** (OXIDIZED_DESIGN #122): an `ltx:personname` `afterClose` handler unwraps a
+personname whose sole meaningful child is a *pure* bold `<text>` (series=bold, otherwise default
+upright serif), so all author names render in the same weight; mixed styles (bold-italic, bold-sans)
+are left untouched. Guard: `06_cluster_frontmatter::frontmatter_neurips_author_bold_coherent`.

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4580,3 +4580,38 @@ figure renders (`xml:id="S0.F1"`) and the reference resolves to "Fig. 1". Shared
 upstream bug recorded as KNOWN_PERL_ERRORS #90.
 
 **Guard**: `06_cluster_frontmatter::frontmatter_maketitle_injected_figure_survives`.
+### 122. A `font="bold"` wrapping an entire author name is unwrapped for coherence
+
+**Perl** captures semantic creators from `\author`, not the class's visual title
+layout. Classes like `neurips_2023` bold the whole author block with a block-level
+`\bf` in their `\@maketitle` (`\begin{tabular}[t]{c}\bf…\@author\end{tabular}`),
+which LaTeXML does not emulate. So when a paper `\textbf`s only *some* author name
+lines and relies on that class `\bf` for the rest, LaTeXML renders the block
+incoherently — bold on the `\textbf` lines, plain on the others. Both engines emit
+`<ltx:personname><ltx:text font="bold">Name</ltx:text></ltx:personname>` on the
+explicit-`\textbf` lines and a bare `<ltx:personname>Name</ltx:personname>` on the
+rest (SHARED-FAILURE, byte-identical same-host on Perl 0.8.8).
+
+**Rust behavior**: an `ltx:personname` `afterClose` handler (`unwrap_whole_name_bold`)
+unwraps a personname whose sole meaningful child is a *pure* bold `<ltx:text>` (decoded
+font series=bold, otherwise the default upright serif) — the case that would serialize
+as exactly `font="bold"`. A trailing reference marker (`\footnotemark`/`\thanks` →
+`<ltx:note>`) or a misused-`\\` `<ltx:break>` is skipped, not counted as content, so it
+does not block the unwrap. Mixed styling (bold-italic, bold-sans, bold on only part of
+the name) is left untouched. Every author then renders in the same weight.
+
+**Why**: bolding a whole author name is presentational author-block styling, not
+semantic content; a class that bolds the block does so uniformly, so partial bold is an
+artifact of inconsistent source, never authorial intent (a corresponding/presenting
+author is marked by a superscript, not by name-weight). Normalizing to plain restores
+the coherence the reporter asked for and matches how ar5iv renders author names for the
+overwhelming majority of classes. One general rule at the personname seam, not a
+per-class binding. User-directed 2026-08-16 (chosen over the per-class "emulate the
+class bold" alternative).
+
+**Witness**: arXiv 2308.06262 (html_feedback #61, neurips_2023) — 7 authors rendered as
+3 plain + 4 bold; now all 7 plain. Also arXiv 2507.06670 (acl) "Zhou Zhao", where a
+`\textbf{Zhou Zhao} \footnotemark[2]` bold name kept its footnotemark marker sibling —
+now unwrapped too. Shared upstream bug recorded as KNOWN_PERL_ERRORS #88.
+
+**Guard**: `06_cluster_frontmatter::frontmatter_neurips_author_bold_coherent`.

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -224,7 +224,10 @@ LoadDefinitions!({
   // Sanitize person names for (obvious) punctuation abuse at start+end
   // (moved here from latex_constructs per PR #2767; the existing Rust
   // punctuation-strip port is carried over).
-  Tag!("ltx:personname", after_close => sub[_document, node] {
+  Tag!("ltx:personname", after_close => sub[document, node] {
+    // Normalize a whole-name bold BEFORE the punctuation strip, so the unwrapped
+    // text is punctuation-cleaned like a plain name (html_feedback#61).
+    unwrap_whole_name_bold(document, node)?;
     if let Some(mut first) = node.get_first_child() {
       if first.get_type() == Some(NodeType::TextNode) {
         let first_text = first.get_content();
@@ -1728,6 +1731,68 @@ fn clean_trailing_break(document: &mut Document, node: &mut Node) -> Result<()> 
       break;
     }
     document.remove_node(last);
+  }
+  Ok(())
+}
+
+/// Unwrap a `font="bold"` that wraps an ENTIRE personname.
+///
+/// SURPASS-Perl (html_feedback#61, OXIDIZED_DESIGN_DIVERGENCES #122). Some classes
+/// (neurips_2023) bold the whole author block with a block-level `\bf` in their
+/// `\@maketitle`, which LaTeXML does not emulate — it captures semantic creators.
+/// A paper that then `\textbf`s only *some* name lines (relying on the class `\bf`
+/// for the rest) renders incoherently: bold on the `\textbf` lines, plain on the
+/// others. Bolding a whole author name is presentational author-block styling, not
+/// semantic, so a personname whose sole meaningful content is one `<ltx:text
+/// font="bold">` is normalized to plain. Mixed-content names (bold on part of the
+/// name, or bold+other styles) are left untouched — only the whole-name pure-bold
+/// wrapper is stripped. Both Perl and Rust emit the wrapper (SHARED-FAILURE).
+fn unwrap_whole_name_bold(document: &mut Document, node: &Node) -> Result<()> {
+  let mut sole_bold: Option<Node> = None;
+  for child in node.get_child_nodes() {
+    match child.get_type() {
+      Some(NodeType::TextNode) => {
+        // Any non-whitespace text directly under the name means it is not a
+        // single whole-name wrapper — leave it alone.
+        if !child.get_content().chars().all(char::is_whitespace) {
+          return Ok(());
+        }
+      },
+      Some(NodeType::ElementNode) => {
+        // A reference marker (`\footnotemark`/`\thanks` → `<ltx:note>`) or a trailing
+        // `<ltx:break>` from a misused `\\` is not name content — skip it so it does
+        // not block the unwrap of an otherwise whole-name bold. Witness: "Zhou Zhao"
+        // in arXiv 2507.06670, `\textbf{Zhou Zhao} \footnotemark[2]`.
+        if with(document::get_node_qname(&child), |qname| {
+          qname == "ltx:note" || qname == "ltx:break"
+        }) {
+          continue;
+        }
+        // A `<ltx:text>` whose decoded font would serialize as EXACTLY `font="bold"` —
+        // i.e. bold is its only departure from the default text font. Reuse the
+        // serializer's own `font_attribute_string()` rather than hand-matching the
+        // family/series/shape defaults, so this cannot drift from what `font=` emits.
+        // Bold+italic / bold-sans yield "bold italic"/"… bold" ≠ "bold" and are left
+        // untouched (extra intent).
+        let is_pure_bold = with(document::get_node_qname(&child), |qname| {
+          qname == "ltx:text"
+        }) && child.get_attribute("_font").is_some_and(|fid| {
+          document
+            .decode_font(&fid)
+            .is_some_and(|f| f.font_attribute_string() == "bold")
+        });
+        if is_pure_bold && sole_bold.is_none() {
+          sole_bold = Some(child);
+        } else {
+          // A second element, or a non-pure-bold element → not a sole whole-name bold.
+          return Ok(());
+        }
+      },
+      _ => {},
+    }
+  }
+  if let Some(bold) = sole_bold {
+    document.unwrap_nodes(bold)?;
   }
   Ok(())
 }

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -103,6 +103,38 @@ fn frontmatter_abstract_centering_name() {
     "alignment declaration leaked as literal text into the abstract name:\n{x}"
   );
 }
+/// html_feedback#61 (arXiv:2308.06262, neurips_2023): the `\author` block bolds
+/// only its second name line (`\textbf{…}`) and relies on the class's block-level
+/// `\bf` to bold the rest — which LaTeXML doesn't emulate, so line 1 rendered plain
+/// and line 2 bold (incoherent). A `font="bold"` that wraps an ENTIRE personname is
+/// presentational author-block styling, not semantic; it is now unwrapped so every
+/// author renders coherently. Surpass-Perl divergence — see
+/// OXIDIZED_DESIGN_DIVERGENCES #122. (Plain `article` reproduces the parse — no
+/// neurips dependency.) `\textbf{Zhou Zhao}\footnotemark[2]` additionally guards that
+/// a trailing reference marker (`<ltx:note>`) does not block the unwrap — witness
+/// "Zhou Zhao" in arXiv 2507.06670.
+#[test]
+fn frontmatter_neurips_author_bold_coherent() {
+  let x = convert_to_xml("tests/cluster_regressions/frontmatter_neurips_author_bold_coherent.tex");
+  // The plain-`\textbf` authors survive as plain personnames…
+  for name in ["Fanqing Meng", "Wenqi Shao", "Kaipeng Zhang", "Yu Qiao"] {
+    assert!(
+      x.contains(&format!("<personname>{name}</personname>")),
+      "author {name} must be a plain personname (whole-name bold unwrapped):\n{x}"
+    );
+  }
+  // …the bold author WITH a trailing footnotemark is also unwrapped (the marker
+  // stays inside the personname, the bold does not).
+  assert!(
+    x.contains("<personname>Zhou Zhao") && x.contains("role=\"footnotemark\""),
+    "bold author with a trailing footnotemark marker was not unwrapped:\n{x}"
+  );
+  // …and none carries a whole-name bold wrapper.
+  assert!(
+    !x.contains("<personname><text font=\"bold\">"),
+    "a whole-personname bold wrapper survived (incoherent with the plain lines):\n{x}"
+  );
+}
 /// IEEEtran `\author{\IEEEauthorblockN{…}\IEEEauthorblockA{…}\and …}`: each
 /// block is one creator; the `1\textsuperscript{st}` ordinals must not be
 /// misread as affiliation markers and drop every author. Witness 2602.05517.

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_neurips_author_bold_coherent.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_neurips_author_bold_coherent.tex
@@ -1,0 +1,9 @@
+\documentclass{article}
+\title{T}
+\author{
+Fanqing Meng$^{1}$, Wenqi Shao$^{1*}$ \\ \textbf{Kaipeng Zhang$^{1}$}, \textbf{Yu Qiao}$^{1}$, \textbf{Zhou Zhao}\footnotemark[2] \\\\
+$^{1}$OpenGVLab, Shanghai AI Laboratory
+}
+\begin{document}
+\maketitle
+\end{document}


### PR DESCRIPTION
**Diagnostic.** neurips_2023 bolds the whole author block with a block-level `\bf` in `\@maketitle` — pure PDF layout LaTeXML doesn't emulate (it captures semantic creators). A paper (arXiv 2308.06262) that `\textbf`s only some name lines then renders incoherently: bold on the `\textbf` lines, plain on the rest. Same-host Perl 0.8.8 is byte-identical (SHARED-FAILURE).

**Approach.** Surpass-Perl (user-directed): an `ltx:personname` `afterClose` handler unwraps a personname whose sole meaningful child is a *pure* bold `<text>` (decoded series=bold, else default upright serif) — the case that serializes as exactly `font="bold"`. A trailing reference marker (`\footnotemark`/`\thanks` → `<note>`) or misused-`\\` `<break>` is skipped, not counted as content. Mixed styles (bold-italic, bold-sans, partial-name bold) are left untouched. OXIDIZED_DESIGN_DIVERGENCES #122 / KNOWN_PERL_ERRORS #88.

**Validation.** Guard `06_cluster_frontmatter::frontmatter_neurips_author_bold_coherent` (red→green; covers a bold name with a trailing `\footnotemark`, witness "Zhou Zhao" in arXiv 2507.06670); witness 2308.06262 now all-plain; no existing golden expected a bold personname; full suite 2007/0; clippy + fmt clean.

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)