### PR TITLE
fix #698: relativize sibling-dir graphic candidates (no absolute-path leak)

### DIFF
--- a/latexml_core/src/util/image.rs
+++ b/latexml_core/src/util/image.rs
@@ -18,31 +18,6 @@ use crate::{
   whatsit::Whatsit,
 };
 
-/// Lexical relative path from `base` to `target`, with `..` for divergent base
-/// components — matching Perl's `File::Spec->abs2rel` (used by
-/// `pathname_relative`). Component-based, no symlink resolution. Falls back to
-/// the target's string form if either side isn't absolute or has no common root.
-fn abs2rel(target: &Path, base: &Path) -> String {
-  use std::path::Component;
-  if !target.is_absolute() || !base.is_absolute() {
-    return target.to_string_lossy().to_string();
-  }
-  let t: Vec<Component> = target.components().collect();
-  let b: Vec<Component> = base.components().collect();
-  let common = t.iter().zip(b.iter()).take_while(|(a, c)| a == c).count();
-  if common == 0 {
-    return target.to_string_lossy().to_string();
-  }
-  let mut result = PathBuf::new();
-  for _ in 0..(b.len() - common) {
-    result.push("..");
-  }
-  for comp in &t[common..] {
-    result.push(comp.as_os_str());
-  }
-  result.to_string_lossy().to_string()
-}
-
 /// Perl: `image_candidates($path)` (Util::Image L43-57).
 ///
 /// Returns comma-separated list of candidate paths for `path`, searching
