### PR TITLE
fix: OmniBus \authors/\affil register proper creators (AGU frontmatter)

### DIFF
--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -4044,7 +4044,12 @@ fn whole_line_cs_wrapper(tokens: &Tokens) -> Option<(Token, Tokens)> {
 ///     as a duplicate affiliation — arXiv 2605.00347), descend through the
 ///     wrapper, split its inner name list, and re-apply `\cmd` to each name so
 ///     every author becomes its own creator with the correct affiliation.
-fn split_author_line(line: Tokens) -> Vec<Tokens> {
+///
+/// Public so a class binding whose `\authors{...}` is a comma/"and"-separated
+/// name list (e.g. AGU's `agujournal2019`) reuses this canonical splitter
+/// instead of re-listing the separators — the same split `\lx@add@authors`
+/// applies to a superscript-marked author line.
+pub fn split_author_line(line: Tokens) -> Vec<Tokens> {
   // Name-level separators: comma and the literal word " and " ("Alice and Bob").
   let name_seps = || vec![SplitDelim::Token(T_OTHER!(",")), literal_and()];
   let top = split_tokens(line.clone(), name_seps());

--- a/latexml_oxide/tests/cluster_frontmatter_classes.rs
+++ b/latexml_oxide/tests/cluster_frontmatter_classes.rs
@@ -5,6 +5,8 @@
 //! economy. All members are subprocess- or few-conversion tests, so
 //! co-locating them in one process stays far under the RSS fuse.
 
+mod cluster;
+
 mod fairmeta_frontmatter {
   //! Regression test: the `fairmeta.cls` (FAIR / Meta pre-print class) binding
   //! captures the class's custom frontmatter into the XML.
@@ -446,5 +448,113 @@ mod scrartcl_titlehead {
         "titlehead content {token:?} missing:\n{xml}"
       );
     }
+  }
+}
+
+mod omnibus_agu_authors {
+  //! An UNKNOWN class using the AGU `agujournal2019` author interface —
+  //! `\authors{A\affil{1}, B\affil{2}, and C\affil{3}}` with numbered
+  //! `\affiliation{n}{text}` blocks — must land as proper document creators +
+  //! affiliation contacts, NOT a side-margin `<note role="authors">` with the
+  //! affiliation bodies leaking into the flow (arXiv/html_feedback #6901, witness
+  //! 2608.15512, `\documentclass[preprint]{agujournal2019}`).
+  //!
+  //! Fixed in OmniBus (the generic unknown-class fallback), so ANY unknown class
+  //! with this interface benefits. An unknown class name (`foo`) resolves to
+  //! OmniBus regardless of whether a `foo.cls` is on disk (`load_class` never
+  //! raw-loads a class — it defaults `notex => true`), so its `\authors` /
+  //! `\affil` / `\affiliation` bindings are exactly what run for the witness's
+  //! `agujournal2019` too (that contrib binding `LoadClass!("OmniBus")`s and
+  //! defines none of these itself).
+  //!
+  //! Resilient dispatch: `\affil{n}`/`\affiliation{n}{..}` take AGU's numbered
+  //! superscript-ref path only when the label is all-digits; a non-numeric
+  //! `\affil{Dept…}`/`\affiliation{Dept…}` (authblk/AAS convention) still routes
+  //! to the plain affiliation-text form.
+  use crate::cluster::convert_to_xml;
+
+  #[test]
+  fn agu_authors_become_creators_not_a_note() {
+    // The fixture uses the AGU interface verbatim (witness 2608.15512): a
+    // comma+"and"-separated \authors list, `\affil{n}` marks, `\affiliation{n}{}`
+    // blocks, and a \thanks on the first author. `\documentclass{foo}` is an
+    // unknown class → OmniBus (never raw-loaded), the same path the witness's
+    // agujournal2019 contrib binding reaches via LoadClass!("OmniBus").
+    let xml = convert_to_xml("tests/cluster_regressions/frontmatter_agu_authors.tex");
+
+    // The four authors are SEPARATE document creators, each with a personname —
+    // never one merged blob and never a side-margin note.
+    assert!(
+      !xml.contains("role=\"authors\""),
+      "authors still land in a <note role=\"authors\"> instead of creators:\n{xml}"
+    );
+    let creators = xml.matches("role=\"author\"").count();
+    assert_eq!(
+      creators, 4,
+      "expected 4 separate author creators, found {creators}:\n{xml}"
+    );
+    for name in [
+      "Keshav Aggarwal",
+      "R. K. Choudhary",
+      "Abhirup Datta",
+      "Anshuman Sharma",
+    ] {
+      assert!(xml.contains(name), "author {name:?} missing:\n{xml}");
+    }
+    // The literal joining word "and" before the last author is a separator, not
+    // part of the name.
+    assert!(
+      !xml.contains("and Anshuman"),
+      "the joining \"and\" leaked into the last author name:\n{xml}"
+    );
+
+    // Each numbered \affiliation{n}{text} is captured as an affiliation contact —
+    // its text must NOT leak into the body flow as a bare paragraph.
+    assert!(
+      xml.contains("role=\"affiliation\""),
+      "no affiliation contact captured:\n{xml}"
+    );
+    for aff in [
+      "Indian Institute of Technology Indore",
+      "Physical Research Laboratory",
+      "Some Other Place",
+    ] {
+      assert!(
+        xml.contains(aff),
+        "affiliation text {aff:?} missing:\n{xml}"
+      );
+    }
+    // The affiliation body leaked into a leading <p> in the buggy baseline; the
+    // first institute text must sit inside frontmatter, never a standalone para.
+    assert!(
+      !xml.contains("<p>Indian Institute of Technology Indore"),
+      "affiliation text leaked into the body flow as a paragraph:\n{xml}"
+    );
+    // The first author's \thanks survives as its own note on that creator.
+    assert!(
+      xml.contains("Corresponding author"),
+      "first author's \\thanks note was dropped:\n{xml}"
+    );
+  }
+
+  #[test]
+  fn authblk_style_affiliation_text_still_works() {
+    // Resilience: a non-numeric argument keeps the authblk/AAS convention where
+    // the argument IS the affiliation text (`\affil{Dept…}`/`\affiliation{Dept…}`),
+    // NOT a numbered superscript reference. `bar` is another unknown class →
+    // OmniBus; the numeric dispatch must not disturb this common path.
+    let xml = convert_to_xml("tests/cluster_regressions/frontmatter_authblk_affil.tex");
+    // Both non-numeric affiliation texts are captured verbatim as affiliation
+    // contacts — not swallowed as superscript labels or dropped.
+    for text in ["Analytical Engine Institute", "Department of Computation"] {
+      assert!(
+        xml.contains(text),
+        "authblk-style affiliation text {text:?} missing:\n{xml}"
+      );
+    }
+    assert!(
+      xml.contains("role=\"affiliation\""),
+      "no affiliation contact for authblk-style text:\n{xml}"
+    );
   }
 }

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_agu_authors.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_agu_authors.tex
@@ -1,0 +1,10 @@
+\documentclass[preprint]{foo}
+\begin{document}
+\title{A Study of Something}
+\authors{Keshav Aggarwal\affil{1}\thanks{Corresponding author}, R. K. Choudhary\affil{2}, Abhirup Datta\affil{1}, and Anshuman Sharma\affil{3}}
+\affiliation{1}{Indian Institute of Technology Indore, India}
+\affiliation{2}{Physical Research Laboratory, India}
+\affiliation{3}{Some Other Place, India}
+\maketitle
+Hello world body text.
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_authblk_affil.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_authblk_affil.tex
@@ -1,0 +1,9 @@
+\documentclass{bar}
+\begin{document}
+\title{Another Study}
+\author{Ada Lovelace}
+\affiliation{Analytical Engine Institute}
+\affil{Department of Computation}
+\maketitle
+Body.
+\end{document}

--- a/latexml_package/src/package/omnibus_cls.rs
+++ b/latexml_package/src/package/omnibus_cls.rs
@@ -33,6 +33,15 @@ fn push_keyword_body_to_frontmatter(whatsit: &mut Whatsit) -> Result<Vec<Digeste
   Ok(Vec::new())
 }
 
