### PR TITLE
fix #703: math-parse discard no longer double-frees nested \sbox subtrees

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -203,14 +203,6 @@ jobs:
       CARGO_INCREMENTAL: "0"
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
       RUST_BACKTRACE: "1"
-      # ASAN instrumentation. Setting RUSTFLAGS overrides the target rustflags
-      # in .cargo/config.toml, so the parallel-frontend flags are re-added here;
-      # mold is dropped — the default linker links the sanitizer runtime fine.
-      RUSTFLAGS: "-Zsanitizer=address -Zthreads=8 -Zunstable-options"
-      # LSAN off: the engine leaks thread-local / arena state by design (see
-      # the reset_thread_engine rationale), which is not what this lane guards.
-      # halt_on_error stays default (1), so a UAF / double-free / OOB fails.
-      ASAN_OPTIONS: "detect_leaks=0"
     steps:
       - name: install dependencies
         run: |
@@ -246,10 +238,22 @@ jobs:
       # `06_cluster_math` exercises the math-parser discard/free paths (the
       # #703 use-after-free lived there). Under ASAN this run is red on any
       # platform when a node is freed twice — the deterministic catch the plain
-      # suite lacks. `--cargo-profile ci` = fast build; `--profile ci` = nextest
-      # profile (unrelated same-named knobs, as in the `test` job).
+      # suite lacks. The sanitizer flags are scoped to THIS step (not the job
+      # env) and paired with an explicit `--target`: that is exactly what makes
+      # cargo build the proc-macros / build-scripts for the host WITHOUT the
+      # sanitizer, so they still load — a job-wide RUSTFLAGS instruments them and
+      # rustc then can't load them (E0463), and it would also contaminate the
+      # `make formats` build above. Setting RUSTFLAGS overrides config.toml's
+      # target rustflags, so the parallel-frontend flags are re-added; mold is
+      # dropped (the default linker links the sanitizer runtime fine). LSAN off
+      # (detect_leaks=0): the engine leaks thread-local / arena state by design;
+      # halt_on_error stays default 1, so a UAF / double-free / OOB fails the job.
+      # `--cargo-profile ci` = fast build; `--profile ci` = nextest profile.
       - name: run memory-safety tests under ASAN
-        run: cargo nextest run --cargo-profile ci --profile ci -p latexml --test 06_cluster_math
+        env:
+          RUSTFLAGS: "-Zsanitizer=address -Zthreads=8 -Zunstable-options"
+          ASAN_OPTIONS: "detect_leaks=0"
+        run: cargo nextest run --cargo-profile ci --profile ci --target x86_64-unknown-linux-gnu -p latexml --test 06_cluster_math
 
   test:
     # Sharded across 4 runners. The suite's cost is ~398 s of in-binary

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -182,6 +182,75 @@ jobs:
       - name: miri (scoped arena UB check)
         run: tools/miri_check.sh
 
