### PR TITLE
feat #655: --whatsin=xml post-processes an already-converted core document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@
     path relative to the source directory when it stays below the destination (else
     flattens to the basename), and rewrites `@src` to where the file actually
     landed — matching Perl `XSLT::copyResource` (#662).
+  - **`--whatsin=xml` post-processes an already-converted core document (the
+    `latexmlpost` role).** The input type was inferred only from the file
+    extension, so a core LaTeXML XML document under a project-specific name (e.g.
+    `paper.preprocessed-xml`) was mistaken for TeX and re-digested as garbage. Now
+    any extension ending in `-xml`/`_xml` (or exactly `.xml`) is auto-detected as
+    XML input, and `--whatsin=xml` forces the XML-input path regardless of the
+    extension — the input analog of `--format` for output. Either way the TeX
+    engine is skipped and the file goes straight to post-processing, so the same
+    XML can be re-rendered to several outputs without re-digesting the source
+    (#655).
   - **`RelaxNGSchema()` actually loads a custom schema.** Selecting a RelaxNG
     schema from raw `.rng` at runtime (the Rhai `RelaxNGSchema()` binding, or any
     non-`LaTeXML` schema with no compiled `.model`) scanned and parsed the file but

--- a/latexml_oxide/bin/latexml_oxide.rs
+++ b/latexml_oxide/bin/latexml_oxide.rs
@@ -331,8 +331,10 @@ struct Cli {
   /// What the input is: `document` (default; a standalone file), `fragment` (a
   /// snippet wrapped with --preamble/--postamble or a standard pre/postamble,
   /// implied if either is given), `math` (a bare formula), `archive` (a `.zip`
-  /// bundle, also implied by a `.zip` source), or `directory` (a source dir,
-  /// also implied by a trailing `/`).
+  /// bundle, also implied by a `.zip` source), `directory` (a source dir, also
+  /// implied by a trailing `/`), or `xml` (an already-converted LaTeXML core
+  /// document to post-process directly — forces the XML-input path regardless of
+  /// the file's extension; also implied by a `.xml`/`*-xml`/`*_xml` extension).
   #[arg(long, value_name = "TYPE")]
   whatsin: Option<String>,
 
@@ -1079,11 +1081,15 @@ fn real_main() -> Result<(), Box<dyn Error>> {
   }
 
   let mut converter = Converter::from_config(opts.clone());
+  // `--whatsin=xml` forces the already-converted-XML input path regardless of the
+  // file's extension (Perl-style: the input analog of `--format` for output),
+  // covering a core document under a name `is_xml_input` doesn't recognise (#655).
+  let xml_input = is_xml_input(&source) || cli.whatsin.as_deref() == Some("xml");
   // Skip engine init for already-converted XML input: post-processing is pure
   // libxml2 and never touches the TeX engine or its dump, so loading
   // TeX.pool/latex + the format dump (~85–160 ms and a chunk of RSS) is wasted
   // work. Init mode (`--init`) and every real TeX conversion still need it.
-  if (cli.init.is_some() || !is_xml_input(&source))
+  if (cli.init.is_some() || !xml_input)
     && let Err(e) = converter.prepare_session(&opts)
   {
     eprintln!("Could not prepare converter session: {}", e);
@@ -1185,7 +1191,7 @@ fn real_main() -> Result<(), Box<dyn Error>> {
     // the file straight to post-processing. Mirrors what
     // `latexmlpost_oxide` did as a separate binary (per the
     // retirement plan in `docs/SYNC_STATUS.md`).
-    let response = if is_xml_input(&source) {
+    let response = if xml_input {
       // Do NOT slurp the file into a String — a large already-converted
       // document (the reporter's index.xml is 614 MB) would sit resident on
       // top of the ~11× libxml2 DOM. Post-processing streams it from disk via
@@ -1316,7 +1322,7 @@ fn real_main() -> Result<(), Box<dyn Error>> {
       // meaningful action is to run the post-pipeline on it.
       // Matches the always-on post-processing behaviour of the now-
       // retired `latexmlpost_oxide` binary.
-      let xml_input_mode = is_xml_input(&source_for_post);
+      let xml_input_mode = xml_input;
       let split_enabled = resolved.split_enabled;
       // Perl `post!` is last-wins (resolved in `ResolvedOptions`); its
       // format-dependent default — post is implied by requested reps / an
@@ -1783,7 +1789,14 @@ fn is_xml_input(source: &str) -> bool {
   Path::new(source)
     .extension()
     .and_then(|e| e.to_str())
-    .is_some_and(|ext| ext.eq_ignore_ascii_case("xml"))
+    .is_some_and(|ext| {
+      // `xml` itself, or any compound extension ending in `-xml`/`_xml`
+      // (e.g. `.preprocessed-xml`, `.core_xml`) — an already-converted
+      // LaTeXML core document under a project-specific name (#655). Force it
+      // explicitly with `--whatsin=xml` for names outside this pattern.
+      let ext = ext.to_ascii_lowercase();
+      ext == "xml" || ext.ends_with("-xml") || ext.ends_with("_xml")
+    })
 }
 
 fn unpack_archive(archive_path: &str) -> Result<(tempfile::TempDir, String), Box<dyn Error>> {

--- a/latexml_oxide/tests/cluster_cli.rs
+++ b/latexml_oxide/tests/cluster_cli.rs
@@ -2253,3 +2253,75 @@ mod resource_src_path {
     );
   }
 }
+
+mod whatsin_xml_input {
+  //! #655: a core LaTeXML XML document is post-processed directly (the
+  //! `latexmlpost` role) when its extension is `.xml` / `*-xml` / `*_xml`, or
+  //! when `--whatsin=xml` forces it regardless of the extension. Neither path
+  //! spins up the TeX engine or re-digests the source.
+  use std::{path::Path, process::Command};
+
+  /// A full core `<document>` (article, with sections) that post-processes to
+  /// HTML — reused from the `latexmlpost` fixtures.
+  fn core_xml() -> String {
+    let p = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/post/hyperref.xml");
+    std::fs::read_to_string(p).expect("read hyperref.xml fixture")
+  }
+
+  fn run(input_name: &str, extra: &[&str]) -> (bool, String, String) {
+    let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join(input_name), core_xml()).expect("write input");
+    let mut cmd = Command::new(bin);
+    cmd.arg(input_name).arg("--dest").arg("out.html");
+    for a in extra {
+      cmd.arg(a);
+    }
+    let out = cmd
+      .current_dir(dir.path())
+      .output()
+      .expect("spawn latexml_oxide");
+    let html = std::fs::read_to_string(dir.path().join("out.html")).unwrap_or_default();
+    (
+      out.status.success(),
+      html,
+      String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+  }
+
+  /// A `.preprocessed-xml` extension (ends in `-xml`) is auto-detected as XML
+  /// input. Before #655 it was treated as TeX and the XML source was digested
+  /// as garbage instead of post-processed.
+  #[test]
+  fn dash_xml_extension_is_post_processed_directly() {
+    let (ok, html, stderr) = run("input.preprocessed-xml", &[]);
+    assert!(
+      ok,
+      "binary failed on a .preprocessed-xml core doc; stderr:\n{stderr}"
+    );
+    // The section titles from the CORE document survive into HTML — proof the
+    // file went through post-processing, not TeX digestion of `<?xml …>`.
+    // The core document's SECTION STRUCTURE (ltx_section + the `xml:id`s S1/S2/S3)
+    // survives into HTML — a signal absent when the XML source is instead digested
+    // as TeX (angle brackets become garbage text, no sections).
+    assert!(
+      html.contains("ltx_section") && html.contains("id=\"S1\""),
+      "the -xml file was not post-processed as a LaTeXML core document; got:\n{html}"
+    );
+  }
+
+  /// An unrecognised extension (`.dat`) is NOT auto-detected; `--whatsin=xml`
+  /// forces the XML-input path anyway.
+  #[test]
+  fn whatsin_xml_forces_post_on_unrecognised_extension() {
+    let (ok, html, stderr) = run("input.dat", &["--whatsin", "xml"]);
+    assert!(
+      ok,
+      "binary failed with --whatsin=xml on a .dat core doc; stderr:\n{stderr}"
+    );
+    assert!(
+      html.contains("ltx_section") && html.contains("id=\"S1\""),
+      "--whatsin=xml did not force post-processing of the core document; got:\n{html}"
+    );
+  }
+}


### PR DESCRIPTION
**Diagnostic.** The input type was inferred only from the file extension, so a core LaTeXML XML document under a project-specific name (e.g. `paper.preprocessed-xml`) was mistaken for TeX and re-digested as garbage — there was no way to force the `latexmlpost` role.

**Approach.** `is_xml_input` now recognises `.xml` and any compound extension ending in `-xml`/`_xml`; `--whatsin=xml` forces the XML-input path regardless of extension (the input analog of `--format`). Either way the TeX engine is skipped and the file goes straight to post-processing, so the same XML re-renders to several outputs without re-digesting.

**Validation.** Guards `dash_xml_extension_is_post_processed_directly` and `whatsin_xml_forces_post_on_unrecognised_extension` (`cluster_cli`, drive the binary; assert the core doc's `ltx_section`/`xml:id` structure survives — absent when the XML is digested as TeX). Verified on minimal samples (`test.a_xml`, `test.b-xml`, forced `.dat`). Full suite 2058/0; clippy clean. (Perl `latexmlc` parity for the same flag is upstream/out of scope.)

Closes #655