### PR TITLE
fix: cleveref \cref matches LaTeX for custom \newtheorem types

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN.md
+++ b/docs/parity/OXIDIZED_DESIGN.md
@@ -9,7 +9,7 @@ This file is the **index + overview**. The detail lives in a themed family:
 
 | Theme file | What it holds |
 |---|---|
-| [OXIDIZED_DESIGN_DIVERGENCES.md](OXIDIZED_DESIGN_DIVERGENCES.md) | The numbered **Intentional Divergences from Perl** (`#1–#15`, `#17–#18`, `#19–#127`) + a brief Known-Upstream-Perl-Issues list. Code comments cite these as `OXIDIZED_DESIGN #N`. |
+| [OXIDIZED_DESIGN_DIVERGENCES.md](OXIDIZED_DESIGN_DIVERGENCES.md) | The numbered **Intentional Divergences from Perl** (`#1–#15`, `#17–#18`, `#19–#131`) + a brief Known-Upstream-Perl-Issues list. Code comments cite these as `OXIDIZED_DESIGN #N`. |
 | [OXIDIZED_DESIGN_MATH.md](../math/OXIDIZED_DESIGN_MATH.md) | Marpa math-parser design: `#16` design rules + the grammar-rule cluster `#7–#18`. |
 | [OXIDIZED_DESIGN_TYPES.md](OXIDIZED_DESIGN_TYPES.md) | Type-system improvements (behavior-neutral) + tactical internal pitfalls. |
 | [OXIDIZED_DESIGN_FUTURE_WORK.md](OXIDIZED_DESIGN_FUTURE_WORK.md) | Beyond-parity directions not yet built. |
@@ -23,7 +23,7 @@ This file is the **index + overview**. The detail lives in a themed family:
 > "Speculative function application"**) are in MATH; (3) **`#76` is a retired
 > number** — its entry was consolidated into `#74` and the number was not
 > reused, so a gap in the sequence is expected, not a missing file. Next free
-> number: **#131**. When in doubt,
+> number: **#132**. When in doubt,
 > `grep '### N\.' docs/parity/OXIDIZED_DESIGN_*.md docs/math/OXIDIZED_DESIGN_MATH.md`.
 
 ---

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4941,5 +4941,14 @@ primary name (the fallback stays dormant).
 Witness html_feedback#140 (arXiv:2305.10391v2 — `\usepackage[capitalize,nameinlink]{cleveref}`
 + `\newtheorem{arch}{Architecture}`).
 
