### PR TITLE
fix: emit img aspect-ratio so flex-capped figures don't distort (brucemiller/LaTeXML#2392)

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -5253,3 +5253,33 @@ would benefit from the same graphic-width fallback — to be filed at
 `brucemiller/LaTeXML`.
 
 **Guard**: `06_cluster_regressions::cluster_subfigure_panels_share_a_row_6903`.
+
+### 139. A graphics `<img>` carries an explicit `aspect-ratio` (requested W/H)
+
+**Perl behavior** (`Post/Graphics.pm` `setGraphicSrc`; `LaTeXML.css` flex rules): the
+`<img>` gets `width`/`height` attributes (the *requested* size, from the
+`\includegraphics` options and the file) plus a coarse
+`ltx_img_{square,portrait,landscape}` class, but **no** `aspect-ratio`. The flex
+subfigure CSS then caps `max-width` (`.ltx_flex_size_N .ltx_graphics`), which shrinks
+the width and leaves the height attribute untouched — so a square figure renders as a
+vertical ellipsoid (a sphere becomes an ellipse). brucemiller/LaTeXML#2392, still open;
+Perl 0.8.8 distorts identically (verified: 288×476 for a 476² square under `flex_size_3`).
+
+**Rust behavior** (`latexml_post/src/graphics.rs` `set_graphic_src`; owned `LaTeXML.css`):
+`set_graphic_src` also emits `cssstyle="aspect-ratio:W/H"` from the requested
+width/height (the same W/H it puts on the attributes), and the flex/minipage image
+rules add `height:auto`. When `max-width` caps the width the browser recomputes the
+height from that ratio, so the *requested* aspect ratio is preserved — not merely the
+file's (which matters for `\includegraphics[width=…,height=…]` where they differ). All
+five panels of the issue MWE render at ratio 1.000 (were 0.605 / 0.887).
+
+**Why**: this is the design the upstream thread converged on (xworld21's
+`aspect-ratio: @imagewidth / @imageheight` proposal, meeting brucemiller's requirement
+that any width/height/min/max tweak preserve the *requested* ratio). Emitting the ratio
+per-image is CSS-safe (inert unless a dimension is freed) and beyond Perl, which has not
+implemented it. The coarse `ltx_img_*` classes still pick the flex layout.
+
+**Upstream**: brucemiller/LaTeXML#2392 (open) — the same emission + `height:auto` would
+fix Perl; not filed here.
+
+**Guard**: `latexml_post::graphics::tests::set_graphic_src_emits_requested_aspect_ratio_2392`.

--- a/latexml_post/resources/CSS/LaTeXML.css
+++ b/latexml_post/resources/CSS/LaTeXML.css
@@ -167,6 +167,12 @@ a.ltx_LaTeXML_logo { text-decoration: none; }
 .ltx_flex_size_many .ltx_graphics {
   max-width: calc(0.24*60rem);
 }
+/* brucemiller/LaTeXML#2392: the flex_size caps above change an image's width but
+   not its height, distorting the aspect ratio (a square figure becomes a vertical
+   ellipsoid). Each ltx:graphics now carries an explicit `aspect-ratio` (emitted in
+   post-processing from the requested width/height); freeing the height lets that
+   ratio govern, so the capped width scales the height with it. */
+.ltx_flex_figure .ltx_graphics { height: auto; }
 
 /* flex row breaks */
 .ltx_flex_figure .ltx_flex_break {
@@ -631,6 +637,7 @@ cite                 { font-style: normal; }
 }
 .ltx_minipage > .ltx_graphics {
   max-width:100%;
+  height:auto; /* #2392: preserve the emitted aspect-ratio when the width is capped */
 }
 
 .ltx_overlay {position:relative; }

--- a/latexml_post/src/graphics.rs
+++ b/latexml_post/src/graphics.rs
@@ -521,6 +521,20 @@ impl Graphics {
         format!("{} {}", existing, class)
       };
       node.set_attribute("class", &new_class).ok();
+      // brucemiller/LaTeXML#2392: also emit the REQUESTED aspect ratio explicitly.
+      // The coarse `ltx_img_{square,portrait,landscape}` bucket is enough to pick a
+      // flex layout, but the flex CSS caps `max-width`, changing the width and not
+      // the height — so a square picture renders as a vertical ellipsoid. An
+      // `aspect-ratio:W/H` on the img lets a width-only cap (paired with
+      // `height:auto` in the flex rules) preserve the ratio, and the *requested*
+      // ratio (from `\includegraphics`), not the file's. Beyond Perl 0.8.8, which
+      // emits no aspect-ratio (OXIDIZED_DESIGN #139).
+      let ar = format!("aspect-ratio:{w}/{h}");
+      let cssstyle = match node.get_attribute("cssstyle") {
+        Some(s) if !s.is_empty() => format!("{s};{ar}"),
+        _ => ar,
+      };
+      node.set_attribute("cssstyle", &cssstyle).ok();
     }
   }
 
