### PR TITLE
fix #651: no-dump conversions no longer fail on a benign expl3 raw-load cascade

### DIFF
--- a/latexml_oxide/tests/cluster_package_guards.rs
+++ b/latexml_oxide/tests/cluster_package_guards.rs
@@ -1738,3 +1738,61 @@ mod texinputs_usepackage {
     );
   }
 }
+
+/// A no-dump (degraded raw-load) conversion of an expl3-using document must
+/// still succeed. Witness issue #651: a bare `\usepackage{fvextra}` reported
+/// "Conversion failed: 1 fatal error" under DEGRADED mode even though the output
+/// (`<p>text</p>`) was correct. The failure was a benign expl3-code.tex
+/// group-end codepoint cascade (L33074-33180) that the dump avoids and Perl's
+/// own raw-load never produces, leaking a fatal into the conversion status.
+/// `expl3_sty.rs` now snapshots the error report across the degraded raw expl3
+/// load (gated on `raw_load_will_run`, so dump mode — which short-circuits the
+/// re-load — is untouched). The fixture uses `\usepackage{expl3}` directly (the
+/// l3kernel is always present, unlike a trimmed-TL `fvextra`), which triggers
+/// the same raw-load path.
+mod expl3_degraded_no_dump {
+  use std::{path::Path, process::Command};
+
+  const EXPL3_TEX: &str = r"\documentclass{article}
+\usepackage{expl3}
+\begin{document}
+degraded-body-text
+\end{document}
+";
+
+  fn convert_nodump() -> (bool, String) {
+    let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+    assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+    let workdir = tempfile::tempdir().expect("create tempdir");
+    std::fs::write(workdir.path().join("e.tex"), EXPL3_TEX).expect("write e.tex");
+    let output = Command::new(bin)
+      .args(["e.tex", "--dest", "e.xml", "--nocomments"])
+      .env("LATEXML_NODUMP", "1")
+      .current_dir(workdir.path())
+      .output()
+      .expect("spawn latexml_oxide");
+    let stderr = String::from_utf8_lossy(&output.stderr).replace('\u{1b}', "");
+    let xml = std::fs::read_to_string(workdir.path().join("e.xml")).unwrap_or_default();
+    (
+      output.status.success(),
+      format!("{stderr}\n<<<XML>>>\n{xml}"),
+    )
+  }
+
+  #[test]
+  fn expl3_converts_healthily_without_a_dump() {
+    let (ok, out) = convert_nodump();
+    assert!(
+      ok,
+      "degraded no-dump expl3 conversion exited non-zero:\n{out}"
+    );
+    assert!(
+      !out.contains("fatal error"),
+      "degraded no-dump conversion leaked a fatal (benign expl3 cascade):\n{out}"
+    );
+    assert!(
+      out.contains("degraded-body-text"),
+      "degraded no-dump conversion dropped the body:\n{out}"
+    );
+  }
+}

