### PR TITLE
fix: resolve sandbox-arxiv-2605 conversion regressions

### DIFF
--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -790,6 +790,21 @@ with file:line, not established facts — re-verify before acting**:
 `docs/parity/OXIDIZED_DESIGN.md` has no font section, so none of these is a
 documented divergence. Method and the two detection traps: [`WISDOM.md`](parity/WISDOM.md) §80.
 
+### (not ranked) scalerel family — NEUTRALIZED, full scaling deferred (2026-08-21)
+
+`\scalerel` / `\scaleto` / `\stretchto` / `\scaleobj` / `\hstretch` / `\vstretch` /
+`\scaleleftright` / `\stretchleftright` are bound
+(`latexml_package/src/package/scalerel_sty.rs`, arXiv/html_feedback#6895) but **neutralized,
+not fully supported**: the object is *preserved* (wrapped in `.ltx_scalerel`, CSS-sized to
+text height) and the requested scale — the target height (`\scaleto`/`\stretchto`/`\scalerel`)
+or the numeric factor (`\scaleobj`/`\hstretch`/`\vstretch`) — is **dropped**, so every scaled
+object renders at ~1em regardless of the requested size. This is **step 1** (preserve content,
+stop `Error:undefined` + broken layout). **Full support** = honour the real scale: measure the
+object box and the reference box (or read the factor), compute the ratio, and emit CSS
+`transform: scale()` / an SVG viewBox — which needs box measurement the engine does not yet
+expose. Witnesses 2605.02053 / 2605.03024 / 2605.03521 (now convert clean, content preserved).
+Do not mistake the text-height approximation for correct sizing.
+
 ## Parked families — pointers, not content
 
 Each outgrew this file and now lives on its own. Read the doc before starting;

--- a/latexml_contrib/src/biblatex_sty.rs
+++ b/latexml_contrib/src/biblatex_sty.rs
@@ -778,7 +778,13 @@ LoadDefinitions!({
   //
   // Save the core \cite FIRST: \cite itself is redefined below, and the
   // fallback must reach the original, not recurse into our closure.
-  Let!("\\blx@saved@cite", "\\cite");
+  // IDEMPOTENT: the versioned-package fallback (\RequirePackage{myBiblatex} ->
+  // biblatex) probes by running the binding and then loads it again
+  // (content.rs find_file_fallback + input_definitions reloadable), so this init
+  // can execute twice. A bare `\let` on the 2nd pass would save biblatex's OWN
+  // \cite closure, and \cite -> \blx@saved@cite -> \cite loops to the TokenLimit
+  // (witness 2605.03965; Perl never loads biblatex on this name, so no loop).
+  RawTeX!(r"\@ifundefined{blx@saved@cite}{\let\blx@saved@cite\cite}{}");
 
   // -- Parenthetical commands: (prenote Author, Year, postnote) ---------
   DefMacro!("\\parencite OptionalMatch:* [][] Semiverbatim", sub[args] {
@@ -1817,7 +1823,9 @@ LoadDefinitions!({
       }
     }
   });
-  Let!("\\biblatex@saved@bibliography", "\\bibliography");
+  // Idempotent for the same double-init reason as \blx@saved@cite above: a bare
+  // \let on a 2nd init would save the already-rebound \bibliography (=\addbibresource).
+  RawTeX!(r"\@ifundefined{biblatex@saved@bibliography}{\let\biblatex@saved@bibliography\bibliography}{}");
   Let!("\\bibliography",                "\\addbibresource");
 
   // \printbibliography: biber's \jobname.bbl is ground truth when present

--- a/latexml_contrib/src/nicematrix_sty.rs
+++ b/latexml_contrib/src/nicematrix_sty.rs
@@ -17,11 +17,16 @@ LoadDefinitions!({
   // DefConstructorI entries wrapping `\begin{<name>}`. Each emits
   // `<ltx:note role='nicematrix-placeholder'>(<name>)</ltx:note>` and discards the environment body
   // via discard_env_body. Paired `\end<name>` macros stay as `\relax`.
-  DefConstructor!(T_CS!("\\begin{NiceTabular}"), None,
-    "<ltx:note role=\"nicematrix-placeholder\">NiceTabular (nicematrix)</ltx:note>",
-    bounded => true, mode => "text", locked => true,
-    before_digest => { discard_env_body("NiceTabular", "nicematrix.sty.ltxml")?; });
-  DefMacro!("\\endNiceTabular", "\\relax", locked => true);
+  // NiceTabular[opts]{colspec}[opts] is nicematrix's tabular-like environment; the
+  // real nicematrix.sty (L3806-3841) reduces it to \NiceArray{colspec} under a
+  // text-mode tabular flag. Degrade faithfully to \tabular with the SAME colspec,
+  // dropping the nicematrix-only [opts] — recovers real tables (witnesses 2605.08776,
+  // 2605.13835, 2605.18423) instead of discarding the body + Error:undefined.
+  // Beyond-Perl: the ar5iv nicematrix.sty.ltxml stub still errors here; mirror this
+  // upgrade there for strict Rust<->ar5iv parity. The math-mode Nice* matrix family
+  // below stays a placeholder stub (no faithful text reduction). OXIDIZED_DESIGN divergence.
+  DefMacro!("\\NiceTabular[]{}[]", "\\tabular{#2}", locked => true);
+  DefMacro!("\\endNiceTabular", "\\endtabular", locked => true);
   DefConstructor!(T_CS!("\\begin{NiceArray}"), None,
     "<ltx:note role=\"nicematrix-placeholder\">NiceArray (nicematrix)</ltx:note>",
     bounded => true, mode => "text", locked => true,

--- a/latexml_core/src/binding/content.rs
+++ b/latexml_core/src/binding/content.rs
@@ -41,6 +41,16 @@ const MAX_INPUT_DEPTH: usize = 500;
 thread_local! {
   /// Current nesting depth of input_definitions calls.
   static INPUT_DEPTH: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+  /// Stack of each active input_definitions frame's `grandparent_in_expl3` flag.
+  /// A native binding that force-raw-loads its own `\ProvidesExplPackage` .sty via
+  /// `InputDefinitions!(noltxml => true)` (e.g. derivative_sty.rs, #630) re-enters
+  /// input_definitions AFTER the outer `\@pushfilename` already ran `\ExplSyntaxOff`
+  /// (`_` -> SUB). A fresh snapshot then reads false, so the exit cleanup over-fires
+  /// `\ExplSyntaxOff` and corrupts `\l__expl_status_stack_tl`. The inner frame
+  /// inherits the outer's flag instead. Witness arXiv:2605.21946 (pomegranate.sty
+  /// -> `\RequirePackage{derivative}`).
+  static INPUT_DEF_EXPL3: std::cell::RefCell<Vec<bool>> =
+    const { std::cell::RefCell::new(Vec::new()) };
 }
 
 /// a configuration for loading LaTeX definition files (such as .sty, .cls, and their bindings)
@@ -386,7 +396,30 @@ pub fn input_definitions(raw_file: &str, mut options: InputDefinitionOptions) ->
   // arXiv:2509.05997 / .07893 / .02344, 2510.13206/.13942/.17317
   // (xsavebox + sys_load_backend + l3backend-dvips.def chain — minimal
   // repro: \usepackage{xsavebox}).
-  let grandparent_in_expl3 = lookup_catcode('_') == Some(Catcode::LETTER);
+  let self_snapshot = lookup_catcode('_') == Some(Catcode::LETTER);
+  // Inherit the immediate parent frame's flag only when the parent WAS in expl3 but
+  // our own fresh read is false — the double-nested same-file case (an outer
+  // `\RequirePackage{X}` whose X-binding force-raw-loads its own expl3 .sty, so this
+  // inner call snapshots after the outer `\@pushfilename` already flipped `_` to SUB).
+  // Never overrides a correct fresh read, so xsavebox/tcolorbox/lipsum are unaffected.
+  let grandparent_in_expl3 = INPUT_DEF_EXPL3
+    .with(|s| {
+      s.borrow()
+        .last()
+        .copied()
+        .filter(|&parent| parent && !self_snapshot)
+    })
+    .unwrap_or(self_snapshot);
+  INPUT_DEF_EXPL3.with(|s| s.borrow_mut().push(grandparent_in_expl3));
+  struct Expl3FrameGuard;
+  impl Drop for Expl3FrameGuard {
+    fn drop(&mut self) {
+      INPUT_DEF_EXPL3.with(|s| {
+        s.borrow_mut().pop();
+      });
+    }
+  }
+  let _expl3_frame = Expl3FrameGuard;
   // Strict-LaTeX-kernel order (latex.ltx `\@onefilewithoptions`, L15518-L15519):
   //   \@pushfilename                        % capture OLD \@currname / \@currext
   //   \xdef\@currname{ <new name> }         % then update to NEW

--- a/latexml_math_parser/src/parser.rs
+++ b/latexml_math_parser/src/parser.rs
@@ -982,6 +982,25 @@ impl MathParser {
       "descendant-or-self::*[@xml:id and contains(@role,'SCRIPT')]",
       None,
     );
+    if apps.is_empty() {
+      return Ok(());
+    }
+    // idref -> [referencing nodes], built in ONE whole-document pass, replacing the
+    // per-app whole-doc `descendant-or-self::*[@idref='X']` findnodes below. That
+    // per-app scan made cleanupScripts O(scriptApps * docNodes) — quadratic on
+    // math-dense papers where one ltx:Math holds hundreds of XMRef-referenced
+    // SUB/SUPERSCRIPT apps (witnesses 2605.25560 / 2605.07347 / 2605.22741: >240s
+    // spin in libxml2 xmlXPathEval on exactly this scan). Perl MathParser.pm:113 has
+    // the identical per-app scan; this index is a semantics-preserving, beyond-Perl
+    // speedup: each XMRef carries exactly one @idref (per-app ref-sets are disjoint)
+    // and every replacement this loop inserts carries idref=script_id (a script
+    // content id, never an app id), so the up-front index stays valid for the loop.
+    let mut refs_by_idref: HashMap<String, Vec<Node>> = HashMap::default();
+    for node in document.findnodes("descendant-or-self::*[@idref]", None) {
+      if let Some(idref) = node.get_attribute("idref") {
+        refs_by_idref.entry(idref).or_default().push(node);
+      }
+    }
     for mut app in apps {
       let role = match app.get_attribute("role") {
         Some(r) => r,
@@ -997,12 +1016,13 @@ impl MathParser {
         Some(id) => id,
         None => continue,
       };
-      // Note: using * instead of ltx:XMRef due to XPath namespace issues in nested predicates
-      let refs_xpath = s!("descendant-or-self::*[@idref = '{}']", appid);
-      let refs = document.findnodes(&refs_xpath, None);
-      if refs.is_empty() {
-        continue;
-      }
+      // Refs to THIS app, from the pre-built index (was a per-app whole-doc
+      // `descendant-or-self::*[@idref='{appid}']`; the `*` node-test, not ltx:XMRef,
+      // is preserved). `remove` takes each app's disjoint ref-set exactly once.
+      let refs = match refs_by_idref.remove(&appid) {
+        Some(v) => v,
+        None => continue,
+      };
       // Get the script content (first child of the XMApp)
       let mut script = match app.get_first_child() {
         Some(child) => child,

--- a/latexml_oxide/tests/cluster_package_guards.rs
+++ b/latexml_oxide/tests/cluster_package_guards.rs
@@ -316,6 +316,99 @@ mod deferred_load_retry {
   }
 }
 
+mod nicetabular_binding {
+  //! `\begin{NiceTabular}[opts]{colspec}` must render a real table, not
+  //! `Error:undefined:{NiceTabular}` + a dropped body.
+  //!
+  //! nicematrix's NiceTabular is a tabular over a standard colspec (nicematrix.sty
+  //! L3806-3841 reduce it to `\NiceArray{colspec}` under a text-mode tabular flag),
+  //! so binding it to `\tabular` recovers real tables for sandbox-arxiv-2605 papers
+  //! (2605.08776, 2605.13835, 2605.18423) the placeholder stub previously errored on.
+  //! Beyond-Perl: the ar5iv nicematrix.sty.ltxml stub still errors here.
+  use std::{path::Path, process::Command};
+
+  const TEX: &str = "\\documentclass{article}\n\
+    \\usepackage{nicematrix}\n\
+    \\begin{document}\n\
+    \\begin{NiceTabular}[colortbl-like]{ccc}\n\
+    1 & 2 & 3 \\\\ 4 & 5 & 6 \\\\\n\
+    \\end{NiceTabular}\n\
+    \\end{document}\n";
+
+  #[test]
+  fn nicetabular_renders_real_table() {
+    let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+    assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+    let workdir = tempfile::tempdir().expect("create tempdir");
+    std::fs::write(workdir.path().join("d.tex"), TEX).expect("write d.tex");
+    let output = Command::new(bin)
+      .arg("d.tex")
+      .arg("--dest")
+      .arg("d.xml")
+      .arg("--nocomments")
+      .current_dir(workdir.path())
+      .output()
+      .expect("spawn latexml_oxide");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+      !stderr.contains("undefined:\\NiceTabular") && !stderr.contains("undefined:{NiceTabular}"),
+      "NiceTabular should be bound, not undefined:\n{stderr}",
+    );
+    let xml = std::fs::read_to_string(workdir.path().join("d.xml")).expect("read d.xml");
+    assert!(
+      xml.contains("<tabular"),
+      "NiceTabular did not render a real table:\n{xml}"
+    );
+    assert!(
+      xml.matches("<td").count() >= 6,
+      "NiceTabular table is missing cells (expected the 6 `1..6`):\n{xml}",
+    );
+  }
+}
+
+mod neurips_anonymous {
+  //! `\if@anonymous` (neurips_2026.sty L72 `\newif`) must be defined by the neurips
+  //! binding. The binding intercepts the versioned name `neurips_2026` and never
+  //! creates the conditional, so a paper copying the style's `\@maketitle` (which
+  //! branches on `\if@anonymous`) hit `Error:undefined:\if@anonymous`. Rust-only
+  //! divergence: Perl 0.8.8 converts the same paper (2605.17249) without it.
+  //! Default false => the `\else` (authors-shown) branch, correct for arXiv uploads.
+  use std::{path::Path, process::Command};
+
+  const TEX: &str = "\\documentclass{article}\n\
+    \\usepackage[preprint]{neurips_2026}\n\
+    \\makeatletter\n\
+    \\renewcommand{\\@maketitle}{\\if@anonymous Anon\\else Named\\fi}\n\
+    \\makeatother\n\
+    \\begin{document}\\maketitle\\end{document}\n";
+
+  #[test]
+  fn neurips_if_anonymous_defined() {
+    let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+    assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+    let workdir = tempfile::tempdir().expect("create tempdir");
+    std::fs::write(workdir.path().join("d.tex"), TEX).expect("write d.tex");
+    let output = Command::new(bin)
+      .arg("d.tex")
+      .arg("--dest")
+      .arg("d.xml")
+      .arg("--nocomments")
+      .current_dir(workdir.path())
+      .output()
+      .expect("spawn latexml_oxide");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+      !stderr.contains("undefined:\\if@anonymous"),
+      "\\if@anonymous should be defined by the neurips binding:\n{stderr}",
+    );
+    let xml = std::fs::read_to_string(workdir.path().join("d.xml")).expect("read d.xml");
+    assert!(
+      xml.contains("Named") && !xml.contains(">Anon"),
+      "default-false \\if@anonymous should take the authors-shown (`Named`) branch:\n{xml}",
+    );
+  }
+}
+
 mod newtcblisting_verbatim {
   //! Regression test: a `\newtcblisting`-defined code box captures its body
   //! verbatim and CLOSES at `\end{name}` (ar5iv #504 / #569 / #570).

--- a/latexml_oxide/tests/cluster_package_guards.rs
+++ b/latexml_oxide/tests/cluster_package_guards.rs
@@ -325,36 +325,12 @@ mod nicetabular_binding {
   //! so binding it to `\tabular` recovers real tables for sandbox-arxiv-2605 papers
   //! (2605.08776, 2605.13835, 2605.18423) the placeholder stub previously errored on.
   //! Beyond-Perl: the ar5iv nicematrix.sty.ltxml stub still errors here.
-  use std::{path::Path, process::Command};
-
-  const TEX: &str = "\\documentclass{article}\n\
-    \\usepackage{nicematrix}\n\
-    \\begin{document}\n\
-    \\begin{NiceTabular}[colortbl-like]{ccc}\n\
-    1 & 2 & 3 \\\\ 4 & 5 & 6 \\\\\n\
-    \\end{NiceTabular}\n\
-    \\end{document}\n";
+  use crate::cluster::convert_to_xml_contrib;
 
   #[test]
   fn nicetabular_renders_real_table() {
-    let bin = env!("CARGO_BIN_EXE_latexml_oxide");
-    assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
-    let workdir = tempfile::tempdir().expect("create tempdir");
-    std::fs::write(workdir.path().join("d.tex"), TEX).expect("write d.tex");
-    let output = Command::new(bin)
-      .arg("d.tex")
-      .arg("--dest")
-      .arg("d.xml")
-      .arg("--nocomments")
-      .current_dir(workdir.path())
-      .output()
-      .expect("spawn latexml_oxide");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-      !stderr.contains("undefined:\\NiceTabular") && !stderr.contains("undefined:{NiceTabular}"),
-      "NiceTabular should be bound, not undefined:\n{stderr}",
-    );
-    let xml = std::fs::read_to_string(workdir.path().join("d.xml")).expect("read d.xml");
+    // Red before the fix: Error:undefined:{NiceTabular} + dropped body (no <tabular>).
+    let xml = convert_to_xml_contrib("tests/cluster_regressions/nicetabular_binding.tex");
     assert!(
       xml.contains("<tabular"),
       "NiceTabular did not render a real table:\n{xml}"
@@ -373,35 +349,12 @@ mod neurips_anonymous {
   //! branches on `\if@anonymous`) hit `Error:undefined:\if@anonymous`. Rust-only
   //! divergence: Perl 0.8.8 converts the same paper (2605.17249) without it.
   //! Default false => the `\else` (authors-shown) branch, correct for arXiv uploads.
-  use std::{path::Path, process::Command};
-
-  const TEX: &str = "\\documentclass{article}\n\
-    \\usepackage[preprint]{neurips_2026}\n\
-    \\makeatletter\n\
-    \\renewcommand{\\@maketitle}{\\if@anonymous Anon\\else Named\\fi}\n\
-    \\makeatother\n\
-    \\begin{document}\\maketitle\\end{document}\n";
+  use crate::cluster::convert_to_xml_contrib_clean;
 
   #[test]
   fn neurips_if_anonymous_defined() {
-    let bin = env!("CARGO_BIN_EXE_latexml_oxide");
-    assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
-    let workdir = tempfile::tempdir().expect("create tempdir");
-    std::fs::write(workdir.path().join("d.tex"), TEX).expect("write d.tex");
-    let output = Command::new(bin)
-      .arg("d.tex")
-      .arg("--dest")
-      .arg("d.xml")
-      .arg("--nocomments")
-      .current_dir(workdir.path())
-      .output()
-      .expect("spawn latexml_oxide");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-      !stderr.contains("undefined:\\if@anonymous"),
-      "\\if@anonymous should be defined by the neurips binding:\n{stderr}",
-    );
-    let xml = std::fs::read_to_string(workdir.path().join("d.xml")).expect("read d.xml");
+    // Red before the fix: Error:undefined:\if@anonymous. Green: 0 errors + the Named branch.
+    let xml = convert_to_xml_contrib_clean("tests/cluster_regressions/neurips_anonymous.tex");
     assert!(
       xml.contains("Named") && !xml.contains(">Anon"),
       "default-false \\if@anonymous should take the authors-shown (`Named`) branch:\n{xml}",
@@ -416,38 +369,13 @@ mod biblatex_fallback_no_cite_loop {
   //! `\cite` on the 2nd init, so `\cite -> \blx@saved@cite -> \cite` looped to
   //! `Fatal:Timeout:TokenLimit`/`Recursion` (witness 2605.03965; Perl never loads
   //! biblatex on this name, so no loop). The save is now `\@ifundefined`-guarded.
-  use std::{path::Path, process::Command};
-
-  const TEX: &str = "\\documentclass{article}\n\
-    \\usepackage{myBiblatex}\n\
-    \\begin{document}\\cite{X}\\end{document}\n";
+  use crate::cluster::convert_to_xml_contrib_clean;
 
   #[test]
   fn mybiblatex_fallback_does_not_loop() {
-    let bin = env!("CARGO_BIN_EXE_latexml_oxide");
-    assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
-    let workdir = tempfile::tempdir().expect("create tempdir");
-    std::fs::write(workdir.path().join("d.tex"), TEX).expect("write d.tex");
-    let output = Command::new(bin)
-      .arg("d.tex")
-      .arg("--dest")
-      .arg("d.xml")
-      .arg("--nocomments")
-      .current_dir(workdir.path())
-      .output()
-      .expect("spawn latexml_oxide");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-      !stderr.contains("Timeout:TokenLimit")
-        && !stderr.contains("Timeout:Recursion")
-        && !stderr.contains("Stomach:Recursion"),
-      "myBiblatex fallback re-ran biblatex init and looped on \\cite:\n{stderr}",
-    );
-    assert!(
-      output.status.success(),
-      "binary exited {:?}:\n{stderr}",
-      output.status.code(),
-    );
+    // Red before the fix: \cite loops to Fatal:Timeout:TokenLimit (fatal status / no result).
+    // Green: converts clean (convert_to_xml_contrib_clean asserts 0 errors + non-fatal).
+    let _ = convert_to_xml_contrib_clean("tests/cluster_regressions/biblatex_mybiblatex_loop.tex");
   }
 }
 
@@ -458,6 +386,12 @@ mod expl3_nested_raw_load_catcodes {
   //! `unexpected:_` (witness 2605.21946, pomegranate.sty). The input_definitions
   //! expl3-frame stack (content.rs) makes the inner load inherit the outer frame's
   //! expl3 state instead of re-snapshotting after the outer `\@pushfilename`.
+  //!
+  //! Subprocess (not the in-process `convert_*` helpers) on purpose: reproducing the
+  //! bug needs `--includestyles` AND the contrib dispatch (for the `derivative` binding)
+  //! AND a paper-local `mymac.sty` on the search path, simultaneously — no single
+  //! in-process helper combines all three. Same legitimate subprocess reason as the
+  //! `newtcblisting_verbatim` / `deferred_load_retry` tests.
   use std::{path::Path, process::Command};
 
   #[test]

--- a/latexml_oxide/tests/cluster_package_guards.rs
+++ b/latexml_oxide/tests/cluster_package_guards.rs
@@ -409,6 +409,103 @@ mod neurips_anonymous {
   }
 }
 
+mod biblatex_fallback_no_cite_loop {
+  //! `\usepackage{myBiblatex}` hits the versioned-package fallback -> the native
+  //! `biblatex` binding, which `find_file_fallback` double-runs (probe then load).
+  //! The non-idempotent `\let\blx@saved@cite\cite` used to capture biblatex's OWN
+  //! `\cite` on the 2nd init, so `\cite -> \blx@saved@cite -> \cite` looped to
+  //! `Fatal:Timeout:TokenLimit`/`Recursion` (witness 2605.03965; Perl never loads
+  //! biblatex on this name, so no loop). The save is now `\@ifundefined`-guarded.
+  use std::{path::Path, process::Command};
+
+  const TEX: &str = "\\documentclass{article}\n\
+    \\usepackage{myBiblatex}\n\
+    \\begin{document}\\cite{X}\\end{document}\n";
+
+  #[test]
+  fn mybiblatex_fallback_does_not_loop() {
+    let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+    assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+    let workdir = tempfile::tempdir().expect("create tempdir");
+    std::fs::write(workdir.path().join("d.tex"), TEX).expect("write d.tex");
+    let output = Command::new(bin)
+      .arg("d.tex")
+      .arg("--dest")
+      .arg("d.xml")
+      .arg("--nocomments")
+      .current_dir(workdir.path())
+      .output()
+      .expect("spawn latexml_oxide");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+      !stderr.contains("Timeout:TokenLimit")
+        && !stderr.contains("Timeout:Recursion")
+        && !stderr.contains("Stomach:Recursion"),
+      "myBiblatex fallback re-ran biblatex init and looped on \\cite:\n{stderr}",
+    );
+    assert!(
+      output.status.success(),
+      "binary exited {:?}:\n{stderr}",
+      output.status.code(),
+    );
+  }
+}
+
+mod expl3_nested_raw_load_catcodes {
+  //! A `\ProvidesExplPackage` file that `\RequirePackage{derivative}` — a native
+  //! binding (#630) that force-raw-loads its own expl3 `.sty` — used to leave `_`
+  //! as SUB after the nested load, so later expl3 lines (`\seq_new:N` …) errored
+  //! `unexpected:_` (witness 2605.21946, pomegranate.sty). The input_definitions
+  //! expl3-frame stack (content.rs) makes the inner load inherit the outer frame's
+  //! expl3 state instead of re-snapshotting after the outer `\@pushfilename`.
+  use std::{path::Path, process::Command};
+
+  #[test]
+  fn nested_expl3_raw_load_preserves_catcodes() {
+    // Self-skip green when derivative.sty is absent (trimmed CI texlive): with no
+    // raw double-load there is nothing to guard.
+    let has_derivative = Command::new("kpsewhich")
+      .arg("derivative.sty")
+      .output()
+      .map(|o| o.status.success() && !o.stdout.is_empty())
+      .unwrap_or(false);
+    if !has_derivative {
+      eprintln!("skip nested_expl3_raw_load_preserves_catcodes: derivative.sty not installed");
+      return;
+    }
+    let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+    assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+    let workdir = tempfile::tempdir().expect("create tempdir");
+    std::fs::write(
+      workdir.path().join("mymac.sty"),
+      "\\ProvidesExplPackage{mymac}{2025/01/01}{1.0}{repro}\n\
+       \\RequirePackage{derivative}\n\
+       \\seq_new:N \\l_mymac_seq\n",
+    )
+    .expect("write mymac.sty");
+    std::fs::write(
+      workdir.path().join("d.tex"),
+      "\\documentclass{article}\n\\usepackage{mymac}\n\\begin{document}hi\\end{document}\n",
+    )
+    .expect("write d.tex");
+    let output = Command::new(bin)
+      .arg("d.tex")
+      .arg("--dest")
+      .arg("d.xml")
+      .arg("--includestyles")
+      .arg("--path")
+      .arg(workdir.path())
+      .current_dir(workdir.path())
+      .output()
+      .expect("spawn latexml_oxide");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+      !stderr.contains("unexpected:_"),
+      "nested expl3 raw-load left `_` as SUB (expl3 catcodes lost after the inner load):\n{stderr}",
+    );
+  }
+}
+
 mod newtcblisting_verbatim {
   //! Regression test: a `\newtcblisting`-defined code box captures its body
   //! verbatim and CLOSES at `\end{name}` (ar5iv #504 / #569 / #570).

--- a/latexml_oxide/tests/cluster_regressions/biblatex_mybiblatex_loop.tex
+++ b/latexml_oxide/tests/cluster_regressions/biblatex_mybiblatex_loop.tex
@@ -1,0 +1,8 @@
+% sandbox-arxiv-2605 (witness 2605.03965): \usepackage{myBiblatex} hits the versioned-package
+% fallback -> the native biblatex binding, which find_file_fallback double-runs (probe then
+% load). The non-idempotent \let\blx@saved@cite\cite captured biblatex's OWN \cite on the 2nd
+% init -> \cite -> \blx@saved@cite -> \cite looped to Fatal:Timeout:TokenLimit. Perl never
+% loads biblatex on this name. The save is now \@ifundefined-guarded, so this converts clean.
+\documentclass{article}
+\usepackage{myBiblatex}
+\begin{document}\cite{X}\end{document}

--- a/latexml_oxide/tests/cluster_regressions/neurips_anonymous.tex
+++ b/latexml_oxide/tests/cluster_regressions/neurips_anonymous.tex
@@ -1,0 +1,11 @@
+% sandbox-arxiv-2605 (witness 2605.17249): the neurips binding intercepts the versioned
+% neurips_2026 name but never creates \if@anonymous (neurips_2026.sty L72 \newif). A paper
+% copying the style's \@maketitle (which branches on \if@anonymous) hit
+% Error:undefined:\if@anonymous. Perl 0.8.8 converts it without the error. Default false =>
+% the authors-shown (\else "Named") branch, correct for arXiv uploads.
+\documentclass{article}
+\usepackage[preprint]{neurips_2026}
+\makeatletter
+\renewcommand{\@maketitle}{\if@anonymous Anon\else Named\fi}
+\makeatother
+\begin{document}\maketitle\end{document}

--- a/latexml_oxide/tests/cluster_regressions/nicetabular_binding.tex
+++ b/latexml_oxide/tests/cluster_regressions/nicetabular_binding.tex
@@ -1,0 +1,12 @@
+% sandbox-arxiv-2605: nicematrix NiceTabular was a placeholder stub that errored
+% (Error:undefined:{NiceTabular}) and dropped the body. It is really a tabular over a
+% standard colspec (nicematrix.sty L3806-3841 -> \NiceArray{colspec}); bound to \tabular it
+% renders real tables. Beyond-Perl (the ar5iv stub still errors). Witnesses 2605.08776,
+% 2605.13835, 2605.18423.
+\documentclass{article}
+\usepackage{nicematrix}
+\begin{document}
+\begin{NiceTabular}[colortbl-like]{ccc}
+1 & 2 & 3 \\ 4 & 5 & 6 \\
+\end{NiceTabular}
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/scalerel_icon_6895.tex
+++ b/latexml_oxide/tests/cluster_regressions/scalerel_icon_6895.tex
@@ -9,4 +9,11 @@
 \begin{document}
 Inline X\scalerel*{\rule{2cm}{2cm}}{Xg}Y here.
 And non-star Z\scalerel{\rule{2cm}{1cm}}{Xg}W appends the reference.
+% Binding scalerel short-circuits the raw .sty, so the whole family it defines must
+% be re-added or papers using them regress to Error:undefined (sandbox-arxiv-2605:
+% \scaleto ×8, \scaleobj ×7, \stretchto ×5). Witnesses: 2605.02053, 2605.03521.
+a\scaleto{\rule{1cm}{1cm}}{2ex}b
+c\stretchto{\rule{1cm}{1cm}}{3ex}d
+e\scaleobj{1.5}{\rule{1cm}{1cm}}f
+g\hstretch{2}{\rule{1cm}{1cm}}h\vstretch{2}{\rule{1cm}{1cm}}i
 \end{document}

--- a/latexml_package/src/package/neurips_sty.rs
+++ b/latexml_package/src/package/neurips_sty.rs
@@ -12,6 +12,13 @@ LoadDefinitions!({
   DefConditional!("\\if@preprint");
   DefConditional!("\\if@submission");
   DefConditional!("\\if@final");
+  // neurips_2026.sty L72 adds \newif\if@anonymous\@anonymoustrue (toggled false by
+  // preprint/final). The binding intercepts the versioned name and never creates it,
+  // so papers copying the style's \@maketitle (which branches on \if@anonymous) hit
+  // Error:undefined:\if@anonymous — a Rust-only divergence: Perl 0.8.8 converts the
+  // same paper without it. Default false = authors shown (correct for preprint/final
+  // arXiv uploads). Witness 2605.17249.
+  DefConditional!("\\if@anonymous");
   DeclareOption!("final", {
     assign_value("neurips_final", Stored::from(1), Some(Scope::Global));
   });

--- a/latexml_package/src/package/scalerel_sty.rs
+++ b/latexml_package/src/package/scalerel_sty.rs
@@ -2,6 +2,18 @@ use crate::prelude::*;
 
 #[rustfmt::skip]
 LoadDefinitions!({
+  // STATUS — the whole scalerel family is NEUTRALIZED, not yet fully supported.
+  // This binding is deliberately STEP 1: *preserve the content* (the object survives,
+  // sized to text height) and stop the `Error:undefined` + broken layout — at the cost
+  // of the ACTUAL scale. The target height (`\scalerel`/`\scaleto`/`\stretchto`) and the
+  // numeric factor (`\scaleobj`/`\hstretch`/`\vstretch`) are DROPPED, so every scaled
+  // object renders at ~1em (text height) regardless of the requested size. Do NOT mistake
+  // this approximation for correct sizing.
+  // FUTURE (complete support): honour the real scale — measure the object box and the
+  // reference box (or read the factor), compute the ratio, and emit a CSS
+  // `transform: scale()` / SVG viewBox — which needs box measurement the engine does not
+  // yet expose. Tracked in docs/SYNC_STATUS.md (scalerel full box-measurement scaling).
+  //
   // arXiv/html_feedback#6895: the `scalerel` package has no `.ltxml` binding in
   // Perl OR Rust, and the raw `.sty` load leaves `\scalerel` undefined — so an
   // inline icon built with `\scalerel*` (the `\orcidicon` of arXiv:2608.12272)

--- a/latexml_package/src/package/scalerel_sty.rs
+++ b/latexml_package/src/package/scalerel_sty.rs
@@ -25,4 +25,29 @@ LoadDefinitions!({
   // `\stretchrel` stretches ignoring the aspect ratio; aspect-preserving is the
   // safe default for an inline icon, so alias it to `\scalerel` (scalerel.sty L86).
   Let!("\\stretchrel", "\\scalerel");
+  // Binding scalerel short-circuits the raw `.sty`, so EVERY command it defines is
+  // lost unless re-added here. Before this binding the raw load defined the whole
+  // family (as `\newcommand`s), so papers using them converted clean; covering only
+  // `\scalerel`/`\stretchrel` regressed `\scaleto`/`\scaleobj`/`\stretchto` &c. to
+  // `Error:undefined` (sandbox-arxiv-2605: 20+ papers, e.g. 2605.02053, 2605.03024,
+  // 2605.03521). Each scales/stretches its OBJECT to a height or by a factor we
+  // cannot measure box-wise, so — as with `\scalerel` — we wrap just the object in
+  // the text-height inline-block and drop the target (scalerel.sty L104/117/145-159).
+  //   \scaleto  [max]{obj}{ht}     obj=#2  (scalerel.sty L104)
+  //   \stretchto[min]{obj}{ht}     obj=#2  (scalerel.sty L117)
+  //   \scaleobj      {factor}{obj} obj=#2  (scalerel.sty L145)
+  //   \hstretch      {factor}{obj} obj=#2  (scalerel.sty L138)
+  //   \vstretch      {factor}{obj} obj=#2  (scalerel.sty L141)
+  DefMacro!("\\scaleto []{}{}",   "\\lx@scalerel@obj{#2}");
+  DefMacro!("\\stretchto []{}{}", "\\lx@scalerel@obj{#2}");
+  DefMacro!("\\scaleobj {}{}",    "\\lx@scalerel@obj{#2}");
+  DefMacro!("\\hstretch {}{}",    "\\lx@scalerel@obj{#2}");
+  DefMacro!("\\vstretch {}{}",    "\\lx@scalerel@obj{#2}");
+  // `\scaleleftright`/`\stretchleftright` place a scaled left and right object around
+  // a reference; both are built on `\scalerel`/`\stretchrel` (scalerel.sty L129-137),
+  // and the `.`-sentinel `\ifx` skips an empty side.
+  DefMacro!("\\scaleleftright []{}{}{}",
+    "\\ifx.#2#3\\else\\scalerel[#1]{#2}{#3}\\fi\\ifx.#4\\else\\scalerel*[#1]{#4}{#3}\\fi");
+  DefMacro!("\\stretchleftright []{}{}{}",
+    "\\ifx.#2#3\\else\\stretchrel[#1]{#2}{#3}\\fi\\ifx.#4\\else\\stretchrel*[#1]{#4}{#3}\\fi");
 });


### PR DESCRIPTION
## What & why

Investigation + fixes for the regressions surfaced on the `sandbox-arxiv-2605` / `oxidized_tex_to_html` corpus (2026-08-20 run vs the 2026-08-02 baseline).

### Key finding: most of the "43 new fatals" are an infra artifact, not code

41/43 new fatals were cortex `never_completed_with_retries` (worker leased the task but never returned — hang/crash/**OOM**). Rebuilding `cortex_worker` at HEAD and re-running all 43 locally under a 240s + 8 GB guard (identical results **with and without** `--preload=ar5iv.sty`):

- **39/43 convert fine locally** (32 clean, 7 error-but-finish). Including the paper whose fleet log showed 4253 `post/xpath` errors — locally **zero** (that message fires when libxml2's XPath aborts under memory pressure, `document.rs:953`). So the never-completes **and** the XPath floods are the same fleet memory-pressure symptom; a rerun clears them.
- **4/43 are genuinely reproducible** and fixed here: 3 hangs + 1 runaway.

## Fixes (6)

**Parity (Rust diverged from Perl; now matches):**
- **scalerel family** — binding `scalerel` (#712) short-circuits the raw `.sty`, losing `\scaleto`/`\scaleobj`/`\stretchto`/`\hstretch`/`\vstretch`/`\scaleleftright`/`\stretchleftright` → `Error:undefined` on 20+ papers. Re-added via the `\lx@scalerel@obj` wrapper.
- **neurips `\if@anonymous`** — the binding intercepts the versioned `neurips_2026` name but never creates `\if@anonymous`; Perl converts the same paper (2605.17249) without it. Defined defensively (default false = authors shown).
- **expl3 catcode leak (#630)** — a `\ProvidesExplPackage` file that `\RequirePackage`s a native binding which force-raw-loads its own expl3 `.sty` (derivative) re-snapshotted `grandparent_in_expl3=false` after the outer `\@pushfilename`, over-fired `\ExplSyntaxOff`, and left `_` = SUB → 23× `unexpected:_` (2605.21946). Fixed with a per-frame expl3 stack in `input_definitions`.
- **biblatex `\cite` loop** — `\usepackage{myBiblatex}` hits the versioned fallback → native `biblatex` binding, which `find_file_fallback` double-runs; the non-idempotent `\let\blx@saved@cite\cite` captured biblatex's own `\cite` on the 2nd init → infinite loop to `TokenLimit` (2605.03965). Guarded with `\@ifundefined`. Perl never loads biblatex on this name.

**Beyond-Perl:**
- **`cleanup_scripts` O(M×N) → O(N+M)** — a whole-document `descendant-or-self::*[@idref='<appid>']` XPath ran once **per** script app, quadratic on math-dense papers → >240 s spin in libxml2 `xmlXPathEval` (the 3 hangs: 2605.25560/07347/22741). Build the idref index once. Measured: 240 s+ hang → 8–22 s. Perl `MathParser.pm:113` has the same per-app scan.
- **NiceTabular → real tables** — the nicematrix stub errored + dropped the body; the real `nicematrix.sty` makes `NiceTabular` a tabular over its colspec, so bind `\NiceTabular`→`\tabular` (10 papers). Diverges from the ar5iv stub (which errors) — mirror there for strict parity.

## Deferred (verified faithful Perl parity — no code change)

- **forest** stub `Error:undefined` — line-for-line Perl port, non-fatal.
- **malformed/ltx:para** — `center`-in-`titlepage`-with-abstract; Perl emits the identical errors (ran the Perl oracle).
- **graphicx** in a neurips paper — Perl fails identically (author-customized style discarded by both engines).

## Tests & scope

New guards in `cluster_package_guards.rs` (NiceTabular, neurips, biblatex, expl3 — the last self-skips without `derivative.sty`) and an extended `cluster_scalerel_defined_6895`. Full suite green.

This branch was rebased off `origin/main` to keep it cortex-only; the unrelated #702 `ltx_break` CSS commit it was previously based on is preserved on `fix-702-breaklines-css-hook` for separate handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Rerun validation (2026-08-21)

Deployed this branch's binary to the cortex fleet with the memory hardening from
[CorTeX#423](https://github.com/dginev/CorTeX/issues/423) (WORKERS 72→56, MemoryMax=200G)
and reran both corpora full:

| corpus | fatal | error | no_problem |
|---|---|---|---|
| sandbox-arxiv-2605 | 293 → **256** (−37) | 4014 → **3979** | 6017 → **6055** |
| sandbox-arxiv-2606 | 279 → **235** (−44) | 4121 → **4094** | 6296 → **6358** |

`never_completed_with_retries` (fleet memory-pressure) fatals dropped **~41 → 13 / 9** —
the hardening's direct effect. Both corpora improved on every severity axis; the residual
fatals are now genuine (Timeout / TooManyErrors / Stomach), not infra.
