### PR TITLE
fix #520: minted \newminted no longer clobbers \[ and swallows the document

### DIFF
--- a/latexml_contrib/src/minted_sty.rs
+++ b/latexml_contrib/src/minted_sty.rs
@@ -81,20 +81,43 @@ LoadDefinitions!({
   DefMacro!("\\listoflistingscaption", "List of listings");
   // Perl minted.sty.ltxml L58-99 dynamically defined new CSes via runtime
   // DefMacroI closures. The TeX-level equivalent uses `\expandafter\def
-  // \csname <name>\endcsname` so the same user input now binds working
-  // aliases. `\newmint{foo}{opts}` → `\foo` behaves like `\verb`;
-  // `\newmintinline{foo}{opts}` → `\fooinline`; `\newminted{foo}{opts}`
-  // → `\begin{foo}`/`\begin{foo*}` expand to `\begin{lstlisting}` (since
-  // listings is the Perl-chosen substrate on L30). `\newmintedfile` binds
-  // either the given optional macro or `\<lang>file` to `\inputminted`.
+  // \csname <name>\endcsname` so the same user input now binds working aliases.
+  //
+  // Each of `\newmint` / `\newmintinline` / `\newminted` / `\newmintedfile` takes
+  // an OPTIONAL `[name]` before the two mandatory `{language}{options}` args (real
+  // minted.sty: `\newcommand{..}[3][]`, each with its own default name). The prior
+  // port declared the first three as two-mandatory `#1#2`, so
+  // `\newminted[leancode]{lean4}{...}` bound `#1 = "["` and then ran
+  // `\expandafter\def\csname [\endcsname{...}` — but `\csname [\endcsname` IS the
+  // control sequence `\[`, silently redefining display-math open to
+  // `\begin{lstlisting}`; every later `\[` opened a listing that ran to EOF,
+  // swallowing the body and `\bibliography` with no `Error:` (arXiv:2606.05629,
+  // issue #520). Each of the three now branches on `\@ifnextchar[` (as
+  // `\newmintedfile` already did) and consumes all three args, so the optional
+  // env/command name binds correctly and nothing (least of all `\[`) leaks. Default names match
+  // minted: `\newmint{lang}` → `\lang` (verb-like); `\newmintinline{lang}` →
+  // `\langinline`; `\newminted{lang}` → env `langcode`; the optional form uses the
+  // given name verbatim. listings is the Perl-chosen substrate (L30), so a
+  // `\newminted` env delegates to `\lstnewenvironment{name}` (as the tcolorbox
+  // binding's `\newtcblisting` does) — whose verbatim reader stops at the env's own
+  // `\end{name}`. The prior alias to `\begin{lstlisting}` read raw until the literal
+  // `\end{lstlisting}`, so a `\newminted` env used normally (closed by `\end{name}`)
+  // never saw its marker and ran to EOF, swallowing the rest of the document.
+  // `\newmintedfile` binds either the given optional macro or `\<lang>file` to
+  // `\inputminted`.
   RawTeX!(
-    r#"\def\newmint#1#2{\expandafter\def\csname #1\endcsname{\verb}}
-\def\newmintinline#1#2{\expandafter\def\csname #1inline\endcsname{\verb}}
-\def\newminted#1#2{%
-  \expandafter\def\csname #1\endcsname{\begin{lstlisting}}%
-  \expandafter\def\csname end#1\endcsname{\end{lstlisting}}%
-  \expandafter\def\csname #1*\endcsname{\begin{lstlisting}}%
-  \expandafter\def\csname end#1*\endcsname{\end{lstlisting}}}
+    r#"\def\newmint{\@ifnextchar[\lx@minted@nm@opt\lx@minted@nm@noopt}
+\def\lx@minted@nm@noopt#1#2{\expandafter\def\csname #1\endcsname{\verb}}
+\def\lx@minted@nm@opt[#1]#2#3{\expandafter\def\csname #1\endcsname{\verb}}
+\def\newmintinline{\@ifnextchar[\lx@minted@nmi@opt\lx@minted@nmi@noopt}
+\def\lx@minted@nmi@noopt#1#2{\expandafter\def\csname #1inline\endcsname{\verb}}
+\def\lx@minted@nmi@opt[#1]#2#3{\expandafter\def\csname #1\endcsname{\verb}}
+\def\newminted{\@ifnextchar[\lx@minted@nmd@opt\lx@minted@nmd@noopt}
+\def\lx@minted@nmd@noopt#1#2{\lx@minted@nmd@def{#1code}}
+\def\lx@minted@nmd@opt[#1]#2#3{\lx@minted@nmd@def{#1}}
+\def\lx@minted@nmd@def#1{%
+  \lstnewenvironment{#1}{}{}%
+  \lstnewenvironment{#1*}[1]{}{}}
 \def\newmintedfile{\@ifnextchar[\lx@minted@nmf@opt\lx@minted@nmf@noopt}
 \def\lx@minted@nmf@opt[#1]#2{\let#1\inputminted}
 \def\lx@minted@nmf@noopt#1{\expandafter\let\csname #1file\endcsname\inputminted}

--- a/latexml_oxide/tests/cluster_package_guards.rs
+++ b/latexml_oxide/tests/cluster_package_guards.rs
@@ -1817,3 +1817,71 @@ degraded-body-text
     );
   }
 }
+
+/// Regression: minted's `\newmintinline`/`\newminted`/`\newmint` take an optional
+/// `[env-name]` before the two mandatory `{language}{options}` args (real
+/// minted.sty: `\newcommand{..}[3][]`). The Rust binding declared them with a
+/// two-mandatory `#1#2` signature, so `\newminted[leancode]{lean4}{...}` captured
+/// `#1 = "["` and ran `\expandafter\def\csname [\endcsname{...}` — and `\csname
+/// [\endcsname` IS the control sequence `\[`, silently redefining display-math open
+/// to `\begin{lstlisting}`. Every later `\[` then opened a listing that ran to
+/// end-of-file, swallowing the body and `\bibliography` with no `Error:` — a silent
+/// bibliography loss. Witness `arXiv:2606.05629` (issue #520). The reporter's first
+/// hypothesis (the comment-wrapped `leancode` env runs away) is not the cause: that
+/// block sits inside `\begin{comment}` and is discarded; the runaway starts at the
+/// first `\[` far earlier.
+mod minted_newminted_optional_env_name {
+  use crate::cluster::convert_to_xml_contrib_clean;
+
+  #[test]
+  fn newminted_optional_name_does_not_clobber_display_math() {
+    let xml =
+      convert_to_xml_contrib_clean("tests/cluster_regressions/minted_newminted_optarg_comment.tex");
+    // The runaway listing is the whole bug: with `\[` clobbered, a single
+    // `<listing>` swallows everything after the first display equation. The
+    // `leancode` block is inside `\begin{comment}` (discarded) and `\[` is math, so
+    // a healthy conversion emits NO listing at all.
+    assert!(
+      !xml.contains("listingline"),
+      "a runaway listing swallowed the document (\\[ clobbered by \\newminted):\n{xml}"
+    );
+    // Content on BOTH sides of the display equation must survive into the flow.
+    assert!(
+      xml.contains("Body text after the display equation"),
+      "body after the display equation was swallowed:\n{xml}"
+    );
+    assert!(
+      xml.contains("Tail paragraph immediately before the bibliography"),
+      "tail before the bibliography was swallowed:\n{xml}"
+    );
+    // `\bibliography` executed (the element exists at the core stage) rather than
+    // being consumed as listing text.
+    assert!(
+      xml.contains("<bibliography "),
+      "\\bibliography never executed — swallowed by the runaway listing:\n{xml}"
+    );
+  }
+
+  /// The title's literal claim: a `\newminted`-created env used the normal way
+  /// (outside a comment) must close at its own `\end{name}` and NOT read on to the
+  /// literal `\end{lstlisting}`. The created env now delegates to
+  /// `\lstnewenvironment{name}`, whose verbatim reader stops at `\end{name}`.
+  #[test]
+  fn newminted_env_closes_at_its_own_end_marker() {
+    let xml =
+      convert_to_xml_contrib_clean("tests/cluster_regressions/minted_newminted_direct_env.tex");
+    // The env body IS captured as a listing (the code is tokenized into
+    // `<text class="ltx_lst_*">` spans, so the raw string is not contiguous — key
+    // off the listing element instead).
+    assert!(
+      xml.contains("ltx_lstlisting"),
+      "the \\newminted env body was not captured as a listing:\n{xml}"
+    );
+    // …and it closes at `\end{leancode}`, so text after it stays in the document
+    // flow instead of being swallowed to EOF.
+    assert!(
+      xml.contains("After the code listing"),
+      "content after the \\newminted env was swallowed (ran past \\end{{name}}):\n{xml}"
+    );
+  }
+}

--- a/latexml_oxide/tests/cluster_regressions/minted_newminted_direct_env.tex
+++ b/latexml_oxide/tests/cluster_regressions/minted_newminted_direct_env.tex
@@ -1,0 +1,17 @@
+\documentclass{article}
+\usepackage{minted}
+% A \newminted-created environment used the normal way (outside any comment). It
+% is closed by \end{leancode}, NOT \end{lstlisting}: the created env must read its
+% body verbatim up to its own \end{name} and hand control back, so the text after
+% it stays in the document flow. Before the fix the env aliased to
+% \begin{lstlisting}, whose reader hunts for the literal \end{lstlisting} and so
+% ran to end-of-file (issue #520, "wrong \end marker").
+\newminted[leancode]{lean4}{fontsize=\footnotesize}
+\begin{document}
+Before the code listing.
+\begin{leancode}
+some lean code
+more lean code
+\end{leancode}
+After the code listing.
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/minted_newminted_optarg_comment.tex
+++ b/latexml_oxide/tests/cluster_regressions/minted_newminted_optarg_comment.tex
@@ -1,0 +1,31 @@
+\documentclass{article}
+\usepackage{comment}
+\usepackage{minted}
+% minted's \newmintinline / \newminted take an optional [env-name] before the two
+% mandatory {language}{options} args (real minted.sty: \newcommand{..}[3][]). The
+% Rust binding must parse that optional arg: with a wrong #1#2 (two-mandatory)
+% signature, \newminted[leancode]{lean4}{...} captures #1 = "[" and then runs
+% \expandafter\def\csname [\endcsname{...} — but \csname [\endcsname IS the control
+% sequence \[ , silently redefining display-math open to \begin{lstlisting}. Every
+% later \[ then opens a listing that runs to end-of-file, swallowing the body and
+% \bibliography with no Error:. Witness arXiv:2606.05629 (issue #520).
+\newmintinline[lean]{lean4}{bgcolor=white}
+\newminted[leancode]{lean4}{
+  fontsize=\footnotesize,
+  breaklines=true
+}
+\begin{document}
+Intro paragraph before the display equation.
+\[
+  4n-3 \le R(B_{n-2},B_n)
+\]
+Body text after the display equation, still in the flow.
+\begin{comment}
+\begin{leancode}[escapeinside=||]
+abbrev Vertex := Fin 37
+\end{leancode}
+\end{comment}
+Tail paragraph immediately before the bibliography.
+\bibliographystyle{plain}
+\bibliography{references}
+\end{document}


### PR DESCRIPTION
**Diagnostic.** minted's `\newmint`/`\newmintinline`/`\newminted` take an optional `[name]` before their two mandatory `{language}{options}` args (real minted.sty: `\newcommand{..}[3][]`), but `latexml_contrib/src/minted_sty.rs` declared them as two-mandatory `#1#2`. So `\newminted[leancode]{lean4}{...}` bound `#1 = "["` and ran `\expandafter\def\csname [\endcsname{...}` — and `\csname [\endcsname` **is** the control sequence `\[`, silently redefining display-math open to `\begin{lstlisting}`. Every later `\[` then opened a listing that ran to EOF, swallowing the body and `\bibliography` with no `Error:` (witness `arXiv:2606.05629`, a silent 0-bibitem loss — the comment-wrapped `leancode` env was a red herring).

**Approach.** All three now branch on `\@ifnextchar[` (the idiom `\newmintedfile` already used) and consume all three args, so the optional name binds and `\[` is untouched; default names match minted (`\newmint`→`\<lang>`, `\newmintinline`→`\<lang>inline`, `\newminted`→env `<lang>code`). A `\newminted` env now delegates to `\lstnewenvironment{name}` (as tcolorbox's `\newtcblisting` does), whose verbatim reader stops at the env's own `\end{name}` — fixing the title's latent "wrong `\end` marker" runaway for a `\newminted` env used outside a comment.

**Validation.** Red→green guards `newminted_optional_name_does_not_clobber_display_math` and `newminted_env_closes_at_its_own_end_marker` (`cluster_package_guards`); witness 2606.05629 now 0-error with 19/19 cited bibentries; full suite 2065/2065; clippy/fmt clean.

Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)