### PR TITLE
feat #683: persist non-default NOMINAL_FONT_SIZE as a <?latexml?> PI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+  - **A non-default `NOMINAL_FONT_SIZE` is persisted as a
+    `<?latexml nominal-font-size="X"?>` processing instruction** so post-processing
+    can size font-relative (`em`) external SVGs correctly — an `em` is
+    `NOMINAL_FONT_SIZE`pt, not always 10pt (#683). Perl never carries this value
+    (it is digestion-only `DEFSIZE`), so this is beyond-Perl (OXIDIZED_DESIGN #136).
+    The PI fires only when the value differs from the 10pt default (a0poster=25,
+    BookML, the NNpt class options), so ordinary documents stay byte-identical.
+    Emitting it also fixed an `insert_pi` bug: a PI added after the root element
+    already exists was queued into the once-drained `pending` list and silently
+    lost; it is now inserted directly before the root, matching Perl
+    `Core/Document.pm::insertPI`.
   - **`--urlstyle=(server|negotiated|file)` rewrites cross-reference URLs for the
     serving environment** (feature parity with `latexmlpost`; #656). `server`
     strips a trailing `index.html` (landing page → `./`), `negotiated` also strips

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -5162,3 +5162,32 @@ coordinate math; the `grid` option (epic's `\grid`, no Rust binding) and the
 the maintainer 2026-08-18.
 
 **Guard:** `cluster_package_guards::overpic_renders_graphic_and_overlays::{overpic_emits_populated_sized_picture_with_graphic_and_overlays, overpic_missing_natural_size_image_does_not_divide_by_zero}`.
+
+### 136. `<?latexml nominal-font-size?>` PI persists a non-default `NOMINAL_FONT_SIZE`
+
+**Decision:** When `NOMINAL_FONT_SIZE` differs from the 10pt default at document
+finalization, emit a `<?latexml nominal-font-size="X"?>` processing instruction,
+alongside the existing `<?latexml class=… package=…?>` metadata PIs. A default
+(10pt) document emits nothing, so its output stays byte-identical.
+
+**Perl behavior:** Perl never persists `NOMINAL_FONT_SIZE` — it is a digestion-only
+value read by `Common/Font.pm::DEFSIZE` and then discarded. Post-processing has no
+way to recover the body font size, so an external SVG sized in `em` units is scaled
+against an assumed 10pt even when the class chose another size.
+
+**Rationale:** an `em` is `NOMINAL_FONT_SIZE`pt, not always 10pt. a0poster (25),
+BookML, and the `NNpt` class options move it off 10, and post-processing needs the
+value to size font-relative external SVGs correctly. Exposing it as a PI (the
+reporter's suggested form) makes it available without touching any element.
+arXiv/html_feedback#683 (xworld21).
+
+**Impact:** only documents whose class sets a non-default `NOMINAL_FONT_SIZE` gain
+the PI. Emitting it also surfaced and fixed an `insert_pi` bug — a PI added after
+the root element already exists was queued into the once-drained `pending` list and
+silently lost; it is now inserted directly before the root, matching Perl
+`Core/Document.pm::insertPI` ("a PI always lands before the root element").
+
+**Upstream:** n/a — beyond-Perl (post-processing metadata Perl does not carry).
+Approved by the maintainer 2026-08-18.
+
+**Guard:** `cluster_sizing::delimiter_size_nominal_font::nominal_font_size_persisted_as_pi_only_when_non_default`.

--- a/latexml_core/src/document.rs
+++ b/latexml_core/src/document.rs
@@ -1121,20 +1121,21 @@ impl Document {
       .document
       .create_processing_instruction(op, &attr_data.join(" "))
       .unwrap();
-    if self.node.get_type() == Some(NodeType::DocumentNode) {
+    // Perl (Core/Document.pm insertPI): a PI always lands before the root
+    // element. When the root already exists — a mid-body or document-final PI
+    // (#683's `<?latexml nominal-font-size?>` is emitted at finalization) —
+    // insert directly before it, whatever the current insertion point. Only
+    // when NO root has been opened yet (the usual pre-`\begin{document}` case)
+    // queue the PI in `pending`, to be flushed the moment the root opens
+    // (`open_element_at`). The old code keyed solely on the insertion point
+    // being the DocumentNode and so re-queued a post-root PI into `pending`,
+    // which drains once and never again — the PI was silently lost.
+    if let Some(mut root) = self.document.get_root_element() {
+      root.add_prev_sibling(&mut pi_node)?;
+    } else if self.node.get_type() == Some(NodeType::DocumentNode) {
       self.pending.push(pi_node);
     } else {
-      // Perl: insertPI always places PIs before the root element.
-      // Find the document root and insert before it.
-      let doc_node = self.document.clone();
-      match doc_node.get_root_element() {
-        Some(mut root) => {
-          root.add_prev_sibling(&mut pi_node)?;
-        },
-        _ => {
-          self.node.add_prev_sibling(&mut pi_node)?;
-        },
-      }
+      self.node.add_prev_sibling(&mut pi_node)?;
     }
     Ok(())
   }

--- a/latexml_oxide/src/core_interface.rs
+++ b/latexml_oxide/src/core_interface.rs
@@ -482,6 +482,23 @@ fn finish_document(document: &mut Document) -> Result<()> {
     }
   }
 
+  // #683 (xworld21): persist NOMINAL_FONT_SIZE as a
+  // `<?latexml nominal-font-size="X"?>` processing instruction when it differs
+  // from the 10pt default, so post-processing can size font-relative (em)
+  // external SVGs correctly (an `em` is `NOMINAL_FONT_SIZE`pt, not always 10pt).
+  // Perl does not emit this — NOMINAL_FONT_SIZE is digestion-only (`DEFSIZE`),
+  // so this is beyond-Perl. Only a0poster (25), the NNpt class options, and
+  // BookML move it off 10, so a normal document's output stays byte-identical
+  // (no new PI). `insert_pi` places it before the root, alongside the other
+  // `<?latexml …?>` metadata PIs (class/package/graphicspath).
+  if let Some(nominal) = state::lookup_float("NOMINAL_FONT_SIZE")
+    && (nominal.0 - 10.0).abs() > 1e-6
+  {
+    let mut attrs = HashMap::default();
+    attrs.insert(String::from("nominal-font-size"), nominal.0.to_string());
+    document.insert_pi("latexml", Some(attrs))?;
+  }
+
   note_begin("Finalizing");
   document.finalize()?;
   note_end("Finalizing");

--- a/latexml_oxide/tests/cluster_regressions/nominal_font_size_default.tex
+++ b/latexml_oxide/tests/cluster_regressions/nominal_font_size_default.tex
@@ -1,0 +1,6 @@
+% A default (10pt) document must NOT emit a <?latexml nominal-font-size?> PI —
+% the value is persisted only when it differs from the 10pt default. #683.
+\documentclass{article}
+\begin{document}
+Plain body text at the default nominal font size.
+\end{document}

--- a/latexml_oxide/tests/cluster_sizing.rs
+++ b/latexml_oxide/tests/cluster_sizing.rs
@@ -117,6 +117,37 @@ mod delimiter_size_nominal_font {
       );
     }
   }
+
+  /// #683 (xworld21): a non-default `NOMINAL_FONT_SIZE` is persisted into the XML
+  /// as a `<?latexml nominal-font-size="X"?>` processing instruction, so
+  /// post-processing can size font-relative (`em`) external SVGs correctly (an
+  /// `em` is `NOMINAL_FONT_SIZE`pt, not always 10pt). Perl does not emit this —
+  /// `NOMINAL_FONT_SIZE` is digestion-only (`DEFSIZE`) — so this is beyond-Perl.
+  /// The PI fires ONLY when the value differs from the 10pt default, so ordinary
+  /// documents stay byte-identical. Emitting it also exercised (and fixed) an
+  /// `insert_pi` bug: a PI added after the root already exists was queued into
+  /// the once-drained `pending` list and silently lost.
+  #[test]
+  fn nominal_font_size_persisted_as_pi_only_when_non_default() {
+    use crate::cluster::{convert_expecting_errors, convert_to_xml};
+    // a0poster sets NOMINAL_FONT_SIZE=25 → the PI carries it. The 4 errors are
+    // a0poster's unrelated class-binding defect (pinned by the sibling delimiter
+    // test); tolerate them here — they are orthogonal to the PI.
+    let a0 = convert_expecting_errors(
+      "tests/cluster_regressions/delimiter_size_nominal_font.tex",
+      4,
+    );
+    assert!(
+      a0.contains("<?latexml nominal-font-size=\"25\"?>"),
+      "a0poster (NOMINAL_FONT_SIZE=25) did not persist the nominal-font-size PI:\n{a0}"
+    );
+    // A default 10pt document must emit NO such PI (output stays byte-identical).
+    let plain = convert_to_xml("tests/cluster_regressions/nominal_font_size_default.tex");
+    assert!(
+      !plain.contains("nominal-font-size"),
+      "a default-size document must not emit a nominal-font-size PI:\n{plain}"
+    );
+  }
 }
 
 mod image_sizing_characterization {


### PR DESCRIPTION
**Diagnostic.** Post-processing sizes font-relative (`em`) external SVGs against an assumed 10pt, but an `em` is `NOMINAL_FONT_SIZE`pt — a0poster (25), BookML, and the NNpt class options move it off 10. Perl never carries the value (digestion-only `DEFSIZE`), so post cannot recover it.

**Approach.** At document finalization, when `NOMINAL_FONT_SIZE` ≠ the 10pt default, emit `<?latexml nominal-font-size="X"?>` alongside the existing `<?latexml class=… package=…?>` metadata PIs. A default document emits nothing (byte-identical output). Beyond-Perl, maintainer-approved (OXIDIZED_DESIGN #136). Also fixes an `insert_pi` bug — a PI added after the root already exists was queued into the once-drained `pending` list and silently lost; it now inserts before the root whenever one exists (Perl `Core/Document.pm::insertPI`).

**Scope.** Emit-only per the agreed design; post-side em-consumption is out of scope. Note: our engine does not currently wire the NNpt *class options* to `NOMINAL_FONT_SIZE` (only a0poster/explicit assignments set it live), a separate pre-existing gap — the PI faithfully persists whatever is set.

**Validation.** Guard `cluster_sizing::delimiter_size_nominal_font::nominal_font_size_persisted_as_pi_only_when_non_default` (a0poster⇒`"25"`; default⇒absent); full suite 2095/0; clippy/fmt clean.

Closes #683