### PR TITLE
fix: multi-line author block with trailing \quad\\ keeps line-2 first author

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3629,3 +3629,23 @@ Rust **surpasses** (OXIDIZED_DESIGN #122): an `ltx:personname` `afterClose` hand
 personname whose sole meaningful child is a *pure* bold `<text>` (series=bold, otherwise default
 upright serif), so all author names render in the same weight; mixed styles (bold-italic, bold-sans)
 are left untouched. Guard: `06_cluster_frontmatter::frontmatter_neurips_author_bold_coherent`.
+
+## 91. Multi-line author block with a trailing `\quad\\` loses the second line's first author (Rust surpasses)
+
+A `\author{}` whose first line ends with `\quad \\` — a common NeurIPS/ACL idiom for wrapping a
+long author list (`… Zhiyuan Zhu\quad \\ \textbf{Ruiqi Li}\quad …`, arXiv 2507.06670) — has the
+`\\` leak to the head of the next `\quad`-split group in the no-marker author arm, so that group's
+first `\\`-piece is empty and its real first author is demoted to a bogus affiliation under an empty
+`<personname/>`. **Same-host Perl LaTeXML 0.8.8 mangles it identically** (SHARED-FAILURE,
+Perl-origin, upstream filing pending). Minimal trigger:
+
+```latex
+\documentclass{article}\title{T}
+\author{Alice One\quad Bob Two\quad \\ Carol Three\quad Dan Four \\ Some University \\}
+\begin{document}\maketitle\end{document}
+```
+
+→ Perl/pre-fix Rust: "Carol Three" is an empty `<personname/>` + a "Carol Three" affiliation. Rust
+**surpasses** (OXIDIZED_DESIGN #52(d)): empty `\\`-pieces are dropped before choosing the name line,
+so the first NON-empty piece is the names. Guard:
+`06_cluster_frontmatter::frontmatter_multiline_author_leading_break`.

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -1393,6 +1393,18 @@ before the marker ⇒ author, split into creators) or "\textsuperscript{n}Affil"
 the four authors but ALSO emits the affiliation line itself as phantom author
 creators.
 
+**(d) Multi-line author block with a trailing `\quad\\`.** In the no-marker arm,
+author *groups* split on `\quad`/`\and` and each group then splits on `\\` into a
+name line + trailing affiliations. When a line ends with `\quad \\` (a common
+NeurIPS/ACL idiom for wrapping a long author list), the `\\` leaks to the HEAD of
+the next `\quad`-group, so that group's first `\\`-piece is empty and its real
+first author was demoted to an affiliation under an empty `<personname/>`. Fixed by
+dropping empty `\\`-pieces before choosing the name line: the first NON-empty piece
+is the names, the rest affiliations. Witness arXiv:2507.06670 (acl): line 2's first
+author "Ruiqi Li" was an empty personname + a bogus "Ruiqi Li" affiliation; now an
+author. Same-host Perl 0.8.8 mangles it identically (SHARED-FAILURE) — recorded as
+KNOWN_PERL_ERRORS #91.
+
 **Scope/limits:**
 - The `*` equal-contribution suffix on a combined author mark (`$^{1*}$`) still
   labels `affiliation:1*`, so it does not yet match a plain `affiliation:1`

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -972,12 +972,20 @@ LoadDefinitions!({
         if block.is_empty() {
           continue;
         }
-        let mut pieces = split_tokens(block, vec![SplitDelim::Token(T_CS!("\\\\"))]).into_iter();
+        // Drop empty `\\`-pieces up front. A group that BEGINS with `\\` — because
+        // the previous author line ended with a trailing `\quad\\` (or `\and\\`) that
+        // leaked the line-break into this group — would otherwise give an EMPTY
+        // names_line, demoting the group's real first author to an affiliation. The
+        // first NON-empty piece is the name list; the rest are affiliations. Witness
+        // arXiv 2507.06670 (acl): `…Zhiyuan Zhu\quad \\ \textbf{Ruiqi Li}\quad…`
+        // rendered "Ruiqi Li" as an empty `<personname/>` + a bold "Ruiqi Li"
+        // affiliation; now "Ruiqi Li" is an author. (A `\\`-only block still yields a
+        // single empty author below, so its affiliations are not dropped.)
+        let mut pieces = split_tokens(block, vec![SplitDelim::Token(T_CS!("\\\\"))])
+          .into_iter()
+          .filter(|l| !l.is_empty());
         let names_line = pieces.next().unwrap_or_default();
-        let affils: Vec<Tokens> = pieces.filter(|l| !l.is_empty()).collect();
-        // A `\\`-leading block (`\author{\\ MIT}`) has an empty name list; keep a
-        // single (empty) author so its affiliations are still emitted rather than
-        // silently dropped (matches the pre-#52 `unwrap_or_default()` behaviour).
+        let affils: Vec<Tokens> = pieces.collect();
         let mut names = split_author_line(names_line);
         if names.is_empty() {
           names.push(Tokens::default());

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -135,6 +135,35 @@ fn frontmatter_neurips_author_bold_coherent() {
     "a whole-personname bold wrapper survived (incoherent with the plain lines):\n{x}"
   );
 }
+/// A multi-line `\author` block whose first line ends with a trailing `\quad \\`
+/// (arXiv 2507.06670, acl): the leaked `\\` heads the next `\quad`-group, so its
+/// first author ("Carol Three" here; "Ruiqi Li" in the paper) landed on an EMPTY
+/// names_line and was demoted to a bogus affiliation with an empty `<personname/>`.
+/// Dropping empty `\\`-pieces up front keeps every line-2 author an author.
+#[test]
+fn frontmatter_multiline_author_leading_break() {
+  let x =
+    convert_to_xml("tests/cluster_regressions/frontmatter_multiline_author_leading_break.tex");
+  // All four authors — including the first of the second line — are personnames.
+  for name in ["Alice One", "Bob Two", "Carol Three", "Dan Four"] {
+    assert!(
+      x.contains(&format!("<personname>{name}</personname>")),
+      "author {name} missing as a personname:\n{x}"
+    );
+  }
+  // The reported canary: no empty personname, and the line-2 first author is NOT
+  // demoted to an affiliation.
+  assert!(
+    !x.contains("<personname/>") && !x.contains("<personname></personname>"),
+    "a leading `\\\\` produced an empty personname:\n{x}"
+  );
+  assert!(
+    !x.contains("role=\"affiliation\">Carol Three"),
+    "line-2 first author Carol Three misclassified as an affiliation:\n{x}"
+  );
+  // The genuine affiliation still attaches.
+  assert!(x.contains("Some University"), "affiliation dropped:\n{x}");
+}
 /// IEEEtran `\author{\IEEEauthorblockN{…}\IEEEauthorblockA{…}\and …}`: each
 /// block is one creator; the `1\textsuperscript{st}` ordinals must not be
 /// misread as affiliation markers and drop every author. Witness 2602.05517.

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_multiline_author_leading_break.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_multiline_author_leading_break.tex
@@ -1,0 +1,10 @@
+\documentclass{article}
+\title{T}
+\author{
+Alice One\quad Bob Two\quad \\
+Carol Three\quad Dan Four \\
+Some University \\
+}
+\begin{document}
+\maketitle
+\end{document}


### PR DESCRIPTION
**Diagnostic.** In the no-marker author arm, groups split on `\quad`/`\and`, then each group splits on `\\`. A first line ending `\quad \\` (a common NeurIPS/ACL wrap idiom, arXiv 2507.06670) leaks the `\\` to the head of the next group, so its first `\\`-piece is empty and the group's real first author is demoted to an affiliation under an empty `<personname/>`. Same-host Perl 0.8.8 mangles it identically (SHARED-FAILURE).

**Approach.** Surpass-Perl. Drop empty `\\`-pieces before choosing the name line: the first NON-empty piece is the names, the rest affiliations. OXIDIZED_DESIGN #52(d) / KNOWN_PERL_ERRORS #91.

**Validation.** Guard `06_cluster_frontmatter::frontmatter_multiline_author_leading_break` (red→green); witness 2507.06670 "Ruiqi Li" now an author, not an empty personname; full suite 2007/0 (pre-rebase), re-running post-rebase; clippy + fmt clean.

Part of the author-markup pipeline effort (`AUTHOR_MARKUP_PIPELINE.md`, F1).