### PR TITLE
fix: distribute up-front amsart author contacts to their own authors (arXiv/html_feedback#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+  - **amsart authors declared up front no longer bunch every address/email under the
+    last author.** The idiom `\author{A}\author{B}\author{C}` followed by one
+    `\address`/`\email` pair each makes LaTeXML's default "attach a contact to the
+    preceding creator" pile every contact onto the last author, so A and B render bare
+    (arXiv/html_feedback#46, witness arXiv:2308.06214v1; Perl 0.8.8 identical — SHARED).
+    A new DOM pass `distribute_upfront_contacts` redistributes ONLY a clean `N × m`
+    pile — the other N−1 authors carry no contact and the last author's `K` contacts
+    split evenly (`K = N·m`) into a role-periodic sequence — handing group *i* to
+    author *i*. Irregular piles (heterogeneous roles, differing per-author counts) and
+    the interleaved idiom fail the gate and are left exactly as Perl attached them, so
+    `tests/structure/amsarticle.tex` is byte-unchanged. Beyond-Perl (OXIDIZED_DESIGN
+    #140 / KNOWN_PERL_ERRORS #104). Guard
+    `06_cluster_frontmatter::frontmatter_amsart_upfront_contact_distribution`.
   - **A non-default `NOMINAL_FONT_SIZE` is persisted as a
     `<?latexml nominal-font-size="X"?>` processing instruction** so post-processing
     can size font-relative (`em`) external SVGs correctly — an `em` is

--- a/docs/parity/KNOWN_PERL_ERRORS.md
+++ b/docs/parity/KNOWN_PERL_ERRORS.md
@@ -4050,3 +4050,34 @@ the *text* height rather than an arbitrary `ref` — correct for the dominant
 inline-icon use. Guard: `06_cluster_regressions::cluster_scalerel_defined_6895`.
 Witness: arXiv/html_feedback#6895 (arXiv:2608.12272). The ar5iv stylesheet carries the
 matching `.ltx_scalerel` rule.
+
+## 104. amsart authors declared up front bunch every address/email under the last author (Rust surpasses)
+
+**Perl source:** `ams_support.sty.ltxml` (`\address`/`\email`/`\curraddr` → `\lx@add@address`
+etc.) + `Base_Utility.pool.ltxml` `\lx@annotate@frontmatter@now` (L510-530). With no
+`label`/`labelseq`/`annotate` option, a contact attaches to the **single preceding**
+(most-recent) creator.
+
+**Symptom:** the amsart idiom that declares all authors first, then one `\address`/`\email`
+pair each —
+```tex
+\documentclass{amsart}\begin{document}\title{T}
+\author{A}\author{B}\author{C}
+\address{A-addr}\email{a@x}\address{B-addr}\email{b@y}\address{C-addr}\email{c@z}
+\maketitle\end{document}
+```
+— makes every `\address`/`\email` attach to the *last* author C, so all three addresses and
+emails render in C's column while A and B are bare. Same on Perl 0.8.8 (verified same-host,
+byte-identical `<ltx:creator>` output). amsart's own PDF also lists them as one flat block
+(no per-author association), so there is no ground-truth pairing — only reading-order intent.
+
+**Impact:** Perl-origin (default single-preceding attachment), shared with Rust. **Rust status
+(FIXED — surpasses):** `base_utilities.rs::distribute_upfront_contacts` (a DOM pass beside
+`coalesce_empty_creators`) redistributes ONLY a clean `N × m` pile — the other N−1 authors
+carry no contact and the last author's `K` contacts split evenly (`K = N·m`) into a
+role-periodic sequence — handing group *i* to author *i*. Any irregular pile (heterogeneous
+roles, differing per-author counts) or already-interleaved contacts fail the gate and are left
+exactly as Perl attached them, so the common interleaved idiom (guard
+`tests/structure/amsarticle.tex`) is untouched. Guard:
+`06_cluster_frontmatter::frontmatter_amsart_upfront_contact_distribution`. Witness:
+arXiv/html_feedback#46 (arXiv:2308.06214v1). Divergence: OXIDIZED_DESIGN #140.

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -5283,3 +5283,33 @@ implemented it. The coarse `ltx_img_*` classes still pick the flex layout.
 fix Perl; not filed here.
 
 **Guard**: `latexml_post::graphics::tests::set_graphic_src_emits_requested_aspect_ratio_2392`.
+
+### 140. amsart up-front author/contact grid redistributes to the right author
+
+**Perl behavior** (`ams_support.sty.ltxml` `\address`/`\email`; `Base_Utility.pool.ltxml`
+`\lx@annotate@frontmatter@now` L510-530): a contact with no `label`/`labelseq`/`annotate`
+attaches to the **single most-recent** creator. When a document declares every `\author`
+before any `\address`/`\email` (a common amsart idiom, witness arXiv:2308.06214v1), the
+most-recent author at every contact is the *last* one, so all addresses/emails bunch under
+that last author. Perl 0.8.8 does the same (verified same-host, byte-identical).
+
+**Rust behavior** (`base_utilities.rs::distribute_upfront_contacts`, a DOM pass in
+`insert_frontmatter` between `coalesce_empty_creators` and `relocate_annotations`):
+after creators are built, a *clean* pile is redistributed — the signature is that the
+other N−1 authors carry no `ltx:contact` and the last author's `K` contacts split evenly
+(`K = N·m`) into a role-periodic sequence (`role[i] == role[i+m]`); group *i* is then
+handed to author *i* (`address i` → author i, `email i` → author i, …). All-same-role
+piles (`m = 1`) work too.
+
+**Why**: the input is genuinely ambiguous (amsart's PDF renders one flat block, no
+pairing), so we distribute ONLY the unambiguous regular grid and otherwise keep Perl's
+attachment verbatim. This mirrors the shared-email splitter's "distribute-when-clean,
+else keep prior" rule (#52(j)). The gate's `N-1`-empty + periodicity conditions make the
+interleaved idiom (each author immediately followed by its own contacts — already correct)
+fail the check, so it is never disturbed (guard `tests/structure/amsarticle.tex`, whose
+Joe-Blow/Frank-Zappa/Someone-Else block is interleaved and byte-unchanged).
+
+**Upstream**: brucemiller/LaTeXML — the same redistribution would help Perl; not filed here.
+
+**Guard**: `06_cluster_frontmatter::frontmatter_amsart_upfront_contact_distribution`
+(up-front pile distributes; interleaved control untouched). KNOWN_PERL_ERRORS #104.

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -2469,6 +2469,7 @@ pub fn insert_frontmatter(document: &mut Document) -> Result<()> {
     }
   }
   coalesce_empty_creators(document)?;
+  distribute_upfront_contacts(document)?;
   relocate_annotations(document)?;
   Ok(())
 }
