### PR TITLE
test: guard IEEE-journal superscript author/affiliation block

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3872,3 +3872,43 @@ on submission mode (neither `neurips_preprint` nor `neurips_final` set), matchin
 the real class; submission-mode `\begin{hide}…\end{hide}` still hides. Guard:
 `06_cluster_regressions::neurips_hide_preprint_preserves_body`. Witness:
 html_feedback #861 (arXiv:2403.15796v1).
+
+---
+
+## 99. IEEE journal `\textsuperscript`-keyed author/affiliation block scrambles into phantom authors (Rust surpasses)
+
+**Perl source:** the default `\author` name-splitter (`Base_Utility.pool.ltxml`),
+which has no notion of a trailing `\textsuperscript{N}`-keyed affiliation list.
+
+**Symptom:** The IEEEtran *journal* front-matter idiom — all authors first, each
+tagged `\textsuperscript{N}` (a comma list `\textsuperscript{1,2}` links one author
+to several), then the affiliations one per `\\` line each led by `\textsuperscript{N}`,
+then a `\texttt{…}` email block, `\\[1em]` spacing between groups — comes out
+scrambled: `\\[1em]` leaks as literal `[1em]`, and the affiliation lines
+("University of Pisa", "Italy", …) are promoted to **phantom authors** (9 creators
+for a 6-author paper). Distinct from entry #94 (the `\IEEEauthorblockN` *conference*
+grid).
+
+**Minimal trigger:**
+```tex
+\documentclass[12pt,onecolumn]{IEEEtran}
+\author{
+Alice\textsuperscript{1,2}, Bob\textsuperscript{3} \\[1em]
+
+\textsuperscript{1}Univ A \\
+\textsuperscript{2}Lab B \\
+\textsuperscript{3}Univ C
+}
+\title{T}\begin{document}\maketitle\end{document}
+```
+Perl → a single phantom creator named `[1em]`, the real authors Alice/Bob dropped
+entirely; on the full witness the affiliation lines themselves surface as extra
+creators ("University of Pisa", "Italy") — 9 for a 6-author paper. Correct (Rust):
+`Alice` (→ Univ A, Lab B) and `Bob` (→ Univ C).
+
+**Impact:** Perl-origin. **Rust status (FIXED — surpasses, OXIDIZED_DESIGN #52):**
+the beyond-Perl author-splitter keys each author to its affiliation(s) by the
+superscript number (comma lists attach to several), drops the `\\[1em]` spacing, and
+never promotes an affiliation line to a creator. Guard:
+`06_cluster_frontmatter::frontmatter_ieeetran_journal_superscript_affil`. Witness:
+html_feedback #6880 (arXiv:2605.23553v1). Sibling of #6242 (single-line variant).

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -116,6 +116,67 @@ fn frontmatter_multi_affil_superscript() {
     "the two superscript affiliations merged into one:\n{x}"
   );
 }
