### PR TITLE
fix #638: don't leak LaTeXML font attributes onto raw xhtml markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@
     typed value, `()` when absent) and `document.getProperties()` (the whole map)
     read the same construction-time property map, matching Perl, which hands
     `$whatsit->getProperties` to a CODE replacement (`Constructor.pm:137`) (#635).
+  - **The font `encoding` is no longer emitted as an output attribute.** The
+    font-encoding property is a FontMap-lookup key used *during* digestion to decode
+    unicode; it is meaningless afterwards and no `ltx:` element declares it. It was
+    still placed in the relativized font-attribute set, where it normally vanished
+    (no element accepts it) but leaked onto raw xhtml a binding splices in via
+    `insertXML` — `\fontencoding{T1}\selectfont` + a `\bmlRawHTML`-style binding
+    produced `<xhtml:div encoding="T1">` (the div's `attribute *` schema wildcard
+    accepts anything). `Font::relative_to` now omits it, so `@encoding` appears
+    nowhere (#638).
   - **A shared author-email line distributes across the authors instead of bunching
     on the last one.** `\email{a@x, b@y, c@z}` (or a single `\email` covering several
     authors) previously attached every address to whichever creator was open when the

--- a/latexml_core/src/common/font.rs
+++ b/latexml_core/src/common/font.rs
@@ -1264,15 +1264,13 @@ impl Font {
         }),
       );
     }
