### PR TITLE
fix: imsart bibliography reads the `.bib` when no `.bbl` ships

### DIFF
--- a/latexml_contrib/src/imsart_cls.rs
+++ b/latexml_contrib/src/imsart_cls.rs
@@ -19,6 +19,20 @@ LoadDefinitions!({
   // imsart.cls L149: \RequirePackage{imsart}.
   InputDefinitions!("imsart", noltxml => true, extension => Some(Cow::Borrowed("sty")));
 
+  // imsart.sty (L3015) redefines `\bibliography#1` to only
+  // `\@input@{\jobname.bbl}` — it inputs a pre-built `.bbl` and NEVER reads the
+  // `.bib`. arXiv imsart submissions routinely ship the `.bib` alone (no
+  // compiled `<jobname>.bbl`), so that raw definition silently drops the whole
+  // bibliography (0 bibitems, no diagnostic). Restore the core `\bibliography`
+  // (`latex_constructs.rs`): `\lx@ifusebbl` inputs `<jobname>.bbl` when it
+  // exists (unchanged for `.bbl` papers) and otherwise reads the `.bib` directly
+  // via `\lx@bibliography`, which is our beyond-Perl `.bib` path. Witnesses
+  // 2606.00231 (`reference.bib`, 0→N) and 2606.17491 (two `.bib` files, 0→N).
+  DefMacro!(
+    "\\bibliography Semiverbatim",
+    r#"\lx@ifusebbl{#1}{\input{\jobname.bbl}}{\lx@bibliography{#1}}"#
+  );
+
   // Frontmatter primitives commonly used in imsart papers but not
   // always defined by imsart.sty (some are journal-driver dependent).
   // \startlocaldefs / \endlocaldefs are defined in imsart.sty L657-660;


### PR DESCRIPTION
**Diagnostic.** imsart.sty (L3015) redefines `\bibliography#1` to only `\@input@{\jobname.bbl}` — it inputs a pre-built `.bbl` and never reads the `.bib`, overriding our `\lx@ifusebbl` `.bib` reader. arXiv imsart submissions routinely ship the `.bib` alone (no compiled `<jobname>.bbl`), so the whole bibliography was silently dropped (0 bibitems, no diagnostic). R3b silent-loss family; `\bibdata` is `\string`-written to the aux, so the `.bib` name isn't otherwise recoverable.

**Approach.** In the existing `imsart_cls` binding, restore the core `\bibliography` (`\lx@ifusebbl`) right after raw-loading imsart. It inputs `<jobname>.bbl` when present (**unchanged for `.bbl` papers**) and otherwise reads the `.bib` directly. Only the no-`.bbl` case changes behavior. One `DefMacro`.

**Validation.** Verified through the cortex/ar5iv pipeline: **2606.00231 (0 → 31 bibitems, 0 missing citations)** and **2606.17491 (0 → 30)**. Full suite **2055/2055**; the existing `cluster_arximspdf_imsart` binding test is unchanged. (No synthetic guard: real imsart isn't in TeX Live and the in-process harness can't resolve a stub `imsart.sty` from a fixture subdir; the fix rests on the production-pipeline witnesses.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)