### PR TITLE
fix: transpose IEEEtran multi-row author grid to row-major reading order (arXiv:2403.16405)

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3694,3 +3694,26 @@ give `[1]`. Reported as arXiv/html_feedback#4295 (witness 2410.05202, 57 entries
 **surpasses**: `\NAT@wrout` forces number style for `'numbers'`/`'super'` too, so the whole list is
 `[N]`, matching the PDF — the `authoryear` path is untouched. Full rationale + guard in
 OXIDIZED_DESIGN #126.
+
+## 94. IEEEtran multi-row author grid is linearized column-major, scrambling author order (Rust surpasses)
+
+An IEEEtran conference `\author{}` grid — `\and` starts a new COLUMN, a top-level `\\` a
+new ROW within a column (arXiv:2403.16405, 6 authors in 3×2) — has each
+`\IEEEauthorblockN` emit its creator in token order (down each column), so the sequence
+is **column-major** (Zhao, Ding, Chen, Kong, Huang, Zhang) instead of the **row-major
+reading order** the PDF / arXiv `citation_author` metadata show (Zhao, Chen, Huang, Ding,
+Kong, Zhang). **Same-host Perl LaTeXML 0.8.8 mis-handles the same grid** (SHARED-FAILURE,
+Perl-origin, upstream filing pending). Minimal trigger:
+
+```latex
+\documentclass[conference]{IEEEtran}
+\author{\IEEEauthorblockN{A}\\ \IEEEauthorblockN{B}
+\and \IEEEauthorblockN{C}\\ \IEEEauthorblockN{D}}
+\begin{document}\maketitle\end{document}
+```
+
+→ column-major A, B, C, D; reading order is A, C, B, D. Rust **surpasses**
+(OXIDIZED_DESIGN #127): the IEEEtran `\author` dispatch transposes a REGULAR `\and`×`\\`
+grid to row-major before emitting creators, guarded so single-row `\and` lists and
+`\\` inside `\IEEEauthorblockA` are never reordered. Guard:
+`06_cluster_frontmatter::frontmatter_ieee_author_grid_transpose`.

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4783,3 +4783,33 @@ escapeinside=!!]{python}` with `!$\label{line:world}$!`; before, `\ref{line:worl
 vanished (empty `ltx_missing_label`); now it registers on the line and links.
 
 **Guard**: `06_cluster_regressions::minted_escapeinside_label_registers_on_the_code_line`.
+### 128. IEEEtran multi-row author grid emits creators in row-major (reading) order
+
+**Perl**: an IEEEtran conference `\author{}` can lay authors out as a 2-D grid where
+`\and` starts a new COLUMN and a top-level `\\` a new ROW within a column —
+`\IEEEauthorblockN{Zhao}…\\ \IEEEauthorblockN{Ding}… \and \IEEEauthorblockN{Chen}…\\
+\IEEEauthorblockN{Kong}… \and …` (arXiv:2403.16405, 6 authors in 3 columns × 2 rows).
+Each `\IEEEauthorblockN` emits its creator in token (declaration) order, i.e. down each
+column, so the creator sequence is **column-major** (Zhao, Ding, Chen, Kong, Huang,
+Zhang) — scrambling the **row-major reading order** the PDF and the arXiv
+`citation_author` metadata show (Zhao, Chen, Huang, Ding, Kong, Zhang). Same-host Perl
+LaTeXML 0.8.8 mis-handles the same grid (SHARED-FAILURE, Perl-origin).
+
+**Rust behavior**: the IEEEtran `\author` dispatch (`ieeetran_cls.rs`) transposes a
+genuine grid to row-major before emitting creators (`transpose_ieee_author_grid`). The
+transpose is guarded TIGHTLY: it fires only for a REGULAR grid — ≥2 `\and` columns,
+every column the SAME number of top-level `\\` rows, that count ≥2. A single-row `\and`
+author list (no top-level `\\`) and `\\` used only INSIDE `\IEEEauthorblockA{…\\…}`
+(nested, brace-depth > 0) are left in their declared order untouched.
+
+**Why**: the reading/metadata order is the authoritative author sequence (it drives
+citation, attribution, and search indexing); a column-major linearization silently
+reorders authors 2…n−1. The tight regular-grid guard keeps every non-grid IEEE block
+(the common case) byte-identical.
+
+**Witness**: arXiv:2403.16405 (IEEEtran, 6 authors) — was Zhao, Ding, Chen, Kong, Huang,
+Zhang; now Zhao, Chen, Huang, Ding, Kong, Zhang. Shared upstream bug recorded as
+KNOWN_PERL_ERRORS #94.
+
+**Guard**: `06_cluster_frontmatter::frontmatter_ieee_author_grid_transpose` (grid
+transposed + a single-row control proven un-reordered).

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -105,6 +105,41 @@ fn frontmatter_multi_affil_superscript() {
     "the two superscript affiliations merged into one:\n{x}"
   );
 }
