### PR TITLE
fix: drop hand-typeset title that duplicates structured \title{} (arXiv/html_feedback#6924)

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -5529,3 +5529,38 @@ there for strict Rust↔ar5iv parity.
 **Guards**: `06_cluster_regressions::cluster_nicematrix_codebefore_6569` (the witness's first matrix:
 `ltx:XMArray` present, exactly 6 `backgroundcolor` cells at the nonzero entries, `thead` on the
 first-row/first-col labels, 0 errors, no `nicematrix-placeholder`).
+
+### 146. A hand-typeset title that duplicates the structured `\title{}` is dropped
+
+**Background.** LaTeXML's unified Frontmatter API captures `\title{}` into a semantic
+`<ltx:title>` the moment it is seen — independent of `\maketitle` (unlike LaTeX, where `\title{}`
+without `\maketitle` renders nothing), and the stylesheet renders that title as the visible
+document heading. When a paper *also* hand-typesets its title as ordinary body text — a leading
+centered display-font block, with `\title{}` set but `\maketitle` never called — the title appears
+twice: once from the structured frontmatter, once as the author's "ink". Witness arXiv 2608.10928
+(`\title{…}` + a `\begin{center}{\LARGE\bfseries …}` reproduction; no `\maketitle`).
+
+**Perl behavior**: SHARED — Perl LaTeXML emits the structured `<ltx:title>` from `\title{}` without
+`\maketitle` too, so it duplicates identically (verified on the witness). This is not a Rust-only
+bug; the divergence below is a deliberate surpass-Perl.
+
+**Rust behavior**: at frontmatter finalization (`\lx@frontmatter@fallback`, the no-`\maketitle`
+path), once the structured `<ltx:title>` is in the tree, `maybe_dedup_leading_title_ink`
+(`base_utilities.rs`) removes a **leading, non-sectional, centered, display-font** paragraph whose
+normalized text **exactly** reproduces the structured title. Structure wins over ink: the semantic
+`<ltx:title>` is kept; the redundant hand-typeset copy is dropped (empty wrappers pruned). It is the
+mirror of `maybe_promote_leading_title` (which, when *no* structured title exists, promotes such a
+block *into* the title) and reuses the same detection helpers.
+
+**Why it's safe / precise.** Fires only for `\title`-without-`\maketitle` papers (the `\maketitle`
+path disables the fallback), and only on a full normalized-text match against the structured title
+in a leading display-font centered block. A paper that sets `\title` but doesn't hand-typeset keeps
+its title; a leading centered block that *doesn't* match the title is left untouched; author/abstract
+"ink" (no structured counterpart) is preserved. Never removes a title the PDF actually shows —
+`\title{}` without `\maketitle` renders nothing in the PDF, so only the manual block was ever
+visible there.
+
+**Witnesses**: arXiv/html_feedback#6924 (witness arXiv 2608.10928).
+
+**Guards**: `06_cluster_regressions::cluster_frontmatter_title_ink_dedup_6924` (structured `<title>`
+kept, title text appears exactly once, hand-typeset author block preserved).

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -1353,6 +1353,9 @@ LoadDefinitions!({
       document.unwrap_nodes(wrapper)?;
       document.set_node(&savenode);
     }
+    // With the structured <ltx:title> now in the tree, drop a redundant leading
+    // hand-typeset copy of it (no \maketitle; #6924). Author/abstract ink stays.
+    maybe_dedup_leading_title_ink(document)?;
     }
   },
   after_digest => {
@@ -2372,6 +2375,93 @@ fn maybe_promote_leading_title(document: &mut Document) -> Result<()> {
   // Drop the now-empty paragraph, and any wrapper ancestor it leaves empty
   // (para → logical-block), so we don't strand empty blocks above the abstract.
   let mut victim = title_p;
+  loop {
+    let parent = victim.get_parent();
+    document.remove_node(victim);
+    match parent {
+      Some(p) if !has_element_child(&p) => {
+        let is_wrapper = with(document::get_node_qname(&p), |name| {
+          name == "ltx:para" || name == "ltx:logical-block"
+        });
+        if is_wrapper {
+          victim = p;
+          continue;
+        }
+      },
+      _ => {},
+    }
+    break;
+  }
+  Ok(())
+}
+
+/// Whitespace-collapsed, lowercased text — so a `<break>` (`\\`) and any spacing
+/// differences between the structured title and its hand-typeset copy don't
+/// defeat the comparison in [`maybe_dedup_leading_title_ink`].
+fn normalize_frontmatter_text(s: &str) -> String {
+  s.split_whitespace()
+    .collect::<Vec<_>>()
+    .join(" ")
+    .to_lowercase()
+}
+
+/// Companion to [`maybe_promote_leading_title`] for the mirror case
+/// (arXiv/html_feedback#6924, witness arXiv 2608.10928): a structured
+/// `<ltx:title>` DOES exist (from `\title`), but the author ALSO hand-typeset the
+/// title as a leading centered display-font block and never called `\maketitle`,
+/// so that block reproduces the structured title and the title renders twice.
+///
+/// Prioritize the structured metadata (LaTeXML's unified Frontmatter API stays
+/// authoritative): remove the redundant leading title *ink*, keeping the semantic
+/// `<ltx:title>` and any author/abstract ink (which has no structured counterpart,
+/// so is the only copy). Fires only on a FULL normalized-text match against the
+/// structured title, and only for a leading, non-sectional, display-font centered
+/// paragraph — so an unrelated centered display block is never removed. Reuses the
+/// same detection helpers as the promote path.
+fn maybe_dedup_leading_title_ink(document: &mut Document) -> Result<()> {
+  // Needs a structured document title to prioritize over.
+  let Some(title) = document.findnode("/ltx:document/ltx:title", None) else {
+    return Ok(());
+  };
+  let title_text = normalize_frontmatter_text(&title.get_content());
+  if title_text.is_empty() {
+    return Ok(());
+  }
+  let nominal = {
+    let v = lookup_float("NOMINAL_FONT_SIZE").map_or(0.0, |f| f.0);
+    if v > 0.0 { v } else { 10.0 }
+  };
+  // Leading centered paragraphs — anywhere in the pre-first-section frontmatter
+  // region, NOT inside a section (a hand-formatted title block sits at document
+  // level, often after a `\vspace`/`\rule` so it isn't the first body element).
+  // Absolute query so the returned nodes support child traversal (shared-node
+  // caveat in `maybe_promote_leading_title`).
+  let candidates = document.findnodes(
+    "/ltx:document//ltx:p[@align='center']\
+     [not(preceding::ltx:section) and not(ancestor::ltx:section)]",
+    None,
+  );
+  // Remove the FIRST leading centered display-font block that EXACTLY reproduces
+  // the structured title. Only one — a paper may repeat the title text later
+  // (e.g. a running head); we drop just the redundant hand-typeset title.
+  let Some(victim) = candidates.into_iter().find(|p| {
+    descendant_has_display_font(document, p, nominal)
+      && normalize_frontmatter_text(&p.get_content()) == title_text
+  }) else {
+    return Ok(());
+  };
+  // Log what we drop (never remove content silently; #6924).
+  Info!(
+    "frontmatter",
+    "title_ink_dedup",
+    s!(
+      "dropped a hand-typeset title block duplicating the structured <ltx:title> (\"{title_text}\")"
+    )
+  );
+  // Remove the redundant title ink, pruning any wrapper it leaves empty
+  // (para → logical-block) — mirroring the promote path's cleanup. Sibling `<p>`s
+  // (e.g. the author block) keep their wrapper non-empty and survive.
+  let mut victim = victim;
   loop {
     let parent = victim.get_parent();
     document.remove_node(victim);

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -226,6 +226,38 @@ fn cluster_break_optional_glue_722() {
      stay attribute-free):\n{xml}"
   );
 }
+/// arXiv/html_feedback#6924 (witness arXiv 2608.10928): the paper sets `\title{}`
+/// (structured `<ltx:title>`) but never calls `\maketitle`; it hand-typesets the
+/// title (and authors) as a leading centered display-font block. LaTeXML captured
+/// the structured title AND kept the ink → the title rendered twice. We prioritize
+/// the structured metadata: the redundant leading title-ink is removed, the
+/// semantic `<ltx:title>` kept, and the author ink (no structured counterpart) is
+/// preserved.
+#[test]
+fn cluster_frontmatter_title_ink_dedup_6924() {
+  let xml = convert_to_xml("tests/cluster_regressions/frontmatter_title_ink_dedup_6924.tex");
+  // The structured title survives.
+  assert!(
+    xml.contains("<title>"),
+    "the structured <ltx:title> must remain:\n{xml}"
+  );
+  // The title text now appears exactly ONCE (structured only; the body ink is gone).
+  assert_eq!(
+    xml.matches("My Great Title").count(),
+    1,
+    "title should appear once (structured), not duplicated as body ink:\n{xml}"
+  );
+  assert_eq!(
+    xml.matches("A Longer Subtitle").count(),
+    1,
+    "subtitle line once:\n{xml}"
+  );
+  // The hand-typeset AUTHOR block has no structured counterpart, so it stays.
+  assert!(
+    xml.contains("Jane Q. Author"),
+    "author ink must be preserved:\n{xml}"
+  );
+}
 /// arXiv/html_feedback#6569 (witness arXiv 2410.00317): a nicematrix
 /// `bNiceMatrix[first-row,first-col]` with a `\CodeBefore … \Body` cell-coloring
 /// block. Beyond-Perl (no Perl `nicematrix.sty.ltxml`): the family reduces to a real

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_title_ink_dedup_6924.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_title_ink_dedup_6924.tex
@@ -1,0 +1,18 @@
+% arXiv/html_feedback#6924 (witness arXiv 2608.10928): the paper sets \title{}
+% (structured frontmatter) but never calls \maketitle; it hand-typesets the title
+% (and authors) as "ink" in the body. LaTeXML captures the structured <ltx:title>
+% AND renders the ink block -> the title shows twice. Prioritize structured
+% metadata over the redundant title ink: drop the leading body block that
+% reproduces the <ltx:title> text, keep the structured title + the author ink
+% (which has no structured counterpart).
+\documentclass{article}
+\title{My Great Title \\[2pt] A Longer Subtitle}
+\begin{document}
+\begin{center}
+{\LARGE\bfseries My Great Title \\[3pt] A Longer Subtitle\par}
+\vspace{6pt}
+{\large Jane Q. Author \quad John R. Coauthor\par}
+\end{center}
+\section{Introduction}
+Body text of the paper.
+\end{document}


### PR DESCRIPTION
**Diagnostic.** LaTeXML's Frontmatter API captures `\title{}` into a semantic `<ltx:title>` (rendered as the visible heading) independent of `\maketitle`. When a paper *also* hand-typesets its title as a leading centered display-font block — `\title{}` set, `\maketitle` never called (arXiv 2608.10928) — the title shows twice. Perl LaTeXML duplicates identically (verified), so this is a deliberate **surpass-Perl**, not a Rust-only bug.

**Approach.** Prioritize structured metadata over "titlepage ink", keeping the unified Frontmatter API authoritative. At frontmatter finalization (`\lx@frontmatter@fallback`, the no-`\maketitle` path), `maybe_dedup_leading_title_ink` (`base_utilities.rs`) removes a leading, non-sectional, centered, display-font paragraph whose normalized text **exactly** reproduces the structured title — keeping the `<ltx:title>` and any author/abstract ink (no structured counterpart). It's the mirror of the existing `maybe_promote_leading_title` and reuses its detection helpers + empty-wrapper prune. Never hides a title the PDF shows (`\title` without `\maketitle` renders nothing in LaTeX).

**Validation.** `06_cluster_regressions::cluster_frontmatter_title_ink_dedup_6924` (RED→green: structured `<title>` kept, title once, author ink preserved); witness 2608.10928 goes 2→1 title with authors/abstract intact; non-regression checked on normal `\maketitle`, `\title`-no-manual, and non-matching-block cases; full suite 2141/0; clippy/fmt. Beyond-Perl divergence #146.

For arXiv/html_feedback#6924

🤖 Generated with [Claude Code](https://claude.com/claude-code)