### PR TITLE
fix: aliascnt theorem counters get xml:id so labels/refs resolve to the theorem

### DIFF
--- a/latexml_contrib/src/aliascnt_sty.rs
+++ b/latexml_contrib/src/aliascnt_sty.rs
@@ -1,5 +1,53 @@
+use latexml_core::state::{assign_mapping, with_mapping};
 use latexml_package::prelude::*;
 
 LoadDefinitions!({
   InputDefinitions!("aliascnt", noltxml => true, extension => Some(Cow::Borrowed("sty")));
+
+  // aliascnt.sty (`\newaliascnt{A}{B}`) `\let`-aliases the standard LaTeX counter
+  // machinery from B onto A: `\c@A`, `\theA`, `\theHA`, `\p@A`, `\cl@A`. That is
+  // everything real LaTeX needs. But LaTeXML additionally keys a counter's element
+  // `xml:id` off an internal `\the<ctr>@ID` macro (built by `NewCounter`,
+  // `Package.pm:695`), and aliascnt has no idea it exists — so an alias counter has
+  // no `@ID` route.
+  //
+  // The bite: `\newtheorem{lemma}[lemma]{Lemma}` where `lemma` is a `\newaliascnt`
+  // of `theorem`. `define_new_theorem` (latex_constructs.rs) only records
+  // `counter_for_type` when the shared-counter name differs from the theorem name
+  // (`[thm]` ≠ `lem`); here they coincide (`[lemma]` == `lemma`), so no mapping is
+  // set and it assumes `lemma` is a real LaTeXML counter with `\thelemma@ID`. It is
+  // not, so `RefStepCounter('lemma')` sees `has_id = false`, the theorem node gets
+  // NO `xml:id`, and `\label` inside it floats up to the nearest ancestor that
+  // already has an id (the enclosing section/subsection). Two lemmas then share the
+  // ancestor's ref number and both `\ref`s point at the wrong anchor.
+  //
+  // Fix: make the alias behave exactly like a normal shared-counter theorem
+  // (`\newtheorem{lem}[thm]{Lemma}`, which works because `define_new_theorem` sets
+  // `counter_for_type('lem') = 'thm'`). We map `counter_for_type(alias) => root`,
+  // where root is B's own root counter (following any alias chain via our already
+  // recorded mapping). Then `RefStepCounter(alias)` resolves through the root
+  // counter's real `\the<root>@ID`, and the theorem node gets an id in the same
+  // `Thm<root>` namespace as its sibling theorems — id, labels, and refs all land
+  // on the theorem. arXiv witness: 2605.20695 (html_feedback#6560), "Proof of
+  // Lemma 2.1" / "Proof of Lemma 2.2" (aliascnt lemmas under amsart).
+  DefPrimitive!("\\lx@aliascnt@register@id{}{}", sub[(alias, base)] {
+    let alias_s = alias.to_string();
+    let base_s = base.to_string();
+    // Only patch a successfully-created alias (aliascnt `\gdef`s `\AC@cnt@A`
+    // exactly when the alias is defined; a name clash leaves it undefined).
+    if is_defined(&s!("\\AC@cnt@{alias_s}")) {
+      // Follow the chain to the root: if B is itself an alias we already recorded
+      // its root under counter_for_type; otherwise B is the root.
+      let root = with_mapping("counter_for_type", &base_s, |m| m.map(ToString::to_string))
+        .unwrap_or(base_s);
+      assign_mapping("counter_for_type", &alias_s, Some(root));
+    }
+  });
+
+  RawTeX!(r"\let\lx@saved@newaliascnt\newaliascnt");
+  RawTeX!(
+    r"\renewcommand*{\newaliascnt}[2]{%
+    \lx@saved@newaliascnt{#1}{#2}%
+    \lx@aliascnt@register@id{#1}{#2}}"
+  );
 });

--- a/latexml_oxide/tests/contrib/aliascnt.tex
+++ b/latexml_oxide/tests/contrib/aliascnt.tex
@@ -1,0 +1,28 @@
+\documentclass{article}
+\usepackage{amsthm}
+\usepackage{aliascnt}
+\newtheorem{theorem}{Theorem}[section]
+\newaliascnt{lemma}{theorem}
+\newtheorem{lemma}[lemma]{Lemma}
+\aliascntresetthe{lemma}
+% Chained alias: corollary -> lemma -> theorem (root). Guards root-following.
+\newaliascnt{corollary}{lemma}
+\newtheorem{corollary}[corollary]{Corollary}
+\aliascntresetthe{corollary}
+\begin{document}
+\section{First}
+\begin{theorem}\label{thm:a}
+First theorem.
+\end{theorem}
+\section{Second}
+\begin{lemma}\label{lem:a}
+First lemma.
+\end{lemma}
+\begin{lemma}\label{lem:b}
+Second lemma.
+\end{lemma}
+\begin{corollary}\label{cor:a}
+A corollary.
+\end{corollary}
+References: \ref{thm:a}, \ref{lem:a}, \ref{lem:b}, \ref{cor:a}.
+\end{document}

--- a/latexml_oxide/tests/contrib/aliascnt.xml
+++ b/latexml_oxide/tests/contrib/aliascnt.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article"?>
+<?latexml package="amsthm"?>
+<?latexml package="aliascnt"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <section inlist="toc" xml:id="S1">
+    <tags>
+      <tag>1</tag>
+      <tag role="refnum">1</tag>
+      <tag role="typerefnum">§1</tag>
+    </tags>
+    <title><tag close=" ">1</tag>First</title>
+    <theorem class="ltx_theorem_theorem" inlist="thm theorem:theorem" labels="LABEL:thm:a" xml:id="S1.Thmtheorem1">
+      <tags>
+        <tag>Theorem 1.1</tag>
+        <tag role="refnum">1.1</tag>
+        <tag role="typerefnum">Theorem 1.1</tag>
+      </tags>
+      <title class="ltx_runin"><tag><text font="bold">Theorem 1.1</text></tag><text font="bold">.</text></title>
+      <para xml:id="S1.Thmtheorem1.p1">
+        <p><text font="italic">First theorem.</text></p>
+      </para>
+    </theorem>
+  </section>
+  <section inlist="toc" xml:id="S2">
+    <tags>
+      <tag>2</tag>
+      <tag role="refnum">2</tag>
+      <tag role="typerefnum">§2</tag>
+    </tags>
+    <title><tag close=" ">2</tag>Second</title>
+    <theorem class="ltx_theorem_lemma" inlist="thm theorem:lemma" labels="LABEL:lem:a" xml:id="S2.Thmtheorem1">
+      <tags>
+        <tag>Lemma 2.1</tag>
+        <tag role="refnum">2.1</tag>
+        <tag role="typerefnum">Lemma 2.1</tag>
+      </tags>
+      <title class="ltx_runin"><tag><text font="bold">Lemma 2.1</text></tag><text font="bold">.</text></title>
+      <para xml:id="S2.Thmtheorem1.p1">
+        <p><text font="italic">First lemma.</text></p>
+      </para>
+    </theorem>
+    <theorem class="ltx_theorem_lemma" inlist="thm theorem:lemma" labels="LABEL:lem:b" xml:id="S2.Thmtheorem2">
+      <tags>
+        <tag>Lemma 2.2</tag>
+        <tag role="refnum">2.2</tag>
+        <tag role="typerefnum">Lemma 2.2</tag>
+      </tags>
+      <title class="ltx_runin"><tag><text font="bold">Lemma 2.2</text></tag><text font="bold">.</text></title>
+      <para xml:id="S2.Thmtheorem2.p1">
+        <p><text font="italic">Second lemma.</text></p>
+      </para>
+    </theorem>
+    <theorem class="ltx_theorem_corollary" inlist="thm theorem:corollary" labels="LABEL:cor:a" xml:id="S2.Thmtheorem3">
+      <tags>
+        <tag>Corollary 2.3</tag>
+        <tag role="refnum">2.3</tag>
+        <tag role="typerefnum">Corollary 2.3</tag>
+      </tags>
+      <title class="ltx_runin"><tag><text font="bold">Corollary 2.3</text></tag><text font="bold">.</text></title>
+      <para xml:id="S2.Thmtheorem3.p1">
+        <p><text font="italic">A corollary.</text></p>
+      </para>
+    </theorem>
+    <para xml:id="S2.p1">
+      <p>References: <ref labelref="LABEL:thm:a"/>, <ref labelref="LABEL:lem:a"/>, <ref labelref="LABEL:lem:b"/>, <ref labelref="LABEL:cor:a"/>.</p>
+    </para>
+  </section>
+</document>


### PR DESCRIPTION
**Diagnostic.** `\newaliascnt{lemma}{theorem}` + `\newtheorem{lemma}[lemma]{Lemma}` (amsthm + aliascnt) leaves the alias counter without LaTeXML's internal `\the<ctr>@ID` macro (only `NewCounter` defines it; aliascnt copies just `\c@`/`\the`/`\theH`/`\p@`). `RefStepCounter` then sees `has_id=false`, the lemma node gets no `xml:id`, and its `\label` floats up to the enclosing section/subsection — so several `\ref`s collapse onto one wrong anchor.

**Approach.** The aliascnt binding now wraps `\newaliascnt` to also set `counter_for_type(alias) => root` (following alias chains). The alias then behaves exactly like a normal shared-counter theorem (`\newtheorem{lem}[thm]{…}`), so the id lands in the root `Thm<root>` namespace and label/refs attach to the theorem itself.

**Validation.** Red→green guard `aliascnt_test` (`tests/contrib/aliascnt.{tex,xml}`, single + chained alias). Full suite 2135/2135; clippy `-D warnings` + fmt clean. Witness arXiv 2605.20695 (arXiv/html_feedback#6560) now converts with 0 errors and its two "Proof of Lemma" refs resolve to 2.1 / 2.2 (previously both 2.1) — verified with and without `--preload=ar5iv.sty`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)