### PR TITLE
test: guard titlepic \@maketitle-redefine teaser figure (already surpasses Perl)

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3608,6 +3608,14 @@ Same-host Perl 0.8.8 drops it identically (SHARED-FAILURE, Perl-origin). Minimal
 accumulated content in a title-neutralized group before relaxing it, so the figure renders and the
 reference resolves to "Fig. 1". Guard:
 `06_cluster_frontmatter::frontmatter_maketitle_injected_figure_survives`.
+
+Second witness via `titlepic.sty`, which *redefines* `\@maketitle` (rather than
+`\g@addto@macro`-appending) to inject a `\@titlepic`-held `\captionof{figure}`+`\label`:
+arXiv/html_feedback#6675 (witness 2606.25280, the boids/EvoFlock paper — teaser
+`\ref{fig:boid_flock}` rendered "Figure LABEL:fig:boid_flock", the figure dropped, and
+the real Figure 2 became Figure 1). Same #124 mechanism recovers it (the redefinition
+leaves `\@maketitle` non-empty, so it is deposited); production ar5iv (Perl) still drops
+it. Guard: `06_cluster_frontmatter::frontmatter_titlepic_redefined_maketitle_figure_survives`.
 ## 88. Partially-bold author block renders incoherently (Rust surpasses)
 
 `neurips_2023` (and similar classes) bold the *whole* author block with a block-level `\bf` in

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -4704,7 +4704,19 @@ figure vanished and `\figref{fig:teaser}` rendered "Fig. LABEL:fig:teaser". Now 
 figure renders (`xml:id="S0.F1"`) and the reference resolves to "Fig. 1". Shared
 upstream bug recorded as KNOWN_PERL_ERRORS #90.
 
