### PR TITLE
fix #6242: split multiple \textsuperscript{n} affiliations on one line

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -1417,6 +1417,21 @@ marker — 2507.06670 "Yu Zhang" — are untouched). Same-host Perl 0.8.8 emits 
 empty creators (SHARED-FAILURE); Rust surpasses. Guard:
 `06_cluster_frontmatter::frontmatter_ieee_membership_no_phantom`.
 
+**(f) Multiple `\textsuperscript{n}Affil` on one space-separated affiliation line.** A
+marker-led affiliation line may carry several numbered institutions with only spaces
+between them — `\textsuperscript{1}University A \textsuperscript{2}University B`
+(html_feedback#6242, arXiv:2510.02340). The marker-branch classified the whole line as
+ONE affiliation, merging both (and attaching them to a single author). Now the line is
+split at each whitespace-preceded mark (reusing `split_before_affiliation_marks`, the
+`\thanks`-abuse splitter — which by construction never breaks a superscript glued
+INSIDE an institution name, e.g. "Center for R$^2$ Studies"), so each numbered
+institution becomes its own affiliation and `relocate_annotations` attaches it to the
+authors bearing that number. Perl produces no structured creators for this superscript
+idiom at all, so Rust already surpasses; this refines the surpass. Guard:
+`06_cluster_frontmatter::frontmatter_multi_affil_superscript`. (Residual, separate: when
+a `\texttt{…}` email is glued to the last affil with no `\\`, it still bleeds into that
+affiliation — a distinct email-boundary defect.)
+
 **Scope/limits:**
 - The `*` equal-contribution suffix on a combined author mark (`$^{1*}$`) still
   labels `affiliation:1*`, so it does not yet match a plain `affiliation:1`

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -934,7 +934,20 @@ LoadDefinitions!({
                 entries.push((AuthorLineKind::Author, author));
               }
             } else {
-              entries.push((AuthorLineKind::Affiliation, line));
+              // A marker-led affiliation line may carry MULTIPLE
+              // `\textsuperscript{n}Affil` institutions on one space-separated line
+              // (html_feedback#6242, arXiv:2510.02340) — `\textsuperscript{1}Univ A
+              // \textsuperscript{2}Univ B`. Split at each whitespace-preceded mark
+              // (reusing the `\thanks`-abuse splitter, which never breaks a
+              // superscript glued INSIDE an institution name) so each numbered
+              // institution becomes its own affiliation and attaches to its authors
+              // by number, instead of merging into one.
+              for seg in split_before_affiliation_marks(line) {
+                if seg.unlist_ref().iter().all(|t| *t == T_SPACE!()) {
+                  continue;
+                }
+                entries.push((AuthorLineKind::Affiliation, seg));
+              }
             }
           },
         }

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -74,6 +74,37 @@ fn frontmatter_biblatex_xr_preamble_no_leak() {
     );
   }
 }
+/// html_feedback#6242 (arXiv:2510.02340): two `\textsuperscript{n}Affil` institutions
+/// on one space-separated affiliation line — `\textsuperscript{1}University A
+/// \textsuperscript{2}University B` — must split into TWO affiliations so each attaches
+/// to its authors by number, not merge into one under a single author. Reuses the
+/// `\thanks`-abuse splitter (never breaks a superscript glued inside an institution
+/// name). Refines OXIDIZED_DESIGN #52(f); Rust surpasses (Perl emits no structured
+/// creators for this superscript idiom at all).
+#[test]
+fn frontmatter_multi_affil_superscript() {
+  let x = convert_to_xml("tests/cluster_regressions/frontmatter_multi_affil_superscript.tex");
+  // Both authors present…
+  assert!(
+    x.contains("<personname>Alice</personname>") && x.contains("<personname>Bob</personname>"),
+    "authors missing:\n{x}"
+  );
+  // …two SEPARATE affiliations, each a standalone contact…
+  assert_eq!(
+    x.matches("role=\"affiliation\"").count(),
+    2,
+    "expected exactly two split affiliations:\n{x}"
+  );
+  assert!(
+    x.contains(">University A") && x.contains(">University B<"),
+    "the two numbered institutions did not both survive:\n{x}"
+  );
+  // …and NOT merged into one (the reported canary).
+  assert!(
+    !x.contains("University A University B"),
+    "the two superscript affiliations merged into one:\n{x}"
+  );
+}
 /// html_feedback#6614 (arXiv:2606.08234, ACL): a `\author{Name\quad Name… \\
 /// \textsuperscript{n}Affil}` block must keep SHORT author names as authors, not
 /// reclassify them as affiliations. "Min Xu" (7 tokens) tripped the old `p < 8`

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_multi_affil_superscript.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_multi_affil_superscript.tex
@@ -1,0 +1,7 @@
+\documentclass{article}
+\author{Alice\textsuperscript{1} \quad Bob\textsuperscript{2} \\
+\textsuperscript{1}University A \textsuperscript{2}University B}
+\title{T}
+\begin{document}
+\maketitle
+\end{document}


### PR DESCRIPTION
**Diagnostic.** A marker-led affiliation line can carry several numbered institutions separated only by spaces — `\textsuperscript{1}University A \textsuperscript{2}University B` (arXiv 2510.02340). The marker-branch classified the whole line as ONE affiliation, merging both onto a single author; the other authors got none.

**Approach.** Surpass-Perl (Perl emits no structured creators for this superscript idiom — the whole marker-based structuring is Rust's #52). Split the affiliation line at each whitespace-preceded mark, reusing `split_before_affiliation_marks` (the `\thanks`-abuse splitter, which by construction never breaks a superscript glued *inside* an institution name), so each numbered institution attaches to its authors by number. Refines OXIDIZED_DESIGN #52(f).

**Validation.** Guard `06_cluster_frontmatter::frontmatter_multi_affil_superscript` (red→green); witness 2510.02340 sup-1 authors→UC San Diego, sup-2→SUNY Buffalo; the affiliation witnesses (acl_quad, llncs, sn_jnl) unregressed; full suite 2014/0; clippy + fmt clean. Fixture is warning-free.

Addresses arXiv/html_feedback#6242 (affiliation-merge half; a residual `\texttt` email-bleed with no `\\` boundary is a separate defect, noted in #52(f)).