### PR TITLE
feat: convert + join Supplementary-Material documents into one output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+  - **Supplementary-Material documents are converted and joined into the output.**
+    A submission with several top-level `.tex` files (a main paper + a
+    Supplementary-Information document, both `.bbl`-backed — arXiv's canonical
+    shape) previously lost everything but the main. The directory front-end now
+    detects the ordered set (`find_top_level_texs`, template-safe) and converts
+    each independently, joining them into one document: the main first, each
+    supplement an appendix titled by its own `\title`, with the supplement's
+    id/label space prefixed so cross-references resolve within each document and
+    never collide. Several files given side-by-side on the CLI
+    (`latexml_oxide main.tex supplement.tex`) are joined the same way. In-memory
+    join (`latexml::multidoc`); streaming-scale submissions remain a follow-up.
   - **Multi-file arXiv submissions select the real paper, not a bundled template.**
     When the true `main.tex` delegates its figures to `\input`-ed sections (no
     direct `\includegraphics`) but a shipped class template / how-to / supplement

--- a/latexml_oxide/bin/latexml_oxide.rs
+++ b/latexml_oxide/bin/latexml_oxide.rs
@@ -1090,27 +1090,32 @@ fn real_main() -> Result<(), Box<dyn Error>> {
     process::exit(1);
   }
 
