### PR TITLE
fix #634: Undigested constructor arg reaches a Rhai body as Tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+  - **An `Undigested` constructor argument reaches a Rhai body as `Tokens`.** A
+    runtime `DefConstructor` with an `Undigested` (or `OptionalUndigested`) parameter
+    handed its imperative `|document, arg|` body an opaque `Digested` handle wrapping
+    nonsensical-looking token data, so `UnTeX`/`Expand` on the argument threw and the
+    binding degraded. It now arrives as `Tokens` — matching Perl, where an undigested
+    reader keeps its argument as raw Tokens (`Constructor.pm` `getArgs`) — and
+    `document.absorb(tokens)` accepts it directly (#634).
   - **A shared author-email line distributes across the authors instead of bunching
     on the last one.** `\email{a@x, b@y, c@z}` (or a single `\email` covering several
     authors) previously attached every address to whichever creator was open when the

--- a/latexml_contrib/src/script_bindings/API.md
+++ b/latexml_contrib/src/script_bindings/API.md
@@ -146,11 +146,11 @@ Called at the top level of a binding file, or from inside any body.
 
 Reached through the `document` handle a constructor body receives as its first argument — Perl's `$document->method`.
 
-27 functions, 39 calls.
+27 functions, 40 calls.
 
 | call | documentation |
 |---|---|
-| `absorb(Digested)` | Absorb a digested value at the current insertion point. ([`Document::absorb`](latexml_core::document::Document::absorb)) |
+| `absorb(Digested)`<br>`absorb(Tokens)` | Absorb a digested value at the current insertion point. ([`Document::absorb`](latexml_core::document::Document::absorb)) |
 | `absorbProperty(string)` | Absorb one of the whatsit's properties, by name. ([`Document::absorb`](latexml_core::document::Document::absorb)) |
 | `absorbString(string)` | Absorb a plain string at the current insertion point. ([`Document::absorb_string`](latexml_core::document::Document::absorb_string)) |
 | `addClass(Node, string)` | Add CSS classes to a node, keeping those it already has. ([`Document::add_class`](latexml_core::document::Document::add_class)) |

--- a/latexml_contrib/src/script_bindings/engine.rs
+++ b/latexml_contrib/src/script_bindings/engine.rs
@@ -1749,6 +1749,21 @@ pub(super) fn make_engine() -> Engine {
       })
     },
   );
+  // absorb overload for a `Tokens` value — an `Undigested` constructor arg reaches
+  // the body as `Tokens` (#634), and the dominant Perl port idiom is
+  // `$document->absorb($tokens)`. Wrapping as `Digested::from` yields the
+  // `Postponed(Tokens)` the core absorbs as text under the active font/mode —
+  // identical to how the arg was absorbed before it was unwrapped at the boundary.
+  engine.register_fn(
+    "absorb",
+    |_d: &mut DocProxy, tokens: Tokens| -> std::result::Result<(), Box<EvalAltResult>> {
+      let arg = Digested::from(tokens);
+      with_doc(|doc, _props| {
+        doc.absorb(&arg, None).map_err(rhai_err)?;
+        Ok(())
+      })
+    },
+  );
   // Absorb a whatsit property at the current point — the imperative analog of a
   // template's `#name` hole at content position. The workhorse is
   // `document.absorbProperty("body")` inside an imperative `DefEnvironment`

--- a/latexml_contrib/src/script_bindings/tests.rs
+++ b/latexml_contrib/src/script_bindings/tests.rs
@@ -364,6 +364,50 @@ fn lookup_str(key: &str) -> String {
   }
 }
 
+/// #634: the constructor-argument boundary. A Rhai imperative body must receive
+/// an `Undigested` arg as `Tokens` (Perl `Constructor.pm:137` hands `getArgs`,
+/// which keeps an undigested reader's arg as raw Tokens), a normal digested arg
+/// as an opaque `Digested` handle, and an omitted optional as unit. This guards
+/// `ctor_arg_to_dynamic` directly — the one body-invocation path that passes a
+/// live typed value rather than a stringified form — without needing a Document.
+#[test]
+fn ctor_arg_boundary_maps_undigested_to_tokens() {
+  use latexml_core::{
+    binding::content::digest_text, digested::Digested, reset_thread_engine, tokens::Tokens,
+  };
+  fresh_state();
+
+  // An `Undigested` arg is a `Digested::Postponed(Tokens)` in Rust.
+  let undigested: Digested = Digested::from(mouth::tokenize_internal("hi"));
+  let dyn_und = ctor_arg_to_dynamic(&Some(undigested));
+  assert!(
+    dyn_und.is::<Tokens>(),
+    "an Undigested arg must reach the body as Tokens, got {}",
+    dyn_und.type_name()
+  );
+
+  // A normal `{}` arg digests to a box/list — stays an opaque Digested handle.
+  let digested = digest_text(mouth::tokenize_internal("ab")).expect("digest");
+  assert!(
+    digested.raw_tokens().is_none(),
+    "a digested {{}} arg must not be a Postponed(Tokens)"
+  );
+  let dyn_dig = ctor_arg_to_dynamic(&Some(digested));
+  assert!(
+    dyn_dig.is::<Digested>(),
+    "a normal digested arg must stay a Digested handle, got {}",
+    dyn_dig.type_name()
+  );
+
+  // An omitted optional is Rhai unit.
+  assert!(
+    ctor_arg_to_dynamic(&None).is_unit(),
+    "an omitted optional arg must be unit"
+  );
+
+  reset_thread_engine();
+}
+
 /// Conformance: the *same* `afterDigest` constructor defined two ways —
 /// macro-style (calling `ConstructorBuilder` directly, as `DefConstructor!`
 /// lowers) and via Rhai (which now also routes through `ConstructorBuilder`) —