@@ -2518,6 +2519,74 @@ fn coalesce_empty_creators(document: &mut Document) -> Result<()> {
   }
   for creator in to_remove {
     document.remove_node(creator);
+  }
+  Ok(())
+}
+
+/// Redistribute a mis-piled contact block back to its authors (surpass-Perl).
+///
+/// The amsart idiom `\author{A}\author{B}\author{C}` followed by paired
+/// `\address{}\email{}` declares every author up front, then all the contacts.
+/// LaTeXML's default "attach a contact to the preceding creator" then bunches
+/// EVERY address+email under the LAST author (arXiv:2308.06214v1,
+/// arXiv/html_feedback#46); Perl 0.8.8 does the same (SHARED limitation).
+///
+/// Fix ONLY the clean, unambiguous pile — an `N × m` grid: the other `N-1`
+/// authors carry no contact, the last author's `K` contacts split evenly
+/// (`K = N·m`) into a role-periodic sequence (`role[i] == role[i+m]`), so group
+/// `j` is handed to author `j`. Any irregular pile — a heterogeneous role
+/// sequence, per-author counts that differ, or contacts already spread across
+/// authors (the interleaved idiom, which is correct as-is) — fails the gate and
+/// is left EXACTLY as Perl attached it. Mirrors the "distribute-when-clean, else
+/// keep prior" rule of the shared-email splitter (OXIDIZED_DESIGN #52(j)).
+fn distribute_upfront_contacts(document: &mut Document) -> Result<()> {
+  let creators = document.findnodes("//ltx:creator[@role='author']", None);
+  let n = creators.len();
+  if n < 2 {
+    return Ok(());
+  }
+  let contacts_of = |c: &Node| -> Vec<Node> {
+    c.get_child_nodes()
+      .into_iter()
+      .filter(|x| {
+        x.get_type() == Some(NodeType::ElementNode)
+          && with(document::get_node_qname(x), |q| q == "ltx:contact")
+      })
+      .collect()
+  };
+  // Signature: only the LAST author carries any contacts.
+  for creator in &creators[..n - 1] {
+    if !contacts_of(creator).is_empty() {
+      return Ok(());
+    }
+  }
+  let last = creators[n - 1].clone();
+  let contacts = contacts_of(&last);
+  let k = contacts.len();
+  if k == 0 || k % n != 0 {
+    return Ok(());
+  }
+  let m = k / n;
+  // Role sequence must be periodic with period m (every group has the same
+  // role pattern), else the pile is not a clean grid — leave it to Perl's rule.
+  let roles: Vec<String> = contacts
+    .iter()
+    .map(|x| x.get_attribute("role").unwrap_or_default())
+    .collect();
+  if (0..k - m).any(|i| roles[i] != roles[i + m]) {
+    return Ok(());
+  }
+  // Group j (contacts[j*m .. (j+1)*m]) -> author j. The last group stays put;
+  // the earlier groups clone onto their author and the originals are removed.
+  let mut to_remove: Vec<Node> = Vec::new();
+  for (j, creator) in creators.iter().enumerate().take(n - 1) {
+    let group: Vec<Node> = contacts[j * m..(j + 1) * m].to_vec();
+    let mut target = creator.clone();
+    document.append_clone(&mut target, group.clone())?;
+    to_remove.extend(group);
+  }
+  for node in to_remove {
+    document.remove_node(node);
   }
   Ok(())
 }

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -22,6 +22,15 @@ fn creator_has_email(xml: &str, name: &str, mail: &str) -> bool {
   })
 }
 
