### PR TITLE
test: guard svg+subcaption \subfloat survives (surpasses Perl, brucemiller/LaTeXML#2563)

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -3986,3 +3986,36 @@ side-by-side layout. Guard:
 `06_cluster_regressions::cluster_panel_merge_never_wraps_a_figure_in_a_block_2709`.
 An upstream Perl patch (same model-guard at L3305/3322) is to be filed at
 brucemiller/LaTeXML#2709.
+
+## 102. Loading `svg` after `subcaption` breaks subfig's `\subfloat` (Rust surpasses)
+
+**Perl source:** `subfig.sty.ltxml:114` — the RawTeX trailer
+`\@ifundefined{c@subfigure}{\newsubfloat{figure}}{}`. `svg.sty.ltxml:19` does
+`RequirePackage('subfig')`, so loading `svg` pulls subfig in.
+
+**Symptom:** `\newsubfloat{figure}` defines *both* the `subfigure` counter and the
+actual `\lx@subfloat@figure` implementation macro, but subfig guards the whole call
+on the **counter** existing. When `subcaption` is loaded first it already defines
+`c@subfigure` (`subcaption.sty.ltxml:25`), so subfig skips `\newsubfloat` entirely
+and never defines `\lx@subfloat@figure`. `\subfloat` then expands through
+`\sf@subfloat` → `\csname lx@subfloat@figure\endcsname` = `\relax`, and its
+`[caption]{body}` arguments leak as literal text. Same on Perl 0.8.8.
+
+**Minimal trigger:**
+```tex
+\documentclass{article}
+\usepackage{subcaption}
+\usepackage{svg}
+\begin{document}
+\begin{figure}\subfloat[This is a caption.]{This is a figure.}\end{figure}
+\end{document}
+```
+Perl → `<figure><p>[This is a caption.]This is a figure.</p></figure>` (no panel,
+no caption). Correct (Rust): a `<figure>` panel whose `<caption>` carries
+`This is a caption.` and whose body is `This is a figure.`.
+
+**Impact:** Perl-origin, in subfig's load-time guard. **Rust status (FIXED —
+surpasses):** `subfig_sty.rs` defines `\lx@subfloat@figure`/`\lx@subfloat@table`
+**unconditionally** and calls `NewCounter!` directly (idempotent), dropping the
+counter guard — so the subfloat macros exist regardless of a pre-existing counter.
+Guard: `06_cluster_regressions::cluster_svg_subfloat_survives_subcaption_2563`.

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -83,6 +83,34 @@ fn cluster_subfigure_panels_share_a_row_6903() {
      break count, so the reflow is either not firing or too eager:\n{xml}"
   );
 }
+/// brucemiller/LaTeXML#2563: loading `svg` (which does `RequirePackage('subfig')`)
+/// after `subcaption` must not break subfig's `\subfloat`. Perl 0.8.8 gates
+/// subfig's `\lx@subfloat@figure` behind `\@ifundefined{c@subfigure}{\newsubfloat
+/// {figure}}{}` (subfig.sty.ltxml:114) — a guard on the COUNTER, which subcaption
+/// already defined. So Perl skips the definition and `\subfloat` leaks its args as
+/// literal text: `<p>[This is a caption.]This is a figure.</p>`. Rust's
+/// `subfig_sty.rs` defines the subfloat macros unconditionally (NewCounter is
+/// idempotent), so the panel + its subcaption survive. Guards that surpass-Perl win.
+#[test]
+fn cluster_svg_subfloat_survives_subcaption_2563() {
+  let xml = convert_to_xml("tests/cluster_regressions/svg_subfloat_2563.tex");
+  // The Perl breakage signature: the optional arg dumped verbatim, unparsed.
+  assert!(
+    !xml.contains("[This is a caption.]"),
+    "svg+subcaption broke \\subfloat — its optional arg was dumped as literal text \
+     (#2563 Perl breakage). Expected a figure panel, not a raw `[...]`:\n{xml}"
+  );
+  // The subcaption must render as an actual caption, and the body as the panel.
+  assert!(
+    xml.contains("<caption") && xml.contains("This is a caption."),
+    "\\subfloat's subcaption was lost — expected a <caption> carrying \
+     'This is a caption.':\n{xml}"
+  );
+  assert!(
+    xml.contains("This is a figure."),
+    "\\subfloat's body content was lost:\n{xml}"
+  );
+}
 #[test]
 fn cluster_fvextra_preserves_ltx_verbatim() {
   let xml = convert_to_xml("tests/cluster_regressions/fvextra_ltx_verbatim.tex");

--- a/latexml_oxide/tests/cluster_regressions/svg_subfloat_2563.tex
+++ b/latexml_oxide/tests/cluster_regressions/svg_subfloat_2563.tex
@@ -1,0 +1,20 @@
+% brucemiller/LaTeXML#2563: loading `svg` after `subcaption` must not break
+% subfig's `\subfloat`. LaTeXML's svg.sty.ltxml does RequirePackage('subfig'),
+% and subfig's RawTeX tail defines `\lx@subfloat@figure` only inside
+% `\@ifundefined{c@subfigure}{\newsubfloat{figure}}{}` — a guard on the COUNTER.
+% subcaption (loaded first) already defined `c@subfigure`, so Perl 0.8.8 skips
+% \newsubfloat, leaves `\lx@subfloat@figure` undefined, and `\subfloat` dumps its
+% args as literal text: `<p>[This is a caption.]This is a figure.</p>`.
+%
+% Rust's subfig_sty.rs defines `\lx@subfloat@figure`/`\lx@subfloat@table`
+% UNCONDITIONALLY (the counter guard is dropped because NewCounter is idempotent),
+% so `\subfloat` still yields a proper figure panel with its subcaption. This
+% fixture guards that surpass-Perl win.
+\documentclass{article}
+\usepackage{subcaption}
+\usepackage{svg}
+\begin{document}
+\begin{figure}
+    \subfloat[This is a caption.]{This is a figure.}
+\end{figure}
+\end{document}


### PR DESCRIPTION
**Diagnostic.** Loading `svg` (which does `RequirePackage('subfig')`) after `subcaption` breaks subfig's `\subfloat`. subfig's load-time trailer defines `\lx@subfloat@figure` only inside `\@ifundefined{c@subfigure}{\newsubfloat{figure}}{}` — a guard on the **counter**, which `subcaption` already defined. Perl 0.8.8 then skips the definition and `\subfloat` dumps its args as literal text (`<p>[This is a caption.]This is a figure.</p>`). Reported upstream: brucemiller/LaTeXML#2563.

**Approach.** No code change — Rust's `subfig_sty.rs` already defines `\lx@subfloat@figure`/`\lx@subfloat@table` **unconditionally** (calling `NewCounter!` directly, which is idempotent), so the subfloat macros exist regardless of a pre-existing counter and the panel + its subcaption survive. This adds a **surpass-Perl regression guard** locking that in, plus the `KNOWN_PERL_ERRORS.md` #102 entry.

**Validation.** Guard `cluster_svg_subfloat_survives_subcaption_2563` (GREEN on current Rust; proven RED by temporarily regressing the binding to Perl's counter-gated structure — the conversion then errors on the undefined `\lx@subfloat@figure`). Full suite N/0; clippy + fmt clean. Same-host Perl 0.8.8 confirms the breakage; Rust yields a proper `<figure>` panel with the subcaption.

Guards the Rust side of brucemiller/LaTeXML#2563 (a Perl-only bug Rust already surpasses); no upstream Perl change is bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
