### PR TITLE
fix #761: math in a title serializes cleanly in cross-ref tooltips

### DIFF
--- a/latexml_oxide/tests/cluster_regressions/ref_title_math.tex
+++ b/latexml_oxide/tests/cluster_regressions/ref_title_math.tex
@@ -1,0 +1,12 @@
+\documentclass[12pt]{article}
+\begin{document}
+\title{my title to solve $\sin x = x$}
+\tableofcontents
+
+\section{first section}
+text
+
+\section{second section $\sin x$}
+text
+
+\end{document}

--- a/latexml_oxide/tests/cluster_xslt_split.rs
+++ b/latexml_oxide/tests/cluster_xslt_split.rs
@@ -1104,6 +1104,37 @@ mod cluster_toc_navigation {
        hardcoded `toc` bucket did exactly that:\n{x}"
     );
   }
+
+  /// Issue #761: math in a title leaked into the `title=` tooltip of every TOC /
+  /// cross-ref link as the raw *content*-tree token dump — operator-first
+  /// (`= sin x x`) with all the inter-token whitespace preserved — producing a
+  /// huge, wrongly-ordered browser tooltip. Perl's `CrossRef::getTextContent_rec`
+  /// routes an `ltx:Math` node through `unicodemath` (presentation-order infix,
+  /// `sin𝑥=𝑥`), and `getTextContent` collapses whitespace to single spaces.
+  /// Witness = the issue MWE (doc title `$\sin x = x$`, two sections).
+  #[test]
+  fn ref_title_math_uses_unicodemath_not_content_dump() {
+    let x = convert_and_post("tests/cluster_regressions/ref_title_math.tex");
+    // The document title carries `$\sin x = x$`; it becomes the "In <doc title>"
+    // context on every section's cross-ref `title=` tooltip.
+    let start = x
+      .find("title=\"In my title")
+      .unwrap_or_else(|| panic!("#761: expected an `In my title…` ref tooltip:\n{x}"));
+    let rest = &x[start + "title=\"".len()..];
+    let end = rest
+      .find('"')
+      .expect("#761: ref title attribute must close");
+    let title_val = &rest[..end];
+    // Byte-for-byte the Perl LaTeXML oracle output: presentation-order infix
+    // (`sin` right after `solve `, RELOP `=` in the middle — NOT the
+    // operator-first content dump `= sin x x`), math-italic `𝑥` (U+1D465) from
+    // the tokens' `font="italic"`, and whitespace collapsed to single spaces
+    // (no `&#10;` newline runs bloating the tooltip).
+    assert_eq!(
+      title_val, "In my title to solve sin\u{1D465}=\u{1D465}",
+      "#761: ref title must match Perl's unicodemath serialization; got: {title_val:?}"
+    );
+  }
 }
 
 mod cleanup_scripts_xmlid {

--- a/latexml_post/src/crossref.rs
+++ b/latexml_post/src/crossref.rs
@@ -60,13 +60,20 @@ fn ref_fallbacks(key: &str) -> &'static [&'static str] {
 }
 
 /// Derive the STRING form of a stored value (page `<title>`, `title=` tooltip).