+Upstream context: cleveref's `\newtheorem` naming is a long-standing sore spot with newer
+LaTeX. TeX Live 2025 broke it so that *every* `\cref` to a theorem prints the same name
+([arXiv TeX Live FAQ](https://info.arxiv.org/help/faq/texlive.html), "cleveref"); arXiv's
+workaround is `\AddToHook{env/<thm>/begin}{\crefalias{<counter>}{<thm>}}`. LaTeXML is immune
+because it keys `creftype` on each theorem's own type (via `type_tag_formatter`), not on the
+shared counter, so it yields distinct correct names and needs no workaround — standard names
+(`theorem`, `proposition`, …) still come from cleveref's raw defaults; only non-standard names
+(`arch`) use the heading fallback. `\crefalias` remains a harmless no-op here.
+
 **Guards**: `06_cluster_regressions::cleveref_custom_theorem_cref_shows_heading_name`
 (heading fallback) and `::cleveref_explicit_crefname_overrides_heading` (explicit name wins).

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4904,3 +4904,42 @@ gives `\@topnewpage`: the header keeps its `\Large`, the body returns to normal 
 This surpasses Perl's simplification. Witness html_feedback#6638 (arXiv:2511.14625v1).
 
 **Guard**: `06_cluster_regressions::twocolumn_optional_header_font_does_not_leak_into_body`.
+
+### 131. cleveref `\cref` names custom `\newtheorem` types by their heading
+
+**Perl & Rust (shared limit)**: real cleveref patches LaTeX's `\@ynthm`/`\@xnthm`/`\@othm`
+so that `\newtheorem{arch}{Architecture}` auto-registers "Architecture" as the cleveref
+type name — `\cref{...}` then renders "Architecture 1" (as in the PDF). LaTeXML's
+`\newtheorem` is a native primitive (`define_new_theorem`) that never routes through
+those patches, so `\cref@arch@name` stays undefined. Both engines therefore emit the
+type-tag empty (dropped by `removeEmptyElement`) and `\cref` degrades to a bare
+"1" — the `creftype` component of `show="creftype~refnum"` resolves to nothing.
+
+**Rust (surpass-Perl)**: two changes, in precedence order.
+
+1. `\crefname`/`\Crefname` are now **real definitions** (`cleveref_sty.rs::cref_define_name`,
+   a clean port of raw cleveref's `\@crefname` — the raw macros' `\toksdef`/`\expandafter`
+   chains mis-consumed tokens here, so they had been no-op stubs). An explicit
+   `\crefname{arch}{…}` therefore populates `\cref@arch@name` and takes precedence, exactly
+   as in LaTeX. The cross-variant `\MakeUppercase` derivation (deriving `\Cref@…` from a lone
+   `\crefname`) is not reproduced — provide `\Crefname` for the capitalised form — matching
+   the `thmtools_sty.rs` `\declaretheorem[refname=]` precedent.
+2. When no explicit name is set, the `creftype`/`creftypecap` formatters
+   (`cleveref_sty.rs::cleverref_type_name`) fall back to the theorem heading
+   `\lx@name@<type>` (which `define_new_theorem` already stores), so a bare
+   `\newtheorem{arch}{Architecture}` renders "Architecture 1" — matching the PDF and
+   exceeding Perl. Only the **singular** names get the fallback (cleveref's theorem patches
+   set only `cref@<type>@name@preamble`, never a plural). The heading is emitted verbatim:
+   cleveref's first-letter `capitalize` case transform is not reproduced, so a lowercase
+   `\cref` under the default (non-`capitalize`) option keeps the heading's own case.
+
+`\lx@name@<type>` is also defined by `\floatname`/`\newfloat` (`float_sty.rs`), so the
+fallback additionally auto-names custom floats — matching real cleveref's float auto-naming,
+so it is beneficial, not a leak; standard `figure`/`table`/`equation` keep their raw-cleveref
+primary name (the fallback stays dormant).
+
+Witness html_feedback#140 (arXiv:2305.10391v2 — `\usepackage[capitalize,nameinlink]{cleveref}`
++ `\newtheorem{arch}{Architecture}`).
+
+**Guards**: `06_cluster_regressions::cleveref_custom_theorem_cref_shows_heading_name`
+(heading fallback) and `::cleveref_explicit_crefname_overrides_heading` (explicit name wins).

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -1018,3 +1018,49 @@ fn cleveref_cref_in_math_reverts_tie_as_plain_tilde() {
     "the internal \\lx@tilde CS leaked into the tex= reversion:\n{x}"
   );
 }
