### PR TITLE
feat: minted Pygments colors + acmart affiliation comma wrapping + shared-affiliation-below-authors

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -5776,3 +5776,63 @@ LaTeXML already renders correctly; no positional information was being honoured 
 
 **Upstream**: to be filed at brucemiller/LaTeXML (raw `\tabto`'s `$$` measurement hack
 emits an empty equation and breaks the line; a `\hfill` approximation renders correctly).
+
+### 157. `minted` renders Pygments syntax colors from a committed `_minted/` frozencache
+
+**Perl behavior**: Perl LaTeXML ships no `minted` binding — the `minted` environment
+errors out (no highlighting at all). Our binding already routes `minted` through the
+`listings` substrate (bold-black keywords, no color), which is itself beyond Perl.
+
+**Rust behavior**: when a paper is built with `\usepackage[frozencache]{minted}`, the
+committed `_minted/` directory (sibling of the main `.tex`) already holds Pygments'
+output on disk as plain LaTeX. We read it and re-emit the **actual Pygments colors**
+(green bold keywords, teal italic comments, blue names, gray operators, purple
+decorators, …). Any colored output surpasses Perl's error-out. `\begin{minted}`,
+`\inputminted`, and `\mintinline` all take this path; on a miss they keep the exact
+uncolored `listings` rendering, and with no `_minted/` present the feature is a strict
+no-op.
+
+**The frozencache on disk.** `default.style.minted` defines a `\PYG@tok@<class>` per
+Pygments token class, each `\let\PYG@bf=\textbf` / `\let\PYG@it=\textit` and/or
+`\def\PYG@tc##1{\textcolor[rgb]{r,g,b}{##1}}`. Each `<MD5>.highlight.minted` is a
+`MintedVerbatim` body of `\PYG{<tokclass>}{<text>}` runs interleaved with literal
+spaces and `\PYGZ*` escapes (`\PYGZbs`→`\`, `\PYGZus`→`_`, `\PYGZgt`→`>`, …).
+
+**Method — content-match, not MD5-keying.** minted keys its cache by an MD5 over the
+snippet + options; replicating that keying is fragile. Instead, each highlight file —
+`\PYG` unwrapped and `\PYGZ*` resolved — yields the exact plain code of some snippet.
+We normalize a block's raw body the same way (rstrip each line, drop blank edges) and
+look it up in a `plaincode → lines` map built once per document (memoized by the
+resolved `_minted/` dir, so a later document never reuses a stale cache). Compound
+classes (`n+nf`, `l+m+mf`) are resolved like `\PYG@toks`: color from the LAST
+sub-class that sets one, bold/italic accumulate. Blocks that use `escapeinside`
+(their raw body carries `@…@` markers the highlight file lacks) simply miss and fall
+back — acceptable, since the current path already handles `escapeinside`.
+
+**Emitter.** Colored lines reuse the listings constructors so the output is
+structurally identical to the substrate (same `<ltx:listingline>`, same
+`ltx_lst_space` `white-space:pre` runs for indentation, same `<ltx:listing>`
+container with base64 `data` provenance): the block body is a sequence of
+`\@lst@startline{}` … `\@lst@endline`, each segment's chars mapped through the
+listings special-char table (`<`→`\textless`, `_`→`\textunderscore`, …) and wrapped
+in `\textbf`/`\textit`/`\textcolor[rgb]{…}` per its style. Two small helpers were
+added to `listings_sty` — `lst_process_display_with` / `lst_process_block_with` —
+that accept pre-built body tokens instead of re-parsing the source; the re-parsed
+entry points delegate to them, so the uncolored path is byte-identical.
+
+**Why it's safe.** Reading the host source tree's `_minted/` is in scope (like reading
+a `.sty`; the ban is only on latexml-oxide's *own* embedded resources). The feature
+activates only when `find_file("_minted/default.style.minted")` resolves, so
+non-frozencache papers are untouched; a cache miss keeps the current listings output.
+
+**Witness**: arXiv:2605.03143 (`\begin{minted}{ocaml|python}` blocks in
+`sections/01-introduction.tex`, `02-a-taste-of-pact.tex`, `03-memo.tex`, plus many
+`\mintinline{python}{…}`). Guard: `minted_frozencache_colors_from_pygments_cache_157`
+(`06_cluster_regressions.rs`) — drives the real binary against a hand-built tiny
+`_minted/` and asserts the `#008000`/`#0000FF` color spans, with a no-cache control
+proving the strict no-op. Implementation:
+`latexml_contrib/src/minted_frozencache.rs` + hooks in `minted_sty.rs`.
+
+**Limitation.** `\mintinline` snippets that Pygments leaves as plain names/punctuation
+(classes `n`, `p`) are correctly uncolored (faithful to Pygments); only `\mintinline`
+itself takes the cache path, not the `\newmintinline`-generated aliases.

--- a/latexml_contrib/src/lib.rs
+++ b/latexml_contrib/src/lib.rs
@@ -162,6 +162,7 @@ pub mod mdframed_sty;
 pub mod mdpi_cls;
 pub mod memoir_cls;
 pub mod mhchem_sty;
+pub mod minted_frozencache;
 pub mod minted_sty;
 pub mod mnsymbol_sty;
 pub mod morefloats_sty;

--- a/latexml_contrib/src/minted_frozencache.rs
+++ b/latexml_contrib/src/minted_frozencache.rs
@@ -1,0 +1,472 @@
+//! Pygments-color support for `minted` from a committed `_minted/` frozencache
+//! (surpass-Perl; `docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md` #157).
+//!
+//! Perl LaTeXML has no `minted` binding and errors out on the environment; our
+//! binding already routes minted through the `listings` substrate (bold-black
+//! keywords, no color). When a paper is built with
+//! `\usepackage[frozencache]{minted}`, the `_minted/` directory (a sibling of
+//! the main `.tex`) carries Pygments' output on disk as plain `\textcolor`:
+//!
+//! * `default.style.minted` — `\@namedef{PYG@tok@<class>}{…}` per token class,
+//!   each setting some of a color (`\def\PYG@tc##1{\textcolor[rgb]{r,g,b}{##1}}`),
+//!   bold (`\let\PYG@bf=\textbf`), italic (`\let\PYG@it=\textit`).
+//! * `<MD5>.highlight.minted` — one per highlighted snippet: a `MintedVerbatim`
+//!   body of `\PYG{<tokclass>}{<text>}` runs interleaved with literal spaces and
+//!   `\PYGZ*` escapes.
+//!
+//! Rather than replicate minted's fragile MD5 keying, we **content-match**: each
+//! highlight file, with `\PYG` unwrapped and `\PYGZ*` resolved, yields the exact
+//! plain code of a source snippet. We normalize a minted block's raw body the
+//! same way and look it up. On a hit we emit Pygments-colored listing lines
+//! (reusing the listings `\@lst@startline`/`\@lst@endline`/`\@listingGroup`
+//! constructors and xcolor's `\textcolor`); on a miss the caller keeps the exact
+//! current (uncolored) `listings` path. When no `_minted/` exists the whole
+//! feature is a no-op, so non-frozencache papers are unaffected.
+//!
+//! Reading the host source tree's `_minted/` is in scope (it is like reading a
+//! `.sty`, per CLAUDE.md — the ban is on reading latexml-oxide's *own* resources).
+//!
+//! Witness: arXiv:2605.03143 (`\begin{minted}{ocaml|python}` blocks in
+//! `sections/01-introduction.tex`, `02-a-taste-of-pact.tex`, `03-memo.tex`).
+
+use std::{cell::RefCell, path::Path};
+
+use latexml_core::binding::content::find_file;
+use latexml_package::prelude::*;
+
+/// A resolved token style: an optional `rgb` triple string (e.g.
+/// `"0.00,0.50,0.00"`, passed verbatim to `\textcolor[rgb]{…}`), plus bold /
+/// italic flags. Mirrors what `default.style.minted`'s `PYG@tok@<class>` sets.
+#[derive(Clone, Default)]
+struct Style {
+  rgb:    Option<String>,
+  bold:   bool,
+  italic: bool,
+}
+
+/// One `\PYG{tok}{text}` run (or a literal run with `tok = None`).
+struct Seg {
+  tok:  Option<String>,
+  text: String,
+}
+
+type Line = Vec<Seg>;
+
+/// A loaded `_minted/` cache, keyed on the resolved directory path so a later
+/// document on the same thread (a different `_minted/`, or none) never reuses it.
+struct CacheData {
+  dir:          String,
+  styles:       HashMap<String, Style>,
+  /// normalized plaincode → the highlighted lines that produced it.
+  by_plaincode: HashMap<String, Vec<Line>>,
+}
+
+thread_local! {
+  static CACHE: RefCell<Option<Rc<CacheData>>> = const { RefCell::new(None) };
+}
+
+/// Map `\PYGZxx` escape names to the literal character they stand for
+/// (`default.style.minted` L81-99).
+fn pygz_char(name: &str) -> Option<&'static str> {
+  Some(match name {
+    "PYGZbs" => "\\",
+    "PYGZus" => "_",
+    "PYGZob" => "{",
+    "PYGZcb" => "}",
+    "PYGZca" => "^",
+    "PYGZam" => "&",
+    "PYGZlt" => "<",
+    "PYGZgt" => ">",
+    "PYGZsh" => "#",
+    "PYGZpc" => "%",
+    "PYGZdl" => "$",
+    "PYGZhy" => "-",
+    "PYGZsq" => "'",
+    "PYGZdq" => "\"",
+    "PYGZti" => "~",
+    "PYGZat" => "@",
+    "PYGZlb" => "[",
+    "PYGZrb" => "]",
+    _ => return None,
+  })
+}
+
+/// Resolve every `\PYGZxx` / `\PYGZxx{}` occurrence in `s` to its literal char.
+fn resolve_pygz(s: &str) -> String {
+  static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\\(PYGZ[a-z][a-z])(\{\})?").unwrap());
+  RE.replace_all(s, |c: &regex::Captures| pygz_char(&c[1]).unwrap_or(""))
+    .into_owned()
+}
+
+/// Read a `{…}`-balanced group. `s` must start with `{`. Returns
+/// `(inner, rest_after_close)`. `\PYGZob{}`/`\PYGZcb{}` contribute balanced
+/// `{}` pairs, so brace counting stays correct.
+fn read_group(s: &str) -> Option<(String, &str)> {
+  let mut depth = 0i32;
+  for (idx, ch) in s.char_indices() {
+    match ch {
+      '{' => depth += 1,
+      '}' => {
+        depth -= 1;
+        if depth == 0 {
+          return Some((s[1..idx].to_string(), &s[idx + 1..]));
+        }
+      },
+      _ => {},
+    }
+  }
+  None
+}
+
+/// Parse one raw highlight line into `\PYG{tok}{text}` and literal segments.
+fn parse_line(line: &str) -> Line {
+  let mut segs: Line = Vec::new();
+  let mut lit = String::new();
+  let mut rest = line;
+  while !rest.is_empty() {
+    if let Some(after) = rest.strip_prefix("\\PYG{") {
+      // `tok}{content}` — tok never contains a brace.
+      if let Some(tok_end) = after.find('}') {
+        let tok = &after[..tok_end];
+        let after_tok = &after[tok_end + 1..];
+        if let Some((content, rest2)) = read_group(after_tok) {
+          if !lit.is_empty() {
+            segs.push(Seg {
+              tok:  None,
+              text: std::mem::take(&mut lit),
+            });
+          }
+          segs.push(Seg {
+            tok:  Some(tok.to_string()),
+            text: resolve_pygz(&content),
+          });
+          rest = rest2;
+          continue;
+        }
+      }
+      // Malformed \PYG — treat the backslash literally and move on.
+      lit.push('\\');
+      rest = &rest[1..];
+    } else if let Some(after) = rest.strip_prefix("\\PYGZ") {
+      // A bare escape outside \PYG (e.g. in an escapeinside remnant).
+      if after.len() >= 2 {
+        let name = format!("PYGZ{}", &after[..2]);
+        if let Some(ch) = pygz_char(&name) {
+          lit.push_str(ch);
+          rest = &after[2..];
+          rest = rest.strip_prefix("{}").unwrap_or(rest);
+          continue;
+        }
+      }
+      lit.push('\\');
+      rest = &rest[1..];
+    } else {
+      let c = rest.chars().next().unwrap();
+      lit.push(c);
+      rest = &rest[c.len_utf8()..];
+    }
+  }
+  if !lit.is_empty() {
+    segs.push(Seg { tok: None, text: lit });
+  }
+  segs
+}
+
+/// The concatenated plain text of a line.
+fn line_text(line: &Line) -> String { line.iter().map(|s| s.text.as_str()).collect() }
+
+/// Drop leading/trailing all-whitespace lines (in place).
+fn strip_blank_edges(lines: &mut Vec<Line>) {
+  while lines
+    .first()
+    .is_some_and(|l| line_text(l).trim().is_empty())
+  {
+    lines.remove(0);
+  }
+  while lines.last().is_some_and(|l| line_text(l).trim().is_empty()) {
+    lines.pop();
+  }
+}
+
+/// Normalized-plaincode key for a set of highlight lines: each line's trailing
+/// whitespace trimmed, joined by `\n` (blank edges already stripped).
+fn lines_key(lines: &[Line]) -> String {
+  lines
+    .iter()
+    .map(|l| line_text(l).trim_end().to_string())
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
+/// Normalize a minted block's raw source body to the same key form: rstrip each
+/// line, drop leading/trailing blank lines.
+fn normalize_source(text: &str) -> String {
+  let mut v: Vec<String> = text.split('\n').map(|l| l.trim_end().to_string()).collect();
+  while v.first().is_some_and(|l| l.is_empty()) {
+    v.remove(0);
+  }
+  while v.last().is_some_and(|l| l.is_empty()) {
+    v.pop();
+  }
+  v.join("\n")
+}
+
+/// Extract the `MintedVerbatim` body of a highlight file → its lines.
+fn parse_highlight(text: &str) -> Option<Vec<Line>> {
+  let begin = text.find("\\begin{MintedVerbatim}")?;
+  let body_start = text[begin..].find('\n')? + begin + 1;
+  let end = text.rfind("\\end{MintedVerbatim}")?;
+  if end < body_start {
+    return None;
+  }
+  let body = &text[body_start..end];
+  let mut lines: Vec<Line> = body.split('\n').map(parse_line).collect();
+  strip_blank_edges(&mut lines);
+  Some(lines)
+}
+
+/// Parse `default.style.minted` into a `tokclass → Style` map.
+fn parse_styles(text: &str) -> HashMap<String, Style> {
+  static NAME_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\\@namedef\{PYG@tok@([A-Za-z0-9]+)\}").unwrap());
+  static COLOR_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\\textcolor\[rgb\]\{([0-9.,]+)\}").unwrap());
+  let mut map: HashMap<String, Style> = HashMap::default();
+  for line in text.lines() {
+    if let Some(caps) = NAME_RE.captures(line) {
+      let class = caps[1].to_string();
+      let style = Style {
+        rgb:    COLOR_RE.captures(line).map(|c| c[1].to_string()),
+        bold:   line.contains(r"\PYG@bf=\textbf"),
+        italic: line.contains(r"\PYG@it=\textit"),
+      };
+      map.insert(class, style);
+    }
+  }
+  map
+}
+
+/// Load (and memoize) the `_minted/` cache for the current document. Keyed on
+/// the resolved directory, so repeated blocks reuse it and a different document
+/// reloads. Returns `None` when no frozencache is present.
+fn load_cache() -> Option<Rc<CacheData>> {
+  let style_path = find_file("_minted/default.style.minted", None)?;
+  let dir = Path::new(&style_path)
+    .parent()?
+    .to_string_lossy()
+    .into_owned();
+
+  if let Some(cached) = CACHE.with(|c| c.borrow().as_ref().filter(|d| d.dir == dir).cloned()) {
+    return Some(cached);
+  }
+
+  let styles = std::fs::read_to_string(&style_path)
+    .ok()
+    .map(|s| parse_styles(&s))?;
+  let mut by_plaincode: HashMap<String, Vec<Line>> = HashMap::default();
+  if let Ok(entries) = std::fs::read_dir(&dir) {
+    for entry in entries.flatten() {
+      let name = entry.file_name();
+      let name = name.to_string_lossy();
+      if !name.ends_with(".highlight.minted") {
+        continue;
+      }
+      if let Ok(text) = std::fs::read_to_string(entry.path())
+        && let Some(lines) = parse_highlight(&text)
+        && !lines.is_empty()
+      {
+        by_plaincode.entry(lines_key(&lines)).or_insert(lines);
+      }
+    }
+  }
+
+  let data = Rc::new(CacheData { dir, styles, by_plaincode });
+  CACHE.with(|c| *c.borrow_mut() = Some(data.clone()));
+  Some(data)
+}
+
+/// True when a `_minted/` frozencache is present for the current document.
+pub fn cache_available() -> bool { load_cache().is_some() }
+
+/// Resolve a (possibly compound, e.g. `n+nf`, `l+m+mf`) token class to a style.
+/// Mirrors `\PYG@toks`: each `+`-separated sub-class is applied in order — color
+/// takes the LAST sub-class that sets one, bold/italic accumulate.
+fn resolve_style(cache: &CacheData, tok: &Option<String>) -> Style {
+  let mut st = Style::default();
+  if let Some(t) = tok {
+    for sub in t.split('+') {
+      if let Some(s) = cache.styles.get(sub) {
+        if s.rgb.is_some() {
+          st.rgb = s.rgb.clone();
+        }
+        st.bold |= s.bold;
+        st.italic |= s.italic;
+      }
+    }
+  }
+  st
+}
+
+/// Map a single code character to its emit tokens: TeX-special chars → the
+/// text-command escape (mirrors listings' `lst_char_mapping`, upquote off);
+/// everything else → a literal `OTHER` char (as the listings char path does).
+fn map_char(c: char) -> Vec<Token> {
+  let cs: &'static str = match c {
+    '#' => "\\#",
+    '$' => "\\textdollar",
+    '&' => "\\&",
+    '\'' => "\\textquoteright",
+    '*' => "\\textasteriskcentered",
+    '<' => "\\textless",
+    '>' => "\\textgreater",
+    '\\' => "\\textbackslash",
+    '^' => "\\textasciicircum",
+    '_' => "\\textunderscore",
+    '`' => "\\textquoteleft",
+    '{' => "\\textbraceleft",
+    '}' => "\\textbraceright",
+    '%' => "\\%",
+    '|' => "\\textbar",
+    '~' => "\\textasciitilde",
+    _ => {
+      let mut tmp = [0u8; 4];
+      return vec![T_OTHER!(c.encode_utf8(&mut tmp))];
+    },
+  };
+  vec![T_CS!(cs)]
+}
+
+/// Emit a run of `n` spaces as a `white-space:pre` group, exactly like the
+/// listings space path (`\@listingGroup{ltx_lst_space}{ … }` with control-space
+/// tokens that survive TeX space-collapsing).
+fn emit_space_run(n: usize, out: &mut Vec<Token>) {
+  out.push(T_CS!("\\@listingGroup"));
+  out.push(T_BEGIN!());
+  out.extend(ExplodeText!("ltx_lst_space"));
+  out.push(T_END!());
+  out.push(T_BEGIN!());
+  for _ in 0..n {
+    out.push(T_CS!(" "));
+  }
+  out.push(T_END!());
+}
+
+/// Emit the characters of a text run, wrapping maximal space runs in a
+/// `ltx_lst_space` group so indentation and interior spacing are preserved
+/// (`.ltx_listingline` is `white-space:nowrap`, which otherwise collapses runs).
+fn emit_text(text: &str, out: &mut Vec<Token>) {
+  let mut chars = text.chars().peekable();
+  while let Some(c) = chars.next() {
+    if c == ' ' || c == '\t' {
+      let mut n = 1usize;
+      while matches!(chars.peek(), Some(' ') | Some('\t')) {
+        chars.next();
+        n += 1;
+      }
+      emit_space_run(n, out);
+    } else {
+      out.extend(map_char(c));
+    }
+  }
+}
+
+/// Wrap `inner` in `\cs{…}`.
+fn wrap_cs(cs: &'static str, inner: Vec<Token>) -> Vec<Token> {
+  let mut out = vec![T_CS!(cs), T_BEGIN!()];
+  out.extend(inner);
+  out.push(T_END!());
+  out
+}
+
+/// Wrap `inner` in `\textcolor[rgb]{r,g,b}{…}`.
+fn wrap_color(rgb: &str, inner: Vec<Token>) -> Vec<Token> {
+  let mut out = vec![T_CS!("\\textcolor"), T_OTHER!("[")];
+  out.extend(ExplodeText!("rgb"));
+  out.push(T_OTHER!("]"));
+  out.push(T_BEGIN!());
+  out.extend(ExplodeText!(rgb));
+  out.push(T_END!());
+  out.push(T_BEGIN!());
+  out.extend(inner);
+  out.push(T_END!());
+  out
+}
+
+/// Emit one segment: its text (with space runs preserved), wrapped in bold /
+/// italic / color per its style. Order mirrors `\PYG@do`: color outside italic
+/// outside bold. Pure-whitespace segments skip the style wrappers (a colored
+/// space is invisible and only bloats the tree).
+fn emit_seg(cache: &CacheData, seg: &Seg, out: &mut Vec<Token>) {
+  let mut inner = Vec::new();
+  emit_text(&seg.text, &mut inner);
+  if seg.text.trim().is_empty() {
+    out.extend(inner);
+    return;
+  }
+  let style = resolve_style(cache, &seg.tok);
+  if style.bold {
+    inner = wrap_cs("\\textbf", inner);
+  }
+  if style.italic {
+    inner = wrap_cs("\\textit", inner);
+  }
+  if let Some(rgb) = style.rgb.as_ref() {
+    inner = wrap_color(rgb, inner);
+  }
+  out.extend(inner);
+}
+
+/// Build the per-line block body tokens (`\@lst@startline{}` … `\@lst@endline`
+/// per line) for a set of highlighted lines.
+fn build_block_body(cache: &CacheData, lines: &[Line]) -> Vec<Token> {
+  let mut out = Vec::new();
+  for line in lines {
+    out.push(T_CS!("\\@lst@startline"));
+    out.push(T_BEGIN!());
+    out.push(T_END!()); // empty line-number tags
+    for seg in line {
+      emit_seg(cache, seg, &mut out);
+    }
+    out.push(T_CS!("\\@lst@endline"));
+  }
+  out
+}
+
+/// If `raw_body` (a minted block's raw source body) matches a frozencache
+/// highlight file, return the Pygments-colored block body tokens (to hand to
+/// `listings_sty::lst_process_display_with`). Otherwise `None`.
+pub fn colored_display_body(raw_body: &str) -> Option<Vec<Token>> {
+  let cache = load_cache()?;
+  let key = normalize_source(raw_body);
+  let lines = cache.by_plaincode.get(&key)?;
+  Some(build_block_body(&cache, lines))
+}
+
+/// Inline body tokens for a `\mintinline` snippet, for use as the argument of
+/// `\@listings@inline`. On a frozencache hit the segments are Pygments-colored;
+/// on a miss (cache present but snippet not found) the code is emitted plain
+/// (uncolored, but text/spacing preserved). Call only when [`cache_available`].
+pub fn inline_body(raw_code: &str) -> Vec<Token> {
+  let key = normalize_source(raw_code);
+  if let Some(cache) = load_cache() {
+    if let Some(lines) = cache.by_plaincode.get(&key) {
+      let mut out = Vec::new();
+      for (i, line) in lines.iter().enumerate() {
+        if i > 0 {
+          out.push(T_CS!(" "));
+        }
+        for seg in line {
+          emit_seg(&cache, seg, &mut out);
+        }
+      }
+      return out;
+    }
+    // Miss: emit plain (uncolored) text, spacing preserved.
+    let mut out = Vec::new();
+    emit_text(&normalize_source(raw_code), &mut out);
+    return out;
+  }
+  let mut out = Vec::new();
+  emit_text(raw_code, &mut out);
+  out
+}

