### PR TITLE
fix: resolve default/foreign namespaces for runtime RelaxNGSchema() (#652)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,10 +45,19 @@
     never distilled it into the tag/attribute/namespace tables the runtime consults
     — so every element was rejected (`<ltx:document> isn't allowed in <#Document>`)
     and the output came out empty. The scan now populates those tables (a port of
-    Perl `Model/RelaxNG.pm`'s `extractContent` + tag loop), including the document
-    namespaces, so a custom schema validates. Disk lookup also appends `.rng` to a
-    bare schema name across all `--path` search dirs (matching Perl), so
-    `RelaxNGSchema('MySchema')` resolves `MySchema.rng` (#652).
+    Perl `Model/RelaxNG.pm`'s `extractContent` + tag loop), so a custom schema
+    validates. Namespaces are now resolved with the full XML expressivity Perl
+    has: a schema's target namespace given only as a default `ns=` (no `xmlns:`
+    prefix — how `LaTeXML.rng` is written) resolves to the conventional code
+    prefix the engine registered (dlmf → `ltx`) instead of a synthetic
+    `namespace1`, and becomes the default output namespace; foreign namespaces,
+    whether built-in (`svg`/`m`/`xlink`/`xhtml`) or supplied by a third-party or
+    runtime `.rhai` `RegisterNamespace`, serialize under their registered prefix
+    instead of a `namespaceN` + "no prefix registered" warning (ports of Perl
+    `encodeQName`/`getNamespacePrefix`, `getDocumentNamespacePrefix`'s code-prefix
+    fallback, and `RelaxNG.pm`'s default-namespace registration). Disk lookup also
+    appends `.rng` to a bare schema name across all `--path` search dirs (matching
+    Perl), so `RelaxNGSchema('MySchema')` resolves `MySchema.rng` (#652).
   - **An `Undigested` constructor argument reaches a Rhai body as `Tokens`.** A
     runtime `DefConstructor` with an `Undigested` (or `OptionalUndigested`) parameter
     handed its imperative `|document, arg|` body an opaque `Digested` handle wrapping

--- a/latexml_contrib/src/script_bindings/tests.rs
+++ b/latexml_contrib/src/script_bindings/tests.rs
@@ -1050,3 +1050,63 @@ fn api_reference_is_up_to_date() {
     );
   }
 }
+
+/// #652 end-to-end through the REAL Rhai binding surface. A `.rhai` preamble
+/// (as BookML emits) calls `RegisterNamespace` + `RelaxNGSchema` on a custom
+/// schema whose target namespace is a bare default `ns=` — exactly how
+/// `LaTeXML.rng` is written. The schema must load with correct namespaces: the
+/// document root validates under the `ltx:` prefix and the primary namespace
+/// becomes the default output namespace — NOT empty out with
+/// `<ltx:document> isn't allowed in <#Document>`. Exercises the full path
+/// Rhai fn → `select_relaxng_schema` → `Model::load_schema` → scan → distil →
+/// namespace resolution, which the model-level `schema_load_tests` reach only
+/// by calling the internals directly.
+#[test]
+fn rhai_relaxngschema_loads_default_ns_schema_with_namespaces() {
+  use latexml_core::common::model::{self, LTX_NAMESPACE};
+  fresh_state();
+  model::initialize_model();
+
+  let dir = std::env::temp_dir().join(format!("lxo652rhai_{}", std::process::id()));
+  std::fs::create_dir_all(&dir).expect("mkdir");
+  // dlmf as the DEFAULT namespace, NO xmlns:ltx — the LaTeXML.rng shape.
+  std::fs::write(
+    dir.join("bookmlschema.rng"),
+    "<grammar xmlns=\"http://relaxng.org/ns/structure/1.0\" \
+         ns=\"http://dlmf.nist.gov/LaTeXML\">\
+       <start><ref name=\"document\"/></start>\
+       <define name=\"document\"><element name=\"document\">\
+         <zeroOrMore><ref name=\"para\"/></zeroOrMore></element></define>\
+       <define name=\"para\"><element name=\"para\">\
+         <attribute name=\"class\"/><text/></element></define>\
+     </grammar>",
+  )
+  .expect("write rng");
+
+  // Drive the ACTUAL Rhai functions the reporter's BookML .rhai uses.
+  load_script(
+    r#"
+      RegisterNamespace("ltx", "http://dlmf.nist.gov/LaTeXML");
+      RelaxNGSchema("bookmlschema");
+    "#,
+  )
+  .expect("rhai load_script");
+
+  // In a real run the load fires at document construction; drive it at our dir.
+  model::load_schema(&[dir.to_str().unwrap()]).expect("load_schema");
+
+  assert!(
+    model::can_contain("#Document", "ltx:document"),
+    ".rhai-selected default-ns schema root must validate under ltx: (#652)"
+  );
+  assert!(
+    model::can_contain("ltx:document", "ltx:para"),
+    "nested default-ns elements validate under ltx: too (#652)"
+  );
+  assert_eq!(
+    model::get_document_namespace("", true).as_deref(),
+    Some(LTX_NAMESPACE),
+    "schema primary ns is the default output namespace (#652)"
+  );
+  let _ = std::fs::remove_dir_all(&dir);
+}

--- a/latexml_core/src/common/model.rs
+++ b/latexml_core/src/common/model.rs
@@ -444,7 +444,25 @@ pub fn load_schema(search_paths: &[&str]) -> Result<()> {
         } else {
           let paths: Vec<&std::path::Path> =
             search_paths.iter().map(std::path::Path::new).collect();
+          // Seed the scanner with the model's registered code-namespace prefixes
+          // (e.g. `ltx` → dlmf from `base_schema`), so a schema whose target
+          // namespace appears only as a default `ns=` — with no `xmlns:` prefix,
+          // exactly how `LaTeXML.rng` is written — resolves to that conventional
+          // prefix instead of a synthetic `namespaceN` the runtime never matches
+          // (Perl: the scanner delegates `encodeQName` to the model; #652).
+          // Collect first: the immutable borrow ends before `schema.as_mut()`.
+          let code_prefix_seed: Vec<(String, String)> = model
+            .code_namespace_prefixes
+            .iter()
+            .map(|(uri, prefix)| {
+              (
+                arena::with(*uri, |s| s.to_string()),
+                arena::with(*prefix, |s| s.to_string()),
+              )
+            })
+            .collect();
           let schema = model.schema.as_mut().unwrap();
+          schema.code_namespace_prefixes = code_prefix_seed.into_iter().collect();
           let schema_name = schema.name.clone();
           match schema.load_schema(&schema_name, &paths) {
             Err(err) => {
@@ -470,6 +488,18 @@ pub fn load_schema(search_paths: &[&str]) -> Result<()> {
               }
               for (prefix, uri) in &data.namespaces {
                 model.register_document_namespace(prefix, Some(uri));
+              }
+              // Perl RelaxNG.pm L78: register the schema's primary namespace as
+              // the DEFAULT document namespace, so the output serializes it with
+              // no prefix (the schema's unprefixed default-`ns=` elements).
+              // Generalized from Perl's hardcoded dlmf to the schema's ACTUAL
+              // primary namespace, so a schema with a different default namespace
+              // gets ITS namespace as the output default — full namespace
+              // expressivity, user-directed (#652). For a LaTeXML-namespace
+              // schema this is identical to Perl. (`""` prefix → `#default`.)
+              let primary = model.schema.as_ref().unwrap().primary_namespace.clone();
+              if let Some(primary) = primary {
+                model.register_document_namespace("", Some(&primary));
               }
             },
           }
@@ -507,6 +537,18 @@ pub fn get_document_namespace_prefix(
       .document_namespace_prefixes
       .get_sym(ns_sym)
       .copied();
+  }
+
+  // Perl Model.pm `getDocumentNamespacePrefix` L242: for a non-LaTeXML
+  // namespace with no explicit document prefix, fall back to the registered
+  // CODE prefix. This is what lets FOREIGN namespaces — built-in (`svg`, `m`,
+  // `xlink`, `xhtml`) or supplied by a third-party / runtime `.rhai` binding via
+  // `RegisterNamespace` — serialize under their conventional prefix instead of a
+  // synthetic `namespaceN` + "no prefix registered" warning (#652). The LaTeXML
+  // namespace is excluded: it is the default document namespace (registered from
+  // the schema's primary `ns=`) and serializes with no prefix.
+  if docprefix.is_none() && namespace != LTX_NAMESPACE {
+    docprefix = model!().code_namespace_prefixes.get_sym(ns_sym).copied();
   }
 
   if docprefix.is_none() && !probe {
@@ -1340,5 +1382,134 @@ mod schema_load_tests {
     );
 
     let _ = std::fs::remove_dir_all(&dir);
+  }
+
+  /// #652 (reopened): a schema whose target namespace is a **default `ns=`** (no
+  /// `xmlns:` prefix — how real `LaTeXML.rng` is written) must resolve to the
+  /// conventional code prefix (`ltx`) that `base_schema` registered, NOT a
+  /// synthetic `namespace1`. Perl: the scanner delegates `encodeQName` to the
+  /// model, which consults `code_namespace_prefixes`.
+  #[test]
+  fn default_ns_schema_uses_registered_code_prefix() {
+    let dir = std::env::temp_dir().join(format!("lxo652def_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    // dlmf as the DEFAULT namespace; NO xmlns:ltx declaration in the schema.
+    let default_ns = "<grammar xmlns=\"http://relaxng.org/ns/structure/1.0\" \
+         ns=\"http://dlmf.nist.gov/LaTeXML\">\
+       <start><ref name=\"document\"/></start>\
+       <define name=\"document\"><element name=\"document\">\
+         <zeroOrMore><ref name=\"para\"/></zeroOrMore></element></define>\
+       <define name=\"para\"><element name=\"para\">\
+         <attribute name=\"class\"/><text/></element></define>\
+       </grammar>";
+    std::fs::write(dir.join("lxo652def.rng"), default_ns).expect("write rng");
+
+    initialize_model();
+    // Mimic base_schema.rs:11 — the engine registers `ltx` for the dlmf namespace
+    // on every conversion, before any RelaxNGSchema() runs.
+    model_mut!().register_namespace("ltx", Some(LTX_NAMESPACE));
+    model_mut!().set_relaxng_schema("lxo652def");
+    let dir_str = dir.to_str().unwrap();
+    load_schema(&[dir_str]).expect("load_schema");
+
+    // The document root is in the default (dlmf) namespace → it must be reachable
+    // under the registered `ltx` prefix, not a synthesized `namespaceN`.
+    assert!(
+      can_contain("#Document", "ltx:document"),
+      "default-ns root must resolve to the registered ltx: prefix (#652)"
+    );
+    assert!(
+      can_contain("ltx:document", "ltx:para"),
+      "ltx:document may contain ltx:para"
+    );
+    assert!(
+      !can_contain("#Document", "namespace1:document"),
+      "must NOT invent a synthetic namespace1 prefix for a registered namespace (#652)"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+  }
+
+  /// #652 fallback guard: a namespace the engine did NOT register, but the
+  /// schema declares an explicit `xmlns:` prefix for, keeps that declared prefix
+  /// (Perl `getNamespacePrefix`: code prefix → document prefix → synthesize).
+  #[test]
+  fn schema_declared_prefix_survives_when_unregistered_in_code() {
+    let dir = std::env::temp_dir().join(format!("lxo652decl_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    // `ex` is declared in the schema (xmlns:ex) but never registered in code.
+    let rng = "<grammar xmlns=\"http://relaxng.org/ns/structure/1.0\" \
+         ns=\"http://example.com/ex\" xmlns:ex=\"http://example.com/ex\">\
+       <start><ref name=\"root\"/></start>\
+       <define name=\"root\"><element name=\"root\"><empty/></element></define>\
+       </grammar>";
+    std::fs::write(dir.join("lxo652decl.rng"), rng).expect("write rng");
+
+    initialize_model();
+    model_mut!().set_relaxng_schema("lxo652decl");
+    load_schema(&[dir.to_str().unwrap()]).expect("load_schema");
+
+    assert!(
+      can_contain("#Document", "ex:root"),
+      "schema-declared xmlns:ex prefix must be used when code has none (#652)"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+  }
+
+  /// #652 output-serialization: the schema's primary (default `ns=`) namespace
+  /// becomes the DEFAULT document namespace — serialized with NO prefix — rather
+  /// than being forgotten (Perl RelaxNG.pm L78).
+  #[test]
+  fn schema_primary_ns_becomes_default_document_namespace() {
+    let dir = std::env::temp_dir().join(format!("lxo652out_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let rng = "<grammar xmlns=\"http://relaxng.org/ns/structure/1.0\" \
+         ns=\"http://dlmf.nist.gov/LaTeXML\">\
+       <start><ref name=\"document\"/></start>\
+       <define name=\"document\"><element name=\"document\"><empty/></element></define>\
+       </grammar>";
+    std::fs::write(dir.join("lxo652out.rng"), rng).expect("write rng");
+
+    initialize_model();
+    model_mut!().register_namespace("ltx", Some(LTX_NAMESPACE));
+    model_mut!().set_relaxng_schema("lxo652out");
+    load_schema(&[dir.to_str().unwrap()]).expect("load_schema");
+
+    // The primary namespace is the output default (`#default` → dlmf) …
+    assert_eq!(
+      get_document_namespace("", true).as_deref(),
+      Some(LTX_NAMESPACE),
+      "schema primary ns must be the default document namespace (#652)"
+    );
+    // … so it serializes with NO prefix (probe → no synthetic namespaceN + warning).
+    assert_eq!(
+      get_document_namespace_prefix(LTX_NAMESPACE, false, true),
+      None,
+      "the default document namespace serializes without a prefix (#652)"
+    );
+  }
+
+  /// #652 foreign prefixes: a namespace registered only in CODE — a built-in
+  /// (`svg`) or a third-party / runtime `.rhai` `RegisterNamespace` — serializes
+  /// under that code prefix, never a synthetic `namespaceN` + warning (Perl
+  /// Model.pm `getDocumentNamespacePrefix` L242 code-prefix fallback).
+  #[test]
+  fn foreign_and_runtime_namespaces_serialize_under_their_code_prefix() {
+    initialize_model();
+    // Built-in foreign namespace, as base_schema registers it.
+    model_mut!().register_namespace("svg", Some("http://www.w3.org/2000/svg"));
+    // A third-party / runtime binding's RegisterNamespace (e.g. a BookML .rhai).
+    model_mut!().register_namespace("bk", Some("http://bookml.example/ns"));
+
+    assert_eq!(
+      get_document_namespace_prefix("http://www.w3.org/2000/svg", false, true),
+      Some(pin!("svg")),
+      "built-in foreign svg namespace serializes under its code prefix (#652)"
+    );
+    assert_eq!(
+      get_document_namespace_prefix("http://bookml.example/ns", false, true),
+      Some(pin!("bk")),
+      "a runtime/third-party registered namespace serializes under its prefix (#652)"
+    );
   }
 }

--- a/latexml_core/src/common/relaxng/mod.rs
+++ b/latexml_core/src/common/relaxng/mod.rs
@@ -176,6 +176,15 @@ pub struct Relaxng {
   /// `xmlns:` attributes on RelaxNG nodes.
   pub document_namespaces: HashMap<String, String>,
 
+  /// URI → code prefix, seeded from the model's `code_namespace_prefixes`
+  /// before scanning (`Model::load_schema`). Lets a namespace referenced only
+  /// as a default `ns=` (no `xmlns:` prefix in the schema) resolve to the
+  /// conventional prefix the engine already registered — e.g.
+  /// `http://dlmf.nist.gov/LaTeXML` → `ltx` from `base_schema` — instead of a
+  /// synthetic `namespaceN`. Port of Perl `encodeQName` → `getNamespacePrefix`
+  /// consulting `code_namespace_prefixes` (#652).
+  pub code_namespace_prefixes: HashMap<String, String>,
+
   /// The master grammar's `<grammar ns="…">` URI — populated by the
   /// first call to `scan_external` (i.e. the schema entry point).
   /// Subsequent included grammars don't overwrite it. Used by the
@@ -202,19 +211,20 @@ pub struct Relaxng {
 impl Default for Relaxng {
   fn default() -> Self {
     Relaxng {
-      name:                   String::from("LaTeXML"),
-      modules:                Vec::new(),
-      elementdefs:            HashMap::default(),
-      element_reverse_defs:   HashMap::default(),
-      elements:               HashMap::default(),
-      defs:                   HashMap::default(),
-      def_combiner:           HashMap::default(),
-      uses_name:              HashMap::default(),
-      internal_grammars:      0,
-      document_namespaces:    HashMap::default(),
-      primary_namespace:      None,
-      display_strip_prefixes: Vec::new(),
-      start:                  Vec::new(),
+      name:                    String::from("LaTeXML"),
+      modules:                 Vec::new(),
+      elementdefs:             HashMap::default(),
+      element_reverse_defs:    HashMap::default(),
+      elements:                HashMap::default(),
+      defs:                    HashMap::default(),
+      def_combiner:            HashMap::default(),
+      uses_name:               HashMap::default(),
+      internal_grammars:       0,
+      document_namespaces:     HashMap::default(),
+      code_namespace_prefixes: HashMap::default(),
+      primary_namespace:       None,
+      display_strip_prefixes:  Vec::new(),
+      start:                   Vec::new(),
     }
   }
 }

--- a/latexml_core/src/common/relaxng/scan.rs
+++ b/latexml_core/src/common/relaxng/scan.rs
@@ -198,6 +198,16 @@ fn encode_qname(rng: &mut Relaxng, ns: Option<&str>, local: &str) -> String {
 }
 
 fn ensure_prefix(rng: &mut Relaxng, uri: &str) -> String {
+  // Perl `getNamespacePrefix` order: the model's CODE prefix wins. Seeded from
+  // `code_namespace_prefixes` before the scan, this maps e.g.
+  // `http://dlmf.nist.gov/LaTeXML` → `ltx` (registered by `base_schema`), so a
+  // namespace referenced only as a default `ns=` — with no `xmlns:` declaration
+  // in the schema — resolves to the conventional prefix the rest of the engine
+  // uses, not a synthetic `namespaceN` that the runtime would never match (#652).
+  if let Some(prefix) = rng.code_namespace_prefixes.get(uri) {
+    return prefix.clone();
+  }
+  // Else a schema-local `xmlns:` prefix for this URI (Perl: document prefix).
   if let Some((prefix, _)) = rng
     .document_namespaces
     .iter()


### PR DESCRIPTION
**Diagnostic.** A raw-`.rng` schema loaded via `RelaxNGSchema()` mishandled XML namespaces (found by @xworld21): its target namespace given only as a default `ns=` (no `xmlns:` prefix — how `LaTeXML.rng` is written) got a synthetic `namespace1` prefix instead of the registered `ltx`, so the document still emptied with `<ltx:document> isn't allowed in <#Document>`, and foreign/third-party namespaces needed manual re-registration. #657 (unreleased) fixed the empty-`tagprop` half but not the namespace half.

**Approach.** Three faithful ports of Perl's namespace machinery: (1) seed the scanner with the model's `code_namespace_prefixes` so element names use the registered code prefix — Perl `encodeQName`→`getNamespacePrefix`; (2) `get_document_namespace_prefix` falls back to the code prefix for a non-LaTeXML namespace — Perl `Model.pm` L242 — so `svg`/`m`/`xlink`/`xhtml` and any runtime `.rhai` `RegisterNamespace` serialize under their prefix; (3) register the schema's primary namespace as the default document namespace — Perl `RelaxNG.pm` L78.

**Validation.** `schema_load_tests::{default_ns_schema_uses_registered_code_prefix, schema_declared_prefix_survives_when_unregistered_in_code, schema_primary_ns_becomes_default_document_namespace, foreign_and_runtime_namespaces_serialize_under_their_code_prefix}` (red→green); #657's `raw_rng_scan_populates_tagprop_end_to_end` stays green; full suite 2090/0; clippy `-D warnings`; fmt.

Closes #652