### PR TITLE
fix: chapterbib/bibunits per-unit bibliography lists id keeps _ raw

### DIFF
--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -8545,7 +8545,7 @@ LoadDefinitions!({
   AssignMapping!("BACKMATTER_ELEMENT", "ltx:index"        => "ltx:section");
 
   DefConstructor!("\\lx@bibliography [] Semiverbatim",
-    "<ltx:bibliography files='#2' xml:id='#id' bibstyle='#bibstyle' citestyle='#citestyle' sort='#sort' lists='#1'><ltx:title font='#titlefont' _force_font='true'>#title</ltx:title></ltx:bibliography>",
+    "<ltx:bibliography files='#2' xml:id='#id' bibstyle='#bibstyle' citestyle='#citestyle' sort='#sort' lists='#lists'><ltx:title font='#titlefont' _force_font='true'>#title</ltx:title></ltx:bibliography>",
     after_digest => sub[whatsit] {
       bgroup();
       begin_bibliography(whatsit)?;
@@ -8553,6 +8553,26 @@ LoadDefinitions!({
     },
     before_construct => sub[doc,whatsit] {
       adjust_backmatter_element(doc, whatsit)?;
+    },
+    properties => sub[args] {
+      // The chapterbib/bibunits unit name (`[#1]`) is a LIST IDENTIFIER, matched
+      // against each `<ltx:bibref inlist=...>` to select the entries for this
+      // per-unit bibliography, so `lists` must be the RAW source string. The unit
+      // name is an included file's basename; `\lx@cb@unitname` explodes it to
+      // catcode-12 OTHER tokens (so `_` is not a subscript — 1611.05798). But the
+      // args here are DIGESTED, and a bare `.to_string()` would render that `_`
+      // through the active OT1 font (slot 0x5F = `˙` U+02D9), giving
+      // `lists="main˙paper"` while the citation side keeps `inlist="main_paper"`
+      // (from the CITE_UNIT string) — the mismatch drops every entry (0 cited, empty
+      // References). So `.revert()` to the source tokens FIRST, then `.to_string()`
+      // — do NOT drop the revert. This matches Perl, which builds `lists` from the
+      // arg's ToString (source `_`). Rust-only; witness arXiv 2605.15421 (0 -> 101).
+      unpack_opt_ref!(args => unit_opt);
+      let lists = match unit_opt.as_ref() {
+        Some(u) => u.revert()?.to_string(),
+        None => String::new(),
+      };
+      Ok(stored_map!("lists" => Stored::String(pin(&lists))))
     }
   );
 

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -2089,6 +2089,26 @@ fn alignment_fenced_amp_does_not_split_a_row() {
   );
 }
 
+/// chapterbib's per-unit bibliography `lists` id must be the RAW unit name so it
+/// matches the citation-side `<ltx:bibref inlist=...>`; otherwise MakeBibliography
+/// selects nothing (0 cited) and the References render empty. An `\include`
+/// basename with `_` was the trigger: `\lx@cb@unitname` explodes it to catcode-12
+/// OTHER tokens, but the digested `[unit]` arg then rendered `_` through the active
+/// OT1 font (slot 0x5F = `˙` U+02D9), so `lists="chap˙one"` no longer equalled
+/// `inlist="chap_one"`. Building `lists` from the arg's reverted SOURCE fixes it,
+/// matching Perl (which keeps `_`). Rust-only; witness arXiv:2605.15421 (0 -> 101
+/// bibitems). The `\include`d `chap_one.tex` + `refs.bib` sit in the fixture's own
+/// subdir so the non-recursive `cluster_regressions` streaming sweep skips them.
+#[test]
+fn chapterbib_underscore_unit_lists_matches_inlist() {
+  let x = convert_and_post_clean("tests/cluster_regressions/chapterbib_underscore/main.tex");
+  let n = x.matches("<bibitem").count();
+  assert_eq!(
+    n, 1,
+    "underscore unit name dropped the cited entry (lists/inlist OT1 mismatch), got {n}\n{x}"
+  );
+}
+
 /// A class we have no binding for must still get biblatex when the document
 /// asks for it.
 ///

--- a/latexml_oxide/tests/cluster_regressions/chapterbib_underscore/chap_one.tex
+++ b/latexml_oxide/tests/cluster_regressions/chapterbib_underscore/chap_one.tex
@@ -1,0 +1,3 @@
+Chapter text that cites \cite{smith2020}.
+\bibliographystyle{plain}
+\bibliography{chapterbib_underscore_refs}

--- a/latexml_oxide/tests/cluster_regressions/chapterbib_underscore/main.tex
+++ b/latexml_oxide/tests/cluster_regressions/chapterbib_underscore/main.tex
@@ -1,0 +1,11 @@
+% Guard for chapterbib per-unit `lists` identifier: an \include basename with an
+% underscore must land in <ltx:bibliography lists="chap_one"> RAW, matching the
+% <ltx:bibref inlist="chap_one"> the citation side emits — not OT1-decoded to
+% "chap˙one", which drops every entry (0 cited). Witness arXiv:2605.15421.
+% Paths are subdir-qualified because the test harness resolves relative to
+% tests/cluster_regressions; the \include BASENAME (`chap_one`) is still the unit.
+\documentclass{article}
+\usepackage{chapterbib}
+\begin{document}
+\include{chap_one}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/chapterbib_underscore_refs.bib
+++ b/latexml_oxide/tests/cluster_regressions/chapterbib_underscore_refs.bib
@@ -1,0 +1,1 @@
+@article{smith2020, author = {Alice Smith}, title = {An Underscore Unit Title}, journal = {J. Testing}, year = {2020}}


### PR DESCRIPTION
**Diagnostic.** chapterbib/bibunits build the per-unit bibliography `lists` id from the digested `[unit]` arg; an `\include` basename with `_` renders that `_` through OT1 (slot 0x5F = `˙` U+02D9), so `lists="main˙paper"` no longer matches the citation-side `inlist="main_paper"` (built from the `CITE_UNIT` string) and MakeBibliography selects **0 entries** — the References render empty.

**Approach.** Build `lists` from the arg's reverted **source** string via a `properties` closure, matching Perl LaTeXML (which keeps the raw `_`). `latex_constructs.rs` `\lx@bibliography` (shared by chapterbib and bibunits `\putbib`).

**Validation.** Guard `chapterbib_underscore_unit_lists_matches_inlist` (RED→GREEN); full suite **2036/0**; clippy/fmt clean; canonical `cortex_worker` on witness **arXiv:2605.15421 → 0→101 bibitems**, matching Perl 0.8.8 (`lists="main_paper"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)