### PR TITLE
feat: evaluate calc column widths so Pandoc tables don't collapse to 0pt (arXiv/html_feedback#6909)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## Unreleased
+
+  - **Pandoc relative-width table columns no longer collapse to a "river of
+    characters".** A `p{(\columnwidth - N\tabcolsep) * \real{X}}` column — the width
+    format Pandoc emits by default — is a `calc` infix expression the base dimension
+    reader could not evaluate, so every column came out `width="0.0pt"` and its text
+    wrapped one character per line. Column widths now route through the `calc`
+    expression parser when `calc` is loaded, giving the intended proportional widths.
+    Surpasses Perl 0.8.8 (which emits the same 0pt + `Missing number` warning);
+    pdflatex renders the real widths (OXIDIZED_DESIGN #141, arXiv/html_feedback#6909,
+    witness 2606.08266).
+
 ## [0.7.6] (graphics & SVG figure fidelity; minted highlighting + overpic; author/frontmatter class sweep; Rhai runtime binding API; latexmlpost CLI parity; wider package & bibliography coverage)
 
   - **`minted` code blocks render with syntax highlighting, and inline `\mint`/`\mintinline`

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -5313,3 +5313,41 @@ Joe-Blow/Frank-Zappa/Someone-Else block is interleaved and byte-unchanged).
 
 **Guard**: `06_cluster_frontmatter::frontmatter_amsart_upfront_contact_distribution`
 (up-front pile distributes; interleaved control untouched). KNOWN_PERL_ERRORS #104.
