### PR TITLE
fix: IJCAI-derivative \author blocks split names/affiliations/emails

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3872,3 +3872,38 @@ on submission mode (neither `neurips_preprint` nor `neurips_final` set), matchin
 the real class; submission-mode `\begin{hide}…\end{hide}` still hides. Guard:
 `06_cluster_regressions::neurips_hide_preprint_preserves_body`. Witness:
 html_feedback #861 (arXiv:2403.15796v1).
+
+---
+
+## 100. IJCAI-derivative `\author{}` with `\affiliations`/`\emails` shreds emails into phantom authors (Rust surpasses)
+
+**Perl source:** the default `\author` splitter (`Base_Utility.pool.ltxml`); Perl's
+`ijcai.sty.ltxml` handles the idiom, but only for a document that actually loads
+the `ijcai` package.
+
+**Symptom:** The IJCAI author idiom (ijcai97.sty) packs names, `\affiliations` and a
+comma-separated `\emails` list into ONE `\author{}`. A paper using a *renamed copy*
+of ijcai97.sty — e.g. the `ttm.sty` bundled with arXiv:2401.03955 — never loads the
+`ijcai` binding, so the raw package is used and neither engine recognises the
+section markers: the comma-joined email list is shredded into phantom author
+creators (13 for 7 authors), the `\affiliations` payload is dropped, and
+`\affiliations`/`\emails` raise `Error:undefined:`. Same on Perl 0.8.8.
+
+**Minimal trigger:**
+```tex
+\documentclass{article}
+\author{Alice \and Bob \affiliations Some Lab \emails a@x.org, b@x.org}
+\title{T}\begin{document}\maketitle\end{document}
+```
+Perl → `Alice`, `Bob`, and a phantom `b@x.org` creator (`Some Lab` mishandled); on
+the full witness it shreds all six emails into creators (13 for 7). Correct (Rust):
+`Alice`/`Bob`, `Some Lab` an affiliation, the addresses as emails, no errors.
+
+**Impact:** Perl-origin, SHARED with the Rust default splitter. **Rust status (FIXED —
+surpasses, OXIDIZED_DESIGN #52):** `\lx@add@authors` detects an `\affiliations`/
+`\emails` marker in the body and delegates to the shared sectioned-author machinery
+(`\lx@ijcai@authorsplit`, hoisted from `ijcai_sty` into `base_utilities.rs`) — names /
+affiliations / emails split, n-th email to n-th author, markers consumed as
+delimiters (no undefined-CS error). Guard:
+`06_cluster_frontmatter::frontmatter_ijcai_affiliations_emails`. Witness:
+html_feedback #1361 + #1362 (arXiv:2401.03955v5, ttm.sty).

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -881,6 +881,27 @@ LoadDefinitions!({
   // AND, matching \\ this way fails to catch \\[1em], so really should Let it
 
   DefMacro!("\\lx@add@authors{}", sub[(stuff)] {
+    // Beyond-Perl (surpasses Perl; KNOWN_PERL_ERRORS #100): IJCAI-style author
+    // blocks — ijcai97.sty and its derivatives (e.g. the ttm.sty in
+    // arXiv:2401.03955) — pack names, `\affiliations` and a comma-separated
+    // `\emails` list into ONE `\author{}`. The default splitter below does not
+    // recognise those section markers, so the comma-joined email list is shredded
+    // into phantom author creators and the affiliation is dropped (Perl 0.8.8 does
+    // the same, and both raise `\affiliations`/`\emails` as undefined). When the
+    // body carries either marker, delegate to the shared sectioned-author machinery
+    // (`\lx@ijcai@authorsplit`, also used by `ijcai_sty`): it consumes the markers
+    // as `Until:` delimiters (so they no longer error) and splits names /
+    // affiliations / emails, attaching the n-th email to the n-th author. This runs
+    // before any dequeue/normalization because the delegate re-enters
+    // `\lx@add@authors` on the (marker-free) name list.
+    // Witness html_feedback#1361 + #1362.
+    if position_of(&stuff, &[T_CS!("\\affiliations"), T_CS!("\\emails")]).is_some() {
+      let mut out = vec![T_CS!("\\lx@ijcai@authorsplit")];
+      out.extend(stuff.unlist());
+      out.push(T_CS!("\\affiliations"));
+      out.push(T_CS!("\\done"));
+      return Ok(Tokens::new(out));
+    }
     let mut calls: Vec<Token> = Vec::new();
     dequeue_front_matter("ltx:creator", &[("role", "author")]);
     // Consume any `\\[len]` / `\\*[len]` row-break optionals up front so the line
@@ -1093,6 +1114,33 @@ LoadDefinitions!({
     }
     Ok(Tokens::new(calls))
   });
+
+  // Shared "sectioned author block" machinery for the IJCAI author idiom
+  // (ijcai97.sty and its derivatives): one `\author{}` holding names, then
+  // `\affiliations`, then a comma-separated `\emails` list. Used both by the
+  // `ijcai_sty` binding's `\author` override and by the `\lx@add@authors`
+  // marker-branch above (so raw-loaded derivatives like ttm.sty work too).
+  // `\lx@ijcai@authorsplit` reads the names up to `\affiliations` and runs them
+  // through `\lx@add@authors` (now marker-free), then splits the remainder into
+  // affiliations (up to `\emails`) and the comma-separated emails, attaching the
+  // n-th email to the n-th author. Ported from Perl ijcai.sty.ltxml (PR #2767).
+  DefMacro!(
+    "\\lx@ijcai@authorsplit Until:\\affiliations Until:\\done",
+    "\\lx@add@authors{#1}\\ifx.#2.\\else\\lx@ijcai@affilsplit#2\\emails\\affiliations\\done\\fi"
+  );
+  DefMacro!(
+    "\\lx@ijcai@affilsplit  Until:\\emails Until:\\affiliations Until:\\done",
+    "\\ifx.#1.\\else\\expandafter\\lx@ijcai@affiliations\\expandafter{\\lx@strip@braces{#1}}\\fi\\ifx.#2.\\else\\expandafter\\lx@ijcai@emails\\expandafter{\\lx@strip@braces{#2}}\\fi"
+  );
+  DefMacro!(
+    "\\lx@ijcai@affiliations{}",
+    "\\lx@add@affiliations[labelseq=author]{#1}"
+  );
+  DefMacro!(
+    "\\lx@ijcai@emails{}",
+    "\\lx@clear@frontmatter{ltx:contact}[role=email]\\lx@splitting{\\lx@ijcai@email}{,}{#1}"
+  );
+  DefMacro!("\\lx@ijcai@email{}", "\\lx@add@email[labelseq=author]{#1}");
 
   // Superscript markers in author/affiliation blocks carry the affiliation
   // number. Both sides use the "affiliation" prefix so the author's requested

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -116,6 +116,55 @@ fn frontmatter_multi_affil_superscript() {
     "the two superscript affiliations merged into one:\n{x}"
   );
 }
+/// html_feedback#1361 + #1362 (arXiv:2401.03955, ttm.sty — an ijcai97.sty
+/// derivative): the IJCAI author idiom packs names, `\affiliations` and a
+/// comma-separated `\emails` list into ONE `\author{}`. Neither engine's default
+/// splitter recognises those section markers, so the email list is shredded into
+/// phantom author creators (13 for 7 authors) and the affiliation is dropped —
+/// same on Perl 0.8.8 (parity). The fix delegates any `\author{}` carrying an
+/// `\affiliations`/`\emails` marker to the shared sectioned-author machinery
+/// (also used by `ijcai_sty`), which splits names / affiliations / emails and
+/// attaches the n-th email to the n-th author. Rust surpasses Perl.
+#[test]
+fn frontmatter_ijcai_affiliations_emails() {
+  let x = convert_to_xml("tests/cluster_regressions/frontmatter_ijcai_affiliations_emails.tex");
+  // Exactly the seven real authors — the email list must NOT become creators.
+  assert_eq!(
+    x.matches("role=\"author\"").count(),
+    7,
+    "IJCAI author block: expected exactly 7 author creators (the \\emails list must \
+     not become phantom authors):\n{x}"
+  );
+  for name in [
+    "Vijay Ekambaram",
+    "Arindam Jati",
+    "Nam H. Nguyen",
+    "Pankaj Dayama",
+    "Chandra Reddy",
+    "Wesley M.\u{a0}Gifford", // `Wesley M.~Gifford` — the ~ tie is a NBSP
+    "Jayant Kalagnanam",
+  ] {
+    assert!(
+      x.contains(&format!("<personname>{name}</personname>")),
+      "IJCAI author block: author {name:?} missing as its own creator:\n{x}"
+    );
+  }
+  // No email address promoted to a phantom author.
+  assert!(
+    !x.contains("<personname>arindam.jati") && !x.contains("<personname>nnguyen"),
+    "IJCAI author block: an email address leaked into a <personname>:\n{x}"
+  );
+  // The `\affiliations` payload survives as a structured affiliation contact…
+  assert!(
+    x.contains("role=\"affiliation\"") && x.contains("IBM Research"),
+    "IJCAI author block: the \\affiliations \"IBM Research\" was dropped:\n{x}"
+  );
+  // …and the emails are email contacts, not names.
+  assert!(
+    x.contains("role=\"email\"") && x.contains("vijaye12@in.ibm.com"),
+    "IJCAI author block: the \\emails list is not structured as email contacts:\n{x}"
+  );
+}
 /// html_feedback#6255 (googledeepmind, authblk): a single `\author{A, B, C}` comma
 /// list is authblk's one-author-arg form, so it stayed as one merged
 /// `<personname>A, B, C</personname>`. The DEFAULT `\author` already splits a comma

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_ijcai_affiliations_emails.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_ijcai_affiliations_emails.tex
@@ -1,0 +1,21 @@
+\documentclass{article}
+% IJCAI-style author block (arXiv:2401.03955, ttm.sty — an ijcai97.sty
+% derivative): names \and/\And-separated, then \affiliations, then a
+% comma-separated \emails list, all inside ONE \author{}. The markers are
+% undefined at \author-time (ttm.sty \def's them only inside \@maketitle), so
+% they reach the splitter as literal tokens — exactly the real condition.
+\title{A Study}
+\author{
+    Vijay Ekambaram \and Arindam Jati \and Nam H. Nguyen \and \\
+    Pankaj Dayama \and Chandra Reddy \and Wesley M.~Gifford \And Jayant Kalagnanam
+    \affiliations
+    IBM Research
+    \emails
+    vijaye12@in.ibm.com, arindam.jati@ibm.com, nnguyen@us.ibm.com,
+    pankajdayama@in.ibm.com,\{creddy,wmgifford,jayant\}@us.ibm.com
+}
+\begin{document}
+\maketitle
+\section{Introduction}
+Body text.
+\end{document}

--- a/latexml_package/src/package/ijcai_sty.rs
+++ b/latexml_package/src/package/ijcai_sty.rs
@@ -21,17 +21,10 @@ LoadDefinitions!({
   def_macro_noop("\\affiliations")?;
   def_macro_noop("\\emails")?;
 
+  // `\author{}` → the shared sectioned-author splitter. The `\lx@ijcai@*`
+  // machinery it drives now lives in the engine (base_utilities.rs), so a
+  // raw-loaded ijcai derivative (e.g. ttm.sty) that never loads this binding
+  // still gets the same split via the `\lx@add@authors` marker-branch.
+  // n-th email attaches to the n-th author; affiliations are `\\`-separated.
   DefMacro!("\\author{}", "\\lx@ijcai@authorsplit#1\\affiliations\\done");
-  DefMacro!("\\lx@ijcai@authorsplit Until:\\affiliations Until:\\done",
-    "\\lx@add@authors{#1}\\ifx.#2.\\else\\lx@ijcai@affilsplit#2\\emails\\affiliations\\done\\fi");
-  DefMacro!("\\lx@ijcai@affilsplit  Until:\\emails Until:\\affiliations Until:\\done",
-    "\\ifx.#1.\\else\\expandafter\\lx@ijcai@affiliations\\expandafter{\\lx@strip@braces{#1}}\\fi\\ifx.#2.\\else\\expandafter\\lx@ijcai@emails\\expandafter{\\lx@strip@braces{#2}}\\fi");
-  DefMacro!("\\lx@ijcai@affiliations{}", "\\lx@add@affiliations[labelseq=author]{#1}");
-
-  // emails is expected WITHIN \author.
-  // Multiple affiliations separated by ,
-  // the n-th email is attached to n-th author
-  DefMacro!("\\lx@ijcai@emails{}",
-    "\\lx@clear@frontmatter{ltx:contact}[role=email]\\lx@splitting{\\lx@ijcai@email}{,}{#1}");
-  DefMacro!("\\lx@ijcai@email{}", "\\lx@add@email[labelseq=author]{#1}");
 });


### PR DESCRIPTION
**Diagnostic.** The IJCAI author idiom (ijcai97.sty) packs names, `\affiliations` and a comma-separated `\emails` list into one `\author{}`. A paper using a *renamed copy* — e.g. the `ttm.sty` bundled with arXiv:2401.03955 — never loads the `ijcai` binding, so the default splitter shredded the email list into phantom author creators (13 for 7), dropped the affiliation, and raised `\affiliations`/`\emails` as undefined. Perl 0.8.8 does the same (parity).

**Approach.** Hoist the `\lx@ijcai@*` sectioned-author machinery from `ijcai_sty` into the engine (`base_utilities.rs`) and give `\lx@add@authors` a marker-branch: an `\author{}` carrying an `\affiliations`/`\emails` marker delegates to it (names / affiliations / emails split, n-th email to n-th author, markers consumed as delimiters). Now any IJCAI-derivative works whether or not `\usepackage{ijcai}` is present; the `ijcai` binding reuses the same code. Surpasses Perl (`KNOWN_PERL_ERRORS` #100).

**Validation.** Guard `frontmatter_ijcai_affiliations_emails` — RED (13 creators / 2 undefined-CS errors) → GREEN (7 authors, `IBM Research` affiliation, per-author emails, 0 errors). Witness 2401.03955v5 verified end-to-end; `ijcai`-binding path unregressed (7 authors). Full suite 2103/0; clippy/fmt clean.

Resolves arXiv/html_feedback#1361 and arXiv/html_feedback#1362 (same paper, v3/v5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)