### PR TITLE
fix #627: GetKeyVals accepts a digested KeyVals, and Revert keeps its values

### DIFF
--- a/latexml_contrib/src/script_bindings/API.md
+++ b/latexml_contrib/src/script_bindings/API.md
@@ -76,7 +76,7 @@ Called at the top level of a binding file, or from inside any body.
 | `ExpandPartially(Tokens) -> Tokens` | Expand tokens only up to the first unexpandable one. ([`do_expand_partially`](latexml_core::gullet::do_expand_partially)) |
 | `Fatal(string, string, string)` | End the conversion with a `Fatal:`. |
 | `GetKeyVal(?, string) -> string` | One value out of a parsed keyval set. |
-| `GetKeyVals(string) -> map` | Parse a whole keyval string into a map. ([`split_keyval_source`](latexml_core::keyval::split_keyval_source)) |
+| `GetKeyVals(?) -> map` | A whole parsed keyval set as a map. Accepts a digested `KeyVals` argument (as `KeyVals`/`OptionalKeyVals` params deliver to a constructor) or its `k=v,…` source string. |
 | `Info(string, string, string)` | Log an `Info:` line. |
 | `InputDefinitions(string)`<br>`InputDefinitions(string, map)` | Find and load the definitions for a package or class. ([`input_definitions`](latexml_core::binding::content::input_definitions)) |
 | `IsDefined(string) -> bool` | Whether a control sequence is defined, and not `\let` to `\relax`. ([`is_defined_token`](latexml_core::binding::def::dialect::is_defined_token)) |

--- a/latexml_contrib/src/script_bindings/api_doc.rs
+++ b/latexml_contrib/src/script_bindings/api_doc.rs
@@ -360,9 +360,10 @@ const DOCS: &[(&str, Doc)] = &[
   ),
   (
     "GetKeyVals",
-    Doc::Rust(
-      "Parse a whole keyval string into a map.",
-      "latexml_core::keyval::split_keyval_source",
+    Doc::Note(
+      "A whole parsed keyval set as a map. Accepts a digested `KeyVals` argument \
+       (as `KeyVals`/`OptionalKeyVals` params deliver to a constructor) or its \
+       `k=v,…` source string.",
     ),
   ),
   ("Info", Doc::Note("Log an `Info:` line.")),

--- a/latexml_contrib/src/script_bindings/engine.rs
+++ b/latexml_contrib/src/script_bindings/engine.rs
@@ -648,10 +648,31 @@ pub(super) fn make_engine() -> Engine {
     }
     String::new()
   });
