### PR TITLE
feat #697: \subimport* accepts an absolute directory path (match pdflatex)

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN.md
+++ b/docs/parity/OXIDIZED_DESIGN.md
@@ -9,7 +9,7 @@ This file is the **index + overview**. The detail lives in a themed family:
 
 | Theme file | What it holds |
 |---|---|
-| [OXIDIZED_DESIGN_DIVERGENCES.md](OXIDIZED_DESIGN_DIVERGENCES.md) | The numbered **Intentional Divergences from Perl** (`#1–#15`, `#17–#18`, `#19–#134`) + a brief Known-Upstream-Perl-Issues list. Code comments cite these as `OXIDIZED_DESIGN #N`. |
+| [OXIDIZED_DESIGN_DIVERGENCES.md](OXIDIZED_DESIGN_DIVERGENCES.md) | The numbered **Intentional Divergences from Perl** (`#1–#15`, `#17–#18`, `#19–#137`) + a brief Known-Upstream-Perl-Issues list. Code comments cite these as `OXIDIZED_DESIGN #N`. |
 | [OXIDIZED_DESIGN_MATH.md](../math/OXIDIZED_DESIGN_MATH.md) | Marpa math-parser design: `#16` design rules + the grammar-rule cluster `#7–#18`. |
 | [OXIDIZED_DESIGN_TYPES.md](OXIDIZED_DESIGN_TYPES.md) | Type-system improvements (behavior-neutral) + tactical internal pitfalls. |
 | [OXIDIZED_DESIGN_FUTURE_WORK.md](OXIDIZED_DESIGN_FUTURE_WORK.md) | Beyond-parity directions not yet built. |

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -5191,3 +5191,31 @@ silently lost; it is now inserted directly before the root, matching Perl
 Approved by the maintainer 2026-08-18.
 
 **Guard:** `cluster_sizing::delimiter_size_nominal_font::nominal_font_size_persisted_as_pi_only_when_non_default`.
+
+### 137. `\subimport*`/`\subimport` accept an ABSOLUTE directory argument
+
+**Perl behavior** (`import.sty.ltxml` L31-42, `\lx@append@path`): the directory
+argument of `\subimport` is **always** `pathname_concat`'d onto the current lead
+search path. For an absolute argument that yields `<lead>//abs/dir`, which never
+resolves, so `\subimport*{/abs/dir/}{file}` reports `missing_file` — even though
+real LaTeX (pdflatex, verified) opens the file. `\import`/`\import*`
+(`\lx@set@path`) already special-case absolute paths; `\subimport` does not.
+
+**Rust behavior**: `\lx@append@path` uses an absolute argument **verbatim**
+(`pathname::canonical`, as `\lx@set@path` does), so `\subimport*{/abs/dir/}{file}`
+resolves and matches pdflatex. A relative argument is still concatenated onto the
+lead path (unchanged — the common `\subimport*{sub/}{file}` case), so no
+currently-passing document changes: the fix only turns a `missing_file` failure
+into a success (it cannot regress, since no document resolves an absolute
+`\subimport` today).
+
+**Why**: real LaTeX is the ground truth and it resolves the absolute path; both
+LaTeXML engines diverging from `pdflatex` here is a file-resolution quality bug,
+not a TeX-semantics choice. The reporter hit it converting a book whose chapters
+`\subimport*` shared assets by absolute path. Approved by the maintainer 2026-08-19
+(#697), conditional on the confirmed pdflatex behavior.
+
+**Upstream**: Perl's `\lx@append@path` has the identical limitation and would
+benefit from the same one-line fix — to be filed at `brucemiller/LaTeXML`.
+
+**Guard**: `06_cluster_standalone_subfiles::subimport_absolute_path_resolves_like_real_latex`.

--- a/latexml_oxide/tests/06_cluster_standalone_subfiles.rs
+++ b/latexml_oxide/tests/06_cluster_standalone_subfiles.rs
@@ -386,3 +386,43 @@ fn subimport_sibling_graphic_candidate_is_relative() {
      (it leaks into the output `data=`/`src=` URL):\n{xml}"
   );
 }
