### PR TITLE
feat: OmniBus captures \orcid, no-ops \lefttitle/\righttitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+  - **OmniBus fallback captures `\orcid` and no-ops the `\lefttitle`/`\righttitle`
+    running heads.** Unbound bundled journal classes fall through to the generic
+    OmniBus fallback, where Perl's `OmniBus.cls.ltxml` leaves these three undefined
+    (→ `Error`, content dropped). `\orcid[]{}` now routes to the existing
+    `\lx@add@orcid` helper, so the identifier is captured as a real
+    `<ltx:contact role="orcid">` with an `orcid.org` link (surpass-Perl, like
+    `scrartcl`'s `\titlehead`); the running-head registers are no-op'd (presentational,
+    correctly dropped). Only this verified, class-consistent subset is added — the
+    ambiguous/variant journal spellings (`\aff` is a superscript ref marker in jfm,
+    NOT affiliation; `\contribution`/`\correspondence`/`\data`/`\ack`/`\reportnumber`)
+    stay unhandled pending per-class review. From the sandbox-arxiv-2606 study;
+    witnesses 2606.00213 (pasj02 `\orcid`), 2606.00645 (jfm running heads).
+    OXIDIZED_DESIGN #160; guard `omnibus_captures_orcid_and_drops_running_heads`.
+
   - **`--quiet` reduces console output only; the `.latexml.log` keeps a minimum
     verbosity floor.** Previously `--quiet` lowered the single `log` level filter to
     `Warn`, which dropped the identity banner, every `(Processing …`/`(Loading …`

--- a/docs/SYNC_STATUS.md
+++ b/docs/SYNC_STATUS.md
@@ -961,14 +961,24 @@ Rust-only vs shared. The dominant finding — the 2605 "43 new fatals" were ~90%
   \restartappendixnumbering` undefined. **Perl fails identically** (Rust slightly ahead:
   3 vs 5 errors on the witness). ~15+ distinct bundled classes. Witnesses: 2606.01241
   (xiaomiev: contribution/correspondence/checkdata), 2606.00645 (jfm: aff/lefttitle/righttitle),
-  2606.04098 (iopjournal: data), 2606.00213 (pasj02: orcid). Lever: extend OmniBus's generic
-  vocabulary ONLY for commands with clean `\lx@add@*` mappings (`\aff`→`\lx@add@affiliation`,
-  `\reportnumber`→`\lx@add@pubnote`, `\ack`→`Let \acknowledgments`); gobble the
-  running-head/presentational ones — **`\lefttitle`/`\righttitle` are running-head / journal-name
-  registers, do NOT route to title**; `\data` embeds a HuggingFace `\includegraphics`. Single
-  edit to `omnibus_cls.rs`, NOT 15 class bindings; do NOT raw-load the 2000-line classes (the
-  cascade OmniBus exists to prevent). Must upstream the same to Perl's `OmniBus.cls.ltxml` to
-  stay parity. CUP family (jfm/iau/pas) subsumed here.
+  2606.04098 (iopjournal/youtu: data), 2606.00213 (pasj02: orcid). Single edit to `omnibus_cls.rs`,
+  NOT 15 class bindings; do NOT raw-load the 2000-line classes (the cascade OmniBus exists to
+  prevent). Must upstream the same to Perl's `OmniBus.cls.ltxml` to stay parity.
+  - **SAFE SLICE LANDED (0.7.6, OXIDIZED_DESIGN #160):** `\orcid[]{}`→`\lx@add@orcid{#2}` (captures
+    the id as `<contact role=orcid>` with an orcid.org link) + `\lefttitle`/`\righttitle` no-op'd
+    (presentational running heads). Guard `omnibus_captures_orcid_and_drops_running_heads`.
+  - **CORRECTION to the original plan (verified against the real classes, 2026-08-23):** the plan's
+    `\aff`→`\lx@add@affiliation` mapping is **WRONG** — jfm's `\def\aff#1{\ignorespaces\textsuperscript{#1}}`
+    is a **superscript reference marker**, NOT affiliation text; routing it to affiliation would inject
+    "1"/"2" as affiliations and corrupt every jfm byline. Likewise the semantics of `\correspondence`
+    (xiaomiev→checkdata, youtu→email-metadata, others→store), `\data` (youtu HuggingFace URL), and
+    `\contribution`/`\checkdata` (xiaomiev author-contribution lists) **vary by class**, so a single
+    generic mapping risks corrupt output — these need per-class output review before capture. `\ack`
+    is `\begin{acknowledgments}#1\end{...}` (1 arg, needs the acks env wired); `\reportnumber` has NO
+    texmf definition (arity unknown). REMAINING DEFERRED: `\aff \contribution \correspondence \data
+    \ack \reportnumber \checkdata \restartappendixnumbering`. Note `\contribution`/`\correspondence`
+    are already captured for classes with dedicated bindings (fairmeta/selfevolagent) — only the
+    generic OmniBus path is open. CUP family (jfm/iau/pas) subsumed here.
 - **native newunicodechar binding** (~50 docs, ~100 occurrences). `\newunicodechar{<non-ASCII>}{repl}`
   → both engines take the 8-bit path (UTF-8 char = one Unicode token → length 1 →
   `\nuc@onebyteerr` → `Error:latex:(newunicodechar) ASCII character requested`). **Perl

--- a/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
+++ b/docs/parity/OXIDIZED_DESIGN_DIVERGENCES.md
@@ -6076,6 +6076,33 @@ affiliation once, full-width, centered, below the author row.
 (`\inst`) attachment and genuine cross-prefix misuse recovery are untouched. Guarded by
 `frontmatter_llncs_shared_affiliation_below_authors`.
 
+### 160. OmniBus captures `\orcid` and no-ops the running-head registers `\lefttitle`/`\righttitle`
+
+**Background.** Unbound bundled journal `.cls` files fall through to the generic OmniBus fallback
+(`INCLUDE_CLASSES` defaults false), which supplies a shared frontmatter vocabulary. Many journal
+classes spell frontmatter macros in their own way; three appear widely and unambiguously across
+the sandbox-arxiv-2606 corpus: `\orcid{id}` (a stored ORCID identifier, e.g. pasj02
+`\def\orcid#1{…ORCID: #1…}`; some classes use the `\orcid[name]{id}` form), and the running-head
+registers `\lefttitle`/`\righttitle` (e.g. jfm `\lefttitle#1{\gdef\@lefttitle{#1}}`).
+
+**Perl behavior**: SHARED failure — Perl's `OmniBus.cls.ltxml` defines none of these three, so each
+is `Error:undefined` and its content is dropped. pdflatex renders them (the ORCID as a link, the
+running heads in the page headers).
+
+**Rust behavior**: OmniBus (`omnibus_cls.rs`) maps `\orcid[]{}` → the existing `\lx@add@orcid`
+helper, so the identifier is captured as a real `<ltx:contact role="orcid">` with an `orcid.org`
+link (a surpass-Perl content recovery, sibling of divergence #144's `scrartcl \titlehead`); and
+no-ops `\lefttitle`/`\righttitle`, which are page-layout registers with no document-content
+meaning (correctly dropped, never leaked). Only this verified, class-consistent subset is added;
+the ambiguous/variant journal spellings (`\aff` — a **superscript reference marker** in jfm, NOT
+an affiliation; `\contribution`, `\correspondence`, `\data`, `\ack`, `\reportnumber`) stay
+unhandled pending per-class output review (tracked in `SYNC_STATUS.md`).
+
+**Why it's safe.** The three names are currently undefined for OmniBus docs (they only affect docs
+that use them, all of which error today), the ORCID mapping reuses the canonical helper, and the
+running-head no-ops drop only presentational registers. Upstream the same to Perl's
+`OmniBus.cls.ltxml`. Guarded by `omnibus_captures_orcid_and_drops_running_heads`.
+
 **Witnesses**: arXiv 2402.19043 (WDM: 5 authors, one shared `\institute`, no `\inst`).
 Guardrails that must NOT regress: 2608.11332 (shared `\email` under `\inst{1}`), 2603.23669
 (two-author-per-creator dedup), 2606.00313 (`\thanks`-abuse affiliations).

--- a/latexml_oxide/tests/cluster_frontmatter_classes.rs
+++ b/latexml_oxide/tests/cluster_frontmatter_classes.rs
@@ -587,3 +587,72 @@ mod omnibus_agu_authors {
     );
   }
 }
