### PR TITLE
fix: colortbl \columncolor overhang read no longer eats a \lbrack cell

### DIFF
--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -2089,6 +2089,28 @@ fn alignment_fenced_amp_does_not_split_a_row() {
   );
 }
 
+/// A `\columncolor` in a p/m column, followed by a cell whose content starts with
+/// `\lbrack` (a CS `\let` to `[`), made colortbl's overhang-arg gobble run forward
+/// past the row's `\\`, cascading the paragraph-column mode
+/// (`\@end@tabular … internal_vertical`) — truncating the document and dropping the
+/// bibliography below. `\toprule[1pt]` (a booktabs rule with an optional-width arg)
+/// completes the trigger. Reading the overhang args with LaTeXML's optional reader
+/// (literal `[` only, never a `\lbrack` CS) keeps the cell content, as pdflatex
+/// renders it. Rust-only; witness arXiv:2606.02077 (0 -> 15 bibitems, matching Perl).
+#[test]
+fn columncolor_lbrack_cell_does_not_cascade_the_column_mode() {
+  let x = convert_and_post_clean("tests/cluster_regressions/bib_columncolor_lbrack_overhang.tex");
+  assert!(
+    x.contains("[3]") && x.contains("second cell"),
+    "the `\\lbrack` cell content was eaten as a colortbl overhang arg:\n{x}"
+  );
+  let n = x.matches("<bibitem").count();
+  assert_eq!(
+    n, 1,
+    "the paragraph-column mode cascade truncated the bibliography, got {n}\n{x}"
+  );
+}
+
 /// A class we have no binding for must still get biblatex when the document
 /// asks for it.
 ///

--- a/latexml_oxide/tests/cluster_regressions/bib_columncolor_lbrack_overhang.tex
+++ b/latexml_oxide/tests/cluster_regressions/bib_columncolor_lbrack_overhang.tex
@@ -1,0 +1,19 @@
+% A `\columncolor` in a p/m column, followed by a cell whose content starts with
+% `\lbrack` (a CS \let to `[`), used to make the overhang-arg gobble run forward
+% past the row's `\\` and cascade the paragraph-column mode
+% (`\@end@tabular ... internal_vertical`), truncating the document and losing the
+% bibliography below. `\toprule[1pt]` (a booktabs rule with an optional-width arg)
+% is part of the trigger. Fixed by reading the overhang args with LaTeXML's
+% optional reader (literal `[` only). Witness arXiv:2606.02077.
+\documentclass{article}
+\usepackage{booktabs}\usepackage[table]{xcolor}\usepackage{array}
+\begin{document}
+\begin{tabular}{>{\columncolor{blue}}p{2cm}>{\columncolor{blue}}p{2cm}}
+\toprule[1pt]
+\lbrack3\rbrack & second cell \\
+\bottomrule[1pt]
+\end{tabular}
+\begin{thebibliography}{9}
+\bibitem{a} A cited entry below the table.
+\end{thebibliography}
+\end{document}

--- a/latexml_package/src/package/colortbl_sty.rs
+++ b/latexml_package/src/package/colortbl_sty.rs
@@ -68,21 +68,25 @@ LoadDefinitions!({
   // so DefMacro! expansion strings containing \@setcellcolor produce two tokens
   // (\@ + setcellcolor) instead of one CS (\@setcellcolor).
   // RawTeX! tokenizes at package loading time when @ has catcode "letter".
-  // \columncolor[model]{color}[left_overhang][right_overhang]
-  // The overhang args are layout-only (ignored by LaTeXML) but must be consumed.
-  RawTeX!(r"\def\columncolor{\@ifnextchar[\lx@columncolor@ii{\lx@columncolor@ii[]}}");
+  // \columncolor[model]{color}[left_overhang][right_overhang] — Perl
+  // colortbl.sty.ltxml L50 `DefMacro('\columncolor[]{}[][]', …)`. The two trailing
+  // overhang args are layout-only (ignored) but must be consumed. Read them with
+  // LaTeXML's optional-arg reader (the `[]{}[][]` signature), NOT TeX's
+  // `\@ifnextchar[` + a delimited `[#1]`: `\@ifnextchar[` matches a `\lbrack` (a CS
+  // `\let` to `[`) via `\ifx`, but the delimited reader then runs forward hunting a
+  // LITERAL `[`, swallowing the row's `\\` and cascading the p/m-column mode
+  // (`\@end@tabular … internal_vertical`, document + bibliography lost). LaTeXML's
+  // `[]` reader matches only a literal `[` char, so a cell that starts with
+  // `\lbrack…\rbrack` stays content, as pdflatex renders it. Rust-only; witness
+  // arXiv:2606.02077 (booktabs `\toprule[1pt]` + `\lbrack` in a
+  // `>{\columncolor{…}}m{…}` column). `\@setcellcolor` carries `@`, which the
+  // compile-time DefMacro! tokenizer would split, so a RawTeX helper (where `@` is a
+  // letter) holds the body and the DefMacro only supplies the optional signature.
   RawTeX!(
-    r"\long\def\lx@columncolor@ii[#1]#2{%
-    \if@@rowcolored\else
-      \ifx.#1.\pagecolor{#2}\else\pagecolor[#1]{#2}\fi
-      \@setcellcolor
-    \fi
-    \@ifnextchar[{\lx@gobble@optopt}{}%
-  }"
+    r"\long\def\lxcolumncolorbody#1#2{%
+      \if@@rowcolored\else\ifx.#1.\pagecolor{#2}\else\pagecolor[#1]{#2}\fi\@setcellcolor\fi}"
   );
-  // Consume up to two optional arguments (overhang params)
-  RawTeX!(r"\def\lx@gobble@optopt[#1]{\@ifnextchar[{\lx@gobble@opt}{}}");
-  RawTeX!(r"\def\lx@gobble@opt[#1]{}");
+  DefMacro!("\\columncolor[]{}[][]", "\\lxcolumncolorbody{#1}{#2}");
 
   RawTeX!(r"\def\cellcolor{\@ifnextchar[\lx@cellcolor@ii{\lx@cellcolor@ii[]}}");
   RawTeX!(


### PR DESCRIPTION
**Diagnostic.** In a `>{\columncolor{…}}p{…}`/`m{…}` column, colortbl's trailing overhang gobble (`\@ifnextchar[` + a delimited `[#1]`) matched a cell-leading `\lbrack` (a CS `\let` to `[`) via `\ifx`, then ran **forward** hunting a literal `[`, swallowing the row's `\\` and cascading the paragraph-column mode (`\@end@tabular … internal_vertical`) — truncating the document and dropping the bibliography below. `\toprule[1pt]` (a booktabs rule with an optional-width arg) completes the trigger.

**Approach.** Port Perl's `DefMacro('\columncolor[]{}[][]', …)` (`colortbl.sty.ltxml` L50): read the two overhang args with LaTeXML's optional reader, which matches only a **literal** `[`, so a cell starting with `\lbrack…\rbrack` stays content, exactly as pdflatex renders it. (`\@setcellcolor` carries `@`, so a RawTeX helper holds the body.)

**Validation.** Guard `columncolor_lbrack_cell_does_not_cascade_the_column_mode` (RED→GREEN); full suite **2035/0**; clippy/fmt clean; canonical `cortex_worker` on witness **arXiv:2606.02077 → 0→15 bibitems**, matching Perl 0.8.8; bracket cell content preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)