### PR TITLE
fix: hyperref \url/\href keep a leftover control sequence literal, not digested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+  - **A control sequence in a hyperref `\url`/`\href` no longer disappears.** A
+    non-expandable primitive inside a URL (e.g. `\url{https://ex/q=\def}`) was read
+    semiverbatim and then *digested* — `\def` executed, consumed the following
+    tokens, truncated the URL to `…q=` and raised errors — where pdflatex (and real
+    `url.sty`, via `\meaning`) keep it as literal link text. The hyperref reader now
+    stringifies any leftover control sequence (recatcodes it to `other`) instead of
+    handing it to digestion, while still expanding the `url.sty` escapes (`\%`,
+    `\_`, `\^`, `\textbackslash`, …) during the read, so realistic URLs are
+    unchanged and `\url`/`\href` now agree. Perl LaTeXML digests the same way
+    (byte-identical output, more errors) — a deliberate surpass (OXIDIZED_DESIGN
+    #147). Follow-up to issue #723's rebuttal (reporter xworld21 / Vincenzo
+    Mantova); guards `cluster_url_cs_verbatim_723`, `hyperurls_test`.
   - **`fairmeta.cls` papers now link each author to their institution.** The
     Meta/FAIR pre-print template (and its `selfevolagent`/`openmoss` siblings)
     connects authors to institutions and contribution notes by superscript mark —

--- a/docs/parity/OXIDIZED_DESIGN.md
+++ b/docs/parity/OXIDIZED_DESIGN.md
@@ -9,7 +9,7 @@ This file is the **index + overview**. The detail lives in a themed family:
 
 | Theme file | What it holds |
 |---|---|
-| [OXIDIZED_DESIGN_DIVERGENCES.md](OXIDIZED_DESIGN_DIVERGENCES.md) | The numbered **Intentional Divergences from Perl** (`#1–#15`, `#17–#18`, `#19–#137`) + a brief Known-Upstream-Perl-Issues list. Code comments cite these as `OXIDIZED_DESIGN #N`. |
+| [OXIDIZED_DESIGN_DIVERGENCES.md](OXIDIZED_DESIGN_DIVERGENCES.md) | The numbered **Intentional Divergences from Perl** (`#1–#15`, `#17–#18`, `#19–#147`) + a brief Known-Upstream-Perl-Issues list. Code comments cite these as `OXIDIZED_DESIGN #N`. |
 | [OXIDIZED_DESIGN_MATH.md](../math/OXIDIZED_DESIGN_MATH.md) | Marpa math-parser design: `#16` design rules + the grammar-rule cluster `#7–#18`. |
 | [OXIDIZED_DESIGN_TYPES.md](OXIDIZED_DESIGN_TYPES.md) | Type-system improvements (behavior-neutral) + tactical internal pitfalls. |
 | [OXIDIZED_DESIGN_FUTURE_WORK.md](OXIDIZED_DESIGN_FUTURE_WORK.md) | Beyond-parity directions not yet built. |
@@ -23,7 +23,7 @@ This file is the **index + overview**. The detail lives in a themed family:
 > "Speculative function application"**) are in MATH; (3) **`#76` is a retired
 > number** — its entry was consolidated into `#74` and the number was not
 > reused, so a gap in the sequence is expected, not a missing file. Next free
-> number: **#134**. When in doubt,
+> number: **#148**. When in doubt,
 > `grep '### N\.' docs/parity/OXIDIZED_DESIGN_*.md docs/math/OXIDIZED_DESIGN_MATH.md`.
 
 ---

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -5573,3 +5573,57 @@ visible there.
 
 **Guards**: `06_cluster_regressions::cluster_frontmatter_title_ink_dedup_6924` (structured `<title>`
 kept, title text appears exactly once, hand-typeset author block preserved).