-    if is_diff(self.encoding.as_ref(), other.encoding.as_ref()) {
-      result.insert(
-        "encoding".to_string(),
-        (self.encoding.as_ref().unwrap().to_string(), Font {
-          encoding: self.encoding.clone(),
-          ..Font::default()
-        }),
-      );
-    }
+    // #638: the font `encoding` is a FontMap-lookup key consumed DURING digestion
+    // (unicode decoding), not a presentation property — it is meaningless as an
+    // output attribute and no ltx element even declares it, so Perl emits no
+    // `@encoding` anywhere. Emitting it here only ever surfaced (spuriously) on a
+    // foreign `xhtml:*` element whose `attribute *` wildcard accepts anything.
+    // Omit it from the relativized attribute set entirely (Perl `Font.pm` keeps
+    // the analogous line, but the value never reaches real output there).
     if is_diff(self.language.as_ref(), other.language.as_ref()) {
       result.insert(
         "xml:lang".to_string(),
@@ -2322,6 +2320,56 @@ mod tests {
     // An integral float still reads back cleanly.
     assign_value("NOMINAL_FONT_SIZE", Float(12.0), None);
     assert_eq!(defsize(), 12.0, "12pt reads back as 12.0");
+  }
+
+  /// #638: LaTeXML treats the font `encoding` three different ways, and this
+  /// pins all three so the "omit encoding from `relative_to`" fix cannot drift
+  /// into collapsing font *identity*. Two fonts that differ ONLY in encoding are:
+  ///   - **unequal** (`eq`) and **distinctly hashable** — a T1 span is a
+  ///     different font than an OT1 span, so `set_node_font`'s `_font` /
+  ///     `node_fonts` keys keep them apart;
+  ///   - **distance 0** — encoding alone never opens a font wrapper (Perl's
+  ///     `distance` skips it explicitly, `Common/Font.pm`);
+  ///   - **empty under `relative_to`** — encoding is a FontMap-lookup key consumed
+  ///     at digestion, meaningless as output, so it is omitted from the relativized
+  ///     attribute set (otherwise it leaks onto raw `xhtml:*`, whose `attribute *`
+  ///     schema wildcard accepts it — the reported bug).
+  #[test]
+  fn encoding_is_font_identity_but_not_distance_or_output() {
+    use crate::state::{State, StateOptions, set_state};
+    set_state(State::new(StateOptions::default()));
+
+    let base = Font::default();
+    let mut t1 = base.clone();
+    t1.encoding = Some(Cow::Borrowed("T1"));
+    let mut ot1 = base.clone();
+    ot1.encoding = Some(Cow::Borrowed("OT1"));
+
+    // Identity: different encodings ⇒ different fonts.
+    assert_ne!(
+      t1, ot1,
+      "fonts differing only in encoding must not be equal"
+    );
+    assert_ne!(
+      t1.to_hashable(),
+      ot1.to_hashable(),
+      "differently-encoded fonts must get distinct `_font` ids"
+    );
+
+    // Distance: encoding is not a font-switch factor (faithful to Perl).
+    assert_eq!(
+      t1.distance(&ot1),
+      0,
+      "encoding alone must not count as a font-switch distance"
+    );
+
+    // Output: encoding is never emitted as a relativized attribute (#638). Since
+    // the two fonts differ only in encoding, the relativized set is empty.
+    let rel = t1.relative_to(&ot1);
+    assert!(
+      rel.is_empty(),
+      "relative_to must not emit @encoding (it leaks onto foreign xhtml); got {rel:?}"
+    );
   }
 
   #[test]

--- a/latexml_oxide/tests/30_script_bindings.rs
+++ b/latexml_oxide/tests/30_script_bindings.rs
@@ -1162,6 +1162,77 @@ fn a_throwing_script_body_degrades_only_its_binding() {
   latexml_core::reset_thread_engine();
 }
 
+// #638: a raw-HTML binding (BookML `\bmlRawHTML`) that ParseXML+insertXML a
+// foreign `xhtml:div` while a non-default font encoding is active.
+const RAWHTML_SAMPLE: &str = r##"
+  DefConstructor("\\bmlraw{}", |document, rawhtml| {
+    let nodes = ParseXML("<div xmlns='http://www.w3.org/1999/xhtml'>" + ToString(rawhtml) + "</div>");
+    document.openElement("ltx:rawhtml");
+    document.insertXML(nodes);
+    document.closeElement("ltx:rawhtml");
+  });
+"##;
+
+fn rawhtml_dispatch(request: &str) -> Option<Result<()>> {
+  let base = request.split('.').next().unwrap_or(request);
+  if base == "lxrawhtmltest" {
+    Some(latexml_contrib::script_bindings::load_script(RAWHTML_SAMPLE).map(|_| ()))
+  } else {
+    None
+  }
+}
+
+/// #638: the font `encoding` is a FontMap-lookup key, meaningless as an output
+/// attribute — no ltx element declares it, so it must never appear. It used to
+/// leak onto a foreign `xhtml:div` a `\bmlRawHTML`-style binding splices in under
+/// `\fontencoding{T1}\selectfont` (the div's `attribute *` schema wildcard accepts
+/// anything), producing `<xhtml:div encoding="T1">`. `relative_to` no longer emits
+/// it, so it appears nowhere.
+#[test]
+fn raw_html_insertxml_does_not_leak_font_encoding() {
+  use latexml_core::common::error::{LogStatus, get_status};
+  let mut latexml = Core::new(CoreOptions {
+    verbosity: Some(-2),
+    include_comments: Some(false),
+    ..CoreOptions::default()
+  });
+  state::set_bindings_dispatch(latexml_core::common::native_dispatcher(
+    latexml_package::dispatch,
+  ));
+  state::add_binding_names(latexml_package::binding_names());
+  state::set_extra_bindings_dispatch(Rc::new(rawhtml_dispatch));
+
+  // A non-default font encoding is active when the raw HTML is spliced.
+  let tex = concat!(
+    "literal:\\documentclass{article}\\usepackage{lxrawhtmltest}\\begin{document}",
+    "\\fontencoding{T1}\\selectfont\\bmlraw{leaked}",
+    "\\end{document}"
+  );
+  let doc = latexml
+    .convert_file(tex.to_string())
+    .expect("raw-html conversion should succeed");
+  let xml = doc.serialize_to_string();
+
+  assert!(
+    get_status(LogStatus::Error) == 0 && get_status(LogStatus::Fatal) == 0,
+    "conversion logged errors: {}",
+    latexml_core::common::error::get_status_message()
+  );
+  // The div and its content are present …
+  assert!(
+    xml.contains("<rawhtml") && xml.contains("leaked") && xml.contains("div"),
+    "raw html was not inserted; xml=\n{xml}"
+  );
+  // … and no font `encoding` attribute appears anywhere in the output.
+  assert!(
+    !xml.contains("encoding=\"T1\""),
+    "font encoding leaked as an output attribute (#638); xml=\n{xml}"
+  );
+
+  drop(latexml);
+  latexml_core::reset_thread_engine();
+}
+
 const OPTBAG_SAMPLE: &str = r##"
   DefPrimitive("\\optbagprim", || { AssignValue("optbag:body", "X", "global"); }, #{
     beforeDigest: || { AssignValue("optbag:before", "B", "global"); },


### PR DESCRIPTION
**Diagnostic.** The font `encoding` is a FontMap-lookup key used *during* digestion to decode unicode — meaningless as an output attribute, and no `ltx:` element declares it. `Font::relative_to` still placed it in the relativized attribute set, where it normally vanished (`canHaveAttribute` false everywhere) but leaked onto raw xhtml a binding splices in via `insertXML`: the schema's `htmlElement { attribute * }` wildcard makes `canHaveAttribute('xhtml:div','encoding')` true, so `\fontencoding{T1}\selectfont` + a `\bmlRawHTML`-style binding produced `<xhtml:div encoding="T1">`.

**Approach.** Omit `encoding` from `Font::relative_to` (`common/font.rs`), so `@encoding` is never emitted anywhere. Supersedes the earlier namespace-gate approach per review (thread below) — the leak reproduces identically in a freshly-built upstream `brucemiller/LaTeXML` master, and no `ltx:` element ever accepts `@encoding`.

**Validation.** Guard `raw_html_insertxml_does_not_leak_font_encoding`; full suite 2052/0; clippy clean. (The only `@encoding` in output is MathML `<annotation encoding="…">`, set explicitly — unaffected.)

Closes #638