### PR TITLE
fix: biblatex must not globally define \type (broke user math macros)

### DIFF
--- a/latexml_contrib/src/biblatex_sty.rs
+++ b/latexml_contrib/src/biblatex_sty.rs
@@ -2069,9 +2069,23 @@ LoadDefinitions!({
     r"\@ifundefined{true}{\let\true\blx@bbl@booltrue}{}\@ifundefined{false}{\let\false\blx@bbl@boolfalse}{}"
   ))?;
 
-  // Perl L646-671: \the* counter-readouts (all empty)
-  def_macro_noop("\\type{}")?;
-  def_macro_noop("\\subtype{}")?;
+  // \type / \subtype are DELIBERATELY NOT defined here (the ar5iv
+  // `biblatex.sty.ltxml` L646-647 defined both globally as `Tokens()`). Real
+  // biblatex.sty defines `\def\type#1{type=#1}` / `\def\subtype#1{...}` ONLY
+  // inside the `\begingroup` of a bibliography-filter body (biblatex.sty
+  // L9380-9388, `\blx@defbibfilter`) — so in the document body `\type` is
+  // undefined and a user's `\newcommand{\type}{...}` (a ubiquitous math macro)
+  // takes effect. Defining `\type{}` globally as an arg-grabbing noop shadowed
+  // that user macro AND, being `#1`-arity, ate the token after it: `\(\type\)`
+  // consumed the closing `\)`, inline math never closed, and every following
+  // display equation nested as `<ltx:equation> isn't allowed in <ltx:XMath>` —
+  // the document rendered "half missing". arXiv/html_feedback#6681, witness
+  // 2606.22155. (A `\defbibfilter{...\type{...}...}` is the only place biblatex
+  // itself uses `\type`; our binding doesn't process filter bodies, so nothing
+  // here needs the global stub.)
+  //
+  // Perl L648-671: \the* counter-readouts (all empty, argument-less — safe to
+  // keep global).
   def_macro_noop("\\theparenlevel")?;
   def_macro_noop("\\therefsection")?;
   def_macro_noop("\\therefsegment")?;

--- a/latexml_oxide/tests/06_cluster_bibliography.rs
+++ b/latexml_oxide/tests/06_cluster_bibliography.rs
@@ -555,6 +555,33 @@ fn cluster_biblatex_two_datalists() {
     "expected exactly 4 bibitems (2 entries x 2 datalists, no stray):\n{x}"
   );
 }
+/// biblatex must NOT globally define `\type` (nor `\subtype`). Real biblatex
+/// defines `\def\type#1{type=#1}` only inside a `\begingroup` bibliography-filter
+/// body (biblatex.sty L9380-9388), so in the document body `\type` is undefined
+/// and a user's `\newcommand{\type}{\mathrm{type}}` — a ubiquitous math macro —
+/// takes effect. Our binding mirrored ar5iv's global `DefMacro('\type{}',
+/// Tokens())`, an arg-grabbing noop that shadowed the user macro AND ate the
+/// token after it: `\(\type\)` consumed the closing `\)`, inline math never
+/// closed, and every following display equation nested as `<ltx:equation> isn't
+/// allowed in <ltx:XMath>` — the document came out "half missing". The `_clean`
+/// helper's 0-error gate is the red→green signal. arXiv/html_feedback#6681,
+/// witness 2606.22155.
+#[test]
+fn biblatex_does_not_shadow_user_type_macro() {
+  let x = convert_to_xml_contrib_clean("tests/cluster_regressions/biblatex_type_macro_math.tex");
+  // The content AFTER the display equation survives (math mode closed) — the
+  // "half missing" symptom is gone.
+  assert!(
+    x.contains("Body text after the display equation"),
+    "content after the display equation was swallowed (math mode left open):\n{x}"
+  );
+  // The user's `\type` rendered as its math (`\mathrm{type}`), and the display
+  // equation is a proper sibling equation, not a malformed nested one.
+  assert!(
+    x.contains("type") && x.matches("<equation").count() == 1,
+    "expected the user \\type to render and exactly one display <equation>:\n{x}"
+  );
+}
 /// arXiv/html_feedback#6797 — an author-year bibliography built from a `.bib`
 /// used the FULL author list as the entry's refnum LABEL (5104 characters on the
 /// witness, arXiv 2607.21432); and because the author-year branch also skipped

--- a/latexml_oxide/tests/cluster_regressions/biblatex_type_macro_math.tex
+++ b/latexml_oxide/tests/cluster_regressions/biblatex_type_macro_math.tex
@@ -1,0 +1,17 @@
+% biblatex must not globally define \type — real biblatex scopes \type/\subtype
+% to \begingroup bibliography-filter contexts (biblatex.sty L9380-9388), leaving
+% \type undefined in the document body so a user \newcommand{\type} works. Our
+% binding mirrored ar5iv's global `DefMacro('\type{}', Tokens())`, an
+% arg-grabbing noop: \(\type\) then ate the closing \), inline math never
+% closed, and every following display equation nested as
+% `<ltx:equation> isn't allowed in <ltx:XMath>` — the document came out "half
+% missing". arXiv/html_feedback#6681, witness 2606.22155.
+\documentclass{article}
+\usepackage{amsmath,amssymb}
+\usepackage[backend=biber]{biblatex}
+\newcommand{\type}{\mathrm{type}}
+\begin{document}
+The map \(\type\) sends words onto the discrete simplex
+\[ T_{n} = \{a : a = n\}. \]
+Body text after the display equation.
+\end{document}


### PR DESCRIPTION
**Diagnostic.** Our biblatex binding mirrored ar5iv's `DefMacro('\type{}', Tokens())` / `\subtype{}` — **global, arg-grabbing noops**. Real biblatex.sty defines `\def\type#1{type=#1}` only inside a `\begingroup` bibliography-filter body (biblatex.sty L9380-9388), so `\type` is undefined in the document body and a user's `\newcommand{\type}{\mathrm{type}}` takes effect. The global stub shadowed that ubiquitous math macro and ate the token after it: `\(\type\)` consumed the closing `\)`, inline math never closed, and every following display equation nested as `<ltx:equation> isn't allowed in <ltx:XMath>` — the document rendered "half missing".

**Approach.** Drop both global `\type`/`\subtype` definitions (unused in the binding; filter bodies — the only place biblatex needs `\type` — aren't processed). Aligns with real biblatex.sty scoping. Perl ships no biblatex binding and the arxiv.org/html page uses the same ar5iv stub, so it breaks identically.

**Validation.** Guard `biblatex_does_not_shadow_user_type_macro` (red→green via the 0-error `_clean` gate); full suite 2103/0; clippy/fmt. Witness 2606.22155 drops ~66 errors → 3 (the residual 3 are a separate embedfile-abort, a PDF-only package — no visible defect, all sections present).

Context: arXiv/html_feedback#6681.