+/// True when `arg` (trimmed) is one or more ASCII digits and nothing else — the
+/// signal that a `\affil{n}` / `\affiliation{n}{…}` uses AGU's numbered
+/// superscript-reference convention rather than authblk/AAS affiliation text.
+fn is_all_ascii_digits(arg: &Tokens) -> bool {
+  let s = arg.to_string();
+  let s = s.trim();
+  !s.is_empty() && s.chars().all(|c| c.is_ascii_digit())
+}
+
 #[rustfmt::skip]
 LoadDefinitions!({
   // Perl L33: LoadClass('article');
@@ -152,10 +161,31 @@ LoadDefinitions!({
   // gobble (redundant running head). Match Perl; preserving it errored on a
   // literal `&` in the running head. See 0709.4236 and aas_support_sty.rs.
   def_macro_noop("\\shortauthors{}")?;
-  // \authors{author list} — alternative to \author; preserve as
-  // author list note.
-  DefMacro!("\\authors{}",
-    "\\lx@add@frontmatter{ltx:note}[role=authors]{#1}");
+  // \authors{author list} — the plural byline macro used by journal classes
+  // (AGU's agujournal2019, ametsoc, …) as an alternative to \author. It holds
+  // ONE comma-separated list of authors, the last joined with "and", each name
+  // trailed by an `\affil{n}` superscript that cross-references a numbered
+  // `\affiliation{n}{text}` block (see \affil / \affiliation below). Split it on
+  // comma + the literal " and " into SEPARATE creators (never one merged blob,
+  // never the old side-margin `<note role=authors>` — arXiv/html_feedback #6901,
+  // witness 2608.15512). Each piece keeps its `\affil{n}`, which registers the
+  // affiliation annotation on that creator during personname digestion. Empty
+  // pieces (a trailing comma, or the "and" split leaving nothing) are dropped.
+  DefMacro!("\\authors{}", sub[(list)] {
+    // Reuse the engine's canonical author-name splitter (comma + literal " and ",
+    // plus its font-wrapper descent) rather than re-listing separators — this is
+    // exactly the split `\lx@add@authors` applies to a superscript-marked author
+    // line. Each piece keeps its `\affil{n}`, which registers the affiliation
+    // annotation on that creator during personname digestion.
+    let mut calls: Vec<Token> = Vec::new();
+    for piece in split_author_line(list) {
+      if piece.to_string().trim().is_empty() {
+        continue;
+      }
+      calls.extend(Invocation!(T_CS!("\\lx@add@author"), vec![None, Some(piece)]).unlist());
+    }
+    Ok(Tokens::new(calls))
+  });
   def_macro_noop("\\alignauthor")?;
   // \correspondingauthor{name/email} — common journal-class CS used
   // inside author lists (AAS / AGU / AMS / many journals). aas_support
@@ -188,8 +218,41 @@ LoadDefinitions!({
 
   DefMacro!("\\address[]{}", "\\lx@add@address{#2}");
   Let!("\\affaddr", "\\address");
-  DefMacro!("\\affil{}",       "\\lx@add@affiliation{#1}");
-  DefMacro!("\\affiliation{}", "\\lx@add@affiliation{#1}");
+  // \affil / \affiliation carry two incompatible conventions across unknown
+  // classes, so dispatch resiliently on the argument (OmniBus must "do the best
+  // with the available information"):
+  //   * an ALL-DIGITS argument is AGU's `agujournal2019` superscript reference —
+  //     `\affil{1}` marks its author as belonging to affiliation 1, and
+  //     `\affiliation{1}{text}` declares that numbered block. Route them through
+  //     the same label/annotation pair as \altaffilmark/\altaffiltext (and
+  //     llncs \inst/\institute), so the mark cross-references the block.
+  //   * any other argument is the authblk / AAS convention where the argument IS
+  //     the affiliation text — keep the original `\lx@add@affiliation` behavior.
+  // Witness 2608.15512 (AGU) for the numbered path; authblk papers for the text
+  // path. arXiv/html_feedback #6901.
+  DefMacro!("\\affil{}", sub[(arg)] {
+    if is_all_ascii_digits(&arg) {
+      Ok(Invocation!(T_CS!("\\lx@omnibus@affil@ref"), vec![Some(arg)]))
+    } else {
+      Ok(Invocation!(T_CS!("\\lx@add@affiliation"), vec![None, Some(arg)]))
+    }
+  });
+  DefMacro!("\\lx@omnibus@affil@ref{}",
+    "\\lx@request@frontmatter@annotation[affiliation]{#1}");
+  DefMacro!("\\affiliation{}", sub[(arg)] {
+    if is_all_ascii_digits(&arg) {
+      // AGU's `\affiliation{n}{text}` — a second brace group follows. Grab it via
+      // \@ifnextchar\bgroup so a bare numeric `\affiliation{5}` (no text block)
+      // still falls back to single-arg text rather than swallowing what follows.
+      Ok(Invocation!(T_CS!("\\lx@omnibus@affiliation@numbered"), vec![Some(arg)]))
+    } else {
+      Ok(Invocation!(T_CS!("\\lx@add@affiliation"), vec![None, Some(arg)]))
+    }
+  });
+  DefMacro!("\\lx@omnibus@affiliation@numbered{}",
+    "\\@ifnextchar\\bgroup{\\lx@omnibus@affiliation@numbered@ii{#1}}{\\lx@add@affiliation{#1}}");
+  DefMacro!("\\lx@omnibus@affiliation@numbered@ii{}{}",
+    "\\lx@add@contact[role=affiliation,label={affiliation:#1}]{#2}");
   DefRegister!("\\affilskip" => Dimension::new(0));
 
   // Perl L104-123: misc name macros, mostly no-ops


### PR DESCRIPTION
**Diagnostic.** OmniBus (the generic unknown-class fallback) deposited `\authors{…}` as a side-margin `<note role=authors>` and let each numbered `\affiliation{n}{text}`'s body leak into the document flow — so an AGU `agujournal2019` paper lost its author byline entirely (arXiv/html_feedback#6901, witness 2608.15512). Perl's own OmniBus has the same gap.

**Approach.** `\authors` now splits on comma / literal "and" / the `\and` family into separate `<ltx:creator>` personnames; `\affil{n}` / `\affiliation{n}{text}` dispatch to the numbered superscript-reference pair (`\lx@request@frontmatter@annotation` / `\lx@add@contact[label=affiliation:n]` — the same mechanism as `\altaffilmark`/`\altaffiltext` and llncs `\inst`/`\institute`) on an all-digit argument, keeping the authblk/AAS affiliation-**text** form for any non-numeric argument. Resilient to the different conventions unknown classes use.

**Validation.** New guards `omnibus_agu_authors::{agu_authors_become_creators_not_a_note, authblk_style_affiliation_text_still_works}` (via the in-process convert API); full suite 2062/0; clippy/fmt clean; witness 2608.15512 converts 0-error with four cross-referenced creators (was a `<note role=authors>` + leaked affiliation paragraphs).

Resolves arXiv/html_feedback#6901

🤖 Generated with [Claude Code](https://claude.com/claude-code)