### PR TITLE
feat: frontmatter affiliation surpasses (acmart comma wrapping + shared affiliation below authors)

### DIFF
--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -5836,3 +5836,69 @@ proving the strict no-op. Implementation:
 **Limitation.** `\mintinline` snippets that Pygments leaves as plain names/punctuation
 (classes `n`, `p`) are correctly uncolored (faithful to Pygments); only `\mintinline`
 itself takes the cache path, not the `\newmintinline`-generated aliases.
+
+### 158. acmart affiliation parts break AFTER the comma, not before
+
+**Background.** acmart's `\affiliation{\institution{}\city{}\state{}\country{}}` puts each
+address part on its own source line. The real `acmart.cls` `\institution`/`\city`/… use
+`\unskip`/`\ignorespaces` (`acmart.cls` L1679, L2879) so the inter-part source newlines do
+not become spaces, and joins the parts with a `, ` separator.
+
+**Perl behavior**: SHARED failure. `acmart.cls.ltxml` (L97-101) ports `\lx@acm@addresspart`
+WITHOUT the `\unskip`/`\ignorespaces`, and with a `,~` (comma + non-breaking-space)
+separator. So each source newline between `\institution{}` and `\city{}` leaks as a space
+BEFORE the comma (serialized `…Institute</ltx:text>\n, <ltx:text>New York…`). On a wrap
+the breakable space sits before the comma, pushing the comma to the START of the next line;
+and the `~` forbids a break AFTER the comma, so long affiliations break mid-part instead.
+Same-host Perl renders identically.
+
+**Rust behavior**: `\lx@acm@addresspart` (`acmart_cls.rs`) appends `\ignorespaces` (after its
+`\fi`) so the trailing source newline is gobbled — the comma binds directly to the preceding
+part — and uses a `, ` (comma + a REGULAR breakable space) separator, so a wrap breaks AFTER
+the comma, matching the pdflatex golden. Empty parts are still skipped.
+
+**Why it's safe.** Scoped to acmart's address-part joiner; the only change is which side of the
+comma the breakable space sits on (and that inter-part source newlines no longer leak).
+
+**Witnesses**: arXiv 2605.03143 ("Basis Research Institute, New York, New York, USA").
+
+**Upstream**: to be filed at brucemiller/LaTeXML (acmart address parts should `\ignorespaces`
+between parts and break after the comma, per the real `acmart.cls`).
+
+### 159. A shared single affiliation renders once below all authors, not stranded on author 1
+
+**Background.** LLNCS-style markup `\author{A \and B \and C}` + one `\institute{…}` with NO
+per-author `\inst` marker means the institute is shared by every author (pdflatex centers it
+once below the author row). LaTeXML's frontmatter model has no document-level affiliation slot
+(`ltx:contact` lives only inside `ltx:creator`, per the RelaxNG `contact` content model), and
+its only mechanism for "shared" is per-author replication.
+
+**Perl behavior**: SHARED failure. `\institute` → `\lx@add@affiliation[labelseq=affiliation]`
+gives the affiliation the label `affiliation:1`; each author gets an auto sequence label
+`author:N` (`\lx@add@frontmatter@now`). In `relocateAnnotations` (`Base_Utility.pool.ltxml`
+L880-910) the affiliation matches no author by its own prefix, then the prefix-stripped
+fallback (`$unlabeltable{$noprefix}`, L899-900) reduces `affiliation:1` to `1` and binds it to
+the FIRST author's `author:1` — so the whole shared institute is stranded under author 1 only.
+Perl 0.8.8 (installed and vendored) and pre-fix Rust produce byte-identical output.
+
+**Rust behavior**: `relocate_annotations` (`base_utilities.rs`) two-part fix. (1) A creator's
+own role-sequence label (`author:N`/`editor:N`/`translator:N`) is NOT indexed into the
+prefix-stripped fallback table, so a shared `affiliation:1` no longer binds to `author:1` by
+number. A genuine per-author affiliation still matches EXACTLY via `labeltable` (the
+`affiliation:1` that `\inst{1}` requests), so `\inst`-targeted markup is unchanged. (2) The now
+un-targeted shared affiliation — with any `\email`/`\url` that inherited its label — is gathered
+onto ONE trailing name-LESS `<ltx:creator role="author">`, kept as the last child of the authors
+container. The ar5iv theme's existing breakout rule then renders a last-position shared
+affiliation once, full-width, centered, below the author row.
+
+**Why it's safe.** Only the auto self-sequence labels leave the numeric fallback; exact-label
+(`\inst`) attachment and genuine cross-prefix misuse recovery are untouched. Guarded by
+`frontmatter_llncs_shared_affiliation_below_authors`.
+
+**Witnesses**: arXiv 2402.19043 (WDM: 5 authors, one shared `\institute`, no `\inst`).
+Guardrails that must NOT regress: 2608.11332 (shared `\email` under `\inst{1}`), 2603.23669
+(two-author-per-creator dedup), 2606.00313 (`\thanks`-abuse affiliations).
+
+**Upstream**: the ar5iv CSS comment already anticipates this ("Ideally latexml's schema should
+evolve to handle this via differently organized markup") — the trailing-creator normalization is
+that markup.

--- a/latexml_engine/src/base_utilities.rs
+++ b/latexml_engine/src/base_utilities.rs
@@ -2894,7 +2894,8 @@ fn relocate_annotations(document: &mut Document) -> Result<()> {
   // fallback: Same, but without prefix
   let mut unlabeltable: HashMap<String, Vec<Node>> = HashMap::default();
   for target in document.findnodes(".//*[@_annotations]", None) {
-    if target.get_attribute("role").unwrap_or_default() == "pending" {
+    let target_role = target.get_attribute("role").unwrap_or_default();
+    if target_role == "pending" {
       continue;
     }
     // Dedup labels PER TARGET: a creator that cites the same annotation label
@@ -2913,8 +2914,20 @@ fn relocate_annotations(document: &mut Document) -> Result<()> {
         .entry(label.to_string())
         .or_default()
         .push(target.clone());
-      // Misuse of labelling macros can lead to prefix mismatch
-      if let Some(pos) = label.find(':') {
+      // Misuse of labelling macros can lead to a prefix mismatch, so fall back to
+      // a prefix-stripped ("noprefix") index — e.g. an affiliation labelled
+      // `institute:1` can still find an author who cited `affiliation:1`.
+      // BUT a creator's OWN role-sequence label (`author:N` / `editor:N` /
+      // `translator:N`, auto-assigned in `\lx@add@frontmatter@now`) must NEVER
+      // enter that fallback: it would let a SHARED affiliation's `affiliation:1`
+      // bind to the first author's `author:1` purely by number, stranding one
+      // shared `\institute` on author 1 (Perl does exactly this — arXiv:2402.19043
+      // / WDM, 5 authors + one `\institute`, no `\inst`; OXIDIZED_DESIGN #159). A
+      // genuine per-author affiliation instead matches EXACTLY via `labeltable`
+      // (the `affiliation:1` that `\inst{1}` requests), which is untouched here.
+      if let Some(pos) = label.find(':')
+        && label[..pos] != target_role
+      {
         unlabeltable
           .entry(label[pos + 1..].to_string())
           .or_default()
@@ -2922,7 +2935,19 @@ fn relocate_annotations(document: &mut Document) -> Result<()> {
       }
     }
   }
-  for pending in pending_nodes {
+  // Beyond-Perl (OXIDIZED_DESIGN #159): a SHARED affiliation with no per-author
+  // `\inst` target (see Part 1) matches no creator. Perl warns and drops it; the
+  // pre-fix fallback stranded it on author 1. Instead, gather every such orphaned
+  // institute-level contact (the affiliation and any `\email`/`\url` that inherited
+  // its label) into ONE trailing name-LESS `<ltx:creator role="author">`, kept as
+  // the LAST child of the authors container — so the institute renders exactly once
+  // below the whole author row (ar5iv theme already breaks a last-position shared
+  // affiliation out to full width). Witness arXiv:2402.19043 (WDM). We reuse the
+  // first orphaned pending stub in place: it is already a `<creator>` sitting right
+  // after the last real author, so promoting it needs no fresh node.
+  let mut shared_creator: Option<Node> = None;
+  for mut pending in pending_nodes {
+    let mut promote_this = false;
     for note in element_nodes(&pending) {
       let label = note.get_attribute("_label").unwrap_or_default();
       if label.is_empty() {
@@ -2943,6 +2968,23 @@ fn relocate_annotations(document: &mut Document) -> Result<()> {
           let mut target = target;
           document.append_clone(&mut target, vec![note.clone()])?;
         }
+      } else if is_shared_contact_role(&note.get_attribute("role").unwrap_or_default()) {
+        DebugFeature!(
+          "frontmatter",
+          "FRONT Sharing orphaned annotation {label} below authors"
+        );
+        match &mut shared_creator {
+          // First orphaned shared contact: promote THIS pending stub in place into
+          // the trailing shared creator (its note already lives inside it).
+          None => {
+            promote_this = true;
+          },
+          // Later shared contacts (e.g. the institute's `\email`) join it.
+          Some(sc) => {
+            let mut sc = sc.clone();
+            document.append_clone(&mut sc, vec![note.clone()])?;
+          },
+        }
       } else {
         let mut known: Vec<&String> = labeltable.keys().collect();
         known.sort();
@@ -2961,9 +3003,35 @@ fn relocate_annotations(document: &mut Document) -> Result<()> {
         );
       }
     }
-    document.remove_node(pending);
+    if promote_this {
+      // pending → real trailing creator (role=pending would otherwise be dropped
+      // with the node; the `_annotations`/`_label` bookkeeping attrs are stripped
+      // at serialization). Name-LESS: it carries no `<ltx:personname>`.
+      document.set_attribute(&mut pending, "role", "author")?;
+      shared_creator = Some(pending);
+    } else {
+      document.remove_node(pending);
+    }
   }
   Ok(())
+}
+
+/// Contact roles that are institute-level information shared by every author (an
+/// affiliation, or an address / email / url that inherited its label), as opposed
+/// to a single person's own note. When such a contact is orphaned (a shared
+/// `\institute` with no per-author `\inst`), it is collected onto the trailing
+/// shared creator rather than dropped or stranded on author 1 (OXIDIZED_DESIGN #159).
+fn is_shared_contact_role(role: &str) -> bool {
+  matches!(
+    role,
+    "affiliation"
+      | "altaffiliation"
+      | "address"
+      | "altaddress"
+      | "currentaddress"
+      | "email"
+      | "url"
+  )
 }
 
 //======================================================================

--- a/latexml_oxide/tests/06_cluster_frontmatter.rs
+++ b/latexml_oxide/tests/06_cluster_frontmatter.rs
@@ -1446,3 +1446,42 @@ fn frontmatter_fairmeta_author_affiliation_1396() {
     "Yuqing Du (mark 4) wrongly carries Meta — marks not honored:\n{x}"
   );
 }
+
+/// LLNCS `\author{A \and B \and C}` + one shared `\institute{…}` with NO per-author
+/// `\inst` marker. Perl 0.8.8 (and pre-fix Rust) strand the single affiliation on
+/// the FIRST author only — its `affiliation:1` label binds to author 1's `author:1`
+/// sequence label by number in `relocate_annotations`. Beyond-Perl (OXIDIZED_DESIGN
+/// #159, witness arXiv:2402.19043 / WDM): the shared affiliation is emitted ONCE, on a
+/// trailing name-LESS `<creator>` after all authors, so it renders once below the row
+/// (never under author 1, never replicated per author). Guards both regressions.
+#[test]
+fn frontmatter_llncs_shared_affiliation_below_authors() {
+  let x = convert_to_xml("tests/cluster_regressions/frontmatter_llncs_shared_affiliation.tex");
+  // Exactly ONE affiliation contact — not dropped, not replicated per author.
+  assert_eq!(
+    x.matches("Shared Institute").count(),
+    1,
+    "shared affiliation should appear exactly once:\n{x}"
+  );
+  // NOT stranded on the first author.
+  assert!(
+    !creator_block_contains(&x, "Alice Alpha", "Shared Institute"),
+    "shared affiliation wrongly nested under first author Alice:\n{x}"
+  );
+  // Lives on a trailing name-LESS creator (a <creator> with no <personname>).
+  let on_nameless = x.split("<creator").skip(1).any(|rest| {
+    let block = rest.split("</creator>").next().unwrap_or("");
+    block.contains("Shared Institute") && !block.contains("<personname")
+  });
+  assert!(
+    on_nameless,
+    "shared affiliation should sit on a name-less trailing creator:\n{x}"
+  );
+  // All three named authors still present.
+  for name in ["Alice Alpha", "Bob Beta", "Carol Gamma"] {
+    assert!(
+      x.contains(&format!("<personname>{name}</personname>")),
+      "author {name} missing:\n{x}"
+    );
+  }
+}

--- a/latexml_oxide/tests/cluster_regressions/frontmatter_llncs_shared_affiliation.tex
+++ b/latexml_oxide/tests/cluster_regressions/frontmatter_llncs_shared_affiliation.tex
@@ -1,0 +1,7 @@
+\documentclass{llncs}
+\begin{document}
+\title{Shared Affiliation Test}
+\author{Alice Alpha \and Bob Beta \and Carol Gamma}
+\institute{Shared Institute, Example University, Somewhere}
+\maketitle
+\end{document}

--- a/latexml_package/src/package/acmart_cls.rs
+++ b/latexml_package/src/package/acmart_cls.rs
@@ -367,8 +367,16 @@ LoadDefinitions!({
   // Internal structure to affiliation (Perl PR #2767: comma-joined parts;
   // empty parts skipped)
   DefMacro!("\\lx@acm@addresspartsep", "");
+  // `\ignorespaces` (after `\fi`) gobbles the source newline the author writes
+  // between `\institution{}`, `\city{}`, `\state{}`, `\country{}` lines — else it
+  // leaks as a space BEFORE the separator comma, so a wrap puts the comma at the
+  // start of the next line. The real acmart.cls does the same with `\unskip`/
+  // `\ignorespaces` (acmart.cls L1679/L2879). Separator is `, ` (comma + a REGULAR
+  // breakable space, matching real acmart's `, `), not `,~`, so the line breaks
+  // AFTER the comma, never before it. SHARED surpass over Perl (its
+  // acmart.cls.ltxml:98-101 has neither) — OXIDIZED_DESIGN #158. Witness 2605.03143.
   DefMacro!("\\lx@acm@addresspart{}{}",
-    "\\ifx.#2.\\else\\lx@acm@addresspartsep\\def\\lx@acm@addresspartsep{,~}\\lx@acm@addresspart@{#1}{#2}\\fi");
+    "\\ifx.#2.\\else\\lx@acm@addresspartsep\\def\\lx@acm@addresspartsep{, }\\lx@acm@addresspart@{#1}{#2}\\fi\\ignorespaces");
   DefConstructor!("\\lx@acm@addresspart@{}{}",
     "<ltx:text class='ltx_affiliation_#1' _noautoclose='1'>#2</ltx:text>",
     mode => "restricted_horizontal", enter_horizontal => true);


### PR DESCRIPTION
Two faithful, beyond-Perl frontmatter fixes recovered from the minted PR #757's branch after it merged (they were authored after #757's merge). Each SHARED-with-Perl, each with an `OXIDIZED_DESIGN` entry + guard test.

**acmart affiliation parts break AFTER the comma** (OXIDIZED #158). `\lx@acm@addresspart` now `\ignorespaces` between `\institution{}\city{}…` parts and joins with `, ` (comma + breakable space) — matching real `acmart.cls`'s `\unskip`/`\ignorespaces`; Perl's `acmart.cls.ltxml` omits both, so a wrap stranded the comma at the line start. Witness 2605.03143.

**A single affiliation shared by all authors renders once, below the authors** (OXIDIZED #159). `relocate_annotations` skips a creator's own role-sequence label (`author:N`) in the prefix-stripped fallback (so a shared `affiliation:1` no longer binds to author 1 by number) and gathers the orphaned institute-level contact(s) onto ONE trailing name-less `<ltx:creator>`. The ar5iv theme (ar5iv-css #52) breaks that creator out to full width, centered, below the authors. Witness 2402.19043 (LLNCS, 5 authors + one `\institute`). Design note: the shared creator carries `role="author"` (count N+1) — no HTML-path logic keys on it.

**Validation.** Guard `frontmatter_llncs_shared_affiliation_below_authors`; frontmatter suites 45/45 + 74/74; acmart tests green; regression-checked 2201.00244 / 1109.5581 / 2510.11037 (ar5iv's shared-affiliation CSS witnesses) — all unchanged (they use the pre-existing last-author path, byte-identical to Perl); guardrails 2608.11332 / 2603.23669 / 2606.00313 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)