### PR TITLE
chore(release): prepare 0.7.6-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,77 @@
 # Change Log
 
-## [Unreleased]
+## [0.7.6] (graphics & SVG figure fidelity; minted highlighting + overpic; author/frontmatter class sweep; Rhai runtime binding API; latexmlpost CLI parity; wider package & bibliography coverage)
 
+  - **`minted` code blocks render with syntax highlighting, and inline `\mint`/`\mintinline`
+    work.** The `minted` family now emits highlight token classes so a stylesheet colors the
+    source; inline `\mint`/`\mintinline` render like the block form; `\newmint*` accepts the
+    optional `[env-name]`; and `escapeinside` lets a `\label` inside a listing register on its
+    own line (#668, #665, #625). Tier-2 (an exact-Pygments `pygmentize` subprocess) is parked
+    behind issue #670.
+  - **`overpic` renders its base graphic plus `\put` overlays.** The `overpic`/`overpic*`
+    environment — a `graphicx` image carrying a `picture`-coordinate overlay — was unbound; it
+    now draws the base graphic and composes the `\put` overlays on top, recovering ~37 arXiv
+    papers that previously lost the annotated figure entirely (#677).
+  - **Figures and SVG pictures render at the right size and shape.** A sweep of
+    graphics/`picture`/SVG fidelity fixes: an `\includegraphics` in a flex-capped figure keeps
+    its aspect ratio via an emitted `aspect-ratio` (#711); external SVGs are sized from the root
+    `width`/`height` like a browser rather than the `viewBox` (#700, witness #696);
+    `picture`-nested graphics resolve into the SVG `foreignObject` instead of rendering giant,
+    doubled, or dropped (#675, #682, #609/html_feedback#74); two-column subfigure panels share a
+    row instead of stacking full-width and a float panel is never wrapped in an invalid
+    `ltx:block` (#706, #708); `\scalerel*` inline icons scale to text height (#712,
+    html_feedback#6895); sibling-directory graphic candidates are relativized so no absolute path
+    leaks into `@src` (#699/#698); `wrapfig` reduces the inner `\linewidth` to the wrap width
+    (#592); and the `ltx_picture` SVG splice is hardened against attribute order/quoting
+    (#575/#398).
+  - **A large author/frontmatter class sweep — more journal & conference classes emit a
+    correct author list.** Building on the author-markup pipeline unification, many class idioms
+    now attach names, affiliations, and emails to the right creator: IEEEtran multi-row grids
+    transpose to reading order and lazy `\\[1em]`+shared-email blocks structure (#624, #546);
+    LNCS/LLNCS shared `\email` and deduped `\inst` (#545, #590); authblk `\author{A, B, C}` comma
+    lists split into separate creators (#633, html_feedback#6255); IJCAI/ceurart/cvpr keyval
+    author blocks stop leaking `orcid=`/`email=` as text and pre-load numeric natbib (#691, #692,
+    #626); `neurips_2026` registers and neurips/sn-jnl keep the body after the abstract and order
+    the abstract after the title (#690, #687, #685, #681); and OmniBus `\authors`, ACL short
+    names, `\and` as a hard boundary, nested inline-math markers, one-line `\textsuperscript{n}`
+    affiliations, `\quad\\` line-2 authors, whole-name bold, phantom empty creators, an
+    `\abstractname` `\centering` leak, a `\twocolumn` header-font leak, and figures injected into
+    the title via `\g@addto@macro\@maketitle` are all handled (#664, #611, #631, #629, #623,
+    #620, #615, #619, #613, #632, #618).
+  - **Wider package compatibility — more third-party packages convert cleanly instead of
+    cascading errors.** `physics.sty` `\qty(...)` with a braced paren no longer runs away (#654);
+    `comment.sty` `\end{comment}` mid-line no longer swallows the document (#649); a `colortbl`
+    `\columncolor` overhang read stops eating a `\lbrack` cell (#642); `aa.cls` loads
+    `[T1]{fontenc}` so text `<`/`>` render as themselves (#603, html_feedback#84); `\verb` inside
+    `\index` renders as typewriter (#601/#354); `fancyvrb` `frame=single` renders as a semantic
+    box (#573/#525); `parskip` sets `\parindent=0` (#568/#558); an empty `\hypertarget` no longer
+    wraps the open note (#565/#526); `siunitx` empty units render invisibly (#584,
+    html_feedback#970); `\widthof` box widths resolve in every dimension context (#589,
+    html_feedback#6869); `\everyjob` is emulated so l3sys system constants are defined (#583);
+    `biblatex` no longer globally defines `\type` over a user math macro (#689); `cleveref`
+    `\cref` matches LaTeX for custom `\newtheorem` types and reverts a `~` tie (#636, #630); a
+    `pdfcol.sty` no-op stub lets breakable `tcolorbox` work (#579/#531); and a wrapper box merges
+    its class onto a single block child, keeping `ltx_lstlisting` (#614).
+  - **Math rendering fixes.** A nested `\sbox` inside a discarded math parse no longer
+    double-frees its subtree (a crash fix, #709/#703); display math is contained inside a
+    width-constrained table cell (#572/#533); and a unary minus after a relation keeps its
+    spacing (#569/#535).
+  - **More bibliographies and citations recover their content.** `imsart` reads the `.bib` when
+    no `.bbl` ships (#658); a leaked active `@` no longer destroys the `.bib` bibliography (#646);
+    chapterbib/bibunits per-unit list ids keep `_` raw (#641); a numeric-mode natbib `.bbl`
+    labels the References with `[N]` matching pdflatex (#612, #616); and author-year inline
+    citations match the References list label (#587).
+  - **CLI, Rhai, and build additions.** `\subimport*` accepts an absolute directory path to
+    match pdflatex (#701/#697); the serializer keeps foreign mixed content inline without
+    injected whitespace (#684/#680); a no-dump conversion no longer fails on a benign expl3
+    raw-load cascade (#660/#651); `GetKeyVals` accepts a digested KeyVals and `Revert` keeps its
+    values (#628/#627); `canContain`/`floatToElement` are exposed to Rhai (#598/#594);
+    `Note`/`NoteLog`/`NoteSTDERR` write to the correct stream(s) (#596/#593); `--opt`/`--noopt`
+    flag pairs resolve rightmost-wins like `GetOpt::Long` (#563/#530); `enumitem` `leftmargin`
+    is surfaced for CSS theming (#567/#559); `\LaTeXMLversion` reports the running binary version
+    (#553); `\lx@save@parameter` lets `latexml.sty` save conversion params (#551/#536); a UTF-8
+    SIMD fast-path speeds the `.cls`/`.sty` dependency scan (#674); and the nightly toolchain
+    floats again now that the fat-LTO OOM regression is fixed upstream (#582/#512).
   - **amsart authors declared up front no longer bunch every address/email under the
     last author.** The idiom `\author{A}\author{B}\author{C}` followed by one
     `\address`/`\email` pair each makes LaTeXML's default "attach a contact to the

--- a/latexml_codegen/Cargo.toml
+++ b/latexml_codegen/Cargo.toml
@@ -37,4 +37,4 @@ glob = "0.3"
 # codegen path uses only the binding AST and never resolves TeX files. The
 # runtime `latexml_core` (linked into the binary) keeps kpathsea via its
 # default feature; resolver v2 keeps the two builds separate.
-latexml_core = { path = "../latexml_core", version = "0.5.0", default-features = false, features = ["codegen"] }
+latexml_core = { path = "../latexml_core", version = "0.6.0", default-features = false, features = ["codegen"] }

--- a/latexml_contrib/Cargo.toml
+++ b/latexml_contrib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml_contrib"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "CC0-1.0"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
@@ -31,10 +31,10 @@ token-locators = ["latexml_core/token-locators"]
 runtime-bindings = ["dep:rhai", "dep:log"]
 
 [dependencies]
-latexml_core = {path = "../latexml_core", version = "0.5.0"}
+latexml_core = {path = "../latexml_core", version = "0.6.0"}
 latexml_codegen = {path = "../latexml_codegen", version = "0.4.1"}
-latexml_engine = {path = "../latexml_engine", version = "0.6.0"}
-latexml_package = {path = "../latexml_package", version = "0.6.0"}
+latexml_engine = {path = "../latexml_engine", version = "0.7.0"}
+latexml_package = {path = "../latexml_package", version = "0.7.0"}
 rustc-hash = "2.0.0"
 libxml = "0.3.21"
 regex = { version = "1.7.1", default-features = false, features = ["std", "perf", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script"] }

--- a/latexml_core/Cargo.toml
+++ b/latexml_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml_core"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 license = "CC0-1.0"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]

--- a/latexml_engine/Cargo.toml
+++ b/latexml_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml_engine"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "CC0-1.0"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
@@ -37,4 +37,4 @@ rustc-hash = "2.0.0"
 # Same flate2 instance the binary already pulls via zip/tar.
 flate2 = "1"
 latexml_codegen = { path = "../latexml_codegen", version = "0.4.1" }
-latexml_core = { path = "../latexml_core", version = "0.5.0" }
+latexml_core = { path = "../latexml_core", version = "0.6.0" }

--- a/latexml_math_parser/Cargo.toml
+++ b/latexml_math_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml_math_parser"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
 edition = "2024"
 license = "CC0-1.0"
@@ -26,6 +26,6 @@ regex = { version = "1.7.1", default-features = false, features = ["std", "perf"
 marpa = { package = "marpa-asf", version = "0.3.0" }
 once_cell = "1.17.0"
 rustc-hash = "2.0.0"
-latexml_core = { path = "../latexml_core", version = "0.5.0" }
+latexml_core = { path = "../latexml_core", version = "0.6.0" }
 # stack-growth guard now goes through latexml_core::stack_guard (one configurable
 # home for the maybe_grow params); no direct stacker dependency needed here.

--- a/latexml_oxide/Cargo.toml
+++ b/latexml_oxide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml"
-version = "0.7.5"
+version = "0.7.6-rc1"
 edition = "2024"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
 license = "CC0-1.0"
@@ -158,12 +158,12 @@ glob = { version = "0.3", optional = true }
 phf = { version = "0.14.0", features = ["macros"], optional = true }
 rustc-hash = "2.0.0"
 latexml_codegen = {path = "../latexml_codegen", version = "0.4.1"}
-latexml_core = {path = "../latexml_core", version = "0.5.0"}
-latexml_engine = {path = "../latexml_engine", version = "0.6.0"}
-latexml_package = {path = "../latexml_package", version = "0.6.0"}
-latexml_contrib = {path = "../latexml_contrib", version = "0.4.0"}
-latexml_math_parser = {path = "../latexml_math_parser", version = "0.4.0"}
-latexml_post = {path = "../latexml_post", version = "0.4.0"}
+latexml_core = {path = "../latexml_core", version = "0.6.0"}
+latexml_engine = {path = "../latexml_engine", version = "0.7.0"}
+latexml_package = {path = "../latexml_package", version = "0.7.0"}
+latexml_contrib = {path = "../latexml_contrib", version = "0.5.0"}
+latexml_math_parser = {path = "../latexml_math_parser", version = "0.4.1"}
+latexml_post = {path = "../latexml_post", version = "0.5.0"}
 pericortex = { version = "0.2.8", optional = true }
 hostname = { version = "0.4", optional = true }
 # Replaces glibc malloc. glibc's per-arena mutex is a hard scaling bottleneck

--- a/latexml_package/Cargo.toml
+++ b/latexml_package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml_package"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "CC0-1.0"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
@@ -24,6 +24,6 @@ libxml = "0.3.21"
 rustc-hash = "2.0.0"
 base64 = "0.23"
 latexml_codegen = { path = "../latexml_codegen", version = "0.4.1" }
-latexml_core = { path = "../latexml_core", version = "0.5.0" }
+latexml_core = { path = "../latexml_core", version = "0.6.0" }
 winnow = "1.0"
-latexml_engine = { path = "../latexml_engine", version = "0.6.0" }
+latexml_engine = { path = "../latexml_engine", version = "0.7.0" }

--- a/latexml_post/Cargo.toml
+++ b/latexml_post/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml_post"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "CC0-1.0"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
@@ -52,7 +52,7 @@ which = "8"
 # a raw `.bib` is now converted by the injected recursive BibTeX session, which
 # lives in `latexml_oxide` because it needs the model loader. This crate is back
 # to depending on `latexml_core` alone.
-latexml_core = {path = "../latexml_core", version = "0.5.0"}
+latexml_core = {path = "../latexml_core", version = "0.6.0"}
 rusqlite = { version = "0.40.1", features = ["bundled"] }
 serde_json = "1.0.151"
 


### PR DESCRIPTION
**What.** Release-prep for `0.7.6-rc1`: bump `latexml_oxide` 0.7.5 → 0.7.6-rc1 and the six changed sibling crates (`core` 0.6.0, `engine` 0.7.0, `package` 0.7.0, `post` 0.5.0, `contrib` 0.5.0, `math_parser` 0.4.1; `codegen` unchanged at 0.4.1) with matching intra-workspace `path`+`version` pins, so the eventual crates.io publish resolves against fresh siblings (crates.io is immutable).

**CHANGELOG.** Rename the `[Unreleased]` window to `[0.7.6]` and expand it to cover the work merged since 0.7.5 that had no bullet — the graphics/picture/SVG figure-fidelity sweep, minted syntax highlighting (#668) + overpic (#677), the author/frontmatter class-coverage sweep, and the package/math/bibliography/CLI/Rhai fixes. 141 commits since 0.7.5.

**Validation.** `cargo metadata` resolves the graph with the new pins; pre-push clippy/fmt/cargo-deny/cargo-machete green; full suite 2120/0 on this tree (code-identical to the merged #713); maxperf fat-LTO distribution build green on the current nightly (2026-08-15, no OOM) with the embedded-dump self-contained smoke passing. CI is the gate this PR validates. An RC publishes no crates.io release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)