### PR TITLE
feat: bind scalerel so \scalerel* inline icons scale to text height (arXiv/html_feedback#6895)

### DIFF
--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -4019,3 +4019,34 @@ surpasses):** `subfig_sty.rs` defines `\lx@subfloat@figure`/`\lx@subfloat@table`
 **unconditionally** and calls `NewCounter!` directly (idempotent), dropping the
 counter guard — so the subfloat macros exist regardless of a pre-existing counter.
 Guard: `06_cluster_regressions::cluster_svg_subfloat_survives_subcaption_2563`.
+
+## 103. `\scalerel` is undefined, so a scaled inline icon renders unscaled (Rust surpasses)
+
+**Perl source:** none — the `scalerel` package has **no** `.ltxml` binding, and
+`\RequirePackage{scalerel}` loads only the raw `.sty`'s dependencies (calc, graphicx,
+etoolbox), not its body, so `\scalerel` is never defined.
+
+**Symptom:** an inline icon built with `\scalerel*{obj}{ref}` (which should scale
+`obj` to the height of `ref`) — e.g. the `\orcidicon` macro that packs a tikz
+`orcidlogo` picture into `\scalerel*` — raises `Error:undefined:\scalerel` and drops
+the object in **unscaled**, so the ORCID logo covers multiple text lines. Same on
+Perl 0.8.8 (verified same-host: `Error:undefined:\scalerel`).
+
+**Minimal trigger:**
+```tex
+\documentclass{article}\usepackage{scalerel}
+\begin{document}X\scalerel*{\rule{2cm}{2cm}}{Xg}Y\end{document}
+```
+Perl → `Error:undefined:\scalerel`, the `2cm` rule unscaled. Correct (Rust): the
+object wrapped in an inline-block scaled to text height (a 16×16 px inline glyph for
+the ORCID witness), zero errors.
+
+**Impact:** Perl-origin (missing binding), shared with the Rust raw-load. **Rust status
+(FIXED — surpasses):** `scalerel_sty.rs` binds `\scalerel`/`\stretchrel`; `\scalerel*`
+wraps the object in `.ltx_scalerel`, which `LaTeXML.css` sizes to `1em` with its
+`svg`/`img` child at `height:100%; width:auto`, so the object scales to the text
+height (aspect preserved). Box-measurement scaling being unavailable, the CSS sizes to
+the *text* height rather than an arbitrary `ref` — correct for the dominant
+inline-icon use. Guard: `06_cluster_regressions::cluster_scalerel_defined_6895`.
+Witness: arXiv/html_feedback#6895 (arXiv:2608.12272). The ar5iv stylesheet carries the
+matching `.ltx_scalerel` rule.

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -111,6 +111,17 @@ fn cluster_svg_subfloat_survives_subcaption_2563() {
     "\\subfloat's body content was lost:\n{xml}"
   );
 }