+/// True if the `<creator>` whose `<personname>` is `name` has a block containing
+/// `needle` (a contact text/attribute substring).
+fn creator_block_contains(xml: &str, name: &str, needle: &str) -> bool {
+  xml.split("<creator").skip(1).any(|rest| {
+    let block = rest.split("</creator>").next().unwrap_or("");
+    block.contains(&format!("<personname>{name}</personname>")) && block.contains(needle)
+  })
+}
+
 /// acmart `\author[F. Poli]{Federico Poli}`: the real class is `\author[2][]`
 /// (optional running-head short name + full name). The name must render, and
 /// the `[F. Poli]` optarg must NOT leak as a `[` creator. Witness 2405.08372.
@@ -355,6 +364,64 @@ fn frontmatter_shared_email_distribution() {
     !creator_has_email(&s, "Bob", "contact@lab.org"),
     "single shared: must not also land on a trailing author:\n{s}"
   );
+}
+/// arXiv/html_feedback#46 (witness 2308.06214v1, amsart): all `\author` declared up
+/// front, THEN one `\address`/`\email` pair each. LaTeXML's default "attach contact
+/// to the preceding creator" bunches every address+email under the LAST author
+/// (Perl 0.8.8 too — SHARED). A clean N×m grid (3 authors × {address,email}) must
+/// redistribute pair i to author i. The interleaved control (each author followed by
+/// its own contacts) is already correct and must stay untouched.
+/// OXIDIZED_DESIGN #140 / KNOWN_PERL_ERRORS #104.
+#[test]
+fn frontmatter_amsart_upfront_contact_distribution() {
+  let up = convert_to_xml("tests/cluster_regressions/frontmatter_amsart_upfront_46.tex");
+  let authors = [
+    ("Peter Feller", "peter.feller@math.ch", "ETH Zurich"),
+    (
+      "Diana Hubbard",
+      "diana.hubbard@brooklyn.cuny.edu",
+      "Brooklyn College",
+    ),
+    (
+      "Hannah Turner",
+      "hannah.turner@math.gatech.edu",
+      "Georgia Institute",
+    ),
+  ];
+  for (name, mail, addr) in authors {
+    assert!(
+      creator_has_email(&up, name, mail),
+      "up-front: {name} must carry its own email {mail}:\n{up}"
+    );
+    assert!(
+      creator_block_contains(&up, name, addr),
+      "up-front: {name} must carry its own address {addr}:\n{up}"
+    );
+  }
+  // Tight guard: no author may carry another author's email.
+  for (name, ..) in authors {
+    for (_, other_mail, _) in authors.iter().filter(|(n, ..)| *n != name) {
+      assert!(
+        !creator_has_email(&up, name, other_mail),
+        "up-front: {name} must NOT carry another author's email {other_mail}:\n{up}"
+      );
+    }
+  }
+
+  // Interleaved control: already correct; the redistribution pass must not disturb it.
+  let il = convert_to_xml("tests/cluster_regressions/frontmatter_amsart_interleaved_46.tex");
+  for (name, mail, addr) in authors {
+    assert!(
+      creator_has_email(&il, name, mail) && creator_block_contains(&il, name, addr),
+      "interleaved: {name} must keep its own {mail} / {addr}:\n{il}"
+    );
+    for (_, other_mail, _) in authors.iter().filter(|(n, ..)| *n != name) {
+      assert!(
+        !creator_has_email(&il, name, other_mail),
+        "interleaved: {name} must NOT gain another author's email {other_mail}:\n{il}"
+      );
+    }
+  }
 }
 /// arXiv:2403.16405 (IEEEtran conference): a `\author{}` grid where `\and` starts a
 /// COLUMN and top-level `\\` a ROW within it is linearized column-major (declaration

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_amsart_interleaved_46.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_amsart_interleaved_46.tex
@@ -1,0 +1,19 @@
+% arXiv/html_feedback#46 control: the INTERLEAVED amsart idiom (each author
+% immediately followed by its own \address/\email) is already correct under the
+% default "attach to preceding creator". The #46 redistribution pass must NOT
+% disturb it — every contact stays with its own author.
+\documentclass{amsart}
+\begin{document}
+\title{Interleaved control}
+\author{Peter Feller}
+\address{ETH Zurich}
+\email{peter.feller@math.ch}
+\author{Diana Hubbard}
+\address{Brooklyn College CUNY}
+\email{diana.hubbard@brooklyn.cuny.edu}
+\author{Hannah Turner}
+\address{Georgia Institute of Technology}
+\email{hannah.turner@math.gatech.edu}
+\maketitle
+Body text.
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_amsart_upfront_46.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_amsart_upfront_46.tex
@@ -1,0 +1,25 @@
+% arXiv/html_feedback#46 (witness 2308.06214v1, amsart): all three \author are
+% declared up front, THEN one \address/\email pair each. LaTeXML's default
+% "attach contact to the preceding creator" bunches EVERY address+email under the
+% LAST author (Hannah Turner); Perl 0.8.8 does the same (SHARED limitation). The
+% clean N x m grid (3 authors x {address,email}) must redistribute: pair i to
+% author i.
+\documentclass{amsart}
+\begin{document}
+\title{The Dehn twist coefficient}
+\author{Peter Feller}
+\author{Diana Hubbard}
+\author{Hannah Turner}
+
+\address{ETH Zurich, Ramistrasse 101, 8092 Zurich, Switzerland}
+\email{peter.feller@math.ch}
+
+\address{Brooklyn College CUNY, 2900 Bedford Avenue 11210 USA}
+\email{diana.hubbard@brooklyn.cuny.edu}
+
+\address{Georgia Institute of Technology}
+\email{hannah.turner@math.gatech.edu}
+
+\maketitle
+Body text.
+\end{document}


