### PR TITLE
fix #662: post-processing preserves the folder component of a resource @src

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
     `beforeDigestEnd: || EndSemiverbatim()` — to neutralize the math/special
     catcodes (`^ _ ~ & $ # '`) to literal text while keeping `\ { }` special so
     `\end{env}` still parses. Extra single-char strings customize the set (#653).
+  - **Post-processing keeps the folder component of a resource `@src`.** A
+    resource whose `@src` had a directory part (e.g. `<ltx:resource
+    src="subdir/foo.css">`, from `RequireResource("subdir/foo.css")`) was copied to
+    a *flattened* path (`<dest>/foo.css`) while the emitted `<link>`/`<script>`
+    href kept `subdir/foo.css` — a dangling reference. The copy now preserves the
+    path relative to the source directory when it stays below the destination (else
+    flattens to the basename), and rewrites `@src` to where the file actually
+    landed — matching Perl `XSLT::copyResource` (#662).
   - **`RelaxNGSchema()` actually loads a custom schema.** Selecting a RelaxNG
     schema from raw `.rng` at runtime (the Rhai `RelaxNGSchema()` binding, or any
     non-`LaTeXML` schema with no compiled `.model`) scanned and parsed the file but

--- a/latexml_oxide/tests/cluster_cli.rs
+++ b/latexml_oxide/tests/cluster_cli.rs
@@ -2145,3 +2145,111 @@ mod math_greek_no_replacement_char {
     }
   }
 }
+
+mod resource_src_path {
+  //! #662: a resource whose `@src` has a folder component (`subdir/foo.css`) must
+  //! be copied PRESERVING that folder — `<dest>/subdir/foo.css` — so the
+  //! `<link>`/`<script>` href the stylesheet emits still resolves, instead of the
+  //! file being flattened to `<dest>/foo.css` while the tag keeps `subdir/foo.css`.
+  use std::process::Command;
+
+  #[test]
+  fn resource_folder_component_is_preserved_on_copy() {
+    let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("subdir")).unwrap();
+    std::fs::create_dir_all(root.join("out")).unwrap();
+    std::fs::write(root.join("subdir/mystyle.css"), "body{color:red}").unwrap();
+    std::fs::write(
+      root.join("myres.sty.rhai"),
+      "RequireResource(\"subdir/mystyle.css\", #{ type: \"text/css\" });",
+    )
+    .unwrap();
+    std::fs::write(
+      root.join("doc.tex"),
+      "\\documentclass{article}\\usepackage{myres}\\begin{document}Hi.\\end{document}",
+    )
+    .unwrap();
+
+    let out = Command::new(bin)
+      .args([
+        "--format=html5",
+        "--path=.",
+        "--dest=out/doc.html",
+        "doc.tex",
+      ])
+      .env("LATEXML_NODUMP", "1")
+      .current_dir(root)
+      .output()
+      .expect("spawn latexml_oxide");
+    assert!(
+      out.status.success(),
+      "binary failed; stderr:\n{}",
+      String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The file kept its folder …
+    assert!(
+      root.join("out/subdir/mystyle.css").is_file(),
+      "resource was not copied to out/subdir/mystyle.css (folder dropped)"
+    );
+    // … and was NOT flattened to the destination root.
+    assert!(
+      !root.join("out/mystyle.css").exists(),
+      "resource was flattened to out/mystyle.css, dropping its folder (#662)"
+    );
+    // … and the emitted <link> href matches the file location.
+    let html = std::fs::read_to_string(root.join("out/doc.html")).unwrap();
+    assert!(
+      html.contains("href=\"subdir/mystyle.css\""),
+      "the <link> href does not point at the preserved path; html=\n{html}"
+    );
+  }
+
+  /// A resource that ESCAPES the source dir (`../shared.css`) is flattened to the
+  /// basename (Perl's "otherwise flatten" branch), and the tag is rewritten to match.
+  #[test]
+  fn resource_escaping_source_dir_is_flattened() {
+    let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::create_dir_all(root.join("src/out")).unwrap();
+    std::fs::write(root.join("shared.css"), "body{color:blue}").unwrap();
+    std::fs::write(
+      root.join("src/myesc.sty.rhai"),
+      "RequireResource(\"../shared.css\", #{ type: \"text/css\" });",
+    )
+    .unwrap();
+    std::fs::write(
+      root.join("src/doc.tex"),
+      "\\documentclass{article}\\usepackage{myesc}\\begin{document}Hi.\\end{document}",
+    )
+    .unwrap();
+
+    let out = Command::new(bin)
+      .args([
+        "--format=html5",
+        "--path=.",
+        "--dest=out/doc.html",
+        "doc.tex",
+      ])
+      .env("LATEXML_NODUMP", "1")
+      .current_dir(root.join("src"))
+      .output()
+      .expect("spawn latexml_oxide");
+    assert!(out.status.success(), "binary failed on escaping resource");
+
+    // Flattened INTO the destination root — never written outside it via `../`
+    // (which is where a naive "preserve `../shared.css`" would land it).
+    assert!(
+      root.join("src/out/shared.css").is_file(),
+      "escaping resource should flatten into the destination"
+    );
+    assert!(
+      !root.join("src/shared.css").exists(),
+      "escaping resource must NOT be written outside the destination (path traversal)"
+    );
+  }
+}