--- a/latexml_contrib/src/script_bindings/wire.rs
+++ b/latexml_contrib/src/script_bindings/wire.rs
@@ -99,6 +99,25 @@ pub(super) fn wire_macro_string_opts(proto: &str, body: &str, opts: Map) -> Resu
   Ok(())
 }
 
+/// Convert one digested constructor argument to the value a Rhai imperative body
+/// receives. Mirrors Perl `Constructor.pm:137` — `&{$replacement}($document,
+/// $whatsit->getArgs, …)` — where `getArgs` returns the stored arguments in
+/// order: a normal (digested) arg is a boxed object, but an `Undigested`-family
+/// arg (reader flagged `undigested`) is kept as raw `Tokens`. In Rust an
+/// undigested arg is a `Digested::Postponed(Tokens)` (`raw_tokens()` is `Some`
+/// exactly then), so we hand the inner `Tokens` to the script — usable with
+/// `UnTeX`/`Expand`/`absorb` — instead of an opaque `Digested` handle (#634). A
+/// normal arg stays a `Digested` handle; an omitted optional is Rhai `()`.
+pub(super) fn ctor_arg_to_dynamic(a: &Option<Digested>) -> Dynamic {
+  match a {
+    Some(d) => match d.raw_tokens() {
+      Some(tokens) => Dynamic::from(tokens.clone()),
+      None => Dynamic::from(d.clone()),
+    },
+    None => Dynamic::UNIT,
+  }
+}
+
 /// The imperative-body replacement closure: publishes the active context, calls
 /// the body as `|document, arg1, …|`, pops the context. Shared by every
 /// constructor form that uses a closure body.