### PR DESCRIPTION
**Diagnostic.** The amsart idiom that declares every `\author` before any `\address`/`\email` (witness arXiv:2308.06214v1) makes LaTeXML's default "attach a contact to the preceding creator" bunch every address+email under the *last* author, leaving co-authors bare. Perl 0.8.8 does the same — byte-identical `<ltx:creator>` output (SHARED limitation).

**Approach.** New DOM pass `base_utilities.rs::distribute_upfront_contacts` (in `insert_frontmatter`, between `coalesce_empty_creators` and `relocate_annotations`) redistributes ONLY a clean `N × m` pile — the other `N-1` authors carry no contact and the last author's `K` contacts split evenly (`K = N·m`) into a role-periodic sequence — handing group *i* to author *i*. Irregular piles (heterogeneous roles, differing per-author counts) and the already-correct interleaved idiom fail the gate and are left exactly as Perl attached them. Mirrors the shared-email splitter's "distribute-when-clean, else keep prior" rule. Beyond-Perl (OXIDIZED_DESIGN #140 / KNOWN_PERL_ERRORS #104).

**Validation.** Red→green guard `06_cluster_frontmatter::frontmatter_amsart_upfront_contact_distribution` (up-front pile distributes; interleaved control untouched). `tests/structure/amsarticle.tex` (interleaved) byte-unchanged. Witness arXiv:2308.06214v1 re-converted — each author now carries its own address+email. Full suite 2120/0; clippy + rustdoc clean.

Resolves the report at arXiv/html_feedback#46.