### PR TITLE
fix: \twocolumn spanning-header font no longer leaks into the body

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN.md
+++ b/docs/parity/OXIDIZED_DESIGN.md
@@ -23,7 +23,7 @@ This file is the **index + overview**. The detail lives in a themed family:
 > "Speculative function application"**) are in MATH; (3) **`#76` is a retired
 > number** — its entry was consolidated into `#74` and the number was not
 > reused, so a gap in the sequence is expected, not a missing file. Next free
-> number: **#128**. When in doubt,
+> number: **#131**. When in doubt,
 > `grep '### N\.' docs/parity/OXIDIZED_DESIGN_*.md docs/math/OXIDIZED_DESIGN_MATH.md`.
 
 ---

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4859,3 +4859,26 @@ gone.
 
 **Guard**: `06_cluster_frontmatter::frontmatter_nested_math_author_marker` (two clean
 creators linked to a shared affiliation via `$^\text{$\star$}$` markers, 0 errors).
+
+### 130. `\twocolumn[header]` scopes the spanning-header's font/alignment declarations
+
+**Perl**: `\twocolumn[]` is `\ifx.#1.\else\par\noindent#1\fi\par`
+(`latex_constructs.pool.ltxml` L1015) — the optional argument is spliced into the
+stream **unscoped**. A font or alignment declaration inside the header
+(`\centering`, `\Large`, …) therefore runs on into the body. Real LaTeX does not:
+`\twocolumn[#1]` routes through `\@topnewpage`, which typesets `#1` in a box, so the
+header's declarations are bounded to it. Perl rarely exhibits the leak because it
+tends not to render the headers that trigger it — e.g. cvpr's
+`\maketitlesupplementary` (`\twocolumn[\centering\Large … Supplementary Material …]`)
+is undefined under Perl (no cvpr binding, raw loading off), so `\maketitlesupplementary`
+errors and the `\Large` never runs.
+
+**Rust**: our cvpr binding raw-loads the real `cvpr.sty`, so `\maketitlesupplementary`
+*does* run and the header renders at `\Large` — but the unscoped splice then leaked
+that `\Large` into the entire Supplementary Material section (every heading and
+paragraph `font-size:144%`). We wrap the header in a group with its own `\par`
+(`\ifx.#1.\else\par\noindent{#1\par}\fi\par`), matching the box scope real LaTeX
+gives `\@topnewpage`: the header keeps its `\Large`, the body returns to normal size.
+This surpasses Perl's simplification. Witness html_feedback#6638 (arXiv:2511.14625v1).
+
+**Guard**: `06_cluster_regressions::twocolumn_optional_header_font_does_not_leak_into_body`.

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4877,7 +4877,8 @@ errors and the `\Large` never runs.
 *does* run and the header renders at `\Large` — but the unscoped splice then leaked
 that `\Large` into the entire Supplementary Material section (every heading and
 paragraph `font-size:144%`). We wrap the header in a group with its own `\par`