+  # AddressSanitizer lane — the deterministic net for heap memory-safety bugs
+  # (use-after-free, double-free, out-of-bounds) that neither the plain Linux
+  # suite nor miri catches. glibc TOLERATES a use-after-free that Darwin's
+  # allocator aborts on (issue #703: a math-parser discard freed a libxml node
+  # then read it — green on Linux, SIGABRT on the reporter's Mac), so a green
+  # Linux suite is NOT proof of memory safety; and miri cannot cross the
+  # libmarpa/libxml2 C FFI. ASAN intercepts the system allocator, so it catches
+  # heap errors inside those C libraries too. Scoped to the math-parser
+  # discard/free class (`06_cluster_math`, which carries the #703 guard) to stay
+  # a single fast job — widen the nextest selection as new witnesses land.
+  asan:
+    name: asan (memory-safety UB check)
+    needs: changes
+    if: needs.changes.outputs.not_docs == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    env:
+      CARGO_BUILD_JOBS: "2"
+      CARGO_INCREMENTAL: "0"
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+      RUST_BACKTRACE: "1"
+      # ASAN instrumentation. Setting RUSTFLAGS overrides the target rustflags
+      # in .cargo/config.toml, so the parallel-frontend flags are re-added here;
+      # mold is dropped — the default linker links the sanitizer runtime fine.
+      RUSTFLAGS: "-Zsanitizer=address -Zthreads=8 -Zunstable-options"
+      # LSAN off: the engine leaks thread-local / arena state by design (see
+      # the reset_thread_engine rationale), which is not what this lane guards.
+      # halt_on_error stays default (1), so a UAF / double-free / OOB fails.
+      ASAN_OPTIONS: "detect_leaks=0"
+    steps:
+      - name: install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libxml2-dev libxml2-utils libxslt1-dev libkpathsea-dev libkpathsea6 \
+            texlive texlive-latex-extra texlive-science
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          key: asan
+      # Same dump cache as the Linux `test` job (identical key): the dumps are
+      # TL-derived text, independent of the ASAN instrumentation, so the two
+      # jobs share one entry and this step is a no-op on the common cache hit.
+      - name: TeX Live fingerprint (dump cache key)
+        id: tlfp
+        run: echo "year=$(pdflatex --version 2>/dev/null | sed -n 's:.*TeX Live \([0-9]\{4\}\).*:\1:p' | head -1)" >> "$GITHUB_OUTPUT"
+      - name: cache engine dumps
+        id: dumps
+        uses: actions/cache@v4
+        with:
+          path: resources/dumps
+          key: dumps-v1-${{ runner.os }}-tl${{ steps.tlfp.outputs.year }}-${{ hashFiles('latexml_core/src/**', 'latexml_engine/src/**', 'latexml_codegen/src/**') }}
+      - name: make formats
+        if: steps.dumps.outputs.cache-hit != 'true'
+        env:
+          PROFILE: ci
+        run: tools/make_formats.sh
+      - name: install cargo-nextest
+        uses: taiki-e/install-action@nextest
+      # `06_cluster_math` exercises the math-parser discard/free paths (the
+      # #703 use-after-free lived there). Under ASAN this run is red on any
+      # platform when a node is freed twice — the deterministic catch the plain
+      # suite lacks. `--cargo-profile ci` = fast build; `--profile ci` = nextest
+      # profile (unrelated same-named knobs, as in the `test` job).
+      - name: run memory-safety tests under ASAN
+        run: cargo nextest run --cargo-profile ci --profile ci -p latexml --test 06_cluster_math
+
   test:
     # Sharded across 4 runners. The suite's cost is ~398 s of in-binary
     # execution spread over the test targets (consolidated 2026-08 into fewer,
@@ -407,14 +476,14 @@ jobs:
   # repo-settings change that must land WITH this workflow.
   ci-success:
     name: CI success
-    needs: [changes, lint, miri, test, macos]
+    needs: [changes, lint, miri, asan, test, macos]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: verify no required job failed
         run: |
-          results='${{ needs.changes.result }} ${{ needs.lint.result }} ${{ needs.miri.result }} ${{ needs.test.result }} ${{ needs.macos.result }}'
+          results='${{ needs.changes.result }} ${{ needs.lint.result }} ${{ needs.miri.result }} ${{ needs.asan.result }} ${{ needs.test.result }} ${{ needs.macos.result }}'
           echo "upstream job results: $results"
           for r in $results; do
             case "$r" in

