### PR TITLE
fix: recover figures injected into the title via \g@addto@macro\@maketitle

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3581,3 +3581,30 @@ See \cite{alpha}, \cite{beta}, \cite{alpha,beta}.
 numeric-only, `CrossRef::fill_in_bibrefs` collapses to the bracketed number `[N]`/`[N, M]`, matching
 `\NAT@force@numbers`. Guard:
 `06_cluster_bibliography::cluster_bib_natbib_late_numeric_style_forces_numbers`.
+
+## 90. Content injected into `\@maketitle` is discarded with the title machinery (Rust surpasses)
+
+LaTeXML replaces the LaTeX kernel's `\maketitle`→`\@maketitle` typesetting pipeline with its own
+frontmatter model: `\maketitle` deposits the separately-captured title/author/date and then
+`\global\let\@maketitle\relax` (`latex_constructs.pool.ltxml` L1105), the source comment (L1094)
+admitting "In case `\@maketitle` defines these — we can't yet emulate that." So content a document
+appends to `\@maketitle` via `\g@addto@macro` — a teaser figure, an epigraph — is silently dropped,
+and any `\ref` to a `\label` inside it renders the raw internal key `LABEL:fig:teaser`. Real
+pdflatex runs `\@maketitle`, so the figure appears below the title and its `\ref` resolves.
+Same-host Perl 0.8.8 drops it identically (SHARED-FAILURE, Perl-origin). Minimal trigger:
+
+```latex
+\documentclass{article}\usepackage{graphicx}\title{T}\author{A}
+\makeatletter
+\g@addto@macro\@maketitle{\begin{figure}\includegraphics{x}\caption{C}\label{fig:t}\end{figure}}
+\makeatother
+\begin{document}\maketitle See \ref{fig:t}.\end{document}
+```
+
+→ both engines drop the figure and render `\ref` as "LABEL:fig:t"; pdflatex shows the figure and
+"1". Reported as arXiv/html_feedback#4281 (witness 2506.23854, an ICCV paper whose teaser
+`\figref{fig:teaser}` rendered "Fig. LABEL:fig:teaser"). Rust **surpasses** (OXIDIZED_DESIGN #124):
+`\@maketitle` is predefined empty (clean `\g@addto@macro` append) and `\maketitle` deposits its
+accumulated content in a title-neutralized group before relaxing it, so the figure renders and the
+reference resolves to "Fig. 1". Guard:
+`06_cluster_frontmatter::frontmatter_maketitle_injected_figure_survives`.

--- a/docs/parity/OXIDIZED_DESIGN.md
+++ b/docs/parity/OXIDIZED_DESIGN.md
@@ -9,7 +9,7 @@ This file is the **index + overview**. The detail lives in a themed family:
 
 | Theme file | What it holds |
 |---|---|
-| [OXIDIZED_DESIGN_DIVERGENCES.md](OXIDIZED_DESIGN_DIVERGENCES.md) | The numbered **Intentional Divergences from Perl** (`#1–#15`, `#17–#18`, `#19–#123`) + a brief Known-Upstream-Perl-Issues list. Code comments cite these as `OXIDIZED_DESIGN #N`. |
+| [OXIDIZED_DESIGN_DIVERGENCES.md](OXIDIZED_DESIGN_DIVERGENCES.md) | The numbered **Intentional Divergences from Perl** (`#1–#15`, `#17–#18`, `#19–#124`) + a brief Known-Upstream-Perl-Issues list. Code comments cite these as `OXIDIZED_DESIGN #N`. |
 | [OXIDIZED_DESIGN_MATH.md](../math/OXIDIZED_DESIGN_MATH.md) | Marpa math-parser design: `#16` design rules + the grammar-rule cluster `#7–#18`. |
 | [OXIDIZED_DESIGN_TYPES.md](OXIDIZED_DESIGN_TYPES.md) | Type-system improvements (behavior-neutral) + tactical internal pitfalls. |
 | [OXIDIZED_DESIGN_FUTURE_WORK.md](OXIDIZED_DESIGN_FUTURE_WORK.md) | Beyond-parity directions not yet built. |
@@ -18,12 +18,12 @@ This file is the **index + overview**. The detail lives in a themed family:
 > `.rs` comments reference them — so they are kept verbatim, which means three
 > quirks: (1) the numbers are **not globally unique** (the math cluster `#7–#18`
 > collides by value with divergences `#7–#18`); (2) a code-referenced number
-> resolves to the file above that owns that *topic* — most (`#1–#15`, `#19–#123`)
+> resolves to the file above that owns that *topic* — most (`#1–#15`, `#19–#124`)
 > are in DIVERGENCES, the math ones (incl. the code-referenced **`#18` = f(x)
 > "Speculative function application"**) are in MATH; (3) **`#76` is a retired
 > number** — its entry was consolidated into `#74` and the number was not
 > reused, so a gap in the sequence is expected, not a missing file. Next free
-> number: **#124**. When in doubt,
+> number: **#125**. When in doubt,
 > `grep '### N\.' docs/parity/OXIDIZED_DESIGN_*.md docs/math/OXIDIZED_DESIGN_MATH.md`.
 
 ---

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4541,3 +4541,42 @@ byte-matching the golden pdflatex `.bbl`+`.aux`. Shared upstream bug recorded as
 KNOWN_PERL_ERRORS #89.
 
 **Guard**: `06_cluster_bibliography::cluster_bib_natbib_late_numeric_style_forces_numbers`.
+
+### 124. Content injected into `\@maketitle` is recovered, not discarded
+
+**Perl** discards `\@maketitle` wholesale. LaTeXML replaces the LaTeX kernel's
+`\maketitle`→`\@maketitle` typesetting pipeline with its own frontmatter model:
+`\maketitle` deposits the separately-captured title/author/date
+(`\lx@frontmatterhere`) and then `\global\let\@maketitle\relax`
+(`latex_constructs.pool.ltxml` L1105), with the source comment (L1094) admitting
+"In case `\@maketitle` defines these — we can't yet emulate that." So content a
+document appends to `\@maketitle` — a teaser figure, an epigraph, a banner — is
+silently dropped, and any `\ref` to a `\label` inside it renders the raw internal
+key ("LABEL:fig:teaser"). latexml-oxide reproduced this exactly (SHARED-FAILURE,
+verified same-host on 0.8.8: both engines drop the figure).
+
+**Rust behavior**: `\@maketitle` is predefined empty (so `\g@addto@macro\@maketitle`
+appends cleanly — LaTeXML never reimplements the title *layout*, so `\@maketitle`
+is otherwise undefined and appending to it warns "not expandable" and leaves a
+self-reference), and `\maketitle` gains a `\lx@deposit@maketitle` step — after
+`\lx@frontmatterhere`, before `\global\let\@maketitle\relax` — that deposits
+`\@maketitle`'s accumulated content in a title-neutralized group
+(`\let\@title\@empty\let\@author\@empty\let\@date\@empty\let\@thanks\@empty`). An
+`\ifx\@maketitle\@empty` guard makes it a no-op for the vast majority of papers.
+Injected definitions execute LaTeX-scoped (group-local, as real `\maketitle`'s
+`\begingroup` does); injected content deposits.
+
+**Why**: real pdflatex runs `\@maketitle`, so the teaser figure appears right
+below the title and its `\ref` resolves to the figure number. Matching the
+published PDF beats dropping the figure and leaking the internal label key. The
+title-neutralization reuses the same technique as the `\format@title@abstract`
+fix (#121): run the macro with the title-producing pieces neutralized so only the
+injected content survives, rather than fragile token-parsing.
+
+**Witness**: arXiv 2506.23854 (html_feedback #4281) — a teaser figure injected via
+`\g@addto@macro\@maketitle{\begin{figure}…\label{fig:teaser}…\end{figure}}`; the
+figure vanished and `\figref{fig:teaser}` rendered "Fig. LABEL:fig:teaser". Now the
+figure renders (`xml:id="S0.F1"`) and the reference resolves to "Fig. 1". Shared
+upstream bug recorded as KNOWN_PERL_ERRORS #90.
+
+**Guard**: `06_cluster_frontmatter::frontmatter_maketitle_injected_figure_survives`.

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -5053,6 +5053,28 @@ LoadDefinitions!({
   Let!("\\And", "\\and");
   Let!("\\AND", "\\and");
 
+  // SURPASS-PERL (OXIDIZED_DESIGN #124, KNOWN_PERL_ERRORS #90): recover content
+  // a document injects into the title via `\g@addto@macro\@maketitle{…}`.
+  // LaTeXML redefines `\maketitle` to deposit its own captured frontmatter and
+  // then discards `\@maketitle` wholesale (`\global\let\@maketitle\relax`, with
+  // the source comment "we can't yet emulate that"), so a teaser figure appended
+  // to `\@maketitle` — and its `\label` — were silently dropped by BOTH engines.
+  //
+  // Two pieces: (1) predefine `\@maketitle` EMPTY so `\g@addto@macro` appends
+  // cleanly (LaTeXML never reimplements the title *layout*, so `\@maketitle` is
+  // otherwise undefined and appending to it warns "not expandable" and leaves a
+  // self-reference); (2) `\lx@deposit@maketitle` deposits its accumulated content
+  // in a title-neutralized group (nulling `\@title`/`\@author`/`\@date`/`\@thanks`
+  // so the rare class that stuffs real title-layout into `\@maketitle` does not
+  // double-print the title; the common case holds only the injected content).
+  // The `\ifx…\@empty` guard makes this a no-op for the vast majority of papers.
+  // Witness arXiv:2506.23854 (html_feedback#4281).
+  DefMacro!("\\@maketitle", "");
+  DefMacro!(
+    "\\lx@deposit@maketitle",
+    r"\ifx\@maketitle\@empty\else{\let\@title\@empty\let\@author\@empty\let\@date\@empty\let\@thanks\@empty\let\and\relax\@maketitle}\fi"
+  );
+
   // Doesn't produce anything (we're already inserting frontmatter),
   // But, it does make the various frontmatter macros into no-ops.
   // Locked: raw TeX packages (e.g., nips_2017.sty) may \renewcommand{\maketitle}, but
@@ -5069,9 +5091,13 @@ LoadDefinitions!({
   // `\@maketitle`-undefined / XMApp-in-empty cascade. Perl builds this body by
   // string concatenation (no `\`+eol), so its `\maketitle` has no control-space
   // and is robust. Keep it single-line here to match.
+  //
+  // `\lx@deposit@maketitle` runs after `\lx@frontmatterhere` (so injected content
+  // lands right after the title) and before `\global\let\@maketitle\relax` (while
+  // `\@maketitle` still holds its content).
   DefMacro!(
     "\\maketitle",
-    r"\lx@frontmatterhere\let\lx@frontmatter@fallback\relax\@startsection@hook\global\let\thanks\relax\global\let\maketitle\relax\global\let\@maketitle\relax\global\let\@thanks\@empty\global\let\@author\@empty\global\let\@date\@empty\global\let\@title\@empty\global\let\title\relax\global\let\author\relax\global\let\date\relax\global\let\and\relax",
+    r"\lx@frontmatterhere\let\lx@frontmatter@fallback\relax\@startsection@hook\lx@deposit@maketitle\global\let\thanks\relax\global\let\maketitle\relax\global\let\@maketitle\relax\global\let\@thanks\@empty\global\let\@author\@empty\global\let\@date\@empty\global\let\@title\@empty\global\let\title\relax\global\let\author\relax\global\let\date\relax\global\let\and\relax",
     locked => true
   );
   // In case \maketitle isn't used in the document, let's check for it.

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -558,3 +558,37 @@ fn frontmatter_inst_affiliation_dedup() {
     "the second (distinct) affiliation was dropped:\n{x}"
   );
 }
+
+/// A figure injected into the title via `\g@addto@macro\@maketitle{…}` must
+/// survive and register its `\label`.
+///
+/// LaTeXML redefines `\maketitle` to deposit its own captured frontmatter and
+/// then `\global\let\@maketitle\relax` — discarding `\@maketitle` wholesale (the
+/// source even notes "we can't yet emulate that"). So content a document appends
+/// to `\@maketitle` (a teaser figure, an epigraph) was silently dropped, and any
+/// `\ref` to a `\label` inside it rendered the raw internal key
+/// "LABEL:fig:teaser". Both engines shared this blind spot (Perl drops it too).
+///
+/// Fix (surpass-Perl, OXIDIZED_DESIGN #124, KNOWN_PERL_ERRORS #90): `\@maketitle`
+/// is predefined empty (so `\g@addto@macro` appends cleanly) and `\maketitle`
+/// now deposits its accumulated content in a title-neutralized group before
+/// relaxing it. Witness arXiv:2506.23854 (html_feedback#4281).
+#[test]
+fn frontmatter_maketitle_injected_figure_survives() {
+  let x = convert_to_xml("tests/cluster_regressions/maketitle_injected_figure.tex");
+  // The injected figure now exists AND carries its label (before the fix there
+  // was no teaser figure at all, hence no `labels="LABEL:fig:teaser"`).
+  assert!(
+    x.contains(r#"labels="LABEL:fig:teaser""#),
+    "the figure injected into \\@maketitle was dropped (no teaser figure/label):\n{x}"
+  );
+  assert!(
+    x.contains("Teaser caption for the drums scene."),
+    "the injected figure's caption was lost:\n{x}"
+  );
+  // The graphics candidate rode along too.
+  assert!(
+    x.contains("teaser.png"),
+    "the injected figure's graphics were lost:\n{x}"
+  );
+}

--- a/latexml_oxide/tests/cluster_regressions/maketitle_injected_figure.tex
+++ b/latexml_oxide/tests/cluster_regressions/maketitle_injected_figure.tex
@@ -1,0 +1,27 @@
+\documentclass{article}
+\usepackage{graphicx}
+\title{HiNeuS}
+\author{An Author}
+\makeatletter
+% arXiv 2506.23854 (html_feedback#4281): a teaser figure injected into the
+% title via \g@addto@macro\@maketitle. LaTeXML redefines \maketitle and used to
+% discard \@maketitle wholesale, dropping the figure and its \label — so
+% \ref{fig:teaser} rendered "LABEL:fig:teaser".
+% Also exercise the mixed case: \@maketitle can carry a definition AND content.
+% The definition executes (LaTeX-scoped, like real \maketitle's group) and the
+% caption below consumes it, so the fix must run the injection, not just splice
+% tokens.
+\g@addto@macro\@maketitle{%
+\newcommand\teaserscene{drums scene}%
+\begin{figure}
+\centering
+\includegraphics[width=2cm]{teaser.png}
+\caption{Teaser caption for the \teaserscene.}
+\label{fig:teaser}
+\end{figure}%
+}
+\makeatother
+\begin{document}
+\maketitle
+As shown in \ref{fig:teaser}, the method works.
+\end{document}


### PR DESCRIPTION
**Diagnostic.** LaTeXML redefines `\maketitle` to deposit its own captured frontmatter and then `\global\let\@maketitle\relax` (`latex_constructs.pool.ltxml:1099`), discarding `\@maketitle` wholesale — the source even notes "we can't yet emulate that." So content a document injects via `\g@addto@macro\@maketitle{…}` (a teaser figure, and its `\label`) was silently dropped by both engines, and `\ref` to it rendered the raw key "LABEL:fig:teaser".

**Approach.** Surpass-Perl (OXIDIZED_DESIGN 124, KNOWN_PERL_ERRORS 90): predefine `\@maketitle` empty so `\g@addto@macro` appends cleanly, and add a `\lx@deposit@maketitle` step to `\maketitle` — after `\lx@frontmatterhere`, before the `\relax` — that deposits `\@maketitle`'s accumulated content in a title-neutralized group. An `\ifx\@maketitle\@empty` guard makes it a no-op for papers that never touch it; injected definitions execute LaTeX-scoped (group-local, like real `\maketitle`'s `\begingroup`).

**Validation.** Red→green guard `frontmatter_maketitle_injected_figure_survives` (figure + its label recovered, incl. a define-and-use case). Witness arXiv:2506.23854: the teaser figure now renders (`xml:id="S0.F1"`) and `\ref{fig:teaser}` resolves to "1" (zero residual "LABEL:fig:teaser"). Full suite 2008/0; workspace clippy + fmt clean. Same-host Perl 0.8.8 drops the figure identically (shared blind spot).

Addresses the report in arXiv/html_feedback#4281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)