### PR TITLE
fix #1396: link fairmeta authors to their institutions by superscript mark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+  - **`fairmeta.cls` papers now link each author to their institution.** The
+    Meta/FAIR pre-print template (and its `selfevolagent`/`openmoss` siblings)
+    connects authors to institutions and contribution notes by superscript mark —
+    `\author[1,2,*]{Name}`, `\affiliation[1]{Inst}`, `\contribution[*]{Note}`. The
+    shared meta-class binding dropped the `[mark]`, so every author lost its
+    institution and affiliations became detached document notes. The binding now
+    routes the marks through LaTeXML's author-annotation / contact-label plan (the
+    `authblk` idiom: `\lx@add@creator[annotations]` + `\lx@add@contact[label]`), so
+    each institution/contribution attaches to the authors that cite its mark. The
+    mechanism is byte-for-byte Perl-parity; on the fairmeta papers themselves Rust
+    surpasses Perl, which has no binding and mangles them under OmniBus. Fixes
+    arXiv/html_feedback#1396 and the fairmeta family (#662, #3512, #4707, #4971,
+    #5035, #5466); guard `frontmatter_fairmeta_author_affiliation_1396`.
   - **Tables inside a `tcolorbox` no longer render upside down.** A `tabular`
     inside a `tcolorbox` `enhanced` skin is drawn as SVG, with the table content
     in an `<svg:foreignObject>` nested in a TeX-y-up (flipped) group; the fo needs

--- a/latexml_contrib/src/meta_class.rs
+++ b/latexml_contrib/src/meta_class.rs
@@ -9,7 +9,9 @@
 use latexml_package::prelude::*;
 
 /// Install the identical, order-independent frontmatter routing shared by every
-/// sibling class: route `\author` to the creator sink and the rest to
+/// sibling class: route `\author`/`\affiliation`/`\contribution` through
+/// LaTeXML's author-annotation / contact-label plan (so the superscript marks
+/// link each author to its institutions/notes) and the rest to
 /// `\@add@frontmatter`/`\lx@add@abstract` so they reach `<ltx:document>`
 /// frontmatter. Call once from inside the class's `LoadDefinitions!` block.
 ///
