### PR TITLE
Windows: performance profile + path/portability fixes (green Windows suite)

### DIFF
--- a/docs/performance/WINDOWS_PERFORMANCE.md
+++ b/docs/performance/WINDOWS_PERFORMANCE.md
@@ -150,12 +150,21 @@ pass **quantifies and validates** that architecture decision.
   MiKTeX's kpsewhich is ~340 ms/spawn, worse than TL's ~270 ms. MiKTeX users are
   the population that still pays F1 in full.
 
-**F2 — For the subprocess path, batch or cache `kpsewhich`.** The microbench
-proves 5 lookups in one process ≈ 1 (284 vs 273 ms). Two concrete levers for
-the fallback backend: (a) memoise per-file lookups within a conversion so a file
-is never resolved twice; (b) resolve pending includes/fonts in **batched**
-kpsewhich calls instead of one-per-file. Either shrinks the MiKTeX/fallback tax
-by the batching factor. (Neither is needed on the in-process path.)
+**F2 — On the subprocess path, per-file memoisation is already done; only
+batching is left, and it is hard.** `pathname::kpsewhich`
+([`latexml_core/src/util/pathname.rs`](../../latexml_core/src/util/pathname.rs))
+already caches results thread-locally (`KPSE_MEMO`, bounded 4096), so a file is
+never resolved twice within a conversion — the tax is one ~270 ms spawn per
+**unique** file, which is why `various_colors` (≈100 distinct files) is slow and
+`equality_big` (5 files) is not. The microbench shows 5 lookups in one process ≈
+1 (284 vs 273 ms), so the only remaining lever is **batching** distinct lookups
+into fewer kpsewhich processes — but resolution is demand-driven during digest
+(the engine can't know future lookups), so batching is an invasive,
+low-ROI-for-in-process-users refactor. **Conclusion: the in-process backend (F1)
+is the real fix and it already ships; there is no cheap subprocess win** — the
+~270 ms is kpsewhich re-parsing `ls-R` on each fresh process (CPU, not disk: the
+6th warm call is still 273 ms), which only an in-process, load-`ls-R`-once
+backend avoids.
 
 **F3 — Process/exe cost is a non-issue.** ~8 ms spawn, ~2 ms to load the 63–66 MB
 static exe. Binary size and `+crt-static` are not perf problems; no action.
@@ -173,8 +182,11 @@ throughput but found in passing: on Windows a just-written `.pdf` can be briefly
 locked (sharing + Defender scan), and `read_pdf_page_box`
 ([`latexml_core/src/util/image.rs`](../../latexml_core/src/util/image.rs)) does
 `std::fs::read(path).ok()?` — a transient lock becomes a silent `None` (a figure
-reaches the engine at 0×0). It also makes the `read_pdf_page_box_prefers_cropbox…`
-unit test flaky on Windows. Consider a short retry on transient read errors.
+reaches the engine at 0×0). It also made the `read_pdf_page_box_prefers_cropbox…`
+unit test flaky on Windows. **Fixed:** `read_pdf_page_box` now reads through a
+bounded-retry helper (`read_file_resilient`) that backs off briefly on a
+transient lock and still fails fast on a genuine `NotFound`; the happy path pays
+nothing. The test is green on Windows again.
 
 **F6 — Telemetry `max_rss_kb` is 0 on the Windows single-shot CLI.** Peak-RSS is
 only wired through `cortex_worker`'s child accounting; the direct-CLI

