### PR TITLE
fix: arrange_panels never wraps a figure/table panel in an invalid ltx:block (LaTeXML#2709)

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3947,3 +3947,42 @@ affiliations / emails split, n-th email to n-th author, markers consumed as
 delimiters (no undefined-CS error). Guard:
 `06_cluster_frontmatter::frontmatter_ijcai_affiliations_emails`. Witness:
 html_feedback #1361 + #1362 (arXiv:2401.03955v5, ttm.sty).
+
+## 101. `arrange_panels_and_breaks` wraps figure/table panels in a schema-invalid `ltx:block` (Rust surpasses)
+
+**Perl source:** `Engine/latex_constructs.pool.ltxml:3322`
+(`arrange_panels_and_breaks`): `my $block = $document->wrapNodes('ltx:block', $prev_node, $child)`.
+
+**Symptom:** The per-row panel arranger groups two sibling panels into a single
+`ltx:block` when a merge heuristic fires — a zero-width sibling, a >8× size
+disparity, or a joint width below `0.03125·float_width` (L3305). When the panels
+are `ltx:figure`/`ltx:table` (subfigures) the result is
+`<ltx:block><ltx:figure/>…</ltx:block>` — schema-INVALID, since a block cannot
+contain a float. Reported upstream by the LaTeXML author
+(brucemiller/LaTeXML#2709, `acmart` + `subfigure`). Present in Perl 0.8.8
+(identical L3322 code): the `child_width==0` branch fires for **every**
+`\subcaptionbox`/`\subfloat` multi-panel figure (their panels report width 0), so
+Perl-generated HTML carries the invalid block widely — not only Bruce's `acmart`
+case. The Rust port reaches it via the disparity / tiny-sum branches (explicit
+small/disparate `{width}` subfigures).
+
+**Minimal trigger:**
+```tex
+\documentclass{article}\usepackage{graphicx}\usepackage{subcaption}
+\begin{document}
+\begin{figure}\centering
+  \begin{subfigure}{0.9\linewidth}\includegraphics[width=\linewidth]{a}\caption{}\end{subfigure}
+  \begin{subfigure}{0.05\linewidth}\includegraphics[width=\linewidth]{b}\caption{}\end{subfigure}
+  \caption{}\end{figure}
+\end{document}
+```
+Both engines emit `<block>` wrapping the two subfigure `<figure>` panels.
+
+**Impact:** Perl-origin, SHARED with the Rust `arrange_panels`. **Rust status
+(FIXED — surpasses):** the block-merge now asks the MODEL whether `ltx:block` can
+validly contain the incoming panel (`model::can_contain_sym`, per merge branch) —
+a float cannot, so the panels stay siblings: valid markup and the correct
+side-by-side layout. Guard:
+`06_cluster_regressions::cluster_panel_merge_never_wraps_a_figure_in_a_block_2709`.
+An upstream Perl patch (same model-guard at L3305/3322) is to be filed at
+brucemiller/LaTeXML#2709.

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -2098,7 +2098,24 @@ fn arrange_panels(document: &mut Document, node: &mut Node, float_width: f64) ->
       let big_disparity = prev_width > 0.0
         && child_width > 0.0
         && (prev_width.max(child_width) / prev_width.min(child_width) > 8.0);
-      if child_width == 0.0 || big_disparity || (prev_width + child_width < min_panel_width) {
+      // #2709: the merge groups small/disparate content into an `ltx:block`, but
+      // the schema forbids a float (`ltx:figure`/`ltx:table`, or any future
+      // `ltx:float`) as a block child — wrapping one yields an invalid
+      // `<block><figure/></block>`. Ask the MODEL (not a hard-coded name list)
+      // whether the block can hold what would go into it, per merge branch; if
+      // not, keep the panels as siblings. Minipage grids stay valid block content
+      // and are unaffected.
+      let merge_is_valid = if prev_name == block_qname {
+        model::can_contain_sym(block_qname, child_name)
+      } else if child_name == block_qname {
+        model::can_contain_sym(block_qname, prev_name)
+      } else {
+        model::can_contain_sym(block_qname, prev_name)
+          && model::can_contain_sym(block_qname, child_name)
+      };
+      if merge_is_valid
+        && (child_width == 0.0 || big_disparity || (prev_width + child_width < min_panel_width))
+      {
         // Perl L3312-3325: contain the two pieces in a single ltx:block panel.
         let merged_width = prev_width + child_width;
         if prev_name == block_qname {

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -92,6 +92,28 @@ fn cluster_fvextra_preserves_ltx_verbatim() {
      overwrote the fancyvrb hook, so verbatim lines lose white-space:pre:\n{xml}"
   );
 }
+/// brucemiller/LaTeXML#2709: `arrange_panels`' merge heuristic (a >8x size
+/// disparity, a tiny joint width, or a zero-width sibling) grouped two panels
+/// into an `ltx:block`. For `ltx:figure`/`ltx:table` panels that yields a
+/// schema-invalid `<block><figure/></block>` — a block cannot contain a float.
+/// Float panels must stay siblings (the merge is only for small inline content).
+/// Present in both engines (Perl 0.8.8 has the identical `wrapNodes('ltx:block')`
+/// at `latex_constructs.pool.ltxml:3322`); recorded in `KNOWN_PERL_ERRORS.md`.
+#[test]
+fn cluster_panel_merge_never_wraps_a_figure_in_a_block_2709() {
+  let xml = convert_to_xml("tests/cluster_regressions/panel_block_invalid_2709.tex");
+  assert!(
+    !xml.contains("<block"),
+    "arrange_panels wrapped disparate/tiny figure panels in an invalid <block> \
+     (#2709) — a block cannot contain a float; the panels must stay siblings:\n{xml}"
+  );
+  // Both figures keep their two subfigure panels as marked siblings.
+  assert_eq!(
+    xml.matches("ltx_figure_panel").count(),
+    4,
+    "expected 4 subfigure panels (2 per figure) as siblings:\n{xml}"
+  );
+}
 /// An unbound class (->OmniBus) whose `.bbl` `\bibitem[\protect\citeauthoryear…]`
 /// side-loads natbib must not leave a body `\citep` looping. The side-load runs
 /// inside the `thebibliography` group, so natbib's `\citep` would be popped on

--- a/latexml_oxide/tests/cluster_regressions/panel_block_invalid_2709.tex
+++ b/latexml_oxide/tests/cluster_regressions/panel_block_invalid_2709.tex
@@ -1,0 +1,24 @@
+% brucemiller/LaTeXML#2709: arrange_panels_and_breaks merges "disparate" or
+% "tiny" sibling panels into a single ltx:block. When the panels are ltx:figure
+% (subfigures), the resulting <block><figure/></block> is schema-invalid (block
+% cannot contain a float). The merge heuristic is for small inline content, not
+% floats — figure/table panels must stay siblings.
+\documentclass{article}
+\usepackage{graphicx}
+\usepackage{subcaption}
+\begin{document}
+% (1) >8x size disparity between two subfigure panels -> the merge fires.
+\begin{figure}
+  \centering
+  \begin{subfigure}{0.9\linewidth}\includegraphics[width=\linewidth]{wide}\caption{}\end{subfigure}
+  \begin{subfigure}{0.05\linewidth}\includegraphics[width=\linewidth]{narrow}\caption{}\end{subfigure}
+  \caption{Disparate subfigure panels.}
+\end{figure}
+% (2) tiny joint width (< 0.03125 of the float) -> the merge fires.
+\begin{figure}
+  \centering
+  \begin{subfigure}{0.01\linewidth}\includegraphics[width=\linewidth]{tinya}\caption{}\end{subfigure}
+  \begin{subfigure}{0.01\linewidth}\includegraphics[width=\linewidth]{tinyb}\caption{}\end{subfigure}
+  \caption{Tiny subfigure panels.}
+\end{figure}
+\end{document}


### PR DESCRIPTION
**Diagnostic.** `arrange_panels`' merge heuristic (a zero-width sibling, a >8× size disparity, or a tiny joint width) groups two sibling panels into an `ltx:block`. When the panels are `ltx:figure`/`ltx:table` (subfigures), that yields a schema-invalid `<block><figure/></block>` — a block cannot contain a float. Reported upstream by the LaTeXML author: brucemiller/LaTeXML#2709.

**Approach.** The block-merge now asks the schema **model** whether `ltx:block` can validly contain the incoming panel (`model::can_contain_sym`, evaluated per merge branch) — a float cannot, so the panels stay siblings: valid markup and the correct side-by-side layout. Model-driven rather than a hard-coded name list, so it generalizes to `ltx:float` and any future block-invalid element. Shared bug: Perl 0.8.8 has the identical `wrapNodes('ltx:block')` at `latex_constructs.pool.ltxml:3322` (recorded in `KNOWN_PERL_ERRORS.md` #101); an upstream Perl patch with the same guard is to follow.

**Validation.** Red→green guard `cluster_panel_merge_never_wraps_a_figure_in_a_block_2709` (RED: 2 invalid `<block>` wrapping the panels; GREEN: none, panels as siblings). Full suite 2113/0; clippy + fmt clean; the figure/subfigure goldens (`subcaption`, `figure_grids`, `figure_panel_native`, `figures`) unchanged — `figure_grids`' minipage panels still use valid `ltx:block` (the guard only forbids float children).

Resolves the Rust side of brucemiller/LaTeXML#2709; the upstream Perl patch is to follow (the issue stays open until both land).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