+
+/// Issue #697 / OXIDIZED_DESIGN #137 (surpass Perl): `\subimport*` with an
+/// ABSOLUTE directory argument resolves in real LaTeX (pdflatex, verified) but
+/// failed in BOTH LaTeXML engines — `\lx@append@path` concatenated the
+/// absolute arg onto the lead search path (`<lead>//abs/…`), which never
+/// resolved. An absolute arg is now used verbatim (mirroring `\lx@set@path`),
+/// matching pdflatex. The path is generated at runtime, so this is driven
+/// through a tempdir rather than a committed fixture.
+#[test]
+fn subimport_absolute_path_resolves_like_real_latex() {
+  let dir = tempfile::tempdir().expect("tempdir");
+  let child = dir.path().join("child");
+  std::fs::create_dir_all(&child).expect("mk child");
+  std::fs::write(
+    child.join("index.tex"),
+    "\\documentclass{article}\\begin{document}ABSOLUTEsubimportBODY\\end{document}",
+  )
+  .expect("write child");
+  let main = dir.path().join("main.tex");
+  std::fs::write(
+    &main,
+    format!(
+      "\\documentclass{{article}}\\usepackage{{import}}\\usepackage{{standalone}}\
+       \\begin{{document}}\\subimport*{{{}/}}{{index.tex}}\\end{{document}}",
+      child.display()
+    ),
+  )
+  .expect("write main");
+  let src = main.to_str().expect("utf8 path");
+
+  let log = convert_log(src);
+  assert!(
+    !log.contains("missing_file"),
+    "#697: absolute-path \\subimport* must resolve (matches pdflatex):\n{log}"
+  );
+  assert!(
+    convert_to_xml(src).contains("ABSOLUTEsubimportBODY"),
+    "#697: the absolutely-subimported child body was lost"
+  );
+}

--- a/latexml_package/src/package/import_sty.rs
+++ b/latexml_package/src/package/import_sty.rs
@@ -57,6 +57,8 @@ LoadDefinitions!({
   //   If SEARCHPATHS has entries, concat the first with path:
   //   new_lead = concat(lead_path, path); star → [new_lead], else → [new_lead, ...rest].
   //   If SEARCHPATHS is empty, this is a no-op (matches Perl's early-return).
+  //   DIVERGENCE (OXIDIZED_DESIGN #137): an absolute `path` is used verbatim
+  //   rather than concatenated, to match real LaTeX — see the body.
   DefPrimitive!("\\lx@append@path OptionalMatch:* {}", sub[(star, path_tks)] {
     let raw = Expand!(path_tks).to_string();
     let path = raw.trim().to_string();
@@ -64,7 +66,18 @@ LoadDefinitions!({
     let mut paths = get_search_paths();
     if paths.is_empty() { return Ok(Vec::new()); }
     let lead = paths.remove(0);
-    let new_lead = pathname::concat(&lead, &path);
+    // OXIDIZED_DESIGN #137 — surpass Perl to match real LaTeX (pdflatex,
+    // verified): an ABSOLUTE directory arg is used verbatim, not concatenated
+    // onto the lead search path (which yields an unresolvable `<lead>//abs/…`).
+    // Perl's \lx@append@path (import.sty.ltxml L31-42) ALWAYS concats, so both
+    // engines fail `\subimport*{/abs/}{file}` where pdflatex succeeds — issue
+    // #697. \lx@set@path already special-cases absolute; mirror it here.
+    // Relative args are unchanged (the common `\subimport*{sub/}{file}` case).
+    let new_lead = if pathname::is_absolute(&path) {
+      pathname::canonical(&path)
+    } else {
+      pathname::concat(&lead, &path)
+    };
     // LOCAL (see `\lx@set@path`): the `{…}` group reverts it.
     if star.is_some() {
       set_search_paths_local(vec![new_lead]);


### PR DESCRIPTION
**Diagnostic.** `\lx@append@path` (import.sty binding) always `concat`s the directory arg onto the lead search path, so `\subimport*{/abs/dir/}{file}` becomes an unresolvable `<lead>//abs/dir/…` and reports `missing_file` — in **both** LaTeXML engines — even though real LaTeX (`pdflatex`, verified: exit 0, file opened) resolves it.

**Approach.** Use an absolute argument **verbatim** (`pathname::canonical`), mirroring `\lx@set@path`, which already special-cases absolute paths for `\import*`. Relative args are still concatenated (the common `\subimport*{sub/}{file}` case), so no passing document changes — the fix only turns a `missing_file` failure into success. Sanctioned surpass-Perl divergence **OXIDIZED_DESIGN #137**; the identical Perl limitation is to be filed upstream (`brucemiller/LaTeXML`).

**Validation.** Guard `subimport_absolute_path_resolves_like_real_latex` (tempdir-driven, runtime absolute path); relative subimport unregressed; full suite 2109/0; clippy + fmt clean.

#697