### PR TITLE
fix: \fmtversion reflects the precompiled kernel dump (#739)

### DIFF
--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -3843,8 +3843,14 @@ LoadDefinitions!({
   enter_horizontal => true,
   sizer => { Ok((Dimension!("3.7em"), Dimension!("1.6ex"), Dimension!("0.5ex"))) });
 
-  DefMacro!("\\fmtname", "LaTeX2e");
-  DefMacro!("\\fmtversion", "2018/12/01");
+  // \fmtname / \fmtversion are intentionally NOT (re)defined here. Perl defines
+  // them once, in latex_base.pool (↔ our latex_base.rs); this constructs-phase
+  // copy was a Rust-only duplicate. Crucially, `constructs` runs AFTER the dump
+  // apply (LoadFormat: bootstrap → dump → constructs), so re-hardcoding here
+  // CLOBBERED the real per-TL-year kernel value the dump already carries
+  // (e.g. \fmtversion 2025-11-01 on TL2025), pinning every \@ifl@t@r\fmtversion
+  // check to the stale 2018/12/01 (issue #739). The dump is authoritative; the
+  // no-dump/base path falls back to latex_base.rs's Perl-faithful value.
 
   DefMacro!("\\today", { ExplodeText!(Today!()) });
 


### PR DESCRIPTION
**Diagnostic.** `\fmtversion` was pinned to the stale `2018/12/01`: a Rust-only duplicate hardcode of `\fmtname`/`\fmtversion` in the *constructs* phase (`latex_constructs.rs`) re-defined them **after** the dump apply (`bootstrap → dump → constructs`), clobbering the real per-TL-year kernel value the precompiled dump already carries (`\fmtversion 2025-11-01` on TL2025). So `\@ifl@t@r\fmtversion` package checks (filehook, rollback machinery, class version gates) all saw an ancient LaTeX.

**Approach.** Perl defines these only in `latex_base.pool` — the constructs copy was a Rust-only duplicate. Removed it, so the dump's authoritative kernel value stands. `latex_base.rs` still defines them once (Perl-faithful): the base/no-dump fallback, and the dump-build placeholder the real kernel overwrites. No runtime `latex.ltx` read, no dump rebuild.

**Validation.** Manually verified: dump path → `\fmtversion 2025-11-01` (+ `\fmtname LaTeX2e`); base/no-dump path → `2018/12/01` fallback. Full suite 2140/0; clippy `-D warnings`; fmt. No golden pinned the old value, and no version-branching test shifted.

For #739