### PR TITLE
fix: sn-jnl sn-apa style loads apacite for its APA bibliography

### DIFF
--- a/latexml_contrib/src/sn_jnl_cls.rs
+++ b/latexml_contrib/src/sn_jnl_cls.rs
@@ -58,6 +58,26 @@ LoadDefinitions!({
   // (sn-basic), 2606.10215, 2606.11534.
   RequirePackage!("natbib");
 
+  // sn-jnl.cls reference styles select the bibliography package by class
+  // option (sn-jnl.cls L1656-1694): the numeric/author-year styles use natbib
+  // (loaded above), but the `sn-apa` style loads apacite —
+  // `\if@APA@refstyle \usepackage[natbibapa]{apacite} \fi` (L1683-1685,
+  // guarded by `\DeclareOption{sn-apa}{\@APA@refstyletrue}` L111). Without it,
+  // an `sn-apa` paper's apacite-formatted `.bbl` (`\APACinsertmetastar`,
+  // `\BOthers`, `\BDBL`, `{APACrefauthors}`, `\APACrefYearMonthDay`,
+  // `\PrintBackRefs`, …) hits our apacite binding UNLOADED, so every one of
+  // those macros floods `Error:undefined:` and the References render as raw
+  // macro names. Mirror the class: fire apacite when `sn-apa` is passed.
+  // (natbib above stays unconditional — the existing simplification; apacite
+  // requires natbib anyway, so loading both under `sn-apa` is harmless.)
+  // Perl ships no sn-jnl / apacite binding at all → Rust surpasses.
+  // arXiv/html_feedback#1261, witness 2404.15224
+  // (`\documentclass[referee,sn-apa,pdflatex,natbib]{sn-jnl}`).
+  DeclareOption!("sn-apa", {
+    RequirePackage!("apacite");
+  });
+  ProcessOptions!();
+
   // sn-jnl frontmatter — gobble layout-only / preserve author text.
   DefMacro!("\\bmhead{}", "\\subsubsection*{#1}");
   DefMacro!("\\bmsection{}", "\\section*{#1}");

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -965,6 +965,48 @@ fn cluster_apacite_old_bbl_format_renders() {
     );
   }
 }
+/// `sn-jnl.cls` (Springer Nature journal class) with the `sn-apa` reference
+/// style loads apacite for its APA-formatted bibliography — sn-jnl.cls L1683
+/// `\if@APA@refstyle \usepackage[natbibapa]{apacite} \fi`. Our class binding
+/// short-circuits the raw `.cls`, so it must reproduce that conditional load;
+/// before the fix it required only natbib, leaving the `.bbl`'s apacite macros
+/// (`\APACinsertmetastar`, `\BOthers`, `\BDBL`, `{APACrefauthors}`,
+/// `\APACrefYearMonthDay`, `\APACjournalVolNumPages`, `\PrintBackRefs`, …)
+/// undefined — an `Error:undefined:` flood, References as raw macro names.
+/// Now `sn_jnl_cls`'s `DeclareOption("sn-apa", RequirePackage("apacite"))`
+/// loads the (already-complete) apacite binding. The `_clean` helper gates on
+/// 0 errors — the red→green signal. Perl ships no sn-jnl/apacite binding →
+/// Rust surpasses. arXiv/html_feedback#1261, witness 2404.15224.
+#[test]
+fn sn_jnl_apa_option_loads_apacite_bibliography_macros() {
+  let x = convert_to_xml_contrib_clean("tests/cluster_regressions/sn_jnl_apacite_bbl.tex");
+  // No apacite macro name leaks into the rendered bibliography as raw text.
+  for leak in [
+    "APACinsertmetastar",
+    "BOthers",
+    "APACrefYearMonthDay",
+    "APACjournalVolNumPages",
+    "PrintBackRefs",
+    "APACrefauthors",
+  ] {
+    assert!(
+      !x.contains(leak),
+      "sn-jnl/apacite macro `{leak}` leaked into the output (apacite not loaded):\n{x}"
+    );
+  }
+  // The entry renders its real content (authors, title, arXiv id).
+  for needle in ["Ottersten", "survey on deep learning", "1808.01462"] {
+    assert!(
+      x.contains(needle),
+      "sn-jnl/apacite bibitem content `{needle}` missing:\n{x}"
+    );
+  }
+  // And it is a structured bibitem, not leaked body text.
+  assert!(
+    x.contains("<bibitem"),
+    "sn-jnl/apacite bibliography did not produce a <bibitem>:\n{x}"
+  );
+}
 /// Loading `bibunits` — even without ever opening a `bibunit` environment —
 /// made EVERY citation dangle. `\cite` runs bibunits' `\lx@bibunits@resetglobal`,
 /// stamping `CITE_UNIT=bu0`, so the bibref asks for `BIBLABEL:bu0:<key>`; the