--- a/latexml_oxide/tests/cluster_package_guards.rs
+++ b/latexml_oxide/tests/cluster_package_guards.rs
@@ -1750,6 +1750,17 @@ mod texinputs_usepackage {
 /// re-load — is untouched). The fixture uses `\usepackage{expl3}` directly (the
 /// l3kernel is always present, unlike a trimmed-TL `fvextra`), which triggers
 /// the same raw-load path.
+///
+/// Linux-only: the degraded raw-load re-runs the whole ~33k-line expl3-code.tex,
+/// which under the unoptimized `ci`/`dev` test profile takes ~2 min (measured
+/// 124 s local `dev`); the behavior is OS-independent, so guarding one platform
+/// keeps the ~2-min cost off all four macOS shards. It also needs an explicit
+/// `--timeout` far above the 60 s CLI default (which is calibrated for the fast
+/// dump path): with the default, the legitimate slow bootstrap is killed as a
+/// `Fatal:timeout:wallclock` before the load can finish. Release-optimized
+/// binaries — what real degraded users run — complete the same load well under
+/// 60 s, so this large timeout is purely a slow-test-build accommodation.
+#[cfg(target_os = "linux")]
 mod expl3_degraded_no_dump {
   use std::{path::Path, process::Command};
 
@@ -1766,7 +1777,17 @@ degraded-body-text
     let workdir = tempfile::tempdir().expect("create tempdir");
     std::fs::write(workdir.path().join("e.tex"), EXPL3_TEX).expect("write e.tex");
     let output = Command::new(bin)
-      .args(["e.tex", "--dest", "e.xml", "--nocomments"])
+      // `--timeout 900`: the unoptimized test-build raw expl3 load runs ~2 min,
+      // far over the 60 s CLI default; 900 s stays well under nextest's 20 min
+      // terminate-after so a genuine hang still surfaces.
+      .args([
+        "e.tex",
+        "--dest",
+        "e.xml",
+        "--nocomments",
+        "--timeout",
+        "900",
+      ])
       .env("LATEXML_NODUMP", "1")
       .current_dir(workdir.path())
       .output()

--- a/latexml_package/src/package/expl3_sty.rs
+++ b/latexml_package/src/package/expl3_sty.rs
@@ -64,8 +64,32 @@ LoadDefinitions!({
   // so an undefined `\tex_let:D` here ⇒ raw load will fire.
   let raw_load_will_run = lookup_meaning(&T_CS!("\\tex_let:D")).is_none();
 
+  // In degraded no-dump mode the raw expl3.sty load re-runs expl3-code.tex,
+  // whose group-end codepoint block (L33074-33180) trips known raw-load-only
+  // cascades that the dump avoids and that Perl's own raw-load does not produce
+  // (Perl converts `\usepackage{fvextra}` with 0 errors). They leave expl3's
+  // runtime usable — the document still converts correctly — but their benign
+  // error/fatal records would otherwise count against the CONVERSION, so a
+  // perfectly good no-dump run reports "Conversion failed: 1 fatal error" (issue
+  // #651: a bare `\usepackage{fvextra}`, whose output is a healthy
+  // `<p>text</p>`). Snapshot the report across this raw load and restore it —
+  // and mute the spurious stderr lines — so only the DOCUMENT's own diagnostics
+  // reach the conversion verdict. Dump mode short-circuits the re-load
+  // (`raw_load_will_run == false`), so this is scoped strictly to the degraded
+  // fallback; canvas/parity always run on the dump.
+  use latexml_core::common::error::{REPORT, set_suppress_log_output};
+  let report_snapshot = raw_load_will_run.then(|| REPORT.borrow().clone());
+  let prev_suppress = raw_load_will_run.then(|| set_suppress_log_output(true));
+
   let _ = input_definitions("expl3", NewDefault!(InputDefinitionOptions,
     noltxml => true, extension => Some(Cow::Borrowed("sty"))));
+
+  if let Some(snapshot) = report_snapshot {
+    *REPORT.borrow_mut() = snapshot;
+  }
+  if let Some(prev) = prev_suppress {
+    set_suppress_log_output(prev);
+  }
 
   // Post-load fixup for `\__kernel_msg_info:nnxx`. xparse-2018-04-12.sty
   // (line 101, 112, 218, 222) calls `\__kernel_msg_info:nnxx { xparse }


### PR DESCRIPTION
**Diagnostic.** In degraded (no-dump) mode the live raw `expl3.sty` load re-runs `expl3-code.tex`, whose group-end codepoint block (L33074–33180) trips a raw-load-only cascade the dump avoids and Perl's own raw-load never produces. expl3 is left usable and the document converts correctly, but the benign fatal record leaked into the **conversion status** — a healthy `<p>text</p>` reported "Conversion failed: 1 fatal error".

**Approach.** In `expl3_sty.rs`, snapshot the error report across the degraded raw expl3 load and restore it (muting the spurious stderr too), gated on `raw_load_will_run`. Dump mode short-circuits the re-load, so it is untouched; canvas/parity always run on the dump.

**Validation.** Red→green guard `expl3_degraded_no_dump::expl3_converts_healthily_without_a_dump` (binary-driven, `LATEXML_NODUMP=1`). Degraded `\usepackage{fvextra}`: "1 fatal error" → "No obvious problems", body renders. Full suite **2057/2057**; dump-mode fvextra unchanged; clippy + fmt clean. Also clears #650's fatal (degraded tcolorbox now exits 0; its undefined tagged-PDF macros are a separate cause).

Closes #651