+/// arXiv:2403.16405 (IEEEtran conference): a `\author{}` grid where `\and` starts a
+/// COLUMN and top-level `\\` a ROW within it is linearized column-major (declaration
+/// order), scrambling the row-major reading order shown in the PDF/arXiv metadata.
+/// `Zhao\\Ding \and Chen\\Kong \and Huang\\Zhang` must emit creators row-major: Zhao,
+/// Chen, Huang, Ding, Kong, Zhang. Perl 0.8.8 also mis-orders/drops this grid
+/// (SHARED-FAILURE); Rust surpasses (OXIDIZED_DESIGN #127 / KNOWN_PERL_ERRORS #94).
+/// The single-row control must NOT be reordered (tight-guard proof).
+#[test]
+fn frontmatter_ieee_author_grid_transpose() {
+  let x = convert_to_xml("tests/cluster_regressions/frontmatter_ieee_author_grid_transpose.tex");
+  // Creators come out in row-major reading order.
+  let want = ["Zhao", "Chen", "Huang", "Ding", "Kong", "Zhang"];
+  let mut last = 0usize;
+  for name in want {
+    let pos = x
+      .find(&format!("<personname>{name}</personname>"))
+      .unwrap_or_else(|| panic!("author {name} missing:\n{x}"));
+    assert!(
+      pos >= last,
+      "author {name} out of row-major order (column-major not transposed):\n{x}"
+    );
+    last = pos;
+  }
+  // Control: a plain single-row `\and` list keeps its DECLARED order (no transpose).
+  let c = convert_to_xml("tests/cluster_regressions/frontmatter_ieee_author_row_no_transpose.tex");
+  let (a, b, cc) = (
+    c.find("<personname>Alice</personname>"),
+    c.find("<personname>Bob</personname>"),
+    c.find("<personname>Carol</personname>"),
+  );
+  assert!(
+    a.is_some() && a < b && b < cc,
+    "single-row \\and list was wrongly reordered:\n{c}"
+  );
+}
 /// html_feedback#6614 (arXiv:2606.08234, ACL): a `\author{Name\quad Name… \\
 /// \textsuperscript{n}Affil}` block must keep SHORT author names as authors, not
 /// reclassify them as affiliations. "Min Xu" (7 tokens) tripped the old `p < 8`

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_ieee_author_grid_transpose.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_ieee_author_grid_transpose.tex
@@ -1,0 +1,16 @@
+\documentclass[conference]{IEEEtran}
+\author{\IEEEauthorblockN{Zhao}\IEEEauthorblockA{Univ 1}
+\\
+\IEEEauthorblockN{Ding}\IEEEauthorblockA{Univ 2}
+\and
+\IEEEauthorblockN{Chen}\IEEEauthorblockA{Univ 3}
+\\
+\IEEEauthorblockN{Kong}\IEEEauthorblockA{Univ 4}
+\and
+\IEEEauthorblockN{Huang}\IEEEauthorblockA{Univ 5}
+\\
+\IEEEauthorblockN{Zhang}\IEEEauthorblockA{Univ 6}}
+\title{T}
+\begin{document}
+\maketitle
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_ieee_author_row_no_transpose.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_ieee_author_row_no_transpose.tex
@@ -1,0 +1,10 @@
+\documentclass[conference]{IEEEtran}
+\author{\IEEEauthorblockN{Alice}\IEEEauthorblockA{Univ A}
+\and
+\IEEEauthorblockN{Bob}\IEEEauthorblockA{Univ B}
+\and
+\IEEEauthorblockN{Carol}\IEEEauthorblockA{Univ C}}
+\title{T}
+\begin{document}
+\maketitle
+\end{document}

