### PR TITLE
fix #4539: drop phantom empty author creators from comma-split \IEEEmembership

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -1404,6 +1404,18 @@ is the names, the rest affiliations. Witness arXiv:2507.06670 (acl): line 2's fi
 author "Ruiqi Li" was an empty personname + a bogus "Ruiqi Li" affiliation; now an
 author. Same-host Perl 0.8.8 mangles it identically (SHARED-FAILURE) — recorded as
 KNOWN_PERL_ERRORS #91.
+**(e) Phantom empty creators from comma-split `\IEEEmembership`/`\thanks`.** A flat
+comma author list with interspersed non-name commands — `\author{Alice,
+\IEEEmembership{…}, and Bob, …\thanks{…}}` (html_feedback#4539, witness 2508.00603) —
+comma/" and "-splits into pieces where the `\IEEEmembership{…}` pieces digest to
+nothing, surfacing as empty `<ltx:personname/>` creators; a trailing `\thanks` then
+strands its affiliation/email on a nameless creator, and the reader sees a stray "`,
+,`" between authors. `insert_frontmatter`'s `coalesce_empty_creators` drops
+name-empty author creators, moving any contacts they carry to the preceding real
+author (a `\footnotemark`-note keeps a personname non-empty, so real authors with a
+marker — 2507.06670 "Yu Zhang" — are untouched). Same-host Perl 0.8.8 emits the same
+empty creators (SHARED-FAILURE); Rust surpasses. Guard:
+`06_cluster_frontmatter::frontmatter_ieee_membership_no_phantom`.
 
 **Scope/limits:**
 - The `*` equal-contribution suffix on a combined author mark (`$^{1*}$`) still

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -2255,8 +2255,71 @@ pub fn insert_frontmatter(document: &mut Document) -> Result<()> {
       document.expire_box_to_absorb();
     }
   }
+  coalesce_empty_creators(document)?;
   relocate_annotations(document)?;
   Ok(())
+}
+
+/// Remove author creators whose `<ltx:personname>` is empty, moving any contacts they
+/// carry to the preceding real creator (else the first following one).
+///
+/// A flat comma author list with interspersed `\IEEEmembership{…}`/`\thanks{…}` — e.g.
+/// `\author{Alice, \IEEEmembership{…}, and Bob, …\thanks{…}}` (html_feedback#4539,
+/// witness 2508.00603) — comma/" and "-splits into pieces where the membership pieces
+/// digest to nothing, surfacing as empty `<ltx:personname/>` creators; a trailing
+/// `\thanks` then strands its affil/email on a nameless creator. This coalesces those:
+/// contactless empties are dropped; a contact-bearing empty's contacts move to the
+/// preceding real author. `\footnotemark`-note markers keep a personname non-empty
+/// (2507.06670 "Yu Zhang"), so real authors are untouched.
+fn coalesce_empty_creators(document: &mut Document) -> Result<()> {
+  let creators = document.findnodes("//ltx:creator[@role='author']", None);
+  let mut to_remove: Vec<Node> = Vec::new();
+  let mut last_real: Option<Node> = None;
+  // Contacts of leading empties (before any real author) held until the first real one.
+  let mut orphan_contacts: Vec<Node> = Vec::new();
+  for creator in creators {
+    if creator_personname_empty(document, &creator) {
+      let contacts: Vec<Node> = creator
+        .get_child_nodes()
+        .into_iter()
+        .filter(|c| {
+          c.get_type() == Some(NodeType::ElementNode)
+            && with(document::get_node_qname(c), |q| q == "ltx:contact")
+        })
+        .collect();
+      if let Some(ref mut prev) = last_real {
+        if !contacts.is_empty() {
+          document.append_clone(prev, contacts)?;
+        }
+      } else {
+        orphan_contacts.extend(contacts);
+      }
+      to_remove.push(creator);
+    } else {
+      if !orphan_contacts.is_empty() {
+        let mut first = creator.clone();
+        document.append_clone(&mut first, std::mem::take(&mut orphan_contacts))?;
+      }
+      last_real = Some(creator);
+    }
+  }
+  for creator in to_remove {
+    document.remove_node(creator);
+  }
+  Ok(())
+}
+
+/// True if `creator`'s `<ltx:personname>` carries no name — no element child and no
+/// non-whitespace text (a bare `<ltx:personname/>`), or no personname at all. A
+/// personname with a real name (text) or a `<ltx:text>`/`<ltx:note>` child is NOT empty.
+fn creator_personname_empty(document: &mut Document, creator: &Node) -> bool {
+  match document.findnode("ltx:personname", Some(creator)) {
+    None => true,
+    Some(person) => !person.get_child_nodes().iter().any(|c| {
+      c.get_type() == Some(NodeType::ElementNode)
+        || (c.get_type() == Some(NodeType::TextNode) && !c.get_content().trim().is_empty())
+    }),
+  }
 }
 
 /// Streaming: insert frontmatter that arrived AFTER the in-document insertion

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -186,7 +186,10 @@ fn frontmatter_ieee_authorblock() {
 }
 /// IEEEtran `\IEEEmembership{Senior Member, IEEE}` inside a flat comma author
 /// list must not become a phantom "Senior Member, IEEE" creator. Witness
-/// 2508.00603.
+/// 2508.00603 (html_feedback#4539: reader saw a stray "," between authors). The
+/// comma-split leaves EMPTY name pieces where each `\IEEEmembership`/" and " sat;
+/// those must not surface as empty `<personname/>` creators, and a trailing
+/// `\thanks` must attach to the preceding real author, not to a nameless creator.
 #[test]
 fn frontmatter_ieee_membership_no_phantom() {
   let x = convert_to_xml("tests/cluster_regressions/frontmatter_ieee_membership.tex");
@@ -197,6 +200,22 @@ fn frontmatter_ieee_membership_no_phantom() {
   assert!(
     !x.contains("<personname>Senior Member") && !x.contains("<personname>Member, IEEE"),
     "IEEEmembership leaked as a phantom creator:\n{x}"
+  );
+  // No empty personname creators from the comma-split membership/" and " gaps.
+  assert!(
+    !x.contains("<personname/>") && !x.contains("<personname></personname>"),
+    "comma-split left an empty <personname/> creator:\n{x}"
+  );
+  // Exactly the two real authors.
+  assert_eq!(
+    x.matches("<creator role=\"author\"").count() + x.matches("<creator before").count(),
+    2,
+    "expected exactly 2 author creators (Alice, Bob):\n{x}"
+  );
+  // The \thanks note is not stranded on a nameless creator.
+  assert!(
+    !x.contains("<personname/>\n") || !x.contains("Funding note"),
+    "the \\thanks funding note stranded on an empty creator:\n{x}"
   );
 }
 /// IEEEtran lazy single-`\author` block with `\\[1em]` row breaks (witness


### PR DESCRIPTION
**Diagnostic.** A flat comma author list with interspersed `\IEEEmembership{…}`/`\thanks{…}` (arXiv 2508.00603) comma-splits into pieces where the membership pieces digest to nothing, surfacing as empty `<personname/>` creators; a trailing `\thanks` strands its affiliation/email on a nameless creator, and the reader sees a stray "`, ,`". Same-host Perl 0.8.8 emits the same empties (SHARED-FAILURE).

**Approach.** Surpass-Perl (first fix from the author-markup evidence base, see `AUTHOR_MARKUP_PIPELINE.md`). `insert_frontmatter` now runs `coalesce_empty_creators`: drop name-empty author creators, moving any contacts they carry to the preceding real author. A `\footnotemark`-note keeps a personname non-empty, so real marked authors (2507.06670 "Yu Zhang") are untouched. Refines OXIDIZED_DESIGN #52(e).

**Validation.** Guard `06_cluster_frontmatter::frontmatter_ieee_membership_no_phantom` strengthened (red→green: no empty creators, exactly 2 authors, `\thanks` on a real author); witness 2508.00603 now 3 clean creators; the global coalesce pass causes **no regression** — full suite 2007/0; clippy + fmt clean.

Addresses the phantom-empty-creator half of arXiv/html_feedback#4539 (witness 2508.00603).