-(`\ifx.#1.\else\par\noindent{#1\par}\fi\par`), matching the box scope real LaTeX
+(`\ifx.#1.\else\par{\noindent#1\par}\fi\par` — `\noindent` inside the group so the
+header paragraph keeps its non-indent), matching the box scope real LaTeX
 gives `\@topnewpage`: the header keeps its `\Large`, the body returns to normal size.
 This surpasses Perl's simplification. Witness html_feedback#6638 (arXiv:2511.14625v1).
 

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -4900,8 +4900,23 @@ LoadDefinitions!({
   def_primitive_noop("\\leftmark")?;
   def_primitive_noop("\\rightmark")?;
   def_primitive_noop("\\pagenumbering{}")?;
-  // Perl: DefMacro('\twocolumn[]', '\ifx.#1.\else\par\noindent#1\fi\par');
-  DefMacro!("\\twocolumn[]", "\\ifx.#1.\\else\\par\\noindent#1\\fi\\par");
+  // Perl: DefMacro('\twocolumn[]', '\ifx.#1.\else\par\noindent#1\fi\par').
+  //
+  // SURPASS-PERL (OXIDIZED_DESIGN): the optional argument is a one-column-
+  // spanning header; real LaTeX typesets it in a box (`\@topnewpage`), so any
+  // font/alignment declaration inside it (`\centering`, `\Large`, …) is scoped
+  // to the header and does NOT leak into the body. Perl's simplified macro
+  // splices `#1` unscoped, so a `\Large` in the header runs on into everything
+  // after — e.g. cvpr's `\maketitlesupplementary` does
+  // `\twocolumn[\centering\Large … Supplementary Material …]`, and the whole
+  // Supplementary section renders oversized. (Perl escapes this only because it
+  // has no cvpr binding and never runs `\maketitlesupplementary` at all.) Wrap
+  // `#1` in a group with its own `\par`, matching the box scope real LaTeX
+  // gives it. Witness html_feedback#6638 (arXiv:2511.14625v1).
+  DefMacro!(
+    "\\twocolumn[]",
+    "\\ifx.#1.\\else\\par{\\noindent#1\\par}\\fi\\par"
+  );
   // Perl: DefMacro('\onecolumn', '\par');
   DefMacro!("\\onecolumn", "\\par");
   DefMacro!("\\@onecolumna", "", locked => true);

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -952,6 +952,29 @@ fn mathversion_switches_the_mathfont_like_boldmath() {
   );
 }
 
+/// arXiv/html_feedback#6638 (arXiv:2511.14625v1): the `\twocolumn[...]` optional
+/// argument is a one-column-spanning header that real LaTeX typesets in a box
+/// (`\@topnewpage`), so a font declaration inside it (`\Large`) is scoped to the
+/// header and must not leak into the body. Perl's simplified `\twocolumn` splices
+/// the argument unscoped and leaks — cvpr's `\maketitlesupplementary` does
+/// `\twocolumn[\centering\Large … Supplementary Material …]`, which made the whole
+/// Supplementary section render oversized. Our `\twocolumn` now groups the header.
+#[test]
+fn twocolumn_optional_header_font_does_not_leak_into_body() {
+  let x = convert_to_xml("tests/cluster_regressions/twocolumn_optarg_font_scope.tex");
+  // The spanning header itself IS \Large (the fix must not swallow that).
+  assert!(
+    x.contains(r#"fontsize="144%""#),
+    "the \\twocolumn spanning header lost its \\Large size:\n{x}"
+  );
+  // But the section heading and body after it must be normal size — no leak.
+  let after = &x[x.find("Body Section").unwrap_or(0)..];
+  assert!(
+    !after.contains("fontsize="),
+    "the header's \\Large leaked past \\twocolumn into the body:\n{x}"
+  );
+}
+
 /// arXiv/html_feedback#6876 (arXiv:2311.15365v3): the `derivative` package's
 /// differential/derivative operators leaked as undefined control sequences.
 /// physics.sty covers the `\dv`/`\pdv`/`\dd` overlap but NOT derivative-only

--- a/latexml_oxide/tests/cluster_regressions/twocolumn_optarg_font_scope.tex
+++ b/latexml_oxide/tests/cluster_regressions/twocolumn_optarg_font_scope.tex
@@ -1,0 +1,12 @@
+\documentclass{article}
+% arXiv:2511.14625v1 (html_feedback#6638): the \twocolumn[...] optional argument
+% is a one-column-spanning header; real LaTeX boxes it (\@topnewpage), so a font
+% declaration inside it (\Large) is scoped to the header and must NOT leak into
+% the body. cvpr's \maketitlesupplementary does exactly this
+% (\twocolumn[\centering\Large ... Supplementary Material ...]); before the fix
+% the whole Supplementary section rendered oversized.
+\begin{document}
+\twocolumn[\centering\Large Spanning Header Title\\ Second header line]
+\section{Body Section}
+Ordinary body text after the spanning header must be normal size.
+\end{document}


### PR DESCRIPTION
**Diagnostic.** `\twocolumn[header]`'s optional argument is a one-column-spanning header that real LaTeX boxes (`\@topnewpage`), scoping any font/alignment declaration inside it. Our macro (a faithful port of Perl's *simplified* `\twocolumn`) spliced it unscoped, so cvpr's `\maketitlesupplementary` — `\twocolumn[\centering\Large … Supplementary Material …]` — leaked `\Large` into the entire Supplementary section (every heading/paragraph at `font-size:144%`). Perl only escapes this by having no cvpr binding and never running `\maketitlesupplementary`.

**Approach.** Wrap the header in a group with its own `\par` (`\par{\noindent#1\par}`), matching the box scope `\@topnewpage` gives it: the header keeps its `\Large`, the body returns to normal, and the header's `\noindent` is preserved. Surpass-Perl, OXIDIZED_DESIGN 130.

**Validation.** Red→green guard `twocolumn_optional_header_font_does_not_leak_into_body`; full suite 2023/0; clippy/fmt clean. Witness arXiv:2511.14625v1: supplementary `font-size:144%` count 151 → 0 (only the title stays large). The ticket's headline ablation table already parses correctly in the current binary (0 errors, all data present) — Perl errors 41× on its `\noalign`/`\omit`/`\cdashline`-in-`\resizebox`.

Addresses the report in arXiv/html_feedback#6638.

🤖 Generated with [Claude Code](https://claude.com/claude-code)