### PR TITLE
fix: 2606 corpus — cleveref class stubs, AASTeX, subdir package-path shadow

### DIFF
--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -809,7 +809,8 @@ Do not mistake the text-height approximation for correct sizing.
 Two waves of subagent triage over the 2605/2606 `oxidized_tex_to_html` error+fatal
 clusters. Landed: PR #720 (scalerel, neurips `\if@anonymous`, NiceTabular, expl3
 `#630`, biblatex loop, `cleanup_scripts` O(M×N)→O(N+M)) + stacked PR (cleveref class
-stubs, AASTeX). Method for every row below: reproduce the witness with
+stubs, AASTeX, subdir/`.sty` binding shadow — no directory stripping in dispatch or
+`find_file_fallback`). Method for every row below: reproduce the witness with
 `--preload=ar5iv.sty --path ar5iv-bindings/originals` (raw-loads bundled **styles**,
 NOT bundled **classes**), then run the same-host Perl `latexml` oracle to classify
 Rust-only vs shared. The dominant finding — the 2605 "43 new fatals" were ~90% fleet
@@ -830,14 +831,21 @@ Rust-only vs shared. The dominant finding — the 2605 "43 new fatals" were ~90%
   patch is reckless. Min-repro: `\documentclass[sn-mathphys]{sn-jnl}` (real .cls present)
   + a `\toprule`/`\bottomrule` tabular → Rust undefined; generic class + same
   `\usepackage{booktabs}` → 0 errors.
-- **cleveref Mechanism B — subdir/`.sty` dispatch shadow** (landed separately IF suite
-  passes; else deferred). `\RequirePackage{utils/mathenv}` (paper-local `utils/mathenv.sty`
-  that `\RequirePackage`s cleveref) → `lib.rs:1100` strips the dir → matches the CTAN
-  `mathenv` binding (mdwtools) → no-ops → local file never loads → `\cref`/`{theorem}`
-  undefined. Witness **2606.02073**. Perl doesn't strip → raw-loads local → clean. Fix:
-  restrict the dir-strip to `.cls` only; GATE on `cargo nextest run --workspace` (changes
-  global package resolution). General: any `subdir/<name>.sty` colliding with a bound CTAN
-  package name.
+- **subdir/`.sty` binding shadow — LANDED (no directory stripping anywhere).** A paper-local
+  `\usepackage{subdir/<name>}` whose basename collided with a bound CTAN package (e.g.
+  `utils/mathenv` → the `mathenv` binding, `latexml_package/src/package/mathenv_sty.rs`, a
+  no-op) had its directory stripped at TWO sites — the package dispatcher (`lib.rs`) and
+  `find_file_fallback`/`_exists` (`content.rs`, the `BasenameOnly` fallback) — so the binding
+  shadowed the local file and its cleveref/theorem defs never loaded. Perl never strips a
+  directory (`Package.pm:2191` FindFile_fallback strips VERSION suffixes only). Fix: dropped
+  the strip at BOTH sites — `subdir/<name>` is a PATH, so the local file raw-loads under
+  `localrawstyles`. The retired `find_file_fallback` `BasenameOnly` convenience (subdir copies
+  of KNOWN packages — 2105.02087 `misc/ieeetran`, 2405.18387 `assets/equations`) now falls to
+  OmniBus/raw-load like Perl (no test guarded them; full-suite blast radius nil). Witness
+  **2606.02073** (its own `\cref` is also defined via the icml binding, so the corpus error
+  there was already masked — the shadow is proven by the synthetic guards). Guards:
+  `cluster_package_guards.rs::subdir_dispatch_no_strip` (`.sty` raw-loads, `.cls` stays OmniBus
+  under classes-off), both driven through `convert_to_xml_ar5iv` (the real fleet config).
 
 **B. Beyond-Perl levers — policy call (need an OXIDIZED_DESIGN entry + Perl upstream):**
 

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -804,6 +804,86 @@ object box and the reference box (or read the factor), compute the ratio, and em
 `transform: scale()` / an SVG viewBox — which needs box measurement the engine does not yet
 expose. Witnesses 2605.02053 / 2605.03024 / 2605.03521 (now convert clean, content preserved).
 Do not mistake the text-height approximation for correct sizing.