+/// html_feedback#6880 (arXiv:2605.23553, IEEEtran journal): the "all authors, then
+/// all affiliations keyed by `\textsuperscript{N}`" block — the harder variation of
+/// #6242. A comma-list superscript (`\textsuperscript{1,2}`) links ONE author to
+/// TWO affiliations; the affiliations sit one-per-`\\`-line, each led by its own
+/// `\textsuperscript{N}`; and `\\[1em]` spacing separates the groups. The reporter's
+/// deployed binary — and Perl 0.8.8 — scrambled it: `[1em]` leaked as literal text
+/// and the affiliation lines ("University of Pisa", "Italy") became phantom authors
+/// (9 creators instead of 6). HEAD's OXIDIZED_DESIGN #52 author-splitter maps each
+/// author to its affiliation(s) by number; Rust surpasses Perl. Deployed-lag; this
+/// pins the correct mapping so it cannot regress back.
+#[test]
+fn frontmatter_ieeetran_journal_superscript_affil() {
+  let x =
+    convert_to_xml("tests/cluster_regressions/frontmatter_ieeetran_journal_superscript_affil.tex");
+  // Exactly the six real authors — no affiliation fragment promoted to a creator.
+  assert_eq!(
+    x.matches("role=\"author\"").count(),
+    6,
+    "IEEEtran journal: expected exactly 6 author creators (affiliation lines must \
+     not become phantom authors):\n{x}"
+  );
+  for name in [
+    "Davide Cosimo",
+    "Davide Costa",
+    "Riccardo Costanzi",
+    "Filippo Campagnaro",
+    "Andrea Caiti",
+    "Michele Zorzi",
+  ] {
+    assert!(
+      x.contains(&format!("<personname>{name}</personname>")),
+      "IEEEtran journal: author {name:?} missing as its own creator:\n{x}"
+    );
+  }
+  // No affiliation fragment promoted to a phantom author, and no `\\[1em]` leak.
+  for phantom in [
+    "<personname>University of Pisa",
+    "<personname>Italy</personname>",
+    "<personname>Dept. of Information",
+  ] {
+    assert!(
+      !x.contains(phantom),
+      "IEEEtran journal: affiliation fragment leaked as a phantom author ({phantom}):\n{x}"
+    );
+  }
+  assert!(
+    !x.contains("[1em]"),
+    "IEEEtran journal: `\\\\[1em]` leaked as literal text:\n{x}"
+  );
+  // Comma-list `\textsuperscript{1,2}`: the first author (Cosimo) links to BOTH
+  // affiliation 1 (Pisa) AND affiliation 2 (Naval).
+  let cosimo = x
+    .split("<creator")
+    .find(|b| b.contains("<personname>Davide Cosimo</personname>"))
+    .unwrap_or("");
+  assert!(
+    cosimo.contains("University of Pisa") && cosimo.contains("Naval Support"),
+    "IEEEtran journal: comma-list superscript {{1,2}} must link Cosimo to BOTH \
+     Pisa and Naval:\n{cosimo}"
+  );
+}
 /// html_feedback#6255 (googledeepmind, authblk): a single `\author{A, B, C}` comma
 /// list is authblk's one-author-arg form, so it stayed as one merged
 /// `<personname>A, B, C</personname>`. The DEFAULT `\author` already splits a comma

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_ieeetran_journal_superscript_affil.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_ieeetran_journal_superscript_affil.tex
@@ -1,0 +1,26 @@
+\documentclass[12pt,onecolumn]{IEEEtran}
+\begin{document}
+\title{A Study}
+% IEEE journal author block (arXiv:2605.23553): all authors first, each with
+% a \textsuperscript marker (comma lists link one author to several), then the
+% affiliations one per \\ line each led by its own \textsuperscript{N}, then a
+% \texttt email block, then \thanks. \\[1em] spacing must NOT leak as "[1em]",
+% and affiliation lines must NOT become phantom authors.
+\author{
+Davide Cosimo\textsuperscript{1,2}, Davide Costa\textsuperscript{3}, Riccardo Costanzi\textsuperscript{1},
+Filippo Campagnaro\textsuperscript{3}, \\
+Andrea Caiti\textsuperscript{1}, Michele Zorzi\textsuperscript{3} \\[1em]
+
+\textsuperscript{1}Dept. of Information Engineering, University of Pisa, Italy \\
+\textsuperscript{2}Naval Support and Experimentation Centre - Italian Navy, La Spezia, Italy \\
+\textsuperscript{3}Dept. of Information Engineering, University of Padua, Italy \\[1em]
+
+\texttt{davide.cosimo@phd.unipi.it, costadavid@dei.unipd.it, riccardo.costanzi@unipi.it,}\\
+\texttt{filippo.campagnaro@unipd.it, andrea.caiti@unipi.it, michele.zorzi@unipd.it}
+
+\thanks{This manuscript has been submitted for consideration for publication in the IEEE JOE.}
+}
+\maketitle
+\section{Introduction}
+Body text.
+\end{document}


### PR DESCRIPTION
**Diagnostic.** IEEEtran *journal* front-matter (all authors first, each `\textsuperscript{N}`-keyed — a comma list `{1,2}` links one author to several — then affiliations one-per-`\\`-line, then emails, `\\[1em]` spacing). The deployed binary the reporter saw leaked `[1em]` as literal text **3×** in the author block (confirmed against the live arXiv HTML for 2605.23553v1); Perl 0.8.8 additionally promotes the affiliation lines to **phantom authors** (9 creators for 6). Distinct from #94 (the `\IEEEauthorblockN` conference grid).

**Approach.** No source change — HEAD's OXIDIZED_DESIGN #52 author-splitter already maps each author to its affiliation(s) by number and emits neither defect (deployed-lag). This pins that correct behavior so it cannot regress back, and records the Perl-origin bug as `KNOWN_PERL_ERRORS` #99 (minimal trigger verified against both engines).

**Validation.** Guard `frontmatter_ieeetran_journal_superscript_affil` (green on HEAD; would be RED on the deployed `[1em]` leak and on Perl's phantom authors) asserts exactly 6 authors, Cosimo → both Pisa and Naval (comma `{1,2}`), no `[1em]` leak, no phantom authors. Full suite 2103/0; clippy/fmt clean.

Resolves arXiv/html_feedback#6880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)