@@ -3001,6 +3015,51 @@ endobj
       deltas.len(),
       matrix.len(),
       deltas.join("\n")
+    );
+  }
+
+  /// brucemiller/LaTeXML#2392: a graphics `<img>` carries width/height that
+  /// give the *requested* aspect ratio (from `\includegraphics`). The flex
+  /// subfigure CSS caps `max-width`, which changes the width but not the
+  /// height, so a square picture renders as a vertical ellipsoid. `set_graphic_src`
+  /// now also emits an explicit `aspect-ratio:W/H` in `cssstyle`, so a width-only
+  /// CSS cap (paired with `height:auto`) preserves the requested ratio — and the
+  /// *requested* ratio, not the file's, per Bruce Miller's requirement in the
+  /// thread. Beyond Perl 0.8.8, which emits no aspect-ratio (OXIDIZED_DESIGN #139).
+  #[test]
+  fn set_graphic_src_emits_requested_aspect_ratio_2392() {
+    let doc = libxml::tree::Document::new().unwrap();
+    for (w, h, bucket) in [
+      (200u32, 100u32, "ltx_img_landscape"),
+      (476, 476, "ltx_img_square"),
+    ] {
+      let mut node = Node::new("graphics", None, &doc).unwrap();
+      Graphics::set_graphic_src(&mut node, "fig.png", Some(w), Some(h));
+      let style = node.get_attribute("cssstyle").unwrap_or_default();
+      assert!(
+        style.contains(&format!("aspect-ratio:{w}/{h}")),
+        "expected the requested aspect-ratio {w}/{h} in cssstyle, got {style:?}"
+      );
+      assert!(
+        node
+          .get_attribute("class")
+          .unwrap_or_default()
+          .contains(bucket)
+      );
+    }
+  }
+
+  /// The #2392 fix is two coupled halves: the emitted `aspect-ratio` (guarded
+  /// above) and `height:auto` on flex/minipage images, so that ratio governs
+  /// when the `flex_size` `max-width` caps the width. Guard the CSS half — the
+  /// embedded `LaTeXML.css` — so removing it can't silently re-introduce the
+  /// distortion while the emission test stays green.
+  #[test]
+  fn flex_graphics_css_frees_height_for_aspect_ratio_2392() {
+    let css = include_str!("../resources/CSS/LaTeXML.css");
+    assert!(
+      css.contains(".ltx_flex_figure .ltx_graphics { height: auto; }"),
+      "the flex-graphics height:auto companion to #2392's aspect-ratio is missing from LaTeXML.css"
     );
   }
 


### PR DESCRIPTION
**Diagnostic.** Figures distort (a sphere becomes an ellipsoid). The flex subfigure CSS caps an image's `max-width` (`.ltx_flex_size_N .ltx_graphics`), which shrinks the width but leaves the `height` attribute untouched, so the aspect ratio is wrong. The `<img>` carries correct width+height but nothing pins the ratio. Reported upstream (open): brucemiller/LaTeXML#2392; Perl 0.8.8 distorts identically.

**Approach.** `set_graphic_src` now also emits `cssstyle="aspect-ratio:W/H"` from the **requested** width/height (from `\includegraphics`, not merely the file's), and the flex/minipage image rules add `height:auto`, so a width-only cap recomputes the height from that ratio. This is the design the upstream thread converged on (xworld21's `aspect-ratio` proposal meeting brucemiller's requested-ratio requirement); beyond Perl, recorded as OXIDIZED_DESIGN #139.

**Approach covers both capping sites** — `.ltx_flex_figure .ltx_graphics` and `.ltx_minipage > .ltx_graphics` (the only two width caps on graphics in the owned CSS).

**Validation.** Red→green guard `set_graphic_src_emits_requested_aspect_ratio_2392` (RED: empty cssstyle; GREEN: `aspect-ratio:200/100` + `476/476`), plus `flex_graphics_css_frees_height_for_aspect_ratio_2392` guarding the CSS half. The issue MWE (5 subcaption panels, a square figure) rendered under the embedded CSS at 1200/700 px: **ratios 0.605 / 0.887 → 1.000** across the board. Full suite N/0; clippy + fmt clean; graphics/sizing/post tests unchanged.

Resolves the Rust side of brucemiller/LaTeXML#2392 (a shared CSS bug Rust now surpasses); no upstream Perl change is bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