-**Guard**: `06_cluster_frontmatter::frontmatter_maketitle_injected_figure_survives`.
+Second witness, a distinct authoring path into the same mechanism: arXiv 2606.25280
+(html_feedback #6675) uses `titlepic.sty`, which does not *append* to `\@maketitle`
+but *redefines* it wholesale (`\renewcommand\@maketitle{…{\centering\@titlepic\par}…}`)
+with the teaser `\captionof{figure}`+`\label` held in `\@titlepic`. Because the
+redefinition makes `\@maketitle` non-empty, the `\ifx\@maketitle\@empty` guard falls
+through and `\lx@deposit@maketitle` runs it — so the figure survives and takes number 1
+here too, while production ar5iv (Perl) still drops it. (Author-local `\def\name`
+*inside* a redefined `\@maketitle` remains unsupported — that needs the author block, not
+just the injected content; KNOWN_PERL_ERRORS #47.)
+
+**Guard**: `06_cluster_frontmatter::frontmatter_maketitle_injected_figure_survives`
+(append path); `06_cluster_frontmatter::frontmatter_titlepic_redefined_maketitle_figure_survives`
+(titlepic redefine path).
 ### 122. A `font="bold"` wrapping an entire author name is unwrapped for coherence
 
 **Perl** captures semantic creators from `\author`, not the class's visual title

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -1026,3 +1026,38 @@ fn frontmatter_maketitle_injected_figure_survives() {
     "the injected figure's graphics were lost:\n{x}"
   );
 }
+
+/// `titlepic` variant of the injected-figure case above. `titlepic.sty` does not
+/// APPEND to `\@maketitle` (`\g@addto@macro`); it stores its argument in
+/// `\@titlepic` and REDEFINES `\@maketitle` wholesale (`\renewcommand`) to inject
+/// `{\centering\@titlepic\par}` between the author block and the abstract. That is
+/// a different path into the same machinery OXIDIZED_DESIGN #124 repaired, so it
+/// gets its own guard: the teaser `\captionof{figure}`+`\label` must survive,
+/// register its label, and take figure number 1 — otherwise every `\ref` renders
+/// the raw "LABEL:fig:…" and the real second figure shifts to Figure 1.
+///
+/// New witness arXiv:2606.25280 (html_feedback#6675). The production ar5iv (Perl)
+/// still drops it — this is a Rust-supersedes-Perl behavior, locked here.
+#[test]
+fn frontmatter_titlepic_redefined_maketitle_figure_survives() {
+  let x = convert_to_xml("tests/cluster_regressions/frontmatter_titlepic_teaser_figure.tex");
+  // Teaser figure survived and carries its label (dropped before #124).
+  assert!(
+    x.contains(r#"labels="LABEL:fig:teaser""#),
+    "titlepic teaser figure dropped (no label):\n{x}"
+  );
+  assert!(
+    x.contains("Teaser flock caption"),
+    "titlepic teaser caption lost:\n{x}"
+  );
+  // Numbered as the first figure (xml:id S0.F1) — so the body `\ref{fig:teaser}`
+  // resolves to "Figure 1", not the raw key, and the real figure stays Figure 2.
+  assert!(
+    x.contains(r#"labels="LABEL:fig:teaser" xml:id="S0.F1""#),
+    "titlepic teaser figure not numbered first (expected xml:id S0.F1):\n{x}"
+  );
+  assert!(
+    x.contains(r#"labels="LABEL:fig:second""#),
+    "the real second figure lost its label:\n{x}"
+  );
+}

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_titlepic_teaser_figure.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_titlepic_teaser_figure.tex
@@ -1,0 +1,23 @@
+\documentclass{article}
+\usepackage{caption}
+% titlepic.sty's essential mechanism, inlined so the guard needs neither the host
+% titlepic.sty nor --includestyles: \titlepic stores its argument in \@titlepic,
+% and the redefined \@maketitle injects it between the author block and the
+% abstract. The witness (arXiv:2606.25280, arXiv/html_feedback#6675) places a
+% \captionof{figure}+\label "teaser" figure there.
+\makeatletter
+\def\titlepic#1{\gdef\@titlepic{#1}}
+\def\@titlepic{}
+\renewcommand\@maketitle{\newpage\null\vskip 2em%
+  \begin{center}{\LARGE \@title \par}\vskip 1.5em{\large\@author \par}\end{center}%
+  \vskip .5em{\centering\@titlepic\par}\par\vskip 1.5em}
+\makeatother
+\title{Teaser}\author{A. Author}\date{}
+\titlepic{\captionof{figure}{Teaser flock caption}\label{fig:teaser}}
+\begin{document}
+\maketitle
+\begin{abstract}Abstract text.\end{abstract}
+Body sees Figure~\ref{fig:teaser}.
+\begin{figure}\caption{Second figure}\label{fig:second}\end{figure}
+Body also sees Figure~\ref{fig:second}.
+\end{document}


### PR DESCRIPTION
**Diagnostic.** arXiv/html_feedback#6675 (witness 2606.25280): a `titlepic` teaser figure vanishes from the HTML and every `\ref` renders the raw `LABEL:fig:boid_flock`. Reproduced against **production ar5iv (Perl)** — it drops the figure. **Current latexml-oxide keeps it**, numbers it Figure 1, and resolves the refs: already fixed by OXIDIZED_DESIGN #124.

**Approach.** `titlepic` reaches #124's machinery by a path the existing guard didn't cover — it *redefines* `\@maketitle` (`\renewcommand`) and injects a `\@titlepic`-held `\captionof{figure}`+`\label`, not `\g@addto@macro`. The redefinition leaves `\@maketitle` non-empty, so `\lx@deposit@maketitle` runs it. Add a core-XML guard for that path; record the second witness in OXIDIZED_DESIGN #124 / KNOWN_PERL_ERRORS #90. No engine change.

**Validation.** New guard `06_cluster_frontmatter::frontmatter_titlepic_redefined_maketitle_figure_survives` (green); sibling `frontmatter_maketitle_injected_figure_survives` still green; full suite **2077/0**; fmt + clippy clean. Same-host Perl 0.8.8 confirmed still dropping the figure.

Witness arXiv/html_feedback#6675 (no auto-close — external tracker).