+### (not ranked) sandbox-arxiv-2605/2606 cortex corpus triage — deferred items (2026-08-21)
+
+Two waves of subagent triage over the 2605/2606 `oxidized_tex_to_html` error+fatal
+clusters. Landed: PR #720 (scalerel, neurips `\if@anonymous`, NiceTabular, expl3
+`#630`, biblatex loop, `cleanup_scripts` O(M×N)→O(N+M)) + stacked PR (cleveref class
+stubs, AASTeX). Method for every row below: reproduce the witness with
+`--preload=ar5iv.sty --path ar5iv-bindings/originals` (raw-loads bundled **styles**,
+NOT bundled **classes**), then run the same-host Perl `latexml` oracle to classify
+Rust-only vs shared. The dominant finding — the 2605 "43 new fatals" were ~90% fleet
+**memory pressure**, not code — is in [[reference_cortex_fleet_memory_pressure_hardening]]
+/ CorTeX#423; the error population is overwhelmingly faithful-Perl-parity.
+
+**A. Genuine Rust-only — worth fixing, needs deeper work:**
+
+- **sn-jnl.cls raw-load drops booktabs + appendix** → `\toprule`/`\midrule`/`\bottomrule`
+  undefined → table breaks → `malformed:ltx:{section,subsection,appendix}` cascade.
+  Witness **2606.00121** (`\documentclass[sn-mathphys]{sn-jnl}`). Method: Perl dep-scans
+  sn-jnl.cls (booktabs loads → 11 clean errors, no cascade); Rust raw-loads the full
+  1765-line sn-jnl.cls but `\usepackage{booktabs}` (sn-jnl.cls:307) + `\usepackage[title]{appendix}`
+  (:303) fail to take effect while flat-block neighbours (multirow:298, rotating:302,
+  xcolor:304, algorithm:308) load fine. Isolated `\usepackage{booktabs}` loads correctly
+  — only the full raw-cls-load drops it. Needs instrumented tracing of raw-load dependency
+  handling (`content.rs:1993` `maybe_require_dependencies`, ~10-witness guard); a blind
+  patch is reckless. Min-repro: `\documentclass[sn-mathphys]{sn-jnl}` (real .cls present)
+  + a `\toprule`/`\bottomrule` tabular → Rust undefined; generic class + same
+  `\usepackage{booktabs}` → 0 errors.
+- **cleveref Mechanism B — subdir/`.sty` dispatch shadow** (landed separately IF suite
+  passes; else deferred). `\RequirePackage{utils/mathenv}` (paper-local `utils/mathenv.sty`
+  that `\RequirePackage`s cleveref) → `lib.rs:1100` strips the dir → matches the CTAN
+  `mathenv` binding (mdwtools) → no-ops → local file never loads → `\cref`/`{theorem}`
+  undefined. Witness **2606.02073**. Perl doesn't strip → raw-loads local → clean. Fix:
+  restrict the dir-strip to `.cls` only; GATE on `cargo nextest run --workspace` (changes
+  global package resolution). General: any `subdir/<name>.sty` colliding with a bound CTAN
+  package name.
+
+**B. Beyond-Perl levers — policy call (need an OXIDIZED_DESIGN entry + Perl upstream):**
+
+- **OmniBus frontmatter vocabulary extension** (~150 docs, the biggest cluster). Bundled
+  journal `.cls` (INCLUDE_CLASSES defaults false → OmniBus fallback, `content.rs:2457-2622`,
+  faithful port of Perl `LoadClass`) leaves `\orcid \contribution {contribution} \ack
+  \correspondence \aff \lefttitle \righttitle \reportnumber \data \checkdata
+  \restartappendixnumbering` undefined. **Perl fails identically** (Rust slightly ahead:
+  3 vs 5 errors on the witness). ~15+ distinct bundled classes. Witnesses: 2606.01241
+  (xiaomiev: contribution/correspondence/checkdata), 2606.00645 (jfm: aff/lefttitle/righttitle),
+  2606.04098 (iopjournal: data), 2606.00213 (pasj02: orcid). Lever: extend OmniBus's generic
+  vocabulary ONLY for commands with clean `\lx@add@*` mappings (`\aff`→`\lx@add@affiliation`,
+  `\reportnumber`→`\lx@add@pubnote`, `\ack`→`Let \acknowledgments`); gobble the
+  running-head/presentational ones — **`\lefttitle`/`\righttitle` are running-head / journal-name
+  registers, do NOT route to title**; `\data` embeds a HuggingFace `\includegraphics`. Single
+  edit to `omnibus_cls.rs`, NOT 15 class bindings; do NOT raw-load the 2000-line classes (the
+  cascade OmniBus exists to prevent). Must upstream the same to Perl's `OmniBus.cls.ltxml` to
+  stay parity. CUP family (jfm/iau/pas) subsumed here.
+- **native newunicodechar binding** (~50 docs, ~100 occurrences). `\newunicodechar{<non-ASCII>}{repl}`
+  → both engines take the 8-bit path (UTF-8 char = one Unicode token → length 1 →
+  `\nuc@onebyteerr` → `Error:latex:(newunicodechar) ASCII character requested`). **Perl
+  byte-identical**, non-fatal (char passes through; the mapping is DROPPED by both).
+  Witnesses: 2606.00241 (icml2026.sty), 2606.00683 (colm2024), 2606.00739 (acl.sty).
+  Min-repro: `\usepackage{newunicodechar}\newunicodechar{，}{,}` (， = U+FF0C). Lever
+  (separate branch, upstream to Perl): a native binding that registers the
+  Unicode-char→replacement mapping and suppresses the spurious error.
+
+**C. Pure Perl-parity — record only (Perl-origin; belongs in KNOWN_PERL_ERRORS too):**
+
+- **forest** `Error:undefined:{forest}` — line-for-line port of ar5iv `forest.sty.ltxml`,
+  non-fatal (body swallowed via `discard_env`, valid output). Witnesses 2605.07358/12090/12792.
+  Shared helper `discard_env.rs` also backs nicematrix (math family)/diagrams/pb-diagram.
+  Whole-family lever (policy): `Error!`→`Warn!` at `discard_env.rs:55`.
+- **malformed:ltx:para** — `\begin{center}` inside `\begin{titlepage}` with an abstract +
+  multi-paragraph flow → `insertBlock` fallback forces `ltx:block` (`TeX_Box.pool.ltxml:516`)
+  which can't hold `ltx:para`/`ltx:abstract`. Perl identical (oracle-verified). Witnesses
+  2605.00729/00750/12448.
+- **malformed:ltx:section/subsection (parity subset — the majority)** — broken source
+  (unclosed lists/boxes, broken alignments) traps sectioning inside an open container; a
+  CASCADE, not a sectioning bug. Perl identical. Witnesses 2606.00338 (unclosed `\squishlist`
+  `\begin{list}`), 2606.00679 (`\ytableaushort` inside an `eqnarray*` alignment).
+- **graphicx-in-neurips** — author-customized `neurips_2026.sty` (does `\usepackage{graphicx}`)
+  is discarded by the neurips-binding interception (#690); `\includegraphics`/`\rotatebox`
+  undefined + a downstream `_` cascade. Perl fails identically (22 errors; version-suffix
+  fallback → `neurips.sty.ltxml`, which also lacks graphicx). Witness 2605.21325. #690 brought
+  Rust *to* Perl parity (it was accidentally better before).
 
 ## Parked families — pointers, not content
 

--- a/latexml_contrib/src/ieeetaes_cls.rs
+++ b/latexml_contrib/src/ieeetaes_cls.rs
@@ -5,6 +5,10 @@ LoadDefinitions!({
   LoadClass!("IEEEtran");
   RequirePackage!("hyperref");
   RequirePackage!("authblk");
+  // IEEEtaes.cls:5158 `\usepackage[capitalize]{cleveref}`; the IEEEtran stub replaces
+  // the real `.cls`, so \cref/\Cref come out Error:undefined — Perl raw-loads the `.cls`
+  // and gets cleveref. Must load AFTER hyperref. Witness 2606.01169.
+  RequirePackage!("cleveref", options => vec!["capitalize".to_string()]);
 
   // IEEEtaes-specific frontmatter — preserve author content.
   DefMacro!("\\doiinfo{}", "\\@add@frontmatter{ltx:note}[role=doi]{#1}");

--- a/latexml_contrib/src/lipics_cls.rs
+++ b/latexml_contrib/src/lipics_cls.rs
@@ -23,6 +23,11 @@ LoadDefinitions!({
   // loads xcolor with its own options; `\color`/`\definecolor` stay
   // available via hyperref→color. See ifacconf_cls.rs / SYNC_STATUS.
   RequirePackage!("hyperref");
+  // lipics-v2021.cls:1113 `\RequirePackage[capitalise,noabbrev]{cleveref}` (guarded by
+  // the `cleveref` class option). This OmniBus stub replaces the real `.cls`, so without
+  // it `\cref`/`\Cref` come out Error:undefined — Perl (no lipics binding) raw-loads the
+  // `.cls` and gets cleveref. Must load AFTER hyperref. Witness 2606.01187.
+  RequirePackage!("cleveref", options => vec!["capitalise".to_string(), "noabbrev".to_string()]);
 
   // LIPIcs frontmatter — preserve author content as ltx:note
   // frontmatter entries with role markers.

--- a/latexml_core/src/binding/content.rs
+++ b/latexml_core/src/binding/content.rs
@@ -2709,26 +2709,31 @@ pub fn find_file_fallback_exists(name: &str, ext_type: &str) -> bool {
   } else {
     basename
   };
-  let mut changed = base != name;
+  // Mirror find_file_fallback: a directory strip ALONE must not qualify (a `subdir/<name>` is a
+  // path, not a version — it must not name-match `<name>`'s binding). Only a real version
+  // suffix/prefix strip counts; guard the `^`-anchored prefix strip behind `!dir_stripped` so
+  // `sty/myunits` doesn't become `units`.
+  let dir_stripped = base != name;
+  let mut suffix_stripped = false;
   loop {
     if let Some(m) = suffix_rx.find(&base) {
       base = base[..m.start()].to_string();
-      changed = true;
+      suffix_stripped = true;
       continue;
     }
     if let Some(m) = glued_rx.find(&base) {
       base = base[..m.start()].to_string();
-      changed = true;
+      suffix_stripped = true;
       continue;
     }
-    if let Some(m) = prefix_rx.find(&base) {
+    if !dir_stripped && let Some(m) = prefix_rx.find(&base) {
       base = base[m.end()..].to_string();
-      changed = true;
+      suffix_stripped = true;
       continue;
     }
     break;
   }
-  if !changed || base.is_empty() || base == name {
+  if !suffix_stripped || base.is_empty() || base == name {
     return false;
   }
   binding_exists(&base, ext_type)
@@ -2818,18 +2823,21 @@ pub fn find_file_fallback(name: &str, ext_type: &str) -> Option<(String, Fallbac
     break;
   }
 
-  if !suffix_stripped && !dir_stripped {
+  // A directory strip ALONE no longer triggers a fallback: `subdir/<name>` is a PATH, not a
+  // version, so it must not name-match `<name>`'s binding (that shadowed paper-local subdir
+  // packages, e.g. `utils/mathenv` -> the unrelated CTAN mathenv binding, leaving the local
+  // file — and its cleveref/theorem defs — unloaded). Only a real VERSION suffix/prefix strip
+  // (neurips_2026->neurips, mysvjour3->svjour3) qualifies, matching Perl's FindFile_fallback
+  // (which never strips a directory). The retired `BasenameOnly` convenience (2105.02087
+  // misc/ieeetran, 2405.18387 assets/equations) now falls to raw-load/OmniBus like Perl.
+  if !suffix_stripped {
     return None;
   }
   if base.is_empty() || base == name {
     return None;
   }
 
-  let kind = if suffix_stripped {
-    FallbackKind::Versioned
-  } else {
-    FallbackKind::BasenameOnly
-  };
+  let kind = FallbackKind::Versioned;
 
   let fallback_filename = format!("{base}.{ext_type}");
   // Check if fallback binding exists

--- a/latexml_oxide/tests/cluster_package_guards.rs
+++ b/latexml_oxide/tests/cluster_package_guards.rs
@@ -446,33 +446,28 @@ mod cleveref_class_stubs {
   //! came out `Error:undefined`. Perl (no lipics/IEEEtaes binding) raw-loads the `.cls`
   //! and gets cleveref, so this was a Rust-only parity gap. The stubs now require
   //! cleveref after hyperref. Witnesses 2606.01187 (lipics), 2606.01169 (IEEEtaes).
-  use std::{path::Path, process::Command};
-
-  const TEX: &str = "\\documentclass[cleveref]{lipics-v2021}\n\
-    \\begin{document}\n\
-    \\section{Intro}\\label{sec:intro}\n\
-    See \\cref{sec:intro} and \\Cref{sec:intro}.\n\
-    \\end{document}\n";
+  use crate::cluster::convert_to_xml_contrib_clean;
 
   #[test]
   fn lipics_stub_requires_cleveref() {
-    let bin = env!("CARGO_BIN_EXE_latexml_oxide");
-    assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
-    let workdir = tempfile::tempdir().expect("create tempdir");
-    std::fs::write(workdir.path().join("d.tex"), TEX).expect("write d.tex");
-    let output = Command::new(bin)
-      .arg("d.tex")
-      .arg("--dest")
-      .arg("d.xml")
-      .arg("--nocomments")
-      .current_dir(workdir.path())
-      .output()
-      .expect("spawn latexml_oxide");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-      !stderr.contains("undefined:\\cref") && !stderr.contains("undefined:\\Cref"),
-      "lipics stub must require cleveref so \\cref/\\Cref resolve:\n{stderr}",
-    );
+    // Red before the fix: `\cref`/`\Cref` come out Error:undefined; green: 0 errors.
+    let _ = convert_to_xml_contrib_clean("tests/cluster_regressions/cleveref_lipics_stub.tex");
+  }
+}
+
+mod aastex_contribution_appendix {
+  //! aastex701/631/7 digit-strip to the aastex-v5 `aastex.cls.ltxml` shim, which predates
+  //! aastex7, so the `{contribution}` env and `\restartappendixnumbering` came out
+  //! `Error:undefined` (Perl errors identically — this is a beyond-Perl addition in the
+  //! `aas_support_sty.rs` home that already carries the `\uat` beyond-Perl addition).
+  //! Witnesses 2606.03375/04105 (contribution), 2606.00569/03850/07452 (restartappendixnumbering).
+  use crate::cluster::convert_to_xml_contrib_clean;
+
+  #[test]
+  fn aastex_contribution_and_restartappendix_defined() {
+    // Red before the fix: `{contribution}` / `\restartappendixnumbering` Error:undefined;
+    // green: 0 errors.
+    let _ = convert_to_xml_contrib_clean("tests/cluster_regressions/aastex_contribution.tex");
   }
 }
 

--- a/latexml_oxide/tests/cluster_package_guards.rs
+++ b/latexml_oxide/tests/cluster_package_guards.rs
@@ -471,6 +471,43 @@ mod aastex_contribution_appendix {
   }
 }
 
+mod subdir_dispatch_no_strip {
+  //! Neither the package dispatcher (latexml_package::lib) nor `find_file_fallback`
+  //! (latexml_core::binding::content) strips a leading directory any more, so `subdir/<name>`
+  //! is a file PATH, not a binding name. Both tests drive the REAL fleet config via
+  //! `convert_to_xml_ar5iv` — `ar5iv.sty` sets INCLUDE_STYLES="searchpaths" (`localrawstyles`:
+  //! raw-load local `.sty`, classes OFF), the exact `cortex_worker --preload=ar5iv.sty` route.
+  use crate::cluster::convert_to_xml_ar5iv;
+
+  /// A paper-local `subdirdispatch/mathenv.sty`, whose basename collides with the CTAN `mathenv`
+  /// binding, must raw-load under `localrawstyles` (via SOURCEDIRECTORY), not be shadowed by a
+  /// directory-stripped binding match — the 2606.02073 cleveref/theorem bug. RED before the drop
+  /// (strip -> `mathenv` binding no-op -> the local `\subdirstymarker` never defined), GREEN
+  /// after. Guards both the dispatch strip and the `find_file_fallback` BasenameOnly strip stay
+  /// gone.
+  #[test]
+  fn subdir_sty_raw_loads_not_shadowed() {
+    let xml = convert_to_xml_ar5iv("tests/cluster_regressions/subdir_sty_not_shadowed.tex");
+    assert!(
+      xml.contains("SUBDIRSTYLOADED"),
+      "subdirdispatch/mathenv.sty should raw-load its local def (not be shadowed by the CTAN \
+       mathenv binding):\n{xml}",
+    );
+  }
+
+  /// INCLUDE_CLASSES stays disabled under `localrawstyles` (styles-only): a paper-local subdir
+  /// `.cls` must NOT raw-load — it falls to OmniBus, so its `\subdirclsmarker` stays undefined
+  /// and SUBDIRCLSLOADED never reaches the output. (Enabling `rawclasses` would flip this.)
+  #[test]
+  fn subdir_cls_does_not_raw_load_include_classes_off() {
+    let xml = convert_to_xml_ar5iv("tests/cluster_regressions/subdir_cls_not_rawloaded.tex");
+    assert!(
+      !xml.contains("SUBDIRCLSLOADED"),
+      "subdir `.cls` raw-loaded despite INCLUDE_CLASSES off (localrawstyles is styles-only):\n{xml}",
+    );
+  }
+}
+
 mod newtcblisting_verbatim {
   //! Regression test: a `\newtcblisting`-defined code box captures its body
   //! verbatim and CLOSES at `\end{name}` (ar5iv #504 / #569 / #570).

--- a/latexml_oxide/tests/cluster_package_guards.rs
+++ b/latexml_oxide/tests/cluster_package_guards.rs
@@ -440,6 +440,42 @@ mod expl3_nested_raw_load_catcodes {
   }
 }
 
+mod cleveref_class_stubs {
+  //! lipics-v2021 and IEEEtaes are OmniBus/IEEEtran stub bindings that replace the
+  //! paper's real `.cls` and omitted its `\RequirePackage{cleveref}`, so `\cref`/`\Cref`
+  //! came out `Error:undefined`. Perl (no lipics/IEEEtaes binding) raw-loads the `.cls`
+  //! and gets cleveref, so this was a Rust-only parity gap. The stubs now require
+  //! cleveref after hyperref. Witnesses 2606.01187 (lipics), 2606.01169 (IEEEtaes).
+  use std::{path::Path, process::Command};
+
+  const TEX: &str = "\\documentclass[cleveref]{lipics-v2021}\n\
+    \\begin{document}\n\
+    \\section{Intro}\\label{sec:intro}\n\
+    See \\cref{sec:intro} and \\Cref{sec:intro}.\n\
+    \\end{document}\n";
+
+  #[test]
+  fn lipics_stub_requires_cleveref() {
+    let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+    assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+    let workdir = tempfile::tempdir().expect("create tempdir");
+    std::fs::write(workdir.path().join("d.tex"), TEX).expect("write d.tex");
+    let output = Command::new(bin)
+      .arg("d.tex")
+      .arg("--dest")
+      .arg("d.xml")
+      .arg("--nocomments")
+      .current_dir(workdir.path())
+      .output()
+      .expect("spawn latexml_oxide");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+      !stderr.contains("undefined:\\cref") && !stderr.contains("undefined:\\Cref"),
+      "lipics stub must require cleveref so \\cref/\\Cref resolve:\n{stderr}",
+    );
+  }
+}
+
 mod newtcblisting_verbatim {
   //! Regression test: a `\newtcblisting`-defined code box captures its body
   //! verbatim and CLOSES at `\end{name}` (ar5iv #504 / #569 / #570).

--- a/latexml_oxide/tests/cluster_regressions/aastex_contribution.tex
+++ b/latexml_oxide/tests/cluster_regressions/aastex_contribution.tex
@@ -1,0 +1,14 @@
+% sandbox-arxiv-2606: aastex701/631/7 digit-strip to the aastex-v5 aastex.cls.ltxml
+% shim, which predates aastex7, so the {contribution} environment and
+% \restartappendixnumbering came out Error:undefined (Perl errors identically -- a
+% beyond-Perl addition in aas_support_sty.rs, which already carries the \uat beyond-Perl
+% addition). Witnesses 2606.03375/04105 (contribution), 2606.00569/03850/07452
+% (restartappendixnumbering).
+\documentclass{aastex701}
+\begin{document}
+\begin{contribution}
+Author did the work.
+\end{contribution}
+\appendix
+\restartappendixnumbering
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/cleveref_lipics_stub.tex
+++ b/latexml_oxide/tests/cluster_regressions/cleveref_lipics_stub.tex
@@ -1,0 +1,10 @@
+% sandbox-arxiv-2606: the lipics-v2021 / IEEEtaes class stubs (OmniBus/IEEEtran
+% LoadClass) replace the paper's real .cls and omitted its \RequirePackage{cleveref},
+% so \cref/\Cref came out Error:undefined. Perl (no lipics/IEEEtaes binding) raw-loads
+% the .cls and gets cleveref -> Rust-only parity gap. The stubs now require cleveref
+% after hyperref. Witnesses 2606.01187 (lipics), 2606.01169 (IEEEtaes).
+\documentclass[cleveref]{lipics-v2021}
+\begin{document}
+\section{Intro}\label{sec:intro}
+See \cref{sec:intro} and \Cref{sec:intro}.
+\end{document}

--- a/latexml_oxide/tests/cluster_regressions/subdir_cls_not_rawloaded.tex
+++ b/latexml_oxide/tests/cluster_regressions/subdir_cls_not_rawloaded.tex
@@ -1,0 +1,7 @@
+% INCLUDE_CLASSES must stay off under localrawstyles (styles-only): a paper-local subdir CLASS
+% must not raw-load. subdirdispatch/localjournal.cls defines \subdirclsmarker; with INCLUDE_CLASSES
+% off it never runs (OmniBus fallback), so \subdirclsmarker is undefined and SUBDIRCLSLOADED never
+% reaches the output. Guards that dispatch does not name-match a stripped `localjournal` binding
+% AND that .cls raw-load stays disabled.
+\documentclass{subdirdispatch/localjournal}
+\begin{document}\subdirclsmarker\end{document}

--- a/latexml_oxide/tests/cluster_regressions/subdir_sty_not_shadowed.tex
+++ b/latexml_oxide/tests/cluster_regressions/subdir_sty_not_shadowed.tex
@@ -1,0 +1,8 @@
+% The subdir-dispatch drop: `\usepackage{subdirdispatch/mathenv}` names a paper-local
+% subdirdispatch/mathenv.sty. The name collides with the CTAN `mathenv` binding; before the
+% directory-strip was dropped, dispatch stripped to `mathenv`, matched that binding (a no-op),
+% and the local file never loaded -> \subdirstymarker undefined (like 2606.02073's cleveref).
+% Now the local file raw-loads under localrawstyles/INCLUDE_STYLES.
+\documentclass{article}
+\usepackage{subdirdispatch/mathenv}
+\begin{document}\subdirstymarker\end{document}

--- a/latexml_oxide/tests/cluster_regressions/subdirdispatch/localjournal.cls
+++ b/latexml_oxide/tests/cluster_regressions/subdirdispatch/localjournal.cls
@@ -1,0 +1,4 @@
+% Paper-local subdir CLASS. With INCLUDE_CLASSES off it must NOT raw-load
+% (falls to OmniBus); its marker must stay undefined.
+\newcommand\subdirclsmarker{SUBDIRCLSLOADED}
+\LoadClass{article}

--- a/latexml_oxide/tests/cluster_regressions/subdirdispatch/mathenv.sty
+++ b/latexml_oxide/tests/cluster_regressions/subdirdispatch/mathenv.sty
@@ -1,0 +1,4 @@
+% Paper-local subdir package that COLLIDES with the CTAN `mathenv` binding
+% (latexml_package/src/package/mathenv_sty.rs, registered lib.rs:262). It must
+% raw-load (localrawstyles), not be shadowed by a directory-stripped binding match.
+\newcommand\subdirstymarker{SUBDIRSTYLOADED}

--- a/latexml_package/src/lib.rs
+++ b/latexml_package/src/lib.rs
@@ -1091,34 +1091,30 @@ pub const BINDINGS: &[(&str, &str, BindingLoader)] = &[
 /// pgf / pgfmath / pgfmathcalc bindings, breaking tikz tests.
 pub fn dispatch(filename: &str) -> Option<Result<()>> {
   let (base, ext) = filename.split_once('.')?;
-  // Strip a leading directory path: `\documentclass{Definitions/mdpi}` →
-  // dispatch on basename `mdpi`. Perl Package.pm L2167-2170
-  // (FindFile_fallback) does the same. Without this, paper-bundled
-  // class files like `Definitions/mdpi.cls` miss the registered
-  // `mdpi.cls.ltxml`-style binding and fall through to OmniBus,
-  // producing 50+ cascading undefined errors. Witness 2403.18716.
-  let base_only = base.rsplit_once(['/', '\\']).map_or(base, |(_, b)| b);
-  // Perl pathname_find L383-389: try strict-case match first, then fall back
-  // to case-insensitive (`m/$i_regex/i` then `@nocase_paths`) — so
-  // `\documentclass{jhep}` resolves the `JHEP.cls.ltxml`-derived binding.
-  // Without the fallback, lowercase-input / uppercase-binding pairs miss
-  // and trigger spurious `missing_file` warnings.
+  // NO directory strip: a subdir name like `Definitions/mdpi` or `utils/mathenv` is a file
+  // PATH, not a binding name — dispatch matches a compile-time binding by the class/package
+  // NAME only. A subdir-bundled file with no exact-name binding falls through to the caller's
+  // raw load — a local `.sty` under `localrawstyles` (INCLUDE_STYLES:searchpaths), or, for a
+  // `.cls` with INCLUDE_CLASSES off, to OmniBus — which MATCHES Perl: its FindFile_fallback
+  // (Package.pm:2191) strips VERSION suffixes (neurips_2026->neurips, aastex701->aastex), never
+  // a directory. Witnesses: 2606.02073 (`\RequirePackage{utils/mathenv}` now raw-loads its
+  // local cleveref/theorem defs — a prior directory-strip matched the unrelated CTAN `mathenv`
+  // binding and shadowed the local file); `\documentclass{Definitions/mdpi}` now OmniBuses like
+  // Perl (the strip was a beyond-Perl name-match convenience for a bundled journal-class copy,
+  // dropped to stop conflating a path with a binding name — the `localrawstyles`/INCLUDE_CLASSES
+  // config, not this dispatch, governs whether a local file raw-loads). A future RUNTIME `.rhai`
+  // binding follows the path (`Definitions/mdpi.cls.rhai`) and is looked up there, not here.
+  //
+  // Perl pathname_find L383-389: try strict-case match first, then fall back to case-insensitive
+  // (`m/$i_regex/i` then `@nocase_paths`) — so `\documentclass{jhep}` resolves the
+  // `JHEP.cls.ltxml`-derived binding. Without the fallback, lowercase-input / uppercase-binding
+  // pairs miss and trigger spurious `missing_file` warnings.
   BINDINGS
     .iter()
     .find(|(name, extension, _)| *name == base && *extension == ext)
     .or_else(|| {
-      BINDINGS
-        .iter()
-        .find(|(name, extension, _)| *name == base_only && *extension == ext)
-    })
-    .or_else(|| {
       BINDINGS.iter().find(|(name, extension, _)| {
         name.eq_ignore_ascii_case(base) && extension.eq_ignore_ascii_case(ext)
-      })
-    })
-    .or_else(|| {
-      BINDINGS.iter().find(|(name, extension, _)| {
-        name.eq_ignore_ascii_case(base_only) && extension.eq_ignore_ascii_case(ext)
       })
     })
     .map(|(_, _, loader)| loader())

--- a/latexml_package/src/package/aas_support_sty.rs
+++ b/latexml_package/src/package/aas_support_sty.rs
@@ -252,6 +252,19 @@ LoadDefinitions!({
   // ptephy's argument-less form).
   DefMacro!("\\ack{}", "\\begin{acknowledgements}#1\\end{acknowledgements}");
 
+  // AASTeX 7 `{contribution}` — author-contribution statement placed in the document
+  // body just before `{acknowledgments}` (real aastex7/aastex701.cls L7903 renders it as
+  // `\section*{Author contributions}` + body). Map to the established acknowledgement-block
+  // idiom (cf. `\acknowledgements` above; aa_support/acmart/JHEP), NOT title-block frontmatter.
+  // BEYOND PERL: the aastex-v5 `aastex.cls.ltxml` shim (matched via the version-suffix fallback
+  // aastex701->aastex) predates aastex7, so Perl also errors `undefined:{contribution}`.
+  // Witnesses 2606.03375, 2606.04105 (aastex701).
+  DefConstructor!("\\contribution", "<ltx:acknowledgements name='Author contributions'>");
+  DefMacro!("\\endcontribution", "");
+  // AASTeX draft `\watermark{DRAFT}` — page-header decoration only; gobble. BEYOND PERL.
+  // Witness 2606.04105.
+  DefMacro!("\\watermark{}", "");
+
   // \uat{name}{id} — Unified Astronomy Thesaurus term link. Used in
   // \keywords by AASTeX 6.3+. Round-34 surpass: emit as a clickable
   // link to https://astrothesaurus.org/uat/<id> so the UAT id is
@@ -291,6 +304,18 @@ LoadDefinitions!({
       Some(ExpandableOptions { scope: Some(Scope::Global), ..Default::default() }),
     )?;
   });
+
+  // AASTeX 6.3+/7 `\restartappendixnumbering` (== `\apptablenumbers`, aastex701.cls L13630 /
+  // aastex631.cls L7206): restart table/figure/equation numbering within each appendix
+  // section, prefixed by the lettered section number. Faithful port of `\apptablenumbers`
+  // (drops the presentational `\fnum@`/`\theH` lines). BEYOND PERL: absent from the aastex-v5
+  // shim, so Perl also errors `undefined:\restartappendixnumbering`. Witnesses 2606.00569,
+  // 2606.03850, 2606.07452.
+  DefMacro!("\\apptablenumbers",
+    "\\setcounter{table}{0}\\setcounter{figure}{0}\\setcounter{equation}{0}\
+     \\def\\thetable{\\thesection\\arabic{table}}\
+     \\def\\thefigure{\\thesection\\arabic{figure}}");
+  Let!("\\restartappendixnumbering", "\\apptablenumbers");
 
   // 2.12 Equations
   DefMacro!("\\mathletters", "\\lx@equationgroup@subnumbering@begin");


### PR DESCRIPTION
Wave-2 landables from the sandbox-arxiv-2605/2606 `oxidized_tex_to_html` corpus triage. Each is a genuine Rust-only gap or a faithful-parity stub; the dominant error population there is faithful Perl parity and stays as-is (recorded in `docs/SYNC_STATUS.md`).

## Commits

1. **lipics/IEEEtaes require cleveref** — the class stubs now `\RequirePackage` cleveref (lipics with `capitalise,noabbrev`; ieeetaes with `capitalize`) so `\cref`/`\Cref` resolve, matching what the real classes pull in.
2. **docs: SYNC_STATUS 2605/2606 corpus-triage deferred items** — records the remaining clusters (sn-jnl booktabs drop, OmniBus frontmatter vocab, etc.) and the fleet-memory-pressure finding.
3. **AASTeX `{contribution}`/`\restartappendixnumbering`** (beyond-Perl) — binds `\contribution`→acknowledgements, `\watermark` gobble, `\apptablenumbers`/`\restartappendixnumbering`. Wave-2 tests refactored to the in-process convert API (no `Command::new`).
4. **subdir package name is a path — drop directory strip in dispatch + `find_file_fallback`** — a paper-local `\usepackage{subdir/<name>}` whose basename collided with a bound CTAN package (e.g. `utils/mathenv` → the `mathenv` binding, a no-op) had its directory stripped at two sites, so the binding shadowed the local file and its cleveref/theorem defs never loaded. Perl never strips a directory (`Package.pm:2191` strips version suffixes only). Both strips dropped; the retired `BasenameOnly` convenience (subdir copies of KNOWN packages: 2105.02087 `misc/ieeetran`, 2405.18387 `assets/equations`) falls to OmniBus/raw-load like Perl. `\documentclass{Definitions/mdpi}` OmniBuses like Perl; the `localrawstyles`/INCLUDE_CLASSES config, not this dispatch, governs whether a local file raw-loads.

## Guards

`cluster_package_guards.rs::subdir_dispatch_no_strip` (RED before the drop, GREEN after): a subdir `.sty` raw-loads its local def, a subdir `.cls` stays OmniBus under INCLUDE_CLASSES-off — both driven through `convert_to_xml_ar5iv` (the real `cortex_worker --preload=ar5iv.sty` config). Plus the wave-2 cleveref/AASTeX in-process tests. Full suite green; clippy + rustdoc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
