### PR TITLE
fix html_feedback#6637: \hspace separates co-authors, footnote-symbol marks render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+  - **`\hspace`-separated authors split, and equal-contribution superscript marks
+    render.** An `\author` block that lays co-authors out with `\hspace{len}`/
+    `\hfill` instead of `\and` collapsed into one `<personname>`, and a literal
+    footnote-symbol mark (`$^{*}$`, `\textsuperscript{\dagger}` — equal-contribution
+    / corresponding notes) was consumed into an affiliation label that matched
+    nothing and silently dropped. Horizontal-space macros now normalize to the
+    `\quad` author separator, and symbol marks render as a visible superscript
+    (numeric affiliation marks are untouched). For the witness — arXiv 2506.06941,
+    "The Illusion of Thinking", whose arXiv HTML is byte-identical Perl 0.8.8 — the
+    six welded authors now split, Iman Mirzadeh's `$^{*}$` returns, and "Apple"
+    becomes the last author's affiliation. Surpasses Perl (arXiv/html_feedback#6637).
   - **apacite's old `.bbl` format renders.** apacite's pre-2012 bibliography
     format labels each `\bibitem` with `\BCAY{full}{short}{year}` and formats
     entries with `\Bem`/`\BBACOMMA` — macros the binding did not define, so a

