### PR TITLE
fix: \newtcblisting leading [init-options] optarg + 2606 study plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@
     `quiet_keeps_log_floor::{quiet_log_keeps_floor_but_stderr_is_muted,
     loud_log_and_stderr_both_keep_floor}`.
 
+  - **`\newtcblisting` now accepts its leading `[init-options]` optional argument.**
+    The binding stub took `{name}[N][default]{options}`, omitting the leading
+    `[init-options]` that the real tcolorbox macro carries (`{ m +O{} m o +o +m }`).
+    A call like `\newtcblisting[auto counter, number within=section]{promptbox}[2][]{…}`
+    therefore read the bracket group as the mandatory name, left `{promptbox}`
+    undefined, and let its verbatim body tokenize as ordinary LaTeX — so every `_`/`^`
+    in the listing raised "Script can only appear in math mode" (455 errors on the
+    witness). The spec now leads with the optional; both it and the trailing tcb
+    options are dropped as before, and calls without a leading optional are unchanged.
+    Found in the sandbox-arxiv-2606 study; witness 2606.00555 (455→0 errors). Guard
+    `cluster_newtcblisting_leading_optarg`.
+
 ## [0.7.6] (graphics & SVG figure fidelity; minted highlighting + overpic; author/frontmatter class sweep; Rhai runtime binding API; latexmlpost CLI parity; wider package & bibliography coverage)
 
   - **`minted` code blocks render Pygments syntax colors, not just bold-black.** When the

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -998,6 +998,65 @@ Rust-only vs shared. The dominant finding — the 2605 "43 new fatals" were ~90%
   fallback → `neurips.sty.ltxml`, which also lacks graphicx). Witness 2605.21325. #690 brought
   Rust *to* Perl parity (it was accidentally better before).
 