+
+mod omnibus_orcid_running_heads {
+  //! sandbox-arxiv-2606 study (OXIDIZED_DESIGN #160): the safe slice of the
+  //! OmniBus journal-frontmatter vocabulary extension. Perl's OmniBus leaves
+  //! `\orcid` / `\lefttitle` / `\righttitle` undefined (→ Error), even though
+  //! `\orcid` maps cleanly to the existing `\lx@add@orcid` helper and the
+  //! running heads are presentational. We capture the ORCID (surpass-Perl,
+  //! like `scrartcl`'s `\titlehead`) and no-op the running heads. `\orcid`
+  //! appears both as `\orcid{id}` (pasj02, 2606.00213) and `\orcid[name]{id}`
+  //! (aas-style), so the binding accepts the leading optional. Binary-driven
+  //! because an unknown `.cls` `LoadClass!`es OmniBus (see 92_fairmeta_frontmatter).
+
+  use std::{path::Path, process::Command};
+
+  const TEX: &str = "\\documentclass{someunknownjournal}\n\
+    \\lefttitle{Left Running Head}\n\
+    \\righttitle{Right Running Head}\n\
+    \\title{A Study of Things}\n\
+    \\author{Ada Lovelace\\orcid{0000-0002-2709-7338}}\n\
+    \\begin{document}\n\
+    \\maketitle\n\
+    \\section{Body}\n\
+    Text.\n\
+    \\end{document}\n";
+
+  #[test]
+  fn omnibus_captures_orcid_and_drops_running_heads() {
+    let bin = env!("CARGO_BIN_EXE_latexml_oxide");
+    assert!(Path::new(bin).is_file(), "binary not staged at {bin}");
+
+    let workdir = tempfile::tempdir().expect("create tempdir");
+    std::fs::write(workdir.path().join("a.tex"), TEX).expect("write a.tex");
+
+    let output = Command::new(bin)
+      .arg("a.tex")
+      .arg("--dest")
+      .arg("a.xml")
+      .arg("--nocomments")
+      .current_dir(workdir.path())
+      .output()
+      .expect("spawn latexml_oxide");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+      output.status.success(),
+      "binary exited {:?}\nstderr:\n{stderr}",
+      output.status.code(),
+    );
+    // \orcid / \lefttitle / \righttitle must no longer be undefined-errors.
+    assert!(
+      !stderr.contains("Error:") && !stderr.contains("Fatal:"),
+      "expected an error-clean conversion, stderr had errors:\n{stderr}",
+    );
+
+    let xml = std::fs::read_to_string(workdir.path().join("a.xml")).expect("read a.xml");
+    // The ORCID is captured as a real frontmatter contact, not dropped.
+    assert!(
+      xml.contains("role=\"orcid\"") && xml.contains("orcid.org/0000-0002-2709-7338"),
+      "expected a captured ORCID contact:\n{xml}",
+    );
+    // The running heads are presentational — dropped, never leaked into the body.
+    for leaked in ["Left Running Head", "Right Running Head"] {
+      assert!(
+        !xml.contains(leaked),
+        "running-head {leaked:?} must be dropped, not emitted:\n{xml}",
+      );
+    }
+  }
+}

