### PR TITLE
fix: minted honours escapeinside so a code-line \label links

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN.md
+++ b/docs/parity/OXIDIZED_DESIGN.md
@@ -9,7 +9,7 @@ This file is the **index + overview**. The detail lives in a themed family:
 
 | Theme file | What it holds |
 |---|---|
-| [OXIDIZED_DESIGN_DIVERGENCES.md](OXIDIZED_DESIGN_DIVERGENCES.md) | The numbered **Intentional Divergences from Perl** (`#1–#15`, `#17–#18`, `#19–#126`) + a brief Known-Upstream-Perl-Issues list. Code comments cite these as `OXIDIZED_DESIGN #N`. |
+| [OXIDIZED_DESIGN_DIVERGENCES.md](OXIDIZED_DESIGN_DIVERGENCES.md) | The numbered **Intentional Divergences from Perl** (`#1–#15`, `#17–#18`, `#19–#127`) + a brief Known-Upstream-Perl-Issues list. Code comments cite these as `OXIDIZED_DESIGN #N`. |
 | [OXIDIZED_DESIGN_MATH.md](../math/OXIDIZED_DESIGN_MATH.md) | Marpa math-parser design: `#16` design rules + the grammar-rule cluster `#7–#18`. |
 | [OXIDIZED_DESIGN_TYPES.md](OXIDIZED_DESIGN_TYPES.md) | Type-system improvements (behavior-neutral) + tactical internal pitfalls. |
 | [OXIDIZED_DESIGN_FUTURE_WORK.md](OXIDIZED_DESIGN_FUTURE_WORK.md) | Beyond-parity directions not yet built. |
@@ -18,12 +18,12 @@ This file is the **index + overview**. The detail lives in a themed family:
 > `.rs` comments reference them — so they are kept verbatim, which means three
 > quirks: (1) the numbers are **not globally unique** (the math cluster `#7–#18`
 > collides by value with divergences `#7–#18`); (2) a code-referenced number
-> resolves to the file above that owns that *topic* — most (`#1–#15`, `#19–#126`)
+> resolves to the file above that owns that *topic* — most (`#1–#15`, `#19–#127`)
 > are in DIVERGENCES, the math ones (incl. the code-referenced **`#18` = f(x)
 > "Speculative function application"**) are in MATH; (3) **`#76` is a retired
 > number** — its entry was consolidated into `#74` and the number was not
 > reused, so a gap in the sequence is expected, not a missing file. Next free
-> number: **#127**. When in doubt,
+> number: **#128**. When in doubt,
 > `grep '### N\.' docs/parity/OXIDIZED_DESIGN_*.md docs/math/OXIDIZED_DESIGN_MATH.md`.
 
 ---

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4729,3 +4729,42 @@ guard mislabels every numeric-mode `.bbl` with authors+years).
 
 **Guard**: `06_cluster_bibliography::cluster_bib_natbib_bbl_numeric_refnum`
 (numbers + super go numeric; the `authoryear` control keeps `Shor (1994)`).