@@ -114,14 +133,11 @@ pub(super) fn closure_replacement(
       // panic out of `body.call` (Rhai doesn't catch_unwind native calls) — so
       // a script-body panic can't leave a stale CTOR_CTX entry. Review M1.
       let _ctx_guard = CtorCtxGuard::new(CtorCtx { document, props });
-      // `document` first (Perl's `$_[0]`), then each digested arg as a handle.
+      // `document` first (Perl's `$_[0]`), then each argument as its Rhai value.
       let mut call_args: Vec<Dynamic> = Vec::with_capacity(args.len() + 1);
       call_args.push(Dynamic::from(DocProxy));
       for a in args {
-        call_args.push(match a {
-          Some(d) => Dynamic::from(d.clone()),
-          None => Dynamic::UNIT,
-        });
+        call_args.push(ctor_arg_to_dynamic(a));
       }
       match call_deferred_body(&engine, &ast, &body, call_args) {
         Ok(_) => Ok(()),

--- a/latexml_oxide/tests/30_script_bindings.rs
+++ b/latexml_oxide/tests/30_script_bindings.rs
@@ -19,11 +19,37 @@ const SAMPLE: &str = r##"
   DefMacro("\\twicex{}", |x| x + x);
 
   // Constructor (imperative, proxy syntax close to Perl's $document->method):
-  // \myemph{X} -> <ltx:emph>X</ltx:emph>.
+  // \myemph{X} -> <ltx:emph>X</ltx:emph>. `x` is a digested `{}` arg — an opaque
+  // Digested handle the body hands to `document.absorb`.
   DefConstructor("\\myemph{}", |document, x| {
     document.openElement("ltx:emph");
     document.absorb(x);
     document.closeElement("ltx:emph");
+  });
+
+  // Undigested parameter (#634): Perl hands an `Undigested` arg to a CODE
+  // replacement as raw *Tokens* (Constructor.pm:137 `$whatsit->getArgs`), never a
+  // digested box — the reader keeps it undigested. So a Rhai imperative body must
+  // receive `Tokens` (usable with UnTeX/Expand/absorb), NOT an opaque `Digested`
+  // handle. \uarg{hi} -> <ltx:text class="uarg">U[hi]</ltx:text>. `UnTeX` is
+  // registered ONLY for `Tokens`; before the fix `toks` arrived as a `Digested`
+  // and this threw, degrading the binding (the reported "value of type Digested").
+  DefConstructor("\\uarg Undigested", |document, toks| {
+    let s = "U[" + UnTeX(toks) + "]";
+    document.openElement("ltx:text");
+    document.setAttribute("class", "uarg");
+    document.absorbString(s);
+    document.closeElement("ltx:text");
+  });
+
+  // Undigested arg absorbed directly: the dominant Perl port idiom
+  // `$document->absorb($tokens)`. Guards the `absorb(Tokens)` overload (#634) —
+  // \uabs{ZZ} -> <ltx:text class="uabs">ZZ</ltx:text>.
+  DefConstructor("\\uabs Undigested", |document, toks| {
+    document.openElement("ltx:text");
+    document.setAttribute("class", "uabs");
+    document.absorb(toks);
+    document.closeElement("ltx:text");
   });
 
   // The documentation example, translated 1:1 from Perl. A no-arg constructor
@@ -313,7 +339,7 @@ fn script_binding_macro_and_constructor_convert() {
 
   let tex = concat!(
     "literal:\\documentclass{article}\\usepackage[draft]{lxrhaitest}",
-    "\\begin{document}\\twicex{ab} \\myemph{hi} \\mytext{zz} \\wrap{\\myemph{deep}} \\wrap{\\wrap{\\myemph{deeper}}} \\note{N} \\rot{xx}{yy}{zz2} \\cif{Y}\\cif{} ",
+    "\\begin{document}\\twicex{ab} \\myemph{hi} \\uarg{hi} \\uabs{ZZ} \\mytext{zz} \\wrap{\\myemph{deep}} \\wrap{\\wrap{\\myemph{deeper}}} \\note{N} \\rot{xx}{yy}{zz2} \\cif{Y}\\cif{} ",
     "body\\fnote{*}{Marked}more\\fnote{}{Plain} \\pnote{dyn} \\snote{st} \\mypi{d1} ",
     "\\begin{rquote}Quotable\\end{rquote} \\begin{bio}{Ada}Pioneer\\end{bio} ",
     "\\begin{biop}{Ada}Idiom\\end{biop} \\begin{rbox}Boxed\\end{rbox} ",
@@ -348,6 +374,18 @@ fn script_binding_macro_and_constructor_convert() {
   assert!(
     xml.contains("<emph>hi</emph>"),
     "imperative constructor \\myemph did not emit its element; xml=\n{xml}"
+  );
+  // #634: an `Undigested` arg reaches the imperative body as `Tokens` (UnTeX,
+  // registered only for Tokens, succeeds) — not a `Digested` handle.
+  assert!(
+    xml.contains("class=\"uarg\"") && xml.contains("U[hi]"),
+    "Undigested arg did not reach the body as Tokens (\\uarg); xml=\n{xml}"
+  );
+  // #634: `document.absorb(tokens)` — the Perl `$document->absorb($tokens)` port
+  // idiom — works on the Undigested Tokens arg.
+  assert!(
+    xml.contains("class=\"uabs\"") && xml.contains(">ZZ<"),
+    "absorb(Tokens) on an Undigested arg failed (\\uabs); xml=\n{xml}"
   );
   assert!(
     xml.contains("class=\"rhai\"") && xml.contains("zz"),


### PR DESCRIPTION
**Diagnostic.** A runtime `DefConstructor` with an `Undigested`/`OptionalUndigested` parameter handed its imperative `|document, arg|` body an opaque `Digested` handle — a `Postponed(Tokens)` whose Debug repr reads as nonsensical token data — so `UnTeX`/`Expand` on the arg threw and the binding degraded. The constructor closure body is the *only* arg-crossing site that passes a live typed value; every other (macro/primitive/conditional/properties/reversion/`argString`) stringifies via `untex`/`to_string` and is type-agnostic.

**Approach.** Unwrap the `Postponed` at that single boundary (`wire::ctor_arg_to_dynamic`) so an undigested arg arrives as `Tokens` — faithful to Perl, where an undigested reader keeps its argument as raw Tokens (`Constructor.pm:137` `getArgs`). Normal digested args stay opaque `Digested` handles; an omitted optional stays unit. Add an `absorb(Tokens)` overload so the dominant `$document->absorb($tokens)` port idiom works.

**Validation.** Guards `ctor_arg_boundary_maps_undigested_to_tokens` (unit, direct on the boundary) and the `\uarg`/`\uabs` specimens in `script_binding_macro_and_constructor_convert` (end-to-end through construction — the path that was uncovered and let the bug hide). Full suite 2052/0; clippy clean; `API.md` regenerated.

Closes #634