--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3752,3 +3752,34 @@ wrappers read a FULL superscript operand (`read_frontmatter_sup_operand`,
 and undigested; the surrounding math stays balanced. Witness arXiv:2403.11905
 (html_feedback#1021): 6 errors → 0. Guard
 `06_cluster_frontmatter::frontmatter_nested_math_author_marker`.
+
+## 96. `\hspace`-separated authors bunch, and footnote-symbol marks vanish (Rust surpasses)
+
+**Perl source:** `LaTeXML/Engine/Base_Utility.pool.ltxml` L679-740 (`\lx@add@authors` split
+sets `@authorsplits`/`@authoraffilsplits` know only `\and`/`\quad`/`\qquad`/`\\`;
+`\lx@author@withsup` `\let`s `^`/`\textsuperscript` onto the affiliation-linker).
+
+**Symptom:** no error is raised — the frontmatter is silently mis-structured. Authors laid
+out with `\hspace`/`\hfill` between them collapse into a single `<personname>`, and a
+literal equal-contribution superscript (`$^{*}$`) is consumed into an affiliation label that
+matches nothing and is discarded (the visible mark disappears).
+
+**Minimal trigger:**
+```latex
+\author{Alice \hspace{1cm} Bob$^{*}$ \hspace{1cm} Carol}
+\begin{document}\maketitle\end{document}
+```
+Perl 0.8.8 yields one creator `<personname>Alice     Bob     Carol</personname>` — Bob's
+`$^{*}$` gone. Witness arXiv:2506.06941 (the arXiv production HTML is byte-identical Perl
+0.8.8): six authors welded, "Apple" glued to the last name, Iman Mirzadeh's `$^{*}$` dropped.
+
+**Perl status:** present in 0.8.8 (same-host), same output. Author blocks that avoid `\and`
+(using `\hspace`/`\\` layout) and mark equal contribution with a literal `$^{*}$` are a
+regular arXiv idiom Perl does not structure. Upstream filing pending.
+
+**Rust status (FIXED, beneficial divergence — OXIDIZED_DESIGN #52(i)):** `\hspace`/`\hfill`
+normalize to the `\quad` separator, and footnote-SYMBOL superscripts rewrite to a visible
+`\lx@frontmatter@keepsup` sup before branch selection (`normalize_hspace_separators`,
+`rewrite_symbol_superscripts`, `base_utilities.rs`). Numeric affiliation marks are untouched.
+Guards `06_cluster_frontmatter::{frontmatter_hspace_author_split,
+frontmatter_symbol_superscript_mark, frontmatter_thanks_literal_mark_mix}`.

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -1465,6 +1465,43 @@ that is the pre-existing #52 comma tradeoff the default `\author` already makes,
 divergence; the label and single-name (no-comma) authblk paths stay Perl-faithful. Guard:
 `06_cluster_frontmatter::frontmatter_authblk_comma_list`.
 
+**(i) `\hspace` separates co-authors; footnote-symbol marks render instead of vanishing.**
+Two composable normalizations applied to the `\author` argument BEFORE branch selection
+(`normalize_hspace_separators` + `rewrite_symbol_superscripts`), addressing
+html_feedback#6637 (arXiv:2506.06941, "The Illusion of Thinking", plain `article`), where
+the six authors were welded into one `<personname>` with "Apple" glued on and Iman
+Mirzadeh's literal `$^{*}$` silently dropped — Perl 0.8.8 (the arXiv production engine)
+produced byte-identical output, so this is a surpass, not a Rust-only fix.
+- **`\hspace{len}` / `\hspace*{len}` / `\hfill` → `\quad`.** Authors laid out with
+  `A \hspace{1cm} B \hspace{1cm} C` (a regular poor-man's separator) collapsed into one
+  creator, because the splitter only knew `\and`/`\quad`. `\quad` is already a hard
+  separator in every author/affiliation split set, so the rewrite needs no new plumbing;
+  `\hspace`'s optional `*` and mandatory length are consumed so the length cannot leak.
+- **Footnote-SYMBOL superscripts (`$^{*}$`, `${}^{\dagger}$`, `\textsuperscript{\ddagger}`)
+  → a visible `\lx@frontmatter@keepsup` sup.** These are equal-contribution / corresponding
+  notes, NEVER affiliation numbers (the same note-vs-affiliation split already encoded in
+  `starts_with_affiliation_mark`). Rewriting them onto a sentinel the `\lx@author@withsup`
+  hijack does not touch means they (1) render as a real superscript instead of being consumed
+  into an `affiliation:*` label that matches nothing and is discarded, and (2) no longer count
+  as an affiliation-marker trigger, so a block whose ONLY superscript is such a note-mark takes
+  the clean no-marker branch. NUMERIC/lettered affiliation marks (`$^{1}$`) are untouched, and
+  a superscript with a non-empty base (`$x^2$`) is real math, left alone.
+- **Combined effect on the witness:** removing Mirzadeh's `$^{*}$` (its only literal `^`)
+  drops the whole block into the no-marker branch, where the `\quad`s split all six authors,
+  "Apple" becomes the last author's affiliation, and Shojaee keeps his two `\thanks`. Verified
+  by an OLD-vs-NEW full-XML diff over all 57 author-bearing fixtures: exactly the THREE new
+  fixtures changed, zero existing regressions. Guards:
+  `06_cluster_frontmatter::{frontmatter_hspace_author_split, frontmatter_symbol_superscript_mark,
+  frontmatter_thanks_literal_mark_mix}`. (This is also why (g)'s guard fixture now uses a
+  numeric `$^{1}$` marker: a symbol `$^{*}$` there is now a note-mark and would reroute out of
+  the marker branch it is meant to exercise.)
+- **Residual (out of scope):** the *exact* `\fnsymbol` marks the author intended next to
+  Shojaee's name (∗ for footnote 1, † for footnote 2) are not reconstructed — `\thanks`
+  becomes a `role=thanks` contact note, not a numbered superscript. And an author block that
+  mixes marked and UNMARKED authors while still carrying a NUMERIC affiliation mark stays in
+  the marker branch, where marker-less horizontally-separated co-authors can still append; the
+  clean recovery above depends on the note-marks being the *only* superscripts.
+
 **Scope/limits:**
 - The `*` equal-contribution suffix on a combined author mark (`$^{1*}$`) still
   labels `affiliation:1*`, so it does not yet match a plain `affiliation:1`

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -890,6 +890,20 @@ LoadDefinitions!({
     // `<tabular>`-in-`<personname>` output is a presentational artifact we do not
     // want in frontmatter anyway, so there is nothing to preserve by skipping it.
     let stuff = strip_linebreak_options(stuff);
+    // Beyond-Perl (OXIDIZED_DESIGN #52), two composable normalizations applied
+    // BEFORE branch selection so both branches benefit, and so a symbol mark can
+    // no longer spuriously trigger the affiliation-marker branch:
+    //   1. horizontal-space separators (`\hspace{len}` / `\hfill`) → `\quad`, the
+    //      "regular" poor-man's author separator LaTeXML's `\and`/`\quad` splitter
+    //      otherwise misses (witness arXiv:2506.06941, six authors bunched);
+    //   2. footnote-SYMBOL superscripts (`$^{*}$`, `\textsuperscript{\dagger}` —
+    //      equal-contribution / corresponding notes, NEVER affiliation numbers) →
+    //      a visible `\lx@frontmatter@keepsup` sup, so they render instead of
+    //      being consumed into an unmatched `affiliation:*` label and dropped.
+    // For the witness, (2) removes its ONLY `^`, dropping the whole block into the
+    // clean no-marker branch where (1)'s `\quad`s split all six authors.
+    let stuff = normalize_hspace_separators(stuff);
+    let stuff = rewrite_symbol_superscripts(stuff);
     // If too much formatting, fall back to unstructured author content
     let stuff_string = stuff.to_string();
     if stuff_string.contains("{tabular}")
@@ -1101,6 +1115,16 @@ LoadDefinitions!({
     "\\lx@affiliation@withsup{}",
     "\\bgroup\\let^\\lx@sup@setlabel@affiliation\\let\\textsuperscript\\lx@sup@setlabel@affiliation#1\\egroup"
   );
+  // A VISIBLE author superscript mark that must survive the `\lx@author@withsup`
+  // hijack (which `\let`s `^`/`\textsuperscript` onto the affiliation-linker).
+  // `rewrite_symbol_superscripts` rewrites footnote-SYMBOL marks (`$^{*}$`,
+  // `\textsuperscript{\dagger}` — equal-contribution / corresponding-author
+  // notes, never affiliation numbers) onto this sentinel BEFORE author parsing,
+  // so they neither trigger the affiliation-marker branch nor get consumed into
+  // an unmatched `affiliation:*` label and dropped. Renders identically to
+  // `\textsuperscript` but under a name the hijack does not touch.
+  // OXIDIZED_DESIGN #52; witness arXiv:2506.06941 (Mirzadeh's `$^{*}$`).
+  DefConstructor!("\\lx@frontmatter@keepsup{}", "<ltx:sup>#1</ltx:sup>", mode => "text");
 
   DefMacro!("\\lx@add@affiliations[]{}", sub[(attr, stuff)] {
     let mut calls: Vec<Token> = Vec::new();
@@ -4187,6 +4211,208 @@ fn strip_linebreak_options(tokens: Tokens) -> Tokens {
   Tokens::new(out)
 }
 
+/// Rewrite horizontal-space macros into `\quad`, so the author/affiliation
+/// splitter treats them as separators. `\author{A \hspace{1cm} B \hspace{1cm} C}`
+/// (and `\hfill`-separated variants) is a "regular" way to lay out co-authors
+/// that LaTeXML's `\and`/`\quad` splitter otherwise misses, collapsing every name
+/// into one `<personname>`. `\quad` is already a hard separator in every author /
+/// affiliation split set, so rewriting to it needs no new delimiter plumbing.
+/// `\hspace`'s optional `*` and mandatory `{len}` argument are consumed together
+/// so the length cannot leak as literal text. OXIDIZED_DESIGN #52; witness
+/// arXiv:2506.06941 (six authors separated by `\hspace{0.5cm}`).
+fn normalize_hspace_separators(tokens: Tokens) -> Tokens {
+  let src = tokens.unlist();
+  let n = src.len();
+  let mut out: Vec<Token> = Vec::with_capacity(n);
+  let mut i = 0;
+  while i < n {
+    let t = src[i];
+    if t == T_CS!("\\hspace") {
+      let mut j = i + 1;
+      // optional `*` (\hspace*)
+      if j < n && src[j] == T_OTHER!("*") {
+        j += 1;
+      }
+      // mandatory `{len}` group
+      if j < n && src[j] == T_BEGIN!() {
+        let mut depth = 1usize;
+        j += 1;
+        while j < n && depth > 0 {
+          if src[j] == T_BEGIN!() {
+            depth += 1;
+          } else if src[j] == T_END!() {
+            depth -= 1;
+          }
+          j += 1;
+        }
+      }
+      out.push(T_CS!("\\quad"));
+      i = j;
+      continue;
+    }
+    if t == T_CS!("\\hfill") || t == T_CS!("\\hfil") {
+      out.push(T_CS!("\\quad"));
+      i += 1;
+      continue;
+    }
+    out.push(t);
+    i += 1;
+  }
+  Tokens::new(out)
+}
+
+/// The footnote-SYMBOL characters (`\fnsymbol`-style) and control sequences that,
+/// as a superscript on an author, mark an equal-contribution / corresponding /
+/// note relation — NEVER an affiliation (which is numbered). Kept deliberately to
+/// pure symbols so a numeric (`1`) or lettered (`a`) affiliation mark is never
+/// misread as a note. Mirrors the note-vs-affiliation split already documented in
+/// `starts_with_affiliation_mark`.
+fn is_footnote_symbol_operand(sym: &[Token]) -> bool {
+  const SYMBOL_CHARS: &[&str] = &[
+    "*", "\u{2217}", "\u{2020}", "\u{2021}", "\u{A7}", "\u{B6}", "\u{22C6}", "\u{2605}",
+    "\u{2022}", "\u{25E6}", "\u{2666}",
+  ];
+  const SYMBOL_CS: &[&str] = &[
+    "\\ast",
+    "\\star",
+    "\\dagger",
+    "\\ddagger",
+    "\\S",
+    "\\P",
+    "\\bullet",
+    "\\diamond",
+    "\\circ",
+    "\\sharp",
+    "\\|",
+    "\\#",
+  ];
+  let mut saw_symbol = false;
+  for t in sym {
+    match t.get_catcode() {
+      Catcode::SPACE => continue,
+      Catcode::CS => {
+        if !t.with_str(|s| SYMBOL_CS.contains(&s)) {
+          return false;
+        }
+        saw_symbol = true;
+      },
+      Catcode::OTHER | Catcode::LETTER => {
+        if !t.with_str(|s| SYMBOL_CHARS.contains(&s)) {
+          return false;
+        }
+        saw_symbol = true;
+      },
+      _ => return false,
+    }
+  }
+  saw_symbol
+}
+
+/// Rewrite footnote-SYMBOL author superscripts — `$^{*}$`, `${}^{\dagger}$`,
+/// `\textsuperscript{\ddagger}`, a bare `^{*}` — onto the visible
+/// `\lx@frontmatter@keepsup` sentinel, BEFORE author-block branch selection.
+///
+/// Two effects, both wanted (OXIDIZED_DESIGN #52; witness arXiv:2506.06941, where
+/// Iman Mirzadeh's literal `$^{*}$` was silently dropped):
+///   * the mark no longer counts as an affiliation superscript, so a block whose
+///     ONLY superscript is such a note-mark takes the clean no-marker author
+///     branch instead of the affiliation-linking one;
+///   * the symbol renders as a real superscript instead of being consumed into an
+///     `affiliation:*` label that matches no affiliation and is discarded.
+///
+/// NUMERIC/lettered affiliation marks (`$^{1}$`, `\textsuperscript{a}`) are left
+/// untouched, so affiliation linking is unaffected. Only the specific
+/// superscript-mark token shapes are matched; a superscript inside real math
+/// (`$x^2$`) is not (its base is not empty), so math content is preserved.
+fn rewrite_symbol_superscripts(tokens: Tokens) -> Tokens {
+  let src = tokens.unlist();
+  let n = src.len();
+  let mut out: Vec<Token> = Vec::with_capacity(n);
+  let mut i = 0;
+  // Read a superscript operand at `src[k]`: a braced `{...}` group, or a single
+  // token. Returns (operand tokens, index past the operand) or None.
+  let read_operand = |k: usize| -> Option<(Vec<Token>, usize)> {
+    if k >= n {
+      return None;
+    }
+    if src[k] == T_BEGIN!() {
+      let mut depth = 1usize;
+      let mut m = k + 1;
+      let mut inner = Vec::new();
+      while m < n && depth > 0 {
+        if src[m] == T_BEGIN!() {
+          depth += 1;
+        } else if src[m] == T_END!() {
+          depth -= 1;
+          if depth == 0 {
+            break;
+          }
+        }
+        inner.push(src[m]);
+        m += 1;
+      }
+      if depth == 0 {
+        Some((inner, m + 1))
+      } else {
+        None
+      }
+    } else {
+      Some((vec![src[k]], k + 1))
+    }
+  };
+  while i < n {
+    let t = src[i];
+    // `\textsuperscript{sym}` — always braced in practice.
+    if t == T_CS!("\\textsuperscript")
+      && src.get(i + 1) == Some(&T_BEGIN!())
+      && let Some((sym, next)) = read_operand(i + 1)
+      && is_footnote_symbol_operand(&sym)
+    {
+      out.extend(keepsup(sym));
+      i = next;
+      continue;
+    }
+    // `$ [ {} ] ^ sym $` — a math span whose whole content is a superscript on an
+    // empty base. Rewrite the entire span (delimiters included) to a text sup.
+    if t == T_MATH!()
+      && let Some(close) = (i + 1..n).find(|&m| src[m] == T_MATH!())
+    {
+      // optional empty base `{}` before the superscript
+      let p = if i + 2 < close && src[i + 1] == T_BEGIN!() && src[i + 2] == T_END!() {
+        i + 3
+      } else {
+        i + 1
+      };
+      if p < close
+        && src[p] == T_SUPER!()
+        && let Some((sym, next)) = read_operand(p + 1)
+        && next == close
+        && is_footnote_symbol_operand(&sym)
+      {
+        out.extend(keepsup(sym));
+        i = close + 1;
+        continue;
+      }
+    }
+    // Only the math-delimited (`$…$`) and `\textsuperscript{…}` spellings are
+    // rewritten — the correct ways to write a text superscript. A bare `^` is NOT
+    // matched here: outside math it is invalid LaTeX, and a `^` reached mid-scan is
+    // the superscript operator of real inline math on a non-empty base (`$a^{*}$`),
+    // which must be left intact.
+    out.push(t);
+    i += 1;
+  }
+  Tokens::new(out)
+}
+
+/// `\lx@frontmatter@keepsup{<sym>}` as a token list.
+fn keepsup(sym: Vec<Token>) -> Vec<Token> {
+  let mut v = vec![T_CS!("\\lx@frontmatter@keepsup"), T_BEGIN!()];
+  v.extend(sym);
+  v.push(T_END!());
+  v
+}
+
 /// Does this token list *begin* with a NUMERIC affiliation superscript mark
 /// (`$^{1}…` / `$^1…` / `\textsuperscript{1}…`)? This is the signature of the
 /// arXiv "`\thanks` abuse" idiom (affiliations smuggled into an author
@@ -4825,5 +5051,89 @@ mod author_split_tests {
     setup();
     // Only unwrap when there is actually an inner list to split.
     assert_eq!(split_author_line(tk("\\textbf{Alice}")).len(), 1);
+  }
+
+  // --- html_feedback#6637 helpers (OXIDIZED_DESIGN #52) ---
+
+  #[test]
+  fn normalize_hspace_becomes_quad_separator() {
+    setup();
+    let out = normalize_hspace_separators(tk("A \\hspace{1cm} B \\hspace*{2em} C \\hfill D"));
+    // Every horizontal-space macro became a \quad separator…
+    assert_eq!(position_of(&out, &[T_CS!("\\quad")]), Some(3));
+    assert!(position_of(&out, &[T_CS!("\\hspace")]).is_none());
+    assert!(position_of(&out, &[T_CS!("\\hfill")]).is_none());
+    // …and the length arguments did not leak as text.
+    let s = out.to_string();
+    assert!(
+      !s.contains("1cm") && !s.contains("2em"),
+      "length leaked: {s}"
+    );
+  }
+
+  #[test]
+  fn footnote_symbol_operand_classification() {
+    setup();
+    // Note-marks (symbols) are recognised…
+    for sym in ["*", "**", "\\dagger", "\\ddagger", "\\ast", "\\star", "\\S"] {
+      assert!(
+        is_footnote_symbol_operand(&tk(sym).unlist()),
+        "{sym} should be a footnote symbol"
+      );
+    }
+    // …affiliation marks (numeric/lettered) and non-symbol CS are NOT.
+    for aff in ["1", "12", "a", "\\text", "\\inst"] {
+      assert!(
+        !is_footnote_symbol_operand(&tk(aff).unlist()),
+        "{aff} must NOT be a footnote symbol"
+      );
+    }
+    // An empty operand is not a mark.
+    assert!(!is_footnote_symbol_operand(&[]));
+  }
+
+  #[test]
+  fn rewrite_symbol_superscripts_recovers_marks() {
+    setup();
+    // $^{*}$, ${}^{\dagger}$, \textsuperscript{*}, $^{**}$ → keepsup sentinel, and
+    // the superscript token is gone (no longer an affiliation-marker trigger).
+    for marked in [
+      "X$^{*}$",
+      "X${}^{\\dagger}$",
+      "X\\textsuperscript{*}",
+      "X$^{**}$",
+    ] {
+      let out = rewrite_symbol_superscripts(tk(marked));
+      assert!(
+        position_of(&out, &[T_CS!("\\lx@frontmatter@keepsup")]).is_some(),
+        "{marked} did not rewrite to keepsup: {out}"
+      );
+      assert!(
+        position_of(&out, &[T_SUPER!()]).is_none(),
+        "{marked} left a bare superscript trigger: {out}"
+      );
+    }
+  }
+
+  #[test]
+  fn rewrite_symbol_superscripts_leaves_affiliation_and_math() {
+    setup();
+    // Numeric affiliation marks stay as superscript markers (untouched)…
+    let aff = rewrite_symbol_superscripts(tk("X$^{1}$ \\and Y$^{1}$Institute"));
+    assert!(
+      position_of(&aff, &[T_SUPER!()]).is_some(),
+      "numeric affiliation mark must be preserved: {aff}"
+    );
+    assert!(position_of(&aff, &[T_CS!("\\lx@frontmatter@keepsup")]).is_none());
+    // …and real math (non-empty base) is not rewritten — including a SYMBOL
+    // superscript on a base (`$a^{*}$`), which is genuine math, not a note-mark.
+    for expr in ["$x^2$", "$a^{*}$"] {
+      let math = rewrite_symbol_superscripts(tk(expr));
+      assert!(
+        position_of(&math, &[T_SUPER!()]).is_some(),
+        "real math superscript lost in {expr}: {math}"
+      );
+      assert!(position_of(&math, &[T_CS!("\\lx@frontmatter@keepsup")]).is_none());
+    }
   }
 }

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -205,7 +205,7 @@ fn frontmatter_nested_math_author_marker() {
 /// boundary in the superscript-marker branch. When a 2nd/3rd author's marker is
 /// delivered by a macro (no literal `^` on that segment), the old flat
 /// `\and`/`\quad`/`\\` split appended the marker-less segment to the PREVIOUS
-/// author, collapsing `Alice\mk$^*$ \and Bob\mk \and Carol\mk` into one merged
+/// author, collapsing `Alice\mk$^{1}$ \and Bob\mk \and Carol\mk` into one merged
 /// `<personname>`. Grouping on `\and` first (append bounded to the group) keeps
 /// them separate. OXIDIZED_DESIGN #52(g).
 #[test]
@@ -226,6 +226,118 @@ fn frontmatter_and_hard_author_boundary() {
   assert!(
     !x.contains("AliceBob") && !x.contains("BobCarol"),
     "\\and-separated authors merged into one personname:\n{x}"
+  );
+}
+/// html_feedback#6637 construct 1 (OXIDIZED_DESIGN #52): co-authors separated by
+/// `\hspace{len}` (a "regular" poor-man's separator LaTeXML's `\and`/`\quad`
+/// splitter otherwise misses) must split into distinct creators, not weld into
+/// one `<personname>`. `\hspace`'s length argument must not leak as text.
+#[test]
+fn frontmatter_hspace_author_split() {
+  let x = convert_to_xml("tests/cluster_regressions/frontmatter_hspace_author_split.tex");
+  for name in ["Alice Alpha", "Bob Beta", "Carol Gamma"] {
+    assert!(
+      x.contains(&format!("<personname>{name}</personname>")),
+      "\\hspace-separated author {name} must be its own creator:\n{x}"
+    );
+  }
+  assert_eq!(
+    x.matches("role=\"author\"").count(),
+    3,
+    "expected three creators split on \\hspace:\n{x}"
+  );
+  // The reported canary: names must not weld, and the length must not leak.
+  assert!(
+    !x.contains("AlphaBob") && !x.contains("BetaCarol") && !x.contains("1cm"),
+    "\\hspace authors merged or the length leaked as text:\n{x}"
+  );
+}
+/// html_feedback#6637 construct 2 (OXIDIZED_DESIGN #52): a footnote-SYMBOL author
+/// superscript (`$^{*}$`, `$^{\dagger}$`, `\textsuperscript{*}` — equal-
+/// contribution / corresponding notes, never affiliation numbers) must render as
+/// a visible `<sup>`, not be consumed into an unmatched `affiliation:*` label and
+/// silently dropped. All three marker spellings are covered; a plain author stays
+/// plain, and every author still splits on `\and`.
+#[test]
+fn frontmatter_symbol_superscript_mark() {
+  let x = convert_to_xml("tests/cluster_regressions/frontmatter_symbol_superscript_mark.tex");
+  // Each marked author keeps a visible superscript symbol…
+  assert!(
+    x.contains("<personname>Dana Delta<sup>*</sup>"),
+    "literal $^{{*}}$ mark dropped from Dana Delta:\n{x}"
+  );
+  assert!(
+    x.contains("<personname>Evan Echo<sup>†</sup>"),
+    "$^{{\\dagger}}$ mark dropped from Evan Echo:\n{x}"
+  );
+  assert!(
+    x.contains("<personname>Fiona Foxtrot<sup>*</sup>"),
+    "\\textsuperscript{{*}} mark dropped from Fiona Foxtrot:\n{x}"
+  );
+  // …the unmarked author stays plain…
+  assert!(
+    x.contains("<personname>Gina Golf</personname>"),
+    "unmarked author Gina Golf must stay plain:\n{x}"
+  );
+  // …all four split, and the mark never became an affiliation.
+  assert_eq!(
+    x.matches("role=\"author\"").count(),
+    4,
+    "expected four authors:\n{x}"
+  );
+  assert!(
+    !x.contains("role=\"affiliation\""),
+    "a symbol mark was misread as an affiliation:\n{x}"
+  );
+}
+/// html_feedback#6637 combined (arXiv:2506.06941, "The Illusion of Thinking",
+/// plain article): six authors separated by `\hspace{0.5cm}`/`\\`, one lead with
+/// two `\thanks`, a second lead with a literal `$^{*}$`, trailing "Apple"
+/// affiliation. Both engines (Perl 0.8.8 == HEAD before this fix) welded all six
+/// names into one `<personname>` with "Apple" glued on and Mirzadeh's `$^{*}$`
+/// dropped. With `\hspace`→separator + symbol-mark→visible-sup (removing the only
+/// affiliation-marker trigger), the block takes the clean no-marker branch: all
+/// six split, Mirzadeh keeps his `∗`, Shojaee keeps his thanks, and "Apple"
+/// becomes the last author's affiliation. OXIDIZED_DESIGN #52.
+#[test]
+fn frontmatter_thanks_literal_mark_mix() {
+  let x = convert_to_xml("tests/cluster_regressions/frontmatter_thanks_literal_mark_mix.tex");
+  // All six authors are their own creators (was one welded blob).
+  for name in [
+    "Parshin Shojaee",
+    "Keivan Alizadeh",
+    "Maxwell Horton",
+    "Samy Bengio",
+    "Mehrdad Farajtabar",
+  ] {
+    assert!(
+      x.contains(&format!("<personname>{name}")),
+      "author {name} missing as a distinct creator:\n{x}"
+    );
+  }
+  assert_eq!(
+    x.matches("role=\"author\"").count(),
+    6,
+    "expected six split authors:\n{x}"
+  );
+  // Mirzadeh's literal $^{*}$ survives as a visible superscript.
+  assert!(
+    x.contains("<personname>Iman Mirzadeh<sup>*</sup>"),
+    "Mirzadeh's literal $^{{*}}$ mark was dropped:\n{x}"
+  );
+  // Shojaee's two \thanks attach to HIS creator (not the welded blob).
+  assert!(
+    x.contains("Equal contribution.") && x.contains("Work done during an internship at Apple."),
+    "Shojaee's \\thanks notes were lost:\n{x}"
+  );
+  // "Apple" is the trailing affiliation, not glued into a name.
+  assert!(
+    x.contains("role=\"affiliation\">Apple"),
+    "\"Apple\" must be the last author's affiliation, not welded into a name:\n{x}"
+  );
+  assert!(
+    !x.contains("FarajtabarApple") && !x.contains("[0.5cm]"),
+    "\"Apple\" welded onto a name or the \\\\[0.5cm] length leaked:\n{x}"
   );
 }
 /// html_feedback#6614 (arXiv:2606.08234, ACL): a `\author{Name\quad Name… \\

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_and_hard_author_boundary.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_and_hard_author_boundary.tex
@@ -5,7 +5,11 @@
 % `^` on that segment). The marker branch used to flat-split \and/\quad/\\
 % together and append a marker-less segment to the PREVIOUS author, merging
 % \and-separated authors into one <personname>. \and is now a hard boundary.
+% Alice's NUMERIC `$^{1}$` (an affiliation-style mark) keeps the block in the
+% superscript-marker branch — a footnote SYMBOL there (`$^{*}$`) is instead a
+% note-mark that html_feedback#6637 recovers as a visible sup and reroutes out of
+% this branch, so it would no longer exercise the \and-grouping this fixture guards.
 \newcommand{\mk}{$^\text{$\star$}$}
-\author{Alice\mk$^*$ \and Bob\mk \and Carol\mk}
+\author{Alice\mk$^{1}$ \and Bob\mk \and Carol\mk}
 \title{And hard author boundary}
 \begin{document}\maketitle\end{document}

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_hspace_author_split.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_hspace_author_split.tex
@@ -1,0 +1,7 @@
+\documentclass{article}
+\title{Horizontal-Space Author Separators}
+\author{Alice Alpha \hspace{1cm} Bob Beta \hspace{1cm} Carol Gamma}
+\begin{document}
+\maketitle
+Body.
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_symbol_superscript_mark.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_symbol_superscript_mark.tex
@@ -1,0 +1,7 @@
+\documentclass{article}
+\title{Equal-Contribution Superscript Marks}
+\author{Dana Delta$^{*}$ \and Evan Echo$^{\dagger}$ \and Fiona Foxtrot\textsuperscript{*} \and Gina Golf}
+\begin{document}
+\maketitle
+Body.
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_thanks_literal_mark_mix.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_thanks_literal_mark_mix.tex
@@ -1,0 +1,21 @@
+% Witness arXiv:2506.06941 ("The Illusion of Thinking"), plain article.
+% Six authors separated by \hspace{0.5cm}/\\, one lead marked with \thanks
+% (equal-contribution + internship notes), a second lead marked with a literal
+% $^{*}$, and a trailing "Apple" affiliation. Real names kept as the witness.
+\documentclass{article}
+\renewcommand{\thefootnote}{\fnsymbol{footnote}}
+\title{The Illusion of Thinking}
+\author{%
+  Parshin Shojaee\thanks{Equal contribution.} \thanks{Work done during an internship at Apple.} \hspace{0.5cm}
+  Iman Mirzadeh$^{*}$
+  \hspace{0.5cm}
+  Keivan Alizadeh  \hspace{0.5cm} \\
+  Maxwell Horton \hspace{0.5cm}
+  Samy Bengio \hspace{0.5cm}
+  Mehrdad Farajtabar \\[0.5cm]
+Apple
+}
+\begin{document}
+\maketitle
+Body.
+\end{document}


### PR DESCRIPTION
**Diagnostic.** `\lx@add@authors` (`base_utilities.rs`) knew only `\and`/`\quad` separators and hijacked every author `^`/`\textsuperscript` onto the affiliation-linker, so `\hspace`-separated co-authors welded into one `<personname>` and a literal equal-contribution `$^{*}$` was consumed into an unmatched `affiliation:*` label and silently dropped. The arXiv production HTML for the witness is byte-identical Perl 0.8.8 — a shared limitation, so this is a surpass.

**Approach.** Two composable normalizations of the `\author` argument before branch selection: `\hspace`/`\hfill` → the `\quad` separator, and footnote-SYMBOL superscripts (`$^{*}$`, `\textsuperscript{\dagger}`) → a visible `\lx@frontmatter@keepsup` sup. Numeric affiliation marks are untouched. Removing the note-mark trigger also drops such blocks into the clean no-marker branch. Surpass-Perl — OXIDIZED_DESIGN #52(i), KNOWN_PERL_ERRORS #96.

**Validation.** Guards `06_cluster_frontmatter::{frontmatter_hspace_author_split, frontmatter_symbol_superscript_mark, frontmatter_thanks_literal_mark_mix}` + 4 helper unit tests. Witness arXiv:2506.06941: 1 welded author → 6 split, Mirzadeh's `∗` recovered, "Apple" → affiliation, no new errors. OLD-vs-NEW full-XML diff over all 57 author-bearing fixtures changed only the 3 new ones. Full suite 2032/0; clippy/fmt clean.

Ref arXiv/html_feedback#6637