### PR TITLE
feat: distribute a shared author-email line per author instead of bunching on the last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+  - **A shared author-email line distributes across the authors instead of bunching
+    on the last one.** `\email{a@x, b@y, c@z}` (or a single `\email` covering several
+    authors) previously attached every address to whichever creator was open when the
+    line was digested — usually the last — leaving the rest email-less. A distributed
+    list now maps email *i* to author *i*; grouped brace-expansion (`{a,b,c}@dom`)
+    expands then distributes without leaking into an affiliation; and a single shared
+    address lands on the lead (first) author (OXIDIZED_DESIGN #52(j)). Witness
+    arXiv:2605.23553.
   - **Supplementary-Material documents are converted and joined into the output.**
     A submission with several top-level `.tex` files (a main paper + a
     Supplementary-Information document, both `.bbl`-backed — arXiv's canonical

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -1502,6 +1502,22 @@ produced byte-identical output, so this is a surpass, not a Rust-only fix.
   the marker branch, where marker-less horizontally-separated co-authors can still append; the
   clean recovery above depends on the note-marks being the *only* superscripts.
 
+**(j) A shared author-email line distributes per author instead of bunching on the last.**
+`\email{a@x, b@y, c@z}` (or a single `\email` covering several authors) attached every address to
+whichever creator was open when the line digested — usually the LAST — leaving the rest
+email-less. The `Email` author-line branch now resolves the individual addresses and, when there
+are no more than one per author, hands each to `\lx@add@email` with `labelseq=author`, so address
+*i* relocates to creator *i*'s own `author:N` label:
+- **Distributed (`a@x, b@y, c@z`)** → email *i* to author *i*, in declaration order.
+- **Grouped brace-expansion (`{a,b,c}@dom`)** → expand to `a@dom, b@dom, c@dom` first, then
+  distribute; the expansion is never glued into an affiliation label.
+- **A single shared address** → `author:1`, the LEAD author, never a trailing one.
+A whole-line `\texttt`/`\url` wrapper is re-applied per address. MORE addresses than authors
+cannot map cleanly, so the original line is kept as one contact (the prior behavior). Witness
+arXiv:2605.23553 (`frontmatter_ieee_linebreak_optarg`). Guard
+`06_cluster_frontmatter::frontmatter_shared_email_distribution` (fixtures
+`frontmatter_email_{distributed,grouped,single_shared}.tex`).
+
 **Scope/limits:**
 - The `*` equal-contribution suffix on a combined author mark (`$^{1*}$`) still
   labels `affiliation:1*`, so it does not yet match a plain `affiliation:1`

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -986,6 +986,10 @@ LoadDefinitions!({
           }
         }
       }
+      let author_count = entries
+        .iter()
+        .filter(|(k, _)| *k == AuthorLineKind::Author)
+        .count();
       for (kind, line) in entries {
         match kind {
           AuthorLineKind::Author => {
@@ -999,9 +1003,39 @@ LoadDefinitions!({
               Invocation!(T_CS!("\\lx@add@affiliation"), vec![None, Some(withsup)]).unlist());
           },
           AuthorLineKind::Email => {
-            // Same routing the no-superscript arm uses for a bare email line.
-            calls.extend(
-              Invocation!(T_CS!("\\lx@add@email"), vec![None, Some(line)]).unlist());
+            // A shared email line otherwise attaches to whatever creator is
+            // "current" (the LAST author), bunching every address under one
+            // person. Instead, resolve the individual addresses (`a@x, b@y, c@z`
+            // distributed, or `{a,b,c}@dom` grouped -> expanded) and, when there
+            // are no more than one per author, hand each to `\lx@add@email` with
+            // labelseq=author: address i gets label author:i, which relocates to
+            // the creator's own author:N sequence label. So N addresses distribute
+            // one-per-author, and a single shared address lands on author:1 (the
+            // lead), never a random trailing author. Preserve a whole-line
+            // \texttt/\url wrapper by re-wrapping each address. If there are MORE
+            // addresses than authors (cannot map cleanly), keep the original line
+            // as one contact (the prior behavior). OXIDIZED_DESIGN #52(j).
+            let wrapper = whole_line_cs_wrapper(&line).map(|(cmd, _)| cmd);
+            let addrs = email_addresses(&line).unwrap_or_default();
+            if !addrs.is_empty() && author_count >= 1 && addrs.len() <= author_count {
+              for addr in addrs {
+                let mut toks = mouth::tokenize(TeXString::assembled(addr)).unlist();
+                if let Some(cmd) = wrapper {
+                  let mut wrapped = vec![cmd, T_BEGIN!()];
+                  wrapped.append(&mut toks);
+                  wrapped.push(T_END!());
+                  toks = wrapped;
+                }
+                let opts = mouth::tokenize_internal("labelseq=author");
+                calls.extend(
+                  Invocation!(T_CS!("\\lx@add@email"), vec![Some(opts), Some(Tokens::new(toks))])
+                    .unlist(),
+                );
+              }
+            } else {
+              calls.extend(
+                Invocation!(T_CS!("\\lx@add@email"), vec![None, Some(line)]).unlist());
+            }
           },
         }
       }
@@ -4505,22 +4539,60 @@ fn line_is_email(line: &Tokens) -> bool {
 /// comma authors often leave): every non-empty comma item must itself carry '@'.
 /// A prose affiliation line ("Dept. of Foo, University of Pisa, Italy") has no
 /// '@' and is rejected, so this never misclassifies an address as an email.
-fn line_is_email_list(line: &Tokens) -> bool {
+fn line_is_email_list(line: &Tokens) -> bool { email_addresses(line).is_some() }
+
+/// Parse an email line into its individual address strings, or `None` if the line
+/// is not an email list. Two forms are recognized (both after skipping wrapper
+/// commands / braces — only visible letter/other/space chars are read):
+/// - **Distributed** — `a@x, b@y, c@z`: every comma item carries its own `@`.
+/// - **Grouped brace-expansion** — `{a,b,c}@dom` (flattens to `a,b,c@dom`): only
+///   the LAST item carries `@`; the earlier bare local-parts are each expanded
+///   against the shared domain → `a@dom, b@dom, c@dom`. This is the compact form
+///   co-located authors use for one shared address per person.
+///
+/// A prose affiliation line ("Dept. of Foo, University of Pisa, Italy") has no `@`
+/// and is rejected, so an address is never misclassified.
+fn email_addresses(line: &Tokens) -> Option<Vec<String>> {
   let mut visible = String::new();
   for t in line.unlist_ref() {
-    if t.code == Catcode::LETTER || t.code == Catcode::OTHER {
-      t.with_str(|s| visible.push_str(s));
-    } else if t.code == Catcode::SPACE {
-      visible.push(' ');
+    match t.code {
+      Catcode::LETTER | Catcode::OTHER => t.with_str(|s| visible.push_str(s)),
+      Catcode::SPACE => visible.push(' '),
+      _ => {},
     }
   }
   let v = visible.trim();
-  v.contains('@')
-    && v
-      .split(',')
-      .map(str::trim)
-      .filter(|p| !p.is_empty())
-      .all(|p| p.contains('@') && !p.chars().any(char::is_whitespace))
+  if !v.contains('@') {
+    return None;
+  }
+  let parts: Vec<&str> = v
+    .split(',')
+    .map(str::trim)
+    .filter(|p| !p.is_empty())
+    .collect();
+  if parts.is_empty() {
+    return None;
+  }
+  let has_at = |p: &str| p.contains('@') && !p.chars().any(char::is_whitespace);
+  // Distributed: every item is a full address.
+  if parts.iter().all(|p| has_at(p)) {
+    return Some(parts.iter().map(|s| (*s).to_string()).collect());
+  }
+  // Grouped: only the last item carries the domain; earlier items are bare
+  // local-parts expanded against it (`{a,b,c}@dom` → a@dom, b@dom, c@dom).
+  if let Some((last, heads)) = parts.split_last()
+    && has_at(last)
+    && heads
+      .iter()
+      .all(|p| !p.contains('@') && !p.chars().any(char::is_whitespace))
+    && let Some(at) = last.find('@')
+  {
+    let domain = &last[at..];
+    let mut out: Vec<String> = heads.iter().map(|p| format!("{p}{domain}")).collect();
+    out.push((*last).to_string());
+    return Some(out);
+  }
+  None
 }
 
 /// Line role within a superscript-labeled author block (see `\lx@add@authors`).

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -11,6 +11,17 @@
 mod cluster;
 use cluster::{convert_to_xml, convert_to_xml_contrib, convert_to_xml_contrib_clean};
 
+/// True if the `<creator>` whose `<personname>` is `name` carries an `email`
+/// contact whose text contains `mail`.
+fn creator_has_email(xml: &str, name: &str, mail: &str) -> bool {
+  xml.split("<creator").skip(1).any(|rest| {
+    let block = rest.split("</creator>").next().unwrap_or("");
+    block.contains(&format!("<personname>{name}</personname>"))
+      && block.contains("role=\"email\"")
+      && block.contains(mail)
+  })
+}
+
 /// acmart `\author[F. Poli]{Federico Poli}`: the real class is `\author[2][]`
 /// (optional running-head short name + full name). The name must render, and
 /// the `[F. Poli]` optarg must NOT leak as a `[` creator. Witness 2405.08372.
@@ -128,6 +139,56 @@ fn frontmatter_authblk_comma_list() {
   assert!(
     !x.contains("<personname>Alice One, Bob"),
     "the comma list stayed welded into one personname:\n{x}"
+  );
+}
+/// A shared author email line must not bunch every address under the last author.
+/// Distributed (`a@x, b@y, c@z`) → email i to author i; grouped brace-expansion
+/// (`{a,b,c}@dom`) → expand then distribute (and NOT glue into the affiliation);
+/// a single shared address → the lead (first) author. OXIDIZED_DESIGN #52(j).
+#[test]
+fn frontmatter_shared_email_distribution() {
+  // 1. Distributed list, one address per author.
+  let d = convert_to_xml("tests/cluster_regressions/frontmatter_email_distributed.tex");
+  for (name, mail) in [
+    ("Alice", "alice@mit.edu"),
+    ("Bob", "bob@cmu.edu"),
+    ("Carol", "carol@mit.edu"),
+  ] {
+    assert!(
+      creator_has_email(&d, name, mail),
+      "distributed: {name} must carry {mail}:\n{d}"
+    );
+  }
+  // 2. Grouped {a,b,c}@dom expands per author; the affiliation stays clean.
+  let g = convert_to_xml("tests/cluster_regressions/frontmatter_email_grouped.tex");
+  for (name, mail) in [
+    ("Alice", "alice@mit.edu"),
+    ("Bob", "bob@mit.edu"),
+    ("Carol", "carol@mit.edu"),
+  ] {
+    assert!(
+      creator_has_email(&g, name, mail),
+      "grouped: {name} must carry expanded {mail}:\n{g}"
+    );
+  }
+  // The grouped email must NOT be glued into an affiliation (a clean affiliation
+  // carries no '@').
+  for aff in g.split("role=\"affiliation\"").skip(1) {
+    let text = aff.split("</contact>").next().unwrap_or("");
+    assert!(
+      !text.contains('@'),
+      "grouped email leaked into the affiliation text:\n{g}"
+    );
+  }
+  // 3. A single shared address lands on the lead (first) author, not the last.
+  let s = convert_to_xml("tests/cluster_regressions/frontmatter_email_single_shared.tex");
+  assert!(
+    creator_has_email(&s, "Alice", "contact@lab.org"),
+    "single shared: lead author Alice must carry contact@lab.org:\n{s}"
+  );
+  assert!(
+    !creator_has_email(&s, "Bob", "contact@lab.org"),
+    "single shared: must not also land on a trailing author:\n{s}"
   );
 }
 /// arXiv:2403.16405 (IEEEtran conference): a `\author{}` grid where `\and` starts a

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_email_distributed.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_email_distributed.tex
@@ -1,0 +1,8 @@
+\documentclass{article}
+% A shared email-list line (one address per author) must distribute email i to
+% author i, not bunch all under the last author.
+\author{Alice$^{1}$ \and Bob$^{2}$ \and Carol$^{1}$ \\
+$^{1}$MIT \quad $^{2}$CMU \\
+\texttt{alice@mit.edu, bob@cmu.edu, carol@mit.edu}}
+\title{Distributed emails}
+\begin{document}\maketitle\end{document}

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_email_grouped.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_email_grouped.tex
@@ -1,0 +1,7 @@
+\documentclass{article}
+% The compact grouped form {a,b,c}@inst expands to a@inst, b@inst, c@inst and
+% distributes per author (it must NOT glue into the affiliation text).
+\author{Alice$^{1}$ \and Bob$^{1}$ \and Carol$^{1}$ \\
+$^{1}$MIT \\ \texttt{\{alice,bob,carol\}@mit.edu}}
+\title{Grouped emails}
+\begin{document}\maketitle\end{document}

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_email_single_shared.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_email_single_shared.tex
@@ -1,0 +1,5 @@
+\documentclass{article}
+% A single shared address attaches to the lead (first) author, not the last.
+\author{Alice$^{1}$ \and Bob$^{1}$ \\ $^{1}$MIT \\ \texttt{contact@lab.org}}
+\title{Single shared email}
+\begin{document}\maketitle\end{document}


### PR DESCRIPTION
**Diagnostic.** A shared author-email line — `\email{a@x, b@y, c@z}`, or a single `\email` covering several authors — attached every address to whichever creator was open when the line digested (usually the **last**), leaving the other authors email-less.

**Approach.** The `Email` author-line branch (`base_utilities.rs`) now resolves the individual addresses and, when there are no more than one per author, hands each to `\lx@add@email` with `labelseq=author` so address *i* relocates to creator *i*'s own `author:N` label: a distributed list maps one-per-author; grouped brace-expansion (`{a,b,c}@dom`) expands then distributes without gluing into an affiliation; a single shared address lands on the **lead** (first) author. A whole-line `\texttt`/`\url` wrapper is re-applied per address; more addresses than authors keeps the original line as one contact. Surpass-Perl, OXIDIZED_DESIGN #52(j).

**Validation.** Guard `06_cluster_frontmatter::frontmatter_shared_email_distribution` (distributed / grouped / single-shared, + the affiliation-cleanliness canary), fixtures `frontmatter_email_{distributed,grouped,single_shared}.tex`. Full suite **2050/0**; clippy/fmt clean. Witness arXiv:2605.23553 (`frontmatter_ieee_linebreak_optarg`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)