### PR TITLE
fix: neurips preprint/final papers keep the body after the abstract

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3827,3 +3827,48 @@ counter (init 5, `$pdfoutput_checks-- if $pdfoutput_checks`) clamps at 0, so the
 `$pdfoutput_checks >= 0` guard on the `\pdfoutput=1` probe is *always* true — the
 intended "first few lines only" cap is a no-op and `\pdfoutput=1` matches on any
 line. The Rust port (`has_pdftex_marker`) mirrors this effective behavior.
+
+---
+
+## 98. neurips `{hide}` environment defined unconditionally swallows the body in preprint/final mode (Rust surpasses)
+
+**Perl source:** `LaTeXML/lib/LaTeXML/Package/neurips.sty.ltxml` line 59:
+`DefEnvironment('{hide}', '');`
+
+**Symptom:** A `neurips_2019`–`neurips_2025` paper in `[preprint]` (or `[final]`)
+mode that defines its own brace-gobbling `\newcommand{\hide}[1]{}` and uses it as
+`\hide{ … }` loses **everything after the abstract**:
+```
+Info:ignore:\hide Ignoring redefinition (\newcommand) of '\hide'
+Warning:unexpected:\end{document} Attempt to end document with open groups …
+Warning:expected:\endhide body should have ended with '\endhide'
+```
+
+**Root cause:** The real `neurips_20XX.cls` only runs `\NewEnviron{hide}{}` in the
+**submission** branch (`\if@preprint … \else \if@neuripsfinal … \else <here>`,
+neurips_2023.cls L336-390), so in preprint/final mode `\hide` is left undefined
+and the author's own `\newcommand{\hide}[1]{}` wins. Perl's `.ltxml` defines
+`{hide}` **unconditionally**, so `\hide` is already a CS, the `\newcommand` is
+ignored as a redefinition, and `\hide{` opens a runaway environment that consumes
+tokens to `\end{document}` looking for `\endhide` — swallowing the whole body.
+Same failure family as entry #48 (unconditional `DefEnvironment` shadows a
+definition → unclosed group eats the document).
+
+**Minimal trigger:**
+```tex
+\documentclass{article}
+\usepackage[preprint]{neurips_2023}
+\newcommand{\hide}[1]{}
+\begin{document}\maketitle
+\begin{abstract}Abstract.\end{abstract}
+\hide{\section{Hidden}Gone.}
+\section{Visible}Body must survive.
+\end{document}
+```
+
+**Impact:** Perl-origin, SHARED with the Rust binding (a faithful port of L59).
+**Rust status (FIXED — `neurips_sty.rs`):** the `{hide}` `DefEnvironment` is gated
+on submission mode (neither `neurips_preprint` nor `neurips_final` set), matching
+the real class; submission-mode `\begin{hide}…\end{hide}` still hides. Guard:
+`06_cluster_regressions::neurips_hide_preprint_preserves_body`. Witness:
+html_feedback #861 (arXiv:2403.15796v1).

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -1045,6 +1045,35 @@ fn cleveref_custom_theorem_cref_shows_heading_name() {
   );
 }
 
+/// html_feedback#861 (arXiv:2403.15796, neurips_2023 preprint): "everything after
+/// the abstract missing". The paper defines its own brace-gobbling `\newcommand
+/// {\hide}[1]{}` and comments blocks out with `\hide{ … }`. The neurips binding
+/// defined the `{hide}` environment UNCONDITIONALLY, so `\hide` was already a CS,
+/// the author's `\newcommand` was ignored as a redefinition, and `\hide{` opened a
+/// runaway environment that ran to `\end{document}` looking for `\endhide` —
+/// swallowing the whole body. The real neurips_2023.cls only defines `{hide}` in
+/// SUBMISSION mode (not preprint/final), so the binding now gates on it. Perl 0.8.8
+/// drops the body identically; this surpasses it. Canary: the visible sections
+/// AFTER the hidden block must survive, and the hidden content must stay gone.
+#[test]
+fn neurips_hide_preprint_preserves_body() {
+  let x = convert_to_xml("tests/cluster_regressions/neurips_hide_preprint_body.tex");
+  // The body after the abstract survives — the reported symptom.
+  assert!(
+    x.contains("Visible Introduction") && x.contains("The body after the abstract must survive."),
+    "neurips preprint: body after the abstract was swallowed:\n{x}"
+  );
+  assert!(
+    x.contains("Conclusion") && x.contains("Concluding remarks that must not vanish."),
+    "neurips preprint: sections after the hidden block are missing:\n{x}"
+  );
+  // …and `\hide{…}` still hid its argument (the author's intent).
+  assert!(
+    !x.contains("Hidden paragraph") && !x.contains("Hidden Introduction"),
+    "neurips preprint: the \\hide{{…}} block leaked into the output:\n{x}"
+  );
+}
+
 /// Companion to the above (html_feedback#140): an explicit `\crefname{widget}{gadget}
 /// {gadgets}` must WIN over the theorem-heading fallback — `\cref` renders the explicit
 /// "gadget", not the heading "Widget". `\crefname` is now a real definition (a faithful

