### PR TITLE
feat #635: read whatsit properties inside a Rhai constructor body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
     binding degraded. It now arrives as `Tokens` — matching Perl, where an undigested
     reader keeps its argument as raw Tokens (`Constructor.pm` `getArgs`) — and
     `document.absorb(tokens)` accepts it directly (#634).
+  - **A Rhai constructor body can read the whatsit's properties.** Inside an
+    imperative `DefConstructor` body only `document.absorbProperty(name)` existed —
+    it splices a property into the tree but cannot return one, so a body could not
+    branch on or compose from a property. New `document.getProperty(name)` (the
+    typed value, `()` when absent) and `document.getProperties()` (the whole map)
+    read the same construction-time property map, matching Perl, which hands
+    `$whatsit->getProperties` to a CODE replacement (`Constructor.pm:137`) (#635).
   - **A shared author-email line distributes across the authors instead of bunching
     on the last one.** `\email{a@x, b@y, c@z}` (or a single `\email` covering several
     authors) previously attached every address to whichever creator was open when the

--- a/latexml_contrib/src/script_bindings/API.md
+++ b/latexml_contrib/src/script_bindings/API.md
@@ -146,7 +146,7 @@ Called at the top level of a binding file, or from inside any body.
 
 Reached through the `document` handle a constructor body receives as its first argument — Perl's `$document->method`.
 
-27 functions, 40 calls.
+29 functions, 42 calls.
 
 | call | documentation |
 |---|---|
@@ -164,6 +164,8 @@ Reached through the `document` handle a constructor body receives as its first a
 | `generateID(Node, string)` | Give a node an `xml:id`, if it has none. ([`Document::generate_id`](latexml_core::document::Document::generate_id)) |
 | `getElement() -> Node?` | The element at, or containing, the insertion point. ([`Document::get_element`](latexml_core::document::Document::get_element)) |
 | `getNode() -> Node` | The current insertion point. ([`Document::get_node`](latexml_core::document::Document::get_node)) |
+| `getProperties() -> map` | The whatsit's whole property map (a Rhai object map), inside a constructor body. |
+| `getProperty(string) -> ?` | One whatsit property by name, inside a constructor body — its typed value (string / `Digested` handle / …), or `()` when absent. The read-sibling of `absorbProperty`. |
 | `insertElement(string) -> Node`<br>`insertElement(string, Digested) -> Node`<br>`insertElement(string, Digested, map) -> Node`<br>`insertElement(string, map) -> Node` | Open, absorb and close in one step; returns the new element. ([`Document::insert_element`](latexml_core::document::Document::insert_element)) |
 | `insertPI(string)`<br>`insertPI(string, map)` | Insert a processing instruction: a target, with optional attributes. ([`Document::insert_pi`](latexml_core::document::Document::insert_pi)) |
 | `insertXML(Node)`<br>`insertXML(array)`<br>`insertXML(string)` | Splice ALREADY-PARSED nodes in at the insertion point. ([`Document::insert_nodes`](latexml_core::document::Document::insert_nodes)) |

--- a/latexml_contrib/src/script_bindings/api_doc.rs
+++ b/latexml_contrib/src/script_bindings/api_doc.rs
@@ -911,6 +911,16 @@ const DOCS: &[(&str, Doc)] = &[
     ),
   ),
   (
+    "getProperties",
+    Doc::Note("The whatsit's whole property map (a Rhai object map), inside a constructor body."),
+  ),
+  (
+    "getProperty",
+    Doc::Note(
+      "One whatsit property by name, inside a constructor body — its typed value (string / `Digested` handle / …), or `()` when absent. The read-sibling of `absorbProperty`.",
+    ),
+  ),
+  (
     "hasAttribute",
     Doc::Rust(
       "Whether the node carries that attribute.",

--- a/latexml_contrib/src/script_bindings/engine.rs
+++ b/latexml_contrib/src/script_bindings/engine.rs
@@ -1782,6 +1782,33 @@ pub(super) fn make_engine() -> Engine {
       })
     },
   );
+  // Read a whatsit property BY VALUE inside a constructor body — the read-sibling
+  // of `absorbProperty`. Perl hands `$whatsit->getProperties` to the CODE
+  // replacement (Constructor.pm:137), so the body can branch on / compose from a
+  // property; `absorbProperty` alone (which only splices a property into the tree)
+  // could not (#635). Returns the typed value (string / `Digested` handle / int /
+  // bool …), `()` when the property is absent. Reads the same construction-time
+  // property map `absorbProperty` does; errors (like every `document.*` op) when
+  // called outside an active constructor body.
+  engine.register_fn(
+    "getProperty",
+    |_d: &mut DocProxy, name: &str| -> std::result::Result<Dynamic, Box<EvalAltResult>> {
+      with_doc(|_doc, props| {
+        Ok(match props.get(name) {
+          Some(stored) => stored_to_dynamic(stored.clone()),
+          None => Dynamic::UNIT,
+        })
+      })
+    },
+  );
+  // The whole property map as a Rhai object map (Perl `$whatsit->getProperties`) —
+  // for a body that iterates keys or reads several at once (#635).
+  engine.register_fn(
+    "getProperties",
+    |_d: &mut DocProxy| -> std::result::Result<Map, Box<EvalAltResult>> {
+      with_doc(|_doc, props| Ok(props_to_map(props.clone())))
+    },
+  );
 
   // ── whatsit proxy: reached from a hook body via `whatsit()` ──
   engine.register_type_with_name::<WhatsitProxy>("Whatsit");

