### PR TITLE
fix: two-column subfigure panels share a row instead of stacking full-width

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -5219,3 +5219,37 @@ not a TeX-semantics choice. The reporter hit it converting a book whose chapters
 benefit from the same one-line fix — to be filed at `brucemiller/LaTeXML`.
 
 **Guard**: `06_cluster_standalone_subfiles::subimport_absolute_path_resolves_like_real_latex`.
+
+### 138. Subfigure panels with no explicit `{width}` share a row (not stacked full-width)
+
+**Perl behavior** (`latex_constructs.pool.ltxml:3229-3349` `arrange_panels_and_breaks`,
+`subcaption.sty.ltxml:104`, `subfig.sty.ltxml`): a panel's per-row width is its box
+width. `\subcaptionbox` and subfig `\subfloat` carry no explicit `{width}`
+(subcaption's `\subfloat` passes `{\columnwidth}`), so the panel box is sized to the
+full float `\hsize`, and `arrange_panels` then gives each panel its own row. In a
+two-column layout that renders every such panel at the full text width, stacked —
+even though the PDF sets them side-by-side in one column. An explicit-width
+`\begin{subfigure}{0.48\linewidth}` is unaffected (box = 0.48·\hsize → two per row).
+Verified: Perl 0.8.8 emits `width=345.0pt` for the panels and stacks them, identical
+to the pre-fix Rust.
+
+**Rust behavior** (`latex_constructs.rs` `arrange_panels` + `sole_graphic_width`;
+`subcaption_sty.rs` `subcaption_width_props`): when a panel is sized to the full
+float width but wraps exactly one graphic narrower than the float, `arrange_panels`
+uses the graphic's width for the per-row layout, so the panels share a row like an
+explicit-width `{subfigure}{W}`. A `{0pt}` default width (subcaptionbox) no longer
+pins the panel to zero. Only the row-arrangement threshold changes; the markup is
+unchanged. Guarded to only ever *shrink* a full-width panel to its narrower content,
+so it cannot widen or reflow a correctly-sized figure.
+
+**Why**: the HTML is single-column, so a panel meant to sit beside its sibling in one
+PDF column should share a row, not span the full text width. arXiv/html_feedback#6903
+(two-column paper, subfigure figures rendering full-width). The content width is only
+knowable post-digest (the graphic's box), so the fix lives in `arrange_panels`, not
+the binding. Approved by the maintainer 2026-08-20.
+
+**Upstream**: Perl's `arrange_panels_and_breaks` has the identical limitation and
+would benefit from the same graphic-width fallback — to be filed at
+`brucemiller/LaTeXML`.
+
+**Guard**: `06_cluster_regressions::cluster_subfigure_panels_share_a_row_6903`.

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -1962,6 +1962,39 @@ fn panel_width(document: &Document, node: &Node) -> f64 {
     .unwrap_or(0.0)
 }
 
+/// Width (scaled points) of the sole `ltx:graphics` descendant of a figure/table
+/// panel, or `None` unless there is exactly one. `\subcaptionbox` and subfig
+/// `\subfloat` panels carry no explicit `{width}`, so their box is sized to the
+/// full float `\hsize` — which hides the panel's real content width from
+/// [`arrange_panels`] and stacks the panels one-per-row. Sizing such a panel to
+/// its lone graphic lets siblings share a row, the way an explicit-width
+/// `{subfigure}{0.48\linewidth}` already does (#6903). Ambiguous panels (0 or >1
+/// graphic) return `None`, so the caller keeps the box width unchanged.
+fn sole_graphic_width(document: &Document, node: &Node) -> Option<f64> {
+  let qname = document::get_node_qname(node);
+  if qname != pin!("ltx:figure") && qname != pin!("ltx:table") {
+    return None;
+  }
+  let graphics_qname = pin!("ltx:graphics");
+  let mut found: Option<Node> = None;
+  let mut stack = node.get_child_elements();
+  while let Some(n) = stack.pop() {
+    if document::get_node_qname(&n) == graphics_qname {
+      if found.is_some() {
+        return None; // >1 graphic — don't guess which sizes the panel
+      }
+      found = Some(n);
+    } else {
+      stack.extend(n.get_child_elements());
+    }
+  }
+  document
+    .get_node_box(&found?)
+    .and_then(|b| b.get_width(None).ok().flatten())
+    .map(|r| r.value_of() as f64)
+    .filter(|w| *w > 0.0)
+}
+
 /// Insert a `<ltx:break class="ltx_break"/>` immediately before `child`.
 fn insert_break_before(document: &Document, child: &mut Node) -> Result<Node> {
   let ns = child.get_namespace();
@@ -2036,7 +2069,17 @@ fn arrange_panels(document: &mut Document, node: &mut Node, float_width: f64) ->
       row.clear();
     }
 
-    let child_width = panel_width(document, &child);
+    let mut child_width = panel_width(document, &child);
+    // #6903: a subcaptionbox / subfig \subfloat panel is sized to the full float
+    // \hsize (it has no explicit `{width}`), so it would take its own row. When
+    // it wraps a single narrower graphic, size it to that graphic so sibling
+    // panels share a row — an explicit-width `{subfigure}{W}` already does.
+    if child_width >= float_width
+      && let Some(inner) = sole_graphic_width(document, &child)
+      && inner < child_width
+    {
+      child_width = inner;
+    }
 
     if !row.is_empty() && (current_width + child_width > float_width) {
       // Perl L3287-3295: row overflow — break before this child, start a new row.

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -56,23 +56,31 @@ fn cluster_fvextra_breakanywhere() {
 /// arXiv/html_feedback#6903: two-column subfigure panels with no explicit
 /// `{width}` — `\subcaptionbox` and subfig `\subfloat` — are sized to the full
 /// `\hsize` and were stacked one-per-row (each full text width). `arrange_panels`
-/// now sizes such a panel to its sole graphic, so the panels share a row like an
-/// explicit-width `\begin{subfigure}{0.48\linewidth}` already does. Guarded on
-/// the core XML: both panels of each figure carry `ltx_figure_panel`, and no
-/// `<break>` is inserted between them (a break is the "start a new row" marker,
-/// so its absence is exactly "they share a row").
+/// now sizes such a panel to its sole graphic, so panels narrower than the column
+/// share a row like an explicit-width `\begin{subfigure}{0.48\linewidth}` already
+/// does. The fix only ever SHRINKS a full-width panel to a narrower graphic, so a
+/// panel whose content is genuinely full width must still stack — guarded here so
+/// no future change makes the reflow over-eager.
+///
+/// Read from the core XML via `<break>`, the "start a new row" marker: two narrow
+/// figures (fig 1-2) with NO break between their panels = shared row; one
+/// full-width figure (fig 3) with exactly ONE break = still stacked.
 #[test]
 fn cluster_subfigure_panels_share_a_row_6903() {
   let xml = convert_to_xml("tests/cluster_regressions/subfigure_panel_wrapping_6903.tex");
   assert_eq!(
     xml.matches("ltx_figure_panel").count(),
-    4,
-    "expected 4 subfigure panels marked ltx_figure_panel (2 per figure):\n{xml}"
+    6,
+    "expected 6 subfigure panels marked ltx_figure_panel (2 per figure):\n{xml}"
   );
-  assert!(
-    !xml.contains("<break"),
-    "subcaptionbox/subfloat panels must share a row — a <break> means they \
-     stacked full-width (the #6903 bug):\n{xml}"
+  // arrange_panels inserts one `<break>` per stacked row transition. Only the
+  // full-width-content figure (3) stacks; the two narrow figures share a row.
+  assert_eq!(
+    xml.matches("<break").count(),
+    1,
+    "narrow subcaptionbox/subfloat panels must share a row (0 breaks), and the \
+     full-width-content figure must still stack (1 break) — got a different \
+     break count, so the reflow is either not firing or too eager:\n{xml}"
   );
 }
 #[test]

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -53,6 +53,28 @@ fn cluster_fvextra_breakanywhere() {
 /// — the verbatim collapsed to ordinary typewriter text, silently, 0 errors.
 /// `fvextra_sty.rs` re-installs the hook over fvextra's redefinition. Witness:
 /// issue #502 (fancyvrb + fvextra; pre-fix 0 `ltx_verbatim`, post-fix one per line).
+/// arXiv/html_feedback#6903: two-column subfigure panels with no explicit
+/// `{width}` — `\subcaptionbox` and subfig `\subfloat` — are sized to the full
+/// `\hsize` and were stacked one-per-row (each full text width). `arrange_panels`
+/// now sizes such a panel to its sole graphic, so the panels share a row like an
+/// explicit-width `\begin{subfigure}{0.48\linewidth}` already does. Guarded on
+/// the core XML: both panels of each figure carry `ltx_figure_panel`, and no
+/// `<break>` is inserted between them (a break is the "start a new row" marker,
+/// so its absence is exactly "they share a row").
+#[test]
+fn cluster_subfigure_panels_share_a_row_6903() {
+  let xml = convert_to_xml("tests/cluster_regressions/subfigure_panel_wrapping_6903.tex");
+  assert_eq!(
+    xml.matches("ltx_figure_panel").count(),
+    4,
+    "expected 4 subfigure panels marked ltx_figure_panel (2 per figure):\n{xml}"
+  );
+  assert!(
+    !xml.contains("<break"),
+    "subcaptionbox/subfloat panels must share a row — a <break> means they \
+     stacked full-width (the #6903 bug):\n{xml}"
+  );
+}
 #[test]
 fn cluster_fvextra_preserves_ltx_verbatim() {
   let xml = convert_to_xml("tests/cluster_regressions/fvextra_ltx_verbatim.tex");

--- a/latexml_oxide/tests/cluster_regressions/subfigure_panel_wrapping_6903.tex
+++ b/latexml_oxide/tests/cluster_regressions/subfigure_panel_wrapping_6903.tex
@@ -1,0 +1,23 @@
+% arXiv/html_feedback#6903: in a two-column layout, subfigure panels that carry
+% no explicit {width} — subcaption's \subcaptionbox and subfig's \subfloat — were
+% sized to the full \hsize and stacked one-per-row (each spanning the full text
+% width), unlike an explicit-width \begin{subfigure}{0.48\linewidth}. They should
+% share a row: arrange_panels now sizes such a panel to its sole graphic.
+\documentclass[twocolumn]{article}
+\usepackage{graphicx}
+\usepackage{subcaption}
+\usepackage{subfig}
+\begin{document}
+\begin{figure}
+  \centering
+  \subcaptionbox{}{\includegraphics[width=0.48\linewidth]{panel_a}}\hfill
+  \subcaptionbox{}{\includegraphics[width=0.48\linewidth]{panel_b}}
+  \caption{subcaptionbox panels.}
+\end{figure}
+\begin{figure}
+  \centering
+  \subfloat[]{\includegraphics[width=0.48\linewidth]{panel_a}}\hfill
+  \subfloat[]{\includegraphics[width=0.48\linewidth]{panel_b}}
+  \caption{subfig subfloat panels.}
+\end{figure}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/subfigure_panel_wrapping_6903.tex
+++ b/latexml_oxide/tests/cluster_regressions/subfigure_panel_wrapping_6903.tex
@@ -3,21 +3,35 @@
 % sized to the full \hsize and stacked one-per-row (each spanning the full text
 % width), unlike an explicit-width \begin{subfigure}{0.48\linewidth}. They should
 % share a row: arrange_panels now sizes such a panel to its sole graphic.
+%
+% The fix is deliberately conservative — it only ever SHRINKS a full-width panel
+% to a narrower graphic, so panels whose content is genuinely full width must
+% still stack. The third figure guards exactly that (no over-eager reflow).
 \documentclass[twocolumn]{article}
 \usepackage{graphicx}
 \usepackage{subcaption}
 \usepackage{subfig}
 \begin{document}
+% (1) subcaptionbox, panels narrower than the column -> share a row (no break)
 \begin{figure}
   \centering
   \subcaptionbox{}{\includegraphics[width=0.48\linewidth]{panel_a}}\hfill
   \subcaptionbox{}{\includegraphics[width=0.48\linewidth]{panel_b}}
-  \caption{subcaptionbox panels.}
+  \caption{subcaptionbox panels, narrow.}
 \end{figure}
+% (2) subfig \subfloat, narrow -> share a row (no break)
 \begin{figure}
   \centering
   \subfloat[]{\includegraphics[width=0.48\linewidth]{panel_a}}\hfill
   \subfloat[]{\includegraphics[width=0.48\linewidth]{panel_b}}
-  \caption{subfig subfloat panels.}
+  \caption{subfig subfloat panels, narrow.}
+\end{figure}
+% (3) subcaptionbox with FULL-width content -> MUST stay stacked (one break).
+% Guards that the fix never widens a genuinely full-width panel into a shared row.
+\begin{figure}
+  \centering
+  \subcaptionbox{}{\includegraphics[width=\linewidth]{panel_a}}
+  \subcaptionbox{}{\includegraphics[width=\linewidth]{panel_b}}
+  \caption{subcaptionbox panels, full width.}
 \end{figure}
 \end{document}

--- a/latexml_package/src/package/subcaption_sty.rs
+++ b/latexml_package/src/package/subcaption_sty.rs
@@ -18,6 +18,11 @@ fn subcaption_width_props(args: &[Option<Digested>]) -> Result<SymHashMap<Stored
     .get(1)
     .and_then(|a| a.as_ref())
     .and_then(|a| Dimension::spec_to_f64(&a.to_string()).ok())
+    // #6903: a non-positive Dimension (e.g. `\subcaptionbox`'s `{0pt}` default,
+    // subcaption_sty L219) must NOT pin the panel width to 0 — that reads as a
+    // zero-width box in `arrange_panels` and the panels never share a row. Skip
+    // it so `panel_width` falls back to the panel's natural content width.
+    .filter(|w| *w > 0.0)
   {
     props.insert("width", Stored::Dimension(Dimension::new_f64(w)));
   }


### PR DESCRIPTION
**Diagnostic.** In a two-column layout, subfigure panels created by `\subcaptionbox` or subfig's `\subfloat` carry no explicit `{width}`, so their panel box is sized to the full float `\hsize`. `arrange_panels` then gives each panel its own row, so every such panel renders at the full text width, stacked — even though the PDF sets them side-by-side in one column. An explicit-width `\begin{subfigure}{0.48\linewidth}` was already fine (its box is 0.48·`\hsize`).

![before/after: stacked full-width → side-by-side](https://raw.githubusercontent.com/dginev/latexml-oxide/3645f5f62ec0e2d61d65da518315b23cc4a42d45/pr6903_before_after.png)

**Approach.** `arrange_panels` (`latex_constructs.rs`) now sizes a full-width panel that wraps a single narrower graphic to that graphic's width (`sole_graphic_width`), so the panels share a row; a `{0pt}` default width no longer pins the panel to zero (`subcaption_width_props`). Guarded to only ever *shrink* a full-width panel to its narrower content — it cannot widen or reflow a correctly-sized figure. **Surpass-Perl**: Perl 0.8.8 emits `width=345.0pt` and stacks the panels identically; recorded as `OXIDIZED_DESIGN_DIVERGENCES` #138 (upstream fix to be filed at brucemiller/LaTeXML).

**Validation.** Red→green guard `cluster_subfigure_panels_share_a_row_6903`: the two narrow figures share a row (0 `<break>`) and a third **full-width-content** figure **still stacks** (exactly 1 `<break>`) — locking in that the reflow only ever *shrinks* a full-`\hsize` panel, never widens a genuinely full-width one. Regression diligence in Chrome across subcaption / subfig / minipage idioms: the risk cases (full-width content, `0.9\linewidth`, 3-per-row, single figures, plain full-width figures) all render as intended (stacked stays stacked). Full suite 2112/0; clippy + fmt clean; existing figure/subfigure goldens (`subcaption`, `figure_grids`, `figure_panel_native`, `figures`) unchanged; real witness `2503.09799` re-rendered with **byte-identical** subfigure geometry.

Reported at arXiv/html_feedback#6903.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