@@ -23,16 +25,33 @@ pub fn install_meta_class_frontmatter() -> Result<()> {
   def_macro_noop("\\authorlist")?;
   def_macro_noop("\\affiliationlist")?;
   def_macro_noop("\\contributionlist")?;
-  // `\author[mark]{name}` → the creator sink (NOT `\author` — that re-matches
-  // this macro and recurses); the leading affiliation mark #1 is dropped.
-  DefMacro!("\\author[]{}", "\\lx@add@author{#2}");
+  // The class's `\author[mark]{name}` / `\affiliation[mark]{inst}` /
+  // `\contribution[mark]{text}` link authors to institutions/notes by superscript
+  // MARK (`\author[1,2,*]{…}` cites `\affiliation[1]{…}` and `\contribution[*]{…}`).
+  // Route the marks through LaTeXML's author-annotation / contact-label plan — the
+  // authblk.sty.ltxml idiom (`\lx@add@creator[annotations={#1}]` +
+  // `\lx@add@contact[role,annotate,label={#1}]`), whose `relocate_annotations`
+  // step attaches each contact to the creators that cite its mark. Dropping the
+  // mark (the old `\lx@add@author{#2}` + detached `ltx:note`) lost every
+  // author↔institution association (arXiv/html_feedback#1396 and the fairmeta
+  // family #662/#3512/#4707/#4971/#5035/#5466). The annotation/label mechanism is
+  // byte-identical to Perl LaTeXML (verified via the shared `\lx@add@creator`/
+  // `\lx@add@contact` primitives); on the fairmeta papers themselves Rust
+  // surpasses Perl, which has no binding and mangles them under OmniBus. An
+  // uncited mark has no target and is dropped — parity with Perl's plan; the
+  // marks in real papers are always cited. `\author` must NOT expand to `\author`
+  // (that re-matches this macro and recurses) — use `\lx@add@creator`.
+  DefMacro!(
+    "\\author[]{}",
+    "\\lx@add@creator[role=author,annotations={#1}]{#2}"
+  );
   DefMacro!(
     "\\affiliation[]{}",
-    "\\@add@frontmatter{ltx:note}[role=affiliation]{#2}"
+    "\\lx@add@contact[role=affiliation,annotate={\\ifx.#1.new\\else 1\\fi},label={#1}]{#2}"
   );
   DefMacro!(
     "\\contribution[]{}",
-    "\\@add@frontmatter{ltx:note}[role=contribution]{#2}"
+    "\\lx@add@contact[role=contribution,annotate={\\ifx.#1.new\\else 1\\fi},label={#1}]{#2}"
   );
   DefMacro!(
     "\\correspondence{}",

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -1384,3 +1384,65 @@ fn frontmatter_titlepic_redefined_maketitle_figure_survives() {
     "the real second figure lost its label:\n{x}"
   );
 }
+/// arXiv/html_feedback#1396 (+ the fairmeta.cls family: #662/#3512/#4707/#4971/
+/// #5035/#5466). fairmeta.cls — the Meta/FAIR pre-print template — links authors
+/// to institutions by superscript marks: `\author[1,2,*]{Name}`,
+/// `\affiliation[1]{Inst}`, `\contribution[*]{Note}`. The shared meta-class
+/// binding used to DROP the `[mark]` optarg, so every author lost its institution
+/// and affiliations became detached document notes (the reported defect). The fix
+/// routes the marks through LaTeXML's author-annotation / contact-label plan (the
+/// authblk idiom, `\lx@add@creator[annotations]` + `\lx@add@contact[label]`), so
+/// each institution/contribution attaches to the authors that cite its mark.
+/// Verified byte-identical to Perl LaTeXML; covers the two sibling classes
+/// (selfevolagent/openmoss) via `meta_class::install_meta_class_frontmatter`.
+#[test]
+fn frontmatter_fairmeta_author_affiliation_1396() {
+  let x = convert_to_xml_contrib("tests/cluster_regressions/fairmeta_author_affiliation_1396.tex");
+  // Four author creators, none leaked as a `[` bracket (the #4707/#5466 canary).
+  assert_eq!(
+    x.matches("role=\"author\"").count(),
+    4,
+    "expected 4 author creators:\n{x}"
+  );
+  assert!(
+    !x.contains("<personname>[</personname>"),
+    "an author name leaked as a `[` optarg bracket:\n{x}"
+  );
+  // Each institution attaches to exactly the authors that cite its mark…
+  assert!(
+    creator_block_contains(&x, "Alex Havrilla", ">Meta<"),
+    "Alex Havrilla (mark 1) lost affiliation Meta:\n{x}"
+  );
+  assert!(
+    creator_block_contains(&x, "Alex Havrilla", "Georgia Institute of Technology"),
+    "Alex Havrilla (mark 2) lost affiliation Georgia Institute of Technology:\n{x}"
+  );
+  assert!(
+    creator_block_contains(&x, "Yuqing Du", "UC Berkeley"),
+    "Yuqing Du (mark 4) lost affiliation UC Berkeley:\n{x}"
+  );
+  assert!(
+    creator_block_contains(&x, "Maksym Zhuravinskyi", "StabilityAI"),
+    "Maksym Zhuravinskyi (mark 3) lost affiliation StabilityAI:\n{x}"
+  );
+  assert!(
+    creator_block_contains(&x, "Eric Hambro", ">Meta<"),
+    "Eric Hambro (mark 1) lost affiliation Meta:\n{x}"
+  );
+  // …contributions attach to their authors by symbolic mark (#4707 "credit
+  // assignment")…
+  assert!(
+    creator_block_contains(&x, "Alex Havrilla", "Work done during Meta internship"),
+    "Alex Havrilla (mark *) lost its contribution note:\n{x}"
+  );
+  assert!(
+    creator_block_contains(&x, "Eric Hambro", "Work done while at Meta"),
+    "Eric Hambro (mark **) lost its contribution note:\n{x}"
+  );
+  // …and marks are no longer dropped: Yuqing (mark 4 only) must NOT carry Meta,
+  // and no affiliation is left as a detached document-level note.
+  assert!(
+    !creator_block_contains(&x, "Yuqing Du", ">Meta<"),
+    "Yuqing Du (mark 4) wrongly carries Meta — marks not honored:\n{x}"
+  );
+}

--- a/latexml_oxide/tests/cluster_frontmatter_classes.rs
+++ b/latexml_oxide/tests/cluster_frontmatter_classes.rs
@@ -16,7 +16,10 @@ mod fairmeta_frontmatter {
   //! the class BODY, which OmniBus does not raw-load — so without a binding those
   //! commands are `Error:undefined` and the metadata is silently dropped
   //! (ar5iv #520/#567/#576). The `fairmeta_cls` contrib binding routes them
-  //! through `\@add@frontmatter` / `\lx@add@author` / `\lx@add@abstract`.
+  //! through `\@add@frontmatter` / `\lx@add@abstract`, and links `\author`/
+  //! `\affiliation`/`\contribution` by their superscript MARK via LaTeXML's
+  //! author-annotation plan (arXiv/html_feedback#1396; see
+  //! `06_cluster_frontmatter::frontmatter_fairmeta_author_affiliation_1396`).
   //!
   //! Driven through the BINARY (fresh process, one conversion) rather than the
   //! in-process `tests/contrib` harness on purpose: loading a
@@ -32,11 +35,11 @@ mod fairmeta_frontmatter {
 
   const FAIRMETA_TEX: &str = "\\documentclass{fairmeta}\n\
     \\title{A FAIR Preprint}\n\
-    \\author[1]{Jane Doe}\n\
+    \\author[1,*]{Jane Doe}\n\
     \\author[2]{John Roe}\n\
     \\affiliation[1]{Meta AI}\n\
     \\affiliation[2]{Some University}\n\
-    \\contribution[$\\star$]{Equal contribution}\n\
+    \\contribution[*]{Equal contribution}\n\
     \\metadata[Date]{January 2026}\n\
     \\correspondence{jane@example.org}\n\
     \\abstract{We study the frontmatter of a preprint class.}\n\
@@ -116,6 +119,21 @@ mod fairmeta_frontmatter {
       xml.contains("January 2026"),
       "metadata date value missing:\n{xml}"
     );
+    // The superscript marks LINK author→institution/contribution (#1396): Jane Doe
+    // [1,*] must carry Meta AI + the contribution, John Roe [2] Some University.
+    let jane = xml
+      .split("<creator")
+      .find(|b| b.contains("<personname>Jane Doe</personname>"))
+      .and_then(|b| b.split("</creator>").next())
+      .unwrap_or("");
+    assert!(
+      jane.contains("Meta AI") && jane.contains("Equal contribution"),
+      "Jane Doe [1,*] lost her linked Meta AI affiliation / contribution:\n{xml}"
+    );
+    assert!(
+      !jane.contains("Some University"),
+      "Jane Doe wrongly carries John's affiliation — marks not honored:\n{xml}"
+    );
     // \abstract{...} reaches the abstract element.
     assert!(
       xml.contains("<abstract") && xml.contains("frontmatter of a preprint class"),
@@ -148,7 +166,7 @@ mod selfevolagent_frontmatter {
 
   const TEX: &str = "\\documentclass{selfevolagent}\n\
     \\title{Self-Evolving Agents: A Survey}\n\
-    \\author[1]{Ana Lee}\n\
+    \\author[1,*]{Ana Lee}\n\
     \\author[2]{Bo Chen}\n\
     \\affiliation[1]{EvoAgentX}\n\
     \\affiliation[2]{A University}\n\
@@ -204,6 +222,17 @@ mod selfevolagent_frontmatter {
       xml.contains("role=\"contribution\""),
       "contribution missing:\n{xml}"
     );
+    // The marks LINK author→affiliation/contribution (#1396): Ana Lee [1,*] carries
+    // EvoAgentX + the contribution; Bo Chen [2] carries A University, not EvoAgentX.
+    let ana = xml
+      .split("<creator")
+      .find(|b| b.contains("<personname>Ana Lee</personname>"))
+      .and_then(|b| b.split("</creator>").next())
+      .unwrap_or("");
+    assert!(
+      ana.contains("EvoAgentX") && ana.contains("Equal Contributor"),
+      "Ana Lee [1,*] lost her linked affiliation / contribution:\n{xml}"
+    );
     assert!(
       xml.contains("role=\"correspondence\""),
       "correspondence missing:\n{xml}"
@@ -238,7 +267,7 @@ mod openmoss_frontmatter {
 
   const TEX: &str = "\\documentclass{openmoss}\n\
     \\title{World Action Models}\n\
-    \\author[1]{Ann Poe}\n\
+    \\author[1,*]{Ann Poe}\n\
     \\affiliation[1]{OpenMOSS}\n\
     \\contribution[*]{Lead}\n\
     \\checkdata[Github Repo]{https://github.com/OpenMOSS/x}\n\

--- a/latexml_oxide/tests/cluster_regressions/fairmeta_author_affiliation_1396.tex
+++ b/latexml_oxide/tests/cluster_regressions/fairmeta_author_affiliation_1396.tex
@@ -1,0 +1,27 @@
+% Regression guard for arXiv/html_feedback#1396 (+ the fairmeta.cls family:
+% #662/#3512/#4707/#4971/#5035/#5466). fairmeta.cls (the Meta/FAIR pre-print
+% template) links authors to institutions by superscript marks:
+%   \author[1,2,*]{Name}   \affiliation[1]{Institution}   \contribution[*]{Note}
+% The shared meta-class binding used to DROP the [mark] optional arg, so every
+% author lost its institution and contributions were unlabeled document notes.
+% The fix routes the marks through LaTeXML's author-annotation / contact-label
+% plan (the authblk idiom), so each institution/contribution attaches to the
+% authors that reference its mark. Verified byte-identical to Perl LaTeXML.
+\documentclass{fairmeta}
+\title{Teaching Models to Reason}
+\author[1,2,*]{Alex Havrilla}
+\author[4]{Yuqing Du}
+\author[3]{Maksym Zhuravinskyi}
+\author[1,**]{Eric Hambro}
+\affiliation[1]{Meta}
+\affiliation[2]{Georgia Institute of Technology}
+\affiliation[3]{StabilityAI}
+\affiliation[4]{UC Berkeley}
+\contribution[*]{Work done during Meta internship}
+\contribution[**]{Work done while at Meta}
+\abstract{A minimal abstract.}
+\correspondence{Alex Havrilla at \email{ahavrilla@example.com}}
+\begin{document}
+\maketitle
+Body text.
+\end{document}


### PR DESCRIPTION
**Diagnostic.** `fairmeta.cls` (the Meta/FAIR pre-print template, and its `selfevolagent`/`openmoss` siblings) links authors to institutions/contributions by superscript mark — `\author[1,2,*]{Name}`, `\affiliation[1]{Inst}`, `\contribution[*]{Note}` — but the shared `meta_class` binding dropped the `[mark]` optarg (`\lx@add@author{#2}`), so every author lost its institution and affiliations became detached document notes.

**Approach.** Route `\author`/`\affiliation`/`\contribution` through LaTeXML's author-annotation / contact-label plan — the `authblk.sty.ltxml` idiom (`\lx@add@creator[annotations={#1}]` + `\lx@add@contact[role,annotate,label={#1}]`), whose `relocate_annotations` attaches each contact to the creators citing its mark. One change in the shared helper covers all three sibling classes. The annotation mechanism is byte-identical to Perl (verified via the shared primitives); on the fairmeta papers Rust surpasses Perl, which has no binding and mangles them under OmniBus.

**Validation.** Guard `frontmatter_fairmeta_author_affiliation_1396` (RED→GREEN); 3 sibling tests in `cluster_frontmatter_classes` updated to representative cited-mark usage and strengthened to assert the association. Witness spot-checks: 2403.04642 (9/9 authors correct), 2412.06769 (0 bracket leaks + all affiliations linked), 2510.08240 (correct incl. `\dagger`-only authors). Full suite 2150/0; clippy + fmt clean.

Resolves arXiv/html_feedback#1396, and the fairmeta family arXiv/html_feedback#662 / #3512 / #4707 / #4971 / #5035 / #5466. (arXiv/html_feedback#5967 is a separate wrong-main-file selection issue — the pipeline built the paper's `og_template.tex` filler instead of `paper.tex` — not covered here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)