### PR TITLE
fix #763: keep a minimum log verbosity under --quiet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+  - **`--quiet` reduces console output only; the `.latexml.log` keeps a minimum
+    verbosity floor.** Previously `--quiet` lowered the single `log` level filter to
+    `Warn`, which dropped the identity banner, every `(Processing …`/`(Loading …`
+    progress note, and all `Info:` records from the on-disk log as well as stderr —
+    breaking BookML's makefile dependency tracking, which reads the `(Loading …`
+    lines from the log (#763, reported by xworld21). The logger now decouples the
+    two gates (Perl `Common/Error.pm` `_printline`/`ProgressSpinup`: `$LOG` is
+    written whenever the log is open, STDERR only when `$VERBOSITY >= 0`): the log
+    floor stays at `Info` regardless of `--quiet`, while STDERR follows the console
+    verbosity; `--verbose`/`--debug` raise both. `Error`/`Fatal` still always reach
+    stderr (the always-emit-errors divergence). Guards
+    `quiet_keeps_log_floor::{quiet_log_keeps_floor_but_stderr_is_muted,
+    loud_log_and_stderr_both_keep_floor}`.
+
 ## [0.7.6] (graphics & SVG figure fidelity; minted highlighting + overpic; author/frontmatter class sweep; Rhai runtime binding API; latexmlpost CLI parity; wider package & bibliography coverage)
 
   - **`minted` code blocks render Pygments syntax colors, not just bold-black.** When the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,13 @@
     written whenever the log is open, STDERR only when `$VERBOSITY >= 0`): the log
     floor stays at `Info` regardless of `--quiet`, while STDERR follows the console
     verbosity; `--verbose`/`--debug` raise both. `Error`/`Fatal` still always reach
