### PR TITLE
fix #6255: authblk \author{A, B, C} comma list splits into separate creators

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -1452,6 +1452,18 @@ name rather than recognized as an affiliation, because classification keys on a 
 marker and does not expand macros. So arXiv:2403.11905's Kate Sanders now separates from
 Kevin Xu but still carries her institution in the name; full attachment needs
 expansion-aware marker detection.)
+**(h) authblk `\author{A, B, C}` comma list splits into separate creators.** authblk's
+`\author` routes a no-`\and` argument to `\lx@add@creator` (a single creator), so a
+comma list `\author{Alice One, Bob Two, Carol Three}` was kept as ONE
+`<personname>Alice One, Bob Two, Carol Three</personname>` (html_feedback#6255,
+googledeepmind). The DEFAULT `\author` already routes to `\lx@add@authors`, which splits
+a comma / " and " list into separate creators via `split_author_line`. authblk's
+`\author` now routes to `\lx@add@authors` too when the argument has a top-level comma (or
+`\and`), so the comma list resolves to individual creators — matching the default and the
+PDF. A single name that legitimately contains a comma ("Smith, Jr.") is mis-split, but
+that is the pre-existing #52 comma tradeoff the default `\author` already makes, not a new
+divergence; the label and single-name (no-comma) authblk paths stay Perl-faithful. Guard:
+`06_cluster_frontmatter::frontmatter_authblk_comma_list`.
 
 **Scope/limits:**
 - The `*` equal-contribution suffix on a combined author mark (`$^{1*}$`) still

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -105,6 +105,31 @@ fn frontmatter_multi_affil_superscript() {
     "the two superscript affiliations merged into one:\n{x}"
   );
 }
+/// html_feedback#6255 (googledeepmind, authblk): a single `\author{A, B, C}` comma
+/// list is authblk's one-author-arg form, so it stayed as one merged
+/// `<personname>A, B, C</personname>`. The DEFAULT `\author` already splits a comma
+/// list into separate creators; authblk's `\author` routed a no-`\and` list to
+/// `\lx@add@creator` (single) instead. Routing a comma list to `\lx@add@authors`
+/// too fixes the inconsistency. OXIDIZED_DESIGN #52(h).
+#[test]
+fn frontmatter_authblk_comma_list() {
+  let x = convert_to_xml("tests/cluster_regressions/frontmatter_authblk_comma_list.tex");
+  for name in ["Alice One", "Bob Two", "Carol Three"] {
+    assert!(
+      x.contains(&format!("<personname>{name}</personname>")),
+      "author {name:?} must be its own creator, not merged:\n{x}"
+    );
+  }
+  assert_eq!(
+    x.matches("role=\"author\"").count(),
+    3,
+    "authblk comma list must split into three separate creators:\n{x}"
+  );
+  assert!(
+    !x.contains("<personname>Alice One, Bob"),
+    "the comma list stayed welded into one personname:\n{x}"
+  );
+}
 /// arXiv:2403.16405 (IEEEtran conference): a `\author{}` grid where `\and` starts a
 /// COLUMN and top-level `\\` a ROW within it is linearized column-major (declaration
 /// order), scrambling the row-major reading order shown in the PDF/arXiv metadata.

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_authblk_comma_list.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_authblk_comma_list.tex
@@ -1,0 +1,11 @@
+\documentclass{article}
+\usepackage{authblk}
+% html_feedback#6255 (googledeepmind, authblk): a single \author{A, B, C} comma
+% list is authblk's one-author-arg form, so it was kept as ONE
+% <personname>A, B, C</personname>. The default (non-authblk) \author already
+% splits a comma list into separate creators via \lx@add@authors; authblk's
+% \author routes a no-\and list to \lx@add@creator (single) instead. Route a
+% comma list to \lx@add@authors too, matching the default.
+\author{Alice One, Bob Two, Carol Three}
+\title{Authblk comma author list}
+\begin{document}\maketitle\end{document}

--- a/latexml_package/src/package/authblk_sty.rs
+++ b/latexml_package/src/package/authblk_sty.rs
@@ -39,8 +39,18 @@ LoadDefinitions!({
       Ok(Invocation!("\\lx@add@creator[role=author,annotations={#1}]{#2}",
         vec![Some(label), Some(author)]))
     } else if author.unlist_ref().iter().any(|t|
-      t.defined_as(&T_CS!("\\and")) || t.defined_as(&T_CS!("\\And")))
+      t.defined_as(&T_CS!("\\and")) || t.defined_as(&T_CS!("\\And"))
+      || *t == T_OTHER!(","))
     {
+      // `\and`/`\And` OR a top-level comma → a multi-author list; route to
+      // `\lx@add@authors`, which splits it into separate creators via
+      // `split_author_line` (the same comma / " and " name split the DEFAULT
+      // `\author` already applies). authblk's own no-`\and` branch keeps the
+      // whole comma list as ONE `<personname>A, B, C</personname>`; matching the
+      // default fixes that inconsistency (html_feedback#6255, googledeepmind).
+      // A single name that legitimately contains a comma ("Smith, Jr.") is
+      // mis-split, but that is the pre-existing #52 comma tradeoff the default
+      // `\author` already makes, not a new divergence. OXIDIZED_DESIGN #52(h).
       Ok(Invocation!(T_CS!("\\lx@add@authors"), vec![Some(author)]))
     } else {
       Ok(Invocation!(T_CS!("\\lx@add@creator"), vec![None, Some(author)]))


### PR DESCRIPTION
**Diagnostic.** authblk's `\author` routes a no-`\and` argument to `\lx@add@creator` (a single creator), so a comma list `\author{Alice One, Bob Two, Carol Three}` was kept as one merged `<personname>Alice One, Bob Two, Carol Three</personname>` (googledeepmind). The DEFAULT `\author` already routes a comma list to `\lx@add@authors`, which splits it into separate creators via `split_author_line`.

**Approach.** Route authblk's `\author` to `\lx@add@authors` when the argument has a top-level comma (or `\and`), matching the default; the `[mark]` label and single-name (no-comma) paths stay Perl-faithful. Refines OXIDIZED_DESIGN #52 as sub-note (h). A single name containing a comma ("Smith, Jr.") is mis-split — the pre-existing #52 comma tradeoff the default `\author` already makes, not a new divergence.

**Validation.** Guard `06_cluster_frontmatter::frontmatter_authblk_comma_list`. Blast radius: OLD-vs-NEW full-XML diff over all 30 frontmatter fixtures changed **exactly ONE** (this case). Full suite **2023/2023**, clippy/fmt clean.

Closes #6255