### PR TITLE
fix: sn-jnl abstract renders after the title, not before it

### DIFF
--- a/latexml_contrib/src/sn_jnl_cls.rs
+++ b/latexml_contrib/src/sn_jnl_cls.rs
@@ -174,21 +174,26 @@ LoadDefinitions!({
   // Witness 2402.17342.
   Let!("\\botrule", "\\hline");
 
-  // Frontmatter envs — internal_vertical mode for multi-paragraph
-  // bodies (declarations especially carries author prose with \par
-  // separators). Without explicit mode, restricted_horizontal default
-  // trips Endgroup mismatch on \par-containing bodies.
-  DefEnvironment!("{abstract}", "<ltx:abstract>#body</ltx:abstract>",
-    mode => "internal_vertical");
-  // Real sn-jnl.cls defines `\abstract{...}` as a *macro* form (not the
-  // standard env). Without this stub, our environment binding's
-  // auto-created `\abstract` token (which expects a matching
-  // `\endabstract`) eats every subsequent `\title`/`\author`/`\maketitle`
-  // /`\section` into the still-open `<ltx:abstract>`, producing a
-  // cascade of `Error:malformed:ltx:* isn't allowed in <ltx:abstract>`.
-  // Forward to the env so the body is wrapped *and* properly closed.
-  // Witness 2306.11901.
-  DefMacro!("\\abstract{}", "\\begin{abstract}#1\\end{abstract}");
+  // Do NOT override `\abstract` or the `{abstract}` environment here. The
+  // kernel's `\abstract` (latex_constructs `\abstract`, L5153) is `locked`: the
+  // brace form routes to the *deferred* `\lx@add@abstract` frontmatter
+  // accumulator, so `\maketitle` flushes it in schema-canonical order (document
+  // `<title>` first, `<abstract>` after). Perl relies on exactly this lock — the
+  // raw sn-jnl.cls's `\long\def\abstract#1{\def\@abstract{...}}` (deferred store,
+  // emitted by `\@maketitle`'s `\printabstract` AFTER title+authors) cannot pull
+  // the core `\abstract` back to an immediate emit. A binding-level
+  // `DefEnvironment!("{abstract}", <ltx:abstract>...)` + `\abstract{}` forwarder
+  // bypasses that lock and emits `<ltx:abstract>` at the *call site* — which in
+  // every sn-jnl paper is BEFORE `\maketitle`, so the abstract lands ahead of the
+  // still-deferred title. That is the abstract-before-title regression; letting
+  // the locked kernel macro run fixes it and keeps the env properly bounded
+  // (`\begin{abstract}`→`\lx@begin@abstract`, `\end{abstract}`→`\lx@end@abstract`
+  // both deferred). arXiv/html_feedback#3436, witnesses 2411.11158, 2306.11901.
+  //
+  // Frontmatter envs — internal_vertical mode for multi-paragraph bodies
+  // (declarations especially carries author prose with \par separators). Without
+  // explicit mode, restricted_horizontal default trips Endgroup mismatch on
+  // \par-containing bodies.
   DefEnvironment!("{declarations}", "<ltx:acknowledgements name='declarations'>#body</ltx:acknowledgements>",
     mode => "internal_vertical");
   DefEnvironment!("{appendices}", "<ltx:appendix>#body</ltx:appendix>",

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -854,6 +854,38 @@ fn frontmatter_sn_jnl_shared_affil() {
   );
 }
 
+/// Springer-Nature `sn-jnl.cls` with `\abstract{...}` written BEFORE
+/// `\maketitle` (the shape every sn-jnl paper uses). The abstract is a *locked*
+/// deferred-frontmatter macro (`\lx@add@abstract`, latex_constructs `\abstract`
+/// L5153), so `\maketitle` must flush it in schema-canonical order — the
+/// document `<title>` FIRST, the `<abstract>` after it — not emit the abstract
+/// immediately at its call site (which lands it before the still-deferred
+/// title). Perl locks the core `\abstract` so the raw class's `\def\abstract`
+/// cannot pull it back to an immediate emit; the binding must not override it
+/// either. arXiv/html_feedback#3436, witness 2411.11158, 2306.11901.
+#[test]
+fn frontmatter_sn_jnl_abstract_after_title() {
+  let x =
+    convert_to_xml_contrib_clean("tests/cluster_regressions/frontmatter_sn_jnl_abstract_order.tex");
+  let title = x.find("<title>").expect("document <title> present");
+  let abstract_ = x.find("<abstract").expect("<abstract> present");
+  assert!(
+    title < abstract_,
+    "sn-jnl abstract must render AFTER the title, not before it \
+     (title@{title}, abstract@{abstract_}):\n{x}"
+  );
+  // The abstract text is preserved…
+  assert!(
+    x.contains("This is the abstract."),
+    "sn-jnl abstract body missing:\n{x}"
+  );
+  // …and the author frontmatter still flushes with the title block.
+  assert!(
+    x.contains("<personname>") && x.contains("Asare"),
+    "sn-jnl author frontmatter missing:\n{x}"
+  );
+}
+
 /// LNCS `llncs.cls`: several authors all bound to ONE `\institute` via
 /// `\inst{1}`, whose body is the shared affiliation line followed by a single
 /// shared `\email{\{a,b\}@host}` covering every author. Both the affiliation

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -886,6 +886,37 @@ fn frontmatter_sn_jnl_abstract_after_title() {
   );
 }
 
+/// Same defect via the *environment* form `\begin{abstract}…\end{abstract}`
+/// (rather than the braced `\abstract{…}`). In LaTeXML the abstract environment
+/// is NOT backed by the raw-LaTeX `\abstract`/`\endabstract` pair — the kernel
+/// binds `\begin{abstract}`→`\lx@begin@abstract` and `\end{abstract}`→
+/// `\lx@end@abstract` directly (latex_constructs L5147-5148), both deferred — so
+/// the env form routes to the same frontmatter accumulator as the braced form and
+/// must likewise land after the title. Removing the binding's `{abstract}`
+/// override could only *regress* this if it clobbered those kernel bindings; it
+/// does not, and this guard proves it. arXiv/html_feedback#3436.
+#[test]
+fn frontmatter_sn_jnl_abstract_env_after_title() {
+  let x = convert_to_xml_contrib_clean(
+    "tests/cluster_regressions/frontmatter_sn_jnl_abstract_env_order.tex",
+  );
+  let title = x.find("<title>").expect("document <title> present");
+  let abstract_ = x.find("<abstract").expect("<abstract> present");
+  assert!(
+    title < abstract_,
+    "sn-jnl env-form abstract must render AFTER the title, not before it \
+     (title@{title}, abstract@{abstract_}):\n{x}"
+  );
+  assert!(
+    x.contains("This is the env-form abstract."),
+    "sn-jnl env-form abstract body missing:\n{x}"
+  );
+  assert!(
+    x.contains("<personname>") && x.contains("Asare"),
+    "sn-jnl env-form author frontmatter missing:\n{x}"
+  );
+}
+
 /// LNCS `llncs.cls`: several authors all bound to ONE `\institute` via
 /// `\inst{1}`, whose body is the shared affiliation line followed by a single
 /// shared `\email{\{a,b\}@host}` covering every author. Both the affiliation

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_sn_jnl_abstract_env_order.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_sn_jnl_abstract_env_order.tex
@@ -1,0 +1,13 @@
+\documentclass[pdflatex,sn-mathphys]{sn-jnl}
+\begin{document}
+\title{Env-Form sn-jnl Frontmatter}
+\author*{\fnm{Owura} \sur{Asare}}\email{oasare@uwaterloo.ca}
+\affil{\orgdiv{Cheriton School of Computer Science}, \orgname{University of Waterloo}, \orgaddress{\city{Waterloo}, \country{Canada}}}
+\begin{abstract}
+This is the env-form abstract. It is written with begin/end abstract rather than a braced argument, and must still render after the title, not before it.
+\end{abstract}
+\keywords{alpha, beta, gamma}
+\maketitle
+\section{Introduction}
+Body text.
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_sn_jnl_abstract_order.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_sn_jnl_abstract_order.tex
@@ -1,0 +1,11 @@
+\documentclass[pdflatex,sn-mathphys]{sn-jnl}
+\begin{document}
+\title{A Structured sn-jnl Frontmatter}
+\author*{\fnm{Owura} \sur{Asare}}\email{oasare@uwaterloo.ca}
+\affil{\orgdiv{Cheriton School of Computer Science}, \orgname{University of Waterloo}, \orgaddress{\city{Waterloo}, \country{Canada}}}
+\abstract{This is the abstract. It is declared before \textbackslash maketitle in the source, exactly as sn-jnl papers write it, and must render after the title, not before it.}
+\keywords{alpha, beta, gamma}
+\maketitle
+\section{Introduction}
+Body text.
+\end{document}


### PR DESCRIPTION
**Diagnostic.** `sn_jnl_cls.rs` overrode `\abstract` with a `DefEnvironment!("{abstract}", <ltx:abstract>…)` + `\abstract{}` forwarder that emitted `<ltx:abstract>` at the call site. Every sn-jnl paper writes `\abstract{…}` before `\maketitle`, so the abstract landed ahead of the still-deferred title.

**Approach.** Drop the override. The kernel `\abstract` (latex_constructs L5153) is `locked` and routes the brace form to the deferred `\lx@add@abstract` accumulator; the env form routes through the kernel's direct `\begin{abstract}`→`\lx@begin@abstract` binding (L5147-5148), *not* the raw-LaTeX `\abstract`/`\endabstract` pair — so both forms defer, and `\maketitle` flushes frontmatter in schema-canonical order (title first, abstract after creators). This matches Perl, which relies on exactly this lock so the raw class's `\def\abstract` cannot pull the core macro back to an immediate emit.

**Validation.** Guards `frontmatter_sn_jnl_abstract_after_title` (braced form) and `frontmatter_sn_jnl_abstract_env_after_title` (env form) — both RED under the override (`abstract@309` before `title@532`), GREEN after. Full suite 2095/0; clippy/fmt clean. Witnesses 2411.11158, 2306.11901 convert exit 0 / 0 errors / title before abstract; 2306.11901 (the paper the override was added for) does not regress.

Resolves the frontmatter-order half of arXiv/html_feedback#3436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)