### PR TITLE
chore(release): 0.7.6-rc2 (validation RC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+## [0.7.6] (graphics & SVG figure fidelity; minted highlighting + overpic; author/frontmatter class sweep; Rhai runtime binding API; latexmlpost CLI parity; wider package & bibliography coverage)
+
+  - **`minted` code blocks render Pygments syntax colors, not just bold-black.** When the
+    source ships a committed `_minted/` frozencache, `minted_frozencache.rs` content-matches
+    each highlight file's plain code (`\PYG` unwrapped, `\PYGZ*` resolved) to a block body
+    and emits Pygments-colored listing lines, reusing the `listings` constructors + xcolor;
+    a cache miss (or no `_minted/`) falls back byte-identically to the uncolored path. Perl
+    errors on `minted` — beyond-Perl (OXIDIZED_DESIGN #157). Guard
+    `minted_frozencache_colors_from_pygments_cache_157`; witness 2605.03143.
+  - **acmart affiliation parts break after the comma, not before it.** `\lx@acm@addresspart`
+    now `\ignorespaces` between `\institution{}\city{}…` parts and joins with a comma +
+    breakable space, matching real `acmart.cls` — so a line wrap no longer strands the comma
+    at the start of the next line. SHARED-with-Perl (its binding omits the `\unskip`/
+    `\ignorespaces`); beyond-Perl (OXIDIZED_DESIGN #158). Witness 2605.03143.
+  - **A single affiliation shared by all authors renders once, below the authors.**
+    `relocate_annotations` no longer mis-binds a shared `affiliation:1` to author 1 by number,
+    and gathers the orphaned institute-level contacts onto one trailing name-less
+    `<ltx:creator>`. SHARED-with-Perl; beyond-Perl (OXIDIZED_DESIGN #159). Guard
+    `frontmatter_llncs_shared_affiliation_below_authors`; witness 2402.19043 (LLNCS, 5
+    authors + one `\institute`).
   - **Author `\thanks` renders as a marked note, not an inline affiliation-like blob.**
     `\author{Name\thanks{…}}` (correspondence, funding, equal-contribution, …) was emitted
     as an inline `<ltx:contact role="thanks">` that read like an affiliation next to the
@@ -204,8 +224,6 @@
     Surpasses Perl 0.8.8 (which emits the same 0pt + `Missing number` warning);
     pdflatex renders the real widths (OXIDIZED_DESIGN #141, arXiv/html_feedback#6909,
     witness 2606.08266).
-
-## [0.7.6] (graphics & SVG figure fidelity; minted highlighting + overpic; author/frontmatter class sweep; Rhai runtime binding API; latexmlpost CLI parity; wider package & bibliography coverage)
 
   - **`minted` code blocks render with syntax highlighting, and inline `\mint`/`\mintinline`
     work.** The `minted` family now emits highlight token classes so a stylesheet colors the

--- a/latexml_oxide/Cargo.toml
+++ b/latexml_oxide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml"
-version = "0.7.6-rc1"
+version = "0.7.6-rc2"
 edition = "2024"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
 license = "CC0-1.0"


### PR DESCRIPTION
Release-prep for the **0.7.6-rc2** validation RC (an `-rc` tag → draft prerelease across all platforms; no crates.io/containers/homebrew — those are the final's concern).

**Changes.**
- `latexml_oxide` `0.7.6-rc1` → `0.7.6-rc2` (the tag must equal this; `make_release.sh` hard-fails otherwise).
- CHANGELOG: fold the post-rc1 `## Unreleased` entries into the `## [0.7.6]` window (the release-body slice strips `-rcN` and matches `## [0.7.6]`), and add the three merges that landed without a CHANGELOG entry — minted Pygments frozencache colors (OXIDIZED #157, #757), acmart affiliation comma-wrapping (#158, #758), shared affiliation below authors (#159, #758).

**Why merge this before tagging.** Green CI here validates the floating nightly resolves and the suite is N/0 on the release commit — the pre-tag gate. On merge I tag `0.7.6-rc2`, which fires the draft-prerelease matrix build (the real risk gate is **macOS x86_64 fat-LTO OOM**, #512 — the pin was lifted to floating nightly, so this RC re-confirms it holds).

No subcrate bumps here (RC draft build only reads `latexml_oxide`'s version); those + crates.io are the final promotion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUgFzi1zW73EpejP7L1NZ5