### PR TITLE
feat #653: StartSemiverbatim/EndSemiverbatim for verbatim Rhai bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+  - **Rhai bindings can read a verbatim body via `StartSemiverbatim`/`EndSemiverbatim`.**
+    A `DefEnvironment` whose body contains `^`/`_`/`&`/… (e.g. a code block) raised
+    "Script ^ can only appear in math mode" because the body was digested normally.
+    The two Perl `Package.pm` exports are now on the Rhai surface, so a binding can
+    bracket its body — `beforeDigest: || StartSemiverbatim()` +
+    `beforeDigestEnd: || EndSemiverbatim()` — to neutralize the math/special
+    catcodes (`^ _ ~ & $ # '`) to literal text while keeping `\ { }` special so
+    `\end{env}` still parses. Extra single-char strings customize the set (#653).
   - **`RelaxNGSchema()` actually loads a custom schema.** Selecting a RelaxNG
     schema from raw `.rng` at runtime (the Rhai `RelaxNGSchema()` binding, or any
     non-`LaTeXML` schema with no compiled `.model`) scanned and parsed the file but

--- a/latexml_contrib/src/script_bindings/API.md
+++ b/latexml_contrib/src/script_bindings/API.md
@@ -35,7 +35,7 @@ closure-registered functions; only the accepted types are.
 
 Called at the top level of a binding file, or from inside any body.
 
-102 functions, 135 calls.
+104 functions, 138 calls.
 
 | call | documentation |
 |---|---|
@@ -70,6 +70,7 @@ Called at the top level of a binding file, or from inside any body.
 | `DefRewrite(map)`<br>`DefRewrite(map, Fn)` | Register a document rewrite rule (data form, or a replace closure). |
 | `Digest(Tokens) -> Digested` | Digest tokens into boxes, independent of the current gullet. ([`digest`](latexml_core::stomach::digest)) |
 | `DigestText(string) -> Digested` | Digest tokens in text mode, whatever mode the caller is in. ([`digest_text`](latexml_core::binding::content::digest_text)) |
+| `EndSemiverbatim()` | Close a `StartSemiverbatim` region, restoring the saved catcodes. ([`end_semiverbatim`](latexml_core::state::end_semiverbatim)) |
 | `Error(string, string, string)` | Log an `Error:`. Past `MAX_ERRORS` this escalates to `Fatal` and ends the conversion. |
 | `ExecuteOptions(array)` | Run the handlers for a list of class/package options. ([`execute_options`](latexml_core::binding::content::execute_options)) |
 | `Expand(Tokens) -> Tokens` | Fully expand tokens, without digesting them. ([`do_expand`](latexml_core::gullet::do_expand)) |
@@ -123,6 +124,7 @@ Called at the top level of a binding file, or from inside any body.
 | `Revert(Digested) -> Tokens` | A digested value back to the source tokens that made it. ([`Digested::revert`](latexml_core::digested::Digested::revert)) |
 | `ShiftValue(string) -> ?` | Remove and return the first value of a value-table list, type preserved (`()` if empty). ([`shift_value`](latexml_core::state::shift_value)) |
 | `SkipSpaces()` | Discard any run of spaces at the head of the input. ([`skip_spaces`](latexml_core::gullet::skip_spaces)) |
+| `StartSemiverbatim()`<br>`StartSemiverbatim(array)` | Begin reading raw: neutralize the math/special catcodes (`^ _ ~ & $ # '`) to literal `OTHER`, keeping `\ { }` special. Pass extra single-char strings to neutralize them too. Pair with `EndSemiverbatim` — the canonical way to give a `DefEnvironment` a verbatim body (`beforeDigest`/`beforeDigestEnd`). ([`begin_semiverbatim`](latexml_core::state::begin_semiverbatim)) |
 | `StepCounter(string)` | Step a counter; usually you want `RefStepCounter` instead. ([`step_counter`](latexml_core::binding::counter::dialect::step_counter)) |
 | `T_CS(string) -> Tokens` | One control-sequence token, wrapped as `Tokens` so it composes with `Digest`/`Expand`. |
 | `Tag(string, map)` | Declare document-model properties for one element tag. ([`install_tag`](latexml_core::binding::content::install_tag)) |

--- a/latexml_contrib/src/script_bindings/api_doc.rs
+++ b/latexml_contrib/src/script_bindings/api_doc.rs
@@ -327,6 +327,13 @@ const DOCS: &[(&str, Doc)] = &[
     ),
   ),
   (
+    "EndSemiverbatim",
+    Doc::Rust(
+      "Close a `StartSemiverbatim` region, restoring the saved catcodes.",
+      "latexml_core::state::end_semiverbatim",
+    ),
+  ),
+  (
     "Error",
     Doc::Note(
       "Log an `Error:`. Past `MAX_ERRORS` this escalates to `Fatal` and ends the conversion.",
@@ -667,6 +674,16 @@ const DOCS: &[(&str, Doc)] = &[
     Doc::Rust(
       "Discard any run of spaces at the head of the input.",
       "latexml_core::gullet::skip_spaces",
+    ),
+  ),
+  (
+    "StartSemiverbatim",
+    Doc::Rust(
+      "Begin reading raw: neutralize the math/special catcodes (`^ _ ~ & $ # '`) to \
+       literal `OTHER`, keeping `\\ { }` special. Pass extra single-char strings to \
+       neutralize them too. Pair with `EndSemiverbatim` — the canonical way to give a \
+       `DefEnvironment` a verbatim body (`beforeDigest`/`beforeDigestEnd`).",
+      "latexml_core::state::begin_semiverbatim",
     ),
   ),
   (

--- a/latexml_contrib/src/script_bindings/engine.rs
+++ b/latexml_contrib/src/script_bindings/engine.rs
@@ -305,6 +305,30 @@ pub(super) fn make_engine() -> Engine {
       latexml_core::state::assign_catcode(ch, Catcode::from(code as u8), None);
     }
   });
+  // StartSemiverbatim/EndSemiverbatim (Perl `Package.pm` exports, L1002-1008):
+  // read the following content raw — the default neutralizes the math/special
+  // catcodes (`^ _ ~ & $ # '`) to `OTHER` so they are literal, keeping `\ { }`
+  // special so e.g. `\end{env}` still parses (#653). The canonical way to give a
+  // Rhai `DefEnvironment` a verbatim body: `beforeDigest: || StartSemiverbatim()`
+  // + `afterDigestBody: || EndSemiverbatim()`. Pass extra single-char strings to
+  // neutralize them too (e.g. `StartSemiverbatim(["%"])`).
+  engine.register_fn("StartSemiverbatim", || {
+    latexml_core::state::begin_semiverbatim(None);
+  });
+  engine.register_fn("StartSemiverbatim", |extra: rhai::Array| {
+    let chars: Vec<char> = extra
+      .iter()
+      .filter_map(|d| d.clone().into_string().ok())
+      .filter_map(|s| s.chars().next())
+      .collect();
+    latexml_core::state::begin_semiverbatim(Some(&chars));
+  });
+  engine.register_fn(
+    "EndSemiverbatim",
+    || -> std::result::Result<(), Box<EvalAltResult>> {
+      latexml_core::state::end_semiverbatim().map_err(rhai_err)
+    },
+  );
   // LookupMeaning: the meaning of a CS as its display string ("" if none).
   engine.register_fn("LookupMeaning", |cs: &str| -> String {
     match latexml_core::state::lookup_meaning(&latexml_core::T_CS!(cs)) {

--- a/latexml_oxide/tests/30_script_bindings.rs
+++ b/latexml_oxide/tests/30_script_bindings.rs
@@ -192,6 +192,17 @@ const SAMPLE: &str = r##"
     document.closeElement("ltx:text");
   });
 
+  // #653: a VERBATIM environment body via StartSemiverbatim/EndSemiverbatim
+  // (Perl `Package.pm` exports). The default neutralizes `^ _ ~ & $ # '` to
+  // literal `OTHER`, so `2^3`/`a_b` in the body are text, not math sub/superscript
+  // errors — while `\ { }` stay special so `\end{rvverb}` still parses. End at
+  // `beforeDigestEnd` (the `\end`'s before-digest, before the environment's group
+  // pop) so the pushed catcode frame is popped exactly once.
+  DefEnvironment("{rvverb}", "<ltx:block class=\"rvverb\">#body</ltx:block>", #{
+    beforeDigest: || StartSemiverbatim(),
+    beforeDigestEnd: || EndSemiverbatim()
+  });
+
   // ── Wave C/E: package-option machinery through a real \usepackage[draft] ──
   // (ieeetran/article classes' DeclareOption + ProcessOptions shape.)
   DeclareOption("draft", || assign_global("rh:opt", "draft-on"));
@@ -362,6 +373,7 @@ fn script_binding_macro_and_constructor_convert() {
     "body\\fnote{*}{Marked}more\\fnote{}{Plain} \\pnote{dyn} \\snote{st} \\mypi{d1} ",
     "\\begin{rquote}Quotable\\end{rquote} \\begin{bio}{Ada}Pioneer\\end{bio} ",
     "\\begin{biop}{Ada}Idiom\\end{biop} \\begin{rbox}Boxed\\end{rbox} ",
+    "\\begin{rvverb}2^3 and a_b\\end{rvverb} ",
     "\\begin{rproof}QED-body\\end{rproof} \\numbered{NUM} \\rcite*[pre][post]{k1,k2} ",
     "\\gsbox{2}{3}{SCL} \\kvprobe[lang=rust]{KVB} \\sized{SZ} \\racc{o} $a := b$ $c!!$ \\gread[x]{y} \\rwvictim{OLD} ",
     "\\rhrawhtml \\rhfragment \\rhpi ",
@@ -525,6 +537,13 @@ fn script_binding_macro_and_constructor_convert() {
   assert!(
     xml.contains("class=\"rbox\"") && xml.contains("Boxed"),
     "imperative environment ({{rbox}}) / absorbProperty failed; xml=\n{xml}"
+  );
+  // #653: the verbatim env kept `^`/`_` LITERAL — the body renders as text, not
+  // a "Script ^ can only appear in math mode" error (the top-of-test 0-error gate
+  // also catches that). `\end{rvverb}` still parsed (braces stayed special).
+  assert!(
+    xml.contains("class=\"rvverb\"") && xml.contains("2^3 and a_b"),
+    "verbatim env (StartSemiverbatim) did not keep ^/_ literal; xml=\n{xml}"
   );
   // Wave C: \usepackage[draft] → DeclareOption body ran via ProcessOptions.
   let opt = match state::lookup_value("rh:opt") {


### PR DESCRIPTION
**Diagnostic.** A Rhai `DefEnvironment` whose body contained `^`/`_`/`&`/… raised "Script ^ can only appear in math mode": the body was digested normally, with no Rhai way to read it verbatim.

**Approach.** Expose Perl `Package.pm`'s `StartSemiverbatim`/`EndSemiverbatim` exports on the Rhai surface (thin wrappers over `state::begin_semiverbatim`/`end_semiverbatim`). A binding brackets its body — `beforeDigest: || StartSemiverbatim()` + `beforeDigestEnd: || EndSemiverbatim()` — neutralizing the math/special catcodes (`^ _ ~ & $ # '`) to literal `OTHER` while keeping `\ { }` special so `\end{env}` still parses. `beforeDigestEnd` runs before the environment's group pop, so the pushed frame is popped exactly once; extra single-char strings customize the set.

**Validation.** Guard `{rvverb}` in `script_binding_macro_and_constructor_convert` (`\begin{rvverb}2^3 and a_b\end{rvverb}` → literal text, 0 errors). Full suite 2058/0; clippy clean; `API.md` regenerated.

Closes #653