+
+### 127. minted honours `escapeinside`, so a `\label` inside code registers on its line
+
+**Perl** ships **no** `minted` binding — it loads the raw `minted.sty`, which
+(without shell-escape/pygmentize) processes the body as ordinary LaTeX. A
+`\label` inside the code runs, but the code is not rendered as a listing and the
+label bubbles to the document root with no line to attach to. latexml-oxide
+instead provides a richer `minted` binding (`latexml_contrib::minted_sty`) routed
+through the `listings` substrate, producing a real `<ltx:listing>` with numbered
+`<ltx:listingline>`s.
+
+**Rust behavior**: that binding used to *drop* minted's `[options]` — it called
+`lst_process_display` without activating them — so `escapeinside=!!` never reached
+the listings tokenizer. An inline `!$\label{line:x}$!` was emitted as literal code
+characters, its `\label` never ran, the line label was never registered, and
+`\ref{line:x}` rendered as an empty `ltx_missing_label` (earlier: the raw key
+`LABEL:line:x`). `\begin{minted}[opts]{lang}` now feeds `opts` through
+`\lstset{…}` — the same activation `\begin{lstlisting}` uses — so minted's
+`escapeinside`/`mathescape` (shared verbatim with listings) take effect and the
+`\label` attaches to its `<ltx:listingline>`; `\ref` resolves and links to the
+code line. Minted-only keys (`linenos`, `fontsize`, …) are stored harmlessly and
+ignored; the `{language}` arg is left unapplied (current language-agnostic
+rendering is preserved).
+
+**Why**: matching the published PDF, where a line label references and links to
+its code line. This completes our Rust-only minted binding rather than diverging
+from a Perl behavior (Perl has none to match).
+
+**Residual (shared with Perl, out of scope)**: the reference shows the line's
+`xml:id`, not its printed line number, because `\@lst@startline` uses
+`RefStepID('lstnumber')` (id only, no refnum) in *both* engines
+(`listings.sty.ltxml:1546`); giving the line a numeric refnum is a separate
+listings-wide change.
+
+**Witness**: arXiv:2308.03276 (html_feedback#1028) — `\begin{minted}[linenos,
+escapeinside=!!]{python}` with `!$\label{line:world}$!`; before, `\ref{line:world}`
+vanished (empty `ltx_missing_label`); now it registers on the line and links.
+
+**Guard**: `06_cluster_regressions::minted_escapeinside_label_registers_on_the_code_line`.

--- a/latexml_contrib/src/minted_sty.rs
+++ b/latexml_contrib/src/minted_sty.rs
@@ -118,9 +118,21 @@ LoadDefinitions!({
   use latexml_package::package::listings_sty::{listings_read_raw_lines, lst_process_display};
   {
     let cs = T_CS!("\\begin{minted}");
+    // `\begin{minted}[opts]{language}`. Previously the `[opts]` were dropped, so
+    // `escapeinside=!!` never reached the listings tokenizer: an inline
+    // `!$\label{…}$!` was emitted as literal code, its `\label` never ran, and
+    // `\ref` to that line vanished (html_feedback#1028, arXiv:2308.03276;
+    // OXIDIZED_DESIGN #127). We now feed the options through `\lstset{…}` (the
+    // same activation `\begin{lstlisting}` uses), so minted's `escapeinside`/
+    // `mathescape` — shared verbatim with the listings substrate — take effect;
+    // minted-only keys (`linenos`, `fontsize`, …) are stored harmlessly and
+    // ignored. The `{language}` arg is left unapplied (we keep the current
+    // language-agnostic rendering). Scoped to the environment's `bgroup`.
     let params = parse_parameters("[]{}", &cs, true)?;
     let expansion: Option<ExpansionBody> = Some(ExpansionBody::Closure(Rc::new(
-      move |_args: Vec<ArgWrap>| {
+      move |args: Vec<ArgWrap>| {
+        // args[0] = `[opts]` (optional); args[1] = `{language}` (unapplied).
+        let opts = args.into_iter().next().and_then(|a| a.owned_tokens());
         bgroup();
         assign_value(
           "current_environment",
@@ -133,6 +145,17 @@ LoadDefinitions!({
           Tokens!(T_OTHER!("lstlisting")),
           None,
         )?;
+        if let Some(opts) = opts
+          && !opts.unlist_ref().is_empty()
+        {
+          let _ = digest(Tokens::new(
+            vec![T_CS!("\\lstset"), T_BEGIN!()]
+              .into_iter()
+              .chain(opts.unlist().iter().cloned())
+              .chain(std::iter::once(T_END!()))
+              .collect(),
+          ));
+        }
         let text = listings_read_raw_lines("minted");
         let result = lst_process_display(None, &text);
         Ok(Tokens::new(result))

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -11,7 +11,7 @@
 mod cluster;
 use cluster::{
   convert_and_post_clean, convert_and_post_pmml_clean, convert_clean, convert_expecting_errors,
-  convert_log, convert_to_xml,
+  convert_log, convert_to_xml, convert_to_xml_contrib,
 };
 
 #[test]
@@ -652,6 +652,36 @@ fn inline_end_lstlisting_does_not_swallow_the_document() {
   assert!(
     x.contains("hello") && x.contains("world"),
     "inline \\end{{lstlisting}}: the listing body was lost:\n{x}"
+  );
+}
+
+/// minted's `escapeinside=!!` must let a `\label` inside the code attach to its
+/// listing line, so `\ref{line:...}` resolves and links.
+///
+/// Witness arXiv:2308.03276 (html_feedback#1028). Our `minted` binding
+/// (`minted_contrib`) parsed `\begin{minted}[opts]{lang}` but *dropped* the
+/// options — calling `lst_process_display` without activating them — so
+/// `escapeinside`/`mathescape` never reached the listings tokenizer. The
+/// `!$\label{line:world}$!` was emitted as literal code, `\label` never ran, the
+/// line label was never registered, and `\ref{line:world}` rendered as an empty
+/// `ltx_missing_label`. The fix forwards the options through `lst_activate` (as
+/// `lstlisting` does). Perl has no minted binding (it processes the body as raw
+/// LaTeX), so this completes our richer binding — surpass-Perl / OXIDIZED_DESIGN
+/// #127.
+#[test]
+fn minted_escapeinside_label_registers_on_the_code_line() {
+  let x = convert_to_xml_contrib("tests/cluster_regressions/minted_escapeinside_label.tex");
+  // The escaped `\label` now runs and registers its line label (before the fix
+  // there was no `labels="LABEL:line:world"` anywhere — the label was lost).
+  assert!(
+    x.contains(r#"labels="LABEL:line:world""#) && x.contains(r#"labels="LABEL:line:road""#),
+    "escapeinside \\label did not register on the code line:\n{x}"
+  );
+  // ...and the escape markers / raw `\label` are consumed, not left as literal
+  // code characters in the listing.
+  assert!(
+    !x.contains(r"\label{line:world}"),
+    "the escapeinside `\\label` leaked into the listing as literal text:\n{x}"
   );
 }
 /// `\usepackage{xparse}` (or `expl3`) must not clobber LaTeX's cedilla accent.

--- a/latexml_oxide/tests/cluster_regressions/minted_escapeinside_label.tex
+++ b/latexml_oxide/tests/cluster_regressions/minted_escapeinside_label.tex
@@ -1,0 +1,13 @@
+\documentclass{article}
+\usepackage{minted}
+\begin{document}
+% arXiv:2308.03276 (html_feedback#1028): minted with escapeinside=!! lets a
+% \label attach to a code line; \ref{line:...} must resolve to the line number
+% and link. Our minted binding dropped the [options], so escapeinside was never
+% honored — the \label ran as literal text and the reference vanished.
+\begin{minted}[linenos,mathescape,escapeinside=!!,fontsize=\small]{python}
+world = World()  !$\label{line:world}$!
+road = Road()    !$\label{line:road}$!
+\end{minted}
+Built at line \ref{line:world}; road at line \ref{line:road}.
+\end{document}


### PR DESCRIPTION
**Diagnostic.** Our `minted` binding (`minted_contrib`) parsed `\begin{minted}[opts]{lang}` but *dropped* the options — calling `lst_process_display` without activating them — so `escapeinside=!!` never reached the listings tokenizer. An inline `!$\label{line:x}$!` was emitted as literal code, its `\label` never ran, the line label was never registered, and `\ref{line:x}` rendered as an empty `ltx_missing_label` (the reporter's vanished/"LABEL:" reference).

**Approach.** Feed minted's `[opts]` through `\lstset{…}` — the same activation `\begin{lstlisting}` uses — so `escapeinside`/`mathescape` (shared verbatim with the listings substrate) take effect; the `\label` now attaches to its `<ltx:listingline>` and `\ref` resolves and links. Minted-only keys (`linenos`, `fontsize`, …) are stored harmlessly and ignored. Perl ships no minted binding, so this completes our richer one — surpass-Perl / OXIDIZED_DESIGN 127.

**Validation.** Red→green guard `minted_escapeinside_label_registers_on_the_code_line`; witness arXiv:2308.03276 (line labels now register on their lines, zero leaked `\label` text, `\ref` links to the code line). Full suite 2014/0; clippy + fmt clean. Residual (documented, shared with Perl, out of scope): the reference shows the line's `xml:id`, not its printed number — `\@lst@startline` uses `RefStepID` (no refnum) in both engines.

Addresses the report in arXiv/html_feedback#1028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)