### PR TITLE
fix #1021: nested inline-math author markers no longer desync math mode

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3717,3 +3717,38 @@ Perl-origin, upstream filing pending). Minimal trigger:
 grid to row-major before emitting creators, guarded so single-row `\and` lists and
 `\\` inside `\IEEEauthorblockA` are never reordered. Guard:
 `06_cluster_frontmatter::frontmatter_ieee_author_grid_transpose`.
+---
+
+## 95. Nested inline-math superscript author markers desync math mode (Rust surpasses)
+
+**Perl source:** `LaTeXML/Engine/Base_Utility.pool.ltxml` L687-740 (`\lx@add@authors`,
+`\lx@author@withsup`) + L552 (`\lx@request@frontmatter@annotation`).
+
+**Symptom:**
+```
+Error:unexpected:\lx@end@inline@math Attempt to end mode math
+	current frame is boxing group due to T_BEGIN[{]
+```
+repeated once per marker, with every author collapsed into one garbled creator.
+
+**Root cause:** the author-marker branch `\let`s `^`/`\textsuperscript` onto
+`\lx@request@frontmatter@annotation`, whose `{}` argument reads a single token. A marker
+operand that is a control sequence carrying its own group — `^\text{...}`, which real
+LaTeX math reads as `^{\text{...}}` — has `\text` severed from its `{...}`; inside the
+marker's inline math the orphaned `{...}` leaves a brace-group frame on top, so the
+closing `$` ends math against the brace group. Nested `$^\text{$...$}$` markers cascade.
+
+**Minimal trigger:**
+```latex
+\author{Alice$^\text{$\star$}$ \and Bob$^\text{$\star$}$ \\ $^\text{$\star$}$ Uni}
+\begin{document}\maketitle\end{document}
+```
+
+**Perl status:** present in 0.8.8 (same-host), errs identically. Upstream filing pending.
+
+**Rust status (FIXED, beneficial divergence — OXIDIZED_DESIGN #129):** the `^`-hijack
+wrappers read a FULL superscript operand (`read_frontmatter_sup_operand`,
+`base_utilities.rs`), keeping `\text{...}` with its group and any nested `$...$` whole
+and undigested; the surrounding math stays balanced. Witness arXiv:2403.11905
+(html_feedback#1021): 6 errors → 0. Guard
+`06_cluster_frontmatter::frontmatter_nested_math_author_marker`.

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4813,3 +4813,49 @@ KNOWN_PERL_ERRORS #94.
 
 **Guard**: `06_cluster_frontmatter::frontmatter_ieee_author_grid_transpose` (grid
 transposed + a single-row control proven un-reordered).
+
+### 129. Nested inline-math superscript author markers (`$^\text{$...$}$`) no longer desync math mode
+
+**Perl**: in an author/affiliation block using `^`/`\textsuperscript` markers,
+`\lx@add@authors` takes the marker (withsup) branch and `\let`s `^` onto
+`\lx@request@frontmatter@annotation`, whose bare `{}` argument reads a single token.
+For a marker whose operand is a control sequence carrying its own group —
+`^\text{...}`, which real LaTeX math reads as `^{\text{...}}` (`\text` grabbing its
+`{...}`) — the `{}` read grabs only `\text` and orphans the following `{...}`. Inside
+the marker's own inline math that stray `{...}` leaves a brace-group frame on top of
+the digestion stack, so the marker's closing `$` fires `\lx@end@inline@math` against
+the brace group rather than the math: `Error:unexpected:\lx@end@inline@math Attempt to
+end mode math`. Nested markers (`$^\text{$...$}$`, e.g. an icon built from
+`\newcommand`-chained `$^\text{...}$`) cascade the error and merge every creator into
+one garbled `<personname>`. **Same-host Perl LaTeXML 0.8.8 errs identically**
+(SHARED-FAILURE, Perl-origin; KNOWN_PERL_ERRORS #95).
+
+**Rust**: the two `^`-hijack wrappers (`\lx@sup@request@affiliation`,
+`\lx@sup@setlabel@affiliation`) are primitives that read a FULL superscript operand
+(`read_frontmatter_sup_operand`), mirroring `TeX_Math` `scriptHandler`: a braced
+operand is taken whole, and a bare leading control sequence keeps its following
+`{...}` group. So `\text{...}` — and any `$...$` nested inside it, at any depth — is
+captured together and undigested, the surrounding inline math stays balanced, and the
+now-empty `$...$` collapses so the marker links the author to the shared affiliation
+instead of leaving a stray box. Numeric/char markers (`^1`) and already-braced markers
+(`^{...}`, `\textsuperscript{...}`) read exactly as before.
+
+**Why**: nested `$...$`/`\text{}` is a fundamental LaTeX capability authors do use
+(icons-as-markers here); erroring and merging creators is never the right outcome. The
+change is surgical — only a bare `^`-control-sequence-with-argument operand behaves
+differently — and every existing frontmatter marker test is unaffected.
+
+**Witness**: arXiv:2403.11905 (html_feedback#1021) — `\handPointerZ` =
+`$^\text{\mouseOne}$`, `\mouseOne` = `$^\text{\faMousePointer}$` (double-nested icon
+markers). Was 6× "Attempt to end mode math" + one merged personname; now 0 errors.
+
+**Residual (separate, pre-existing)**: an author line whose ONLY marker is delivered
+through a macro (`\handPointerZ`, no literal `^`) is still classified "no marker" and
+merged into the previous `\and`-separated author — `\lx@add@authors` conflates `\and`
+(new author) with `\\` (continuation) and keys classification on a LITERAL `^`. That is
+the F2 author-classification gap (shared with Perl), independent of this math-mode fix,
+and is why arXiv:2403.11905's own creators still merge even though the error cascade is
+gone.
+
+**Guard**: `06_cluster_frontmatter::frontmatter_nested_math_author_marker` (two clean
+creators linked to a shared affiliation via `$^\text{$\star$}$` markers, 0 errors).

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -1032,14 +1032,47 @@ LoadDefinitions!({
   // ("affiliation:N") in relocate_annotations -- avoiding the prefix-stripped
   // fallback that would otherwise conflate them with a creator's own "author:N"
   // sequence label and double-attach.
-  DefMacro!(
-    "\\lx@sup@request@affiliation",
-    "\\lx@request@frontmatter@annotation[affiliation]"
-  );
-  DefMacro!(
-    "\\lx@sup@setlabel@affiliation",
-    "\\lx@set@frontmatter@label[affiliation]"
-  );
+  // OXIDIZED_DESIGN #129 (html_feedback#1021, arXiv:2403.11905): these two are
+  // `\let` onto `^`/`\textsuperscript` inside an author/affiliation line, so they
+  // must consume their operand the way a real math superscript does — grabbing a
+  // FULL nucleus (`\text{...}` kept with its group, any `$...$` nested inside it
+  // captured whole+undigested). The old `[affiliation]{}` read grabbed only the
+  // leading `\text`, orphaning its `{...}`; inside inline math that stray group
+  // left a brace-group frame on top and the closing `$` fired
+  // `\lx@end@inline@math` against it ("Attempt to end mode math"), arbitrarily
+  // deep for `$^\text{$...$}$` markers. Both engines erred (SHARED-FAILURE);
+  // reading the whole operand keeps the surrounding math balanced.
+  DefPrimitive!(T_CS!("\\lx@sup@request@affiliation"), None, {
+    let operand = read_frontmatter_sup_operand()?;
+    let label = clean_frontmatter_labels(&operand.to_string(), "affiliation").join(",");
+    with_pending_entry_attr(move |attr| {
+      let labels = attr.get("_annotations").cloned().unwrap_or_default();
+      let newval = if labels.is_empty() {
+        label.clone()
+      } else {
+        s!("{labels},{label}")
+      };
+      DebugFeature!("frontmatter", "FRONT add annotation label {label}");
+      attr.insert("_annotations".to_string(), newval);
+    });
+    Ok(Vec::new())
+  });
+  DefPrimitive!(T_CS!("\\lx@sup@setlabel@affiliation"), None, {
+    let operand = read_frontmatter_sup_operand()?;
+    let label = clean_frontmatter_labels(&operand.to_string(), "affiliation")
+      .into_iter()
+      .next();
+    with_pending_entry_attr(move |attr| match label {
+      Some(label) => {
+        DebugFeature!("frontmatter", "FRONT set label {label}");
+        attr.insert("_annotations".to_string(), label);
+      },
+      None => {
+        attr.remove("_annotations");
+      },
+    });
+    Ok(Vec::new())
+  });
   DefMacro!(
     "\\lx@author@withsup{}",
     "\\bgroup\\let^\\lx@sup@request@affiliation\\let\\textsuperscript\\lx@sup@request@affiliation#1\\egroup"
@@ -1816,6 +1849,47 @@ fn unwrap_whole_name_bold(document: &mut Document, node: &Node) -> Result<()> {
     document.unwrap_nodes(bold)?;
   }
   Ok(())
+}
+
+/// Read a full superscript operand as RAW (undigested) tokens for a frontmatter
+/// author/affiliation marker (`^X` / `\textsuperscript{X}`).
+///
+/// A real math superscript digests its nucleus (`TeX_Math` `scriptHandler`
+/// "invoke tokens until you get a box"), so `^\text{x}` binds `\text` to its
+/// `{x}` and reads as one box — i.e. `^\text{x}` == `^{\text{x}}`. The hijacked
+/// marker instead captures the operand as tokens for a matching label; the bare
+/// `{}` read used to grab only the leading control sequence (`\text`), orphaning
+/// its `{...}` argument. In inline math that stray `{...}` left a brace-group
+/// frame on top, so the marker's closing `$` fired `\lx@end@inline@math` against
+/// it — "Attempt to end mode math" — arbitrarily deep for nested
+/// `$^\text{$...$}$` markers (html_feedback#1021, arXiv:2403.11905; both engines
+/// erred, SHARED-FAILURE). Grabbing the control sequence together with its
+/// following group keeps `\text{...}` — and any `$...$` nested inside it — whole
+/// and undigested, so the surrounding math stays balanced. Numeric/char markers
+/// (`^1`) and already-braced markers (`^{...}`, `\textsuperscript{...}`) read
+/// exactly as before. See OXIDIZED_DESIGN #129.
+fn read_frontmatter_sup_operand() -> Result<Tokens> {
+  skip_spaces()?;
+  // `^{...}` / `\textsuperscript{...}`: the whole braced group is the operand.
+  if if_next(T_BEGIN!())? {
+    return read_arg(ExpansionLevel::Off);
+  }
+  let Some(first) = read_token()? else {
+    return Ok(Tokens::new(Vec::new()));
+  };
+  // `^\text{...}` (bare control-sequence operand): keep a following `{...}` group
+  // so the CS is not severed from its argument.
+  if first.get_catcode() == Catcode::CS && if_next(T_BEGIN!())? {
+    let group = read_arg(ExpansionLevel::Off)?;
+    let inner = group.unlist_ref();
+    let mut operand = Vec::with_capacity(inner.len() + 3);
+    operand.push(first);
+    operand.push(T_BEGIN!());
+    operand.extend(inner.iter().copied());
+    operand.push(T_END!());
+    return Ok(Tokens::new(operand));
+  }
+  Ok(Tokens::new(vec![first]))
 }
 
 /// Perl: cleanFrontmatterLabels($labels, $prefix).

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -140,6 +140,42 @@ fn frontmatter_ieee_author_grid_transpose() {
     "single-row \\and list was wrongly reordered:\n{c}"
   );
 }
+/// html_feedback#1021 (arXiv:2403.11905): an author carries a doubly-nested
+/// inline-math superscript (`$^\text{$...$}$`) as an affiliation marker. The
+/// author-marker (withsup) branch `\let`s `^` onto an annotation primitive that
+/// read a bare `{}` operand, grabbing only the leading `\text` and orphaning its
+/// `{...}` argument; inside the marker's own inline math the stray `{...}` left a
+/// brace-group frame on top, so the closing `$` fired `\lx@end@inline@math`
+/// against it — a cascade of "Attempt to end mode math" that garbled every
+/// creator. Both engines erred (SHARED-FAILURE); the Rust marker now reads a FULL
+/// superscript operand, keeping `\text{...}` and its nested `$...$` whole. Reading
+/// the operand undigested also collapses the empty math, so the marker links the
+/// author to the shared affiliation instead of rendering. OXIDIZED_DESIGN #129.
+#[test]
+fn frontmatter_nested_math_author_marker() {
+  let x = convert_to_xml("tests/cluster_regressions/frontmatter_nested_math_author_marker.tex");
+  // Zero-error gate (convert_to_xml) already guards the "Attempt to end mode
+  // math" cascade; assert the markup is clean and the creators did NOT merge.
+  assert!(
+    x.contains("<personname>Alice</personname>") && x.contains("<personname>Bob</personname>"),
+    "both creators must survive as clean, separate personnames:\n{x}"
+  );
+  assert_eq!(
+    x.matches("role=\"author\"").count(),
+    2,
+    "expected exactly two author creators, not a merged blob:\n{x}"
+  );
+  // The nested-math markers link both authors to the shared affiliation.
+  assert_eq!(
+    x.matches("role=\"affiliation\"").count(),
+    2,
+    "each author should carry the shared affiliation contact:\n{x}"
+  );
+  assert!(
+    x.contains("Shared University"),
+    "the shared affiliation text must survive:\n{x}"
+  );
+}
 /// html_feedback#6614 (arXiv:2606.08234, ACL): a `\author{Name\quad Name… \\
 /// \textsuperscript{n}Affil}` block must keep SHORT author names as authors, not
 /// reclassify them as affiliations. "Min Xu" (7 tokens) tripped the old `p < 8`

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_nested_math_author_marker.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_nested_math_author_marker.tex
@@ -1,0 +1,10 @@
+\documentclass{article}
+\usepackage{amsmath}
+% html_feedback#1021 (arXiv:2403.11905): authors carry a doubly-nested inline-math
+% superscript ($^\text{$...$}$) as an affiliation marker. A literal `^` forces the
+% author-marker (withsup) branch, whose `\let^` then hijacks the `^` inside the
+% nested $...$, orphaning \text's argument and desyncing math mode. Both engines
+% erred here (SHARED-FAILURE); the Rust marker now reads a full superscript operand.
+\author{Alice$^\text{$\star$}$ \and Bob$^\text{$\star$}$ \\ $^\text{$\star$}$ Shared University}
+\title{Nested math author marker}
+\begin{document}\maketitle\end{document}


### PR DESCRIPTION
**Diagnostic.** In an author/affiliation block, `\lx@add@authors` `\let`s `^`/`\textsuperscript` onto an annotation primitive that read a bare `{}` operand. For `^\text{...}` (which real math reads as `^{\text{...}}`) it grabbed only `\text`, orphaning its `{...}`; inside the marker's own inline math the stray `{...}` left a brace-group frame on top, so the closing `$` fired `\lx@end@inline@math` against it — `Attempt to end mode math`, cascading and merging every creator for nested `$^\text{$...$}$` markers. Same-host Perl 0.8.8 errs identically (SHARED-FAILURE).

**Approach.** The two `^`-hijack wrappers (`\lx@sup@request@affiliation`/`…setlabel…`) now read a FULL superscript operand (`read_frontmatter_sup_operand`, mirroring `TeX_Math` `scriptHandler`): a braced operand whole, a bare control sequence kept with its following `{...}` group. So `\text{...}` and any nested `$...$` are captured whole+undigested and the math stays balanced. Numeric/braced markers (`^1`, `^{...}`, `\textsuperscript{...}`) read exactly as before. Surpass-Perl: OXIDIZED_DESIGN #129 / KNOWN_PERL_ERRORS #95.

**Validation.** New guard `06_cluster_frontmatter::frontmatter_nested_math_author_marker` (two clean creators linked to a shared affiliation, 0 errors); witness arXiv:2403.11905 (`\handPointerZ` double-nested icon markers) 6→0 errors. Full suite 2017/2017, clippy/fmt clean. Residual (documented, pre-existing, separate): a marker delivered purely via macro with no literal `^` is still merged by the `\and`-vs-`\\` classifier (F2 gap, shared with Perl).

Closes #1021