### PR TITLE
fix: streaming byte-identity for a framed breaklines verbatim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,6 +250,13 @@
     fragile `:has(.ltx_parbox)` selector, which was previously the only distinguisher.
     Beyond-Perl (both engines emit no breaklines hook natively), same spirit as the
     `frame=single`→`ltx_framed_verbatim` remap (#702).
+  - **Streaming byte-identity for a framed `breaklines=true` verbatim.** A single-line
+    such verbatim (its parbox layer crosses a fragment seam) used to render nested under
+    `--streaming` yet collapsed under the eager path, because `spill_closed_subtrees`
+    spilled the frame's sole `ltx:text` child before the frame closed, leaving a
+    `<_spilled_/>` placeholder that `auto_collapse_children` could not merge. The spill
+    guard now keeps that lone child resident until its frame closes, so both paths
+    collapse identically (#702).
 
   - **`minted` code blocks render with syntax highlighting, and inline `\mint`/`\mintinline`
     work.** The `minted` family now emits highlight token classes so a stylesheet colors the

--- a/latexml_core/src/document.rs
+++ b/latexml_core/src/document.rs
@@ -3681,6 +3681,28 @@ impl Document {
         let parent_qname = get_node_qname(&parent);
         model::can_contain_sym(parent_qname, pin!("#PCDATA"))
       };
+      // Do NOT spill the sole `ltx:text` child of an open `ltx:text` frame: that
+      // is exactly the `auto_collapse_children` pattern (a redundant font/frame
+      // wrapper merged into its parent at close). Spilling the child first leaves
+      // the still-open frame with a `<_spilled_/>` placeholder, so the close-time
+      // collapse sees a non-`ltx:text` child and skips the merge the EAGER path
+      // performs — the streamed output then nests where eager collapses, breaking
+      // the byte-identity invariant (witness: a `breaklines=true` framed
+      // `Verbatim` whose parbox layer crosses a fragment seam, issue #702). The
+      // protected node is a small wrapper; keeping it resident until the frame
+      // closes costs negligible memory. Conservative on purpose: it also spares a
+      // few wrappers `auto_collapse` would NOT merge (`_force_font` /
+      // non-mergeable attr), which stay nested in BOTH paths anyway.
+      let parent_is_collapse_frame = get_node_qname(&parent) == pin!("ltx:text") && {
+        let elem_kids: Vec<Node> = parent
+          .get_child_nodes()
+          .into_iter()
+          .filter(|c| {
+            c.get_type() == Some(NodeType::ElementNode) && c.get_name() != SPILL_PLACEHOLDER
+          })
+          .collect();
+        elem_kids.len() == 1 && get_node_qname(&elem_kids[0]) == pin!("ltx:text")
+      };
       let mut run: Vec<Node> = Vec::new();
       for child in parent.get_child_nodes() {
         if Some(&child) == barrier.as_ref() {
@@ -3688,6 +3710,7 @@ impl Document {
         }
         let eligible = child.get_type() == Some(NodeType::ElementNode)
           && child.get_name() != SPILL_PLACEHOLDER
+          && !parent_is_collapse_frame
           && (level > 0 || ROOT_SPILLABLE.contains(&child.get_name().as_str()))
           // A bibliography pins its subtree in RAM: a LATER `\bibstyle`
           // writes attributes onto it through a doc-wide search (sweep

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -1428,13 +1428,15 @@ fn cluster_fvextra_backgroundcolor_paints_the_frame_box() {
 /// `fvextra_sty.rs` redefines to fire off `\ifFV@breaklines`. Only the break box
 /// gets it: exactly one `ltx_break` against two `ltx_framed_verbatim` boxes.
 ///
-/// The fixture verbatims are deliberately MULTI-LINE. A *single-line*
-/// `breaklines=true` framed verbatim trips a PRE-EXISTING streaming divergence
-/// (unrelated to this feature — reproduces with the `ltx_break` class removed):
-/// the frame's lone `ltx:text` child coalesces into the frame under the eager
-/// path but not under the fragment (`--streaming`) path, so the `114_streaming_*`
-/// sweep diverges. Multiple lines give the frame several children, so neither
-/// path collapses the wrapper and the two agree. Keep ≥2 lines here.
+/// The fixture verbatims are deliberately SINGLE-LINE: that is also the
+/// red/green guard for the streaming coalesce fix (`document.rs`
+/// `spill_closed_subtrees`). A single-line `breaklines=true` framed verbatim has
+/// a lone `ltx:text` child that `auto_collapse_children` merges into the frame at
+/// close — but the breaklines parbox layer crosses a fragment seam, so under
+/// `--streaming` the child used to spill first (→ `<_spilled_/>`), the frame then
+/// saw a non-`ltx:text` child and skipped the merge, and the `114_streaming_*`
+/// eager-vs-streamed sweep diverged. The spill guard keeps that sole child
+/// resident until the frame closes, so both paths collapse identically.
 #[test]
 fn cluster_fvextra_breaklines_class() {
   let x = convert_to_xml("tests/cluster_regressions/fvextra_breaklines_class.tex");

--- a/latexml_oxide/tests/cluster_regressions/fvextra_breaklines_class.tex
+++ b/latexml_oxide/tests/cluster_regressions/fvextra_breaklines_class.tex
@@ -2,11 +2,9 @@
 \usepackage{fvextra}
 \begin{document}
 \begin{Verbatim}[frame=single]
-no break line one
-no break line two
+no break line
 \end{Verbatim}
 \begin{Verbatim}[breaklines=true,frame=single]
-break line one
-break line two
+break line
 \end{Verbatim}
 \end{document}


### PR DESCRIPTION
**Diagnostic.** A single-line `breaklines=true` framed `fvextra` Verbatim rendered NESTED under `--streaming` but COLLAPSED under the eager path, breaking the streaming byte-identity invariant. Its parbox layer crosses a fragment seam, so `document.rs::spill_closed_subtrees` spilled the frame's sole `ltx:text` child while the frame was still open — leaving a `<_spilled_/>` placeholder that `auto_collapse_children` could not merge at close, so the streamed tree kept the wrapper the eager path folds away.

**Approach.** `spill_closed_subtrees` no longer spills the sole `ltx:text` child of an open `ltx:text` frame — exactly the `auto_collapse_children` pattern — so the child is resident at close and both paths collapse identically. Narrow and conservative (a small font/frame wrapper; negligible memory).

**Validation.** `fvextra_breaklines_class.tex` reverts to single-line (widened to multi-line in #718 only to dodge this), so it is the red/green guard: it diverges in the `114_streaming_*` sweep without this fix and converges with it. Guard `cluster_fvextra_breaklines_class`; full suite 2175/2175; clippy 0 / fmt clean.

Refs #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)