### PR TITLE
docs #297: Perl .ltxml bindings are not loaded — rewrite as .rhai

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,16 @@ DefMacro("\\greet{}", |name| "Hello, " + name + "!");
 DefConstructor("\\mytext{}", "<ltx:text class=\"rhai\">#1</ltx:text>");
 ```
 
+> **Coming from Perl LaTeXML?** A Perl `.sty.ltxml` / `.cls.ltxml` binding is
+> **not** loaded — latexml-oxide has no Perl interpreter. Rewrite it as a
+> `.sty.rhai` / `.cls.rhai` file: the common `Def…` entry points (`DefMacro`,
+> `DefEnvironment`, `DefConstructor`, `DefPrimitive`, …) keep the same names and
+> signatures, in Rhai syntax (doubled backslashes). For example, Perl
+> `DefEnvironment('{nowrap}', "<ltx:block class='nowrap'>#body</ltx:block>")`
+> becomes, verbatim minus the `use`/`1;` boilerplate,
+> `DefEnvironment("{nowrap}", "<ltx:block class='nowrap'>#body</ltx:block>");`.
+> See the worked example and interface reference below for the full surface.
+
 Discovery rides the ordinary search paths (the document's own directory, plus any
 `--path DIR`), and the `.rhai` tier is consulted **first** — so a
 `article.cls.rhai` deliberately *overrides* the built-in `article` binding, which


### PR DESCRIPTION
**Diagnostic.** #297 tracked the removed `nowrap.sty.ltxml` binding-transition path. latexml-oxide has no Perl interpreter, so a `.sty.ltxml` / `.cls.ltxml` file is never loaded — the migration target is a `.rhai` binding. This was undocumented, so a Perl user has no signpost.

**Approach.** Docs-only: a "Coming from Perl LaTeXML?" callout after the Rhai example in README.md, showing the `DefEnvironment('{nowrap}', …)` → `.sty.rhai` rewrite (same entry-point names/signatures, Rhai syntax).

**Validation.** Verified empirically: a `nowrap.sty.rhai` with `DefEnvironment("{nowrap}", "<ltx:block class='nowrap'>#body</ltx:block>");` on `--path` produces `<block class="nowrap">…</block>` with zero warnings; `DefMacro`/`DefEnvironment`/`DefConstructor`/`DefPrimitive` are all registered on the Rhai surface. No code changed.

Closes #297