### PR TITLE
fix: ceurart \author keyval no longer leaks orcid=/email= into the body

### DIFF
--- a/latexml_contrib/src/ceurart_cls.rs
+++ b/latexml_contrib/src/ceurart_cls.rs
@@ -81,6 +81,39 @@ LoadDefinitions!({
   def_macro_noop("\\eadsep")?;
   def_macro_noop("\\eadauthor")?;
 
+  // ceurart.cls L1247 `\RenewDocumentCommand\author{ O{} m O{} }` —
+  // `\author[affil]{name}[orcid=…,email=…,url=…,…]`. The trailing keyval bracket
+  // is the modern per-author metadata carrier. Our binding didn't define
+  // `\author`, so it fell to OmniBus's `\author[]{}`, leaving the `[keyval]`
+  // bracket unconsumed — it LEAKED as raw `orcid=…, email=…` text into the body.
+  // Define the 3-arg form: route the name to a structured creator and parse the
+  // keyval (ceurart.cls L1033-1061) so the content-bearing keys survive as
+  // frontmatter notes (matching `\orcidauthor`/`\ead` above), while the
+  // formatting/flag keys are gobbled — so `\setkeys` never hits an undefined
+  // key. arXiv/html_feedback#6650, witness 2511.11770 (both authors'
+  // `orcid=…,email=…` leaked).
+  RequirePackage!("keyval");
+  RawTeX!(
+    r"\define@key{lx@ceur@au}{orcid}{\@add@frontmatter{ltx:note}[role=orcid]{#1}}%
+\define@key{lx@ceur@au}{email}{\@add@frontmatter{ltx:note}[role=email]{#1}}%
+\define@key{lx@ceur@au}{url}{\@add@frontmatter{ltx:note}[role=url]{#1}}%
+\define@key{lx@ceur@au}{twitter}{\@add@frontmatter{ltx:note}[role=twitter]{#1}}%
+\define@key{lx@ceur@au}{facebook}{\@add@frontmatter{ltx:note}[role=facebook]{#1}}%
+\define@key{lx@ceur@au}{linkedin}{\@add@frontmatter{ltx:note}[role=linkedin]{#1}}%
+\define@key{lx@ceur@au}{plus}{\@add@frontmatter{ltx:note}[role=gplus]{#1}}%
+\define@key{lx@ceur@au}{gplus}{\@add@frontmatter{ltx:note}[role=gplus]{#1}}%
+\define@key{lx@ceur@au}{prefix}{}\define@key{lx@ceur@au}{suffix}{}%
+\define@key{lx@ceur@au}{degree}{}\define@key{lx@ceur@au}{role}{}%
+\define@key{lx@ceur@au}{auid}{}\define@key{lx@ceur@au}{bioid}{}%
+\define@key{lx@ceur@au}{alt}{}\define@key{lx@ceur@au}{style}{}%
+\define@key{lx@ceur@au}{collab}{}\define@key{lx@ceur@au}{anon}{}%
+\define@key{lx@ceur@au}{deceased}{}\define@key{lx@ceur@au}{type}{}"
+  );
+  DefMacro!(
+    "\\author []{} []",
+    "\\lx@add@creator[annotations={#1}]{#2}\\setkeys{lx@ceur@au}{#3}"
+  );
+
   // ORCID/URL/email per-author; preserve user-visible value (#2) as
   // ltx:note. #1 is the author tag (used for cross-ref; ignored here).
   DefMacro!(

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -659,6 +659,34 @@ fn frontmatter_czipreprint_author_star() {
     "czipreprint `[n]` optarg leaked a `]`:\n{x}"
   );
 }
+/// ceurart `\author[affil]{name}[orcid=…,email=…]` — the modern per-author
+/// keyval bracket (ceurart.cls L1247 `\RenewDocumentCommand\author{O{} m O{}}`).
+/// The binding didn't define `\author`, so the trailing `[keyval]` fell through
+/// OmniBus's `\author[]{}` unconsumed and LEAKED as raw `orcid=…, email=…` text.
+/// The 3-arg form now routes the name to a creator and parses the keyval into
+/// role=orcid/email notes. arXiv/html_feedback#6650, witness 2511.11770.
+#[test]
+fn frontmatter_ceurart_author_orcid_keyval() {
+  let x = convert_to_xml_contrib("tests/cluster_regressions/ceurart_author_orcid_keyval.tex");
+  // The keyval no longer leaks as literal `key=value` text.
+  assert!(
+    !x.contains("orcid=") && !x.contains("email="),
+    "ceurart author keyval leaked as raw text:\n{x}"
+  );
+  // The author renders, and the orcid/email VALUES are preserved as notes.
+  assert!(
+    x.contains("Alice Smith"),
+    "ceurart author name missing:\n{x}"
+  );
+  assert!(
+    x.contains("role=\"orcid\"") && x.contains("0000-0003-0583-6969"),
+    "ceurart orcid value not preserved as a note:\n{x}"
+  );
+  assert!(
+    x.contains("role=\"email\"") && x.contains("alice@example.org"),
+    "ceurart email value not preserved as a note:\n{x}"
+  );
+}
 /// spconf.sty / INTERSPEECH2021.sty single-arg `\name{Author1$^1$, Author2$^2$}`
 /// on `\documentclass{article}`: the name list becomes structured creators
 /// rather than being stashed and dropped. Witness 2309.14838, 2405.13379.

--- a/latexml_oxide/tests/cluster_regressions/ceurart_author_orcid_keyval.tex
+++ b/latexml_oxide/tests/cluster_regressions/ceurart_author_orcid_keyval.tex
@@ -1,0 +1,16 @@
+% ceurart's modern author API is `\author[affil]{name}[orcid=…,email=…]` — a
+% trailing keyval bracket (ceurart.cls L1247 `\RenewDocumentCommand\author{O{} m
+% O{}}`). Our binding didn't define `\author`, so the bracket fell through
+% OmniBus's `\author[]{}` unconsumed and LEAKED as raw `orcid=…, email=…` text.
+% Now the 3-arg form routes the name to a creator and parses the keyval into
+% role=orcid/email notes. arXiv/html_feedback#6650, witness 2511.11770.
+\documentclass{ceurart}
+\author[1]{Alice Smith}[
+  orcid=0000-0003-0583-6969,
+  email=alice@example.org,
+]
+\address[1]{Test University}
+\begin{document}
+\maketitle
+Body text after the title.
+\end{document}


### PR DESCRIPTION
**Diagnostic.** ceurart's modern author API is `\author[affil]{name}[orcid=…,email=…]` (ceurart.cls L1247 `\RenewDocumentCommand\author{O{} m O{}}`). The binding never defined `\author`, so the trailing `[keyval]` bracket fell through OmniBus's `\author[]{}` unconsumed and **leaked as raw `orcid=…, email=…` text** into the body (both authors of the witness).

**Approach.** Define the 3-arg form: route the name to a structured creator and parse the keyval (ceurart.cls L1033-1061) via `\define@key`/`\setkeys` — content keys (orcid/email/url/social) survive as frontmatter notes (matching the binding's `\orcidauthor`/`\ead`), formatting/flag keys are gobbled so `\setkeys` never hits an undefined key.

**Validation.** Guard `frontmatter_ceurart_author_orcid_keyval` (no `key=value` leak; orcid/email preserved as notes); full suite 2104/0; clippy/fmt. Witness 2511.11770 no longer leaks.

**Scope.** This addresses the `orcid=` keyval leak. The **reported** tcolorbox "large container" (2511.11770 §3.2.1) is a separate, deeper issue — tcolorbox is raw-loaded by both Perl and Rust (`InputDefinitions … noltxml`), so its content lands in the SVG box *depth* via the tikz/pgf node-anchor path and Perl renders it the same way. arXiv/html_feedback#6650 stays open for that.