--- a/latexml_oxide/tests/cluster_regressions/neurips_hide_preprint_body.tex
+++ b/latexml_oxide/tests/cluster_regressions/neurips_hide_preprint_body.tex
@@ -1,0 +1,24 @@
+\documentclass{article}
+\usepackage[preprint]{neurips_2023}
+% The author's own "comment this out" helper — a brace-gobbling macro, exactly
+% the shape witness 2403.15796 uses. In preprint mode the real neurips_2023.cls
+% leaves \hide undefined, so this \newcommand wins and \hide{...} eats its arg.
+\newcommand{\hide}[1]{}
+\title{Emergent Abilities}
+\author{A. Author}
+\begin{document}
+\maketitle
+\begin{abstract}
+This is the abstract.
+\end{abstract}
+\hide{
+\section{Hidden Introduction}
+Hidden paragraph one.
+
+Hidden paragraph two, after a blank line, inside the hidden block.
+}
+\section{Visible Introduction}
+The body after the abstract must survive.
+\section{Conclusion}
+Concluding remarks that must not vanish.
+\end{document}

--- a/latexml_package/src/package/neurips_sty.rs
+++ b/latexml_package/src/package/neurips_sty.rs
@@ -65,8 +65,24 @@ LoadDefinitions!({
   DefEnvironment!("{ack}", "#body",
     before_digest => { unread_one(T_CS!("\\acksection")); });
 
-  // {hide} environment — Perl L59
-  DefEnvironment!("{hide}", "");
+  // {hide} environment. Perl (neurips.sty.ltxml L59) defines it
+  // UNCONDITIONALLY, but the raw neurips_2023.sty (L336-390) only runs
+  // `\NewEnviron{hide}{}` in the SUBMISSION branch —
+  // `\if@preprint … \else \if@neuripsfinal … \else <here> \fi \fi` — so in
+  // preprint/final mode `\hide` is left undefined. That matters: papers define
+  // their own `\newcommand{\hide}[1]{}` (a brace-gobbling "comment this out"
+  // helper) and use it as `\hide{ … }`. Defining `{hide}` unconditionally
+  // shadows that `\newcommand` (silently ignored as a redefinition), so `\hide{`
+  // is parsed as the environment opener and runs away to `\end{document}`
+  // looking for `\endhide` — swallowing the whole body (everything after the
+  // abstract). Gate on submission mode (neither preprint nor final) to match the
+  // real class. SURPASSES Perl, which drops the body identically here.
+  // arXiv/html_feedback#861, witness 2403.15796.
+  if with_value("neurips_preprint", |v| v.is_none())
+    && with_value("neurips_final", |v| v.is_none())
+  {
+    DefEnvironment!("{hide}", "");
+  }
 
   // Theorem-likes — neurips_2024.sty L451-460 (and similar in 2022-2025).
   // Real templates define a `theorem` counter and a small set of named


### PR DESCRIPTION
**Diagnostic.** The neurips binding defined the `{hide}` environment unconditionally (a faithful port of Perl `neurips.sty.ltxml:59`). The real `neurips_20XX.cls` only runs `\NewEnviron{hide}{}` in the **submission** branch (`\if@preprint … \else \if@neuripsfinal … \else <here>`); in preprint/final mode `\hide` is left undefined, so a paper's own brace-gobbling `\newcommand{\hide}[1]{}` wins. Defining `{hide}` unconditionally shadowed that `\newcommand` (ignored as a redefinition), so `\hide{` opened a runaway environment that ran to `\end{document}` looking for `\endhide` — swallowing **everything after the abstract**. Same failure family as `KNOWN_PERL_ERRORS` #48 (subcaption/subfigure).

**Approach.** Gate the `{hide}` `DefEnvironment` on submission mode (neither `neurips_preprint` nor `neurips_final` set), mirroring the real class and the existing `neurips_nonatbib` check one block up. Submission/default-mode `\begin{hide}…\end{hide}` still hides. Surpasses Perl 0.8.8, which drops the body identically (recorded as `KNOWN_PERL_ERRORS` #98).

**Validation.** Guard `06_cluster_regressions::neurips_hide_preprint_preserves_body` — RED (body swallowed) → GREEN. Full suite 2095/0; clippy/fmt clean. Witness **2403.15796v1** now converts to a full 187 KB / 20-section document with 54 bibitems (was 5.6 KB — title + abstract only); submission and final modes hand-verified correct.

Resolves arXiv/html_feedback#861 (gwern: "everything after abstract missing").

🤖 Generated with [Claude Code](https://claude.com/claude-code)