+### (not ranked) sandbox-arxiv-2606 study — 2026-08-23 (methodology-corrected)
+
+Third-wave triage of the 2606 `oxidized_tex_to_html` clusters (6 clusters, parallel
+subagents), under the CORRECT same-host method: BOTH engines with `--preload=ar5iv.sty
+--path=ar5iv-bindings/bindings`, NO `--quiet` (it hides Perl's `Error:` lines), ANSI-strip
+Perl stderr (`sed 's/\x1b\[[0-9;]*m//g'` — else `^Error:` reads 0 on Perl), real `--dest`.
+A first pass WITHOUT these produced FALSE "Rust-only" verdicts (comparing oxidized-with-the-
+paper's-`macros.sty` against Perl-without-it): every top cluster re-classified to parity once
+corrected. See [[feedback_sandbox_preload_ar5iv]] + [[feedback_strict_vs_lax_error_grep]].
+
+**Net: the 2606 clusters are overwhelmingly PARITY + error amplification, not regressions.**
+2605↔2606 cluster doc-counts are near-identical (stable long-tail, not new breakage). Under
+the correct method Perl and oxidized fail on the SAME constructs; oxidized is often marginally
+BETTER (clean DOM vs Perl's `<ltx:ERROR/>` nodes; runaway backstop bails as fast or faster).
+
+**LANDED (PR fix/newtcblisting-leading-optarg):** `\newtcblisting` binding stub
+`tcolorbox_sty.rs:41` lacked the LEADING `[init-options]` optional (real sig `{ m +O{} m o +o +m }`),
+so `\newtcblisting[auto counter,...]{name}[2][]{...}` read `[...]` as the mandatory name → env
+undefined → verbatim body tokenized as LaTeX → every `_`/`^` → "Script can only appear in math
+mode". The ONLY genuine Rust-only witness across the `unexpected/_` cluster. Witness **2606.00555**
+455→0 errors; priors 2507.00833/2402.13846 preserved; guard `cluster_newtcblisting_leading_optarg`.
+
+**Cross-cluster policy item — ERROR AMPLIFICATION (biggest measurement distortion):** oxidized's
+diagnostic error cap (500/1000) vs Perl's MAX_ERRORS=100 → oxidized emits 1.4–30× more error
+records on the SAME shared failure (2606.14954 `_`: 141 vs Perl 100; alignment 213 vs 17; achemso
+"501 hits" = the 500-cap on ONE doc = 5× Perl's cap-100). Inflates cluster hit-counts AND the
+`TooManyErrors(500/1000)` fatal population (~96 docs) vs Perl's cap-100 fatals; does NOT reflect
+worse conversion. Policy call (needs an OXIDIZED_DESIGN entry): align the DIAGNOSTIC cap toward
+Perl's 100 — this is distinct from the runaway/expansion backstops, which
+[[feedback_runaway_limit_raise_not_reduce]] governs (raise, never lower) and this does not touch.
+Per-doc DOMINANT-cluster counts (robust to amplification): `unexpected/_` 360, newunicodechar 119,
+`\GenericError` 96, `&` 93, `malformed:ltx:caption` 88.
+
+**Deferred plan, priority order (cross-ref the 2026-08-21 section above; do NOT duplicate):**
+1. **newunicodechar (~119 docs) — ROOT CAUSE found** (deepens §B "native newunicodechar binding"):
+   newunicodechar.sty's engine-probe uses four-hex `^^^^HHHH` caret (XeTeX/LuaTeX only); neither
+   engine supports it (`mouth.rs:715 get_next_char` ≈ Perl `Mouth.pm:156`, both only two-hex `^^HH`
+   + single `^^X`) → both take the utf8-byte-count path → both error. Better fix than a per-package
+   binding: add four-hex/six-hex caret in `get_next_char` so newunicodechar takes its Unicode branch
+   (oxidized's Unicode branch already maps α→945 correctly). Diverges from Perl (oxidized clean / Perl
+   still errors) — upstream the same to `Mouth.pm`. Min-repro
+   `\usepackage{newunicodechar}\newunicodechar{α}{\ensuremath{\alpha}}` → OX/Perl 1 err, pdflatex 0.
+2. **OmniBus frontmatter vocabulary (~150 docs)** — §B above (confirmed parity, unchanged).
+3. **Missing package/class bindings (beyond-Perl conversion wins)** — `tabu`/`tabularray` (alignment
+   cluster; both engines unbound; oxidized amplifies 2–12× and misparses `\begin{tabu} to <dim>{preamble}`
+   as a column template `t`, `alignment.rs:997`), qcircuit/semantex/nicematrix (cascade fatals),
+   achemso/revtex4-2 (frontmatter classes unbound in both). quantikz already landed on HEAD.
+4. **`_` math-mode-loss residual (~360 dominant docs, minus 00555) — PARITY:** both engines lose math
+   mode on shared constructs (theorem `\label{..._..}` + crossreftools active; undefined metadata envs
+   like `{CCSXML}` leaking verbatim bodies; math-`array` `\tabularnewline`+`\hline`). No single Rust fix;
+   the amplification item is the only oxidized-side lever, plus per-binding cascade prevention.
+5. **floatrow raw-load (2606.10047)** — narrow genuine residue (OX 18 `malformed` vs Perl 0); floatrow
+   reroutes subcaption placement, oxidized's raw interp still malforms. Own ticket.
+
+Runaway/fatal re-verification (corrects any "oxidized hard-loops worse than Perl" impression): on
+2606.13219 (pgfplots) oxidized bails `Fatal:Timeout:PushbackLimit` <90s while Perl HANGS (timeout);
+on 2606.30928 (tikz-cd/quiver) oxidized bails in 3s vs Perl 23s. Runaway-fatals = PARITY; the 650k
+PushbackLimit backstop is a strength, not a regression.
+
 ### (not ranked) fairmeta.cls family trailing items (2026-08-21)
 
 The fairmeta author↔institution binding fix (arXiv/html_feedback#1396 + the

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -1052,6 +1052,23 @@ Per-doc DOMINANT-cluster counts (robust to amplification): `unexpected/_` 360, n
 5. **floatrow raw-load (2606.10047)** — narrow genuine residue (OX 18 `malformed` vs Perl 0); floatrow
    reroutes subcaption placement, oxidized's raw interp still malforms. Own ticket.
 
+**Confirmed PARITY — do NOT re-triage or "fix" (both engines identical / oxidized cleaner):**
+- `latex/\GenericError` "Not in outer par mode" (88) + "strip used only in twocolumn mode!" (56) —
+  `cuted.sty` `\begin{strip}` misused (one-column, or after `\maketitle` in non-outer-par). Both
+  engines emit the same message at the SAME source line/col; pdflatex would too. Witnesses 2606.27050
+  (ECOC template `\begin{strip}` after `\maketitle`), 2606.00001 (`jaist` one-column + cuted). Do NOT
+  touch par-mode / twocolumn tracking — it is correct.
+- `malformed/ltx:listing` (52) — always a CASCADE, never root: listings style-hooks with mode-switching
+  bodies (`keywordstyle=\..\bfseries{#1}`, `stringstyle=\text{#1}`) raise "close a group that switched
+  to mode horizontal" in BOTH engines (`stomach.rs:733`); the listing malforms only surface past the
+  100-cap (amplification). Witnesses 2606.00625 (lstlisting in adjustbox), 2606.30854 (macros.tex `\code`
+  = `\lstinline` with style hooks), 2606.29025 (algorithm2e+algorithmic). 2606.17850 is mis-clustered
+  (actually an `ltx:td`/`ltx:tr` table cluster). The only real (shared, deep, not-small) defect is the
+  mode-switch-in-listing-style-hook — a future parity-improvement, not a regression.
+- `misdefined/#` "token # (catcode PARAM) should never reach Stomach" (~32) — algpseudocode `#` leak;
+  both engines emit it ~equally (2606.03769 OX 98 / Perl 96, both capped); oxidized clean where Perl
+  errors on 2606.05922. PARITY.
+
 Runaway/fatal re-verification (corrects any "oxidized hard-loops worse than Perl" impression): on
 2606.13219 (pgfplots) oxidized bails `Fatal:Timeout:PushbackLimit` <90s while Perl HANGS (timeout);
 on 2606.30928 (tikz-cd/quiver) oxidized bails in 3s vs Perl 23s. Runaway-fatals = PARITY; the 650k

--- a/latexml_oxide/tests/06_cluster_regressions.rs
+++ b/latexml_oxide/tests/06_cluster_regressions.rs
@@ -457,6 +457,18 @@ fn cluster_tcolorbox_tabular_not_flipped_6873() {
      (else the table renders upside down):\n{fo_open}"
   );
 }
+/// sandbox-arxiv-2606 study (witness 2606.00555): `\newtcblisting`'s real
+/// signature carries a LEADING `[init-options]` optional before the mandatory
+/// `{name}` (real tcolorbox `{ m +O{} m o +o +m }`). The binding stub omitted it,
+/// so `\newtcblisting[auto counter,...]{promptbox}[2][]{...}` read the bracket
+/// group as the name, left `{promptbox}` undefined, and its verbatim body
+/// tokenized as normal LaTeX — every `_`/`^` raising "Script can only appear in
+/// math mode" (455 in the witness). Perl raw-loads the real macro and is clean.
+/// RED before the fix: 4 errors ({promptbox} undefined + `_` scripts).
+#[test]
+fn cluster_newtcblisting_leading_optarg() {
+  convert_clean("tests/cluster_regressions/newtcblisting_leading_optarg.tex");
+}
 /// Issue #723 (reporter xworld21): a Rhai binding's `HyperVerbatim` argument
 /// under T1 fontencoding produced non-ASCII `~`/`^`, breaking URLs. The T1
 /// fontmap deliberately maps slots 94/126 to accent glyphs U+02C6/U+02DC (Bruce

--- a/latexml_oxide/tests/cluster_regressions/newtcblisting_leading_optarg.tex
+++ b/latexml_oxide/tests/cluster_regressions/newtcblisting_leading_optarg.tex
@@ -1,0 +1,16 @@
+% Regression guard for the sandbox-arxiv-2606 study (witness 2606.00555).
+% \newtcblisting's real signature has a LEADING [init-options] optional before
+% the mandatory {name}. The binding stub omitted it, so a call like
+% \newtcblisting[auto counter,...]{promptbox}[2][]{...} read the bracket group as
+% the name, left {promptbox} undefined, and its verbatim body tokenized as normal
+% LaTeX — every `_`/`^` in the listing raising "Script can only appear in math
+% mode". Perl raw-loads the real macro and is clean; pdflatex compiles.
+\documentclass{article}
+\usepackage{tcolorbox}
+\tcbuselibrary{listings}
+\newtcblisting[auto counter, number within=section]{promptbox}[2][]{listing only}
+\begin{document}
+\begin{promptbox}[lbl]{cap}
+prompt text with x_1 and y_2 subscripts_here
+\end{promptbox}
+\end{document}

--- a/latexml_package/src/package/tcolorbox_sty.rs
+++ b/latexml_package/src/package/tcolorbox_sty.rs
@@ -27,19 +27,29 @@ LoadDefinitions!({
   // Make the check a no-op — the versions are always compatible in practice.
   DefMacro!("\\tcb@check@library@version", "", locked => true);
 
-  // \newtcblisting{name}[N][default]{tcb-options} (tcolorbox `listings`/`minted`
-  // library) — a code-listing box. Its box styling is purely visual; what
-  // matters for the logical output is the code BODY, which must be captured
-  // verbatim and CLOSED at \end{name}. The raw library's body capture does not
-  // integrate with LaTeXML's verbatim reader, so the listing runs past its
-  // \end{name} and swallows following content (sections leak into
+  // \newtcblisting[init-options]{name}[N][default]{tcb-options} (tcolorbox
+  // `listings`/`minted` library) — a code-listing box. Its box styling is purely
+  // visual; what matters for the logical output is the code BODY, which must be
+  // captured verbatim and CLOSED at \end{name}. The raw library's body capture
+  // does not integrate with LaTeXML's verbatim reader, so the listing runs past
+  // its \end{name} and swallows following content (sections leak into
   // <ltx:verbatim>). Delegate to listings' \lstnewenvironment (same
-  // name/[N][default] shape; the tcb options are dropped), whose verbatim reader
-  // terminates correctly. `locked` so a later raw `\tcbuselibrary{listings}`
-  // can't clobber it. Witness: 2507.00833 (ar5iv #569/#570), 2402.13846 (#504).
+  // name/[N][default] shape; the leading [init-options] and trailing tcb options
+  // are dropped), whose verbatim reader terminates correctly. `locked` so a later
+  // raw `\tcbuselibrary{listings}` can't clobber it.
+  //
+  // The signature MUST include the leading `[init-options]` optional (real
+  // tcolorbox `\NewDocumentCommand \__tcobox_new_tcolorbox:w { m +O{} m o +o +m }`,
+  // mirrored by tcblistings): omitting it made a call like
+  // `\newtcblisting[auto counter,...]{promptbox}[2][]{...}` read `[auto counter,...]`
+  // as the mandatory name, so `{promptbox}` was never defined and its verbatim body
+  // tokenized as normal LaTeX — every `_`/`^` in the listing then raising
+  // "Script can only appear in math mode" (Perl raw-loads the real macro and is
+  // clean). Witness: 2606.00555 (leading init-options). Prior witnesses use no
+  // leading optional and are unaffected: 2507.00833 (ar5iv #569/#570), 2402.13846 (#504).
   DefMacro!(
-    "\\newtcblisting{}[][]{}",
-    "\\lstnewenvironment{#1}[#2][#3]{}{}",
+    "\\newtcblisting[]{}[][]{}",
+    "\\lstnewenvironment{#2}[#3][#4]{}{}",
     locked => true
   );
 });


### PR DESCRIPTION
## What

`\newtcblisting`'s binding stub took `{name}[N][default]{options}`, omitting the **leading `[init-options]`** optional that the real tcolorbox macro carries (`{ m +O{} m o +o +m }`). So a call like

```latex
\newtcblisting[auto counter, number within=section]{promptbox}[2][]{listing only}
```

read the bracket group as the mandatory name, left `{promptbox}` undefined, and let its verbatim body tokenize as ordinary LaTeX — every `_`/`^` in the listing then raising *"Script can only appear in math mode"* (455 errors on the witness). Perl raw-loads the real macro and is clean; pdflatex compiles.

Fix: prepend the leading optional to the spec and drop it (with the trailing tcb options) as before. Calls without a leading optional are unchanged.

## Why it's in this PR

This is the **one genuine Rust-only regression** surfaced by the methodology-corrected `sandbox-arxiv-2606` study. Under the correct cortex condition (both engines `--preload=ar5iv.sty`, no `--quiet`, ANSI-stripped) the rest of the top clusters are **parity + error amplification**, not regressions — that analysis and the deferred plan (newunicodechar four-hex caret, OmniBus frontmatter, missing bindings, error-cap policy) are recorded in `docs/SYNC_STATUS.md`.

## Verification

- Witness **2606.00555**: 455 → **0** errors.
- Prior witnesses **2507.00833** / **2402.13846** preserved (envs still defined; existing verbatim-close guard still green).
- New guard `cluster_newtcblisting_leading_optarg` (RED before: 4 errors; GREEN after).
- **Full suite: 2176 passed, 0 failed.** Clippy + rustdoc gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVYUo91xN1c9Bd7ziu1C5d