--- a/latexml_contrib/src/minted_sty.rs
+++ b/latexml_contrib/src/minted_sty.rs
@@ -68,7 +68,12 @@ LoadDefinitions!({
       Tokens!(T_OTHER!("lstlisting")),
       None,
     )?;
-    let mut result = lst_process_display(None, &contents);
+    // Beyond-Perl frozencache color path (see \begin{minted}); falls back to the
+    // uncolored listings display on a cache miss / no `_minted/`.
+    let mut result = match crate::minted_frozencache::colored_display_body(&contents) {
+      Some(body) => lst_process_display_with(None, &contents, body),
+      None => lst_process_display(None, &contents),
+    };
     // lst_process_display ends with T_END to balance bgroup we opened above
     // (mirrors `\begin{lstlisting}`'s convention).
     if !matches!(result.last(), Some(t) if t.get_catcode() == Catcode::END) {
@@ -137,7 +142,64 @@ LoadDefinitions!({
   def_macro_noop("\\usemintedstyle[]{}")?;
   def_macro_noop("\\SetupFloatingEnvironment{}{}")?;
   DefMacro!("\\mint[]{}", "\\lstinline[language=#2]");
-  DefMacro!("\\mintinline[]{}", "\\lstinline[language=#2]");
+  // `\mintinline[opts]{lang}{code}` — beyond-Perl frozencache color path.
+  // When NO `_minted/` frozencache is present the code arg is left untouched in
+  // the stream and we reconstruct the historical `\lstinline[language=<lang>]`
+  // expansion (byte-for-byte the old behavior, so non-frozencache papers are
+  // unaffected). When a frozencache IS present we read the `{code}` verbatim
+  // (mirroring `\lx@lstinline`) and emit a colored inline `ltx_lstlisting` span
+  // on a content-match hit, or the plain code on a miss. (OXIDIZED_DESIGN_
+  // DIVERGENCES #157.)
+  {
+    let cs = T_CS!("\\mintinline");
+    let params = parse_parameters("[]{}", &cs, true)?;
+    let expansion: Option<ExpansionBody> = Some(ExpansionBody::Closure(Rc::new(
+      move |args: Vec<ArgWrap>| {
+        let mut it = args.into_iter();
+        let _opts = it.next();
+        let lang = it.next().and_then(|a| a.owned_tokens()).unwrap_or_default();
+        if !crate::minted_frozencache::cache_available() {
+          // Delegate to \lstinline, which reads the following {code} verbatim.
+          let mut out = vec![T_CS!("\\lstinline"), T_OTHER!("[")];
+          out.extend(Tokenize!("language=").unlist());
+          out.extend(lang.unlist());
+          out.push(T_OTHER!("]"));
+          return Ok(Tokens::new(out));
+        }
+        // Frozencache present: read the verbatim code ourselves (mirror
+        // \lx@lstinline listings.sty:2076-2108).
+        let init = read_token()?;
+        let until = init.as_ref().map(|t| {
+          if t.get_catcode() == Catcode::BEGIN {
+            T_END!()
+          } else {
+            *t
+          }
+        });
+        let verbatim_chars = ['%', '\\', '{', '}', '$', '&', '#', '^', '_', '~'];
+        let saved: Vec<(char, Catcode)> = verbatim_chars
+          .iter()
+          .map(|&c| (c, lookup_catcode(c).unwrap_or(Catcode::OTHER)))
+          .collect();
+        push_frame();
+        for c in verbatim_chars {
+          assign_catcode(c, Catcode::OTHER, Some(Scope::Local));
+        }
+        let body = listings_read_raw_string(until.as_ref(), &saved);
+        pop_frame()?;
+        let segs = crate::minted_frozencache::inline_body(&body);
+        let mut out = vec![
+          T_CS!("\\leavevmode"),
+          T_CS!("\\@listings@inline"),
+          T_BEGIN!(),
+        ];
+        out.extend(segs);
+        out.push(T_END!());
+        Ok(Tokens::new(out))
+      },
+    )));
+    def_macro(cs, params, expansion, None)?;
+  }
   // \begin{minted}[opts]{language} — port of Perl mintedEnvBody
   // (minted.sty.ltxml L68-85). Read raw input lines until \end{minted},
   // then dispatch to listings' lst_process_display, mirroring Perl's
@@ -147,7 +209,10 @@ LoadDefinitions!({
   // it never sees its own `\end{lstlisting}` marker (the user wrote
   // `\end{minted}`).
   use latexml_core::stomach::bgroup;
-  use latexml_package::package::listings_sty::{listings_read_raw_lines, lst_process_display};
+  use latexml_package::package::listings_sty::{
+    listings_read_raw_lines, listings_read_raw_string, lst_process_display,
+    lst_process_display_with,
+  };
   {
     let cs = T_CS!("\\begin{minted}");
     // `\begin{minted}[opts]{language}`. Previously the `[opts]` were dropped, so
@@ -207,7 +272,14 @@ LoadDefinitions!({
           ));
         }
         let text = listings_read_raw_lines("minted");
-        let result = lst_process_display(None, &text);
+        // Beyond-Perl: if a `_minted/` frozencache holds this block's Pygments
+        // colors (content-match on the normalized body), emit colored listing
+        // lines; otherwise keep the exact uncolored listings path.
+        // (OXIDIZED_DESIGN_DIVERGENCES #157.)
+        let result = match crate::minted_frozencache::colored_display_body(&text) {
+          Some(body) => lst_process_display_with(None, &text, body),
+          None => lst_process_display(None, &text),
+        };
         Ok(Tokens::new(result))
       },
     )));

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -1710,3 +1710,111 @@ fn cluster_algpseudocodex_no_spurious_empty_equation() {
     "algpseudocodex emitted {spurious} spurious empty <equation/> element(s) (Perl emits none):\n{xml}"
   );
 }
+
+/// Beyond-Perl (OXIDIZED_DESIGN_DIVERGENCES #157): with `minted`'s
+/// `[frozencache]`, a committed `_minted/` directory carries Pygments' output on
+/// disk as plain `\textcolor`. Our binding content-matches a block's normalized
+/// body against the `*.highlight.minted` files and emits Pygments-colored listing
+/// lines (green bold keywords, blue names, preserved indentation) — Perl LaTeXML
+/// has no minted binding and errors out, so any colored output surpasses it.
+///
+/// This drives the real binary against a hand-built tiny `_minted/` cache in a
+/// tempdir (the cache MUST sit beside the main `.tex`, as minted writes it), and
+/// asserts the keyword/name color spans appear. A control run WITHOUT the cache
+/// proves the feature is a strict no-op there (no color, unchanged rendering) —
+/// guarding the "keep current minted behavior identical on a cache miss" contract.
+#[test]
+fn minted_frozencache_colors_from_pygments_cache_157() {
+  use std::process::Command;
+  let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+
+  const DOC: &str = "\\documentclass{article}\n\
+     \\usepackage[frozencache]{minted}\n\
+     \\begin{document}\n\
+     Inline \\mintinline{python}{foo} here.\n\
+     \\begin{minted}{python}\n\
+     def foo():\n\
+     \x20   return 1\n\
+     \\end{minted}\n\
+     \\end{document}\n";
+
+  const STYLE: &str = "\\makeatletter\n\
+     \\@namedef{PYG@tok@k}{\\let\\PYG@bf=\\textbf\\def\\PYG@tc##1{\\textcolor[rgb]{0.00,0.50,0.00}{##1}}}\n\
+     \\@namedef{PYG@tok@nf}{\\def\\PYG@tc##1{\\textcolor[rgb]{0.00,0.00,1.00}{##1}}}\n\
+     \\makeatother\n";
+  // Block body matches DOC's minted block after normalization:
+  //   line1 "def foo():"   line2 "    return 1"
+  const BLOCK_HL: &str = "\\begin{MintedVerbatim}[commandchars=\\\\\\{\\}]\n\
+     \\PYG{k}{def}\\PYG{+w}{ }\\PYG{n+nf}{foo}\\PYG{p}{(}\\PYG{p}{)}\\PYG{p}{:}\n\
+     \\PYG{+w}{    }\\PYG{k}{return}\\PYG{+w}{ }\\PYG{l+m+mi}{1}\n\
+     \\end{MintedVerbatim}\n";
+  // Inline snippet `foo` (blue name).
+  const INLINE_HL: &str = "\\begin{MintedVerbatim}[commandchars=\\\\\\{\\}]\n\
+     \\PYG{n+nf}{foo}\n\
+     \\end{MintedVerbatim}\n";
+
+  // ---- With the frozencache: colors appear. ----
+  let dir = tempfile::tempdir().expect("tempdir");
+  std::fs::write(dir.path().join("main.tex"), DOC).expect("write tex");
+  let mdir = dir.path().join("_minted");
+  std::fs::create_dir(&mdir).expect("mkdir _minted");
+  std::fs::write(mdir.join("default.style.minted"), STYLE).expect("write style");
+  std::fs::write(mdir.join("AAAA.highlight.minted"), BLOCK_HL).expect("write block hl");
+  std::fs::write(mdir.join("BBBB.highlight.minted"), INLINE_HL).expect("write inline hl");
+
+  let out = Command::new(bin)
+    .args(["main.tex", "--dest", "main.html", "--nocomments"])
+    .current_dir(dir.path())
+    .output()
+    .expect("spawn latexml_oxide");
+  let html = std::fs::read_to_string(dir.path().join("main.html")).unwrap_or_default();
+  let lc = html.to_ascii_lowercase();
+  assert!(
+    out.status.success(),
+    "conversion failed:\n{}",
+    String::from_utf8_lossy(&out.stderr)
+  );
+  // Green bold keyword (`def`/`return`, PYG class `k`).
+  assert!(
+    lc.contains("--ltx-fg-color:#008000"),
+    "frozencache keyword color (#008000) missing — minted block was not colored:\n{html}"
+  );
+  // Blue name (`foo`, PYG class `nf`) — appears in BOTH the block and the inline.
+  assert!(
+    lc.contains("--ltx-fg-color:#0000ff"),
+    "frozencache name color (#0000FF) missing — nf token not colored:\n{html}"
+  );
+  // Indentation preserved as a white-space:pre span.
+  assert!(
+    html.contains("ltx_lst_space"),
+    "minted indentation not preserved via ltx_lst_space:\n{html}"
+  );
+  // Code text intact, and no raw \PYG / \textcolor leaked as literal text.
+  assert!(html.contains("def") && html.contains("foo") && html.contains("return"));
+  assert!(
+    !html.contains("\\PYG") && !html.contains("MintedVerbatim"),
+    "raw frozencache markup leaked into the output:\n{html}"
+  );
+
+  // ---- Control: NO `_minted/` → strict no-op (no frozencache color). ----
+  let dir2 = tempfile::tempdir().expect("tempdir2");
+  std::fs::write(dir2.path().join("main.tex"), DOC).expect("write tex2");
+  let out2 = Command::new(bin)
+    .args(["main.tex", "--dest", "main.html", "--nocomments"])
+    .current_dir(dir2.path())
+    .output()
+    .expect("spawn latexml_oxide (control)");
+  let html2 = std::fs::read_to_string(dir2.path().join("main.html")).unwrap_or_default();
+  assert!(out2.status.success(), "control conversion failed");
+  assert!(
+    !html2
+      .to_ascii_lowercase()
+      .contains("--ltx-fg-color:#008000"),
+    "without a `_minted/` cache the block must NOT be Pygments-colored (feature leaked):\n{html2}"
+  );
+  // The block still renders as a listing (unchanged fallback path).
+  assert!(
+    html2.contains("ltx_lstlisting") && html2.contains("def"),
+    "control minted block did not render via the listings fallback:\n{html2}"
+  );
+}

--- a/latexml_package/src/package/listings_sty.rs
+++ b/latexml_package/src/package/listings_sty.rs
@@ -170,7 +170,10 @@ fn tokenize_balanced(text: &str) -> Vec<Token> {
 /// Handles mathescape: within $...$, content is read with normal catcodes
 /// and preserved as TeX (backslashes intact). Outside math, CS tokens have \ stripped.
 /// Returns UnTeX'd string representation.
-fn listings_read_raw_string(until: Option<&Token>, saved_catcodes: &[(char, Catcode)]) -> String {
+pub fn listings_read_raw_string(
+  until: Option<&Token>,
+  saved_catcodes: &[(char, Catcode)],
+) -> String {
   let mathescape = lst_get_boolean("mathescape");
   let mut inmath = false;
   let mut tokens: Vec<Token> = Vec::new();
@@ -1815,8 +1818,16 @@ fn lst_process_inline(text: &str) -> Vec<Token> {
   invoke(T_CS!("\\@listings@inline"), vec![body])
 }
 
-/// Perl: lstProcessBlock — wraps block listing, stores data.
-fn lst_process_block(name: Option<Tokens>, text: &str) -> (Vec<Token>, Vec<Token>) {
+/// Perl: lstProcessBlock — wraps block listing, stores data. The per-line body
+/// tokens are supplied by the caller (the re-parsed path passes
+/// `lst_process("block", text).unlist()`; the minted frozencache path passes
+/// its Pygments-colored listing lines). `text` still feeds the base64 `data`
+/// provenance slot (the true source).
+pub fn lst_process_block_with(
+  name: Option<Tokens>,
+  text: &str,
+  processed: Vec<Token>,
+) -> (Vec<Token>, Vec<Token>) {
   // Store listing data for base64 encoding
   let c_val = lookup_value("LISTINGS_DATA_COUNTER")
     .map(|v| v.to_string().parse::<i64>().unwrap_or(0))
@@ -1830,8 +1841,6 @@ fn lst_process_block(name: Option<Tokens>, text: &str) -> (Vec<Token>, Vec<Token
   let data_key = s!("LISTINGS_DATA_{c_val}");
   assign_value(&data_key, Stored::String(pin(text)), Some(Scope::Global));
 
-  let processed = lst_process("block", text);
-
   let mut body_tokens = Vec::new();
   // Add preamble_before
   if let Some(Stored::Tokens(pre)) = lookup_value("LISTINGS_PREAMBLE_BEFORE") {
@@ -1841,7 +1850,7 @@ fn lst_process_block(name: Option<Tokens>, text: &str) -> (Vec<Token>, Vec<Token
   let name_tokens = name.unwrap_or(Tokens!());
   body_tokens.extend(invoke(T_CS!("\\@@listings@block"), vec![
     Tokens::new(ExplodeText!(&c_val.to_string())),
-    processed,
+    Tokens::new(processed),
     name_tokens,
   ]));
 
@@ -1856,7 +1865,20 @@ fn lst_process_block(name: Option<Tokens>, text: &str) -> (Vec<Token>, Vec<Token
 
 /// Perl: lstProcessDisplay — generate full display listing with optional caption/title.
 pub fn lst_process_display(name: Option<Tokens>, text: &str) -> Vec<Token> {
-  let (mut body, trailer) = lst_process_block(name.clone(), text);
+  let processed = lst_process("block", text).unlist();
+  lst_process_display_with(name, text, processed)
+}
+
+/// Like [`lst_process_display`], but the block body tokens are supplied by the
+/// caller (see [`lst_process_block_with`]). The caption/title/label wrapping,
+/// float numbering, and container are identical to the re-parsed path — only the
+/// per-line content differs. Used by the minted frozencache color path.
+pub fn lst_process_display_with(
+  name: Option<Tokens>,
+  text: &str,
+  processed: Vec<Token>,
+) -> Vec<Token> {
+  let (mut body, trailer) = lst_process_block_with(name.clone(), text, processed);
 
   // Perl: AssignValue('LST@toctitle', $name) — so it shows up in list of listings
   if let Some(ref n) = name


### PR DESCRIPTION
This PR bundles this manual-review run's **latexml-oxide engine surpasses** (the paired ar5iv-css theme deltas are in ar5iv-css PR #52). Three independent, faithful, beyond-Perl fixes, each with an `OXIDIZED_DESIGN` entry + guard test + green suites.

**1. minted Pygments colors from a committed `_minted/` frozencache** (OXIDIZED #157). Perl errors on `minted`; we routed it through `listings` (bold-black). New `minted_frozencache.rs` **content-matches** each highlight file's plain code (`\PYG` unwrapped, `\PYGZ*` resolved) to a block body — no MD5 keying — and emits Pygments-colored listing lines reusing the listings constructors + xcolor. Cache miss / no `_minted/` ⇒ byte-identical uncolored path. Guard `minted_frozencache_colors_from_pygments_cache_157`; witness 2605.03143 (green `#008000` keywords, teal `#3D7A7A` comments).

**2. acmart affiliation parts break AFTER the comma** (OXIDIZED #158, SHARED-with-Perl). `\lx@acm@addresspart` now `\ignorespaces` between `\institution{}\city{}…` parts and joins with `, ` (comma + breakable space) — matching real `acmart.cls`'s `\unskip`/`\ignorespaces` — so a wrap no longer strands the comma at the line start. Witness 2605.03143.

**3. a single affiliation shared by all authors renders once, below the authors** (OXIDIZED #159, SHARED-with-Perl). `relocate_annotations` skips a creator's own role-sequence label in the prefix-stripped fallback (so a shared `affiliation:1` no longer binds to author 1's `author:1` by number) and gathers the orphaned institute-level contact(s) onto ONE trailing name-less `<ltx:creator>`. Guard `frontmatter_llncs_shared_affiliation_below_authors`; witness 2402.19043 (LLNCS, 5 authors + one `\institute`). Design note: the shared creator carries `role="author"` (author count N+1) — no HTML-path logic keys on it; a JATS/TEI consideration.

**Validation.** Frontmatter suites 45/45 + 74/74; listings/minted suite 36/36; guardrails 2608.11332 / 2603.23669 / 2606.00313 unchanged; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)