--- a/docs/performance/WINDOWS_PERFORMANCE.md
+++ b/docs/performance/WINDOWS_PERFORMANCE.md
@@ -1,0 +1,213 @@
+# Windows performance profile — the kpathsea backend is everything
+
+> First Windows-specific perf pass (2026-08-21), on latest `main`
+> (`f0936ed04d`, the `0.7.6-rc1` line). The prior campaigns
+> ([`PERFORMANCE.md`](PERFORMANCE.md), [`ARXIV_PERFORMANCE.md`](ARXIV_PERFORMANCE.md))
+> only ever measured the Linux CI/benchmark host. This one asks: *does the same
+> code have a Windows-specific bottleneck?*
+>
+> **Answer: yes, exactly one, and it is large — the file-lookup backend.** The
+> subprocess-`kpsewhich` backend re-loads the TeX `ls-R` filename database on
+> every spawn (~270–290 ms fixed cost), and file-heavy documents pay it per
+> lookup, so `digest` swells to **86 %** of wall and a mid-size TikZ paper takes
+> **21.7 s**. Rebuilding the *same commit* with the in-process linked-libkpathsea
+> backend (`--features kpathsea-build-from-source`, which is what the shipped
+> Windows distribution already uses) drops that paper **16×** to **1.35 s** and
+> restores a broad, Linux-shaped phase budget. Nothing else on Windows is a
+> bottleneck: process spawn, exe load, XSLT, serialize are all cheap.
+
+---
+
+## 1. Test bench
+
+| | |
+|---|---|
+| CPU | AMD Ryzen Threadripper 1950X — 16C/32T, Zen 1 (2017), modest single-thread IPC |
+| RAM | 64 GiB (≈53 GiB free during runs) |
+| OS | Windows 10 Home 10.0.19045 |
+| Defender | Real-time protection **ON**, behaviour monitor **ON** |
+| TeX | TeX Live 2026 at `C:\texlive` (forced ahead of MiKTeX on `PATH`) |
+| Toolchain | nightly-msvc, `CARGO_PROFILE_RELEASE_LTO=false`, LLVM `lld-link` |
+| Binary | `target\release\latexml_oxide.exe`, built two ways for the A/B (below) |
+
+Two binaries, same commit, same dumps ([`resources/dumps`](../../resources/dumps)
+regenerated against TL2026 via `tools/make_formats.ps1`):
+
+* **subprocess** — plain `cargo build --release`. No linked libkpathsea, so
+  `select_kpaths` ([`latexml_core/src/util/pathname.rs`](../../latexml_core/src/util/pathname.rs))
+  resolves files by spawning `kpsewhich`. **This is what a default local build
+  gets**, and what any host without a usable linked libkpathsea falls back to
+  (notably MiKTeX — see [Windows port notes]).
+* **in-process** — `cargo build --release --features kpathsea-build-from-source`.
+  Static libkpathsea linked in; `ls-R` is loaded once into the process. **This is
+  what the release `.zip` ships** (per the Windows release leg).
+
+Method: `tools/win_perf_bench.ps1` (committed alongside). It times each
+conversion's *external* wall with a `Stopwatch` and reads the *in-process* wall
++ 17-phase budget from `--telemetry-out` ([`TELEMETRY.md`](TELEMETRY.md)). Warm
+runs, min + median of 6. The external−telemetry gap is the spawn/init/IO the
+pipeline clock never sees.
+
+---
+
+## 2. The headline A/B
+
+External wall, median of 6, identical inputs, identical commit — the **only**
+difference is the kpathsea backend:
+
+| document | file resolutions¹ | subprocess | in-process | speed-up |
+|---|--:|--:|--:|--:|
+| `hello`          |   5 |    857 ms |    505 ms | 1.7× |
+| `book`           |   5 |  1 036 ms |    657 ms | 1.6× |
+| `equality_big`   |   5 |  3 555 ms |  3 261 ms | 1.09× |
+| `si`             |  22 |  3 366 ms |  2 666 ms | 1.3× |
+| `various_colors` | 102 | **21 717 ms** | **1 354 ms** | **16.0×** |
+
+¹ `(Processing definitions …)` + `(Loading …)` lines in the conversion log — the
+count of external files the engine had to resolve.
+
+**The speed-up tracks the file-resolution count, not the document size.**
+`equality_big` is a 170 KB, thousands-of-formulae math torture test but loads
+only 5 files → the backend barely matters (1.09×). `various_colors` is a small
+TikZ document that pulls in 102 files (pgf/TikZ libraries, colour files, fonts)
+→ 16×. The subprocess penalty is `≈ (files needing kpsewhich) × ~272 ms`: for
+`various_colors`, `21 717 − 1 354 = 20 363 ms ≈ 75 × 272 ms`.
+
+The external−telemetry delta is small in **both** backends (≈ 0–120 ms), so this
+is **not** `latexml_oxide` process spawn/teardown — the cost is *inside* the
+pipeline, spent in `digest` waiting on child `kpsewhich` processes.
+
+---
+
+## 3. Why one `kpsewhich` costs ~270 ms (spawn microbench)
+
+Min ms of 6, standalone processes:
+
+| command | ms | what it isolates |
+|---|--:|---|
+| `cmd /c rem` | **8** | Windows `CreateProcess` floor |
+| `latexml_oxide --version` | **10** | + load the 63–66 MB exe & static init |
+| `kpsewhich --version` | **10** | spawn kpsewhich, **no** `ls-R` search |
+| `kpsewhich cmr10.tfm` | **273** | + one `ls-R` filename-DB lookup |
+| `kpsewhich` ×5 files, one process | **284** | five lookups in one process |
+
+Two facts fall straight out:
+
+1. **Process spawn is not the problem.** Windows `CreateProcess` is ~8 ms (vs
+   sub-ms `fork` on Linux — real, but tiny here), and loading the big static exe
+   adds only ~2 ms. `kpsewhich --version` is also ~10 ms.
+2. **The ~270 ms is a per-*process* fixed cost, not per-file.** Five lookups in
+   one process (284 ms) cost essentially the same as one (273 ms). That cost is
+   kpathsea initialising and searching the `ls-R` database. The subprocess
+   backend spawns a **fresh** kpsewhich per lookup, so it re-pays the ~270 ms
+   `ls-R` init every single time. The in-process backend pays it **once** for
+   the whole conversion.
+
+(Defender real-time scanning of `kpsewhich.exe` + the kpathsea DLL on each spawn
+plausibly contributes to the gap between the 8 ms floor and the 270 ms lookup,
+but the dominant term is the per-process `ls-R` work — `--version`, which skips
+the search, is only 10 ms.)
+
+---
+
+## 4. Phase budget: subprocess distorts it, in-process restores it
+
+Aggregate `phase_us` share across the five documents:
+
+| phase | subprocess | in-process | Linux 60k-arXiv² |
+|---|--:|--:|--:|
+| **digest** | **86.3 %** | **32.5 %** | 19.7 % |
+| build | 7.5 % | 42.2 % | 18.1 % |
+| xslt | 2.5 % | 10.2 % | 13.2 % |
+| math_parse | 2.3 % | 9.5 % | 19.2 % |
+| everything else | ≤0.3 % ea. | ≤1.6 % ea. | ≤8.9 % ea. |
+
+² [`ARXIV_PERFORMANCE.md`](ARXIV_PERFORMANCE.md), containerised in-process worker
+over 60 469 arXiv docs. Different corpus (real papers vs 5 repo fixtures), so
+compare *shape*, not absolute cells.
+
+Under the subprocess backend, `digest` eats everything because the per-file
+`kpsewhich` waits are attributed there. Switch to in-process and the budget
+becomes **broad** — `build` + `digest` + `xslt` + `math_parse` spread out — which
+is the Linux shape. The residual `build`/`digest` weight (heavier than Linux) is
+partly the fixture mix and partly this being a 2017 Zen 1 part running the
+single-threaded digest/build engine; the 16C/32T box is idle during a single
+conversion.
+
+---
+
+## 5. Findings & recommendations
+
+**F1 — The kpathsea backend is the one Windows perf lever that matters.**
+In-process linked libkpathsea is 16× on file-heavy docs and ~1.5× on trivial
+ones, for zero output change. The shipped Windows `.zip` already uses it; this
+pass **quantifies and validates** that architecture decision.
+* *Local/dev builds:* a plain `cargo build --release` gets the **subprocess**
+  backend and is misleadingly slow on TikZ/graphics-heavy inputs. Benchmark with
+  `--features kpathsea-build-from-source`, or the numbers lie by up to 16×.
+* *MiKTeX hosts:* in-process can't read MiKTeX's fndb, so `select_kpaths` falls
+  back to subprocess **even in the shipped build** ([Windows port notes]) — and
+  MiKTeX's kpsewhich is ~340 ms/spawn, worse than TL's ~270 ms. MiKTeX users are
+  the population that still pays F1 in full.
+
+**F2 — For the subprocess path, batch or cache `kpsewhich`.** The microbench
+proves 5 lookups in one process ≈ 1 (284 vs 273 ms). Two concrete levers for
+the fallback backend: (a) memoise per-file lookups within a conversion so a file
+is never resolved twice; (b) resolve pending includes/fonts in **batched**
+kpsewhich calls instead of one-per-file. Either shrinks the MiKTeX/fallback tax
+by the batching factor. (Neither is needed on the in-process path.)
+
+**F3 — Process/exe cost is a non-issue.** ~8 ms spawn, ~2 ms to load the 63–66 MB
+static exe. Binary size and `+crt-static` are not perf problems; no action.
+
+**F4 — Windows Defender is a background tax, not a headline.** Real-time
+protection is on and scans each spawned exe and each freshly-written temp/output
+file. With the in-process backend (≈0 child processes) its effect on conversion
+is negligible. It *does* surface as flakiness elsewhere — see F5. Excluding
+`C:\texlive\...\bin` and the scratch/temp dir would trim per-spawn scan time on
+the subprocess path (needs admin; not verifiable here — this box can't read
+exclusions without elevation).
+
+**F5 — Swallowed transient file-lock error (`read_pdf_page_box`).** Unrelated to
+throughput but found in passing: on Windows a just-written `.pdf` can be briefly
+locked (sharing + Defender scan), and `read_pdf_page_box`
+([`latexml_core/src/util/image.rs`](../../latexml_core/src/util/image.rs)) does
+`std::fs::read(path).ok()?` — a transient lock becomes a silent `None` (a figure
+reaches the engine at 0×0). It also makes the `read_pdf_page_box_prefers_cropbox…`
+unit test flaky on Windows. Consider a short retry on transient read errors.
+
+**F6 — Telemetry `max_rss_kb` is 0 on the Windows single-shot CLI.** Peak-RSS is
+only wired through `cortex_worker`'s child accounting; the direct-CLI
+`--telemetry-out` path reports 0 on Windows. Minor, but it blocks RSS profiling
+of one-off conversions here.
+
+---
+
+## 6. Reproduce
+
+```powershell
+# TeX Live 2026 FIRST on PATH (never MiKTeX-first) — the fixtures assume TL.
+$env:PATH = "C:\texlive\2026\bin\windows;" + $env:PATH
+
+# regenerate the ambient-year dumps for the current engine
+$env:PROFILE='release'; $env:CARGO_PROFILE_RELEASE_LTO='false'; tools\make_formats.ps1
+
+# A: subprocess backend (default build)
+cargo build --release --bin latexml_oxide
+tools\win_perf_bench.ps1
+
+# B: in-process backend (shipped Windows config)
+cargo build --release --features kpathsea-build-from-source --bin latexml_oxide
+tools\win_perf_bench.ps1
+```
+
+Confirm which backend a binary uses via the `Info:kpathsea:backend …` line the
+harness echoes (`subprocess kpsewhich` vs `in-process (linked)`).
+
+---
+
+_See also:_ [`ARXIV_PERFORMANCE.md`](ARXIV_PERFORMANCE.md) (Linux baseline),
+[`TELEMETRY.md`](TELEMETRY.md) (the phase instrument),
+`docs/release/WINDOWS_COMPATIBILITY_PLAN.md` (the port + backend-selection
+design). [Windows port notes]: the MiKTeX fallback and the ~340 ms MiKTeX
+kpsewhich are from the port's backend-selection bring-up.

