### PR TITLE
fix: tables inside a tcolorbox no longer render upside down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+  - **Tables inside a `tcolorbox` no longer render upside down.** A `tabular`
+    inside a `tcolorbox` `enhanced` skin is drawn as SVG, with the table content
+    in an `<svg:foreignObject>` nested in a TeX-y-up (flipped) group; the fo needs
+    a counter-flip `transform="matrix(1 0 0 -1 0 h)"` (set by its size-dependent
+    afterClose) or it draws vertically upside down. When building that wrapper,
+    `insert_block` renames a `_CaptureBlock_` — which carries the block's box — to
+    `svg:foreignObject`, but the rename dropped the node box (Perl carries it via
+    the internal `_box` attribute), so the afterClose read a zero size and skipped
+    the flip. `rename_node_internal` now carries the node box across, matching
+    Perl, and the table renders right-side-up (byte-for-byte Perl parity on the
+    foreignObject transforms). Fixes arXiv/html_feedback#6873 (reporter tdsmith,
+    paper 2601.13118); guard `cluster_tcolorbox_tabular_not_flipped_6873`.
   - **Every conversion logs an identity banner: executable, version, revision,
     start time.** At the head of each conversion `latexml_oxide`, `cortex_worker`
     and `latexmlmath_oxide` now log a line like `latexml_oxide (latexml-oxide

--- a/latexml_core/src/document.rs
+++ b/latexml_core/src/document.rs
@@ -5478,6 +5478,20 @@ impl Document {
       }
       std::mem::swap(&mut self.node, &mut new);
     }
+    // Carry the node box across the rename. Perl's `renameNode` copies ALL of
+    // `$node`'s attributes to `$new`, and the box is recorded as the internal
+    // `_box` attribute, so `afterClose`'s `getNodeBox($new)` still finds it. Our
+    // node box lives in a side map keyed by node identity — the fresh `new` node
+    // would otherwise be box-less, so a size-dependent afterClose handler
+    // misfires. Concretely: `insert_block` renames a `_CaptureBlock_` (which
+    // carries the block's box) to `svg:foreignObject`; without the box, the fo's
+    // afterClose (`tex_box.rs`, Perl `TeX_Box.pool.ltxml` L407-423) can't read a
+    // size and skips the y-flip `transform="matrix(1 0 0 -1 0 h)"`, so a
+    // `tabular` inside a `tcolorbox` `enhanced` skin renders upside down in the
+    // TeX-y-up SVG group (arXiv/html_feedback#6873, paper 2601.13118 Table 2).
+    if let Some(nodebox) = self.get_node_box(&node) {
+      self.set_node_box(&new, nodebox);
+    }
     // THEN call afterOpen... ?
     //   It would normally be called before children added,
     //   but how can we know if we're duplicated auto-added stuff?

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -428,6 +428,35 @@ fn cluster_listings_tail_leak_6681() {
     "the Verification appendix must survive:\n{xml}"
   );
 }
+/// arXiv/html_feedback#6873 (reporter tdsmith, paper 2601.13118v1): Table 2 — a
+/// `tabular` inside a `tcolorbox` `enhanced` skin — rendered vertically upside
+/// down. The box is drawn as SVG and the table sits in an `<svg:foreignObject>`
+/// inside a TeX-y-up (flipped) `<svg:g>`; the fo needs a counter-flip
+/// `transform="matrix(1 0 0 -1 0 h)"` (set by its size-dependent afterClose,
+/// `tex_box.rs` / Perl `TeX_Box.pool.ltxml` L407-423) or it renders upside down.
+/// `insert_block` renames a `_CaptureBlock_` — which carries the block's box —
+/// to `svg:foreignObject`; `rename_node_internal` now carries the node box
+/// across (Perl copies it via the `_box` attribute), so the fo's afterClose
+/// finds the size and sets the flip. RED before the fix: the tabular's
+/// foreignObject had no `transform`, so the height was 0 and it drew flipped.
+#[test]
+fn cluster_tcolorbox_tabular_not_flipped_6873() {
+  let xml = convert_to_xml("tests/cluster_regressions/tcolorbox_tabular_flip_6873.tex");
+  // The <svg:foreignObject> that wraps the <tabular> must carry the y-flip
+  // transform — otherwise the table draws upside down inside the flipped group.
+  let tab = xml
+    .find("<tabular")
+    .unwrap_or_else(|| panic!("a tabular should render inside the SVG picture:\n{xml}"));
+  let fo_start = xml[..tab]
+    .rfind("<svg:foreignObject")
+    .unwrap_or_else(|| panic!("the tabular must be wrapped in an svg:foreignObject:\n{xml}"));
+  let fo_open = &xml[fo_start..tab];
+  assert!(
+    fo_open.contains(r#"transform="matrix(1 0 0 -1"#),
+    "the foreignObject wrapping the tabular must carry the y-flip transform \
+     (else the table renders upside down):\n{fo_open}"
+  );
+}
 /// Issue #723 (reporter xworld21): a Rhai binding's `HyperVerbatim` argument
 /// under T1 fontencoding produced non-ASCII `~`/`^`, breaking URLs. The T1
 /// fontmap deliberately maps slots 94/126 to accent glyphs U+02C6/U+02DC (Bruce

--- a/latexml_oxide/tests/cluster_regressions/tcolorbox_tabular_flip_6873.tex
+++ b/latexml_oxide/tests/cluster_regressions/tcolorbox_tabular_flip_6873.tex
@@ -1,0 +1,18 @@
+% Regression guard for arXiv/html_feedback#6873 (paper 2601.13118v1, Table 2).
+% A `tabular` inside a `tcolorbox` `enhanced` skin is drawn as SVG; its content
+% sits in an <svg:foreignObject> nested in a TeX-y-up (flipped) <svg:g>. The fo
+% needs a counter-flip transform="matrix(1 0 0 -1 0 h)" or the table renders
+% vertically upside down. insert_block renames a _CaptureBlock_ (which carries
+% the block's box) to svg:foreignObject; the rename must carry the node box
+% across so the fo's size-dependent afterClose can set the transform.
+\documentclass{article}
+\usepackage{tcolorbox}
+\tcbuselibrary{skins}
+\begin{document}
+\begin{tcolorbox}[enhanced, title=Demo]
+\begin{tabular}{ll}
+apple & 1 \\
+banana & 2 \\
+\end{tabular}
+\end{tcolorbox}
+\end{document}


### PR DESCRIPTION
**Diagnostic.** A `tabular` inside a `tcolorbox` `enhanced` skin is drawn as SVG, with the table in an `<svg:foreignObject>` nested in a TeX-y-up (flipped) group; the fo needs a counter-flip `transform="matrix(1 0 0 -1 0 h)"` (set by its size-dependent afterClose from the node's box) or it draws upside down. `insert_block` builds the wrapper by renaming a `_CaptureBlock_` (which carries the block's box) to `svg:foreignObject`, but `rename_node_internal` dropped the node box, so the afterClose read a zero size and skipped the flip.

**Approach.** `rename_node_internal` now transfers the node box from the old node to the new one, matching Perl `Core/Document.pm` `renameNode` (which carries the box via the internal `_box` attribute it copies with all attributes). The foreignObject transforms are then byte-for-byte Perl parity.

**Validation.** Guard `cluster_tcolorbox_tabular_not_flipped_6873` (RED before the fix — the tabular's foreignObject had no transform); full suite 2144/0; clippy + fmt clean; verified on paper 2601.13118 (Table 2 upright, 14 y-flip transforms vs Perl's 14, at both core XML and final HTML).

Fixes the rotated-table regression reported in arXiv/html_feedback#6873.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUgFzi1zW73EpejP7L1NZ5