-  // Wire state-level options
-  if cli.nobibtex {
-    // Set BIB_CONFIG to ['bbl'] — skip BibTeX, use pre-existing .bbl file
-    latexml_core::state::assign_value(
-      "BIB_CONFIG",
-      latexml_core::common::store::Stored::Strings(Rc::new([latexml_core::common::arena::pin(
-        "bbl",
-      )])),
-      Some(latexml_core::state::Scope::Global),
-    );
+  // Per-document state a fresh converter session resets — factored so the main
+  // document and each joined supplement (see the multi-document branch below)
+  // apply it identically. DOCUMENTID is intentionally excluded: it names the
+  // main document's root, and supplements get their own prefixed id space.
+  fn apply_document_state(nobibtex: bool, number_sections: Option<bool>) {
+    if nobibtex {
+      // BIB_CONFIG = ['bbl'] — skip BibTeX, use the pre-existing `.bbl` file.
+      latexml_core::state::assign_value(
+        "BIB_CONFIG",
+        latexml_core::common::store::Stored::Strings(Rc::new([latexml_core::common::arena::pin(
+          "bbl",
+        )])),
+        Some(latexml_core::state::Scope::Global),
+      );
+    }
+    // Perl `numbersections!` (default on), last-wins: `Some(true)` numbers,
+    // `Some(false)` suppresses, `None` leaves the setting untouched.
+    if let Some(ns) = number_sections {
+      latexml_core::state::assign_value(
+        "no_number_sections",
+        !ns,
+        Some(latexml_core::state::Scope::Global),
+      );
+    }
   }
-  // Perl `numbersections!` (default on), last-wins between the pair. `Some(true)`
-  // ⇒ number sections (no_number_sections=false); `Some(false)` ⇒ suppress them;
-  // `None` leaves the setting untouched.
-  if let Some(number_sections) = resolved.number_sections {
-    latexml_core::state::assign_value(
-      "no_number_sections",
-      !number_sections,
-      Some(latexml_core::state::Scope::Global),
-    );
-  }
+  apply_document_state(cli.nobibtex, resolved.number_sections);
   // Perl Core.pm L48: DOCUMENTID value
   if let Some(ref docid) = cli.documentid {
     latexml_core::state::assign_value(
@@ -1216,25 +1221,9 @@ fn real_main() -> Result<(), Box<dyn Error>> {
               );
               continue;
             }
-            // A fresh session reset thread-local state — re-apply the
-            // per-document flags (DOCUMENTID is intentionally NOT re-applied:
-            // supplements get their own prefixed id space).
-            if cli.nobibtex {
-              latexml_core::state::assign_value(
-                "BIB_CONFIG",
-                latexml_core::common::store::Stored::Strings(Rc::new([
-                  latexml_core::common::arena::pin("bbl"),
-                ])),
-                Some(latexml_core::state::Scope::Global),
-              );
-            }
-            if let Some(number_sections) = resolved.number_sections {
-              latexml_core::state::assign_value(
-                "no_number_sections",
-                !number_sections,
-                Some(latexml_core::state::Scope::Global),
-              );
-            }
+            // A fresh session reset thread-local state — re-apply the shared
+            // per-document flags before converting this supplement.
+            apply_document_state(cli.nobibtex, resolved.number_sections);
             let r = sconv.convert(supp.clone());
             status_max = status_max.max(r.status_code);
             match r.result {

--- a/latexml_oxide/bin/latexml_oxide.rs
+++ b/latexml_oxide/bin/latexml_oxide.rs
@@ -30,10 +30,12 @@ static GLOBAL: dhat::Alloc = dhat::Alloc;
 #[derive(Parser, Debug)]
 #[command(name = "latexml_oxide", version, about)]
 struct Cli {
-  /// The TeX/LaTeX source file to convert (overridden by --source). A `.bib`,
-  /// a `.zip`/`.tar.gz` archive, or a directory is auto-detected.
+  /// The TeX/LaTeX source file(s) to convert (overridden by --source). A `.bib`,
+  /// a `.zip`/`.tar.gz` archive, or a directory is auto-detected. Several files
+  /// given side-by-side (`main.tex supplement.tex`) are converted independently
+  /// and joined into one document, main first, the rest as appendices.
   #[arg(value_name = "SOURCE")]
-  source_positional: Option<String>,
+  source_positional: Vec<String>,
 
   /// Output file (default: stdout). The extension can imply --format (e.g.
   /// .html → html5, .xml → xml, .zip → archive).
@@ -849,19 +851,24 @@ fn real_main() -> Result<(), Box<dyn Error>> {
     process::exit(0);
   }
 
-  // Determine source: --source > --init > positional
+  // Ordered supplementary top-level sources joined onto the main output
+  // (populated by CLI multi-file input below, or by directory auto-detection).
+  let mut supplement_sources: Vec<String> = Vec::new();
+  // Determine source: --source > --init > positional. Multiple positional files
+  // are an explicit multi-document submission — first is the main, the rest are
+  // appended supplements (no archive/directory auto-detection in that case).
   let source = if let Some(ref init) = cli.init {
     init.clone()
   } else if let Some(ref src) = cli.source {
     src.clone()
+  } else if cli.source_positional.is_empty() {
+    eprintln!("Error: no source file specified. Use: latexml_oxide [OPTIONS] <SOURCE>");
+    process::exit(1);
   } else {
-    match cli.source_positional {
-      Some(ref s) => s.clone(),
-      None => {
-        eprintln!("Error: no source file specified. Use: latexml_oxide [OPTIONS] <SOURCE>");
-        process::exit(1);
-      },
+    if cli.source_positional.len() > 1 {
+      supplement_sources = cli.source_positional[1..].to_vec();
     }
+    cli.source_positional[0].clone()
   };
   let target = cli.dest.clone();
 
@@ -917,9 +924,16 @@ fn real_main() -> Result<(), Box<dyn Error>> {
     } else {
       path_flags.push(source.clone());
     }
-    // Find the main .tex file in the directory, matching Perl's behavior
-    match latexml::main_tex::find_main_tex(dir_path) {
-      Ok(main_tex) => main_tex.to_string_lossy().to_string(),
+    // Find the ordered top-level file(s): the main first, then any detected
+    // Supplementary-Material documents (joined onto the output below).
+    match latexml::main_tex::find_top_level_texs(dir_path) {
+      Ok(mut tops) => {
+        let main_tex = tops.remove(0).to_string_lossy().to_string();
+        for supp in tops {
+          supplement_sources.push(supp.to_string_lossy().to_string());
+        }
+        main_tex
+      },
       Err(e) => {
         eprintln!("Failed to find main .tex file in '{}': {}", source, e);
         process::exit(1);
@@ -1179,8 +1193,73 @@ fn real_main() -> Result<(), Box<dyn Error>> {
         status:      String::from("Status:conversion:0"),
         status_code: 0,
       }
-    } else {
+    } else if supplement_sources.is_empty() {
       converter.convert(source)
+    } else {
+      // Multi-document submission (directory with detected supplements, or
+      // several files given on the CLI): convert the main, then each supplement
+      // in its own fresh session, and join them into ONE core document — main
+      // first, each supplement an appendix titled by its own `\title`. In-memory
+      // join (`latexml::multidoc`), which suits the common small
+      // main+supplement case; the whole post pipeline downstream is unchanged.
+      let main_resp = converter.convert(source);
+      match main_resp.result.as_deref() {
+        Some(main_xml) if !main_xml.is_empty() => {
+          let mut supp_xmls: Vec<String> = Vec::new();
+          let mut status_max = main_resp.status_code;
+          for supp in &supplement_sources {
+            let mut sconv = Converter::from_config(opts.clone());
+            if sconv.prepare_session(&opts).is_err() {
+              eprintln!(
+                "Warning: could not prepare a session for supplement '{}'; skipping",
+                supp
+              );
+              continue;
+            }
+            // A fresh session reset thread-local state — re-apply the
+            // per-document flags (DOCUMENTID is intentionally NOT re-applied:
+            // supplements get their own prefixed id space).
+            if cli.nobibtex {
+              latexml_core::state::assign_value(
+                "BIB_CONFIG",
+                latexml_core::common::store::Stored::Strings(Rc::new([
+                  latexml_core::common::arena::pin("bbl"),
+                ])),
+                Some(latexml_core::state::Scope::Global),
+              );
+            }
+            if let Some(number_sections) = resolved.number_sections {
+              latexml_core::state::assign_value(
+                "no_number_sections",
+                !number_sections,
+                Some(latexml_core::state::Scope::Global),
+              );
+            }
+            let r = sconv.convert(supp.clone());
+            status_max = status_max.max(r.status_code);
+            match r.result {
+              Some(x) if !x.is_empty() => supp_xmls.push(x),
+              _ => eprintln!(
+                "Warning: supplement '{}' produced no output; skipping",
+                supp
+              ),
+            }
+          }
+          match latexml::multidoc::join_core_documents(main_xml, &supp_xmls) {
+            Ok(joined) => latexml::converter::ConversionResponse {
+              result:      Some(joined),
+              log:         main_resp.log,
+              status:      main_resp.status,
+              status_code: status_max,
+            },
+            Err(e) => {
+              eprintln!("Warning: multi-document join failed: {e}; rendering main only");
+              main_resp
+            },
+          }
+        },
+        _ => main_resp,
+      }
     };
     let _ = &source_for_post; // keep alive for post-processing
     phase_status_max = phase_status_max.max(response.status_code);

--- a/latexml_oxide/src/lib.rs
+++ b/latexml_oxide/src/lib.rs
@@ -12,6 +12,7 @@ pub mod core_interface;
 pub mod ini_tex;
 pub mod lsp_server;
 pub mod main_tex;
+pub mod multidoc;
 pub mod post;
 pub mod render_workers;
 pub mod util;

--- a/latexml_oxide/src/main_tex.rs
+++ b/latexml_oxide/src/main_tex.rs
@@ -665,39 +665,7 @@ pub fn is_pdf_magic(path: &Path) -> bool {
 /// toplevel source. Perl Pack.pm L68-80: scans `sources[]` for the
 /// entry tagged `usage == "toplevel"`. Minimal hand-rolled JSON
 /// scanner — we don't pull a full JSON dep just for this.
-fn parse_readme_json(dir: &Path) -> Option<String> {
-  let content = std::fs::read_to_string(dir.join("00README.json")).ok()?;
-  let sources_start = content.find("\"sources\"")?;
-  let rest = &content[sources_start..];
-  let arr_start = rest.find('[')?;
-  let arr_end = rest.find(']')?;
-  let arr = &rest[arr_start + 1..arr_end];
-
-  for obj_str in arr.split('}') {
-    if !obj_str.contains("\"toplevel\"") {
-      continue;
-    }
-    if let Some(fn_pos) = obj_str.find("\"filename\"") {
-      let after_key = &obj_str[fn_pos + 10..];
-      let after_key = after_key.trim_start();
-      let after_key = after_key.strip_prefix(':')?;
-      let after_key = after_key.trim_start();
-      let after_key = after_key.strip_prefix('"')?;
-      let mut result = String::new();
-      for ch in after_key.chars() {
-        match ch {
-          '"' => break,
-          '\\' => continue,
-          c => result.push(c),
-        }
-      }
-      if !result.is_empty() {
-        return Some(result);
-      }
-    }
-  }
-  None
-}
+fn parse_readme_json(dir: &Path) -> Option<String> { parse_readme_json_all(dir).into_iter().next() }
 
 // ---------------------------------------------------------------------------
 // Pre-compiled regexes used by `find_main_tex`. Parking these as module-

--- a/latexml_oxide/src/multidoc.rs
+++ b/latexml_oxide/src/multidoc.rs
@@ -1,0 +1,211 @@
+//! In-memory join of multiple core-XML documents into one.
+//!
+//! An arXiv submission may ship several top-level `.tex` files — a main paper
+//! plus Supplementary-Material documents (see [`crate::main_tex::find_top_level_texs`]).
+//! Each is converted **independently** (its own `\documentclass`, its own core
+//! XML), then this module stitches them into a single core-XML document that the
+//! normal post-processing pipeline renders as one output: the main first, each
+//! supplement appended as a top-level appendix `<section>` titled by the
+//! supplement's own `\title`.
+//!
+//! This is the **non-streaming** join — it holds the parsed supplements in
+//! memory — which suits the overwhelmingly common case where a main+supplement
+//! pair is small. Very large submissions that need streaming are a separate
+//! concern (a post-pass "join" over separate core-XML files, tracked
+//! separately); this path deliberately keeps the whole pipeline downstream of a
+//! single `<document>` unchanged.
+//!
+//! **Id de-confliction.** Both documents number from `S1`, share the label
+//! namespace (`LABEL:sec:intro`), etc. Every supplement's id/ref/label space is
+//! rewritten with a per-source prefix (`as1_`, `as2_`, …) before splicing, so
+//! intra-supplement `\ref`s still resolve and never collide with the main. A
+//! supplement that cross-`\ref`s *into the main* will not resolve — faithful to
+//! arXiv, whose separately-compiled PDFs cannot cross-reference either.
+
+use latexml_core::common::xml::XML_NS;
+use latexml_post::document::{PostDocument, PostDocumentOptions};
+use libxml::tree::{Node, NodeType};
+
+/// Frontmatter elements dropped when a supplement becomes an appendix section
+/// (its `<title>` is promoted to the section heading; its own author/abstract
+/// block does not belong mid-document).
+const DROP_FRONTMATTER: &[&str] = &[
+  "resource",
+  "creator",
+  "date",
+  "abstract",
+  "keywords",
+  "classification",
+];
+
+/// Join a `main` core-XML string with zero or more `supplements`, returning the
+/// combined core XML. With no supplements the main is returned verbatim.
+pub fn join_core_documents(main: &str, supplements: &[String]) -> Result<String, String> {
+  if supplements.is_empty() {
+    return Ok(main.to_string());
+  }
+  let mut appendices = String::new();
+  for (i, supp) in supplements.iter().enumerate() {
+    appendices.push_str(&build_appendix(supp, i + 1)?);
+  }
+  splice_before_document_close(main, &appendices)
+}
+
+/// Parse one supplement, prefix its id/ref/label space, and render it as a
+/// top-level appendix `<section>` string (heading = the supplement's `<title>`).
+fn build_appendix(supp_xml: &str, idx: usize) -> Result<String, String> {
+  let doc = PostDocument::new_from_string(supp_xml, PostDocumentOptions::default())
+    .map_err(|e| format!("supplement {idx} parse failed: {e}"))?;
+  let root = doc
+    .get_document_element()
+    .ok_or_else(|| format!("supplement {idx} has no root <document>"))?;
+  let prefix = format!("as{idx}_");
+  prefix_id_space(&root, &prefix);
+
+  let mut title_xml = String::new();
+  let mut body = String::new();
+  for child in root.get_child_nodes() {
+    if child.get_type() != Some(NodeType::ElementNode) {
+      continue;
+    }
+    let name = child.get_name();
+    if name == "title" && title_xml.is_empty() {
+      title_xml = doc.node_to_string(&child);
+    } else if !DROP_FRONTMATTER.contains(&name.as_str()) {
+      body.push_str(&doc.node_to_string(&child));
+    }
+  }
+  if title_xml.is_empty() {
+    title_xml = "<title>Supplementary Material</title>".to_string();
+  }
+  // `class="ltx_appendix"` is the thin presentation hook for XSLT/CSS. `xml:id`
+  // is already namespaced by the reserved `xml:` prefix on re-parse; the section
+  // inherits the main document's default namespace at the splice point.
+  Ok(format!(
+    "<section class=\"ltx_appendix\" inlist=\"toc\" xml:id=\"as{idx}\">{title_xml}{body}</section>"
+  ))
+}
+
+/// Rewrite every id, reference and label under `node` with `prefix`, so a
+/// supplement's id space cannot collide with the main's. `inlist` (TOC list
+/// membership, e.g. `"toc"`) is intentionally left untouched so the appendix
+/// still joins the combined table of contents.
+fn prefix_id_space(node: &Node, prefix: &str) {
+  if node.get_type() == Some(NodeType::ElementNode) {
+    let mut n = node.clone();
+    // `xml:id` is namespaced (reserved xml: prefix) — read NS-aware, write bare.
+    if let Some(v) = n.get_attribute_ns("id", XML_NS) {
+      n.set_attribute("xml:id", &format!("{prefix}{v}")).ok();
+    }
+    for attr in ["idref", "fragid"] {
+      if let Some(v) = n.get_attribute(attr) {
+        n.set_attribute(attr, &format!("{prefix}{v}")).ok();
+      }
+    }
+    for attr in ["labels", "labelref"] {
+      if let Some(v) = n.get_attribute(attr) {
+        let rewritten = v
+          .split_whitespace()
+          .map(|tok| prefix_label(tok, prefix))
+          .collect::<Vec<_>>()
+          .join(" ");
+        n.set_attribute(attr, &rewritten).ok();
+      }
+    }
+    if let Some(v) = n.get_attribute("href")
+      && let Some(frag) = v.strip_prefix('#')
+    {
+      n.set_attribute("href", &format!("#{prefix}{frag}")).ok();
+    }
+  }
+  for child in node.get_child_nodes() {
+    prefix_id_space(&child, prefix);
+  }
+}
+
+/// Prefix a single label token, preserving the `LABEL:` sentinel.
+fn prefix_label(tok: &str, prefix: &str) -> String {
+  match tok.strip_prefix("LABEL:") {
+    Some(rest) => format!("LABEL:{prefix}{rest}"),
+    None => format!("{prefix}{tok}"),
+  }
+}
+
+/// Insert `appendices` immediately before the main document's closing
+/// `</document>` tag. The core-XML root is always a single `<document>` (default
+/// LaTeXML namespace), so its last close tag is an unambiguous splice point.
+fn splice_before_document_close(main: &str, appendices: &str) -> Result<String, String> {
+  let close = "</document>";
+  match main.rfind(close) {
+    Some(pos) => {
+      let mut out = String::with_capacity(main.len() + appendices.len());
+      out.push_str(&main[..pos]);
+      out.push_str(appendices);
+      out.push_str(&main[pos..]);
+      Ok(out)
+    },
+    None => Err("main document has no </document> close tag to splice into".to_string()),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  const MAIN: &str = concat!(
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
+    "<document xmlns=\"http://dlmf.nist.gov/LaTeXML\">",
+    "<title>Main Paper</title>",
+    "<section inlist=\"toc\" labels=\"LABEL:sec:intro\" xml:id=\"S1\">",
+    "<para xml:id=\"S1.p1\"><p>See <ref labelref=\"LABEL:sec:intro\"/>.</p></para>",
+    "</section>",
+    "</document>\n"
+  );
+  const SUPP: &str = concat!(
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
+    "<document xmlns=\"http://dlmf.nist.gov/LaTeXML\">",
+    "<resource src=\"LaTeXML.css\" type=\"text/css\"/>",
+    "<title>Supplementary Information for Main Paper</title>",
+    "<section inlist=\"toc\" labels=\"LABEL:sec:extra\" xml:id=\"S1\">",
+    "<para xml:id=\"S1.p1\"><p>See <ref labelref=\"LABEL:sec:extra\"/>.</p></para>",
+    "</section>",
+    "</document>\n"
+  );
+
+  #[test]
+  fn no_supplements_returns_main_verbatim() {
+    assert_eq!(join_core_documents(MAIN, &[]).unwrap(), MAIN);
+  }
+
+  #[test]
+  fn supplement_appended_as_prefixed_appendix() {
+    let joined = join_core_documents(MAIN, &[SUPP.to_string()]).unwrap();
+    // Exactly one <document> — a single joined core document.
+    assert_eq!(joined.matches("<document").count(), 1);
+    // The main's ids/labels are untouched…
+    assert!(joined.contains("xml:id=\"S1\""));
+    assert!(joined.contains("LABEL:sec:intro"));
+    // …the supplement's are prefixed, so they cannot collide.
+    assert!(joined.contains("xml:id=\"as1_S1\""));
+    assert!(joined.contains("xml:id=\"as1_S1.p1\""));
+    assert!(joined.contains("LABEL:as1_sec:extra"));
+    assert!(joined.contains("labelref=\"LABEL:as1_sec:extra\""));
+    // The supplement is an appendix titled by its own <title>.
+    assert!(joined.contains("class=\"ltx_appendix\""));
+    assert!(joined.contains("Supplementary Information for Main Paper"));
+    // The supplement's per-doc CSS <resource> is dropped.
+    let appendix_start = joined.find("ltx_appendix").unwrap();
+    assert!(!joined[appendix_start..].contains("<resource"));
+    // Appendix is inside the document (before its close).
+    let close = joined.rfind("</document>").unwrap();
+    assert!(appendix_start < close);
+  }
+
+  #[test]
+  fn two_supplements_get_distinct_prefixes() {
+    let joined = join_core_documents(MAIN, &[SUPP.to_string(), SUPP.to_string()]).unwrap();
+    assert!(joined.contains("xml:id=\"as1_S1\""));
+    assert!(joined.contains("xml:id=\"as2_S1\""));
+    assert_eq!(joined.matches("class=\"ltx_appendix\"").count(), 2);
+  }
+}

--- a/latexml_oxide/tests/121_multidoc_join.rs
+++ b/latexml_oxide/tests/121_multidoc_join.rs
@@ -1,0 +1,126 @@
+//! Multi-top-level submission conversion: a main paper + a Supplementary-Material
+//! document (both `.bbl`-backed, arXiv's canonical shape) are converted
+//! independently and joined into ONE output — the main first, the supplement as
+//! an appendix titled by its own `\title`, with the supplement's id/label space
+//! prefixed so it can never collide with the main's.
+//!
+//! Drives the real binary: multi-source handling is CLI behavior (directory
+//! auto-detection via `find_top_level_texs`, and several files given
+//! side-by-side), invisible to the in-process single-document `Converter`.
+
+use std::{fs, path::Path, process::Command};
+
+fn write(dir: &Path, name: &str, body: &str) { fs::write(dir.join(name), body).unwrap(); }
+
+fn fixture(dir: &Path) {
+  write(
+    dir,
+    "main.tex",
+    "\\documentclass{article}\n\\title{The Main Paper}\n\\begin{document}\\maketitle\n\
+     \\section{Introduction}\\label{sec:intro} Main body; see \\ref{sec:intro}.\n\\end{document}\n",
+  );
+  write(
+    dir,
+    "main.bbl",
+    "\\begin{thebibliography}{1}\n\\end{thebibliography}\n",
+  );
+  write(
+    dir,
+    "supplement.tex",
+    "\\documentclass{article}\n\\title{Supplementary Information for The Main Paper}\n\
+     \\begin{document}\\maketitle\n\\section{Extra Derivations}\\label{sec:extra} \
+     Supplement body; see \\ref{sec:extra}.\n\\end{document}\n",
+  );
+  write(
+    dir,
+    "supplement.bbl",
+    "\\begin{thebibliography}{1}\n\\end{thebibliography}\n",
+  );
+}
+
+fn run(args: &[&str]) -> i32 {
+  Command::new(env!("CARGO_BIN_EXE_latexml_oxide"))
+    .args(args)
+    .output()
+    .expect("spawn latexml_oxide")
+    .status
+    .code()
+    .expect("not killed by a signal")
+}
+
+/// The joined output carries both documents, the supplement as a titled
+/// appendix, with distinct (prefixed) ids and self-resolving cross-references.
+fn assert_joined(html: &str) {
+  // Both documents' content is present.
+  assert!(html.contains("The Main Paper"), "main title missing");
+  assert!(html.contains("Introduction"), "main section missing");
+  assert!(
+    html.contains("Supplementary Information for The Main Paper"),
+    "supplement title missing"
+  );
+  assert!(
+    html.contains("Extra Derivations"),
+    "supplement section missing"
+  );
+  // The supplement is an appendix (its own title as the heading).
+  assert!(
+    html.contains("ltx_appendix"),
+    "supplement not attached as an appendix"
+  );
+  // Id de-confliction: the main keeps `S1`, the supplement is prefixed `as1_S1`,
+  // and neither id is duplicated.
+  assert!(html.contains("id=\"S1\""), "main id S1 missing");
+  assert!(html.contains("id=\"as1_S1\""), "supplement id not prefixed");
+  assert_eq!(
+    html.matches("id=\"S1\"").count(),
+    1,
+    "main id S1 duplicated"
+  );
+  assert_eq!(
+    html.matches("id=\"as1_S1\"").count(),
+    1,
+    "supplement id duplicated"
+  );
+  // Cross-references resolve within each document, not across.
+  assert!(
+    html.contains("href=\"#S1\""),
+    "main ref did not resolve to its own section"
+  );
+  assert!(
+    html.contains("href=\"#as1_S1\""),
+    "supplement ref did not resolve to its own (prefixed) section"
+  );
+}
+
+#[test]
+fn directory_mode_joins_detected_supplement() {
+  let d = tempfile::tempdir().unwrap();
+  fixture(d.path());
+  let dir_arg = format!("{}/", d.path().display());
+  let dest = d.path().join("out.html");
+  let code = run(&[
+    "--whatsin=directory",
+    &dir_arg,
+    "--dest",
+    dest.to_str().unwrap(),
+    "--nocomments",
+  ]);
+  assert_eq!(code, 0, "conversion exited nonzero");
+  assert_joined(&fs::read_to_string(&dest).unwrap());
+}
+
+#[test]
+fn cli_multiple_files_are_joined() {
+  let d = tempfile::tempdir().unwrap();
+  fixture(d.path());
+  let dest = d.path().join("cli.html");
+  let code = run(&[
+    d.path().join("main.tex").to_str().unwrap(),
+    d.path().join("supplement.tex").to_str().unwrap(),
+    "--dest",
+    dest.to_str().unwrap(),
+    "--nocomments",
+  ]);
+  assert_eq!(code, 0, "conversion exited nonzero");
+  assert_joined(&fs::read_to_string(&dest).unwrap());
+}


### PR DESCRIPTION
**What.** A submission with several top-level `.tex` files — a main paper + a Supplementary-Information document (both `.bbl`-backed, arXiv's canonical shape) — previously rendered only the main. It now renders both: the main first, each supplement appended as an appendix. Also joins several files given side-by-side on the CLI (`latexml_oxide main.tex supplement.tex`). Builds on #639's `find_top_level_texs` detection.

**How.** Each top-level file is converted **independently** (its own session / `\documentclass`), then `latexml::multidoc::join_core_documents` splices each supplement into the main's `<document>` as a top-level appendix `<section>` titled by the supplement's own `\title`. The supplement's id/label space is prefixed (`as1_`, `as2_`, …) so intra-document `\ref`s resolve and never collide (`#S1` for the main, `#as1_S1` for the supplement). In-memory join — the whole post pipeline downstream of the single `<document>` is unchanged.

**Validation.** `multidoc` unit tests (join / id-prefix / appendix-wrap / resource-drop) + binary-driven `121_multidoc_join` (directory-detection **and** CLI-multi-file forms; asserts both bodies present, ids de-conflicted, cross-refs resolve within each doc). Full suite **2049/0**; clippy/fmt/rustdoc clean.

**Residuals (deferred, faithful).** Streaming-scale submissions still join in-memory here — a streaming post-pass join over separate core-XML files is the tracked next increment. Archives still expand to a single main. A supplement cross-`\ref`-ing *into* the main won't resolve (per-source id spaces — as arXiv's separately-compiled PDFs cannot either). Addresses the "Supplementary missing" class in arXiv/html_feedback #6311 #1993 #1342 #278 #781 (and closed #518 #366 #272).

🤖 Generated with [Claude Code](https://claude.com/claude-code)