+
+/// arXiv/html_feedback#140: a bare `\newtheorem{arch}{Architecture}` (no explicit
+/// `\crefname`) referenced with `\cref` rendered only the number ("1") instead of
+/// "Architecture 1" as in the PDF. Real cleveref auto-names such theorems by their
+/// heading; LaTeXML's native `\newtheorem` bypasses cleveref's `\@ynthm` patches, so
+/// both engines dropped the type name. The creftype formatter now falls back to the
+/// theorem heading `\lx@name@<type>` (surpass-Perl, OXIDIZED_DESIGN #131).
+#[test]
+fn cleveref_custom_theorem_cref_shows_heading_name() {
+  let x = convert_and_post_clean("tests/cluster_regressions/cleveref_newtheorem_crefname.tex");
+  // The \cref now resolves creftype → the theorem heading "Architecture" AND the
+  // refnum "1" — both as ref tags, so the link reads "Architecture 1".
+  assert!(
+    x.contains(r#"<text class="ltx_ref_tag">Architecture</text>"#),
+    "\\cref did not render the custom theorem's type name \"Architecture\":\n{x}"
+  );
+  assert!(
+    x.contains(r#"<text class="ltx_ref_tag">1</text>"#),
+    "\\cref lost the reference number \"1\":\n{x}"
+  );
+  // The type name is surfaced at core time as a creftype tag on the theorem.
+  assert!(
+    x.contains(r#"<tag role="creftype">Architecture</tag>"#),
+    "the theorem is missing its creftype type-tag:\n{x}"
+  );
+}
+
+/// Companion to the above (html_feedback#140): an explicit `\crefname{widget}{gadget}
+/// {gadgets}` must WIN over the theorem-heading fallback — `\cref` renders the explicit
+/// "gadget", not the heading "Widget". `\crefname` is now a real definition (a faithful
+/// port of cleveref's `\@crefname`), not a no-op stub, so it populates `\cref@widget@name`
+/// and the primary branch takes precedence over `\lx@name@widget`.
+#[test]
+fn cleveref_explicit_crefname_overrides_heading() {
+  let x = convert_and_post_clean("tests/cluster_regressions/cleveref_newtheorem_crefname.tex");
+  assert!(
+    x.contains(r#"<text class="ltx_ref_tag">gadget</text>"#),
+    "explicit \\crefname name \"gadget\" did not reach the \\cref link:\n{x}"
+  );
+  // The heading "Widget" must NOT be used as this ref's type name (the explicit
+  // \crefname overrides it). It still appears in the theorem's own <tag>/title.
+  assert!(
+    !x.contains(r#"<text class="ltx_ref_tag">Widget</text>"#),
+    "the heading \"Widget\" leaked past the explicit \\crefname into the ref:\n{x}"
+  );
+}

--- a/latexml_oxide/tests/114_streaming_cluster_regressions.rs
+++ b/latexml_oxide/tests/114_streaming_cluster_regressions.rs
@@ -2,9 +2,15 @@
 //! Every fixture converts twice (eager, and streaming with an aggressive
 //! 3-box budget); the XML must be byte-identical and the error counts equal.
 //! One suite per test binary — see `streaming_sweep/mod.rs` for why.
+//!
+//! `cluster_regressions` (174 fixtures) accretes ~8.3 GB of libxml2 residue in one
+//! process — at the RSS fuse. It is swept in TWO shards across two binaries (this is
+//! shard 0; `_b` is shard 1) so each process stays well under the cap.
 
 mod streaming_sweep;
-use streaming_sweep::sweep_dir;
+use streaming_sweep::sweep_dir_shard;
 
 #[test]
-fn streaming_matches_eager_on_cluster_regressions() { sweep_dir("tests/cluster_regressions"); }
+fn streaming_matches_eager_on_cluster_regressions_shard0() {
+  sweep_dir_shard("tests/cluster_regressions", 0, 2);
+}

--- a/latexml_oxide/tests/114_streaming_cluster_regressions_b.rs
+++ b/latexml_oxide/tests/114_streaming_cluster_regressions_b.rs
@@ -1,0 +1,12 @@
+//! Forced-streaming corpus sweep for `cluster_regressions`, shard 1 of 2.
+//! See `114_streaming_cluster_regressions.rs` (shard 0) and `streaming_sweep/mod.rs`:
+//! the 174-fixture suite is split across two binaries so neither process accretes
+//! enough libxml2 residue to trip the RSS fuse.
+
+mod streaming_sweep;
+use streaming_sweep::sweep_dir_shard;
+
+#[test]
+fn streaming_matches_eager_on_cluster_regressions_shard1() {
+  sweep_dir_shard("tests/cluster_regressions", 1, 2);
+}

--- a/latexml_oxide/tests/cluster_regressions/cleveref_newtheorem_crefname.tex
+++ b/latexml_oxide/tests/cluster_regressions/cleveref_newtheorem_crefname.tex
@@ -1,0 +1,26 @@
+\documentclass{article}
+% arXiv:2305.10391v2 (html_feedback#140): a custom theorem defined with a bare
+% \newtheorem{arch}{Architecture} (no explicit \crefname) is referenced with
+% \cref. Real cleveref auto-names such theorems by their heading, so the PDF
+% renders "Architecture 1"; both LaTeXML engines used to drop the type name and
+% render bare "1". The Rust binding now falls the creftype formatter back to the
+% theorem heading \lx@name@<type> (surpass-Perl, OXIDIZED_DESIGN #131). The real
+% paper loads cleveref with [capitalize]; mirror that so the case is exercised.
+%
+% The `widget` theorem additionally carries an explicit \crefname whose name
+% ("gadget") differs from its heading ("Widget"): the explicit name must WIN over
+% the heading fallback — \crefname is now a real definition, not a no-op stub.
+\usepackage{amsthm}
+\usepackage[capitalize,nameinlink]{cleveref}
+\newtheorem{arch}{Architecture}
+\newtheorem{widget}{Widget}
+\crefname{widget}{gadget}{gadgets}
+\begin{document}
+\begin{arch}\label{myarch}
+A custom theorem.
+\end{arch}
+\begin{widget}\label{mywidget}
+Another custom theorem.
+\end{widget}
+See \cref{myarch} and \cref{mywidget} for details.
+\end{document}

--- a/latexml_oxide/tests/streaming_sweep/mod.rs
+++ b/latexml_oxide/tests/streaming_sweep/mod.rs
@@ -71,7 +71,18 @@ pub fn convert_with(
 
 pub fn sweep_dir(dir: &str) { sweep_dir_with(dir, latexml_contrib::dispatch) }
 
-pub fn sweep_dir_with(dir: &str, dispatch: DispatchFn) {
+pub fn sweep_dir_with(dir: &str, dispatch: DispatchFn) { sweep_dir_shard_with(dir, 0, 1, dispatch) }
+
+/// As [`sweep_dir`], but sweeps only the fixtures at `index % nshards == shard`
+/// (in sorted order). Splitting an over-large suite across several test BINARIES
+/// keeps each process's cumulative libxml2 residue well under the RSS fuse (see the
+/// module docs). `cluster_regressions` (174 fixtures ≈ 8.3 GB residue) needs this and
+/// is swept in two shards; the smaller suites call [`sweep_dir`] (shard 0 of 1 = all).
+pub fn sweep_dir_shard(dir: &str, shard: usize, nshards: usize) {
+  sweep_dir_shard_with(dir, shard, nshards, latexml_contrib::dispatch)
+}
+
+pub fn sweep_dir_shard_with(dir: &str, shard: usize, nshards: usize, dispatch: DispatchFn) {
   let mut fixtures: Vec<_> = std::fs::read_dir(dir)
     .unwrap_or_else(|e| panic!("cannot read {dir}: {e}"))
     .filter_map(|e| e.ok().map(|e| e.path()))
@@ -83,7 +94,10 @@ pub fn sweep_dir_with(dir: &str, dispatch: DispatchFn) {
     "{dir}: no fixtures found — wrong path?"
   );
   let mut divergent: Vec<String> = Vec::new();
-  for path in fixtures {
+  for (i, path) in fixtures.into_iter().enumerate() {
+    if i % nshards != shard {
+      continue;
+    }
     let src = path.to_string_lossy().into_owned();
     let (eager_xml, eager_errs) = convert_with(&src, None, dispatch);
     let (streamed_xml, streamed_errs) = convert_with(&src, Some(3), dispatch);

--- a/latexml_package/src/package/cleveref_sty.rs
+++ b/latexml_package/src/package/cleveref_sty.rs
@@ -25,13 +25,22 @@ LoadDefinitions!({
   // cleveref wraps it; eager Let here would clobber the wrong target.
   at_begin_document(TokenizeInternal!(r"\let\label\lx@cleverref@label"))?;
 
-  // Override raw TeX \crefname/\Crefname/\crefalias with safe stubs.
-  // The raw cleveref.sty definitions use complex \expandafter chains and
-  // \toksdef that cause token consumption bugs with many calls + blank lines.
-  // These stubs store the names for reference formatting without the risky
-  // raw TeX expansion chains.
-  def_macro_noop("\\crefname{}{}{}")?;
-  def_macro_noop("\\Crefname{}{}{}")?;
+  // \crefname{type}{singular}{plural} / \Crefname{...}: register the cleveref type
+  // name so \cref/\Cref render "<name> <num>". A faithful reimplementation of raw
+  // cleveref's \@crefname core (see cref_define_name) replacing the former no-op
+  // stubs. The raw macros use \toksdef/\expandafter chains that mis-consumed tokens
+  // here; this clean port avoids them (the same approach thmtools_sty.rs already
+  // uses for \declaretheorem[refname=]). An explicit \crefname now populates
+  // \cref@<type>@name, so it wins over the theorem-heading fallback (OXIDIZED_DESIGN #131).
+  DefPrimitive!("\\crefname{}{}{}", sub[(type_arg, sg, pl)] {
+    cref_define_name("cref", type_arg, sg, pl)?;
+    Ok(Vec::new())
+  });
+  DefPrimitive!("\\Crefname{}{}{}", sub[(type_arg, sg, pl)] {
+    cref_define_name("Cref", type_arg, sg, pl)?;
+    Ok(Vec::new())
+  });
+  // \crefalias is defined below as a 2-arg primitive; leave it as-is.
   def_macro_noop("\\crefalias{}{}")?;
 
   // Helper: produces the literal `~` (U+007E) as text — a CS so an active `~`
@@ -119,42 +128,19 @@ LoadDefinitions!({
 
   DefPrimitive!("\\crefalias{}{}", sub[(_counter, _ctype)] { Ok(Vec::new()) });
 
-  // Type formatter macros
+  // Type formatter macros. `theorem_fallback` (the singular creftype/creftypecap
+  // variants) supplies the surpass-Perl auto-naming — see cleverref_type_name.
   DefMacro!("\\lx@cleverrefnum@@{}", sub[args] {
-    let ctype = cref_type(&args[0].to_string());
-    let cs = s!("\\cref@{}@name", ctype);
-    if has_meaning(&T_CS!(&cs)) {
-      Ok(Tokens!(T_CS!(&cs)))
-    } else {
-      Ok(Tokens!())
-    }
+    Ok(cleverref_type_name(&args[0].to_string(), "cref", "name", true))
   });
   DefMacro!("\\lx@cleverrefnumplural@@{}", sub[args] {
-    let ctype = cref_type(&args[0].to_string());
-    let cs = s!("\\cref@{}@name@plural", ctype);
-    if has_meaning(&T_CS!(&cs)) {
-      Ok(Tokens!(T_CS!(&cs)))
-    } else {
-      Ok(Tokens!())
-    }
+    Ok(cleverref_type_name(&args[0].to_string(), "cref", "name@plural", false))
   });
   DefMacro!("\\lx@cleverrefnumcap@@{}", sub[args] {
-    let ctype = cref_type(&args[0].to_string());
-    let cs = s!("\\Cref@{}@name", ctype);
-    if has_meaning(&T_CS!(&cs)) {
-      Ok(Tokens!(T_CS!(&cs)))
-    } else {
-      Ok(Tokens!())
-    }
+    Ok(cleverref_type_name(&args[0].to_string(), "Cref", "name", true))
   });
   DefMacro!("\\lx@cleverrefnumpluralcap@@{}", sub[args] {
-    let ctype = cref_type(&args[0].to_string());
-    let cs = s!("\\Cref@{}@name@plural", ctype);
-    if has_meaning(&T_CS!(&cs)) {
-      Ok(Tokens!(T_CS!(&cs)))
-    } else {
-      Ok(Tokens!())
-    }
+    Ok(cleverref_type_name(&args[0].to_string(), "Cref", "name@plural", false))
   });
 
   // Register type_tag_formatter mappings
@@ -163,6 +149,82 @@ LoadDefinitions!({
   AssignMapping!("type_tag_formatter", "creftypecap" => "\\lx@cleverrefnumcap@@");
   AssignMapping!("type_tag_formatter", "creftypepluralcap" => "\\lx@cleverrefnumpluralcap@@");
 });
+
+/// Port of raw cleveref's `\@crefname` core (`\newcommand\crefname[3]` →
+/// `\@crefname{cref}{type}{sg}{pl}{}`): define `\<prefix>@<type>@name` and
+/// `\<prefix>@<type>@name@plural` from the singular/plural arguments. `prefix` is
+/// `"cref"` (for `\crefname`) or `"Cref"` (for `\Crefname`). The names are stored as
+/// **raw** token bodies (never expanded), so markup such as `\textsc{lemma}` survives,
+/// matching cleveref's `\def`. The raw macro's `\toksdef`/`\expandafter` chains are not
+/// reproduced — the same clean approach `thmtools_sty.rs` uses for
+/// `\declaretheorem[refname=]`. Like that precedent, the cross-variant `\MakeUppercase`
+/// derivation (deriving `\Cref@…` from a lone `\crefname`) is not reproduced; provide
+/// `\Crefname` explicitly for the capitalised form.
+fn cref_define_name(
+  prefix: &str,
+  type_arg: Tokens,
+  singular: Tokens,
+  plural: Tokens,
+) -> Result<()> {
+  let ctype = do_expand(type_arg)?.to_string();
+  let ctype = ctype.trim();
+  def_macro(
+    T_CS!(s!("\\{}@{}@name", prefix, ctype)),
+    None,
+    singular,
+    None,
+  )?;
+  def_macro(
+    T_CS!(s!("\\{}@{}@name@plural", prefix, ctype)),
+    None,
+    plural,
+    None,
+  )?;
+  Ok(())
+}
+
+/// Resolve a cleveref type-name control sequence (`\cref@<type>@name`,
+/// `\Cref@<type>@name@plural`, …) to the tokens the `type_tag_formatter` emits.
+///
+/// When the primary CS is undefined and `theorem_fallback` is set, fall back to the
+/// theorem's stored heading `\lx@name@<type>`. This is a **surpass-Perl** divergence
+/// (OXIDIZED_DESIGN #131): real cleveref patches `\@ynthm`/`\@xnthm`/`\@othm` so that
+/// `\newtheorem{arch}{Architecture}` auto-registers "Architecture" as the cref name,
+/// but LaTeXML's `\newtheorem` (`define_new_theorem`) is a native primitive that never
+/// routes through those patches — so Perl and Rust alike leave `\cref@arch@name`
+/// undefined and `\cref{...}` renders bare "1" instead of "Architecture 1". LaTeXML
+/// already stores the heading as `\lx@name@<type>`, so the singular creftype/creftypecap
+/// formatters reuse it, matching the PDF. Only the *singular* names get the fallback:
+/// cleveref's theorem patches set only `cref@<type>@name@preamble` (never `@plural`).
+/// The heading is emitted verbatim; cleveref's first-letter `capitalize` case transform
+/// is not reproduced, so a lowercase-`\cref` under the default (non-`capitalize`) option
+/// keeps the heading's own case.
+///
+/// `\lx@name@<type>` is also set by `\floatname`/`\newfloat` (`float_sty.rs`), so custom
+/// floats get the same auto-naming — matching real cleveref; standard figure/table/equation
+/// keep their raw-cleveref primary name (fallback stays dormant). An explicit `\crefname`
+/// (now a real definition — see `cref_define_name`) populates the primary CS, so it wins
+/// over this fallback. Witness arXiv 2305.10391 (`\usepackage[capitalize,…]{cleveref}` +
+/// `\newtheorem{arch}{Architecture}`).
+fn cleverref_type_name(
+  type_arg: &str,
+  prefix: &str,
+  suffix: &str,
+  theorem_fallback: bool,
+) -> Tokens {
+  let ctype = cref_type(type_arg);
+  let cs = s!("\\{}@{}@{}", prefix, ctype, suffix);
+  if has_meaning(&T_CS!(&cs)) {
+    return Tokens!(T_CS!(&cs));
+  }
+  if theorem_fallback {
+    let name_cs = s!("\\lx@name@{}", ctype);
+    if has_meaning(&T_CS!(&name_cs)) {
+      return Tokens!(T_CS!(&name_cs));
+    }
+  }
+  Tokens!()
+}
 
 /// Perl: crefType($type) — resolve type alias
 fn cref_type(ctype: &str) -> String {


### PR DESCRIPTION
**Diagnostic.** A custom theorem `\newtheorem{arch}{Architecture}` referenced with `\cref` rendered a bare "1" instead of "Architecture 1" (the PDF), and an explicit `\crefname` was ignored. LaTeXML's native `\newtheorem` bypasses real cleveref's `\@ynthm` auto-crefname patches, so `\cref@<type>@name` stays undefined; and `\crefname`/`\Crefname` were no-op stubs.

**Approach.** In `cleveref_sty.rs`: (1) `\crefname`/`\Crefname` become real definitions (`cref_define_name`, a clean port of raw cleveref's `\@crefname`, no `\toksdef` chains) so an explicit name wins; (2) when none is set, the singular creftype/creftypecap formatters fall back to the theorem heading `\lx@name@<type>` — surpass-Perl, matching the PDF (`OXIDIZED_DESIGN #131`).

**Validation.** Guards `cleveref_custom_theorem_cref_shows_heading_name` + `cleveref_explicit_crefname_overrides_heading`; full suite 2027/0; clippy/fmt/doc; Perl parity on the witness (Perl "1" → "Architecture 1"); witness arXiv:2305.10391v2 converts 0-error with 13× "Architecture 1". Second commit shards the 174-fixture `cluster_regressions` streaming sweep across two binaries (it had reached the 9 GB RSS fuse; this new fixture tipped it).

Addresses the report in arXiv/html_feedback#140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)