### PR TITLE
fix: render natbib citations of a numeric .bbl as [N], not the raw key

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3521,3 +3521,38 @@ resolves references in post-processing by design, not through `.aux`/`\r@`; emul
 reference, undefined on pdflatex's run 1 too). The rendering half of #6895 (an oversized inline
 ORCID icon) is unrelated: correct LaTeXML markup, a downstream ar5iv-css over-reach fixed in the
 `ar5iv-css` repo.
+
+## 89. natbib citations of a numeric `.bbl` render the raw key, not the number (Rust surpasses)
+
+natbib loaded in its default author-year mode, cited against a numeric `.bbl` — plain
+`\bibitem{key}` with no `[author(year)]` label, as `\bibliographystyle{unsrt}`/`plain` emit —
+renders every `\cite` as the citation *key*, not the number. Real pdflatex/bibtex handle this
+via natbib's `\NAT@force@numbers`: a numeric `.bbl` writes `\providecommand\NAT@force@numbers{}`
+into the `.aux`, forcing numbers mode *globally* on the next pass, so every citation prints the
+bracketed number `[N]` even when `\bibliographystyle{unsrt}` sits AFTER the `\cite`s. Golden
+pdflatex `.aux`: `\bibcite{foo}{{1}{}{{}}{{}}}` (number=1, author/year empty) →
+`Text citing [1] and also [2] and both [1, 2].`
+
+Single-pass LaTeXML freezes each `\cite`'s author-year `<ltx:bibref show="Authors…">` at digest
+time (natbib is not yet in numbers mode), and post-processing `CrossRef.pm::make_bibcite` L542 —
+`$show = 'refnum' unless … || $keytag;` — keeps the author-year format because its `|| $keytag`
+guard is always satisfied (every `\bibitem` has a key). The numeric `<ltx:bibitem>` has a
+`number`/`refnum` but no author/year, so the citation prints `key ()` (Rust) / `key ` (Perl).
+Verified same-host on 0.8.8 (SHARED-FAILURE, Perl-origin). Minimal trigger:
+
+```tex
+\documentclass{article}\usepackage{natbib}\begin{document}
+See \cite{alpha}, \cite{beta}, \cite{alpha,beta}.
+\bibliographystyle{unsrt}
+\begin{thebibliography}{10}
+\bibitem{alpha} A. Author. A paper. Journal, 2020.
+\bibitem{beta}  C. Coder.  A paper. Proc, 2021.
+\end{thebibliography}\end{document}
+```
+
+→ Perl `alpha `, pre-fix Rust `alpha ()`; pdflatex `[1]`. Reported as arXiv/html_feedback#62
+(witness 2308.06262, a NeurIPS-2023 paper: 263 `\cite`s all rendered `key ()`). Rust **surpasses**
+(OXIDIZED_DESIGN #123): when a frozen author-year bibref resolves to entries that are all
+numeric-only, `CrossRef::fill_in_bibrefs` collapses to the bracketed number `[N]`/`[N, M]`, matching
+`\NAT@force@numbers`. Guard:
+`06_cluster_bibliography::cluster_bib_natbib_late_numeric_style_forces_numbers`.

--- a/docs/parity/OXIDIZED_DESIGN.md
+++ b/docs/parity/OXIDIZED_DESIGN.md
@@ -9,7 +9,7 @@ This file is the **index + overview**. The detail lives in a themed family:
 
 | Theme file | What it holds |
 |---|---|
-| [OXIDIZED_DESIGN_DIVERGENCES.md](OXIDIZED_DESIGN_DIVERGENCES.md) | The numbered **Intentional Divergences from Perl** (`#1–#15`, `#17–#18`, `#19–#103`) + a brief Known-Upstream-Perl-Issues list. Code comments cite these as `OXIDIZED_DESIGN #N`. |
+| [OXIDIZED_DESIGN_DIVERGENCES.md](OXIDIZED_DESIGN_DIVERGENCES.md) | The numbered **Intentional Divergences from Perl** (`#1–#15`, `#17–#18`, `#19–#123`) + a brief Known-Upstream-Perl-Issues list. Code comments cite these as `OXIDIZED_DESIGN #N`. |
 | [OXIDIZED_DESIGN_MATH.md](../math/OXIDIZED_DESIGN_MATH.md) | Marpa math-parser design: `#16` design rules + the grammar-rule cluster `#7–#18`. |
 | [OXIDIZED_DESIGN_TYPES.md](OXIDIZED_DESIGN_TYPES.md) | Type-system improvements (behavior-neutral) + tactical internal pitfalls. |
 | [OXIDIZED_DESIGN_FUTURE_WORK.md](OXIDIZED_DESIGN_FUTURE_WORK.md) | Beyond-parity directions not yet built. |
@@ -18,12 +18,12 @@ This file is the **index + overview**. The detail lives in a themed family:
 > `.rs` comments reference them — so they are kept verbatim, which means three
 > quirks: (1) the numbers are **not globally unique** (the math cluster `#7–#18`
 > collides by value with divergences `#7–#18`); (2) a code-referenced number
-> resolves to the file above that owns that *topic* — most (`#1–#15`, `#19–#102`)
+> resolves to the file above that owns that *topic* — most (`#1–#15`, `#19–#123`)
 > are in DIVERGENCES, the math ones (incl. the code-referenced **`#18` = f(x)
 > "Speculative function application"**) are in MATH; (3) **`#76` is a retired
 > number** — its entry was consolidated into `#74` and the number was not
 > reused, so a gap in the sequence is expected, not a missing file. Next free
-> number: **#104**. When in doubt,
+> number: **#124**. When in doubt,
 > `grep '### N\.' docs/parity/OXIDIZED_DESIGN_*.md docs/math/OXIDIZED_DESIGN_MATH.md`.
 
 ---

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4474,3 +4474,40 @@ superconductivity induced by the Su-Schrieffer-Heeger electron-phonon coupling";
 Shared upstream bug recorded as KNOWN_PERL_ERRORS #84.
 
 **Guard**: `06_cluster_regressions::cluster_eqnarray_nonumber_label_ref_is_the_number`.
+
+### 123. natbib citations of a numeric `.bbl` render as the bracketed number
+
+**Perl** renders such citations as the raw citation key. When natbib is loaded in
+its default author-year mode but the `.bbl` is numeric — plain `\bibitem{key}`
+with no `[author(year)]` label, as `\bibliographystyle{unsrt}`/`plain` produce —
+each `\cite` freezes an author-year `<ltx:bibref show="Authors Phrase1YearPhrase2">`
+at digest time (natbib's mode isn't yet numeric, especially when the
+`\bibliographystyle` sits AFTER the cites). The numeric `<ltx:bibitem>` carries a
+`number`/`refnum` tag but no author/year metadata, only a `keytag`. Post-processing
+`CrossRef.pm::make_bibcite` L542 keeps the author-year format
+(`$show = 'refnum' unless … || $keytag;` — the `|| $keytag` guard is always
+satisfied), so the citation prints the key (`alpha ()` / `alpha `). latexml-oxide
+reproduced this exactly (SHARED-FAILURE, verified same-host on 0.8.8).
+
+**Rust behavior**: in `CrossRef::fill_in_bibrefs` (`latexml_post/src/crossref.rs`),
+when a bibref's frozen `show` wants author-year yet EVERY cited entry is
+numeric-only (a `number`/`refnum`, no real `authors`/`fullauthors`/`year`), the
+citation collapses to natbib's numeric form: the bracketed number `[N]`, or `[N, M]`
+for a multi-key `\cite` (each number a separate link). The brackets are added only
+when the frozen author-year delimiters lived inside the bibref (`\cite`/`\citet`,
+whose `show` has a Phrase after Year); `\citep`, whose parens are sibling text,
+keeps its own delimiter.
+
+**Why**: this mirrors natbib's own algorithm. On a numeric `.bbl`, real
+pdflatex/bibtex write `\NAT@force@numbers` into the `.aux`, forcing numbers mode
+globally so every `\cite` prints `[N]` regardless of a late `\bibliographystyle`.
+The published PDF is the ground truth (`Text citing [1] and also [2] and both
+[1, 2].`); Perl's raw-key output is the defect.
+
+**Witness**: arXiv 2308.06262 (html_feedback #62) — a NeurIPS-2023 paper
+(`neurips_2023.sty` loads natbib, `\bibliographystyle{unsrt}` after 263 `\cite`s,
+numeric `main.bbl`). Every citation rendered `key ()`; now all render `[N]`/`[N, …]`,
+byte-matching the golden pdflatex `.bbl`+`.aux`. Shared upstream bug recorded as
+KNOWN_PERL_ERRORS #89.
+
+**Guard**: `06_cluster_bibliography::cluster_bib_natbib_late_numeric_style_forces_numbers`.

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -322,6 +322,59 @@ fn etoolbox_pretocmd_assigns_through_cite_lock() {
   );
 }
 
+/// natbib citations of a numeric `.bbl` must render as the bracketed number
+/// `[N]`/`[N, M]`, not the raw citation key.
+///
+/// Witness arXiv:2308.06262 (html_feedback#62): `neurips_2023.sty` loads natbib
+/// in its default author-year mode, `\bibliographystyle{unsrt}` sits AFTER all
+/// the `\cite`s, and the shipped `.bbl` is numeric (plain `\bibitem{key}`, no
+/// `[author(year)]` label). Real pdflatex/bibtex handle this via natbib's
+/// `\NAT@force@numbers`: a numeric `.bbl` forces numbers mode GLOBALLY, so every
+/// `\cite` prints `[N]` regardless of the late `\bibliographystyle`. Golden
+/// pdflatex: `[1]`, `[2]`, `[1, 2]`.
+///
+/// Single-pass LaTeXML freezes the bibref's author-year `show` at `\cite` time,
+/// and Perl `CrossRef.pm:542` keeps it (its `|| $keytag` guard is always
+/// satisfied), so BOTH engines render the raw key (`alpha ()` / `alpha `). This
+/// is the surpass-Perl fix (OXIDIZED_DESIGN #123, KNOWN_PERL_ERRORS #89): when a
+/// frozen author-year bibref resolves to entries that are all numeric-only, we
+/// collapse to natbib's bracketed number.
+#[test]
+fn cluster_bib_natbib_late_numeric_style_forces_numbers() {
+  // Text content of each `<cite>` in document order, inner tags stripped and
+  // whitespace normalized ("[<ref>1</ref>, <ref>2</ref>]" -> "[1, 2]").
+  fn cite_texts(xml: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = xml;
+    while let Some(i) = rest.find("<cite") {
+      let after = &rest[i..];
+      let open_end = after.find('>').map(|e| e + 1).unwrap_or(after.len());
+      let close = after.find("</cite>").unwrap_or(after.len());
+      let inner = &after[open_end..close.max(open_end)];
+      let (mut txt, mut depth) = (String::new(), 0);
+      for c in inner.chars() {
+        match c {
+          '<' => depth += 1,
+          '>' => depth -= 1,
+          _ if depth == 0 => txt.push(c),
+          _ => {},
+        }
+      }
+      out.push(txt.split_whitespace().collect::<Vec<_>>().join(" "));
+      rest = &after[close.min(after.len())..];
+      rest = rest.strip_prefix("</cite>").unwrap_or(rest);
+    }
+    out
+  }
+  let x = convert_and_post("tests/cluster_regressions/natbib_late_numeric_style.tex");
+  assert_eq!(
+    cite_texts(&x),
+    vec!["[1]", "[2]", "[1, 2]"],
+    "numeric .bbl cited before a late \\bibliographystyle{{unsrt}} must render \
+     as the bracketed number, not the raw key:\n{x}"
+  );
+}
+
 /// A `refcontext` block must not eat the `\printbibliography` inside it, and
 /// `\addbibresource` must accept its optional argument.
 ///

--- a/latexml_oxide/tests/cluster_regressions/natbib_late_numeric_style.tex
+++ b/latexml_oxide/tests/cluster_regressions/natbib_late_numeric_style.tex
@@ -1,0 +1,23 @@
+\documentclass{article}
+\usepackage{natbib}
+\begin{document}
+Single \cite{alpha}, other \cite{beta}, and multi \cite{alpha,beta}.
+
+% A numeric \bibliographystyle placed AFTER the \cite commands, with a numeric
+% .bbl (plain \bibitem{key}, no [author(year)] label): natbib forces numbers,
+% so pdflatex renders every citation as the bracketed number [N] / [N, M].
+\bibliographystyle{unsrt}
+\begin{thebibliography}{10}
+
+\bibitem{alpha}
+Alice Author and Bob Builder.
+\newblock A first paper.
+\newblock {\em Journal of Things}, 2020.
+
+\bibitem{beta}
+Carol Coder.
+\newblock A second paper.
+\newblock {\em Proceedings of Stuff}, 2021.
+
+\end{thebibliography}
+\end{document}

--- a/latexml_post/src/crossref.rs
+++ b/latexml_post/src/crossref.rs
@@ -1464,15 +1464,12 @@ impl CrossRef {
         .unwrap_or_else(|| "refnum".to_string());
       // natbib emits show patterns like:
       //   "AuthorsPhrase1Year"           → \citep{X} → "Author (Year)"
-      //   "Authors Phrase1YearPhrase2"  → \citet{X} → "Author (Year)"
+      //   "Authors Phrase1YearPhrase2"  → \citet{X}/\cite{X} → "Author (Year)"
       //   "refnum"                       → numeric / default
       // Anything containing "Author" or "Year" wants the author-year
       // text built from the bibentry's `authors`/`year` fields; the
       // legacy refnum-only path serves the numeric case.
-      let want_authoryear = show.contains("Author") || show.contains("Year");
-      let sep = bibref
-        .get_attribute("separator")
-        .unwrap_or_else(|| ",".to_string());
+      let show_wants_ay = show.contains("Author") || show.contains("Year");
       // The lists to search, most-specific first. Perl CrossRef.pm L515 reads
       // `inlist || 'bibliography'` — an *exclusive* choice, which strands every
       // citation of a document that loads `bibunits`/`chapterbib` but keeps a
@@ -1492,6 +1489,62 @@ impl CrossRef {
       if !lists.contains(&"bibliography") {
         lists.push("bibliography");
       }
+      // \NAT@force@numbers (natbib): a numeric `.bbl` — plain `\bibitem{key}`
+      // with no `[author(year)]` label — forces numbers mode globally, so every
+      // `\cite` prints the bracketed number `[N]`/`[N, M]` even when a numeric
+      // `\bibliographystyle{unsrt}` sits AFTER the cites (witness arXiv:2308.06262
+      // / html_feedback#62). Single-pass LaTeXML froze this bibref's author-year
+      // `show`; Perl `CrossRef.pm:542` keeps it because its `|| $keytag` guard is
+      // always satisfied, so both engines render the raw key. When the show wants
+      // author-year yet EVERY cited entry is numeric-only (has a number, no real
+      // author/year), collapse to natbib's numeric form. SURPASS-PERL:
+      // OXIDIZED_DESIGN #123, KNOWN_PERL_ERRORS #89.
+      let force_numeric = show_wants_ay && {
+        let keys: Vec<&str> = keys_str.split(',').filter(|k| !k.is_empty()).collect();
+        !keys.is_empty()
+          && keys.iter().all(|key| {
+            let mut id = None;
+            for list in &lists {
+              if let Some(be) = self.db.lookup(&format!("BIBLABEL:{}:{}", list, key)) {
+                id = be.get_string("id").map(String::from);
+                if id.is_some() {
+                  break;
+                }
+              }
+            }
+            let Some(id) = id else { return false };
+            match self.db.lookup(&format!("ID:{}", id)) {
+              Some(e) => {
+                let nonempty = |k: &str| {
+                  e.get_value(k)
+                    .is_some_and(|v| !v.to_string().trim().is_empty())
+                };
+                !nonempty("authors")
+                  && !nonempty("fullauthors")
+                  && !nonempty("year")
+                  && (nonempty("number") || nonempty("refnum"))
+              },
+              None => false,
+            }
+          })
+      };
+      // Do the frozen author-year delimiters sit INSIDE the bibref (a Phrase
+      // after Year — `\cite`/`\citet` carry their own `( )`) or as sibling text
+      // (`\citep`, whose macro adds the parens outside the bibref)? Only bracket
+      // our numeric group in the former case, else `\citep`'s parens double up.
+      let internal_delims = show
+        .find("Year")
+        .is_some_and(|yp| show[yp + "Year".len()..].contains("Phrase"));
+      // Numeric collapse joins with ", " (natbib numbers mode) and drops the
+      // author-year path; otherwise the loop keeps the bibref's own separator.
+      let want_authoryear = show_wants_ay && !force_numeric;
+      let sep = if force_numeric {
+        ",".to_string()
+      } else {
+        bibref
+          .get_attribute("separator")
+          .unwrap_or_else(|| ",".to_string())
+      };
 
       let mut refs: Vec<NodeData> = Vec::new();
       for key in keys_str.split(',').filter(|k| !k.is_empty()) {
@@ -1592,6 +1645,12 @@ impl CrossRef {
             children:   vec![NodeData::Text(key.to_string())],
           });
         }
+      }
+      // Bracket the numeric group as a whole ([1, 2]), matching natbib's numbers
+      // mode; \citep-style external parens (no internal delimiter) are left be.
+      if force_numeric && internal_delims && !refs.is_empty() {
+        refs.insert(0, NodeData::Text("[".to_string()));
+        refs.push(NodeData::Text("]".to_string()));
       }
       if !refs.is_empty() {
         doc.replace_node(bibref, &refs);


### PR DESCRIPTION
**Diagnostic.** natbib in author-year mode cited against a numeric `.bbl` (plain `\bibitem{key}`, no `[author(year)]` label) with a late `\bibliographystyle{unsrt}` freezes each `\cite` as an author-year `<ltx:bibref>` in single-pass LaTeXML. `CrossRef.pm:542`'s `|| $keytag` guard is always satisfied, so both engines render the raw key — `key ()` (Rust) / `key ` (Perl) — instead of a number.

**Approach.** Mirror natbib's own `\NAT@force@numbers` (a numeric `.bbl` forces numbers mode globally): in `CrossRef::fill_in_bibrefs`, when a frozen author-year bibref resolves to entries that are all numeric-only (a `number`/`refnum`, no real author/year), collapse to the bracketed number `[N]` / `[N, M]`, matching the golden pdflatex `.aux` (`\bibcite{foo}{{1}{}{{}}{{}}}` renders `[1]`). The per-key loop is unchanged. SURPASS-PERL: OXIDIZED_DESIGN 123, KNOWN_PERL_ERRORS 89.

**Validation.** Red to green guard `cluster_bib_natbib_late_numeric_style_forces_numbers`; full suite 2006/0; workspace clippy + fmt clean. Same-host Perl 0.8.8 parity confirmed (`alpha `). Witness arXiv:2308.06262 (263 `\cite`s: all `key ()` become `[N]`), byte-matching the golden pdflatex.

Addresses the report in arXiv/html_feedback#62 (external tracker; unrelated to the already-closed local issue of the same number).

🤖 Generated with [Claude Code](https://claude.com/claude-code)