--- a/latexml_post/src/xslt.rs
+++ b/latexml_post/src/xslt.rs
@@ -218,18 +218,39 @@ impl XSLT {
       .and_then(|f| f.to_str())
       .unwrap_or(src);
 
+    // The path (relative to the destination base) the resource is copied to.
+    // Perl `copyResource`: with a `resource_directory`, flatten into it; otherwise
+    // PRESERVE the src's path relative to the source directory — provided it stays
+    // BELOW the destination (a plain relative path, not escaping via `../` or
+    // absolute), else flatten to the basename. So `subdir/foo.css` lands at
+    // `<dest>/subdir/foo.css`, matching the `<link>`/`<script>` href, instead of a
+    // flattened `foo.css` the tag can no longer resolve (#662).
+    let rel_dest: String = if self.resource_directory.is_some() {
+      basename.to_string()
+    } else {
+      let relpath = latexml_core::util::pathname::relative(src, doc.get_source_directory());
+      if relpath.starts_with("../") || Path::new(&relpath).is_absolute() {
+        basename.to_string()
+      } else {
+        relpath
+      }
+    };
+
     // Determine destination once — same logic regardless of whether
     // the resource ends up on disk or comes from the embedded table.
     let dest = if let Some(ref rd) = self.resource_directory {
       if let Some(site_dir) = doc.get_site_directory() {
-        format!("{}/{}/{}", site_dir, rd, basename)
+        format!("{}/{}/{}", site_dir, rd, rel_dest)
       } else {
-        format!("{}/{}", rd, basename)
+        format!("{}/{}", rd, rel_dest)
       }
-    } else if let Some(dest_dir) = doc.get_destination_directory() {
-      format!("{}/{}", dest_dir, basename)
+    } else if let Some(base) = doc
+      .get_site_directory()
+      .or_else(|| doc.get_destination_directory())
+    {
+      format!("{}/{}", base, rel_dest)
     } else {
-      basename.to_string()
+      rel_dest.clone()
     };
     let ensure_parent = |dest: &str| {
       if let Some(parent) = Path::new(dest).parent() {
@@ -618,7 +639,13 @@ impl Processor for XSLT {
       for node in &resource_nodes {
         if let Some(src) = node.get_attribute("src") {
           let resource_type = node.get_attribute("type");
-          let _path = self.copy_resource(&doc, &src, resource_type.as_deref());
+          let path = self.copy_resource(&doc, &src, resource_type.as_deref());
+          // Perl XSLT.pm:70 — rewrite `@src` to where the file was actually copied,
+          // so the `<link>`/`<script>` the stylesheet emits resolves (#662). Node is
+          // a shared handle, so mutating the clone edits the real node.
+          if path != src {
+            node.clone().set_attribute("src", &path).ok();
+          }
         }
       }
     }


### PR DESCRIPTION
**Diagnostic.** A resource whose `@src` had a directory part (`<ltx:resource src="subdir/foo.css">`) was copied to a flattened path (`<dest>/foo.css`) while the emitted `<link>`/`<script>` href kept `subdir/foo.css` — a dangling reference. `XSLT::copy_resource` always used `file_name()` and the `<ltx:resource>` handler discarded its return.

**Approach.** `copy_resource` now preserves the src's path relative to the source directory when it stays below the destination (a plain relative path, not escaping via `../`/absolute), else flattens to the basename; the handler rewrites `@src` to the returned path — matching Perl `XSLT::copyResource` + `XSLT.pm:70`.

**Validation.** Guards `resource_folder_component_is_preserved_on_copy` and `resource_escaping_source_dir_is_flattened` (drive the binary; assert file location, no traversal, and href match). Full suite 2062/0; clippy clean. Scoped to the `<ltx:resource>` `@src` path; the `--css`/`--javascript` param path (`copy_param_resources`) shares Perl's `copyResource` upstream but has @import-layer recursion here, so its identical latent divergence is left as a focused follow-up.

Closes #662