--- a/latexml_package/src/package/omnibus_cls.rs
+++ b/latexml_package/src/package/omnibus_cls.rs
@@ -161,6 +161,24 @@ LoadDefinitions!({
   // gobble (redundant running head). Match Perl; preserving it errored on a
   // literal `&` in the running head. See 0709.4236 and aas_support_sty.rs.
   def_macro_noop("\\shortauthors{}")?;
+
+  // Beyond-Perl (OXIDIZED_DESIGN #160): journal-class frontmatter spellings
+  // that Perl's OmniBus.cls.ltxml leaves undefined (→ Error). We add only the
+  // subset whose semantics are class-consistent and verified against the
+  // bundled classes; the ambiguous/variant ones (\aff — a superscript ref
+  // marker in jfm, NOT affiliation; \contribution, \correspondence, \data,
+  // \ack, \reportnumber) stay unhandled pending per-class output review
+  // (SYNC_STATUS.md 2026-08-23). Upstream the same to OmniBus.cls.ltxml.
+  //
+  // \orcid — a stored ORCID id (pasj02 `\def\orcid#1{…ORCID: #1…}`); some
+  // classes spell it `\orcid[name]{id}` (aas-style), so accept the leading
+  // optional and route the id to the canonical helper. Witness 2606.00213.
+  DefMacro!("\\orcid[]{}", "\\lx@add@orcid{#2}");
+  // Running heads (jfm `\lefttitle#1{\gdef\@lefttitle{#1}}`, `\righttitle`) —
+  // presentational, correctly dropped (not content). Witness 2606.00645.
+  def_macro_noop("\\lefttitle{}")?;
+  def_macro_noop("\\righttitle{}")?;
+
   // \authors{author list} — the plural byline macro used by journal classes
   // (AGU's agujournal2019, ametsoc, …) as an alternative to \author. It holds
   // ONE comma-separated list of authors, the last joined with "and", each name


### PR DESCRIPTION
## What

The generic **OmniBus fallback** (used for unbound bundled journal classes) left `\orcid`, `\lefttitle`, and `\righttitle` undefined — identically to Perl's `OmniBus.cls.ltxml` — so each errored and dropped its content. This adds the **verified, class-consistent** subset:

- `\orcid[]{}` → `\lx@add@orcid{#2}` — captures the id as a real `<ltx:contact role="orcid">` with an `orcid.org` link (surpass-Perl content recovery, like `scrartcl`'s `\titlehead`). Handles both `\orcid{id}` and `\orcid[name]{id}` spellings.
- `\lefttitle` / `\righttitle` → no-op (presentational running-head registers, correctly dropped).

## The verification that mattered

Checking the **real class definitions** corrected the original SYNC_STATUS plan, which would have introduced a wrong-output bug:

- **`\aff` in jfm is `\def\aff#1{\ignorespaces\textsuperscript{#1}}` — a superscript *reference marker*, NOT affiliation.** Routing it to `\lx@add@affiliation` (as the plan said) would inject "1"/"2" as affiliations and corrupt every jfm byline.
- `\contribution` / `\correspondence` / `\data` / `\ack` / `\reportnumber` have **class-varying semantics**, so a single generic mapping risks corrupt frontmatter. They stay **deferred** to per-class review (and are already captured for classes with dedicated bindings, e.g. fairmeta/selfevolagent).

Scope kept deliberately small for the release — only the zero-ambiguity subset.

## Verification

- Witness **2606.00213** (pasj02): `\orcid` → `<contact role="orcid"><ref class="ltx_orcid" href="https://orcid.org/…">`, 0 `\orcid` undefined errors.
- Witness **2606.00645** (jfm): `\lefttitle`/`\righttitle` no longer error, content correctly dropped (no leak).
- New guard `omnibus_captures_orcid_and_drops_running_heads`; all 8 frontmatter tests green.
- **Full suite: 2177 passed, 0 failed.** Clippy + rustdoc green.
- Documented as OXIDIZED_DESIGN #160 (beyond-Perl; upstream to `OmniBus.cls.ltxml` noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVYUo91xN1c9Bd7ziu1C5d