-/// Perl `CrossRef::getTextContent`. A `Value::Xml` title is flattened tag-aware
-/// (via [`title_text_content`]); any other value uses its plain string form.
-fn value_text(val: &Value) -> String {
-  match val {
-    Value::Xml(node) => title_text_content(node),
+/// Perl `CrossRef::getTextContent` (`CrossRef.pm` L853-859). A `Value::Xml` title
+/// is flattened tag-aware and math-aware (via [`title_text_content`], which routes
+/// `ltx:Math` through `unicodemath`); any other value uses its plain string form.
+/// Either way the result is whitespace-collapsed like Perl: trim both ends, then
+/// `s/\s+/ /g` — so a multi-line math serialization cannot bloat a `title=`
+/// tooltip (issue #761).
+fn value_text(doc: &PostDocument, val: &Value) -> String {
+  let raw = match val {
+    Value::Xml(node) => title_text_content(doc, node),
     other => other.to_string(),
-  }
+  };
+  // Perl `getTextContent`: `s/^\s+//; s/\s+$//; s/\s+/ /g`. `split_whitespace`
+  // does exactly this (drops leading/trailing runs, collapses interior runs).
+  raw.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 /// Build the child nodes of an `<ltx:ref>` from a stored value.
@@ -396,7 +403,7 @@ impl CrossRef {
   /// Generate a title string for a referenced ID, traversing parents for context.
   ///
   /// Port of `CrossRef::generateTitle`.
-  fn generate_title(&self, _doc: &PostDocument, id: &str, shown: &str) -> Option<String> {
+  fn generate_title(&self, doc: &PostDocument, id: &str, shown: &str) -> Option<String> {
     let mut current_id = id.to_string();
     let mut result = String::new();
     let mut prefix = String::new();
@@ -413,7 +420,7 @@ impl CrossRef {
           // The title is stored as a NODE (`Value::Xml`) for sections; derive
           // its string form tag-aware (Perl `getTextContent`). A plain-string
           // title (e.g. abstract/bibliography names) is used verbatim.
-          pieces.push(value_text(title_val));
+          pieces.push(value_text(doc, title_val));
         }
       }
       if pieces.is_empty() {

--- a/latexml_post/src/scan.rs
+++ b/latexml_post/src/scan.rs
@@ -346,14 +346,14 @@ impl Scan {
         let value = self
           .db
           .adopt_xml(&title_node)
-          .unwrap_or_else(|| Value::from(title_text_content(&title_node).as_str()));
+          .unwrap_or_else(|| Value::from(title_text_content(doc, &title_node).as_str()));
         sp.push("title", value);
       }
       if let Some(toctitle_node) = doc.findnode_at("ltx:toctitle", node) {
         let value = self
           .db
           .adopt_xml(&toctitle_node)
-          .unwrap_or_else(|| Value::from(title_text_content(&toctitle_node).as_str()));
+          .unwrap_or_else(|| Value::from(title_text_content(doc, &toctitle_node).as_str()));
         sp.push("toctitle", value);
       }
       if let Some(stub) = node.get_attribute("stub") {
@@ -1056,10 +1056,16 @@ fn get_xml_id(node: &Node) -> Option<String> {
 /// This is the derived STRING form of a title (page `<title>`, `title=`
 /// tooltip). The rich node form is kept in the ObjectDB (`Value::Xml`) so
 /// CrossRef can deep-clone it into `<ltx:ref>` content. Mirrors Perl
-/// `CrossRef::getTextContent_rec`'s `ltx:tag` open/close handling (its
-/// `ltx:Math → unicodemath` branch is not yet ported — math in a title still
-/// flattens to its token text here, unchanged from before).
-pub(crate) fn title_text_content(node: &Node) -> String {
+/// `CrossRef::getTextContent_rec` (`CrossRef.pm` L861-879): `ltx:tag` open/close
+/// handling, plus the `ltx:Math → unicodemath` branch — a title's math renders
+/// as presentation-order infix Unicode (`sin𝑥=𝑥`), NOT the raw content-tree
+/// token text, which is operator-first and whitespace-laden (issue #761).
+///
+/// Whitespace collapse is applied by the caller ([`value_text`] =
+/// `getTextContent`), matching Perl's split of the two functions.
+///
+/// [`value_text`]: crate::crossref
+pub(crate) fn title_text_content(doc: &PostDocument, node: &Node) -> String {
   let mut result = String::new();
   let mut child = node.get_first_child();
   while let Some(c) = child {
@@ -1074,12 +1080,18 @@ pub(crate) fn title_text_content(node: &Node) -> String {
           if let Some(open) = c.get_attribute("open") {
             result.push_str(&open);
           }
-          result.push_str(&title_text_content(&c));
+          result.push_str(&title_text_content(doc, &c));
           if let Some(close) = c.get_attribute("close") {
             result.push_str(&close);
           }
+        } else if name == "Math" {
+          // Perl `CrossRef.pm` L872-873: `return unicodemath($doc, $node)` — the
+          // presentation branch of the math, in reading order. Without this a
+          // math title flattened to its XMApp/XMDual content tree (operator
+          // first: `= sin x x`) with every inter-token newline preserved.
+          result.push_str(&crate::unicode_math::unicodemath(doc, &c));
         } else {
-          result.push_str(&title_text_content(&c));
+          result.push_str(&title_text_content(doc, &c));
         }
       },
       _ => {},

--- a/latexml_post/src/unicode_math.rs
+++ b/latexml_post/src/unicode_math.rs
@@ -437,31 +437,50 @@ fn unimath_underaccent(doc: &PostDocument, op: &Node, base: &Node) -> (String, i
 
 /// Convert an XMTok's content to styled Unicode text.
 ///
-/// Port of `stylizeContent` (simplified — full version needs unicode_convert).
+/// Port of `stylizeContent` (`UnicodeMath.pm` L234-252): resolve the token text
+/// (with the empty-token failsafe), then remap it into the plane-1 math alphabet
+/// for the token's `font` mathvariant — `unicode_convert` is all-or-nothing, so
+/// a partly-unmappable string keeps its original text (Perl: "didn't remap the
+/// text? Keep text & variant"). This is what turns an italic `x` into `𝑥` in a
+/// title tooltip (issue #761) and in the UnicodeMath annotation.
 fn stylize_content(node: &Node) -> String {
   let role = node
     .get_attribute("role")
     .unwrap_or_else(|| "ID".to_string());
-  let text = node.get_content();
+  let font = node.get_attribute("font").unwrap_or_default();
+  let mut text = node.get_content();
   if text.is_empty() {
-    // Fallback for empty tokens
+    // Failsafe for empty tokens: %default_token_content, else name/meaning/role.
     static DEFAULT_CONTENT: &[(&str, &str)] = &[
       ("MULOP", "\u{2062}"), // INVISIBLE TIMES
       ("ADDOP", "\u{2064}"), // INVISIBLE PLUS
       ("PUNCT", "\u{2063}"), // INVISIBLE SEPARATOR
     ];
-    for (r, default) in DEFAULT_CONTENT {
-      if role == *r {
-        return default.to_string();
+    text = DEFAULT_CONTENT
+      .iter()
+      .find(|(r, _)| role == *r)
+      .map(|(_, d)| (*d).to_string())
+      .unwrap_or_else(|| {
+        node
+          .get_attribute("name")
+          .or_else(|| node.get_attribute("meaning"))
+          .unwrap_or_else(|| role.clone())
+      });
+  }
+  // Perl: `$variant = $font ? unicode_mathvariant($font) : ''`, then
+  // `$u_text = $variant && unicode_convert($text, $variant)`; keep `$u_text`
+  // only if it remapped to a non-empty string. Gating on a non-empty `font`
+  // mirrors the ternary — `unicode_mathvariant("")` would otherwise yield
+  // "normal" and trigger a needless lookup.
+  if !font.is_empty() {
+    let variant = crate::unicode::unicode_mathvariant(&font);
+    if let Some(u) = crate::unicode::unicode_convert(&text, variant) {
+      if !u.is_empty() {
+        text = u;
       }
     }
-    node
-      .get_attribute("name")
-      .or_else(|| node.get_attribute("meaning"))
-      .unwrap_or(role)
-  } else {
-    text
   }
+  text
 }
 
 /// Text content in quotes.


### PR DESCRIPTION
**Diagnostic.** Math in a `\title`/section title leaked into the `title=` tooltip of every cross-ref/TOC link as the raw content-tree token dump — operator-first (`= sin x x`) with every inter-token newline preserved — producing a huge, wrongly-ordered browser popup. Perl's `CrossRef::getTextContent_rec` routes an `ltx:Math` node through `unicodemath` (presentation-order infix) and `getTextContent` collapses whitespace; oxide's `scan::title_text_content` ported neither branch, and `unicode_math::stylize_content` was a documented-simplified port skipping the font mathvariant.

**Approach.** Port the missing pieces faithfully: `title_text_content` gains the `ltx:Math → unicodemath` branch (CrossRef.pm:872-873); `value_text` (= `getTextContent`) collapses whitespace (`trim` + `s/\s+/ /g`); `stylize_content` (= `stylizeContent`) applies the token font's mathvariant via the existing `unicode_convert`/`unicode_mathvariant` (italic `x` → `𝑥`). Output is now byte-identical to Perl LaTeXML for both the `title=` tooltip and the page `<head><title>`.

**Validation.** New guard `ref_title_math_uses_unicodemath_not_content_dump` (cluster_xslt_split) pins the exact Perl string; full suite 2172/2172; clippy 0 / fmt clean; Perl parity re-confirmed byte-for-byte on the issue MWE.

Closes #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)