+/// arXiv/html_feedback#6895: `\RequirePackage{scalerel}` leaves `\scalerel`
+/// undefined (no binding in Perl or Rust; the raw `.sty` load fails to define it),
+/// so an inline icon built with `\scalerel*` (the `\orcidicon` of arXiv:2608.12272)
+/// raised `Error:undefined:\scalerel` and rendered its picture unscaled. The
+/// `scalerel_sty` binding defines `\scalerel`/`\stretchrel` so the object scales to
+/// the reference's height. Beyond Perl 0.8.8 (which errors identically). Witness:
+/// 2608.12272.
+#[test]
+fn cluster_scalerel_defined_6895() {
+  convert_clean("tests/cluster_regressions/scalerel_icon_6895.tex");
+}
 #[test]
 fn cluster_fvextra_preserves_ltx_verbatim() {
   let xml = convert_to_xml("tests/cluster_regressions/fvextra_ltx_verbatim.tex");

--- a/latexml_oxide/tests/cluster_regressions/scalerel_icon_6895.tex
+++ b/latexml_oxide/tests/cluster_regressions/scalerel_icon_6895.tex
@@ -1,0 +1,12 @@
+% arXiv/html_feedback#6895: the scalerel package (\RequirePackage{scalerel}) has no
+% .ltxml binding in Perl OR Rust, and the raw .sty load leaves \scalerel undefined,
+% so an inline icon built with \scalerel* (e.g. the \orcidicon macro of
+% arXiv:2608.12272) raises Error:undefined:\scalerel and renders its picture
+% unscaled ("too big / multi-line"). A scalerel binding defines \scalerel so the
+% object scales to the reference's (text) height instead. Witness: 2608.12272.
+\documentclass{article}
+\usepackage{scalerel}
+\begin{document}
+Inline X\scalerel*{\rule{2cm}{2cm}}{Xg}Y here.
+And non-star Z\scalerel{\rule{2cm}{1cm}}{Xg}W appends the reference.
+\end{document}

--- a/latexml_package/src/lib.rs
+++ b/latexml_package/src/lib.rs
@@ -928,6 +928,7 @@ pub const BINDINGS: &[(&str, &str, BindingLoader)] = &[
   ("ragged2e", "sty", package::ragged2e_sty::load_definitions),
   ("relsize", "sty", package::relsize_sty::load_definitions),
   ("scalefnt", "sty", package::scalefnt_sty::load_definitions),
+  ("scalerel", "sty", package::scalerel_sty::load_definitions),
   ("sectsty", "sty", package::sectsty_sty::load_definitions),
   ("xfrac", "sty", package::xfrac_sty::load_definitions),
   ("adjustbox", "sty", package::adjustbox_sty::load_definitions),

--- a/latexml_package/src/package.rs
+++ b/latexml_package/src/package.rs
@@ -387,6 +387,7 @@ pub mod rotate_sty;
 pub mod rotating_sty;
 pub mod rsfs_sty;
 pub mod scalefnt_sty;
+pub mod scalerel_sty;
 pub mod sectsty_sty;
 pub mod setspace_sty;
 pub mod shellesc_sty;

--- a/latexml_package/src/package/scalerel_sty.rs
+++ b/latexml_package/src/package/scalerel_sty.rs
@@ -1,0 +1,28 @@
+use crate::prelude::*;
+
+#[rustfmt::skip]
+LoadDefinitions!({
+  // arXiv/html_feedback#6895: the `scalerel` package has no `.ltxml` binding in
+  // Perl OR Rust, and the raw `.sty` load leaves `\scalerel` undefined — so an
+  // inline icon built with `\scalerel*` (the `\orcidicon` of arXiv:2608.12272)
+  // raised `Error:undefined:\scalerel` and rendered its picture unscaled ("too
+  // big / multi-line"). Beyond Perl 0.8.8, which errors identically.
+  //
+  // `\scalerel*[maxwidth]{obj}{ref}` scales `obj` to the height of `ref`, aspect
+  // preserved (scalerel.sty L68-84). The dominant use is an inline object scaled
+  // to the surrounding *text* height, so — box-measurement scaling being
+  // unavailable in this engine — we wrap `obj` in an inline-block that CSS sizes
+  // to text height (`.ltx_scalerel`, `LaTeXML.css`). The `[maxwidth]` cap
+  // (default `99in`, i.e. unbounded) is accepted and dropped. The starred form
+  // yields just the scaled object; the plain `\scalerel{obj}{ref}` appends `ref`
+  // afterwards (scalerel.sty L84, `\scalerelplus`).
+  DefMacro!("\\scalerel", "\\@ifstar\\lx@scalerel@star\\lx@scalerel@plus");
+  DefMacro!("\\lx@scalerel@star []{}{}", "\\lx@scalerel@obj{#2}");
+  DefMacro!("\\lx@scalerel@plus []{}{}", "\\lx@scalerel@obj{#2}#3");
+  DefConstructor!("\\lx@scalerel@obj{}",
+    "<ltx:inline-block class='ltx_scalerel'>#1</ltx:inline-block>",
+    mode => "restricted_horizontal", enter_horizontal => true, bounded => true);
+  // `\stretchrel` stretches ignoring the aspect ratio; aspect-preserving is the
+  // safe default for an inline icon, so alias it to `\scalerel` (scalerel.sty L86).
+  Let!("\\stretchrel", "\\scalerel");
+});

--- a/latexml_post/resources/CSS/LaTeXML.css
+++ b/latexml_post/resources/CSS/LaTeXML.css
@@ -639,6 +639,13 @@ cite                 { font-style: normal; }
   max-width:100%;
   height:auto; /* #2392: preserve the emitted aspect-ratio when the width is capped */
 }
+/* arXiv/html_feedback#6895: \scalerel*{obj}{ref} scales obj to ref's (text) height.
+   The scalerel binding wraps obj in .ltx_scalerel; size the box to the line height
+   and let its child (an SVG/picture/rule) fill it, so a picture-based inline icon
+   (e.g. \orcidicon) renders as a text-height glyph instead of its unscaled size. */
+.ltx_scalerel { display:inline-block; height:1em; vertical-align:-0.1em; }
+.ltx_scalerel .ltx_inline-block { height:100%; }
+.ltx_scalerel svg, .ltx_scalerel img { height:100%; width:auto; }
 
 .ltx_overlay {position:relative; }
 .ltx_overlay > span:nth-child(2) {position:absolute; left:0; }


### PR DESCRIPTION
**Diagnostic.** The `scalerel` package has no `.ltxml` binding in Perl or Rust, and the raw `.sty` load leaves `\scalerel` undefined — so an inline icon built with `\scalerel*` (the `\orcidicon` of arXiv:2608.12272) raised `Error:undefined:\scalerel` and rendered its tikz picture unscaled ("too big / multi-line"). Perl 0.8.8 errors identically (verified same-host).

**Approach.** `scalerel_sty.rs` binds `\scalerel`/`\stretchrel`: `\scalerel*{obj}{ref}` wraps `obj` in `.ltx_scalerel`, which the owned `LaTeXML.css` sizes to `1em` with its `svg`/`img` child at `height:100%; width:auto` — a text-height inline glyph, aspect preserved. Box-measurement scaling being unavailable, it sizes to the *text* height (correct for the dominant inline-icon use). Beyond Perl; recorded in `KNOWN_PERL_ERRORS.md` #103.

**Validation.** Red→green guard `cluster_scalerel_defined_6895` (RED: `Error:undefined:\scalerel`; GREEN: 0 errors). Witness arXiv:2608.12272 rendered: the ORCID icon is **16×16 px** (was full-size, multi-line). Full suite **2119/0**; clippy + fmt clean. The issue's other half ("internal links broken") does **not** reproduce (200 `ltx_ref` resolve, 0 `ltx_missing`). ar5iv stylesheet mirror: dginev/ar5iv-css#49.