--- a/latexml_math_parser/src/parser.rs
+++ b/latexml_math_parser/src/parser.rs
@@ -3438,6 +3438,15 @@ fn drain_pending_discards(document: &mut Document, queued: &rustc_hash::FxHashSe
   let mut released: rustc_hash::FxHashSet<usize> = rustc_hash::FxHashSet::default();
   for node in crate::data::take_pending_discards() {
     if released.contains(&node.to_hashable()) {
+      // Already freed as part of an earlier subtree in this drain (B ⊂ A, both
+      // queued). Its C memory is gone; `free_subtree` neutralized only the
+      // wrappers still registered in the document, so this unregistered
+      // pending-discard handle kept a dangling `node_ptr`. Letting it Drop
+      // would read freed memory (`_Node::drop` dereferences `node->doc` for an
+      // Unlinked handle — the #703 use-after-free). Mark it linked first —
+      // wrapper-only bookkeeping that makes the drop a no-op at the FFI layer,
+      // exactly as `data::sweep_stale_math_state` does for stale handles.
+      node.set_linked();
       continue;
     }
     let mut ptrs = rustc_hash::FxHashSet::default();

--- a/latexml_oxide/tests/06_cluster_math.rs
+++ b/latexml_oxide/tests/06_cluster_math.rs
@@ -306,3 +306,27 @@ fn cluster_script_chain_depth() {
     );
   }
 }
+
+/// #703: nested `\sbox0{$#1$}\box0` boxes inside display math must not free a
+/// libxml node twice. `\rulebox{\rulebox{foof}}` queues two nested subtrees for
+/// deferred discard (B ⊂ A); `drain_pending_discards` freed A's subtree — B's C
+/// node with it — then dropped B's unregistered handle, whose `_Node::drop`
+/// dereferenced the freed `node->doc` (heap-use-after-free; Darwin's allocator
+/// aborts, glibc tolerates). Verified red→green under AddressSanitizer. This
+/// guard asserts the whole nested structure survives the drain.
+#[test]
+fn cluster_nested_sbox_discard_no_double_free() {
+  let x = convert_to_xml("tests/cluster_regressions/mathparse_nested_sbox_discard.tex");
+  // Innermost `$foof$` box, and the middle box wrapping it, both convert —
+  // proving no subtree was freed out from under the parse.
+  assert!(
+    x.contains(r#"tex="foof""#),
+    "innermost \\sbox math missing — nested discard corrupted the tree:\n{x}"
+  );
+  assert!(
+    x.contains(r#"tex="\hbox{$foof$}\hrule barf""#),
+    "middle \\sbox box missing — nested discard corrupted the tree:\n{x}"
+  );
+  // The trailing `barf` text after each `\box0\hrule` must still be present.
+  assert!(x.contains("barf"), "trailing text lost:\n{x}");
+}

--- a/latexml_oxide/tests/cluster_regressions/mathparse_nested_sbox_discard.tex
+++ b/latexml_oxide/tests/cluster_regressions/mathparse_nested_sbox_discard.tex
@@ -1,0 +1,10 @@
+\documentclass{article}
+\newcommand*\rulebox[1]{%
+  \sbox0{$#1$}%
+  \box0\hrule barf
+}
+\begin{document}
+\[
+  \rulebox{\rulebox{foof}}
+\]
+\end{document}


### PR DESCRIPTION
**Diagnostic.** `drain_pending_discards` (`parser.rs`) freed subtree A — and descendant B ⊂ A with it — via `discard_subtree`, then skipped B on the `released` guard but still dropped B's handle. B was an *unregistered* pending-discard wrapper, so `free_subtree` had not neutralized it; its `_Node::drop` dereferenced the freed `node->doc` → heap-use-after-free (Darwin's allocator aborts, glibc tolerates). Isolated with ASAN + valgrind on Linux.

**Approach.** On the skip path, mark the handle `set_linked()` before `continue` — wrapper-only bookkeeping (libxml `Unlinked → Linked`) that makes `_Node::drop` take the no-op branch, no deref, no re-free, no leak. Same idiom `data::sweep_stale_math_state` already uses for stale handles.

**Validation.** Red→green under AddressSanitizer on `\rulebox{\rulebox{foof}}` (buggy = heap-use-after-free; fixed = clean); 3-deep/sibling/inline variants also ASAN-clean. Guard test `cluster_nested_sbox_discard_no_double_free` (`06_cluster_math.rs`). Full suite 2113/0; clippy `-D warnings`; fmt.

Closes #703