### PR TITLE
feat: minted inline commands render + syntax highlighting (follow-up to #520)

### DIFF
--- a/latexml_contrib/src/minted_sty.rs
+++ b/latexml_contrib/src/minted_sty.rs
@@ -95,29 +95,38 @@ LoadDefinitions!({
   // issue #520). Each of the three now branches on `\@ifnextchar[` (as
   // `\newmintedfile` already did) and consumes all three args, so the optional
   // env/command name binds correctly and nothing (least of all `\[`) leaks. Default names match
-  // minted: `\newmint{lang}` → `\lang` (verb-like); `\newmintinline{lang}` →
-  // `\langinline`; `\newminted{lang}` → env `langcode`; the optional form uses the
-  // given name verbatim. listings is the Perl-chosen substrate (L30), so a
-  // `\newminted` env delegates to `\lstnewenvironment{name}` (as the tcolorbox
+  // minted: `\newmint{lang}` → `\lang`; `\newmintinline{lang}` → `\langinline`;
+  // `\newminted{lang}` → env `langcode`; the optional form uses the given name
+  // verbatim.
+  //
+  // The inline commands (`\mint`, `\mintinline`, and the `\newmint`/`\newmintinline`
+  // aliases) route to `\lstinline[language=<lang>]`, NOT `\verb`: `\verb` is
+  // delimiter-based, so the common `\mintinline{lang}{code}` BRACE form read `{` as
+  // the delimiter and ran past the closing `}` (garbled code + unbalanced-group
+  // errors that broke following content); `\lstinline` accepts braces and, given the
+  // language, highlights the snippet. listings is the Perl-chosen substrate (L30),
+  // so a `\newminted` env delegates to `\lstnewenvironment{name}` (as the tcolorbox
   // binding's `\newtcblisting` does) — whose verbatim reader stops at the env's own
-  // `\end{name}`. The prior alias to `\begin{lstlisting}` read raw until the literal
-  // `\end{lstlisting}`, so a `\newminted` env used normally (closed by `\end{name}`)
-  // never saw its marker and ran to EOF, swallowing the rest of the document.
-  // `\newmintedfile` binds either the given optional macro or `\<lang>file` to
-  // `\inputminted`.
+  // `\end{name}` (the prior alias to `\begin{lstlisting}` read raw until the literal
+  // `\end{lstlisting}`, so a `\newminted` env used normally ran to EOF) — and its
+  // start code activates the language via `\lstset{language=<lang>}` for keyword/
+  // string/comment highlighting. Language matching is case-insensitive and an unknown
+  // language (e.g. `lean4`) is a silent no-op, so minted's Pygments lexer name passes
+  // through verbatim and degrades to plain text rather than erroring. `\newmintedfile`
+  // binds either the given optional macro or `\<lang>file` to `\inputminted`.
   RawTeX!(
     r#"\def\newmint{\@ifnextchar[\lx@minted@nm@opt\lx@minted@nm@noopt}
-\def\lx@minted@nm@noopt#1#2{\expandafter\def\csname #1\endcsname{\verb}}
-\def\lx@minted@nm@opt[#1]#2#3{\expandafter\def\csname #1\endcsname{\verb}}
+\def\lx@minted@nm@noopt#1#2{\expandafter\def\csname #1\endcsname{\lstinline[language=#1]}}
+\def\lx@minted@nm@opt[#1]#2#3{\expandafter\def\csname #1\endcsname{\lstinline[language=#2]}}
 \def\newmintinline{\@ifnextchar[\lx@minted@nmi@opt\lx@minted@nmi@noopt}
-\def\lx@minted@nmi@noopt#1#2{\expandafter\def\csname #1inline\endcsname{\verb}}
-\def\lx@minted@nmi@opt[#1]#2#3{\expandafter\def\csname #1\endcsname{\verb}}
+\def\lx@minted@nmi@noopt#1#2{\expandafter\def\csname #1inline\endcsname{\lstinline[language=#1]}}
+\def\lx@minted@nmi@opt[#1]#2#3{\expandafter\def\csname #1\endcsname{\lstinline[language=#2]}}
 \def\newminted{\@ifnextchar[\lx@minted@nmd@opt\lx@minted@nmd@noopt}
-\def\lx@minted@nmd@noopt#1#2{\lx@minted@nmd@def{#1code}}
-\def\lx@minted@nmd@opt[#1]#2#3{\lx@minted@nmd@def{#1}}
-\def\lx@minted@nmd@def#1{%
-  \lstnewenvironment{#1}{}{}%
-  \lstnewenvironment{#1*}[1]{}{}}
+\def\lx@minted@nmd@noopt#1#2{\lx@minted@nmd@def{#1code}{#1}}
+\def\lx@minted@nmd@opt[#1]#2#3{\lx@minted@nmd@def{#1}{#2}}
+\def\lx@minted@nmd@def#1#2{%
+  \lstnewenvironment{#1}{\lstset{language=#2}}{}%
+  \lstnewenvironment{#1*}[1]{\lstset{language=#2,##1}}{}}
 \def\newmintedfile{\@ifnextchar[\lx@minted@nmf@opt\lx@minted@nmf@noopt}
 \def\lx@minted@nmf@opt[#1]#2{\let#1\inputminted}
 \def\lx@minted@nmf@noopt#1{\expandafter\let\csname #1file\endcsname\inputminted}
@@ -127,8 +136,8 @@ LoadDefinitions!({
   def_macro_noop("\\setmintedinline[]{}")?;
   def_macro_noop("\\usemintedstyle[]{}")?;
   def_macro_noop("\\SetupFloatingEnvironment{}{}")?;
-  DefMacro!("\\mint[]{}", "\\verb");
-  DefMacro!("\\mintinline[]{}", "\\verb");
+  DefMacro!("\\mint[]{}", "\\lstinline[language=#2]");
+  DefMacro!("\\mintinline[]{}", "\\lstinline[language=#2]");
   // \begin{minted}[opts]{language} — port of Perl mintedEnvBody
   // (minted.sty.ltxml L68-85). Read raw input lines until \end{minted},
   // then dispatch to listings' lst_process_display, mirroring Perl's
@@ -145,17 +154,19 @@ LoadDefinitions!({
     // `escapeinside=!!` never reached the listings tokenizer: an inline
     // `!$\label{…}$!` was emitted as literal code, its `\label` never ran, and
     // `\ref` to that line vanished (html_feedback#1028, arXiv:2308.03276;
-    // OXIDIZED_DESIGN #127). We now feed the options through `\lstset{…}` (the
-    // same activation `\begin{lstlisting}` uses), so minted's `escapeinside`/
-    // `mathescape` — shared verbatim with the listings substrate — take effect;
-    // minted-only keys (`linenos`, `fontsize`, …) are stored harmlessly and
-    // ignored. The `{language}` arg is left unapplied (we keep the current
-    // language-agnostic rendering). Scoped to the environment's `bgroup`.
+    // OXIDIZED_DESIGN #127). We now feed both the `{language}` and the options
+    // through `\lstset{…}` (the same activation `\begin{lstlisting}` uses), so
+    // minted's `escapeinside`/`mathescape` — shared verbatim with the listings
+    // substrate — take effect and the language activates listings' keyword/string/
+    // comment highlighting; minted-only keys (`linenos`, `fontsize`, …) are stored
+    // harmlessly. Scoped to the environment's `bgroup`.
     let params = parse_parameters("[]{}", &cs, true)?;
     let expansion: Option<ExpansionBody> = Some(ExpansionBody::Closure(Rc::new(
       move |args: Vec<ArgWrap>| {
-        // args[0] = `[opts]` (optional); args[1] = `{language}` (unapplied).
-        let opts = args.into_iter().next().and_then(|a| a.owned_tokens());
+        // args[0] = `[opts]` (optional); args[1] = `{language}`.
+        let mut it = args.into_iter();
+        let opts = it.next().and_then(|a| a.owned_tokens());
+        let lang = it.next().and_then(|a| a.owned_tokens());
         bgroup();
         assign_value(
           "current_environment",
@@ -168,13 +179,29 @@ LoadDefinitions!({
           Tokens!(T_OTHER!("lstlisting")),
           None,
         )?;
-        if let Some(opts) = opts
-          && !opts.unlist_ref().is_empty()
-        {
+        // Feed `language=<lang>,<opts>` to `\lstset`. The language activates the
+        // listings language pack for keyword/string/comment highlighting; matching
+        // is case-insensitive and an unknown language (e.g. `lean4`) is a silent
+        // no-op, so passing minted's Pygments lexer name verbatim degrades to the
+        // old plain rendering rather than erroring. The `[opts]` still ride along
+        // for `escapeinside`/`mathescape` (html_feedback#1028); minted-only keys
+        // (`linenos`, `fontsize`, …) are stored harmlessly.
+        let mut kv: Vec<Token> = Vec::new();
+        if let Some(lang) = lang.as_ref().filter(|l| !l.unlist_ref().is_empty()) {
+          kv.extend(Tokenize!("language=").unlist());
+          kv.extend(lang.unlist_ref().iter().cloned());
+        }
+        if let Some(opts) = opts.as_ref().filter(|o| !o.unlist_ref().is_empty()) {
+          if !kv.is_empty() {
+            kv.push(T_OTHER!(","));
+          }
+          kv.extend(opts.unlist_ref().iter().cloned());
+        }
+        if !kv.is_empty() {
           let _ = digest(Tokens::new(
-            vec![T_CS!("\\lstset"), T_BEGIN!()]
-              .into_iter()
-              .chain(opts.unlist().iter().cloned())
+            std::iter::once(T_CS!("\\lstset"))
+              .chain(std::iter::once(T_BEGIN!()))
+              .chain(kv)
               .chain(std::iter::once(T_END!()))
               .collect(),
           ));

--- a/latexml_oxide/tests/cluster_package_guards.rs
+++ b/latexml_oxide/tests/cluster_package_guards.rs
@@ -1885,3 +1885,48 @@ mod minted_newminted_optional_env_name {
     );
   }
 }
+
+/// minted binding quality (follow-up to #520): the inline `\mintinline{lang}{code}`
+/// brace form must render without erroring or swallowing following content, and
+/// `\begin{minted}{language}` must activate listings' syntax highlighting.
+mod minted_inline_and_highlighting {
+  use crate::cluster::convert_to_xml_contrib_clean;
+
+  /// `\mintinline{python}{lambda x: x + 1}` used to map to `\verb`, whose
+  /// delimiter is the first char `{` — it ran past the closing `}`, emitted two
+  /// unbalanced-group errors, and broke the `\begin{minted}` block that followed.
+  /// Routing to `\lstinline` (which accepts braces) keeps it inline and clean.
+  #[test]
+  fn mintinline_brace_form_does_not_error_or_swallow() {
+    // The strict 0-error gate is itself the primary canary: the old `\verb`
+    // mapping raised `unexpected:}` / `unexpected:\endgroup` here.
+    let xml =
+      convert_to_xml_contrib_clean("tests/cluster_regressions/minted_inline_and_highlighting.tex");
+    // Text on both sides of the inline snippet survives (the brace form did not
+    // run away), and the following block still renders.
+    assert!(
+      xml.contains("in a sentence"),
+      "text after the inline \\mintinline was swallowed:\n{xml}"
+    );
+    assert!(
+      xml.contains("Tail paragraph after the block"),
+      "the \\begin{{minted}} block or its trailing text was swallowed:\n{xml}"
+    );
+    assert!(
+      xml.contains("ltx_lstlisting"),
+      "the \\begin{{minted}} block did not render as a listing:\n{xml}"
+    );
+  }
+
+  /// `\begin{minted}{python}` now feeds the language to `\lstset`, so listings
+  /// tags `def`/`if`/`return` as keywords (was plain identifiers — no highlighting).
+  #[test]
+  fn minted_language_activates_keyword_highlighting() {
+    let xml =
+      convert_to_xml_contrib_clean("tests/cluster_regressions/minted_inline_and_highlighting.tex");
+    assert!(
+      xml.contains("ltx_lst_keyword"),
+      "minted block produced no highlighted keywords (language not activated):\n{xml}"
+    );
+  }
+}

--- a/latexml_oxide/tests/cluster_regressions/minted_inline_and_highlighting.tex
+++ b/latexml_oxide/tests/cluster_regressions/minted_inline_and_highlighting.tex
@@ -1,0 +1,22 @@
+\documentclass{article}
+\usepackage{minted}
+% Two quality guarantees of the minted binding:
+%  1. \mintinline{lang}{code} (BRACE form) must render inline and not error. It
+%     used to map to \verb, which is delimiter-based: `\verb{code}` reads `{` as
+%     the delimiter and runs past the closing `}`, garbling the code, emitting
+%     unbalanced-group errors, and breaking the following block. Routing to
+%     \lstinline (minted's real listings substrate, which accepts braces) fixes it.
+%  2. \begin{minted}{python} must syntax-highlight: the {language} argument is fed
+%     to \lstset so listings activates its keyword/string/comment classes.
+\begin{document}
+Inline \mintinline{python}{lambda x: x + 1} in a sentence.
+
+\begin{minted}{python}
+def factorial(n):
+    if n <= 1:
+        return 1
+    return n * factorial(n - 1)
+\end{minted}
+
+Tail paragraph after the block.
+\end{document}


### PR DESCRIPTION
Follow-up to #520 on the minted binding's rendering quality (no new issue).

**Diagnostic.** (1) `\mint`/`\mintinline` and the `\newmint`/`\newmintinline` aliases mapped to `\verb`, whose delimiter is the first char — so the common `\mintinline{lang}{code}` **brace form** read `{` as the delimiter, ran past the closing `}` (garbled code, two unbalanced-group errors, and broke the following block). (2) The `{language}` arg was dropped, so every listing rendered as plain identifiers — no syntax highlighting.

**Approach.** (1) Route the inline commands to `\lstinline` (minted's listings substrate, which accepts braces), so both `{code}` and `|code|` forms render inline. (2) Feed `language=<lang>` to `\lstset` for `\begin{minted}`, the `\newminted` env, and the inline commands, activating listings' keyword/string/comment classes. Matching is case-insensitive and an unknown language (e.g. `lean4`) is a silent no-op, so minted's Pygments lexer name passes through verbatim and degrades to plain text rather than erroring — zero regression. (Rich Pygments highlighting via `pygmentize` is deliberately out of scope, parked for a separate spike.)

**Validation.** Red→green guards `mintinline_brace_form_does_not_error_or_swallow` and `minted_language_activates_keyword_highlighting` (both verified RED on `main`, GREEN here); #520 witness `arXiv:2606.05629` regression-free (19/19 cited); full suite 2078/2078; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)