### PR TITLE
test: guard the listings-tail leak that dropped a paper's second half

### DIFF
--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -381,6 +381,53 @@ fn cluster_array_vertical_rule_border_740() {
     "the two `!{{|}}` cells should render `ltx_align_right`:\n{pmml}"
   );
 }
+/// arXiv/html_feedback#6681 (reporter younesmouhib, paper 2606.22155v1): "does
+/// not compile properly: half missing". The deployed page (LaTeXML oxide 0.7.5)
+/// dumped LaTeXML-internal constructors (`\@@listings@block`,
+/// `\@@numbered@section`, `\lx@bibliography`) as literal text from the second
+/// `lstlisting` onward, swallowing the whole document tail — Open questions,
+/// bibliography, and the Verification appendix all became macro soup. The fix
+/// landed after that build; current main converts the paper end-to-end. This
+/// pins the fixed behaviour on the paper's construct: `listings` blocks with
+/// `breaklines=true`/`columns=fullflexible` inside `table`s, followed by more
+/// sectioning and an appendix. A regression would re-leak the internal
+/// constructors and drop the tail. (Any `@@…` in the output is a leak: the
+/// verbatim listing source lives base64-encoded in `data=`, whose alphabet
+/// excludes `@`, so it can never false-match.)
+#[test]
+fn cluster_listings_tail_leak_6681() {
+  let xml = convert_to_xml("tests/cluster_regressions/listings_tail_leak_6681.tex");
+  // No LaTeXML-internal constructor may leak into the serialized body as text.
+  for marker in ["@@listings@block", "@@numbered@section", "lx@bibliography"] {
+    assert!(
+      !xml.contains(marker),
+      "internal constructor `{marker}` leaked as text — the listings tail regressed:\n{xml}"
+    );
+  }
+  // Both witness-table listings survive as real listings, not swallowed text.
+  assert_eq!(
+    xml.matches(r#"class="ltx_lstlisting""#).count(),
+    2,
+    "both lstlisting blocks must render as listings:\n{xml}"
+  );
+  // The document tail after the second listing must render: the second section,
+  // the appendix, and their body paragraphs.
+  for needle in [
+    "Open questions",
+    "Verification",
+    "must render as ordinary text",
+    "must survive as a real appendix",
+  ] {
+    assert!(
+      xml.contains(needle),
+      "tail content `{needle}` missing — the listing swallowed the rest:\n{xml}"
+    );
+  }
+  assert!(
+    xml.contains("<appendix"),
+    "the Verification appendix must survive:\n{xml}"
+  );
+}
 /// Issue #723 (reporter xworld21): a Rhai binding's `HyperVerbatim` argument
 /// under T1 fontencoding produced non-ASCII `~`/`^`, breaking URLs. The T1
 /// fontmap deliberately maps slots 94/126 to accent glyphs U+02C6/U+02DC (Bruce

--- a/latexml_oxide/tests/cluster_regressions/listings_tail_leak_6681.tex
+++ b/latexml_oxide/tests/cluster_regressions/listings_tail_leak_6681.tex
@@ -1,0 +1,50 @@
+% Regression guard for arXiv/html_feedback#6681 (paper 2606.22155v1).
+% A `listings` block with breaklines=true/columns=fullflexible inside a
+% `table`, followed by more sectioning, leaked LaTeXML-internal constructors
+% (\@@listings@block, \@@numbered@section, \lx@bibliography) as literal text in
+% an older build (deployed 0.7.5), swallowing the whole document tail — the
+% user's "half missing". This pins the fixed behaviour: the tail must render.
+\documentclass[11pt]{amsart}
+\usepackage{amsmath,amssymb,amsthm}
+\usepackage{booktabs}
+\usepackage{listings}
+\usepackage[hidelinks]{hyperref}
+\lstdefinestyle{plainstyle}{
+  basicstyle=\ttfamily\footnotesize,
+  showstringspaces=false,
+  breaklines=true,
+  columns=fullflexible,
+  frame=single,
+  framesep=4pt,
+  xleftmargin=4pt,
+  literate={'}{{\textquotesingle}}1
+}
+\begin{document}
+\section{The records}\label{sec:records}
+\begin{table}[t]
+\centering
+\caption{First witness.}\label{tab:T21}
+\begin{lstlisting}[style=plainstyle]
+a= 0:  0102210210210210210022
+a= 1:  121002102102102102210
+a=20:  20
+a=21:  0
+\end{lstlisting}
+\end{table}
+\begin{table}[t]
+\centering
+\caption{Second witness (wrapped lines).}\label{tab:T13}
+\begin{lstlisting}[style=plainstyle]
+a= 0: 01111111000001 0101000110111 010001110101 00101010011
+      0110011010 100110101 01101001 0101100 000110 11010 1010 100 00 0
+a= 1: 1010101001011 000110101110 00111101000 1001000110
+      010011110 00110001 0010111 010001 11000 0011 110 01 1
+a=13: 0
+\end{lstlisting}
+\end{table}
+\section{Open questions}\label{sec:open}
+This paragraph after the second listing must render as ordinary text.
+\appendix
+\section{Verification}\label{app:verifier}
+The verification appendix must survive as a real appendix, not leak as macro text.
+\end{document}


### PR DESCRIPTION
**Diagnostic.** The deployed `arxiv.org/html/2606.22155v1` (LaTeXML oxide 0.7.5) leaked internal constructors (`\@@listings@block`, `\@@numbered@section`, `\lx@bibliography`) as literal text from the second `lstlisting` onward, dropping the whole document tail — the reporter's "half missing". The leak was fixed after 0.7.5; current main converts the paper end-to-end (verified against same-host Perl, both default and `--includestyles`).

**Approach.** Test-only — no behaviour change. A regression guard with a faithful min-repro of the paper's construct: two witness-table `lstlisting` blocks (`breaklines=true`, `columns=fullflexible`) inside `table`s, followed by a section and an appendix (the tail that was swallowed).

**Validation.** New guard `cluster_listings_tail_leak_6681` asserts on the core XML that no `@@…` constructor leaks (the verbatim listing source is base64 in `data=`, whose alphabet excludes `@`, so it can't false-match), both listings render, and the tail (Open questions / Verification appendix / body paragraphs) survives. Full suite 2144/0; clippy + fmt clean.

Guards the regression reported in arXiv/html_feedback#6681.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUgFzi1zW73EpejP7L1NZ5