--- a/latexml_oxide/tests/30_script_bindings.rs
+++ b/latexml_oxide/tests/30_script_bindings.rs
@@ -125,6 +125,25 @@ const SAMPLE: &str = r##"
     properties: #{ cls: "static-props" }
   });
 
+  // #635: READ a whatsit property inside an imperative constructor body. Perl
+  // passes `$whatsit->getProperties` to the CODE replacement (Constructor.pm:137),
+  // so the body can branch on / compose from them; the Rhai body reaches them
+  // through `document.getProperty(name)` (typed, `()` when absent) and
+  // `document.getProperties()` (the whole map) — read-siblings of
+  // `absorbProperty`, off the same construction-time property map. \gp{Z} sets
+  // `tag`/`n` via its properties closure, then the body reads them back:
+  // \gp{Z} -> <ltx:text class="gp">T-Z/2</ltx:text>.
+  DefConstructor("\\gp{}", |document, x| {
+    let t = document.getProperty("tag");
+    let all = document.getProperties();
+    document.openElement("ltx:text");
+    document.setAttribute("class", "gp");
+    document.absorbString(t + "/" + all.n);
+    document.closeElement("ltx:text");
+  }, #{
+    properties: |x| #{ tag: "T-" + x, n: "2" }
+  });
+
   // Processing-instruction template (the class/package PI dialect shape).
   DefConstructor("\\mypi{}", "<?mypi data=\"#1\"?>");
 
@@ -339,7 +358,7 @@ fn script_binding_macro_and_constructor_convert() {
 
   let tex = concat!(
     "literal:\\documentclass{article}\\usepackage[draft]{lxrhaitest}",
-    "\\begin{document}\\twicex{ab} \\myemph{hi} \\uarg{hi} \\uabs{ZZ} \\mytext{zz} \\wrap{\\myemph{deep}} \\wrap{\\wrap{\\myemph{deeper}}} \\note{N} \\rot{xx}{yy}{zz2} \\cif{Y}\\cif{} ",
+    "\\begin{document}\\twicex{ab} \\myemph{hi} \\uarg{hi} \\uabs{ZZ} \\gp{Z} \\mytext{zz} \\wrap{\\myemph{deep}} \\wrap{\\wrap{\\myemph{deeper}}} \\note{N} \\rot{xx}{yy}{zz2} \\cif{Y}\\cif{} ",
     "body\\fnote{*}{Marked}more\\fnote{}{Plain} \\pnote{dyn} \\snote{st} \\mypi{d1} ",
     "\\begin{rquote}Quotable\\end{rquote} \\begin{bio}{Ada}Pioneer\\end{bio} ",
     "\\begin{biop}{Ada}Idiom\\end{biop} \\begin{rbox}Boxed\\end{rbox} ",
@@ -456,6 +475,12 @@ fn script_binding_macro_and_constructor_convert() {
   assert!(
     xml.contains("class=\"static-props\""),
     "static properties map (\\snote) did not populate #cls; xml=\n{xml}"
+  );
+  // #635: reading whatsit properties inside an imperative constructor body via
+  // document.getProperty(name) (typed "T-Z") + document.getProperties() (map, .n).
+  assert!(
+    xml.contains("class=\"gp\"") && xml.contains("T-Z/2"),
+    "getProperty/getProperties did not read the whatsit properties (\\gp); xml=\n{xml}"
   );
   // PI template through the runtime interpreter.
   assert!(


### PR DESCRIPTION
**Diagnostic.** Inside an imperative `DefConstructor` body only `document.absorbProperty(name)` existed — it splices a property into the tree but cannot return one, so a body could not branch on or compose from a whatsit property (only Perl-side `$whatsit->getProperties`, `Constructor.pm:137`, exposes them to a CODE replacement).

**Approach.** Add `document.getProperty(name)` (typed value, `()` when absent) and `document.getProperties()` (whole map) — read-siblings of `absorbProperty`, reading the same construction-time property map via `with_doc` and reusing `stored_to_dynamic`/`props_to_map`. On the `document` proxy because the body has no whatsit handle at construction (Perl flattens the properties into the call, never passing `$whatsit`).

**Validation.** Guard `\gp` specimen in `script_binding_macro_and_constructor_convert` (sets `tag`/`n` via a properties closure, reads them back through both methods, real construction). Full suite 2051/0; clippy clean; `API.md` regenerated.

Closes #635