-  engine.register_fn("GetKeyVals", |kv: &str| -> Map {
+  // `GetKeyVals` mirrors `GetKeyVal`: a `RequiredKeyVals`/`OptionalKeyVals`
+  // argument reaches a constructor closure as a digested `KeyVals` handle, and
+  // reaches other contexts as its `k=v,…` source string. Accept both (plus unit
+  // for an omitted optional set) so a script can `GetKeyVals(#1)` uniformly and
+  // turn the arg into a Rhai map (issue #627). Values are the digested value's
+  // string form (falling back to the raw value pre-digestion).
+  engine.register_fn("GetKeyVals", |kv: Dynamic| -> Map {
     let mut m = Map::new();
-    for (k, v) in latexml_core::keyval::split_keyval_source(kv) {
-      m.insert(k.into(), Dynamic::from(v));
+    if let Some(d) = kv.clone().try_cast::<Digested>() {
+      if let latexml_core::digested::DigestedData::KeyVals(keyval) = d.data() {
+        let mut hash = keyval.get_hash_digested();
+        if hash.is_empty() {
+          hash = keyval.get_hash();
+        }
+        for (k, v) in hash {
+          m.insert(k.into(), Dynamic::from(v));
+        }
+      }
+      return m;
+    }
+    if kv.is_string() {
+      let s = kv.into_string().unwrap_or_default();
+      for (k, v) in latexml_core::keyval::split_keyval_source(&s) {
+        m.insert(k.into(), Dynamic::from(v));
+      }
     }
     m
   });

--- a/latexml_core/src/keyvals.rs
+++ b/latexml_core/src/keyvals.rs
@@ -641,13 +641,25 @@ impl KeyVals {
         use_default,
         keysets: _,
         primary_keyset,
-        digested_value: _,
+        digested_value,
       } = tuple;
       if !primary_keyset.is_empty() {
+        // Post-digestion `be_digested` has `take()`n the raw `value`, leaving
+        // the value only in `digested_value`; fall back to reverting that, so a
+        // reverted KeyVals keeps `key=value` instead of collapsing to a bare
+        // `key` (issue #627). Mirrors `rebuild`'s digested-value fallback.
+        // `strip_braces`: the digested value reverts with its own `{…}` wrapper,
+        // but `revert_keyval`/`rebrace` re-add braces only when the value has an
+        // outer comma — so strip one level first to match Perl's
+        // `rebrace(Revert($value))` (no braces for a plain value).
+        let digested_fallback = match (value, digested_value) {
+          (None, Some(dv)) => Some(ArgWrap::Tokens(dv.revert()?.strip_braces())),
+          _ => None,
+        };
         let reverted = self.revert_keyval(
           key,
           primary_keyset,
-          value.as_ref(),
+          value.as_ref().or(digested_fallback.as_ref()),
           *use_default,
           tokens.is_empty(),
         )?;

--- a/latexml_oxide/tests/30_script_bindings.rs
+++ b/latexml_oxide/tests/30_script_bindings.rs
@@ -1288,3 +1288,82 @@ fn script_binding_discovered_from_file() {
   );
   latexml_core::reset_thread_engine();
 }
+
+/// issue #627: a `RequiredKeyVals`/`OptionalKeyVals` argument reaches a
+/// *constructor* closure body as a digested `KeyVals` handle (not a string), so
+/// a script needs two things the surface did not yet provide:
+///   1. `GetKeyVals(kv)` must accept that Digested and return a map — `GetKeyVal`
+///      already accepts both, `GetKeyVals` took only a string.
+///   2. `UnTeX(Revert(kv))` must keep the VALUES. `KeyVals::revert` iterated the
+///      raw `value`, which digestion (`be_digested`) has already `take()`n —
+///      leaving only `digested_value` — so it emitted bare keys ("lang,size").
+const KVMAP_SAMPLE: &str = r##"
+  DefKeyVal("KVM", "lang", "");
+  DefKeyVal("KVM", "size", "");
+  DefConstructor("\\kvmap RequiredKeyVals:KVM", |document, kv| {
+    let m = GetKeyVals(kv);
+    document.openElement("ltx:text");
+    document.setAttribute("class", "kvmap");
+    document.absorbString("map.lang=" + m["lang"] + " map.size=" + m["size"]
+      + " rev=" + UnTeX(Revert(kv)));
+    document.closeElement("ltx:text");
+  });
+"##;
+
+fn kvmap_dispatch(request: &str) -> Option<Result<()>> {
+  let base = request.split('.').next().unwrap_or(request);
+  if base == "lxkvmaptest" {
+    Some(latexml_contrib::script_bindings::load_script(KVMAP_SAMPLE).map(|_| ()))
+  } else {
+    None
+  }
+}
+
+#[test]
+fn getkeyvals_accepts_a_digested_and_revert_keeps_values() {
+  use latexml_core::common::error::{LogStatus, get_status};
+  let mut latexml = Core::new(CoreOptions {
+    verbosity: Some(-2),
+    include_comments: Some(false),
+    ..CoreOptions::default()
+  });
+  state::set_bindings_dispatch(latexml_core::common::native_dispatcher(
+    latexml_package::dispatch,
+  ));
+  state::add_binding_names(latexml_package::binding_names());
+  state::set_extra_bindings_dispatch(Rc::new(kvmap_dispatch));
+
+  let tex = concat!(
+    "literal:\\documentclass{article}\\usepackage{lxkvmaptest}",
+    "\\begin{document}\\kvmap{lang=rust,size=big}\\end{document}"
+  );
+  let doc = latexml
+    .convert_file(tex.to_string())
+    .expect("conversion with a digested-KeyVals script binding should succeed");
+  let xml = doc.serialize_to_string();
+
+  // GetKeyVals(digested) produced a map whose VALUES are present (bug 1). A
+  // string-only GetKeyVals throws on the Digested, degrading the whole binding —
+  // so the element never appears at all.
+  assert!(
+    xml.contains("map.lang=rust") && xml.contains("map.size=big"),
+    "GetKeyVals did not turn the digested KeyVals into a value-bearing map; xml=\n{xml}"
+  );
+  // Revert(kv) keeps the values, not just the keys (bug 2): post-digestion the
+  // raw value is taken, so revert must fall back to the digested value. The
+  // `{}` around each value is standard keyval reversion (Perl `rebrace` +
+  // `$keytype->revert`); the point is the values are PRESENT, not bare keys.
+  assert!(
+    xml.contains("rev=lang={rust},size={big}"),
+    "UnTeX(Revert(kv)) dropped the values (bare keys only); xml=\n{xml}"
+  );
+  // The binding ran clean — no thrown script body.
+  assert!(
+    get_status(LogStatus::Error) == 0 && get_status(LogStatus::Fatal) == 0,
+    "the digested-KeyVals binding logged errors: {}",
+    latexml_core::common::error::get_status_message()
+  );
+
+  drop(latexml);
+  latexml_core::reset_thread_engine();
+}

--- a/latexml_oxide/tests/complex/figure_mixed_content.xml
+++ b/latexml_oxide/tests/complex/figure_mixed_content.xml
@@ -59,7 +59,7 @@
       <tag role="refnum">1</tag>
       <tag role="typerefnum">Figure 1</tag>
     </tags>
-    <p class="ltx_figure_panel"><Math mode="inline" tex="\begin{array}[]{cc}\begin{subfigure}[345.0pt]\includegraphics[width]{../graphics/none.png} \@@toccaption{{\lx@tag[ ]{{(a)}}{}}}\@@caption{{\lx@tag[ ]{{\small(a)}}{\small}}}\end{subfigure}&amp;\begin{subfigure}[345.0pt]\includegraphics[width]{../graphics/none.png} \@@toccaption{{\lx@tag[ ]{{(b)}}{}}}\@@caption{{\lx@tag[ ]{{\small(b)}}{\small}}}\end{subfigure}\end{array}" text="Array[[absent, absent]]" xml:id="S0.F1.m1">
+    <p class="ltx_figure_panel"><Math mode="inline" tex="\begin{array}[]{cc}\begin{subfigure}[345.0pt]\includegraphics[width=85.35826pt]{../graphics/none.png} \@@toccaption{{\lx@tag[ ]{{(a)}}{}}}\@@caption{{\lx@tag[ ]{{\small(a)}}{\small}}}\end{subfigure}&amp;\begin{subfigure}[345.0pt]\includegraphics[width=85.35826pt]{../graphics/none.png} \@@toccaption{{\lx@tag[ ]{{(b)}}{}}}\@@caption{{\lx@tag[ ]{{\small(b)}}{\small}}}\end{subfigure}\end{array}" text="Array[[absent, absent]]" xml:id="S0.F1.m1">
         <XMath>
           <XMArray role="ARRAY" vattach="middle">
             <XMRow>


### PR DESCRIPTION
**Diagnostic.** A `RequiredKeyVals`/`OptionalKeyVals` argument reaches a constructor closure as a digested `KeyVals` handle, but `GetKeyVals` took only a `&str` (unlike `GetKeyVal`, which already accepted both). Separately, `Revert(kv)` emitted bare keys: `KeyVals::be_digested` `take()`s the raw `value` into a `digested_value` field, and `KeyVals::revert` only read the now-empty `value`.

**Approach.** `GetKeyVals` now accepts a `Dynamic` (Digested → map, or the `k=v` source string), mirroring `GetKeyVal`. `KeyVals::revert` falls back to reverting `digested_value` when the raw value was taken — restoring Perl's `rebrace(revert($value))` semantics (Perl's tuple retains `$value`, so upstream never dropped them).

**Validation.** Red→green guard `getkeyvals_accepts_a_digested_and_revert_keeps_values`; full suite 2017/0; clippy/fmt clean. The `revert` fix also repairs a latent `tex=` parity bug — `figure_mixed_content`'s `\includegraphics[width]` now reads `[width=85.35826pt]`, matching Perl's golden (re-blessed). `API.md` regenerated for the new `GetKeyVals` signature.

Closes #627