--- a/latexml_oxide/tests/cluster_regressions/sn_jnl_apacite_bbl.tex
+++ b/latexml_oxide/tests/cluster_regressions/sn_jnl_apacite_bbl.tex
@@ -1,0 +1,37 @@
+% sn-jnl.cls with the `sn-apa` reference style loads apacite (APA citations),
+% so the apacite-formatted `.bbl` macros must be defined. arXiv/html_feedback
+% #1261, witness 2404.15224 (`\documentclass[referee,sn-apa,...]{sn-jnl}`).
+\documentclass[sn-apa]{sn-jnl}
+\begin{document}
+\title{A note}
+\author[1]{\fnm{Ada} \sur{Lovelace}}
+\affil[1]{\orgname{Analytical Engine Co.}}
+\maketitle
+An analysis of things~\cite{survey2018}.
+\begin{thebibliography}{}
+\bibitem [\protect \citeauthoryear {%
+Ahmed%
+\ \protect \BOthers {.}}{%
+Ahmed%
+\ \protect \BOthers {.}}{%
+{\protect \APACyear {2018}}%
+}]{%
+survey2018}
+\APACinsertmetastar {%
+survey2018}%
+\begin{APACrefauthors}%
+Ahmed, E.%
+, Saint, A.%
+\BDBL {}Ottersten, B.%
+\end{APACrefauthors}%
+\unskip\
+\newblock
+\APACrefYearMonthDay{2018}{}{}.
+\newblock
+{\BBOQ}\APACrefatitle {A survey on deep learning}{A survey on deep learning}.{\BBCQ}
+\newblock
+\APACjournalVolNumPages{arXiv preprint arXiv:1808.01462}{}{}{,}
+\newblock
+\PrintBackRefs{\CurrentBib}
+\end{thebibliography}
+\end{document}


### PR DESCRIPTION
**Diagnostic.** `sn-jnl.cls`'s `sn-apa` reference style loads apacite for APA citations (`sn-jnl.cls` L1683 `\if@APA@refstyle \usepackage[natbibapa]{apacite}\fi`); the other styles use natbib. Our `sn_jnl_cls` binding short-circuits the raw `.cls` but required only natbib, so an `sn-apa` paper's apacite-formatted `.bbl` hit our (already-complete) `apacite_sty` binding **unloaded** — every `\APAC*`/`\B*` macro flooded `Error:undefined:` and the References rendered as raw macro names.

**Approach.** Gate apacite on the class option, mirroring the class: `DeclareOption!("sn-apa", { RequirePackage!("apacite"); }); ProcessOptions!()`. Only `sn-apa` loads a non-natbib package; every other refstyle already had natbib. Perl ships no sn-jnl/apacite binding at all → Rust surpasses (extends the existing `apacite`/`sn-jnl` surpass, no new divergence).

**Validation.** New guard `sn_jnl_apa_option_loads_apacite_bibliography_macros` (red→green: the `_clean` helper gates on 0 errors); full suite 2094/0; clippy/fmt clean. Witness 2404.15224 re-converts 0 errors (was 24 `Error:undefined:`).

Context: arXiv/html_feedback#1261 (the arxiv.org/html page is Perl-generated, which is why the report shows these undefined).