### PR TITLE
fix: cvpr pre-loads natbib with [numbers] so citations render as numbers

### DIFF
--- a/latexml_contrib/src/cvpr_sty.rs
+++ b/latexml_contrib/src/cvpr_sty.rs
@@ -27,7 +27,20 @@ LoadDefinitions!({
   RequirePackage!("amsmath");
   RequirePackage!("amssymb");
   RequirePackage!("booktabs");
-  RequirePackage!("natbib");
+  // Pre-load natbib WITH [numbers,sort&compress] — cvpr.sty (and every
+  // cvpr20NN / iccv variant this binding serves) does
+  // `\RequirePackage[numbers,sort&compress]{natbib}` (cvpr.sty L37), so the
+  // PDF prints numeric `[N]` citations and a numeric References list. If we
+  // pre-load natbib WITHOUT options, the raw cvpr.sty's `[numbers]` load
+  // becomes a repeat-load option-clash no-op (classic `\DeclareOption`
+  // clash-and-drop) and `CITE_STYLE` stays at the default `authoryear` — so
+  // the inline `\cite`s rendered author-year too — WORSE than Perl, which
+  // (having no cvpr binding) raw-loads cvpr.sty and gets `numbers` from that
+  // first natbib load. Same fix (and reason) as the xcolor pre-load above.
+  // With numbers restored, the numeric References label `[N]` follows from the
+  // existing surpass-Perl path in `\NAT@wrout` (OXIDIZED_DESIGN #126). Witness
+  // html_feedback#6742 (arXiv:2405.05145).
+  RequirePackage!("natbib", options => vec!["numbers".to_string(), "sort&compress".to_string()]);
   RequirePackage!("etoolbox");
   RequirePackage!("hyperref");
   // caption.sty for \captionof — many CVPR templates use this for

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -375,6 +375,37 @@ fn cluster_bib_natbib_late_numeric_style_forces_numbers() {
   );
 }
 
+/// arXiv/html_feedback#6742 — a CVPR paper's References showed author-year labels
+/// ("Mo et al. [2022]") instead of the numeric `[N]` its PDF prints.
+///
+/// `cvpr.sty` does `\RequirePackage[numbers,sort&compress]{natbib}` (cvpr.sty L37),
+/// so pdflatex+bibtex render numeric citations and a numeric References list. Perl
+/// has no cvpr binding, raw-loads cvpr.sty, and gets `numbers` from that first
+/// natbib load. Our contrib cvpr binding eagerly pre-loaded natbib WITHOUT options
+/// (`cvpr_sty.rs` L30) BEFORE the raw cvpr.sty's `[numbers]` load, which then no-ops
+/// as a repeat load (classic `\DeclareOption` clash-and-drop) — leaving `CITE_STYLE`
+/// at the default `authoryear`. The fix mirrors the `xcolor` pre-load right above it
+/// (which already passes `[dvipsnames,table]` for the same reason): pre-load natbib
+/// with the `[numbers,sort&compress]` options cvpr always uses. GENUINE-RUST-ONLY.
+#[test]
+fn cvpr_natbib_numbers_option_forces_numeric_labels() {
+  let x = convert_to_xml_contrib("tests/cluster_regressions/cvpr_natbib_numbers.tex");
+  // Bibliography labels are the entry NUMBER `[N]`, not the author-year form.
+  assert!(
+    x.contains(r#"<tag role="refnum">[1]</tag>"#) && x.contains(r#"<tag role="refnum">[2]</tag>"#),
+    "cvpr's [numbers]natbib must label the References [1]/[2], not author-year:\n{x}"
+  );
+  assert!(
+    !x.contains(r#"<tag role="refnum">Mo et al."#),
+    "the author-year refnum label leaked — numbers mode was not applied:\n{x}"
+  );
+  // The inline \cite is in numbers mode too (show="Number"), not author-year.
+  assert!(
+    x.contains(r#"show="Number""#) && !x.contains(r#"show="Authors Phrase1YearPhrase2""#),
+    "inline citations stayed in author-year mode:\n{x}"
+  );
+}
+
 /// A `refcontext` block must not eat the `\printbibliography` inside it, and
 /// `\addbibresource` must accept its optional argument.
 ///

--- a/latexml_oxide/tests/cluster_regressions/cvpr_natbib_numbers.tex
+++ b/latexml_oxide/tests/cluster_regressions/cvpr_natbib_numbers.tex
@@ -1,0 +1,21 @@
+\documentclass[10pt,twocolumn,letterpaper]{article}
+% arXiv:2405.05145 (html_feedback#6742): cvpr.sty does
+% \RequirePackage[numbers,sort&compress]{natbib} (cvpr.sty L37), so pdflatex
+% prints numeric [N] citations and a numeric References list. Our contrib cvpr
+% binding pre-loaded natbib WITHOUT options, so the raw cvpr.sty's [numbers]
+% load no-op'd as a repeat and CITE_STYLE stayed authoryear — the References
+% showed "Mo et al. (2022)" instead of "[1]".
+\usepackage[pagenumbers]{cvpr}
+\begin{document}
+See \cite{key1} and \cite{key2}.
+\begin{thebibliography}{9}
+\bibitem[Mo et~al.(2022)Mo, Foo, and Bar]{key1}
+Mo, Foo, and Bar.
+\newblock A title.
+\newblock 2022.
+\bibitem[Alecu(2021)]{key2}
+Alecu.
+\newblock Another title.
+\newblock 2021.
+\end{thebibliography}
+\end{document}


### PR DESCRIPTION
**Diagnostic.** The contrib `cvpr_sty.rs` binding eagerly pre-loaded natbib *without options*, before the raw `cvpr.sty`'s `\RequirePackage[numbers,sort&compress]{natbib}` (cvpr.sty L37). That later load then no-op'd as a repeat (classic `\DeclareOption` clash-and-drop), so `CITE_STYLE` stayed `authoryear` and both the inline `\cite` and the References showed author-year ("Mo et al. (2022)") instead of the PDF's numeric `[N]` — worse than Perl, which has no cvpr binding, raw-loads cvpr.sty, and gets `numbers` from that first load. GENUINE-RUST-ONLY.

**Approach.** Pre-load natbib with `[numbers,sort&compress]`, mirroring the `xcolor` pre-load right above it (which already passes `[dvipsnames,table]` for the same reason). The numeric References label follows from the existing surpass-Perl path in `\NAT@wrout` (OXIDIZED_DESIGN 126) — no new divergence.

**Validation.** Red->green guard `cvpr_natbib_numbers_option_forces_numeric_labels`; full suite 2016/0; clippy + fmt clean. Witness arXiv:2405.05145 now converts with 0 errors, cites `[18]`/`[49, 12]` and References `[1]`-`[5]`; same-host Perl confirms `show="Number"` parity.

Addresses the report in arXiv/html_feedback#6742.

🤖 Generated with [Claude Code](https://claude.com/claude-code)