### PR TITLE
chore(ci): make asan + macOS lanes robust against two recurring flakes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -209,7 +209,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libxml2-dev libxml2-utils libxslt1-dev libkpathsea-dev libkpathsea6 \
-            texlive texlive-latex-extra texlive-science
+            texlive texlive-latex-extra texlive-science mold
+          # `mold` is REQUIRED even though the ASAN test step drops it: the
+          # `make formats` build below inherits `.cargo/config.toml`'s
+          # `-C link-arg=-fuse-ld=mold` (gated to x86_64-linux), and it runs only
+          # on a COLD dump cache — i.e. exactly when a PR touches the engine. With
+          # mold absent, collect2 could find neither `ld.mold` nor `ld` and every
+          # such PR failed here with `cannot find 'ld'`. The other Linux jobs
+          # already install it; the asan job had been the lone omission.
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2

--- a/latexml_oxide/tests/111_build_memory_guard.rs
+++ b/latexml_oxide/tests/111_build_memory_guard.rs
@@ -44,6 +44,13 @@ fn corpus() -> String {
 /// its own no-recover policy).
 const BUILD_CUT: &str = "build stopped early";
 
+// Skipped on macOS CI: the sweep drives peak RSS toward a 7.2 GB ceiling (the
+// last ceiling below), but GitHub's macOS runners have only ~7 GB, so those
+// runs can never reach the budget — they just keep building the huge document
+// until nextest's terminate-after kills the shard (a recurring ~20 min timeout,
+// not a real failure). The guard's behaviour is platform-independent and fully
+// exercised on the Linux runners, which have the RAM to hit every ceiling.
+#[cfg_attr(target_os = "macos", ignore = "needs >7GB RAM; covered on Linux CI")]
 #[test]
 fn over_budget_build_degrades_gracefully_instead_of_being_killed() {
   let bin = env!("CARGO_BIN_EXE_latexml_oxide");


### PR DESCRIPTION
**Two infra-only flakes reddened nearly every PR:**

- **asan `cannot find 'ld'`** — the asan job never installed `mold`, yet its `make formats` build inherits `.cargo/config.toml`'s `-fuse-ld=mold` (x86_64-linux). That build runs only on a **cold dump cache** — i.e. exactly when a PR touches the engine — so `collect2` found neither `ld.mold` nor `ld`. Fix: install `mold` in the asan job (the other Linux jobs already do).
- **macOS shard timeout** — `over_budget_build_degrades_gracefully_instead_of_being_killed` sweeps peak RSS toward a 7.2 GB ceiling, but macOS runners have ~7 GB, so the high-ceiling runs never hit the budget and build until nextest's terminate kills the shard (~20 min). Skip it on macOS; the guard is platform-independent and fully exercised on Linux.

No product code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)