### PR TITLE
fix #723: keep ~ and ^ ASCII in verbatim contexts under T1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+  - **`~` and `^` stay ASCII in verbatim under T1 font encoding.** A `\verb`, the
+    `verbatim` environment, or a `Verbatim`/`HyperVerbatim` argument (`\url`,
+    `\href`, a Rhai binding's verbatim arg) containing `~`/`^` under
+    `\usepackage[T1]{fontenc}` decoded to the accent glyphs U+02DC/U+02C6 — e.g. a
+    `.../~user` URL broke. Verbatim contexts now select an identity ASCII fontmap
+    for their run (keeping the typewriter styling), so `~`/`^` stay literal, while
+    the T1 fontmap — where those slots are Bruce Miller's deliberate accents
+    (LaTeXML #2435) — is untouched for normal text. A new `tools/fontmap_drift.py`
+    checks our fontmaps against pdftex's `glyphtounicode` golden. Surpasses Perl
+    (verbatim loses ASCII there too); OXIDIZED_DESIGN #143, #723.
   - **Pandoc relative-width table columns no longer collapse to a "river of
     characters".** A `p{(\columnwidth - N\tabcolsep) * \real{X}}` column — the width
     format Pandoc emits by default — is a `calc` infix expression the base dimension

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -5351,3 +5351,51 @@ columns. Rust `(\columnwidth - 4\tabcolsep) * \real{0.30}` now measures 96.3pt (
 **Guards**: `06_cluster_regressions::cluster_pandoc_calc_colwidth_6909` — a two-column
 `p{…*\real{0.30}}` / `p{…*\real{0.70}}` table has no `width="0.0pt"` and carries the expected
 proportional 96.3pt / 224.7pt.
+
+### 143. Verbatim contexts keep `~`/`^` ASCII under T1 (the fontmap accent stays for normal text)
+
+**Background.** LaTeXML's `t1.fontmap` (and `t2a`/`t2b`/`t2c`) *deliberately* map slot 126 (`~`)
+to `U+02DC` SMALL TILDE and slot 94 (`^`) to `U+02C6` MODIFIER LETTER CIRCUMFLEX — Bruce Miller,
+commit `9ec6a4122` "Encodings (#2435)", 2024-11-20: "^ and ~ which should be accents". We KEEP
+that mapping. Those slots are reached only by a *literal catcode-12* `~`/`^`: in normal text `~`
+is active and `^` is superscript, and `\textasciitilde`/`\textasciicircum` emit ASCII U+007E/U+005E
+directly (not via the slot). The one place the slot is hit is a **verbatim** context — `\verb`,
+the `verbatim` environment, a `Verbatim`/`HyperVerbatim` argument (incl. `\url`/`\href` and a Rhai
+binding's verbatim arg) — where the intent is the *literal* character, so a `.../~user` URL must
+stay ASCII (the reporter's Rhai `HyperVerbatim` URL came out `˜`, breaking the link).
+
+**Perl behavior**: a verbatim/URL `~`/`^` under T1 font-decodes through the fontmap to the accent
+glyphs `U+02DC`/`U+02C6` (SHARED-FAILURE — Perl does the same). Only `Semiverbatim` escaped,
+because it swaps to the identity `"ASCII"` fontmap for the whole read+digest — hence #723's
+"Semiverbatim is fine, HyperVerbatim is not".
+**Rust behavior**: every verbatim context now selects the identity `"ASCII"` fontmap for its run,
+so `~`/`^` (and `` ` ``/`'`) stay ASCII, while the fontmap itself is untouched — normal T1 text
+still follows Bruce. Three sites, all leaving the `typewriter` family intact (styling unchanged):
+`Verbatim`/`HyperVerbatim` add `MergeFont(encoding => "ASCII")` in `before_digest`
+(`base_parameter_types.rs`, mirroring how `Semiverbatim`'s descriptor re-runs `begin_semiverbatim`
+at digest time); `\verbatim@font` gains `\fontencoding{ASCII}` (`latex_constructs.rs`, covers the
+`verbatim` environment); and `\@internal@{text,math}@verb`'s `font` clause gains `encoding =>
+"ASCII"` (covers `\verb`).
+
+**Why**: verbatim wants the literal input character; the T1 slot's accent shape is right only for
+the accent-command contexts (a standalone `\^{}`/`\~{}`) that Bruce was protecting, which do not
+take the verbatim path. Scoping ASCII to verbatim reconciles both, and matches what pdflatex
+extracts (a verbatim `~`/`^` under T1 → ASCII U+007E/U+005E, verified via pdftotext and via the
+pdftex golden `ec.enc ∘ glyphtounicode.tex`).
+
+**Fontmap drift tooling**: `tools/fontmap_drift.py` recomputes that pdftex golden for each shipped
+text encoding and fails on un-allowlisted drift. Slots 94/126 are allowlisted there **as Bruce's
+intentional accent choice** (with the `#2435` reason), documenting exactly why our fontmap differs
+from `glyphtounicode` — alongside slot 127 (line-break hyphen `U+2010`) and T2 slots 14/15
+(Cyrillic angle quotes `‹›`).
+
+**Witnesses**: issue #723 (reporter xworld21) — a Rhai `HyperVerbatim` URL argument under T1 whose
+`~` became `U+02DC`. MWE: `\usepackage[T1]{fontenc}` + `\verb|a~b^c|` → `a~b^c`.
+
+**Upstream**: worth filing against `brucemiller/LaTeXML` (verbatim loses ASCII there too, and Bruce
+can weigh the verbatim-vs-accent split).
+
+**Guards**: `06_cluster_regressions::cluster_t1_hyperverbatim_ascii_723` (the reported Rhai
+`HyperVerbatim` URL, ASCII, via a subprocess so the runtime binding loads);
+`cluster_t1_verbatim_ascii_723` (`\verb` + `verbatim` env stay ASCII AND keep `font="typewriter"`);
+`tools/fontmap_drift.py` (the fontmap values, with 94/126 allowlisted as Bruce's accents).

--- a/latexml_engine/src/base_parameter_types.rs
+++ b/latexml_engine/src/base_parameter_types.rs
@@ -453,7 +453,6 @@ LoadDefinitions!({
   );
 
   // Be careful here: if % appears before the initial {, it's still a comment!
-  // Also, note that non-typewriter fonts will mess up some chars on digestion!
   DefParameterType!(Verbatim, sub[_inner, _extra] {
       read_until(&Tokens!(T_BEGIN!()))?;
     begin_semiverbatim(Some(&['%', '\\']));
@@ -464,6 +463,16 @@ LoadDefinitions!({
     before_digest => {
       bgroup();
       MergeFont!(family => "typewriter");
+      // Surpass Perl (OXIDIZED_DESIGN #143, issue #723): keep the identity ASCII
+      // fontmap live THROUGH digestion, not just during the read. `begin_semiverbatim`
+      // sets it, but `end_semiverbatim` pops it before the argument digests, so under
+      // a non-default encoding (e.g. T1, where slots 94/126 are Bruce's accent glyphs
+      // U+02C6/U+02DC — commit 9ec6a4122 #2435) a verbatim `~`/`^` decoded to those
+      // non-ASCII chars (a `.../~user` URL broke). `Semiverbatim` stays ASCII because
+      // its descriptor re-runs `begin_semiverbatim` at digest time; do the same here by
+      // merging `encoding => "ASCII"` for the digestion group. Perl's Verbatim loses
+      // ASCII the same way (SHARED-FAILURE); Bruce's fontmap is unchanged.
+      MergeFont!(encoding => "ASCII");
     },
     after_digest => {
       egroup()?;
@@ -524,7 +533,11 @@ LoadDefinitions!({
     },
     before_digest => {
       bgroup();
-      MergeFont!(family => "typewriter"); },
+      MergeFont!(family => "typewriter");
+      // Keep ASCII live through digestion — see Verbatim above (OXIDIZED_DESIGN
+      // #143, issue #723): this is exactly the reported case, a HyperVerbatim URL
+      // argument whose `~` decoded to U+02DC under T1.
+      MergeFont!(encoding => "ASCII"); },
     after_digest => {
       egroup()?; },
     reversion => sub[arg, _inner, _extra] {

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -6014,15 +6014,19 @@ LoadDefinitions!({
     "\\@internal@verb{}{}{}",
     r"\ifmmode\@internal@math@verb{#1}{#2}{#3}\else\@internal@text@verb{#1}{#2}{#3}\fi"
   );
+  // `encoding => "ASCII"` (OXIDIZED_DESIGN #143, issue #723): `\verb`'s body is
+  // literal catcode-12 text, so under T1 a `~`/`^` would decode to Bruce Miller's
+  // accent glyphs U+02DC/U+02C6 (#2435). Verbatim wants them ASCII; the identity
+  // `ASCII` fontmap keeps `~`/`^` literal while `typewriter` still styles the run.
   DefConstructor!("\\@internal@math@verb{} Undigested {}",
     "<ltx:XMTok font='#font'>#3</ltx:XMTok>",
     mode      => "text",
     enter_horizontal => true,
-    font      => { family => "typewriter", series => "medium", shape => "upright" },
+    font      => { family => "typewriter", series => "medium", shape => "upright", encoding => "ASCII" },
     reversion => "\\verb#1#2#3#2");
   DefConstructor!("\\@internal@text@verb{} Undigested {}",
     "<ltx:verbatim font='#font'>#3</ltx:verbatim>",
-    font            => { family => "typewriter", series => "medium", shape => "upright" },
+    font            => { family => "typewriter", series => "medium", shape => "upright", encoding => "ASCII" },
     enter_horizontal => true,
     before_construct => sub[doc,_whatsit] {
       if !document::can_contain(doc.get_element().as_ref().unwrap(), "#PCDATA") {
@@ -10706,9 +10710,16 @@ LoadDefinitions!({
     "\\normalfont",
     "\\fontfamily{\\rmdefault}\\fontseries{\\mddefault}\\fontshape{\\updefault}\\selectfont"
   );
+  // `\fontencoding{ASCII}` (OXIDIZED_DESIGN #143, issue #723): a verbatim `~`/`^`
+  // is a literal catcode-12 char, so under T1 it decodes through the fontmap to
+  // Bruce Miller's deliberate accent glyphs U+02DC/U+02C6 (LaTeXML #2435). In a
+  // verbatim/URL those must stay ASCII. Selecting the identity `ASCII` fontmap for
+  // the verbatim font (grouped, so it reverts after) keeps `~`/`^` ASCII while the
+  // `\ttdefault` family still drives the typewriter styling — the same treatment
+  // `Verbatim`/`HyperVerbatim` apply at digest time. Perl loses ASCII here too.
   DefMacro!(
     "\\verbatim@font",
-    "\\fontfamily{\\ttdefault}\\fontseries{\\mddefault}\\fontshape{\\updefault}\\selectfont"
+    "\\fontencoding{ASCII}\\fontfamily{\\ttdefault}\\fontseries{\\mddefault}\\fontshape{\\updefault}\\selectfont"
   );
 
   Let!("\\reset@font", "\\normalfont");

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -146,6 +146,67 @@ fn cluster_pandoc_calc_colwidth_6909() {
      (30%/70% of 321pt):\n{xml}"
   );
 }
+/// Issue #723 (reporter xworld21): a Rhai binding's `HyperVerbatim` argument
+/// under T1 fontencoding produced non-ASCII `~`/`^`, breaking URLs. The T1
+/// fontmap deliberately maps slots 94/126 to accent glyphs U+02C6/U+02DC (Bruce
+/// Miller, LaTeXML #2435) — we keep that. Instead, `Verbatim`/`HyperVerbatim`
+/// now hold an identity ASCII fontmap THROUGH digestion (a `before_digest`
+/// `MergeFont(encoding => "ASCII")`, mirroring `Semiverbatim`), so a verbatim/URL
+/// argument stays ASCII while normal T1 text still follows Bruce's mapping.
+/// Surpasses Perl (which loses ASCII the same way). OXIDIZED_DESIGN #143.
+/// Driven by the binary so the runtime Rhai binding loads (the reported path).
+#[test]
+fn cluster_t1_hyperverbatim_ascii_723() {
+  use std::process::Command;
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+  let dir = tempfile::tempdir().expect("tempdir");
+  std::fs::write(
+    dir.path().join("myhyper.sty.rhai"),
+    "DefConstructor(\"\\\\myhyper HyperVerbatim\", \"<ltx:ref class=\\\"myhyper\\\" href=\\\"#1\\\">#1</ltx:ref>\");\n",
+  )
+  .expect("write rhai");
+  std::fs::write(
+    dir.path().join("m.tex"),
+    "\\documentclass{article}\n\\usepackage[T1]{fontenc}\n\\usepackage{myhyper}\n\
+     \\begin{document}\n\\myhyper{http://x/a~b^c}\n\\end{document}\n",
+  )
+  .expect("write m.tex");
+  let out = Command::new(bin)
+    .args(["m.tex", "--dest", "m.xml", "--nocomments"])
+    .current_dir(dir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+  let xml = std::fs::read_to_string(dir.path().join("m.xml")).unwrap_or_default();
+  // Canary: the HyperVerbatim `~`/`^` (href AND text) must be ASCII, not U+02DC/U+02C6.
+  assert!(
+    out.status.success()
+      && xml.contains("http://x/a~b^c")
+      && !xml.contains('\u{02DC}')
+      && !xml.contains('\u{02C6}'),
+    "T1 HyperVerbatim `~`/`^` not ASCII (#723):\n{xml}"
+  );
+}
+/// Issue #723, extended scope: the same rule applies to `\verb` and the
+/// `verbatim` environment (they select the identity ASCII fontmap for their run
+/// while keeping the typewriter family). `~`/`^` stay ASCII, not Bruce's accent
+/// glyphs. OXIDIZED_DESIGN #143.
+#[test]
+fn cluster_t1_verbatim_ascii_723() {
+  let xml = convert_to_xml("tests/cluster_regressions/t1_ascii_tilde_circumflex_723.tex");
+  // \verb|a~b^c| and the verbatim env `d~e^f` — both ASCII, both typewriter.
+  assert!(
+    xml.contains("a~b^c") && xml.contains("d~e^f"),
+    "T1 \\verb / verbatim env did not keep `~`/`^` ASCII (#723):\n{xml}"
+  );
+  assert!(
+    !xml.contains('\u{02DC}') && !xml.contains('\u{02C6}'),
+    "T1 verbatim still emits accent U+02DC/U+02C6 for a literal `~`/`^` (#723):\n{xml}"
+  );
+  assert!(
+    xml.matches(r#"font="typewriter""#).count() >= 2,
+    "verbatim runs lost the typewriter family (#723 — encoding must not clobber font):\n{xml}"
+  );
+}
 #[test]
 fn cluster_fvextra_preserves_ltx_verbatim() {
   let xml = convert_to_xml("tests/cluster_regressions/fvextra_ltx_verbatim.tex");

--- a/latexml_oxide/tests/cluster_regressions/t1_ascii_tilde_circumflex_723.tex
+++ b/latexml_oxide/tests/cluster_regressions/t1_ascii_tilde_circumflex_723.tex
@@ -1,0 +1,15 @@
+\documentclass{article}
+% Issue #723 (reporter xworld21): under T1 fontencoding a literal `~`/`^` decodes
+% through the fontmap to Bruce Miller's accent glyphs U+02DC/U+02C6 (LaTeXML
+% #2435 — kept). In a verbatim context those must stay ASCII, so \verb and the
+% verbatim environment now select the identity ASCII fontmap (keeping the
+% typewriter family). Guards \verb and the verbatim env; the reported Rhai
+% HyperVerbatim path has its own subprocess guard (cluster_t1_hyperverbatim_ascii_723).
+\usepackage[T1]{fontenc}
+\begin{document}
+\verb|a~b^c|
+
+\begin{verbatim}
+d~e^f
+\end{verbatim}
+\end{document}

--- a/latexml_oxide/tests/contrib/cprotect.xml
+++ b/latexml_oxide/tests/contrib/cprotect.xml
@@ -11,7 +11,7 @@
       <tag role="refnum">1</tag>
       <tag role="typerefnum">§1</tag>
     </tags>
-    <title><tag close=" ">1</tag><verbatim font="typewriter">What’s wrong in the \tensor command?</verbatim></title>
+    <title><tag close=" ">1</tag><verbatim font="typewriter">What's wrong in the \tensor command?</verbatim></title>
     <para xml:id="S1.p1">
       <p>Text.<note mark="1" role="footnote" xml:id="footnote1"><tags>
             <tag>1</tag>

--- a/tools/fontmap_drift.py
+++ b/tools/fontmap_drift.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Report where our embedded font-encoding maps drift from pdftex's own golden.
+
+WHY THIS EXISTS
+---------------
+Each `*_fontmap.rs` maps a TeX font-encoding slot (0..255) to the Unicode
+character LaTeXML emits for it. The authoritative "what does pdflatex put in the
+PDF's ToUnicode for this slot" is a COMPOSITION of two files pdftex itself uses:
+
+    slot --(<enc>.enc)--> glyph name --(glyphtounicode.tex)--> Unicode
+
+Both live in the TeX tree and are found with kpsewhich; the composition is
+authoritative *by construction* -- it is the exact data pdftex embeds, which is
+what pdftotext reads back. This tool composes that golden for each text encoding
+we ship and prints every slot where our fontmap differs.
+
+This is a TRIPWIRE, not an oracle. LaTeXML fontmaps sometimes diverge from the
+glyph's ToUnicode DELIBERATELY (a slot's semantic character vs its glyph shape,
+visible-space markers, ligature slots). Such intentional divergences are listed
+in ALLOWLIST below with a reason; everything else is reported for human review.
+Only TEXT encodings with standard AGL glyph names can be checked -- symbol fonts
+(amsa, ding, pzd, ifsym*, lcircle, line) have no such .enc and are skipped.
+
+Usage:  python3 tools/fontmap_drift.py [--all]
+        (--all also prints allowlisted, intentional divergences)
+Exit:   0 = no un-allowlisted drift; 1 = an unreviewed drift appeared.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG = REPO_ROOT / "latexml_package" / "src" / "package"
+
+# fontmap name (the DeclareFontMap! key, lowercased) -> the .enc kpsewhich resolves.
+# Only text encodings with AGL glyph names; symbol fonts are intentionally absent.
+FONTMAP_ENC = {
+    "t1":  "ec.enc",
+    "t2a": "t2a.enc",
+    "t2b": "t2b.enc",
+    "t2c": "t2c.enc",
+    # Deferred — validated to MIS-align against the named .enc, so every slot
+    # would report as false drift. Re-enable once the correct .enc (or the
+    # fontmap's true low-slot layout) is confirmed:
+    #   "ly1": "texnansi.enc"  — ly1_fontmap low slots (accents/ligatures) do
+    #     not match texnansi.enc's (Euro/fraction/…): systematic +11 offset.
+    #   "ts1": "tc.enc", "lgr": "lgr.enc", "ot4": "ot4.enc"  — .enc not resolved
+    #     by kpsewhich in the ambient tree.
+}
+
+# Intentional divergences: (fontmap, slot) -> reason. A slot listed here is NOT
+# reported unless --all. Keep in sync with a human decision; cite it.
+ALLOWLIST = {
+    # slots 94 (^) and 126 (~): Bruce Miller deliberately maps these to the
+    # ACCENT characters U+02C6/U+02DC, not ASCII U+005E/U+007E — LaTeXML commit
+    # 9ec6a4122 "Encodings (#2435)" (2024-11-20): "^ and ~ which should be
+    # accents". We keep that fontmap value; ASCII in verbatim/URL contexts is
+    # instead handled at the parameter level (Verbatim/HyperVerbatim install an
+    # identity ASCII fontmap through digestion — see base_parameter_types.rs,
+    # OXIDIZED_DESIGN #143). glyphtounicode maps asciicircum/asciitilde to ASCII.
+    ("t1", 94): "Bruce #2435: ^ mapped as accent U+02C6, not ASCII",
+    ("t1", 126): "Bruce #2435: ~ mapped as accent U+02DC, not ASCII",
+    ("t2a", 94): "Bruce #2435: ^ mapped as accent U+02C6, not ASCII",
+    ("t2a", 126): "Bruce #2435: ~ mapped as accent U+02DC, not ASCII",
+    ("t2b", 94): "Bruce #2435: ^ mapped as accent U+02C6, not ASCII",
+    ("t2b", 126): "Bruce #2435: ~ mapped as accent U+02DC, not ASCII",
+    ("t2c", 94): "Bruce #2435: ^ mapped as accent U+02C6, not ASCII",
+    ("t2c", 126): "Bruce #2435: ~ mapped as accent U+02DC, not ASCII",
+    # Deliberate LaTeXML choices (all shared with Perl LaTeXML), NOT bugs:
+    # slot 127 is the line-break hyphen char (\-); U+2010 is the typographic
+    # HYPHEN, kept distinct from slot 45's ASCII U+002D. glyphtounicode maps
+    # both glyphs to U+002D.
+    ("t1", 127): "line-break hyphen → U+2010 (typographic), distinct from slot 45",
+    ("t2a", 127): "line-break hyphen → U+2010 (typographic), distinct from slot 45",
+    ("t2b", 127): "line-break hyphen → U+2010 (typographic), distinct from slot 45",
+    ("t2c", 127): "line-break hyphen → U+2010 (typographic), distinct from slot 45",
+    # T2 Cyrillic slots 14/15 hold single angle quotes; ‹›/U+2039-203A are the
+    # correct quotation glyphs, vs glyphtounicode's deprecated CJK 〈〉 U+2329-232A.
+    ("t2a", 14): "Cyrillic single angle quote ‹ (U+2039), not CJK 〈",
+    ("t2a", 15): "Cyrillic single angle quote › (U+203A), not CJK 〉",
+    ("t2b", 14): "Cyrillic single angle quote ‹ (U+2039), not CJK 〈",
+    ("t2b", 15): "Cyrillic single angle quote › (U+203A), not CJK 〉",
+    ("t2c", 14): "Cyrillic single angle quote ‹ (U+2039), not CJK 〈",
+    ("t2c", 15): "Cyrillic single angle quote › (U+203A), not CJK 〉",
+}
+
+
+def sh(*args):
+    return subprocess.run(args, capture_output=True, text=True).stdout.strip()
+
+
+def load_glyphtounicode():
+    """glyph name -> codepoint, from pdftex's own table."""
+    path = sh("kpsewhich", "glyphtounicode.tex")
+    if not path:
+        sys.exit("FATAL: glyphtounicode.tex not found (is pdftex installed?)")
+    table = {}
+    for m in re.finditer(r"\\pdfglyphtounicode\{([^}]+)\}\{([0-9A-Fa-f]+)\}", Path(path).read_text()):
+        table[m.group(1)] = int(m.group(2), 16)
+    return table
+
+
+def glyph_to_cp(name, g2u):
+    """Resolve a glyph name to a codepoint: pdftex table, then uniXXXX, else None."""
+    if name in g2u:
+        return g2u[name]
+    m = re.fullmatch(r"uni([0-9A-Fa-f]{4})", name)
+    if m:
+        return int(m.group(1), 16)
+    m = re.fullmatch(r"u([0-9A-Fa-f]{4,6})", name)
+    if m:
+        return int(m.group(1), 16)
+    return None  # .notdef / unknown -> no golden
+
+
+def parse_enc(enc_path):
+    """.enc (dvips PostScript) -> list of 256 glyph names in slot order."""
+    text = Path(enc_path).read_text()
+    # Strip PostScript % comments, then take the tokens inside the [...] array.
+    text = re.sub(r"%[^\n]*", "", text)
+    m = re.search(r"\[(.*)\]", text, re.DOTALL)
+    if not m:
+        return None
+    names = re.findall(r"/([A-Za-z0-9._]+)", m.group(1))
+    return names if len(names) >= 256 else names + [".notdef"] * (256 - len(names))
+
+
+_CHAR_RE = re.compile(r"'(\\u\{([0-9A-Fa-f]+)\}|\\(.)|([^'\\]))'")
+
+
+def parse_fontmap(rs_path):
+    """*_fontmap.rs -> (name, [256 codepoints]). None if not a DeclareFontMap."""
+    text = rs_path.read_text()
+    m = re.search(r'DeclareFontMap!\("([^"]+)",\s*mixrc!\[(.*?)\]\s*\)', text, re.DOTALL)
+    if not m:
+        return None
+    name = m.group(1)
+    cps = []
+    for lit in _CHAR_RE.finditer(m.group(2)):
+        if lit.group(2):        # \u{XXXX}
+            cps.append(int(lit.group(2), 16))
+        elif lit.group(3):      # \\ , \' , \" , etc.
+            cps.append(ord({"n": "\n", "t": "\t", "r": "\r", "0": "\0"}.get(lit.group(3), lit.group(3))))
+        else:                   # bare char
+            cps.append(ord(lit.group(4)))
+    return (name, cps)
+
+
+def main():
+    show_all = "--all" in sys.argv
+    g2u = load_glyphtounicode()
+    total_drift = 0
+    checked = 0
+    for rs in sorted(PKG.glob("*_fontmap.rs")):
+        parsed = parse_fontmap(rs)
+        if not parsed:
+            continue
+        name, cps = parsed
+        enc_name = FONTMAP_ENC.get(name.lower())
+        if not enc_name:
+            continue  # symbol font / unmapped -> out of scope for this pipeline
+        enc_path = sh("kpsewhich", enc_name)
+        if not enc_path:
+            print(f"SKIP {name}: {enc_name} not found in TeX tree")
+            continue
+        glyphs = parse_enc(enc_path)
+        if not glyphs:
+            print(f"SKIP {name}: could not parse {enc_name}")
+            continue
+        checked += 1
+        drifts = []
+        for slot in range(min(256, len(cps))):
+            golden = glyph_to_cp(glyphs[slot], g2u)
+            if golden is None:
+                continue  # no authoritative golden for this glyph
+            if cps[slot] != golden:
+                allow = (name.lower(), slot) in ALLOWLIST
+                if allow and not show_all:
+                    continue
+                drifts.append((slot, glyphs[slot], cps[slot], golden, allow))
+        if drifts:
+            print(f"\n== {name} ({rs.name} vs {enc_name}) ==")
+            for slot, glyph, ours, golden, allow in drifts:
+                tag = "  [allowlisted]" if allow else ""
+                print(f"  slot {slot:3d} 0x{slot:02X} /{glyph:<16} ours U+{ours:04X} '{chr(ours)}'  "
+                      f"golden U+{golden:04X} '{chr(golden)}'{tag}")
+                if not allow:
+                    total_drift += 1
+    print(f"\n-- checked {checked} text encoding(s); {total_drift} un-allowlisted drift slot(s) --")
+    return 1 if total_drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -171,5 +171,19 @@ if require_or_skip cargo-machete "cargo-machete (unused dependencies)" \
     cargo machete
 fi
 
+# 8. Font-encoding fontmap drift vs pdftex's own golden (<enc>.enc ∘
+#    glyphtounicode.tex). Needs the host TeX tree (kpsewhich + the .enc /
+#    glyphtounicode.tex files), so it skips where those are absent — e.g. the
+#    CI `lint` job, which installs no texlive. It runs for developers with a full
+#    TL and on the pre-push hook; the per-slot conversion guard
+#    (cluster_t1_ascii_tilde_circumflex_723) is the CI-side regression net.
+if command -v kpsewhich >/dev/null 2>&1 && [ -n "$(kpsewhich glyphtounicode.tex 2>/dev/null)" ]; then
+  run "fontmap drift (vs pdftex glyphtounicode golden)" \
+    "a text-encoding fontmap slot drifted from <enc>.enc ∘ glyphtounicode.tex; fix the value or allowlist it with a reason in tools/fontmap_drift.py" -- \
+    python3 tools/fontmap_drift.py
+else
+  skip "fontmap drift" "no TeX tree (kpsewhich/glyphtounicode.tex absent); the T1 conversion guard covers CI"
+fi
+
 summarize
 [ ${#failed[@]} -eq 0 ]


### PR DESCRIPTION
**Diagnostic.** Under `\usepackage[T1]{fontenc}`, a literal catcode-12 `~`/`^` (in `\verb`, the `verbatim` environment, or a `Verbatim`/`HyperVerbatim` argument — `\url`, `\href`, a Rhai binding's verbatim arg) font-decoded through the T1 fontmap to the accent glyphs U+02DC/U+02C6, so a `.../~user` URL broke. Those slots map to accents **deliberately** — Bruce Miller, LaTeXML #2435 ("^ and ~ which should be accents") — so the fontmap is *not* the thing to change.

**Approach.** Scope the fix to verbatim contexts, where the intent is the literal character: each now selects the identity ASCII fontmap for its run (keeping the `typewriter` family) — `Verbatim`/`HyperVerbatim` via `MergeFont(encoding => "ASCII")` in `before_digest` (mirroring `Semiverbatim`), `\verbatim@font` via `\fontencoding{ASCII}`, `\verb` via its `font` clause. The fontmap is untouched, so normal T1 text still follows Bruce. Surpass-Perl (verbatim loses ASCII there too); OXIDIZED_DESIGN #143. Note this also makes verbatim `` ` ``/`'` literal ASCII (consistent with `Semiverbatim`) — one existing golden (`cprotect`) re-blessed.

**Tooling.** New `tools/fontmap_drift.py` checks each shipped text-encoding fontmap against pdftex's own golden (`<enc>.enc ∘ glyphtounicode.tex`); slots 94/126 are allowlisted there **as Bruce's intentional accents**, documenting why we differ from `glyphtounicode`. Wired into `tools/lint.sh` (skips where no TeX tree).

**Validation.** `cluster_t1_hyperverbatim_ascii_723` (reported Rhai path, subprocess); `cluster_t1_verbatim_ascii_723` (`\verb` + `verbatim` env stay ASCII and keep `font="typewriter"`); full suite 2127/0; clippy/fmt/lint (drift check green). The reporter's Rhai `HyperVerbatim` URL is now fully ASCII.

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)