+
+### 147. A leftover control sequence in a hyperref URL stays literal, not digested
+
+**Background.** LaTeXML reads a hyperref `\url`/`\href` argument *semiverbatim*: it neutralizes the
+specials to catcode-12 but keeps the backslash an escape (`hyperref.sty.ltxml:165-186`,
+"Expand as we go!" / "let CS's through!"), so the argument is read with partial expansion and any
+surviving control sequence is then handed to digestion. Real `url.sty` instead `\meaning`-stringifies
+the whole argument (`\edef\Url@String{\expandafter\strip@prefix\meaning\Url@String}`), which turns
+every leftover control sequence into inert characters. The difference bites on a **non-expandable
+primitive** in a URL, e.g. `\url{https://ex/q=\def}`: digesting `\def` *executes* it — it reads the
+following tokens as its name/parameter-text/body, consumes past the closing brace, truncates the URL
+to `…q=` and raises errors. Escapes (`\%`, `\_`, `\^`, `\textasciitilde`, …) are unaffected because
+they resolve to their character before/at digestion; only a genuine leftover CS misbehaves.
+
+**Perl behavior**: SHARED-FAILURE — Perl LaTeXML digests the `\def` the same way and is in fact
+*worse*. Verified same-host (Perl 0.8.8, rev `0d02309d`): `\url{https://www.google.com/search?q=\def}`
+→ **byte-identical** `href="https://www.google.com/search?q="` in both engines, Perl raising **4**
+errors to our 2. Not a Rust-only bug; the change below is a deliberate surpass. pdflatex keeps the
+`\def` as literal link text (via `url.sty`'s `\meaning`), which is what an author expects.
+
+**Rust behavior (beyond-Perl)**: after the semiverbatim read, any *surviving* control sequence is
+recatcoded to `other` (`Token::as_other`) — url.sty's `\meaning` in one step — so `\def` becomes the
+literal href text `\def` instead of executing. To keep the escapes resolving so realistic URLs are
+unchanged, the reader now expands url.sty's escape set (`\%`, `\#`, `\&`, `\_`, `\~`,
+`\textasciitilde`, `\^`, `\textasciicircum`, `\textbackslash`, `\\`) to their character *during* the
+partial read (mirroring `url.sty`'s first pass), leaving only genuine leftovers as CS to stringify.
+Two sites, kept consistent so `\url` and `\href` agree: `\lx@hyper@url` (`hyperref_sty.rs`, the
+hyperref `\url`) and the `HyperVerbatim` parameter type (`base_parameter_types.rs`, backing `\href`).
+Plain `url.sty` without hyperref already did this (it recatcodes the whole argument to `other`), so
+this brings the hyperref path into line with it — and with pdflatex.
+
+**Why it's safe / precise.** Only a leftover *control sequence* changes — every url.sty escape still
+resolves (`\_`→`_`, `\^`→`^`, `\textbackslash`→`\`, …), literal specials pass through, and an
+expandable `\macro` still expands during the read. The net effect on any URL that previously
+converted cleanly is nil; the only behavior that changes is the one that previously *errored* and
+lost data. Consistent with #144 (which fixed the T1 ASCII *display* of verbatim/URL text) — that
+was the font side, this is the token side.
+
+**Scope / limitation.** `\path` already stringified leftovers (plain `url.sty`'s `\lx@url@url`
+recatcodes its whole argument to `other`), so it was never affected. `\nolinkurl` still digests a
+leftover primitive (SHARED-FAILURE with Perl — both truncate `\nolinkurl{…n=\def}` to `n=`): it reads
+through the generic `Semiverbatim` *parameter type*, so bringing it in line would mean changing that
+shared reader — out of this ticket's scope, left as parity.
+
+**Witnesses**: issue #723 rebuttal (reporter xworld21 / Vincenzo Mantova), comment 5380586287:
+`\url{https://www.google.com/search?q=\def}` lost the `\def` and errored while pdflatex kept it.
+
+**Upstream**: worth filing against `brucemiller/LaTeXML` — its `\url`/`\href` digest a leftover
+primitive the same way; adopting `url.sty`'s `\meaning`-stringify would fix it there too.
+
+**Guards**: `06_cluster_regressions::cluster_url_cs_verbatim_723` (distilled reproductions covering
+Vincenzo's cases: `\def` stays literal in both `\url` and `\href`, escapes/`~`/`\textbackslash`
+still resolve, 0 errors); `10_expansion::hyperurls_test` (the full escape matrix — `\#`, `\&`, `\_`,
+`\%`, `\^`, `\~{}`, macro expansion, literal `^`/`$`/`{}` — all still resolve).

--- a/latexml_engine/src/base_parameter_types.rs
+++ b/latexml_engine/src/base_parameter_types.rs
@@ -525,11 +525,25 @@ LoadDefinitions!({
       DefMacro!(T_CS!("\\hyper@tilde"), None, T_OTHER!("~"), scope => Some(Scope::Local));
       let_i(&T_CS!("\\~"), &T_CS!("\\hyper@tilde"), None);
       let_i(&T_CS!("\\textasciitilde"), &T_CS!("\\hyper@tilde"), None);
+      DefMacro!(T_CS!("\\^"), None, T_OTHER!("^"), scope => Some(Scope::Local));
+      let_i(&T_CS!("\\textasciicircum"), &T_CS!("\\^"), None);
       let_i(&T_CS!("\\\\"), &T_CS!("\\@backslashchar"), None);
+      DefMacro!(T_CS!("\\textbackslash"), None, T_OTHER!("\\"), scope => Some(Scope::Local));
       // Having prepared, read in the argument, expanding as we go
       let arg = read_balanced(ExpansionLevel::Partial,false,false)?;
       end_semiverbatim()?;
-      arg
+      // url.sty stringifies the URL via `\meaning`: with the escapes above
+      // already expanded during the read, any LEFTOVER control sequence (a
+      // non-expandable primitive such as `\def`) must become literal characters,
+      // NOT be handed to digestion — digesting `\def` executes it, consumes the
+      // following tokens and truncates the URL (#723, reporter xworld21).
+      // Recatcode surviving CS tokens to `other`; everything else is untouched.
+      use latexml_core::token::Catcode;
+      Tokens::new(
+        arg.unlist().into_iter()
+          .map(|t| if t.get_catcode() == Catcode::CS { t.as_other() } else { t })
+          .collect(),
+      )
     },
     before_digest => {
       bgroup();

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -528,6 +528,49 @@ fn cluster_t1_verbatim_ascii_723() {
     "verbatim/url runs lost the typewriter family (#723 — encoding must not clobber font):\n{xml}"
   );
 }
+/// Issue #723 (reporter xworld21 / Vincenzo Mantova), follow-up rebuttal: a
+/// non-expandable control sequence inside a hyperref `\url`/`\href` (e.g. `\def`)
+/// was DIGESTED — it executed, consumed the following tokens, truncated the URL
+/// and raised errors (`\url{…q=\def}` → `href="…q="` + 2 errors), whereas
+/// pdflatex/url.sty keep it as literal href text. url.sty stringifies the URL via
+/// `\meaning` (all leftover control sequences become inert characters); we now
+/// mirror that faithfully: after the semiverbatim read, any surviving control
+/// sequence is recatcoded to `other` instead of being handed to digestion. The
+/// url.sty escapes (`\_`, `\%`, `\^`, `\textasciitilde`, `\textbackslash`, …)
+/// still RESOLVE to their character (they expand during the read), so realistic
+/// URLs are unchanged. Surpasses Perl (same digest bug). Distilled reproductions
+/// cover Vincenzo's reported cases; the full escape matrix is in `hyperurls`.
+#[test]
+fn cluster_url_cs_verbatim_723() {
+  // `convert_to_xml` gates on ZERO `Error:` markers — RED while `\def` digests.
+  let xml = convert_to_xml("tests/cluster_regressions/url_cs_verbatim_723.tex");
+  // (a)+(b) Canary: the leftover `\def` survives as literal href text in BOTH
+  // `\url` and `\href`, rather than executing and truncating the URL.
+  assert!(
+    xml.contains(r#"href="http://x/q=\def""#),
+    "\\url with a trailing \\def did not keep it as literal href text (#723):\n{xml}"
+  );
+  assert!(
+    xml.contains(r#"href="http://x/h=\def""#),
+    "\\href with a trailing \\def did not keep it as literal href text (#723):\n{xml}"
+  );
+  // (c) Regression guard: resolving control sequences stay resolved and a literal
+  // `~` passes through — \textasciitilde -> ~ , \textbackslash -> \ .
+  assert!(
+    xml.contains(r#"href="http://x/a~b~c\d""#),
+    "`\\textasciitilde`/`\\textbackslash`/literal `~` regressed in a URL (#723):\n{xml}"
+  );
+  // (d) Regression guard: `\href` keeps a literal `~`.
+  assert!(
+    xml.contains(r#"href="http://x/~u""#),
+    "`\\href` dropped a literal `~` (#723):\n{xml}"
+  );
+  // (e) Regression guard: url.sty escapes still resolve to their character.
+  assert!(
+    xml.contains(r#"href="http://x/a_b%c""#),
+    "url.sty escapes `\\_`/`\\%` no longer resolve to `_`/`%` (#723 regression):\n{xml}"
+  );
+}
 #[test]
 fn cluster_fvextra_preserves_ltx_verbatim() {
   let xml = convert_to_xml("tests/cluster_regressions/fvextra_ltx_verbatim.tex");

--- a/latexml_oxide/tests/cluster_regressions/url_cs_verbatim_723.tex
+++ b/latexml_oxide/tests/cluster_regressions/url_cs_verbatim_723.tex
@@ -1,0 +1,26 @@
+\documentclass{article}
+\usepackage[T1]{fontenc}
+\usepackage{hyperref}
+\begin{document}
+% Distilled minimal reproductions covering @xworld21's (Vincenzo Mantova)
+% reported cases on issue #723. The full escape matrix (\#, \&, \_, \%, \^,
+% \~{}, macro expansion, literal specials) is covered by tests/expansion/hyperurls.
+%
+% (a) rebuttal comment 5380586287: a non-expandable primitive (`\def`) inside a
+% URL was DIGESTED — it executed, consumed following tokens, truncated the URL
+% and errored. It must stay LITERAL href text (url.sty `\meaning`), like pdflatex.
+\url{http://x/q=\def}
+
+% (b) the SAME reader backs `\href` — a leftover primitive stays literal there too.
+\href{http://x/h=\def}{link}
+
+% (c) comment 5375053714: control sequences that RESOLVE stay resolved —
+% \textasciitilde -> ~ , \textbackslash -> \ , and a literal ~ passes through.
+\url{http://x/a~b\textasciitilde c\textbackslash d}
+
+% (d) comment 5372406924: `\href` keeps a literal ~ in the URL.
+\href{http://x/~u}{link}
+
+% (e) url.sty escapes still resolve to their character (unchanged behavior).
+\url{http://x/a\_b\%c}
+\end{document}

--- a/latexml_package/src/package/hyperref_sty.rs
+++ b/latexml_package/src/package/hyperref_sty.rs
@@ -436,6 +436,24 @@ LoadDefinitions!({
         assign_catcode(ch, Catcode::OTHER, Some(Scope::Local));
       }
     }
+    // url.sty's defined escapes expand to their character DURING the read (its
+    // first pass, `\edef`), so `\%`/`\_`/… resolve here rather than by later
+    // digestion. This mirrors the `HyperVerbatim` parameter type
+    // (base_parameter_types.rs) so `\url` and `\href` agree, and it leaves ONLY
+    // genuinely-leftover control sequences (e.g. `\def`) as CS tokens, which the
+    // filter below stringifies.
+    DefMacro!(T_CS!("\\%"),              None, T_OTHER!("%"), scope => Some(Scope::Local));
+    DefMacro!(T_CS!("\\#"),              None, T_OTHER!("#"), scope => Some(Scope::Local));
+    DefMacro!(T_CS!("\\&"),              None, T_OTHER!("&"), scope => Some(Scope::Local));
+    DefMacro!(T_CS!("\\textunderscore"), None, T_OTHER!("_"), scope => Some(Scope::Local));
+    let_i(&T_CS!("\\_"), &T_CS!("\\textunderscore"), None);
+    DefMacro!(T_CS!("\\hyper@tilde"),    None, T_OTHER!("~"), scope => Some(Scope::Local));
+    let_i(&T_CS!("\\~"), &T_CS!("\\hyper@tilde"), None);
+    let_i(&T_CS!("\\textasciitilde"), &T_CS!("\\hyper@tilde"), None);
+    DefMacro!(T_CS!("\\^"), None, T_OTHER!("^"), scope => Some(Scope::Local));
+    let_i(&T_CS!("\\textasciicircum"), &T_CS!("\\^"), None);
+    let_i(&T_CS!("\\\\"), &T_CS!("\\@backslashchar"), None);
+    DefMacro!(T_CS!("\\textbackslash"), None, T_OTHER!("\\"), scope => Some(Scope::Local));
     let (open,close,url) = if open.get_catcode() == Catcode::BEGIN {
       ( T_OTHER!("{"), T_OTHER!("}"),
         read_balanced(ExpansionLevel::Partial,false,false)?.unwrap_or_default()) // Expand as we go!
@@ -446,8 +464,11 @@ LoadDefinitions!({
     end_semiverbatim()?;
     let toks : Vec<Token> = url.unlist().into_iter()
       .filter(|t| t.get_catcode() != Catcode::SPACE)
-      // Identical with url's \@Url except, let CS's through!
-      .map(|t| if t.get_catcode() == Catcode::CS { t } else { t.as_other() })
+      // url.sty `\meaning`-stringifies leftover control sequences: recatcode any
+      // surviving CS (e.g. `\def`) to `other` so it is LITERAL href text, not
+      // digested/executed (#723). The escapes above already resolved during the
+      // read. (Perl "let CS's through!" to digestion — the divergence we surpass.)
+      .map(|t| t.as_other())
       .collect();
     let mut url_wrapped = vec![T_CS!("\\UrlFont"), T_CS!("\\UrlLeft")];
     url_wrapped.extend(toks.clone());


### PR DESCRIPTION
**Diagnostic.** Hyperref's `\url`/`\href` read the URL *semiverbatim* and then hand any surviving control sequence to digestion (`hyperref.sty.ltxml:165-186`, *"let CS's through!"*). A non-expandable primitive like `\def` then **executes** — consuming the following tokens, truncating the URL to `…q=` and raising errors — where pdflatex and real `url.sty` (via `\meaning`) keep it as literal link text.

**Approach.** After the semiverbatim read, stringify any surviving control sequence (recatcode it to `other`) — `url.sty`'s `\meaning` in one step — instead of digesting it. To keep escapes resolving, the reader expands the `url.sty` escape set (`\%`,`\#`,`\&`,`\_`,`\~`,`\^`,`\textasciitilde`,`\textbackslash`,…) *during* the read, so realistic URLs are unchanged and `\url`/`\href` now agree. Applied to `\lx@hyper@url` (`hyperref_sty.rs`) and the `HyperVerbatim` parameter type (`base_parameter_types.rs`); plain `url.sty` already did this. Perl LaTeXML digests the same way (verified byte-identical, more errors) — a deliberate surpass, `OXIDIZED_DESIGN #147`.

**Validation.** Red→green guard `cluster_url_cs_verbatim_723` (distilled reproductions covering the reporter's cases — `\def` literal in both `\url` and `\href`, escapes/`~`/`\textbackslash` still resolve, 0 errors); the full escape matrix in `hyperurls_test` (`\#`/`\&`/`\_`/`\%`/`\^`/`\~{}`/macro-expansion/literal specials) still resolves. Full suite 2151/0; clippy + fmt clean; witness re-confirmed same-host vs Perl and pdflatex.

Follow-up to the #723 rebuttal (reporter @xworld21 / Vincenzo Mantova). `\nolinkurl` (generic `Semiverbatim` param type) remains a shared-failure with Perl — left as parity, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUgFzi1zW73EpejP7L1NZ5