### PR TITLE
harden: carry the node box onto clones (complete the node-box invariant)

### DIFF
--- a/latexml_core/src/document.rs
+++ b/latexml_core/src/document.rs
@@ -5288,6 +5288,21 @@ impl Document {
               },
             };
           }
+          // Carry the source node's box onto the clone, matching Perl: its
+          // `cloneNode` copies the internal `_box` attribute, so `getNodeBox`
+          // still resolves on the clone. Our node box is a side map keyed by
+          // node identity, so a fresh clone is box-less unless carried
+          // explicitly — the same invariant repaired in `rename_node_internal`
+          // for arXiv/html_feedback#6873. This completes node-box carrying
+          // across all four node-creating ops (open / wrap / rename / clone).
+          // Latent today — the current `append_clone` sites (MathFork, contacts)
+          // don't re-read a clone's box for size, and box-derived outputs
+          // (`tex=`, ids) ride across as copied attributes — but it keeps a
+          // future size-dependent afterClose on cloned SVG content from
+          // silently misfiring the way the foreignObject y-flip transform did.
+          if let Some(childbox) = self.get_node_box(&child) {
+            self.set_node_box(&new, childbox);
+          }
           self.after_open(&mut new)?;
           self.append_clone_aux(&mut new, child.get_child_nodes(), id_map)?;
           self.after_close(&mut new)?;


### PR DESCRIPTION
**Diagnostic.** Rust records a node's box in a side map keyed by node identity, whereas Perl stores it as the internal `_box` attribute that libxml copies with the node. So "node boxes travel with node-creating ops" is automatic in Perl but must be upheld explicitly in Rust. Three of the four ops already do (`open_element_at` from the live box; `wrap_nodes` from the parent; `rename_node_internal` since #746). `append_clone_aux` was the last gap — it copies attributes, but the box is not an attribute, so a clone was box-less.

**Approach.** `append_clone_aux` now carries the source node's box onto each clone, matching Perl's `cloneNode` (which copies `_box`). This completes the invariant across all four node-creating ops.

**Validation.** Full suite 2149/0 with **no golden shifts** — confirming this is a latent/defensive completion, not a behavior change: every current `append_clone` site (MathFork math duplication, frontmatter contact/note cloning) clones nodes whose box-derived outputs (`tex=`, ids) already ride across as copied attributes and are not re-read from the clone's box. It closes the class so a future size-dependent afterClose on cloned SVG content cannot silently misfire the way the foreignObject y-flip transform did before #746 (arXiv/html_feedback#6873). clippy + fmt clean.

Follow-up to #746; no user-visible change (no CHANGELOG entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUgFzi1zW73EpejP7L1NZ5