--- a/latexml_contrib/src/script_bindings/tests.rs
+++ b/latexml_contrib/src/script_bindings/tests.rs
@@ -818,33 +818,51 @@ fn command_output_runs_by_default_and_is_blockable_via_env() {
   fresh_state();
   // Allowed by default (no env set).
   unsafe { std::env::remove_var("LATEXML_DISABLE_SHELL_ESCAPE") };
-  load_script(
+  // Unix `printf`/`false` don't exist on Windows; use `cmd` there. The
+  // shell-escape gate and stdout/status capture under test are platform-agnostic.
+  let (ok_cmd, bad_cmd) = if cfg!(windows) {
+    (
+      r#"let cmd = Command("cmd"); cmd.args(["/C", "echo hello-world"]);"#,
+      r#"let bad = Command("cmd"); bad.args(["/C", "exit 1"]);"#,
+    )
+  } else {
+    (
+      r#"let cmd = Command("printf"); cmd.args(["%s", "hello-world"]);"#,
+      r#"let bad = Command("false");"#,
+    )
+  };
+  load_script(&format!(
     r#"
-    let cmd = Command("printf");
-    cmd.args(["%s", "hello-world"]);
+    {ok_cmd}
     let out = cmd.output();
     assign_global("cmd:out", out.stdout);
-    assign_global("cmd:ok", if out.success { "yes" } else { "no" });
+    assign_global("cmd:ok", if out.success {{ "yes" }} else {{ "no" }});
     assign_global("cmd:status", out.status.to_string());
 
-    let bad = Command("false");
+    {bad_cmd}
     let bout = bad.output();
-    assign_global("cmd:bad", if bout.success { "ok" } else { "fail" });
-    "#,
-  )
+    assign_global("cmd:bad", if bout.success {{ "ok" }} else {{ "fail" }});
+    "#
+  ))
   .expect("Command(...).output() must run and capture by default");
-  assert_eq!(lookup_str("cmd:out"), "hello-world", "stdout captured");
-  assert_eq!(lookup_str("cmd:ok"), "yes", "printf exits 0 -> success");
+  // `.trim()` tolerates Windows `echo`'s trailing CRLF; Unix `printf` emits none.
+  assert_eq!(lookup_str("cmd:out").trim(), "hello-world", "stdout captured");
+  assert_eq!(lookup_str("cmd:ok"), "yes", "the command exits 0 -> success");
   assert_eq!(lookup_str("cmd:status"), "0", "exit code 0");
   assert_eq!(
     lookup_str("cmd:bad"),
     "fail",
-    "`false` exits 1 -> success == false"
+    "a failing command exits nonzero -> success == false"
   );
 
   // Blockable: with the opt-out env set, `output()` refuses (a Rhai error).
   unsafe { std::env::set_var("LATEXML_DISABLE_SHELL_ESCAPE", "1") };
-  let blocked = load_script(r#"let c = Command("printf"); c.args(["%s", "x"]); c.output();"#);
+  let block_cmd = if cfg!(windows) {
+    r#"let c = Command("cmd"); c.args(["/C", "echo x"]); c.output();"#
+  } else {
+    r#"let c = Command("printf"); c.args(["%s", "x"]); c.output();"#
+  };
+  let blocked = load_script(block_cmd);
   unsafe { std::env::remove_var("LATEXML_DISABLE_SHELL_ESCAPE") };
   assert!(
     blocked.is_err(),

--- a/latexml_contrib/src/script_bindings/tests.rs
+++ b/latexml_contrib/src/script_bindings/tests.rs
@@ -846,8 +846,16 @@ fn command_output_runs_by_default_and_is_blockable_via_env() {
   ))
   .expect("Command(...).output() must run and capture by default");
   // `.trim()` tolerates Windows `echo`'s trailing CRLF; Unix `printf` emits none.
-  assert_eq!(lookup_str("cmd:out").trim(), "hello-world", "stdout captured");
-  assert_eq!(lookup_str("cmd:ok"), "yes", "the command exits 0 -> success");
+  assert_eq!(
+    lookup_str("cmd:out").trim(),
+    "hello-world",
+    "stdout captured"
+  );
+  assert_eq!(
+    lookup_str("cmd:ok"),
+    "yes",
+    "the command exits 0 -> success"
+  );
   assert_eq!(lookup_str("cmd:status"), "0", "exit code 0");
   assert_eq!(
     lookup_str("cmd:bad"),

--- a/latexml_core/src/util/image.rs
+++ b/latexml_core/src/util/image.rs
@@ -1355,8 +1355,7 @@ mod sizing_characterization_tests {
     use std::sync::atomic::{AtomicU64, Ordering};
     static SEQ: AtomicU64 = AtomicU64::new(0);
     let seq = SEQ.fetch_add(1, Ordering::Relaxed);
-    let path =
-      std::env::temp_dir().join(format!("lxsize-{}-{seq}-{name}", std::process::id()));
+    let path = std::env::temp_dir().join(format!("lxsize-{}-{seq}-{name}", std::process::id()));
     std::fs::write(&path, bytes).expect("write fixture");
     path
   }

--- a/latexml_core/src/util/image.rs
+++ b/latexml_core/src/util/image.rs
@@ -769,8 +769,31 @@ fn graphicx_box_pt(nw: f64, nh: f64, options: &str) -> (Dimension, Dimension) {
 /// xref stream; for the figures `\includegraphics` pulls in, which are
 /// single-page, the first box is the page's own (or the `/Pages` node's, which
 /// it inherits).
+/// Read a file, retrying briefly on a transient lock. On Windows a *just*-written
+/// file — a figure the converter emitted a moment ago, or a test fixture — can be
+/// momentarily locked by another handle (antivirus real-time scanning of the
+/// fresh file, or Windows' stricter default file sharing), so a bare
+/// `fs::read(path).ok()?` turns a transient `ERROR_SHARING_VIOLATION`
+/// (`PermissionDenied`) into a silent `None` and a figure reaches the engine at
+/// 0×0. Retry a handful of times with a short backoff; a genuine `NotFound` still
+/// fails fast, and the happy path (Ok on the first try) pays nothing.
+fn read_file_resilient(path: &Path) -> Option<Vec<u8>> {
+  let mut tries = 0u32;
+  loop {
+    match std::fs::read(path) {
+      Ok(bytes) => return Some(bytes),
+      Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+      Err(_) if tries < 5 => {
+        tries += 1;
+        std::thread::sleep(std::time::Duration::from_millis(2 * u64::from(tries)));
+      },
+      Err(_) => return None,
+    }
+  }
+}
+
 pub fn read_pdf_page_box(path: &Path) -> Option<(f64, f64)> {
-  let bytes = std::fs::read(path).ok()?;
+  let bytes = read_file_resilient(path)?;
   if byte_find(&bytes, b"/CropBox").is_some() || byte_find(&bytes, b"/MediaBox").is_some() {
     let content = String::from_utf8_lossy(&bytes);
     if let Some(box_) =

--- a/latexml_core/src/util/image.rs
+++ b/latexml_core/src/util/image.rs
@@ -547,6 +547,41 @@ pub fn image_graphicx_sizer(whatsit: &mut Whatsit) {
   whatsit.set_property("cached_depth", Stored::Dimension(Dimension::default()));
 }
 
+/// Run a fallible I/O op, retrying briefly on a *transient* lock. On Windows a
+/// just-written file — a figure the converter emitted a moment ago, or a test
+/// fixture — can be momentarily locked by another handle (antivirus real-time
+/// scanning of the fresh file, or Windows' stricter default file sharing), which
+/// surfaces as `PermissionDenied` (`ERROR_SHARING_VIOLATION`). A bare
+/// `op().ok()?` would turn that into a silent `None`, and a figure would reach
+/// the engine at 0x0. Retry only that transient class a handful of times with a
+/// short backoff; every other error (incl. a genuine `NotFound`) fails fast, and
+/// the happy path (Ok on the first try) pays nothing.
+fn with_transient_retry<T>(mut op: impl FnMut() -> std::io::Result<T>) -> Option<T> {
+  let mut tries = 0u32;
+  loop {
+    match op() {
+      Ok(v) => return Some(v),
+      Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied && tries < 5 => {
+        tries += 1;
+        std::thread::sleep(std::time::Duration::from_millis(2 * u64::from(tries)));
+      },
+      Err(_) => return None,
+    }
+  }
+}
+
+/// [`std::fs::read`] with the transient-lock retry of [`with_transient_retry`].
+fn read_file_resilient(path: &Path) -> Option<Vec<u8>> {
+  with_transient_retry(|| std::fs::read(path))
+}
+
+/// [`std::fs::File::open`] with the transient-lock retry of
+/// [`with_transient_retry`]. Only the open races with the scanner/writer; reads
+/// on the returned handle do not, so callers keep their streaming reads.
+fn open_file_resilient(path: &Path) -> Option<std::fs::File> {
+  with_transient_retry(|| std::fs::File::open(path))
+}
+
 /// Read image dimensions (width, height) in pixels from a file.
 /// Supports PNG, JPEG, and EPS (PostScript BoundingBox).
 ///
@@ -556,7 +591,7 @@ pub fn image_graphicx_sizer(whatsit: &mut Whatsit) {
 /// so the caller skips sizing (mirroring Perl's `return unless $w`).
 pub fn read_image_dimensions(path: &Path) -> Option<(u32, u32)> {
   use std::io::Read;
-  let mut file = std::fs::File::open(path).ok()?;
+  let mut file = open_file_resilient(path)?;
   let mut header = [0u8; 32];
   file.read_exact(&mut header).ok()?;
 
@@ -769,29 +804,6 @@ fn graphicx_box_pt(nw: f64, nh: f64, options: &str) -> (Dimension, Dimension) {
 /// xref stream; for the figures `\includegraphics` pulls in, which are
 /// single-page, the first box is the page's own (or the `/Pages` node's, which
 /// it inherits).
-/// Read a file, retrying briefly on a transient lock. On Windows a *just*-written
-/// file — a figure the converter emitted a moment ago, or a test fixture — can be
-/// momentarily locked by another handle (antivirus real-time scanning of the
-/// fresh file, or Windows' stricter default file sharing), so a bare
-/// `fs::read(path).ok()?` turns a transient `ERROR_SHARING_VIOLATION`
-/// (`PermissionDenied`) into a silent `None` and a figure reaches the engine at
-/// 0×0. Retry a handful of times with a short backoff; a genuine `NotFound` still
-/// fails fast, and the happy path (Ok on the first try) pays nothing.
-fn read_file_resilient(path: &Path) -> Option<Vec<u8>> {
-  let mut tries = 0u32;
-  loop {
-    match std::fs::read(path) {
-      Ok(bytes) => return Some(bytes),
-      Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
-      Err(_) if tries < 5 => {
-        tries += 1;
-        std::thread::sleep(std::time::Duration::from_millis(2 * u64::from(tries)));
-      },
-      Err(_) => return None,
-    }
-  }
-}
-
 pub fn read_pdf_page_box(path: &Path) -> Option<(f64, f64)> {
   let bytes = read_file_resilient(path)?;
   if byte_find(&bytes, b"/CropBox").is_some() || byte_find(&bytes, b"/MediaBox").is_some() {

--- a/latexml_core/src/util/image.rs
+++ b/latexml_core/src/util/image.rs
@@ -1360,6 +1360,57 @@ mod sizing_characterization_tests {
     path
   }
 
+  fn io_err(kind: std::io::ErrorKind) -> std::io::Error { std::io::Error::from(kind) }
+
+  /// A genuine `NotFound` is a missing file, not a lock: it must map straight to
+  /// `None` on the first attempt, with no retry and no sleep. The "no sleep"
+  /// half is what keeps `read_pdf_page_box`/`read_image_dimensions` cheap for
+  /// the common missing-figure case, so the perf argument depends on it.
+  #[test]
+  fn transient_retry_notfound_is_immediate_none() {
+    let mut calls = 0u32;
+    let got: Option<()> = with_transient_retry(|| {
+      calls += 1;
+      Err(io_err(std::io::ErrorKind::NotFound))
+    });
+    assert!(got.is_none(), "NotFound must map to None");
+    assert_eq!(calls, 1, "NotFound must not be retried");
+  }
+
+  /// A lock that clears after a couple of tries: the op is retried and its
+  /// eventual `Ok` is returned — a fresh figure is not silently dropped to 0x0.
+  #[test]
+  fn transient_retry_recovers_after_transient_errors() {
+    let mut calls = 0u32;
+    let got = with_transient_retry(|| {
+      calls += 1;
+      if calls < 3 {
+        Err(io_err(std::io::ErrorKind::PermissionDenied))
+      } else {
+        Ok(42u32)
+      }
+    });
+    assert_eq!(
+      got,
+      Some(42),
+      "a clearing lock should be retried then succeed"
+    );
+    assert_eq!(calls, 3, "should retry until the op succeeds");
+  }
+
+  /// A persistent non-`NotFound` error gives up with `None` after the retry cap
+  /// (1 initial attempt + 10 retries = 11 invocations) instead of looping.
+  #[test]
+  fn transient_retry_gives_up_after_cap() {
+    let mut calls = 0u32;
+    let got: Option<()> = with_transient_retry(|| {
+      calls += 1;
+      Err(io_err(std::io::ErrorKind::PermissionDenied))
+    });
+    assert!(got.is_none(), "a persistent error must give up with None");
+    assert_eq!(calls, 11, "one attempt then retries up to the cap");
+  }
+
   /// A minimal `%PDF-1.5` whose only object is a Flate-compressed object stream
   /// carrying `payload` — the shape pdflatex emits for a page tree since 1.5.
   fn objstm_pdf(payload: &[u8]) -> Vec<u8> {

--- a/latexml_core/src/util/image.rs
+++ b/latexml_core/src/util/image.rs
@@ -547,23 +547,30 @@ pub fn image_graphicx_sizer(whatsit: &mut Whatsit) {
   whatsit.set_property("cached_depth", Stored::Dimension(Dimension::default()));
 }
 
-/// Run a fallible I/O op, retrying briefly on a *transient* lock. On Windows a
+/// Run a fallible I/O op, retrying on a *transient* lock. On Windows a
 /// just-written file — a figure the converter emitted a moment ago, or a test
 /// fixture — can be momentarily locked by another handle (antivirus real-time
-/// scanning of the fresh file, or Windows' stricter default file sharing), which
-/// surfaces as `PermissionDenied` (`ERROR_SHARING_VIOLATION`). A bare
-/// `op().ok()?` would turn that into a silent `None`, and a figure would reach
-/// the engine at 0x0. Retry only that transient class a handful of times with a
-/// short backoff; every other error (incl. a genuine `NotFound`) fails fast, and
-/// the happy path (Ok on the first try) pays nothing.
+/// scanning of the fresh file, or Windows' stricter default file sharing). A
+/// bare `op().ok()?` would turn that into a silent `None`, and a figure would
+/// reach the engine at 0x0.
+///
+/// A genuine `NotFound` is not a lock, so it fails fast. Every *other* error is
+/// treated as possibly-transient and retried with a widening backoff up to
+/// ~0.5 s total. The fresh-file lock usually surfaces as `PermissionDenied`
+/// (`ERROR_SHARING_VIOLATION`), but under heavy parallel load (a full `cargo
+/// test` with antivirus active) it has shown other kinds and needed longer than
+/// a few ms to clear — so this deliberately retries broadly rather than gating on
+/// one `ErrorKind`. A permanently-unreadable path pays the full budget once and
+/// then fails; the happy path (Ok on the first try) pays nothing.
 fn with_transient_retry<T>(mut op: impl FnMut() -> std::io::Result<T>) -> Option<T> {
   let mut tries = 0u32;
   loop {
     match op() {
       Ok(v) => return Some(v),
-      Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied && tries < 5 => {
+      Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+      Err(_) if tries < 10 => {
         tries += 1;
-        std::thread::sleep(std::time::Duration::from_millis(2 * u64::from(tries)));
+        std::thread::sleep(std::time::Duration::from_millis(u64::from(tries) * 10));
       },
       Err(_) => return None,
     }

--- a/latexml_core/src/util/image.rs
+++ b/latexml_core/src/util/image.rs
@@ -1347,7 +1347,16 @@ mod sizing_characterization_tests {
   use super::*;
 
   fn fixture(name: &str, bytes: &[u8]) -> PathBuf {
-    let path = std::env::temp_dir().join(format!("lxsize-{}-{name}", std::process::id()));
+    // A per-call sequence makes every fixture path unique. Two tests reused the
+    // same `name` ("m.pdf"), so keying only on pid+name let them race on one temp
+    // file when run in parallel: whichever wrote last won, and the other test's
+    // reader saw the wrong bytes -> a flaky `None` under full-suite load (it only
+    // surfaced when scheduling made the two writes overlap).
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    let path =
+      std::env::temp_dir().join(format!("lxsize-{}-{seq}-{name}", std::process::id()));
     std::fs::write(&path, bytes).expect("write fixture");
     path
   }

--- a/latexml_core/src/util/pathname.rs
+++ b/latexml_core/src/util/pathname.rs
@@ -846,10 +846,20 @@ fn abs2rel(target: &Path, base: &Path) -> String {
   for comp in &t[common..] {
     result.push(comp.as_os_str());
   }
-  // `PathBuf` joins with the OS separator (`\` on Windows), but this result
-  // feeds forward-slash-only outputs — graphic `candidates`, resource URLs — that
-  // must match Perl/pdflatex on every platform. Normalize; a no-op on Unix.
-  result.to_string_lossy().replace('\\', "/")
+  // `PathBuf` re-joins with the OS separator, so on Windows the result is
+  // `\`-separated — but this feeds forward-slash-only outputs (graphic
+  // `candidates`, resource URLs) that must match Perl/pdflatex on every
+  // platform. Normalize on Windows only; on Unix `\` is a legal filename byte
+  // (and the parts are already `/`-joined), so the rewrite is compiled out
+  // rather than risk corrupting a backslash-bearing name.
+  #[cfg(windows)]
+  {
+    result.to_string_lossy().replace('\\', "/")
+  }
+  #[cfg(not(windows))]
+  {
+    result.to_string_lossy().into_owned()
+  }
 }
 
 /// Make a pathname relative to a base directory.

--- a/latexml_core/src/util/pathname.rs
+++ b/latexml_core/src/util/pathname.rs
@@ -846,7 +846,10 @@ fn abs2rel(target: &Path, base: &Path) -> String {
   for comp in &t[common..] {
     result.push(comp.as_os_str());
   }
-  result.to_string_lossy().to_string()
+  // `PathBuf` joins with the OS separator (`\` on Windows), but this result
+  // feeds forward-slash-only outputs — graphic `candidates`, resource URLs — that
+  // must match Perl/pdflatex on every platform. Normalize; a no-op on Unix.
+  result.to_string_lossy().replace('\\', "/")
 }
 
 /// Make a pathname relative to a base directory.
@@ -1013,25 +1016,37 @@ mod tests {
   /// source directory (e.g. `xslt.rs`).
   #[test]
   fn relative_emits_dotdot_for_non_descendant() {
+    // A bare `/x` is not absolute on Windows (no drive), so prefix one there to
+    // exercise the abs2rel branch on every platform. Results stay forward-slash.
+    let abs = |p: &str| {
+      if cfg!(windows) {
+        format!("C:{p}")
+      } else {
+        p.to_string()
+      }
+    };
     // Sibling tree: base and target diverge one level up.
     assert_eq!(
       relative(
-        "/home/u/proj/A/child/images/pic.svg",
-        "/home/u/proj/latexml"
+        &abs("/home/u/proj/A/child/images/pic.svg"),
+        &abs("/home/u/proj/latexml")
       ),
       "../A/child/images/pic.svg"
     );
     // Descendant is unchanged (the case strip_prefix already handled).
     assert_eq!(
-      relative("/home/u/proj/sub/pic.png", "/home/u/proj"),
+      relative(&abs("/home/u/proj/sub/pic.png"), &abs("/home/u/proj")),
       "sub/pic.png"
     );
     // Cousin that diverges two levels up.
-    assert_eq!(relative("/a/b/c/f.tex", "/a/x/y"), "../../b/c/f.tex");
+    assert_eq!(
+      relative(&abs("/a/b/c/f.tex"), &abs("/a/x/y")),
+      "../../b/c/f.tex"
+    );
     // A non-absolute pathname is returned canonicalized, as Perl does.
-    assert_eq!(relative("sub/pic.png", "/home/u/proj"), "sub/pic.png");
+    assert_eq!(relative("sub/pic.png", &abs("/home/u/proj")), "sub/pic.png");
     // Empty base short-circuits to the canonical pathname.
-    assert_eq!(relative("/a/b/pic.png", ""), "/a/b/pic.png");
+    assert_eq!(relative(&abs("/a/b/pic.png"), ""), abs("/a/b/pic.png"));
   }
 
   /// `choose_kpaths` branches that a real host cannot exercise: a MiKTeX

--- a/latexml_oxide/src/render_workers.rs
+++ b/latexml_oxide/src/render_workers.rs
@@ -239,10 +239,13 @@ fn parse_child_report(stderr_text: &str) -> ChildReport {
 /// One spawned (or spawn-failed) worker awaiting its fold.
 enum Pending {
   /// The drain thread owns the child and returns its full `Output`; the pid
-  /// is kept so a parent-side timeout can kill the fleet.
+  /// is kept so a parent-side timeout can kill the fleet. Only read on Unix
+  /// (`libc::kill` in the breach path below); the equivalent Windows fleet-kill
+  /// (OpenProcess + TerminateProcess) is not wired yet, so the pid is dead on
+  /// non-unix — scope the `dead_code` allow there rather than workspace-wide.
   Spawned(
     std::thread::JoinHandle<std::io::Result<std::process::Output>>,
-    u32,
+    #[cfg_attr(not(unix), allow(dead_code))] u32,
   ),
   Failed(String),
 }

--- a/latexml_oxide/tests/06_cluster_standalone_subfiles.rs
+++ b/latexml_oxide/tests/06_cluster_standalone_subfiles.rs
@@ -410,7 +410,10 @@ fn subimport_absolute_path_resolves_like_real_latex() {
     format!(
       "\\documentclass{{article}}\\usepackage{{import}}\\usepackage{{standalone}}\
        \\begin{{document}}\\subimport*{{{}/}}{{index.tex}}\\end{{document}}",
-      child.display()
+      // Forward slashes: a Windows abs path (C:\Users\…) in TeX source would
+      // tokenize \U, \d, … as control sequences (`\` is catcode 0). kpathsea
+      // accepts `/` on Windows; no-op on Unix.
+      child.to_string_lossy().replace('\\', "/")
     ),
   )
   .expect("write main");

--- a/latexml_oxide/tests/cluster_cli.rs
+++ b/latexml_oxide/tests/cluster_cli.rs
@@ -556,6 +556,19 @@ mod kpathsea_backend_resolution {
     let produced = fs::read_to_string(dir.join("out.xml")).unwrap_or_default();
     let _ = fs::remove_dir_all(&dir);
 
+    // This test's premise — resolution survives a disabled `kpsewhich` — only
+    // holds when libkpathsea is linked in-process (the shipped distribution,
+    // `--features kpathsea-build-from-source`). A plain `cargo build` links no
+    // libkpathsea and resolves via a spawned `kpsewhich`; with `KPSEWHICH`
+    // pointed at nothing there is no resolver at all, so skip rather than fail.
+    if log.contains("no libkpathsea is linked") {
+      eprintln!(
+        "skipping texinputs_resolves_without_a_resolvable_kpsewhich: build has no \
+         linked libkpathsea (needs --features kpathsea-build-from-source)"
+      );
+      return;
+    }
+
     assert!(
       !log.contains("Error:missing_file:lxo_probe_304"),
       "the TEXINPUTS-only include must resolve with no usable kpsewhich; log:\n{log}"
@@ -1517,13 +1530,15 @@ mod dir_prefixed_package_loading {
     std::fs::create_dir_all(root.join("sub")).unwrap();
     std::fs::create_dir_all(root.join("extra")).unwrap();
 
-    let extra_abs = root.join("extra");
+    // A RELATIVE dir keeps this cross-platform without any path-string surgery:
+    // an absolute OS path in TeX source is hostile on Windows (`\` is catcode 0,
+    // so `C:\Users\…` tokenizes \U, \e, … as control sequences and mangles the
+    // arg that `\lx@set@path` Expand!s). `\lx@set@path` resolves a relative arg
+    // against SOURCEDIRECTORY (here the temp root), so `extra` == root/extra on
+    // every platform.
     std::fs::write(
       root.join("sub/lpkg.sty"),
-      format!(
-        "\\ProvidesPackage{{lpkg}}\n\\RequirePackage{{import}}\n\\lx@set@path{{{}}}\n",
-        extra_abs.to_string_lossy()
-      ),
+      "\\ProvidesPackage{lpkg}\n\\RequirePackage{import}\n\\lx@set@path{extra}\n",
     )
     .unwrap();
     std::fs::write(

--- a/latexml_oxide/tests/cluster_cli.rs
+++ b/latexml_oxide/tests/cluster_cli.rs
@@ -1533,8 +1533,9 @@ mod dir_prefixed_package_loading {
     // A RELATIVE dir keeps this cross-platform without any path-string surgery:
     // an absolute OS path in TeX source is hostile on Windows (`\` is catcode 0,
     // so `C:\Users\…` tokenizes \U, \e, … as control sequences and mangles the
-    // arg that `\lx@set@path` Expand!s). `\lx@set@path` resolves a relative arg
-    // against SOURCEDIRECTORY (here the temp root), so `extra` == root/extra on
+    // arg that `\lx@set@path` Expand!s). A relative arg resolves against
+    // SOURCEDIRECTORY when that is set, else the process cwd — both are the temp
+    // root here (the run uses current_dir(root)), so `extra` == root/extra on
     // every platform.
     std::fs::write(
       root.join("sub/lpkg.sty"),

--- a/latexml_post/src/graphics.rs
+++ b/latexml_post/src/graphics.rs
@@ -2683,14 +2683,55 @@ mod tests {
     assert_eq!(lit, "x2", "the literal-x1 source falls through to x2");
   }
 
+  // ---- cross-platform child-process fixtures for run_with_timeout ----
+  // Unix `true`/`sh`/`sleep` don't exist on Windows; use cmd/ping there so the
+  // kill / exit-status / stderr-capture logic gets real coverage on both.
+
+  /// A child that runs far longer than any test deadline (so the timeout kills
+  /// it). `ping` is a bare exe — no shell wrapper — so `kill()` reaps it with no
+  /// orphaned grandchild.
+  fn spawn_slow_child() -> std::process::Command {
+    let mut cmd;
+    if cfg!(windows) {
+      cmd = std::process::Command::new("ping");
+      cmd.args(["-n", "11", "127.0.0.1"]);
+    } else {
+      cmd = std::process::Command::new("sleep");
+      cmd.arg("10");
+    }
+    cmd
+  }
+
+  /// A child that exits 0 immediately (Unix `true` / Windows `cmd /C exit 0`).
+  fn spawn_fast_ok() -> std::process::Command {
+    let mut cmd = std::process::Command::new(if cfg!(windows) { "cmd" } else { "true" });
+    if cfg!(windows) {
+      cmd.args(["/C", "exit 0"]);
+    }
+    cmd
+  }
+
+  /// A child that writes to stderr and exits non-zero. Returns the command and
+  /// its program name (for the diagnostic assertion).
+  fn spawn_stderr_fail() -> (std::process::Command, &'static str) {
+    if cfg!(windows) {
+      let mut cmd = std::process::Command::new("cmd");
+      cmd.args(["/C", "echo boom on stderr 1>&2 & exit 3"]);
+      (cmd, "cmd")
+    } else {
+      let mut cmd = std::process::Command::new("sh");
+      cmd.arg("-c").arg("echo 'boom on stderr' >&2; exit 3");
+      (cmd, "sh")
+    }
+  }
+
   /// `run_with_timeout` kills the child and returns `None` when the
-  /// process exceeds the deadline. Uses `sleep` as a stand-in for any
+  /// process exceeds the deadline. The slow child stands in for any
   /// runaway subprocess (convert, gs, mutool, …).
   #[test]
   fn run_with_timeout_kills_slow_child() {
     let start = std::time::Instant::now();
-    let mut cmd = std::process::Command::new("sleep");
-    cmd.arg("10");
+    let cmd = spawn_slow_child();
     let result = Graphics::run_with_timeout(cmd, std::time::Duration::from_millis(200));
     let elapsed = start.elapsed();
     assert!(
@@ -2709,10 +2750,10 @@ mod tests {
   /// Fast-completing child returns its real exit status, not a kill.
   #[test]
   fn run_with_timeout_returns_status_for_fast_child() {
-    let cmd = std::process::Command::new("true");
+    let cmd = spawn_fast_ok();
     let result = Graphics::run_with_timeout(cmd, std::time::Duration::from_secs(5));
     let status = result.expect("expected clean exit");
-    assert!(status.success(), "`true` should exit successfully");
+    assert!(status.success(), "a fast child should exit successfully");
   }
 
   /// Missing binary → `None`, not a panic.
@@ -3443,8 +3484,7 @@ endobj
   #[test]
   fn run_with_timeout_captures_stderr_into_diag() {
     take_converter_diag(); // clear
-    let mut cmd = std::process::Command::new("sh");
-    cmd.arg("-c").arg("echo 'boom on stderr' >&2; exit 3");
+    let (cmd, prog) = spawn_stderr_fail();
     let status = Graphics::run_with_timeout(cmd, std::time::Duration::from_secs(5));
     assert!(
       status.map(|s| !s.success()).unwrap_or(false),
@@ -3452,7 +3492,7 @@ endobj
     );
     let diag = take_converter_diag().expect("a diagnostic must be recorded");
     assert!(
-      diag.contains("boom on stderr") && diag.contains("sh"),
+      diag.contains("boom on stderr") && diag.contains(prog),
       "diag should name the program + its stderr; got: {diag}"
     );
   }

--- a/tools/win_perf_bench.ps1
+++ b/tools/win_perf_bench.ps1
@@ -1,0 +1,112 @@
+# win_perf_bench.ps1 — Windows performance probe for latexml_oxide.
+#
+# Measures the three things that make Windows behave differently from the Linux
+# CI/benchmark host (docs/performance/ARXIV_PERFORMANCE.md):
+#   1. Fixed process cost — external wall vs the in-process telemetry `wall_us`
+#      (the gap is spawn + global init + I/O the pipeline clock never sees).
+#   2. Per-phase budget on a mix of repo fixtures (the 17-phase `--telemetry-out`
+#      record; see docs/performance/TELEMETRY.md).
+#   3. Subprocess-spawn microbench — the OS `CreateProcess` floor, the exe-load
+#      floor, and a `kpsewhich` file lookup (the kpathsea `ls-R` init cost that
+#      dominates the subprocess backend — docs/performance/WINDOWS_PERFORMANCE.md).
+#
+# The kpathsea backend the binary was built with (subprocess kpsewhich vs
+# in-process linked libkpathsea, `--features kpathsea-build-from-source`) is
+# echoed from the first conversion's log — run the script once per binary to A/B.
+#
+# Usage (from anywhere; TeX Live for Windows must be reachable):
+#   $env:PATH = "C:\texlive\2026\bin\windows;" + $env:PATH   # NOT MiKTeX-first
+#   tools\win_perf_bench.ps1
+#   tools\win_perf_bench.ps1 -Bin path\to\latexml_oxide.exe -OutDir C:\tmp\perf -K 6
+#
+# Windows PowerShell 5.1 (no &&/||; native-command stderr is wrapped as
+# NativeCommandError records — harmless, we time exit codes not $?).
+
+param(
+  [string]$Bin    = (Join-Path $PSScriptRoot '..\target\release\latexml_oxide.exe'),
+  [string]$OutDir = (Join-Path $env:TEMP 'lxo-winperf'),
+  [int]$K         = 6            # timed reps per doc; report min + median
+)
+
+$ErrorActionPreference = 'Continue'
+$repo = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+New-Item -ItemType Directory -Force $OutDir | Out-Null
+Set-Location $repo
+
+function Median($xs) {
+  $s = @($xs | Sort-Object); $n = $s.Count
+  if ($n -eq 0) { return 0 }
+  if ($n % 2 -eq 1) { return $s[[int]([math]::Floor($n/2))] }
+  return ($s[$n/2 - 1] + $s[$n/2]) / 2.0
+}
+function TimeMs($sb) {
+  $sw = [System.Diagnostics.Stopwatch]::StartNew()
+  & $sb 2>$null | Out-Null
+  $sw.Stop(); return $sw.Elapsed.TotalMilliseconds
+}
+
+Write-Host '==== HOST ===='
+$cpu = Get-CimInstance Win32_Processor | Select-Object -First 1
+Write-Host ("CPU: {0} ({1}C/{2}T)" -f $cpu.Name.Trim(), $cpu.NumberOfCores, $cpu.NumberOfLogicalProcessors)
+$os = Get-CimInstance Win32_OperatingSystem
+Write-Host ("OS: {0}  RAM: {1:N1} GiB free / {2:N1} GiB total" -f $os.Caption, ($os.FreePhysicalMemory/1MB), ($os.TotalVisibleMemorySize/1MB))
+try {
+  $mp = Get-MpComputerStatus -ErrorAction Stop
+  Write-Host ("Defender RealTimeProtection: {0}   BehaviorMonitor: {1}" -f $mp.RealTimeProtectionEnabled, $mp.BehaviorMonitorEnabled)
+} catch { Write-Host "Defender status: unavailable ($($_.Exception.Message))" }
+
+Write-Host "`n==== KPATHSEA BACKEND ===="
+$he = Join-Path $OutDir 'hello.stderr.txt'
+& $Bin (Join-Path $repo 'latexml_oxide\tests\hello\hello.tex') --dest (Join-Path $OutDir 'hello.html') 2> $he | Out-Null
+Write-Host ("  " + (Select-String -Path $he -Pattern 'kpathsea:backend' | Select-Object -First 1).Line)
+
+Write-Host "`n==== SPAWN MICROBENCH (min ms of $K) ===="
+$floor = 1..$K | ForEach-Object { TimeMs { & cmd /c rem } }
+Write-Host ("  cmd /c rem (OS spawn floor):      min {0,7:N1}  median {1,7:N1}" -f ($floor|Measure-Object -Minimum).Minimum, (Median $floor))
+$ver = 1..$K | ForEach-Object { TimeMs { & $Bin --version } }
+Write-Host ("  latexml_oxide --version:          min {0,7:N1}  median {1,7:N1}" -f ($ver|Measure-Object -Minimum).Minimum, (Median $ver))
+$kpseV = 1..$K | ForEach-Object { TimeMs { & kpsewhich --version } }
+Write-Host ("  kpsewhich --version (no lookup):  min {0,7:N1}  median {1,7:N1}" -f ($kpseV|Measure-Object -Minimum).Minimum, (Median $kpseV))
+$kpse = 1..$K | ForEach-Object { TimeMs { & kpsewhich cmr10.tfm } }
+Write-Host ("  kpsewhich cmr10.tfm (ls-R init):  min {0,7:N1}  median {1,7:N1}" -f ($kpse|Measure-Object -Minimum).Minimum, (Median $kpse))
+$kpse5 = 1..$K | ForEach-Object { TimeMs { & kpsewhich cmr10.tfm article.cls tikz.sty xcolor.sty pgf.sty } }
+Write-Host ("  kpsewhich x5 (one process):       min {0,7:N1}  median {1,7:N1}" -f ($kpse5|Measure-Object -Minimum).Minimum, (Median $kpse5))
+
+$inputs = @(
+  'latexml_oxide\tests\hello\hello.tex',
+  'latexml_oxide\tests\structure\book.tex',
+  'latexml_oxide\tests\complex\si.tex',
+  'latexml_oxide\tests\benchmark\equality_big.tex',
+  'latexml_oxide\tests\tikz\various_colors.tex'
+)
+$PHASES = @('bootstrap','digest','build','rewrite','math_parse','post_xml_parse','post_scan','bibliography','crossref','graphics','math_images','mathml_pres','mathml_cont','split','xslt','html5_fixups','serialize')
+
+Write-Host "`n==== PER-DOC WALL (ms) ===="
+Write-Host ("  {0,-16} {1,10} {2,10} {3,10} {4,10}" -f 'doc','ext_min','ext_med','tele_wall','delta')
+$agg = @{}; foreach ($p in $PHASES) { $agg[$p] = [double]0 }
+foreach ($rel in $inputs) {
+  $name = [System.IO.Path]::GetFileNameWithoutExtension($rel)
+  $src  = Join-Path $repo $rel
+  if (-not (Test-Path $src)) { Write-Host ("  {0,-16} MISSING" -f $name); continue }
+  $dest = Join-Path $OutDir ($name + '.html')
+  $tele = Join-Path $OutDir ($name + '.telemetry.json')
+  & $Bin $src --dest $dest --telemetry-out $tele 2>$null | Out-Null   # warm
+  $ext = 1..$K | ForEach-Object { TimeMs { & $Bin $src --dest $dest --telemetry-out $tele } }
+  $extMin = ($ext | Measure-Object -Minimum).Minimum; $extMed = Median $ext
+  $tMs = 0
+  if (Test-Path $tele) {
+    $j = Get-Content $tele -Raw | ConvertFrom-Json
+    $tMs = [double]$j.wall_us / 1000.0
+    for ($i=0; $i -lt $PHASES.Count; $i++) { $agg[$PHASES[$i]] += [double]$j.phase_us[$i] }
+  }
+  Write-Host ("  {0,-16} {1,10:N1} {2,10:N1} {3,10:N1} {4,10:N1}" -f $name, $extMin, $extMed, $tMs, ($extMed-$tMs))
+}
+
+Write-Host "`n==== AGGREGATE PHASE BUDGET (sum over docs) ===="
+$sum = ($agg.Values | Measure-Object -Sum).Sum
+if ($sum -gt 0) {
+  foreach ($p in $PHASES) {
+    if ($agg[$p] -gt 0) { Write-Host ("  {0,-16} {1,7:N1}%  ({2,12:N0} us)" -f $p, (100.0*$agg[$p]/$sum), $agg[$p]) }
+  }
+}
+Write-Host "`n[done]"


### PR DESCRIPTION
## Windows performance profile + the test/lint gaps it surfaced

First Windows-specific perf pass (prior `docs/performance/` campaigns only ever
measured the Linux host), plus fixes for every Windows-only test/lint failure the
work uncovered. Measured on a Threadripper 1950X / Win10 / TeX Live 2026 box.

### Performance finding: the kpathsea backend is the one lever

A/B on the **same commit**, identical inputs, only the kpathsea backend differs:

| document | file resolutions | subprocess `kpsewhich` | in-process libkpathsea | speed-up |
|---|--:|--:|--:|--:|
| `hello`          |   5 |    857 ms |    505 ms | 1.7× |
| `equality_big`   |   5 |  3 555 ms |  3 261 ms | 1.09× |
| `various_colors` | 102 | **21 717 ms** | **1 354 ms** | **16.0×** |

The subprocess backend re-loads the `ls-R` filename DB on **every** `kpsewhich`
spawn (~270 ms fixed, CPU not disk); file-heavy docs pay it per unique file, so
`digest` swells to 86 % of wall. The in-process backend (already shipped via
`--features kpathsea-build-from-source`) loads `ls-R` once. Per-file memoisation
already exists (`KPSE_MEMO`); batching is the only other subprocess lever and is
low-ROI — so **in-process is the real fix and it already ships.** Full write-up +
reproducible harness: `docs/performance/WINDOWS_PERFORMANCE.md`,
`tools/win_perf_bench.ps1`.

### Product fixes

- **Silent 0×0 figures** — `read_pdf_page_box` / `read_image_dimensions` did
  `fs::read/open(path).ok()?`, so any read error became a `None` figure at 0×0. On
  Windows a just-written figure can be briefly locked (AV scan / file sharing).
  Both now go through `with_transient_retry`: `NotFound` fails fast with no sleep,
  every other error is retried with a widening backoff up to ~0.5 s, the happy
  path pays nothing. Retry is deliberately broad (locks have shown kinds beyond
  `PermissionDenied` under load). Unit-tested for all three arms.
- **Broken figure paths on Windows** — `pathname::abs2rel` built its result with
  `PathBuf`, joining with `\`, so graphics `candidates` came out `..\graphics\x.png`
  instead of `../graphics/x.png`. Normalized to `/` under `#[cfg(windows)]` —
  compiled out on Unix (where `\` is a legal filename byte), so goldens are
  unchanged and no Unix name can be corrupted.

### Windows test/lint gaps fixed (no product regressions)

A Windows `cargo test` without Git's `/usr/bin` on PATH had 9 failures, all
Unix-only assumptions in the tests/lint, none product regressions:

- graphics `run_with_timeout_*` and script_bindings `command_output…` shelled out
  to `true`/`sh`/`sleep`/`printf`; now use cmd/ping via `cfg!(windows)`.
- cluster_cli: `import_primitive_search_path…` injected a `C:\…` path into TeX
  source (`\` is catcode 0) — now relative; `texinputs…without_kpsewhich` skips
  cleanly on a subprocess-only build.
- `render_workers.rs`: scoped a pre-existing Windows-only `dead_code` clippy
  failure (the `Spawned` pid is read only in the `#[cfg(unix)]` fleet-kill) to
  non-unix.
- abs2rel-adjacent test assumptions: `relative_emits_dotdot` (a bare `/x` isn't
  absolute on Windows — now drive-prefixed) and `subimport_absolute_path`
  (backslash in TeX source — now forward-slashed).

### Validation

- `cargo test --release --workspace`: **green on Windows** (TL2026, coreutils-free).
- `cargo clippy --workspace --all-targets -- -D warnings`: **clean** on Windows.
- Linux CI was already green; every change here is a no-op or cross-platform there.

**Out of scope (tracked separately):** wire the Windows fleet-kill
(`OpenProcess`+`TerminateProcess`) for `parallel_render`'s timeout/memory breach
path, currently `#[cfg(unix)]`-only (`libc::kill`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