--- a/latexml_package/src/package/ieeetran_cls.rs
+++ b/latexml_package/src/package/ieeetran_cls.rs
@@ -219,10 +219,12 @@ LoadDefinitions!({
   // `\IEEEauthorblockN`, else to the standard name-splitter. `\author` is locked
   // in the kernel; re-lock so a user `\renewcommand` can't shadow this.
   DefMacro!("\\author[]{}", sub[(_short, body)] {
-    let target = if body.to_string().contains("authorblockN") {
-      T_CS!("\\lx@IEEE@author@blocks")
+    let (target, body) = if body.to_string().contains("authorblockN") {
+      // Transpose a genuine `\and`×`\\` grid to row-major reading order first
+      // (arXiv:2403.16405); a single-row `\and` list is returned unchanged.
+      (T_CS!("\\lx@IEEE@author@blocks"), transpose_ieee_author_grid(body))
     } else {
-      T_CS!("\\lx@IEEE@author@plain")
+      (T_CS!("\\lx@IEEE@author@plain"), body)
     };
     Ok(Invocation!(target, vec![Some(body)]))
   }, locked => true);
@@ -775,3 +777,67 @@ LoadDefinitions!({
   // dropped on the floor).
   DefMacro!("\\newlineauthors", "\\par");
 });
+
+/// Split `tokens` at each TOP-LEVEL (brace-depth 0) occurrence of `delim`.
+fn split_top_level(tokens: &[Token], delim: &Token) -> Vec<Vec<Token>> {
+  let mut parts: Vec<Vec<Token>> = vec![Vec::new()];
+  let mut depth: i32 = 0;
+  for t in tokens {
+    match t.get_catcode() {
+      Catcode::BEGIN => depth += 1,
+      Catcode::END => depth -= 1,
+      _ => {},
+    }
+    if depth == 0 && t == delim {
+      parts.push(Vec::new());
+    } else {
+      parts.last_mut().unwrap().push(*t);
+    }
+  }
+  parts
+}
+
+/// Transpose a genuine IEEEtran `\and`×`\\` author grid from column-major
+/// (declaration order) to row-major (reading order).
+///
+/// html_feedback#6242-adjacent (arXiv:2403.16405): a conference `\author{}` lays
+/// authors out as a 2-D grid — `\and` starts a new COLUMN, top-level `\\` a new ROW
+/// within a column. Each `\IEEEauthorblockN` emits its creator in token order, so
+/// LaTeXML (and Perl) linearize down each column = column-major, scrambling the
+/// reading (row-major) order shown in the PDF and the arXiv metadata. Transpose so
+/// creators come out row-major. Guarded TIGHTLY: only a REGULAR grid (≥2 columns,
+/// every column the SAME number of rows ≥2) is reordered. A single-row `\and` list
+/// (no top-level `\\`) and `\\` used only INSIDE `\IEEEauthorblockA{…\\…}` (nested,
+/// depth>0) are left exactly as declared. Surpass-Perl divergence: OXIDIZED_DESIGN
+/// #128 (shared upstream bug KNOWN_PERL_ERRORS #94).
+fn transpose_ieee_author_grid(body: Tokens) -> Tokens {
+  let toks = body.unlist();
+  let columns = split_top_level(&toks, &T_CS!("\\and"));
+  if columns.len() < 2 {
+    return Tokens::new(toks); // not a multi-column grid
+  }
+  let grid: Vec<Vec<Vec<Token>>> = columns
+    .iter()
+    .map(|c| split_top_level(c, &T_CS!("\\\\")))
+    .collect();
+  let rows = grid[0].len();
+  // Only a REGULAR grid transposes: same row count in every column, and ≥2 rows.
+  if rows < 2 || grid.iter().any(|c| c.len() != rows) {
+    return Tokens::new(toks);
+  }
+  let and = T_CS!("\\and");
+  let mut out: Vec<Token> = Vec::new();
+  for r in 0..rows {
+    for col in &grid {
+      let cell = &col[r];
+      if cell.iter().all(|t| *t == T_SPACE!()) {
+        continue;
+      }
+      if !out.is_empty() {
+        out.push(and);
+      }
+      out.extend(cell.iter().copied());
+    }
+  }
+  Tokens::new(out)
+}


### PR DESCRIPTION
**Diagnostic.** An IEEEtran conference `\author{}` can be a 2-D grid — `\and` starts a COLUMN, a top-level `\\` a ROW within it (arXiv 2403.16405, 6 authors in 3×2). Each `\IEEEauthorblockN` emits its creator in token order (down each column), so the sequence is **column-major** (Zhao, Ding, Chen, Kong, Huang, Zhang), scrambling the **row-major reading order** the PDF and arXiv `citation_author` metadata show (Zhao, Chen, Huang, Ding, Kong, Zhang). Perl 0.8.8 mis-handles the same grid (SHARED-FAILURE).

**Approach.** Surpass-Perl. The IEEEtran `\author` dispatch (`ieeetran_cls.rs`) transposes a genuine grid to row-major before emitting creators. Guarded **tightly**: only a REGULAR grid — ≥2 `\and` columns, every column the SAME number of top-level `\\` rows ≥2 — is reordered; a single-row `\and` list and `\\` used only *inside* `\IEEEauthorblockA{…\\…}` (brace-depth > 0) are left in declared order. OXIDIZED_DESIGN #127 / KNOWN_PERL_ERRORS #94.

**Validation.** Guard `06_cluster_frontmatter::frontmatter_ieee_author_grid_transpose` (red→green: grid transposed **and** a single-row control proven un-reordered); witness 2403.16405 now row-major; full suite 2014/0 (IEEE witnesses unregressed); clippy + fmt clean. Warning-free fixtures.

Diagnosed with @dginev; addresses arXiv author-order-vs-PDF mismatch.