### PR TITLE
feat: overpic renders its graphic + \put overlays (~37 arXiv papers)

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -5117,3 +5117,36 @@ by the maintainer 2026-08-18 when resolving #656.
 
 **Guard**: `cluster_xslt_split::urlstyle::default_is_file_style_full_paths` (and
 the `server`/`negotiated` siblings prove the opt-in styles match Perl).
+
+### 135. overpic renders a populated `<ltx:picture>` (not Perl's empty `tex=` stub)
+
+**Decision:** The `overpic` environment emits a **populated** `<ltx:picture>` — the
+`\includegraphics` background nested at the origin plus the body's `\put` overlays,
+sized to the graphic (`unitlength = max(w,h)/100` in the default percent mode) —
+rather than Perl's empty `<ltx:picture tex='…'/>`.
+
+**Perl behavior** (`overpic.sty.ltxml`): emits an EMPTY `<ltx:picture>` carrying a
+`tex=` attribute with the full overpic source, relying on the `PictureImages`
+post-processor to render the whole thing (graphic + overlays) as one LaTeX+dvipng
+image.
+
+**Rationale:** that path is a dead end in Rust — `tex=` on `<ltx:picture>` is
+suppressed unconditionally (divergence #21) and the LaTeXImages renderer is unwired
+(Rust renders pictures as inline SVG from their CHILD elements). A faithful port
+therefore renders NOTHING: no graphic, and `#body` (the overlays) is dropped. Since
+Rust's `{picture}` + `\includegraphics` + `\put` already produce correct SVG, we
+reproduce overpic.sty's OWN construction (`\OVP@picture` / `\OVP@calc@rel`) — box the
+graphic, size a picture to it, `\put(0,0)` the graphic, run the body — routing
+through the picture-nested-graphics SVG path (PR #675). Rust measures a boxed
+`\includegraphics` (`\wd`/`\ht`/`\dp`) as pdfTeX does, which is what makes this
+possible.
+
+**Impact:** ~37 arXiv papers (44 html_feedback reports) whose overpic figures were
+missing/blank now render the image + labels. Faithful to overpic.sty's percent-mode
+coordinate math; the `grid` option (epic's `\grid`, no Rust binding) and the
+`\Overpic` capital-O variant are unported (no report uses either).
+
+**Upstream:** n/a — a Rust-rendering-model adaptation, not a Perl bug. Approved by
+the maintainer 2026-08-18.
+
+**Guard:** `cluster_package_guards::overpic_renders_graphic_and_overlays::{overpic_emits_populated_sized_picture_with_graphic_and_overlays, overpic_missing_natural_size_image_does_not_divide_by_zero}`.

--- a/latexml_oxide/tests/cluster_package_guards.rs
+++ b/latexml_oxide/tests/cluster_package_guards.rs
@@ -1930,3 +1930,52 @@ mod minted_inline_and_highlighting {
     );
   }
 }
+
+mod overpic_renders_graphic_and_overlays {
+  //! overpic: render the `\includegraphics` background + `\put` overlays as a
+  //! populated `<ltx:picture>`. The prior binding faithfully mirrored Perl
+  //! (empty `<ltx:picture tex=.../>` for the unwired LaTeX-image renderer), so
+  //! it emitted NO graphic and dropped `#body` — 37 arXiv papers reported the
+  //! missing overpic figure. See `overpic_sty.rs` (the surpass-perl divergence).
+  use crate::cluster::convert_to_xml;
+
+  #[test]
+  fn overpic_emits_populated_sized_picture_with_graphic_and_overlays() {
+    let xml = convert_to_xml("tests/cluster_regressions/overpic_render.tex");
+    // Emitted and SIZED (the empty binding produced a `<ltx:picture/>` with no
+    // `unitlength`).
+    assert!(xml.contains("<picture"), "no picture element:\n{xml}");
+    assert!(
+      xml.contains("unitlength="),
+      "picture not sized (no unitlength):\n{xml}"
+    );
+    // THE FIX: the `\includegraphics` background renders as a nested graphic
+    // (the empty binding emitted no graphic at all). Holds whether or not
+    // `example-image`'s file resolves — the element is a core-stage product.
+    assert!(
+      xml.contains(r#"graphic="example-image""#),
+      "overpic dropped the background graphic:\n{xml}"
+    );
+    // The body `\put` overlays land as picture content (the empty binding
+    // dropped `#body`).
+    assert!(xml.contains("OVLABELA"), "overlay A was dropped:\n{xml}");
+    assert!(xml.contains("OVLABELB"), "overlay B was dropped:\n{xml}");
+  }
+
+  /// A missing/unmeasurable image with no size option must NOT raise
+  /// `Illegal \divide by 0` (common on arXiv, where submissions omit referenced
+  /// images). `convert_to_xml` asserts zero `Error:` markers; the pre-guard
+  /// binding raised `Error:misdefined:0`.
+  #[test]
+  fn overpic_missing_natural_size_image_does_not_divide_by_zero() {
+    let xml = convert_to_xml("tests/cluster_regressions/overpic_missing_image.tex");
+    assert!(
+      xml.contains("<picture"),
+      "no picture for missing image:\n{xml}"
+    );
+    assert!(
+      xml.contains("OVLABELC"),
+      "overlay dropped for missing image:\n{xml}"
+    );
+  }
+}

--- a/latexml_oxide/tests/cluster_regressions/overpic_missing_image.tex
+++ b/latexml_oxide/tests/cluster_regressions/overpic_missing_image.tex
@@ -1,0 +1,5 @@
+\documentclass{article}
+\usepackage{overpic}
+\begin{document}
+\begin{overpic}{no_such_image_xyz}\put(50,50){OVLABELC}\end{overpic}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/overpic_render.tex
+++ b/latexml_oxide/tests/cluster_regressions/overpic_render.tex
@@ -1,0 +1,5 @@
+\documentclass{article}
+\usepackage{overpic}
+\begin{document}
+\begin{overpic}[width=4cm]{example-image}\put(10,10){OVLABELA}\put(50,50){OVLABELB}\end{overpic}
+\end{document}

--- a/latexml_package/src/package/overpic_sty.rs
+++ b/latexml_package/src/package/overpic_sty.rs
@@ -2,30 +2,62 @@ use crate::prelude::*;
 
 #[rustfmt::skip]
 LoadDefinitions!({
-  // Perl: overpic.sty.ltxml
+  // Perl: overpic.sty.ltxml requires graphicx + epic. epic (only needed for the
+  // `grid` option's `\grid`) has no Rust binding — a benign `missing_file`
+  // warning; the grid option is off by default, so overlay rendering is
+  // unaffected.
   RequirePackage!("graphicx");
   RequirePackage!("epic");
 
-  // Perl: creates an EMPTY picture environment with tex attribute for LaTeX image generation.
-  // afterDigestBody digests \@includegraphicx to get dimensions, sets width/height/tex.
-  // The picture element gets the graphic's dimensions and a tex attribute for fallback rendering.
-  DefEnvironment!("{overpic} OptionalKeyVals:Gin Semiverbatim",
-    "<ltx:picture fill='none' stroke='none' tex='#tex'></ltx:picture>",
-    after_digest_body => sub[whatsit] {
-      // Set tex attribute from reversion of the full overpic content.
-      // `untex()`, NOT `to_string()`: Perl L35 is `UnTeX(Tokens($whatsit->revert))`,
-      // and the whole point of this attribute is to hand valid TeX to an image
-      // generator. `to_string()` drops the space that terminates a control word,
-      // so `\put (1,2)` reverts as `\put(1,2)` and a control word followed by a
-      // letter welds outright. See `Tokens::untex`.
-      let tex_str = whatsit
-        .revert()
-        .map(Tokens::untex)
-        .unwrap_or_default();
-      whatsit.set_property("tex", Stored::String(pin(tex_str)));
-    }
-  );
+  // DIVERGENCE from Perl (OXIDIZED_DESIGN #135): Perl's overpic.sty.ltxml emits an
+  // EMPTY `<ltx:picture tex='...'/>` and relies on the `PictureImages` post-
+  // processor to render the whole thing (graphic + overlays) as one LaTeX image.
+  // Two Rust realities make that produce nothing: `tex=` on `<ltx:picture>` is
+  // suppressed unconditionally (intentional divergence), and the LaTeXImages
+  // renderer is unwired — Rust renders `<ltx:picture>` as inline SVG from its
+  // CHILD elements. So instead we reproduce overpic.sty's OWN construction: box
+  // the graphic to size a `{picture}` to it, place the graphic at the origin, and
+  // let the body's `\put` overlays draw on top. This routes through Rust's
+  // working picture + `<ltx:graphics>` + `\put` machinery (the graphic resolves
+  // via the picture-nested-graphics SVG path, PR #675), so all of the ~37 arXiv
+  // papers that report a missing overpic figure now render.
+  //
+  // Faithful to overpic.sty's `\OVP@picture` + `\OVP@calc@rel` (the default
+  // `percent` mode set by `\ExecuteOptions{percent}` → `rel=100`): the LARGER of
+  // width/total-height gets 100 coordinate units and `\unitlength = max(w,h)/100`
+  // (so `\put(50,50)` is the centre of a square image; on a landscape image x
+  // runs 0..100). Rust measures a boxed `\includegraphics` (`\wd`/`\ht`/`\dp`)
+  // exactly as pdfTeX does, which is what makes this port possible.
+  //
+  // Witnesses (arXiv/html_feedback): 2412.15262 (baseline, no `\put`),
+  // 2510.17772 (one label + trim/clip), 2401.13599, 2409.12952, 2405.00666.
+  RawTeX!(concat!(
+    r"\newsavebox\OVP@box ",
+    r"\newenvironment{overpic}[2][]{%", "\n",
+    r"  \sbox\OVP@box{\includegraphics[#1]{#2}}%", "\n",
+    r"  \@tempcnta=\wd\OVP@box ", "\n",
+    r"  \@tempcntb=\ht\OVP@box \advance\@tempcntb\dp\OVP@box ", "\n",
+    r"  \ifnum\@tempcnta>\@tempcntb ", "\n",
+    r"    \divide\@tempcnta by 100 \ifnum\@tempcnta<\@ne \@tempcnta=\@ne \fi ", "\n",
+    r"    \unitlength=\@tempcnta sp\relax ", "\n",
+    r"    \@tempcnta=100 \divide\@tempcntb by \unitlength ", "\n",
+    r"  \else ", "\n",
+    r"    \divide\@tempcntb by 100 \ifnum\@tempcntb<\@ne \@tempcntb=\@ne \fi ", "\n",
+    r"    \unitlength=\@tempcntb sp\relax ", "\n",
+    r"    \@tempcntb=100 \divide\@tempcnta by \unitlength ", "\n",
+    r"  \fi ", "\n",
+    // Guard: a missing/unmeasurable image with no size option leaves both
+    // dimensions 0, so `max/100` truncates to 0 and `\divide by \unitlength`
+    // would raise `Illegal \divide by 0`; the `<\@ne` clamps keep unitlength at
+    // >=1sp (a degenerate tiny picture, but no error). Common on arXiv, where
+    // submissions routinely omit referenced images.
+    r"  \begin{picture}(\@tempcnta,\@tempcntb)%", "\n",
+    r"    \put(0,0){\makebox(0,0)[bl]{\usebox\OVP@box}}%", "\n",
+    r"}{%", "\n",
+    r"  \end{picture}%", "\n",
+    r"}",
+  ));
 
-  // Perl: {Overpic} (capital O) takes random TeX instead of image — not ported.
-  // Used in only ~3 papers on arXiv.
+  // Perl: {Overpic} (capital O) takes arbitrary TeX instead of an image — used in
+  // ~3 arXiv papers, not ported (none of the 44 overpic reports use it).
 });

--- a/latexml_package/src/package/overpic_sty.rs
+++ b/latexml_package/src/package/overpic_sty.rs
@@ -22,35 +22,58 @@ LoadDefinitions!({
   // via the picture-nested-graphics SVG path, PR #675), so all of the ~37 arXiv
   // papers that report a missing overpic figure now render.
   //
-  // Faithful to overpic.sty's `\OVP@picture` + `\OVP@calc@rel` (the default
-  // `percent` mode set by `\ExecuteOptions{percent}` → `rel=100`): the LARGER of
+  // Faithful to overpic.sty's `\OVP@picture` + coordinate-mode keys. The default
+  // is `percent` (`\ExecuteOptions{percent}` → `rel=100`): the LARGER of
   // width/total-height gets 100 coordinate units and `\unitlength = max(w,h)/100`
-  // (so `\put(50,50)` is the centre of a square image; on a landscape image x
-  // runs 0..100). Rust measures a boxed `\includegraphics` (`\wd`/`\ht`/`\dp`)
-  // exactly as pdfTeX does, which is what makes this port possible.
+  // (so `\put(50,50)` is the centre of a square image). The OVP keys are ported
+  // so a paper that overrides the mode positions its overlays correctly:
+  //   percent / rel=N / permil : `\unitlength = max(w,h)/N`, larger dim spans N.
+  //   abs                      : coordinates are `\unitlength`s (default 1pt or `unit=`).
+  //   unit=<dim>               : set `\unitlength` (used by `abs`).
+  //   grid / tics              : accepted; `grid` needs epic's `\grid` (unbound), so no-op.
+  // Rust measures a boxed `\includegraphics` (`\wd`/`\ht`/`\dp`) as pdfTeX does,
+  // which is what makes this port possible.
   //
   // Witnesses (arXiv/html_feedback): 2412.15262 (baseline, no `\put`),
-  // 2510.17772 (one label + trim/clip), 2401.13599, 2409.12952, 2405.00666.
+  // 2510.17772 (percent labels + trim/clip), 2401.13599 (abs/unit), 2409.06474
+  // (nested `\includegraphics` in `\put` + rotate/scale), 2405.00666 (128 envs).
   RawTeX!(concat!(
-    r"\newsavebox\OVP@box ",
+    r"\newsavebox\OVP@box", "\n",
+    // percent/rel mode: unitlength = max(w,h)/scale; the larger dim spans `scale`
+    // units. The `<\@ne` clamp keeps unitlength >= 1sp so a degenerate (missing /
+    // zero-size) image never triggers `Illegal \divide by 0` — common on arXiv.
+    r"\newcommand\OVP@calc@rel{%", "\n",
+    r"  \ifnum\@tempcnta>\@tempcntb ", "\n",
+    r"    \divide\@tempcnta by \OVP@scale \ifnum\@tempcnta<\@ne \@tempcnta=\@ne \fi ", "\n",
+    r"    \unitlength=\@tempcnta sp\relax \@tempcnta=\OVP@scale \divide\@tempcntb by \unitlength ", "\n",
+    r"  \else ", "\n",
+    r"    \divide\@tempcntb by \OVP@scale \ifnum\@tempcntb<\@ne \@tempcntb=\@ne \fi ", "\n",
+    r"    \unitlength=\@tempcntb sp\relax \@tempcntb=\OVP@scale \divide\@tempcnta by \unitlength ", "\n",
+    r"  \fi}", "\n",
+    // abs mode: coordinates are `\unitlength`s (set by `unit=`, else the 1pt
+    // register default). Clamp unitlength >= 1sp for the same divide-by-0 guard.
+    r"\newcommand\OVP@calc@abs{%", "\n",
+    r"  \ifdim\unitlength<\@ne sp \unitlength=1pt\relax \fi ", "\n",
+    r"  \divide\@tempcnta by \unitlength \divide\@tempcntb by \unitlength}", "\n",
+    // OVP key family (overpic.sty L25-48). `\@m` = 1000 (permil).
+    r"\define@key{OVP}{rel}{\def\OVP@scale{#1}\let\OVP@calc\OVP@calc@rel}", "\n",
+    r"\define@key{OVP}{percent}[]{\def\OVP@scale{100}\let\OVP@calc\OVP@calc@rel}", "\n",
+    r"\define@key{OVP}{permil}[]{\def\OVP@scale{\@m}\let\OVP@calc\OVP@calc@rel}", "\n",
+    r"\define@key{OVP}{abs}[]{\let\OVP@calc\OVP@calc@abs}", "\n",
+    r"\define@key{OVP}{unit}{\unitlength=\dimexpr#1\relax}", "\n",
+    r"\define@key{OVP}{grid}[true]{}", "\n",
+    r"\define@key{OVP}{tics}{}", "\n",
     r"\newenvironment{overpic}[2][]{%", "\n",
     r"  \sbox\OVP@box{\includegraphics[#1]{#2}}%", "\n",
+    // per-env default is percent (overpic.sty `\ExecuteOptions{percent}`); then
+    // read any OVP keys from the optarg. `\setkeys*` is relaxed — it ignores the
+    // graphicx keys (width/trim/clip/...) that also live in `#1`.
+    r"  \def\OVP@scale{100}\let\OVP@calc\OVP@calc@rel ", "\n",
+    r"  \setkeys*{OVP}{#1}%", "\n",
     r"  \@tempcnta=\wd\OVP@box ", "\n",
     r"  \@tempcntb=\ht\OVP@box \advance\@tempcntb\dp\OVP@box ", "\n",
-    r"  \ifnum\@tempcnta>\@tempcntb ", "\n",
-    r"    \divide\@tempcnta by 100 \ifnum\@tempcnta<\@ne \@tempcnta=\@ne \fi ", "\n",
-    r"    \unitlength=\@tempcnta sp\relax ", "\n",
-    r"    \@tempcnta=100 \divide\@tempcntb by \unitlength ", "\n",
-    r"  \else ", "\n",
-    r"    \divide\@tempcntb by 100 \ifnum\@tempcntb<\@ne \@tempcntb=\@ne \fi ", "\n",
-    r"    \unitlength=\@tempcntb sp\relax ", "\n",
-    r"    \@tempcntb=100 \divide\@tempcnta by \unitlength ", "\n",
-    r"  \fi ", "\n",
-    // Guard: a missing/unmeasurable image with no size option leaves both
-    // dimensions 0, so `max/100` truncates to 0 and `\divide by \unitlength`
-    // would raise `Illegal \divide by 0`; the `<\@ne` clamps keep unitlength at
-    // >=1sp (a degenerate tiny picture, but no error). Common on arXiv, where
-    // submissions routinely omit referenced images.
+    r"  \OVP@calc ", "\n",
+    r"  \ifnum\@tempcnta<\@ne \@tempcnta=\@ne \fi \ifnum\@tempcntb<\@ne \@tempcntb=\@ne \fi ", "\n",
     r"  \begin{picture}(\@tempcnta,\@tempcntb)%", "\n",
     r"    \put(0,0){\makebox(0,0)[bl]{\usebox\OVP@box}}%", "\n",
     r"}{%", "\n",


### PR DESCRIPTION
**Diagnostic.** overpic figures are missing across ~37 arXiv papers (44 html_feedback reports). The binding faithfully ported Perl's `overpic.sty.ltxml`, which emits an **empty** `<ltx:picture tex='…'/>` for the `PictureImages` LaTeX-image renderer — but Rust suppresses `tex=` on `<ltx:picture>` (divergence #21) and that renderer is unwired, so the graphic vanished **and** the body's `\put` overlays were dropped (the constructor never referenced `#body`).

**Approach.** Reproduce overpic.sty's own construction (divergence **#135**): box the `\includegraphics` to size a `{picture}` to it, `\put(0,0)` the graphic, and run the body overlays, with `unitlength = max(w,h)/100` (the default percent mode, faithful to `\OVP@calc@rel`). Rust measures a boxed `\includegraphics` (`\wd`/`\ht`/`\dp`) as pdfTeX does, which makes this possible. A divide-by-zero guard handles missing / natural-size images (common on arXiv). The nested graphic's image is resolved into the SVG by the complementary post-stage fix **#675** — this PR is the **core** half (correct populated picture), #675 the **post** half (resolving the picture-nested graphic's `src`); together they render the figures.

**Validation.** Guards `overpic_emits_populated_sized_picture_with_graphic_and_overlays` and `overpic_missing_natural_size_image_does_not_divide_by_zero` (RED-meaningful: the old empty picture had no `graphic=`, no `unitlength`, dropped overlays). Verified across witness variants (width / trim+clip / natural / portrait / missing-image), all 0 errors. Full suite **2080/2080**; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)