### PR TITLE
fix: strip the comma separator from superscript-keyed affiliations

### DIFF
--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -4494,6 +4494,24 @@ fn starts_with_affiliation_mark(content: &Tokens) -> bool {
 /// `affiliation:N` label that the authors' own marks already request
 /// (`relocate_annotations` links them).
 fn split_before_affiliation_marks(tokens: Tokens) -> Vec<Tokens> {
+  // Trim the institution SEPARATOR that clings to the end of a segment when the
+  // affiliations are comma-joined (`\textsuperscript{1}Univ A, \textsuperscript{2}
+  // Univ B`) rather than space-joined: without this the affiliation contact reads
+  // "Univ A," with a stray trailing comma (html_feedback#6588, arXiv:2606.01317).
+  // Only trailing whitespace + a SINGLE trailing comma are removed, so a comma
+  // INSIDE an institution name ("Dept X, Univ Y, City") is untouched.
+  fn trim_trailing_separator(mut toks: Vec<Token>) -> Tokens {
+    while toks.last() == Some(&T_SPACE!()) {
+      toks.pop();
+    }
+    if toks.last() == Some(&T_OTHER!(",")) {
+      toks.pop();
+      while toks.last() == Some(&T_SPACE!()) {
+        toks.pop();
+      }
+    }
+    Tokens::new(toks)
+  }
   let toks = tokens.unlist();
   let mut segments: Vec<Tokens> = Vec::new();
   let mut current: Vec<Token> = Vec::new();
@@ -4507,12 +4525,12 @@ fn split_before_affiliation_marks(tokens: Tokens) -> Vec<Tokens> {
     // wrongly split (reviewer-flagged). The first mark (current empty) always
     // opens segment 0.
     if is_mark_start && current.last() == Some(&T_SPACE!()) {
-      segments.push(Tokens::new(std::mem::take(&mut current)));
+      segments.push(trim_trailing_separator(std::mem::take(&mut current)));
     }
     current.push(*t);
   }
   if !current.is_empty() {
-    segments.push(Tokens::new(current));
+    segments.push(trim_trailing_separator(current));
   }
   segments
 }

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -116,6 +116,61 @@ fn frontmatter_multi_affil_superscript() {
     "the two superscript affiliations merged into one:\n{x}"
   );
 }
+/// html_feedback#6588 (arXiv:2606.01317, ACL superscript block): 10 authors, each
+/// `\textbf{Name\textsuperscript{N}}`, then five affiliations one per
+/// `\textsuperscript{N}`, COMMA-separated across two `\\` lines. Each author must map
+/// to its numbered affiliation, and — the reported "affiliation notes" defect — the
+/// institution's trailing comma separator must NOT cling to the name
+/// ("The University of Hong Kong," was wrong). Rust already surpasses Perl here (Perl
+/// loses every author name). OXIDIZED_DESIGN #52.
+#[test]
+fn frontmatter_superscript_affil_comma() {
+  let x = convert_to_xml("tests/cluster_regressions/frontmatter_superscript_affil_comma.tex");
+  assert_eq!(
+    x.matches("role=\"author\"").count(),
+    10,
+    "expected 10 author creators:\n{x}"
+  );
+  // The reported canary: no affiliation carries a trailing comma separator.
+  for stray in [
+    "The University of Hong Kong,",
+    "Shandong University,",
+    "Carnegie Mellon University,",
+    "National University of Singapore,",
+  ] {
+    assert!(
+      !x.contains(stray),
+      "affiliation kept its trailing comma separator ({stray:?}):\n{x}"
+    );
+  }
+  // …the clean names are all present…
+  for name in [
+    "The University of Hong Kong",
+    "Shandong University",
+    "The Hong Kong University of Science and Technology",
+  ] {
+    assert!(x.contains(name), "affiliation {name:?} missing:\n{x}");
+  }
+  // …and the superscript marks still map each author to the right institution.
+  let by_name = |name: &str| -> String {
+    x.split("<creator")
+      .find(|b| b.contains(&format!("<personname>{name}</personname>")))
+      .unwrap_or("")
+      .to_string()
+  };
+  assert!(
+    by_name("Qi HU").contains("The University of Hong Kong"),
+    "Qi HU (\\textsuperscript{{1}}) not linked to Hong Kong:\n{x}"
+  );
+  assert!(
+    by_name("Pengji Zhang").contains("Carnegie Mellon University"),
+    "Pengji Zhang (\\textsuperscript{{3}}) not linked to CMU:\n{x}"
+  );
+  assert!(
+    by_name("Lin Zhang").contains("The Hong Kong University of Science and Technology"),
+    "Lin Zhang (\\textsuperscript{{5}}) not linked to HKUST:\n{x}"
+  );
+}
 /// html_feedback#6255 (googledeepmind, authblk): a single `\author{A, B, C}` comma
 /// list is authblk's one-author-arg form, so it stayed as one merged
 /// `<personname>A, B, C</personname>`. The DEFAULT `\author` already splits a comma

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_superscript_affil_comma.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_superscript_affil_comma.tex
@@ -1,0 +1,29 @@
+\documentclass[11pt]{article}
+% ACL-style superscript author block (arXiv:2606.01317): authors
+% `\textbf{Name\textsuperscript{N}}`, then affiliations one per `\textsuperscript{N}`,
+% comma-separated across two `\\` lines. The comma is the institution separator and
+% must NOT cling to the affiliation name ("The University of Hong Kong," is wrong).
+\title{A Study}
+\author{
+  \textbf{Qi HU\textsuperscript{1}},
+  \textbf{Yifeng Tang\textsuperscript{1}},
+  \textbf{Qinghua Wang\textsuperscript{2}},
+  \textbf{Lanyang Zhao\textsuperscript{2}},
+  \textbf{Pengji Zhang\textsuperscript{3}},\\
+  \textbf{Yuhao QING\textsuperscript{1}},
+  \textbf{Xin YAO\textsuperscript{1}},
+  \textbf{Dong HUANG\textsuperscript{4}},
+  \textbf{Lin Zhang\textsuperscript{5}},
+  \textbf{Zhuoran Ji\textsuperscript{2}}\\
+  \normalfont
+  \textsuperscript{1}The University of Hong Kong,
+  \textsuperscript{2}Shandong University,
+  \textsuperscript{3}Carnegie Mellon University,\\
+  \textsuperscript{4}National University of Singapore,
+  \textsuperscript{5}The Hong Kong University of Science and Technology
+}
+\begin{document}
+\maketitle
+\section{Introduction}
+Body text.
+\end{document}


### PR DESCRIPTION
**Diagnostic.** An ACL-style `\author{}` lists affiliations one per `\textsuperscript{N}`, comma-separated across `\\` lines (arXiv:2606.01317). The superscript-affiliation splitter kept the separator, so each institution rendered with a stray trailing comma ("The University of Hong Kong**,**").

**Approach.** Trim a trailing comma (plus surrounding whitespace) off each segment in `split_before_affiliation_marks` — a comma *inside* an institution name is untouched. One shared helper, so both the author-block and `\thanks`-abuse affiliation paths benefit. The author→affiliation mapping was already correct (Rust surpasses Perl, which loses every author name); this is the remaining "affiliation notes" accuracy fix the reporter noted.

**Validation.** Guard `frontmatter_superscript_affil_comma` — RED (trailing comma) → GREEN (10 authors correctly mapped, clean names). #6242 witness (space-separated, no comma) unaffected; `author_split_tests` all pass. Full suite 2105/0; clippy/fmt clean.

Resolves the residual affiliation-notes item in arXiv/html_feedback#6588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)