-    stderr (the always-emit-errors divergence). Guards
+    stderr (the always-emit-errors divergence). The same floor now covers the TeX
+    terminal-output primitives, which Perl calls without a verbosity guard: `\typeout`
+    (Perl `Note` — log always, stderr when not quiet) and `\message` (Perl `NoteLog`
+    — log-only, never stderr); both previously vanished from the log under `--quiet`.
+    Two raw `eprintln!` fallback diagnostics (`store.rs` Stored→Number cast, the math
+    parser's ambiguous-action fallback) now route through the logger instead of
+    printing unconditionally and bypassing the report tally. Guards
     `quiet_keeps_log_floor::{quiet_log_keeps_floor_but_stderr_is_muted,
     loud_log_and_stderr_both_keep_floor}`.
 

--- a/latexml_core/src/common/error.rs
+++ b/latexml_core/src/common/error.rs
@@ -859,14 +859,17 @@ macro_rules! generate_message {
 
 /// Progress note to BOTH the log and stderr — Perl `Note` (`_printline`): the LOG
 /// always (if a buffer is bound, ANSI-stripped), STDERR only when the verbosity
-/// admits it (`$USE_STDERR && $VERBOSITY>=0` ≈ `max_level >= Info`).
+/// admits it (`$USE_STDERR && $VERBOSITY>=0`). The STDERR gate is the decoupled
+/// console verbosity ([`crate::util::logger::stderr_shows_info`]), NOT `max_level`
+/// — under `--quiet` the log-file floor keeps `max_level` at `Info`, but the
+/// console note must still be silenced (issue #763).
 #[macro_export]
 macro_rules! Note {
   ($input:expr_2021) => {{
     let msg = $input;
     $crate::util::logger::note_to_log(&msg.to_string());
     if !$crate::common::error::is_log_output_suppressed()
-      && log::max_level() >= log::LevelFilter::Info
+      && $crate::util::logger::stderr_shows_info()
     {
       $crate::println_stderr!("{msg}");
       $crate::util::logger::mark_stderr_at_line_start();
@@ -884,12 +887,14 @@ macro_rules! NoteLog {
 }
 
 /// Progress note to STDERR only — Perl `NoteSTDERR` (`if $USE_STDERR &&
-/// $VERBOSITY>=0`). Never touches the log.
+/// $VERBOSITY>=0`). Never touches the log. Gated on the decoupled console
+/// verbosity ([`crate::util::logger::stderr_shows_info`]), not `max_level`
+/// (issue #763).
 #[macro_export]
 macro_rules! NoteSTDERR {
   ($input:expr_2021) => {
     if !$crate::common::error::is_log_output_suppressed()
-      && log::max_level() >= log::LevelFilter::Info
+      && $crate::util::logger::stderr_shows_info()
     {
       let msg = $input;
       $crate::println_stderr!("{msg}");

--- a/latexml_core/src/common/store.rs
+++ b/latexml_core/src/common/store.rs
@@ -1045,7 +1045,15 @@ impl<'a> From<&'a Stored> for Option<Number> {
       Stored::MuDimension(n) => Some(Number::new(n.value_of())),
       Stored::MuGlue(n) => Some(Number::new(n.value_of())),
       other => {
-        eprintln!("TODO: auto-cast of Stored to Number attempted on {other:?}");
+        // No Number projection for this Stored variant — surface it through the
+        // logger (counts in REPORT, respects the log floor + `--quiet` stderr gate)
+        // rather than a raw `eprintln!` that bypassed both; callers degrade on the
+        // None. Mirrors the `Warn!("stored", "cast", …)` fallback for the CS cast.
+        Warn!(
+          "stored",
+          "cast",
+          s!("no auto-cast of Stored to Number for {other:?}")
+        );
         None
       },
     }

--- a/latexml_core/src/util/logger.rs
+++ b/latexml_core/src/util/logger.rs
@@ -1,6 +1,6 @@
 use std::{
   cell::RefCell,
-  sync::atomic::{AtomicBool, Ordering},
+  sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
 use log::{Level, LevelFilter, Metadata, Record, SetLoggerError, max_level};
@@ -31,6 +31,42 @@ fn stderr_use_color() -> bool {
   *USE_COLOR
     .get_or_init(|| std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none())
 }
+
+/// The STDERR verbosity gate, decoupled from the log-file floor.
+///
+/// Perl LaTeXML separates the two: the log file (`$LOG`) receives every message
+/// while it is open, but STDERR prints only when `$USE_STDERR && $VERBOSITY >= 0`
+/// (`Common/Error.pm` `_printline`). `--quiet` lowers THIS (to `Warn`) without
+/// lowering what the log keeps — so `(Loading …)` progress notes and `Info:`
+/// records still reach `.latexml.log`, which is what BookML's makefile dependency
+/// tracking reads (issue #763). `--verbose`/`--debug` raise it (to `Debug`).
+///
+/// Stored as the `LevelFilter` discriminant (`Off`=0 … `Trace`=5). Process-global
+/// like `max_level`: one shared stderr descriptor across `cortex_worker`'s pool.
+static STDERR_LEVEL: AtomicUsize = AtomicUsize::new(LevelFilter::Info as usize);
+
+/// The current STDERR verbosity (see [`STDERR_LEVEL`]).
+fn stderr_level() -> LevelFilter {
+  match STDERR_LEVEL.load(Ordering::Relaxed) {
+    0 => LevelFilter::Off,
+    1 => LevelFilter::Error,
+    2 => LevelFilter::Warn,
+    3 => LevelFilter::Info,
+    4 => LevelFilter::Debug,
+    _ => LevelFilter::Trace,
+  }
+}
+
+/// Does the current STDERR verbosity admit a record of `level`? `Error`/`Fatal`
+/// are handled unconditionally by the caller (the project's deliberate
+/// always-emit-errors divergence); this governs the verbosity-gated levels.
+pub fn stderr_admits(level: Level) -> bool { level.to_level_filter() <= stderr_level() }
+
+/// Whether STDERR currently shows `Info`-level progress notes — Perl
+/// `$VERBOSITY >= 0`. The `Note!`/`NoteSTDERR!` macros gate their STDERR echo on
+/// this, decoupled from the log-file floor so `--quiet` silences the console note
+/// while the log keeps it (issue #763).
+pub fn stderr_shows_info() -> bool { stderr_admits(Level::Info) }
 
 struct LatexmlLogger;
 static LOGGER: LatexmlLogger = LatexmlLogger;
@@ -258,9 +294,13 @@ impl log::Log for LatexmlLogger {
         {
           append_note(log, &strip_ansi(&note));
         }
-        // Write and publish the cursor state under ONE stderr lock, so a
-        // concurrent diagnostic record cannot observe a stale flag.
-        {
+        // The LOG append above is the log-file record (Perl `$LOG` write, always).
+        // The STDERR echo is the live console indicator and is gated on the
+        // decoupled verbosity: `--quiet` silences the note here while the log
+        // still keeps it (issue #763; Perl `ProgressSpinup` gates STDERR on
+        // `$VERBOSITY >= 0`). Write and publish the cursor state under ONE stderr
+        // lock, so a concurrent diagnostic record cannot observe a stale flag.
+        if stderr_admits(record.level()) {
           use std::io::Write;
           let mut err = std::io::stderr().lock();
           let _ = err.write_all(note.as_bytes());
@@ -375,7 +415,17 @@ impl log::Log for LatexmlLogger {
       // STDERR_AT_LINE_START). One critical section: read the flag, write, and
       // republish it while holding the stderr lock, so the "record starts at
       // line start" guarantee survives concurrent loggers.
-      {
+      //
+      // The LOG_BUFFER append above is the log-file record (Perl `$LOG`, always,
+      // subject only to the Info floor). The STDERR echo is gated on the decoupled
+      // console verbosity so `--quiet` reduces the console without touching the log
+      // (issue #763) — EXCEPT `Error`/`Fatal`, which always reach STDERR (the
+      // project's deliberate always-emit-errors divergence, since cortex aggregates
+      // success rates from `Error:`/`Fatal:` lines). `Error` is the lowest `Level`
+      // value and Fatal records are emitted at `Level::Error`, so `<= Error`
+      // captures both.
+      let to_stderr = record.level() <= Level::Error || stderr_admits(record.level());
+      if to_stderr {
         use std::io::Write;
         let text = if stderr_use_color() {
           painted_message
@@ -397,7 +447,15 @@ impl log::Log for LatexmlLogger {
   fn flush(&self) {}
 }
 
-/// initialize the logger at a given verbosity `level`
+/// initialize the logger at a given STDERR verbosity `level`
+///
+/// `level` is the **console** verbosity (`--quiet` ⇒ `Warn`, default ⇒ `Info`,
+/// `--verbose`/`--debug` ⇒ `Debug`). Perl decouples this from the log-file floor:
+/// the `.latexml.log` keeps a minimum of `Info` regardless of `--quiet`, while
+/// STDERR follows `level` (`Common/Error.pm` `_printline`; issue #763). So the
+/// global `log` `max_level` is set to the MORE verbose of `level` and `Info` (the
+/// floor), admitting to `LatexmlLogger::log` everything the log needs; the STDERR
+/// echo is then gated separately on the `STDERR_LEVEL` atomic.
 ///
 /// Returns the underlying `SetLoggerError` if another `log` global logger
 /// is already installed (e.g. an embedder set up `tracing-log` first).
@@ -405,9 +463,12 @@ impl log::Log for LatexmlLogger {
 /// `flush_log` buffers are independent of the `log` crate sink and keep
 /// working either way.
 pub fn init(level: LevelFilter) -> Result<(), SetLoggerError> {
-  log::set_logger(&LOGGER)?;
-  log::set_max_level(level);
-  Ok(())
+  // Global config (STDERR gate + log-file floor) is set unconditionally — it must
+  // reflect the requested verbosity even if the logger was already installed (a
+  // second `init` in-process returns `Err` from `set_logger`, which callers `.ok()`).
+  STDERR_LEVEL.store(level as usize, Ordering::Relaxed);
+  log::set_max_level(level.max(LevelFilter::Info));
+  log::set_logger(&LOGGER)
 }
 
 #[cfg(test)]

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -9416,11 +9416,13 @@ LoadDefinitions!({
   //======================================================================
   // C.11.6 Terminal Input and Output
   //======================================================================
+  // Perl latex_constructs.pool.ltxml L4538-4541: `Note(ToString($stuff))` — called
+  // UNCONDITIONALLY. `Note!` does the log-always / stderr-if-`$VERBOSITY>=0` split
+  // itself, so no `current_verbosity()` guard here — the old guard dropped
+  // `\typeout` from the log under `--quiet` (the #763 log-floor bug).
   DefPrimitive!("\\typeout{}", sub[(stuff)] {
-    if current_verbosity() > -1 {
-      let content = Expand!(stuff);
-      Note!(s!("{content}"));
-    }
+    let content = Expand!(stuff);
+    Note!(s!("{content}"));
   });
   def_primitive_noop("\\typein[]{}")?;
 

--- a/latexml_engine/src/tex_debugging.rs
+++ b/latexml_engine/src/tex_debugging.rs
@@ -50,10 +50,13 @@ LoadDefinitions!({
   // doubles #, converts to string; optionally adds spaces after control sequences
   // in the spirit of the B Book, "show_token_list" routine, in 292.
   // [This could be a $tokens->unpackParameters, but for the curious space treatment]
+  // Perl TeX_Debugging.pool.ltxml L65-68: `NoteLog(writableTokens(Expand($stuff)))`
+  // — the log gets it unconditionally (no `$VERBOSITY` guard) and it never reaches
+  // stderr. `NoteLog!` is the faithful vehicle; the old `if current_verbosity() > -1
+  // { Note!(...) }` both echoed to stderr (Perl does not) and dropped `\message`
+  // from the log under `--quiet` (the #763 log-floor bug).
   DefPrimitive!("\\message{}", sub [(message)] {
-    if current_verbosity() > -1 {
-      Note!(writable_tokens(&do_expand(message)?));
-    }
+    NoteLog!(writable_tokens(&do_expand(message)?));
   });
 
   DefRegister!("\\errhelp", Tokens!());

--- a/latexml_math_parser/src/semantics.rs
+++ b/latexml_math_parser/src/semantics.rs
@@ -66,8 +66,16 @@ impl Actions {
         0 => Ok(None),
         1 => Ok(args.remove(0)),
         more => {
-          eprintln!(
-            "Only returning first of {more:?} elements at rule id {id:?} content: {args:?}"
+          // No registered action for this rule id with multiple children — the
+          // ambiguous grammar's fallback keeps the first parse (the "aggressively
+          // prune" design). Route it through the math-parser diagnostic path
+          // (`Info:` — captured in the log floor, `--quiet`-gated on stderr, and
+          // NOT inflating the warning verdict) instead of a raw `eprintln!` that
+          // bypassed the logger and printed unconditionally.
+          log_math_info!(
+            "ambiguous",
+            "action",
+            format!("rule {id:?}: returning first of {more} children; dropped {args:?}")
           );
           Ok(args.remove(0))
         },

--- a/latexml_oxide/bin/latexmlmath_oxide.rs
+++ b/latexml_oxide/bin/latexmlmath_oxide.rs
@@ -177,8 +177,10 @@ fn real_main() -> Result<()> {
 
   // Identity banner (executable, version, git revision, exact start time) —
   // the same line `Converter::convert` logs for the document front-ends, emitted
-  // here because latexmlmath drives its own digest path. `Note!` self-gates on
-  // verbosity, so `--quiet` (log level Warn) suppresses it.
+  // here because latexmlmath drives its own digest path. `Note!` does the
+  // log-always / stderr-gated split, so `--quiet` mutes it on the console
+  // (`stderr_shows_info()` is false at Warn); latexmlmath binds no log buffer, so
+  // there is no log file to keep it in either.
   Note!(latexml::identity::identity_banner());
 
   let mut core_engine = new_test_engine();

--- a/latexml_oxide/src/converter.rs
+++ b/latexml_oxide/src/converter.rs
@@ -250,12 +250,13 @@ impl Converter {
 
     self.bind_log();
     // 1.2 Inform of identity, increase conversion counter. Perl `bin/latexml`
-    // L83 logs `Note("$LaTeXML::IDENTITY processing $source")`; our banner adds
-    // the executable name, git revision and exact start time (`identity.rs`).
-    if self.opts.verbosity >= 0 {
-      Note!(crate::identity::identity_banner());
-      // info!( "invoked as [$0 " . join(' ', @ARGV) . "]\n" if $$opts{verbosity} >= 1;
-    }
+    // L83 logs `Note("$LaTeXML::IDENTITY processing $source")` UNCONDITIONALLY;
+    // our banner adds the executable name, git revision and exact start time
+    // (`identity.rs`). `Note!` itself does the log-always / stderr-gated split, so
+    // the banner reaches `.latexml.log` even under `--quiet` (issue #763) while
+    // still being muted on the console — no verbosity guard here.
+    Note!(crate::identity::identity_banner());
+    // info!( "invoked as [$0 " . join(' ', @ARGV) . "]\n" if $$opts{verbosity} >= 1;
 
     // 1.3 Prepare for What's IN:
     // - We use a new temporary variable to avoid confusion with daemon caching

--- a/latexml_oxide/tests/119_final_status_report.rs
+++ b/latexml_oxide/tests/119_final_status_report.rs
@@ -220,11 +220,13 @@ fn raw_log_warnings_register_in_the_final_verdict() {
 }
 
 /// Error and Fatal messages are the success-rate signal — they must reach the
-/// log at ANY verbosity (user directive 2026-08-02). The quietest CLI mapping
-/// floors the level filter at `Warn`, so `Fatal:`/`Error:` records always
-/// flow; this pins that floor — if someone maps quiet to `LevelFilter::Error`
-/// or `Off`, the Fatal line or the verdict would vanish and this test names
-/// the contract being broken. (`-q` is a plain bool flag — quietest mode.)
+/// log AND stderr at ANY verbosity (user directive 2026-08-02). The quietest CLI
+/// mapping sets the STDERR level to `Warn`, and the logger always echoes
+/// `Error`/`Fatal` records to stderr regardless of the console level
+/// (`logger.rs`: `level <= Error || stderr_admits(level)`); this pins that
+/// contract — if someone dropped the always-emit-errors clause, the Fatal line or
+/// the verdict would vanish and this test names it. (`-q` is a plain bool flag —
+/// quietest mode.)
 #[test]
 fn quiet_mode_still_reports_error_and_fatal() {
   let workdir = tempfile::tempdir().expect("tempdir");

--- a/latexml_oxide/tests/cluster_cli.rs
+++ b/latexml_oxide/tests/cluster_cli.rs
@@ -2669,12 +2669,22 @@ mod quiet_keeps_log_floor {
   //! `bin/latexml` L83 emits the identity `Note` unconditionally. Confirmed on the
   //! same host: Perl 0.8.8 `--quiet` keeps the banner + every `(Loading …` line in
   //! its `.log`.
+  //!
+  //! The same log-floor rule governs the TeX terminal-output primitives, which
+  //! must also survive `--quiet` (Perl calls them WITHOUT a verbosity guard):
+  //! `\typeout` → `Note` (log always + stderr if `$VERBOSITY >= 0`,
+  //! `latex_constructs.pool.ltxml` L4538), `\message` → `NoteLog` (log ONLY, never
+  //! stderr, `TeX_Debugging.pool.ltxml` L65). The `\message` distinction is the
+  //! sharp one: its content must reach the log at any verbosity yet never appear on
+  //! stderr, even loud.
 
   use std::{path::Path, process::Command};
 
   const DOC: &str = "\\documentclass{article}\n\
                      \\usepackage{amsmath}\n\
                      \\begin{document}\n\
+                     \\typeout{TypeoutMarker763}\n\
+                     \\message{MessageMarker763}\n\
                      Hello $x^2$.\n\
                      \\end{document}\n";
 
@@ -2686,6 +2696,8 @@ mod quiet_keeps_log_floor {
       "(Processing content", // Mouth progress note (ProgressSpinup)
       "(Loading ",           // binding-module load note (BookML depends on this)
       "Info:",               // an Info-level diagnostic record
+      "TypeoutMarker763",    // \typeout → Note (log always)
+      "MessageMarker763",    // \message → NoteLog (log always)
       "Status:conversion:",  // the final verdict line
     ] {
       assert!(
@@ -2733,7 +2745,8 @@ mod quiet_keeps_log_floor {
   fn quiet_log_keeps_floor_but_stderr_is_muted() {
     let (log, stderr) = run(true);
     assert_log_has_floor(&log, "--quiet");
-    // STDERR is reduced: progress notes and Info records do not reach the console.
+    // STDERR is reduced: progress notes, Info records, and \typeout do not reach
+    // the console.
     assert!(
       !stderr.contains("(Loading "),
       "--quiet must mute progress notes on STDERR, got:\n{stderr}"
@@ -2742,10 +2755,20 @@ mod quiet_keeps_log_floor {
       !stderr.contains("Info:"),
       "--quiet must mute Info records on STDERR, got:\n{stderr}"
     );
+    assert!(
+      !stderr.contains("TypeoutMarker763"),
+      "--quiet must mute \\typeout on STDERR, got:\n{stderr}"
+    );
+    // \message uses NoteLog — never on stderr at any verbosity.
+    assert!(
+      !stderr.contains("MessageMarker763"),
+      "\\message (NoteLog) must never reach STDERR, got:\n{stderr}"
+    );
   }
 
-  /// Parity companion: without `--quiet`, both the log AND stderr keep the floor
-  /// (the normal, unchanged behavior).
+  /// Parity companion: without `--quiet`, the log keeps the whole floor, and stderr
+  /// keeps the verbosity-gated notes (`(Loading …`, `Info:`, `\typeout`) — but
+  /// `\message` (Perl `NoteLog`) stays log-only, off stderr even loud.
   #[test]
   fn loud_log_and_stderr_both_keep_floor() {
     let (log, stderr) = run(false);
@@ -2757,6 +2780,14 @@ mod quiet_keeps_log_floor {
     assert!(
       stderr.contains("Info:"),
       "loud STDERR should show Info records, got:\n{stderr}"
+    );
+    assert!(
+      stderr.contains("TypeoutMarker763"),
+      "loud STDERR should show \\typeout (Note), got:\n{stderr}"
+    );
+    assert!(
+      !stderr.contains("MessageMarker763"),
+      "\\message (NoteLog) must stay log-only, never on STDERR — got:\n{stderr}"
     );
   }
 }

--- a/latexml_oxide/tests/cluster_cli.rs
+++ b/latexml_oxide/tests/cluster_cli.rs
@@ -2655,3 +2655,108 @@ mod identity_banner {
     );
   }
 }
+
+mod quiet_keeps_log_floor {
+  //! Issue #763 (xworld21/Vincenzo Mantova, BookML author): `--quiet` must
+  //! reduce STDERR only — the `.latexml.log` keeps a minimum verbosity floor
+  //! (identity banner, `(Processing …`/`(Loading …` progress notes, `Info:`
+  //! records, the `Status:conversion:` verdict). BookML's makefile dependency
+  //! tracking reads the `(Loading …` lines from the log, so stripping them under
+  //! `--quiet` broke it.
+  //!
+  //! Perl ground truth — `Common/Error.pm` `_printline`/`ProgressSpinup` write to
+  //! `$LOG` whenever the log is open, gating only STDERR on `$VERBOSITY >= 0`;
+  //! `bin/latexml` L83 emits the identity `Note` unconditionally. Confirmed on the
+  //! same host: Perl 0.8.8 `--quiet` keeps the banner + every `(Loading …` line in
+  //! its `.log`.
+
+  use std::{path::Path, process::Command};
+
+  const DOC: &str = "\\documentclass{article}\n\
+                     \\usepackage{amsmath}\n\
+                     \\begin{document}\n\
+                     Hello $x^2$.\n\
+                     \\end{document}\n";
+
+  /// The log-floor lines every run must keep, quiet or not.
+  fn assert_log_has_floor(log: &str, label: &str) {
+    for needle in [
+      "; revision ",         // identity banner
+      " started ",           // identity banner start time
+      "(Processing content", // Mouth progress note (ProgressSpinup)
+      "(Loading ",           // binding-module load note (BookML depends on this)
+      "Info:",               // an Info-level diagnostic record
+      "Status:conversion:",  // the final verdict line
+    ] {
+      assert!(
+        log.contains(needle),
+        "{label} log missing floor line {needle:?}; full log:\n{log}"
+      );
+    }
+  }
+
+  fn run(quiet: bool) -> (String, String) {
+    let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+    assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+    let workdir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(workdir.path().join("doc.tex"), DOC).expect("write doc.tex");
+    let log_name = if quiet { "quiet.log" } else { "loud.log" };
+
+    let mut cmd = Command::new(bin);
+    cmd
+      .arg("doc.tex")
+      .arg("--dest")
+      .arg("doc.html")
+      .arg("--log")
+      .arg(log_name);
+    if quiet {
+      cmd.arg("--quiet");
+    }
+    let output = cmd
+      .current_dir(workdir.path())
+      .output()
+      .expect("spawn latexml_oxide");
+    assert!(
+      output.status.success(),
+      "binary exited {:?}\nstderr:\n{}",
+      output.status.code(),
+      String::from_utf8_lossy(&output.stderr),
+    );
+    let log = std::fs::read_to_string(workdir.path().join(log_name)).expect("read log");
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    (log, stderr)
+  }
+
+  /// THE FIX: under `--quiet` the on-disk `.log` still carries the full floor,
+  /// while STDERR is quieted (no `Info:` records, no `(Loading …` notes).
+  #[test]
+  fn quiet_log_keeps_floor_but_stderr_is_muted() {
+    let (log, stderr) = run(true);
+    assert_log_has_floor(&log, "--quiet");
+    // STDERR is reduced: progress notes and Info records do not reach the console.
+    assert!(
+      !stderr.contains("(Loading "),
+      "--quiet must mute progress notes on STDERR, got:\n{stderr}"
+    );
+    assert!(
+      !stderr.contains("Info:"),
+      "--quiet must mute Info records on STDERR, got:\n{stderr}"
+    );
+  }
+
+  /// Parity companion: without `--quiet`, both the log AND stderr keep the floor
+  /// (the normal, unchanged behavior).
+  #[test]
+  fn loud_log_and_stderr_both_keep_floor() {
+    let (log, stderr) = run(false);
+    assert_log_has_floor(&log, "loud");
+    assert!(
+      stderr.contains("(Loading "),
+      "loud STDERR should show progress notes, got:\n{stderr}"
+    );
+    assert!(
+      stderr.contains("Info:"),
+      "loud STDERR should show Info records, got:\n{stderr}"
+    );
+  }
+}

--- a/latexml_post/src/diag.rs
+++ b/latexml_post/src/diag.rs
@@ -55,7 +55,10 @@
 #[macro_export]
 macro_rules! Note {
   ($input:expr_2021) => {{
-    if log::max_level() >= log::LevelFilter::Info {
+    // STDERR-only post note, gated on the decoupled console verbosity (Perl
+    // `$VERBOSITY >= 0`), NOT `max_level` — under `--quiet` the log-file floor
+    // holds `max_level` at `Info`, but the console note must stay silent (#763).
+    if latexml_core::util::logger::stderr_shows_info() {
       eprintln!("{}", $input);
     }
   }};


### PR DESCRIPTION
**Diagnostic.** `--quiet` lowered the single `log` `max_level` to `Warn`, so the logger dropped the identity banner, `(Processing …`/`(Loading …` progress notes and `Info:` records from the on-disk `.latexml.log` — not just stderr. BookML reads the `(Loading …` lines from the log for makefile dependency tracking, so `--quiet` broke it.

**Approach.** Decouple the two gates in `latexml_core/util/logger.rs` (Perl `Common/Error.pm` `_printline`/`ProgressSpinup` write `$LOG` whenever the log is open, gating only STDERR on `$VERBOSITY >= 0`): the log-file floor stays at `Info` regardless of `--quiet`, while a new `STDERR_LEVEL` follows the console verbosity (`--verbose`/`--debug` raise both). `Error`/`Fatal` still always reach stderr. The identity banner drops its verbosity guard (Perl `bin/latexml` L83 is unconditional).

**Validation.** RED→GREEN guards `quiet_keeps_log_floor::{quiet_log_keeps_floor_but_stderr_is_muted, loud_log_and_stderr_both_keep_floor}`; `119_final_status_report::quiet_mode_still_reports_error_and_fatal` + logger/error unit tests re-confirmed. Full suite 2173/0, clippy `-D warnings` clean, rustdoc clean. Perl 0.8.8 `--quiet` parity confirmed same-host (banner + every `(Loading …` kept in its `.log`).

Closes #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUgFzi1zW73EpejP7L1NZ5