### PR TITLE
feat: \and is a hard author boundary in the superscript-marker branch (#1021 F2)

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -1432,6 +1432,27 @@ idiom at all, so Rust already surpasses; this refines the surpass. Guard:
 a `\texttt{…}` email is glued to the last affil with no `\\`, it still bleeds into that
 affiliation — a distinct email-boundary defect.)
 
+**(g) `\and` is a HARD author boundary in the superscript-marker branch.** The
+marker-branch flat-split `\and`/`\quad`/`\\` into one list, then appended any
+marker-less line to the PREVIOUS entry. When a 2nd/3rd author's superscript is
+macro-delivered — `Alice\mk$^*$ \and Bob\mk \and Carol\mk`, where `\mk` expands to a
+`$^…$` marker so `Bob\mk`/`Carol\mk` carry no *literal* `^` — those segments merged
+back across the `\and` into one `<personname>AliceBobCarol</personname>`
+(html_feedback#1021 F2 residual, arXiv:2403.11905). Now the branch groups on the `\and`
+family FIRST and only appends a marker-less line to an entry created WITHIN the same
+`\and` group, so `\and`-separated authors never merge. Groups carry no `\and`, so the
+intra-group split (reusing `author_affil_splits`) is equivalent to splitting on
+`\quad`/`\\`; the *only* behavior change is that a marker-less first line of a non-first
+`\and` group becomes a new author instead of merging — verified by an OLD-vs-NEW full-XML
+diff over all 30 frontmatter fixtures, exactly ONE (this case) changed. Guard:
+`06_cluster_frontmatter::frontmatter_and_hard_author_boundary`. (Residual, separate —
+deferred as Phase 2: a marker delivered *purely* by macro with no literal `^` anywhere on
+its line, e.g. `\handPointerZ Johns Hopkins University`, is still appended to the author
+name rather than recognized as an affiliation, because classification keys on a literal
+marker and does not expand macros. So arXiv:2403.11905's Kate Sanders now separates from
+Kevin Xu but still carries her institution in the name; full attachment needs
+expansion-aware marker detection.)
+
 **Scope/limits:**
 - The `*` equal-contribution suffix on a combined author mark (`$^{1*}$`) still
   labels `affiliation:1*`, so it does not yet match a plain `affiliation:1`

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -898,58 +898,78 @@ LoadDefinitions!({
     {
       calls.extend(Invocation!(T_CS!("\\lx@add@author"), vec![None, Some(stuff)]).unlist());
     } else if position_of(&stuff, &authorsup_markers()).is_some() {
-      let lines = split_tokens(stuff, author_affil_splits());
       let mut entries: Vec<(AuthorLineKind, Tokens)> = Vec::new();
-      for line in lines {
-        if line.is_empty() {
+      // Split on the `\and` family FIRST so an `\and` is a HARD author boundary:
+      // a marker-less line — an author whose only superscript is macro-delivered
+      // (`\handPointerZ`), or a continuation affiliation — never merges into an
+      // author from a PREVIOUS `\and` group. Within a group, `\quad`/`\\` still
+      // separate the name line from its affiliation lines, and a marker-less line
+      // still continues the group's own last entry. Groups carry no `\and`, so
+      // reusing `author_affil_splits` for the intra-group split is equivalent to
+      // splitting on `\quad`/`\qquad`/`\\`. html_feedback#1021 F2 residual:
+      // `Alice\mk$^*$ \and Bob\mk` was one merged creator; now two.
+      // OXIDIZED_DESIGN #52(g).
+      for group in split_tokens(stuff, author_and_splits()) {
+        if group.is_empty() {
           continue;
         }
-        match position_of(&line, &authorsup_markers()) {
-          None => {
-            // A marker-less line that is purely a list of email addresses is a
-            // SHARED email line (\texttt{a@x, b@y}) covering all the authors, not
-            // a continuation of the previous affiliation — give it its own email
-            // contact so it is shown once instead of being welded into an
-            // affiliation's text (KNOWN_PERL_ERRORS #75, witness 2605.23553).
-            if line_is_email_list(&line) {
-              entries.push((AuthorLineKind::Email, line));
-            } else if let Some(last) = entries.last_mut() {
-              // continues previous entry; Append
-              let mut appended = last.1.clone().unlist();
-              appended.extend(line.unlist());
-              last.1 = Tokens::new(appended);
-            } else {
-              entries.push((AuthorLineKind::Author, line)); // safest to assume author?
-            }
-          },
-          Some(p) => {
-            // "\textsuperscript{n}Affil" (the marker LEADS the line) → an
-            // affiliation; "Name\textsuperscript{n}" (a name precedes the
-            // marker) → an author line, split into the individual creators it
-            // names (see split_author_line). The old `p < 8` token-count proxy
-            // misread short author names like "Min Xu" (html_feedback#6614) —
-            // key on name-before-marker, which is length-independent.
-            if name_precedes_marker(&line, p) {
-              for author in split_author_line(line) {
-                entries.push((AuthorLineKind::Author, author));
+        // Marker-less lines may only continue an entry created WITHIN this
+        // `\and` group — never one from a previous group.
+        let group_start = entries.len();
+        for line in split_tokens(group, author_affil_splits()) {
+          if line.is_empty() {
+            continue;
+          }
+          match position_of(&line, &authorsup_markers()) {
+            None => {
+              // A marker-less line that is purely a list of email addresses is a
+              // SHARED email line (\texttt{a@x, b@y}) covering all the authors, not
+              // a continuation of the previous affiliation — give it its own email
+              // contact so it is shown once instead of being welded into an
+              // affiliation's text (KNOWN_PERL_ERRORS #75, witness 2605.23553).
+              if line_is_email_list(&line) {
+                entries.push((AuthorLineKind::Email, line));
+              } else if entries.len() > group_start {
+                // continues an entry from THIS `\and` group; Append
+                let last = entries.last_mut().unwrap();
+                let mut appended = last.1.clone().unlist();
+                appended.extend(line.unlist());
+                last.1 = Tokens::new(appended);
+              } else {
+                // First line of this `\and` group and it has no marker → a NEW
+                // author (never merge back into the previous group).
+                entries.push((AuthorLineKind::Author, line));
               }
-            } else {
-              // A marker-led affiliation line may carry MULTIPLE
-              // `\textsuperscript{n}Affil` institutions on one space-separated line
-              // (html_feedback#6242, arXiv:2510.02340) — `\textsuperscript{1}Univ A
-              // \textsuperscript{2}Univ B`. Split at each whitespace-preceded mark
-              // (reusing the `\thanks`-abuse splitter, which never breaks a
-              // superscript glued INSIDE an institution name) so each numbered
-              // institution becomes its own affiliation and attaches to its authors
-              // by number, instead of merging into one.
-              for seg in split_before_affiliation_marks(line) {
-                if seg.unlist_ref().iter().all(|t| *t == T_SPACE!()) {
-                  continue;
+            },
+            Some(p) => {
+              // "\textsuperscript{n}Affil" (the marker LEADS the line) → an
+              // affiliation; "Name\textsuperscript{n}" (a name precedes the
+              // marker) → an author line, split into the individual creators it
+              // names (see split_author_line). The old `p < 8` token-count proxy
+              // misread short author names like "Min Xu" (html_feedback#6614) —
+              // key on name-before-marker, which is length-independent.
+              if name_precedes_marker(&line, p) {
+                for author in split_author_line(line) {
+                  entries.push((AuthorLineKind::Author, author));
                 }
-                entries.push((AuthorLineKind::Affiliation, seg));
+              } else {
+                // A marker-led affiliation line may carry MULTIPLE
+                // `\textsuperscript{n}Affil` institutions on one space-separated line
+                // (html_feedback#6242, arXiv:2510.02340) — `\textsuperscript{1}Univ A
+                // \textsuperscript{2}Univ B`. Split at each whitespace-preceded mark
+                // (reusing the `\thanks`-abuse splitter, which never breaks a
+                // superscript glued INSIDE an institution name) so each numbered
+                // institution becomes its own affiliation and attaches to its authors
+                // by number, instead of merging into one.
+                for seg in split_before_affiliation_marks(line) {
+                  if seg.unlist_ref().iter().all(|t| *t == T_SPACE!()) {
+                    continue;
+                  }
+                  entries.push((AuthorLineKind::Affiliation, seg));
+                }
               }
-            }
-          },
+            },
+          }
         }
       }
       for (kind, line) in entries {
@@ -4045,6 +4065,17 @@ fn author_group_splits() -> Vec<SplitDelim> {
     T_CS!("\\AND").into(),
     T_CS!("\\quad").into(),
     T_CS!("\\qquad").into(),
+  ]
+}
+
+/// The `\and` family only — the HARD author boundary the superscript-marker
+/// branch groups on FIRST, so a marker-less line never merges into an author
+/// from a previous `\and` group (html_feedback#1021 F2; OXIDIZED_DESIGN #52(g)).
+fn author_and_splits() -> Vec<SplitDelim> {
+  vec![
+    T_CS!("\\and").into(),
+    T_CS!("\\And").into(),
+    T_CS!("\\AND").into(),
   ]
 }
 // Things to split author & affiliation mix; NO comma in affiliations!!!

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -176,6 +176,33 @@ fn frontmatter_nested_math_author_marker() {
     "the shared affiliation text must survive:\n{x}"
   );
 }
+/// html_feedback#1021 F2 residual (arXiv:2403.11905): `\and` must be a HARD author
+/// boundary in the superscript-marker branch. When a 2nd/3rd author's marker is
+/// delivered by a macro (no literal `^` on that segment), the old flat
+/// `\and`/`\quad`/`\\` split appended the marker-less segment to the PREVIOUS
+/// author, collapsing `Alice\mk$^*$ \and Bob\mk \and Carol\mk` into one merged
+/// `<personname>`. Grouping on `\and` first (append bounded to the group) keeps
+/// them separate. OXIDIZED_DESIGN #52(g).
+#[test]
+fn frontmatter_and_hard_author_boundary() {
+  let x = convert_to_xml("tests/cluster_regressions/frontmatter_and_hard_author_boundary.tex");
+  for name in ["Alice", "Bob", "Carol"] {
+    assert!(
+      x.contains(&format!("<personname>{name}</personname>")),
+      "author {name} must be its own clean creator, not merged:\n{x}"
+    );
+  }
+  assert_eq!(
+    x.matches("role=\"author\"").count(),
+    3,
+    "expected exactly three separate author creators across the \\and boundaries:\n{x}"
+  );
+  // The reported canary: the three names must not weld into one personname.
+  assert!(
+    !x.contains("AliceBob") && !x.contains("BobCarol"),
+    "\\and-separated authors merged into one personname:\n{x}"
+  );
+}
 /// html_feedback#6614 (arXiv:2606.08234, ACL): a `\author{Name\quad Name… \\
 /// \textsuperscript{n}Affil}` block must keep SHORT author names as authors, not
 /// reclassify them as affiliations. "Min Xu" (7 tokens) tripped the old `p < 8`

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_and_hard_author_boundary.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_and_hard_author_boundary.tex
@@ -1,0 +1,11 @@
+\documentclass{article}
+\usepackage{amsmath}
+% html_feedback#1021 F2 residual (arXiv:2403.11905): authors separated by \and
+% where the 2nd author's superscript marker is delivered by a macro (no literal
+% `^` on that segment). The marker branch used to flat-split \and/\quad/\\
+% together and append a marker-less segment to the PREVIOUS author, merging
+% \and-separated authors into one <personname>. \and is now a hard boundary.
+\newcommand{\mk}{$^\text{$\star$}$}
+\author{Alice\mk$^*$ \and Bob\mk \and Carol\mk}
+\title{And hard author boundary}
+\begin{document}\maketitle\end{document}


### PR DESCRIPTION
**Diagnostic.** The superscript-marker branch of `\lx@add@authors` flat-split `\and`/`\quad`/`\\` into one list, then appended any *marker-less* line to the previous entry. When a 2nd/3rd author's superscript is macro-delivered (`Alice\mk$^*$ \and Bob\mk`, `\mk`→`$^…$`, so Bob's segment has no literal `^`), the segment merged back across the `\and` → one `<personname>AliceBob</personname>`. Both engines merge (SHARED-FAILURE). This is the #1021 F2 residual: why arXiv:2403.11905 still showed merged authors after the nested-math error fix.

**Approach.** Group on the `\and` family FIRST (hard author boundary); a marker-less line may only continue an entry created WITHIN the same `\and` group. Groups carry no `\and`, so the intra-group split reuses `author_affil_splits` unchanged — the *only* behavior change is that a marker-less first line of a non-first `\and` group becomes a new author instead of merging. Refines OXIDIZED_DESIGN #52 as sub-note (g).

**Validation.** Guard `06_cluster_frontmatter::frontmatter_and_hard_author_boundary` (three `\and`-separated macro-marked authors stay separate). Blast radius examined rigorously: an **OLD-vs-NEW full-XML diff over all 30 frontmatter fixtures changed exactly ONE** (this case) — the other 29 byte-identical. Full suite **2020/2020**, clippy/fmt clean.

**Deferred (Phase 2).** Recognizing a *purely* macro-delivered marker (no literal `^` on its line, e.g. `\handPointerZ Johns Hopkins University`) so its affiliation attaches — needs expansion-aware marker detection, riskier; tracked as the residual in #52(g). So 2403.11905's authors now separate but the last one still carries its institution in the name.

Refs #1021