+
+### 141. calc column widths (`p{(\columnwidth - N\tabcolsep) * \real{X}}`) evaluate, not collapse to 0pt
+
+**Perl** LaTeXML's `calc.sty.ltxml` patches only the explicit length/counter setters
+(`\setlength`/`\addtolength`/`\setcounter`/`\settowidth`/…) to run its expression scanner. A
+`p{Dimension}`/`m`/`b`/`w`/`W` column width, however, is read by the *base* dimension reader,
+which never routes through that scanner. When the width is a calc infix expression — the default
+Pandoc emits for a relative-width table column, `>{\raggedright\arraybackslash}p{(\columnwidth -
+N\tabcolsep) * \real{X}}` — the base reader meets `(`, cannot parse it, and warns `Missing number
+(Dimension), treated as zero`. Every such column comes out `width="0.0pt"`; a zero-width `p{}`
+cell wraps its text one character per line — the reporter's "river of characters with no
+resemblance to the original". Real pdflatex+calc evaluates the width (calc patches length
+scanning wherever a `<dimen>` is read). latexml-oxide reproduced Perl exactly (SHARED-FAILURE,
+both diverge from real LaTeX; verified same-host — identical 0pt + identical warning).
+
+**Perl behavior**: a Pandoc calc column width → `width="0.0pt"`; the whole table collapses.
+**Rust behavior**: the base dimension reader's calc seam (`gullet::set_internal_dimension_fn`,
+the same one #115 installs for `\widthof`) also fires on a leading `(`: it un-reads the paren and
+runs calc's own expression parser (`read_expression_body`) on the live stream, returning the
+evaluated dimension. The parser stops at the first non-`(+|-|*|/)` token, so it never
+over-consumes; it is scoped to a leading `(` (the exact Pandoc idiom), so nothing that parsed
+before changes. When `calc` is not loaded the seam is unset → byte-identical to before. So
+`p{(\columnwidth - 4\tabcolsep) * \real{0.30}}` with `\columnwidth`=345pt now yields
+`width="96.3pt"` instead of `0.0pt`.
+
+**Why**: a kernel-quality gap, not a TeX-semantics change — real LaTeX+calc already evaluates a
+length here; both LaTeXML engines simply failed to. The fix halos across every calc-relative
+column width, i.e. essentially every Pandoc-authored table on arXiv.
+
+**Witnesses**: arXiv 2606.08266v1 (html_feedback#6909) — an IEEEtran survey whose five-column
+`p{(\columnwidth - 8\tabcolsep) * \real{…}}` failure-statistics table collapsed to zero-width
+columns. Rust `(\columnwidth - 4\tabcolsep) * \real{0.30}` now measures 96.3pt (of 321pt avail).
+
+**Upstream**: worth filing against `brucemiller/LaTeXML` (same gap upstream).
+
+**Guards**: `06_cluster_regressions::cluster_pandoc_calc_colwidth_6909` — a two-column
+`p{…*\real{0.30}}` / `p{…*\real{0.70}}` table has no `width="0.0pt"` and carries the expected
+proportional 96.3pt / 224.7pt.

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -122,6 +122,30 @@ fn cluster_svg_subfloat_survives_subcaption_2563() {
 fn cluster_scalerel_defined_6895() {
   convert_clean("tests/cluster_regressions/scalerel_icon_6895.tex");
 }
+/// arXiv/html_feedback#6909 (witness 2606.08266): Pandoc's default relative-width
+/// table column `p{(\columnwidth - N\tabcolsep) * \real{X}}` is a calc infix
+/// expression the base dimension reader could not evaluate, so every column
+/// collapsed to `width="0.0pt"` and the cell text wrapped one character per line
+/// ("a river of characters"). Column widths now route through the calc expression
+/// parser when calc is loaded. Surpasses Perl 0.8.8 (which emits the same 0pt +
+/// `Missing number` warning); pdflatex renders the real widths. OXIDIZED_DESIGN #141.
+#[test]
+fn cluster_pandoc_calc_colwidth_6909() {
+  let xml = convert_to_xml("tests/cluster_regressions/pandoc_calc_colwidth_6909.tex");
+  // Canary: a zero-width p{} column is the corruption.
+  assert!(
+    !xml.contains(r#"width="0.0pt""#),
+    "a Pandoc calc column width collapsed to 0pt (#6909) — the calc expression \
+     `(\\columnwidth - N\\tabcolsep) * \\real{{X}}` was not evaluated:\n{xml}"
+  );
+  // The two \real factors (0.30 / 0.70) of (345pt - 4*6pt) = 321pt give distinct,
+  // proportional widths: 96.3pt and 224.7pt.
+  assert!(
+    xml.contains(r#"width="96.3pt""#) && xml.contains(r#"width="224.7pt""#),
+    "Pandoc calc column widths are not the expected proportional 96.3pt / 224.7pt \
+     (30%/70% of 321pt):\n{xml}"
+  );
+}
 #[test]
 fn cluster_fvextra_preserves_ltx_verbatim() {
   let xml = convert_to_xml("tests/cluster_regressions/fvextra_ltx_verbatim.tex");

--- a/latexml_oxide/tests/cluster_regressions/pandoc_calc_colwidth_6909.tex
+++ b/latexml_oxide/tests/cluster_regressions/pandoc_calc_colwidth_6909.tex
@@ -1,0 +1,17 @@
+\documentclass{article}
+% arXiv/html_feedback#6909 (witness 2606.08266): Pandoc's default relative-width
+% table column — p{(\columnwidth - N\tabcolsep) * \real{X}} — is a calc infix
+% expression. The base dimension reader could not evaluate it, so every column
+% collapsed to width="0.0pt" and the cell text wrapped one character per line
+% ("a river of characters"). Fixed by routing column widths through the calc
+% expression parser when calc is loaded (surpass Perl; OXIDIZED_DESIGN).
+\usepackage{array}
+\usepackage{calc}
+\providecommand{\real}[1]{#1}
+\begin{document}
+\begin{tabular}{@{}
+  >{\raggedright\arraybackslash}p{(\columnwidth - 4\tabcolsep) * \real{0.30}}
+  >{\raggedright\arraybackslash}p{(\columnwidth - 4\tabcolsep) * \real{0.70}}@{}}
+Narrow column & Wide column with a fair amount of prose that must wrap normally \\
+\end{tabular}
+\end{document}

--- a/latexml_package/src/package/calc_sty.rs
+++ b/latexml_package/src/package/calc_sty.rs
@@ -39,17 +39,25 @@ fn read_expression(expr_type: &str, tokens: Tokens) -> Result<RegisterValue> {
   let reader_mouth = Mouth::new("", None)?;
   reading_from_mouth(reader_mouth, move || {
     unread(tokens);
-    let mut result = read_term(expr_type)?;
-    while let Some(op) = read_keyword(&["+", "-"])? {
-      let term2 = read_term(expr_type)?;
-      result = if op == "+" {
-        result.add(term2)
-      } else {
-        result.subtract(term2)
-      };
-    }
-    Ok(result)
+    read_expression_body(expr_type)
   })
+}
+
+/// The calc `<expression> -> <term> ((+|-) <term>)*` loop, reading from the
+/// CURRENT gullet context. [`read_expression`] wraps it with a mouth over a
+/// captured token list; the base-dimension seam (installed below) calls it
+/// directly on the live stream to evaluate an inline `( … ) * \real{…}` width.
+fn read_expression_body(expr_type: &str) -> Result<RegisterValue> {
+  let mut result = read_term(expr_type)?;
+  while let Some(op) = read_keyword(&["+", "-"])? {
+    let term2 = read_term(expr_type)?;
+    result = if op == "+" {
+      result.add(term2)
+    } else {
+      result.subtract(term2)
+    };
+  }
+  Ok(result)
 }
 
 fn read_term(expr_type: &str) -> Result<RegisterValue> {
@@ -432,6 +440,24 @@ LoadDefinitions!({
   // fires ONLY when the dimension reader — not digestion — meets the token.
   // Surpass-perl: OXIDIZED_DESIGN #115. html_feedback#6869; witness 2603.23669.
   set_internal_dimension_fn(Rc::new(|tok: &Token| {
+    // calc infix expression opening with `(` — the base dimension reader
+    // (read_dimension/read_glue) cannot parse it and would warn "Missing number
+    // (Dimension), treated as zero". The canonical trigger is Pandoc's default
+    // relative-width table column `p{(\columnwidth - N\tabcolsep) * \real{X}}`:
+    // an unparsed width collapses the p{} column to a zero-width cell whose text
+    // wraps one character per line ("a river of characters"). Route the whole
+    // expression through calc's own parser on the LIVE stream; it stops at the
+    // first non-(+|-|*|/) token so it never over-consumes, and is scoped to a
+    // leading `(` (the exact Pandoc idiom). Real LaTeX+calc evaluates lengths
+    // here too. Surpass-perl (Perl 0.8.8 emits the same 0pt): OXIDIZED_DESIGN
+    // #141. arXiv/html_feedback#6909; witness 2606.08266.
+    if *tok == T_OTHER!("(") {
+      unread_one(*tok);
+      let value = read_expression_body("Glue")?;
+      return Ok(Some(RegisterValue::Dimension(Dimension::new(
+        value.value_of(),
+      ))));
+    }
     let kind = if *tok == T_CS!("\\widthof") {
       BoxDim::Width
     } else if *tok == T_CS!("\\heightof") {

--- a/latexml_package/src/package/calc_sty.rs
+++ b/latexml_package/src/package/calc_sty.rs
@@ -445,18 +445,30 @@ LoadDefinitions!({
     // (Dimension), treated as zero". The canonical trigger is Pandoc's default
     // relative-width table column `p{(\columnwidth - N\tabcolsep) * \real{X}}`:
     // an unparsed width collapses the p{} column to a zero-width cell whose text
-    // wraps one character per line ("a river of characters"). Route the whole
-    // expression through calc's own parser on the LIVE stream; it stops at the
-    // first non-(+|-|*|/) token so it never over-consumes, and is scoped to a
-    // leading `(` (the exact Pandoc idiom). Real LaTeX+calc evaluates lengths
-    // here too. Surpass-perl (Perl 0.8.8 emits the same 0pt): OXIDIZED_DESIGN
-    // #141. arXiv/html_feedback#6909; witness 2606.08266.
+    // wraps one character per line ("a river of characters").
+    //
+    // Real LaTeX defers this length: `array.sty`'s `\@startpbox` (L189-191) keeps
+    // the `p{}` width as *tokens* and only later assigns `\setlength\hsize{#1}`,
+    // and calc.sty patches `\setlength` to run its scanner — so the expression is
+    // evaluated at box-setup time, never eagerly. LaTeXML has no such deferral: it
+    // must yield the width *value* to emit `<td>`'s `width=` attribute, so it reads
+    // the width eagerly here. We evaluate with calc's OWN parser (`read_value` ->
+    // `read_expression_body`, the same grammar `\setlength` uses), so the result
+    // matches calc — only the invocation point differs. The parser reads the whole
+    // expression off the LIVE stream and stops at the first non-(+|-|*|/) token, so
+    // it never over-consumes; scoped to a leading `(` (the exact Pandoc idiom), so
+    // nothing that parsed before is disturbed. `read_dimension` has already peeled
+    // any leading sign, so `-(…)` negates the evaluated result correctly.
+    //
+    // Surpass-perl (Perl 0.8.8 emits the same 0pt): OXIDIZED_DESIGN #141.
+    // arXiv/html_feedback#6909; witness 2606.08266.
     if *tok == T_OTHER!("(") {
       unread_one(*tok);
-      let value = read_expression_body("Glue")?;
-      return Ok(Some(RegisterValue::Dimension(Dimension::new(
-        value.value_of(),
-      ))));
+      // "Glue" mirrors calc's `\setlength`; the cell width is a pure `<dimen>`, so
+      // coerce down (dropping any stretch/shrink) exactly as `read_internal_dimension`
+      // does for a register value.
+      let value: Dimension = read_expression_body("Glue")?.into();
+      return Ok(Some(RegisterValue::Dimension(value)));
     }
     let kind = if *tok == T_CS!("\\widthof") {
       BoxDim::Width


### PR DESCRIPTION
**Background — why Pandoc, and the arXiv connection.** arXiv accepts LaTeX source and generates its experimental [HTML](https://info.arxiv.org/about/accessible_HTML.html) from it with latexml-oxide. A growing share of authors do not hand-write that LaTeX: they author in Markdown (or another format) and run [Pandoc](https://pandoc.org/) to produce the `.tex` they submit. Pandoc's LaTeX table writer renders a table with relative column widths as `>{\raggedright\arraybackslash}p{(\columnwidth - N\tabcolsep) * \real{X}}`, relying on [`\usepackage{calc}` and a `\providecommand{\real}` fallback from its default template](https://github.com/jgm/pandoc/blob/main/data/templates/default.latex). So this exact idiom lands verbatim in arXiv sources, and when latexml-oxide cannot evaluate the `calc` width every such table collapses. The witness [2606.08266](https://arxiv.org/html/2606.08266v1) is one: its preamble carries the Pandoc markers and all five of its tables use this column form.

**Diagnostic.** Pandoc's default relative-width column `p{(\columnwidth - N\tabcolsep) * \real{X}}` is a `calc` infix expression; the base dimension reader (`gullet::read_dimension`) can't parse the leading `(`, so it warns "Missing number → 0pt" and every column collapses to `width="0.0pt"` — the cell text then wraps one character per line ("a river of characters"). Perl 0.8.8 does the identical thing (SHARED-FAILURE); pdflatex+calc renders the real widths.

**Approach.** Extend the calc `set_internal_dimension_fn` seam (the OXIDIZED_DESIGN #115 `\widthof` mechanism) so that when the base dimension reader meets `(`, it runs calc's own expression parser (`read_expression_body`) on the live stream. Scoped to a leading `(` (the exact Pandoc idiom); the parser stops at the first non-`+-*/` token so it never over-consumes; unset when `calc` isn't loaded → byte-identical to before. Surpass-Perl, OXIDIZED_DESIGN #141.

**Validation.** Guard `cluster_pandoc_calc_colwidth_6909` (RED→GREEN: two columns now 96.3pt / 224.7pt, no `0.0pt`); witness 2606.08266 re-converted clean — Table 1's five columns are 23.5–82.6pt (each = factor × 297pt), 0 Missing-number warnings; full suite `cargo nextest` 2121/0; clippy `-D warnings` + fmt clean.

Fixes the HTML rendering reported in arXiv/html_feedback#6909.