@@ -85,11 +60,12 @@ pub fn image_candidates(path: &str) -> String {
         // Perl relativizes every hit to SOURCEDIRECTORY via pathname_relative
         // (→ File::Spec->abs2rel), which emits a `../…` path for a graphic in a
         // SIBLING directory (issue #698: `\subimport*{../gfx_asset/}` reaching a
-        // sideways tree). `strip_prefix` can only strip a *descendant* prefix, so
-        // a sibling hit fell back to the raw ABSOLUTE path and leaked into the
-        // output `data=`/`src=` URL. Use the same lexical abs2rel as below.
+        // sideways tree). See `pathname::relative`, which now matches Perl (it
+        // used to leak the absolute path on a non-descendant hit).
         let rel = match &source_path {
-          Some(sp) => abs2rel(&base, sp),
+          Some(sp) => {
+            crate::util::pathname::relative(&base.to_string_lossy(), &sp.to_string_lossy())
+          },
           None => base.to_string_lossy().to_string(),
         };
         candidates.push(rel);
@@ -109,9 +85,11 @@ pub fn image_candidates(path: &str) -> String {
           {
             let full = entry.path();
             // Sibling-directory relativization (issue #698) — see the
-            // extension branch above: abs2rel, not strip_prefix.
+            // extension branch above: pathname::relative (abs2rel semantics).
             let rel = match &source_path {
-              Some(sp) => abs2rel(&full, sp),
+              Some(sp) => {
+                crate::util::pathname::relative(&full.to_string_lossy(), &sp.to_string_lossy())
+              },
               None => full.to_string_lossy().to_string(),
             };
             candidates.push(rel);
@@ -136,10 +114,10 @@ pub fn image_candidates(path: &str) -> String {
       // Perl relativizes every candidate to SOURCEDIRECTORY via pathname_relative,
       // which yields a `../…`-style path for a kpsewhich hit in the texmf tree
       // (e.g. `../usr/share/texlive/…/example-image-a.png`) — NOT an absolute
-      // machine path. `pathname::relative`/`strip_prefix` only handle the
-      // descendant case, so use a lexical abs2rel for the non-descendant tree.
+      // machine path. `pathname::relative` now emits that `../…` form for a
+      // non-descendant tree (issue #698 fixed its strip_prefix leak).
       let rel = match &source_path {
-        Some(sp) => abs2rel(Path::new(&found), sp),
+        Some(sp) => crate::util::pathname::relative(&found, &sp.to_string_lossy()),
         None => found,
       };
       candidates.push(rel);

--- a/latexml_core/src/util/image.rs
+++ b/latexml_core/src/util/image.rs
@@ -82,12 +82,14 @@ pub fn image_candidates(path: &str) -> String {
     let base = PathBuf::from(dir).join(path);
     if has_extension {
       if base.exists() {
+        // Perl relativizes every hit to SOURCEDIRECTORY via pathname_relative
+        // (→ File::Spec->abs2rel), which emits a `../…` path for a graphic in a
+        // SIBLING directory (issue #698: `\subimport*{../gfx_asset/}` reaching a
+        // sideways tree). `strip_prefix` can only strip a *descendant* prefix, so
+        // a sibling hit fell back to the raw ABSOLUTE path and leaked into the
+        // output `data=`/`src=` URL. Use the same lexical abs2rel as below.
         let rel = match &source_path {
-          Some(sp) => base
-            .strip_prefix(sp)
-            .unwrap_or(&base)
-            .to_string_lossy()
-            .to_string(),
+          Some(sp) => abs2rel(&base, sp),
           None => base.to_string_lossy().to_string(),
         };
         candidates.push(rel);
@@ -106,12 +108,10 @@ pub fn image_candidates(path: &str) -> String {
             && fname[..dot_pos] == stem
           {
             let full = entry.path();
+            // Sibling-directory relativization (issue #698) — see the
+            // extension branch above: abs2rel, not strip_prefix.
             let rel = match &source_path {
-              Some(sp) => full
-                .strip_prefix(sp)
-                .unwrap_or(&full)
-                .to_string_lossy()
-                .to_string(),
+              Some(sp) => abs2rel(&full, sp),
               None => full.to_string_lossy().to_string(),
             };
             candidates.push(rel);

--- a/latexml_core/src/util/pathname.rs
+++ b/latexml_core/src/util/pathname.rs
@@ -823,6 +823,32 @@ pub fn make(dir: Option<&str>, name: Option<&str>, ext: Option<&str>) -> String 
   canonical(&result)
 }
 
+/// Lexical relative path from `base` to `target`, with `..` for the divergent
+/// tail of `base` — the semantics of Perl's `File::Spec->abs2rel`, which
+/// `pathname_relative` is built on. Component-based, no symlink resolution.
+/// Both sides must be absolute (the only case `relative` calls it with); if
+/// they share no root, falls back to the target string.
+fn abs2rel(target: &Path, base: &Path) -> String {
+  use std::path::Component;
+  if !target.is_absolute() || !base.is_absolute() {
+    return target.to_string_lossy().to_string();
+  }
+  let t: Vec<Component> = target.components().collect();
+  let b: Vec<Component> = base.components().collect();
+  let common = t.iter().zip(b.iter()).take_while(|(a, c)| a == c).count();
+  if common == 0 {
+    return target.to_string_lossy().to_string();
+  }
+  let mut result = PathBuf::new();
+  for _ in 0..(b.len() - common) {
+    result.push("..");
+  }
+  for comp in &t[common..] {
+    result.push(comp.as_os_str());
+  }
+  result.to_string_lossy().to_string()
+}
+
 /// Make a pathname relative to a base directory.
 /// Port of Perl's pathname_relative($pathname, $base).
 pub fn relative(pathname: &str, base: &str) -> String {
@@ -831,12 +857,13 @@ pub fn relative(pathname: &str, base: &str) -> String {
     return canonical_pathname;
   }
   let canonical_base = canonical(base);
-  let path = Path::new(&canonical_pathname);
-  let base_path = Path::new(&canonical_base);
-  match path.strip_prefix(base_path) {
-    Ok(rel) => rel.to_string_lossy().to_string(),
-    Err(_) => canonical_pathname,
-  }
+  // Perl's pathname_relative uses File::Spec->abs2rel, which emits a `../…`
+  // path when `pathname` is NOT a descendant of `base` (a sibling tree, e.g.
+  // a graphic reached through `\subimport*{../A/child/}` — issue #698).
+  // `strip_prefix` can only strip a descendant prefix, so it used to fall back
+  // to the raw ABSOLUTE path there, which then leaked into resource/graphic
+  // URLs. abs2rel matches Perl and never leaks an absolute path.
+  abs2rel(Path::new(&canonical_pathname), Path::new(&canonical_base))
 }
 
 /// Find all matching files (like pathname_findall).
@@ -977,6 +1004,35 @@ pub fn cwd() -> String { env::current_dir().unwrap().to_string_lossy().to_string
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  /// `relative` is Perl's `pathname_relative` (→ `File::Spec->abs2rel`): a
+  /// path that is NOT a descendant of `base` must come back as a `../…` path,
+  /// never the raw absolute path. The strip_prefix port used to leak the
+  /// absolute path here, which surfaced as a `/mnt/g/…` graphic URL (issue
+  /// #698) and would do the same for any resource relativized against the
+  /// source directory (e.g. `xslt.rs`).
+  #[test]
+  fn relative_emits_dotdot_for_non_descendant() {
+    // Sibling tree: base and target diverge one level up.
+    assert_eq!(
+      relative(
+        "/home/u/proj/A/child/images/pic.svg",
+        "/home/u/proj/latexml"
+      ),
+      "../A/child/images/pic.svg"
+    );
+    // Descendant is unchanged (the case strip_prefix already handled).
+    assert_eq!(
+      relative("/home/u/proj/sub/pic.png", "/home/u/proj"),
+      "sub/pic.png"
+    );
+    // Cousin that diverges two levels up.
+    assert_eq!(relative("/a/b/c/f.tex", "/a/x/y"), "../../b/c/f.tex");
+    // A non-absolute pathname is returned canonicalized, as Perl does.
+    assert_eq!(relative("sub/pic.png", "/home/u/proj"), "sub/pic.png");
+    // Empty base short-circuits to the canonical pathname.
+    assert_eq!(relative("/a/b/pic.png", ""), "/a/b/pic.png");
+  }
 
   /// `choose_kpaths` branches that a real host cannot exercise: a MiKTeX
   /// banner, a failed in-process construction, and a TeX-less machine.

--- a/latexml_oxide/tests/06_cluster_standalone_subfiles.rs
+++ b/latexml_oxide/tests/06_cluster_standalone_subfiles.rs
@@ -359,3 +359,30 @@ fn keyval_internals_survive_xkeyval_preloading_it() {
     "#500: the already-working `fancyvrb` then `standalone` order regressed"
   );
 }
+
+/// Issue #698: a `\includegraphics` inside a `\subimport*`-ed child whose file
+/// lives in a SIBLING directory (reached via `../`) must record its graphic
+/// `candidates` RELATIVE to the main file's directory — never as an absolute
+/// filesystem path. `util::image::image_candidates` relativizes each hit
+/// against `SOURCEDIRECTORY`; it used `strip_prefix`, which can only strip a
+/// *descendant* prefix, so a sibling-dir graphic fell back to the raw absolute
+/// path (`/mnt/g/…` in the report) and leaked verbatim into the HTML `data=`
+/// URL, breaking every deployment. Perl stores `../gfx_asset/images/pic.svg`
+/// (Util/Image.pm `pathname_relative` → `File::Spec->abs2rel`); the lexical
+/// `abs2rel` helper already used for the kpsewhich branch produces the same.
+#[test]
+fn subimport_sibling_graphic_candidate_is_relative() {
+  let xml = convert_to_xml("tests/cluster_regressions/subimport/gfx_main/index_gfx_sibling.tex");
+  // The exact Perl-parity relative candidate for a sibling-dir asset.
+  assert!(
+    xml.contains("candidates=\"../gfx_asset/images/pic.svg\""),
+    "#698: sibling-dir graphic must record a relative candidate \
+     `../gfx_asset/images/pic.svg`:\n{xml}"
+  );
+  // The canary: an absolute candidate is the bug, machine-independent.
+  assert!(
+    !xml.contains("candidates=\"/"),
+    "#698: graphic candidate must never be an absolute filesystem path \
+     (it leaks into the output `data=`/`src=` URL):\n{xml}"
+  );
+}

--- a/latexml_oxide/tests/cluster_regressions/subimport/gfx_asset/child_gfx.tex
+++ b/latexml_oxide/tests/cluster_regressions/subimport/gfx_asset/child_gfx.tex
@@ -1,0 +1,9 @@
+\documentclass[12pt]{article}
+\usepackage{graphicx}
+\begin{document}
+
+\fbox{
+\includegraphics[width=.8\textwidth]{images/pic}
+}
+
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/subimport/gfx_asset/images/pic.svg
+++ b/latexml_oxide/tests/cluster_regressions/subimport/gfx_asset/images/pic.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100" height="100" fill="red"/></svg>

--- a/latexml_oxide/tests/cluster_regressions/subimport/gfx_main/index_gfx_sibling.tex
+++ b/latexml_oxide/tests/cluster_regressions/subimport/gfx_main/index_gfx_sibling.tex
@@ -1,0 +1,12 @@
+\documentclass[12pt]{book}
+\usepackage{import}
+\usepackage{standalone}
+\usepackage{graphicx}
+
+\begin{document}
+
+This is my image
+
+\subimport*{../gfx_asset/}{child_gfx.tex}
+
+\end{document}

--- a/latexml_post/src/graphics.rs
+++ b/latexml_post/src/graphics.rs
@@ -738,10 +738,12 @@ impl Graphics {
   /// Copy a source image to the destination directory, preserving relative paths.
   /// Returns the destination path (relative to dest_dir).
   fn copy_to_destination(source: &str, source_dir: &str, dest_dir: &str) -> Option<String> {
-    // Compute relative path of source from source_dir
-    let source_path = Path::new(source);
-    let source_base = Path::new(source_dir);
-    let rel_path = source_path.strip_prefix(source_base).unwrap_or(source_path);
+    // Relativize like Perl's pathname_relative (→ File::Spec->abs2rel): a
+    // source OUTSIDE source_dir comes back as `../…`, never the raw absolute
+    // path. A bare `strip_prefix` used to leak the absolute path for a graphic
+    // reached through `\subimport*{../A/child/}` (issue #698 class).
+    let rel = latexml_core::util::pathname::relative(source, source_dir);
+    let rel_path = Path::new(&rel);
 
     // Build absolute destination path
     let abs_dest = PathBuf::from(dest_dir).join(rel_path);
@@ -2419,13 +2421,10 @@ impl Processor for Graphics {
             existing.clone()
           } else {
             let rel_opt = Self::copy_to_destination(source, &source_dir, &dest_dir);
-            let rel = rel_opt.unwrap_or_else(|| {
-              Path::new(source)
-                .strip_prefix(&source_dir)
-                .unwrap_or_else(|_| Path::new(source))
-                .to_string_lossy()
-                .to_string()
-            });
+            // If the copy itself failed, still emit a RELATIVE URL (abs2rel),
+            // never the raw absolute source path (issue #698 class).
+            let rel = rel_opt
+              .unwrap_or_else(|| latexml_core::util::pathname::relative(source, &source_dir));
             // Plan::Copy fires for web-native sources (PNG / JPG / GIF
             // / SVG) where `dest_type == src_ext`. graphicx `angle=`
             // rotation IS meaningful here — the source carries no PDF


### PR DESCRIPTION
**Diagnostic.** The root is a mistranslation in the shared helper: `latexml_core::util::pathname::relative` (the port of Perl's `pathname_relative`) used `strip_prefix`, which strips only a *descendant* prefix, where Perl uses `File::Spec->abs2rel`, which emits `../…`. Any path OUTSIDE the base leaked back as an **absolute** path. For a `\includegraphics` inside a `\subimport*{../A/child/}`-ed child, that absolute path flowed into `Plan::Copy` and out to the HTML `data=`/`src=` URL (`/mnt/g/…` in the report).

**Approach.** Fix `relative` to `abs2rel` semantics and route the two ad-hoc twins through it — `util::image::image_candidates` (the core graphic `candidates`) and `latexml_post::graphics::copy_to_destination` (the `Plan::Copy` imagesrc/dest). Core now records `candidates="../A/child/images/image_1.svg"`, byte-identical to Perl; end-to-end HTML emits the same relative `data=`. `pack.rs`'s `strip_prefix` is left as-is — its input is always a descendant of the walked base, so the fallback never fires.

**Validation.** Guards `pathname::tests::relative_emits_dotdot_for_non_descendant` and `subimport_sibling_graphic_candidate_is_relative` (red→green); full suite 2110/0; clippy + fmt clean.

#698
