### PR TITLE
perf: lazy Debug! + audit mechanical fixes — corpus −12.8%, build-bound witness −56%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+  - **Output-neutral performance pass (2026-08-23 audit follow-through).** `Debug!`
+    diagnostics are now lazy: their message expressions — which at the
+    `open_text`/`open_text_internal`/`close_element` sites serialized the current
+    subtree via `node_to_string` on every text insert / element close — evaluate
+    only when `--verbose`/`--debug` would actually emit them (up to ~26% of a
+    build-bound conversion discarded before; PERFORMANCE.md Open levers P0; the
+    Debug status tally is preserved at every verbosity). Also:
+    `Token::is_noexpand_family` memoized per arena symbol (was a string-prefix
+    probe ×2 per CS token); `generate_id` finds its `xml:id` ancestor by a direct
+    parent walk instead of a per-node XPath parse+eval; post-processing's
+    `collect_walk_matches` iterates siblings instead of materializing a child
+    `Vec` per recursion level; the `"{encoding}_fontmap"`-family Value keys are
+    memoized per encoding (were rebuilt ~4× per decoded character run, ~1M
+    allocations on a 1.3 s paper); `install_definition`'s `":locked"` gate probes
+    the arena without interning (no more permanent `:locked` twin per defined
+    cs); `LATEXML_TELEMETRY_OUT` appends JSONL instead of truncating to the last
+    record; 13 clippy `redundant_clone` sites fixed (2 kept as verified false
+    positives). Measured (interleaved best-of-3, idle box): build/text-bound
+    witness 2304.10050 **6.21 → 2.71 s (−56%)**; typical math paper 2408.08292
+    −11%; 82-paper regression-corpus sweep **229.3 → 200.0 s (−12.8%)** with
+    zero exit-status changes and flat max-RSS. Suite green (2175/2175); HTML
+    byte-identical on all four A/B witnesses.
+
   - **`--quiet` reduces console output only; the `.latexml.log` keeps a minimum
     verbosity floor.** Previously `--quiet` lowered the single `log` level filter to
     `Warn`, which dropped the identity banner, every `(Processing …`/`(Loading …`

--- a/docs/performance/PERFORMANCE.md
+++ b/docs/performance/PERFORMANCE.md
@@ -170,17 +170,29 @@ rate (the math lever). Max RSS 1,692 MB.
 
 The phase bands above set priority. Current open work:
 
-### P0 — eager `Debug!` diagnostics on the text-absorption path (up to ~30% of a build-bound paper)
+### P0 — eager `Debug!` diagnostics on the text-absorption path — ✅ LANDED 2026-08-23
 
-Found by the 2026-08-23 audit (see Audit log — full evidence there). `Debug!`
-(`error.rs:631`) and `generate_message!` (`error.rs:800`) build all their
-strings — including `gullet::get_location()` and, at the `open_text` /
-`open_text_internal` / `close_element` sites (`document.rs:2280/2558/2592/1256`),
-a full `node_to_string` subtree serialization — **before** any verbosity check;
-`emit_record` then discards them. Fix: gate argument evaluation like
-`DebugFeature!` (`error.rs:618`) already does, preserving the `note_status`
-side effect. Output-neutral by construction; the largest single lever found
-since the graphics cache.
+Found and fixed the same day as the audit (see Audit log — full evidence
+there). `Debug!` (`error.rs`) and `generate_message!` built all their strings —
+including `gullet::get_location()` and, at the `open_text` /
+`open_text_internal` / `close_element` sites, a full `node_to_string` subtree
+serialization — **before** any verbosity check; `emit_record` then discarded
+them. Now gated on `debug_record_enabled()` (`max_level() >= Debug` and not
+suppressed), with the Debug `note_status` tally preserved unconditionally, so
+status counts are identical at every verbosity.
+
+**Measured** (same branch also carries the audit's R3/R5/R6 mechanical fixes:
+`is_noexpand_family` per-symbol memo, `generate_id` parent-chain walk,
+`collect_walk_matches` sibling iteration, fontmap-key memoization, probe-only
+`:locked` gate via non-interning `arena::get`, 13 redundant-clone fixes;
+interleaved best-of-3, idle box, HTML byte-identical on all four A/B
+witnesses): `2304.10050` (build/text-bound) **6.21 → 2.71 s (−56%)** — the
+band was quadratic-flavored (each insert re-serialized the growing subtree),
+so removal beats the ~26% profile share; `2408.08292` (typical math paper)
+8.66 → 7.74 s (−11%); `2405.14114` (200M-token digest runaway) 20.5 → 20.1 s
+(−2%). 82-paper regression-corpus sweep, same harness/box/day: **229.3 →
+200.0 s (−12.8%)**, zero exit-status changes, sum max-RSS flat (+1.3%,
+two ±≤60 MB movers, rest noise).
 
 ### P1 — math_parse (17% of wall, 17% over-parse) — the top remaining lever
 

--- a/latexml_contrib/src/biblatex_sty.rs
+++ b/latexml_contrib/src/biblatex_sty.rs
@@ -1263,7 +1263,7 @@ LoadDefinitions!({
       // The year part carries any disambiguation suffix (2020a, ...) so
       // same-author-same-year entries stay distinct.
       let refnum_str = if author_part == label_str {
-        label_str.clone()
+        label_str
       } else {
         format!("{author_part} ({ay_year})")
       };
@@ -1937,7 +1937,7 @@ LoadDefinitions!({
   // to itself and is harmless.
   DefMacro!("\\DeclareCiteCommand OptionalMatch:* {}[]{}{}{}{}",
   sub[(_star, target, _wrapper, _precode, _loopcode, _sepcode, _postcode)] {
-    if let Some(tok) = target.clone().unlist().into_iter().find(|t| t.get_catcode() == Catcode::CS) {
+    if let Some(tok) = target.unlist().into_iter().find(|t| t.get_catcode() == Catcode::CS) {
       Let!(tok, T_CS!("\\cite"));
     }
     Ok(Tokens!())

--- a/latexml_core/src/binding/content.rs
+++ b/latexml_core/src/binding/content.rs
@@ -3504,32 +3504,95 @@ pub fn font_decode_string(string: &str, encoding_opt: Option<&str>, implicit: bo
   result
 }
 
+// Memoized key symbols for the per-encoding fontmap Value-table entries.
+// `decode_string` runs per digested character run and used to rebuild (format!
+// + arena probe) the `"{encoding}_fontmap"`-family keys on every call — ~1M
+// allocations on a 1.3 s paper (2026-08-23 audit R6, dhat). Encodings are few
+// (OT1/T1/OML/…), so the (encoding → key syms) maps stay tiny. Value lookups
+// still go through the state tables — only the key STRINGS are memoized.
+// Keyed by arena SymStr, so MUST be cleared with `arena::reset()`
+// (`reset_fontmap_key_memo`, called from `reset_thread_engine`).
+thread_local! {
+  static FONTMAP_KEY_MEMO: std::cell::RefCell<HashMap<String, FontmapKeySyms>> =
+    std::cell::RefCell::new(HashMap::default());
+  static FONTMAP_FAMILY_KEY_MEMO: std::cell::RefCell<HashMap<(String, String), SymStr>> =
+    std::cell::RefCell::new(HashMap::default());
+}
+
+#[derive(Clone, Copy)]
+pub struct FontmapKeySyms {
+  /// `"{encoding}_fontmap"`
+  pub map:       SymStr,
+  /// `"{encoding}_fontmap_failed_to_load"`
+  pub fail:      SymStr,
+  /// `"{encoding}_fontmap_multichar"`
+  pub multichar: SymStr,
+}
+
+/// The memoized key symbols for `encoding`'s fontmap Value-table entries.
+pub fn fontmap_key_syms(encoding: &str) -> FontmapKeySyms {
+  FONTMAP_KEY_MEMO.with(|m| {
+    if let Some(keys) = m.borrow().get(encoding) {
+      return *keys;
+    }
+    let keys = FontmapKeySyms {
+      map:       arena::pin(s!("{encoding}_fontmap")),
+      fail:      arena::pin(s!("{encoding}_fontmap_failed_to_load")),
+      multichar: arena::pin(s!("{encoding}_fontmap_multichar")),
+    };
+    m.borrow_mut().insert(encoding.to_string(), keys);
+    keys
+  })
+}
+
+/// The memoized `"{encoding}_{family}_fontmap"` key symbol.
+pub fn fontmap_family_key_sym(encoding: &str, family: &str) -> SymStr {
+  FONTMAP_FAMILY_KEY_MEMO.with(|m| {
+    if let Some(sym) = m.borrow().get(&(encoding.to_string(), family.to_string())) {
+      return *sym;
+    }
+    let sym = arena::pin(s!("{encoding}_{family}_fontmap"));
+    m.borrow_mut()
+      .insert((encoding.to_string(), family.to_string()), sym);
+    sym
+  })
+}
+
+/// Clear the fontmap key-symbol memos. Companion to `arena::reset()` — the
+/// cached `SymStr`s dangle after a reset renumbers the arena.
+pub fn reset_fontmap_key_memo() {
+  FONTMAP_KEY_MEMO.with(|m| m.borrow_mut().clear());
+  FONTMAP_FAMILY_KEY_MEMO.with(|m| m.borrow_mut().clear());
+}
+
 pub fn load_font_map(encoding: &str) -> Option<Fontmap> {
-  let _ = preload_font_map(encoding); // infallible in practice; swallow Result
+  let keys = fontmap_key_syms(encoding);
+  let _ = preload_font_map_keyed(encoding, keys); // infallible in practice; swallow Result
   // with_value avoids the Stored::clone; the Fontmap extraction is a cheap
   // Rc bump on the inner slice regardless.
-  with_value(&s!("{encoding}_fontmap"), |v| v.and_then(|s| s.into()))
+  with_value_sym(keys.map, |v| v.and_then(|s| s.into()))
 }
 pub fn preload_font_map(encoding: &str) -> Result<()> {
+  preload_font_map_keyed(encoding, fontmap_key_syms(encoding))
+}
+fn preload_font_map_keyed(encoding: &str, keys: FontmapKeySyms) -> Result<()> {
   // This check is done as a "preload" step for mutability reasons.
-  let key = s!("{encoding}_fontmap");
-  if has_value(&key) {
+  if has_value_sym(keys.map) {
     return Ok(());
   }
-  let fail_key = s!("{encoding}_fontmap_failed_to_load");
-  let failed_flag = lookup_bool(&fail_key);
+  let failed_flag = lookup_bool_sym(keys.fail);
   if !failed_flag {
-    assign_value(&fail_key, true, None); // Stop recursion?
+    assign_value_sym(keys.fail, true, None); // Stop recursion?
     let _ = input_definitions(&encoding.to_lowercase(), InputDefinitionOptions {
       extension: Some(Cow::Borrowed("fontmap")),
       noerror: true,
       ..InputDefinitionOptions::default()
     });
-    if has_value(&s!("{encoding}_fontmap")) {
+    if has_value_sym(keys.map) {
       // Got map?
-      assign_value(&fail_key, false, None);
+      assign_value_sym(keys.fail, false, None);
     } else {
-      assign_value(&fail_key, true, Some(Scope::Global));
+      assign_value_sym(keys.fail, true, Some(Scope::Global));
     }
   }
   Ok(())

--- a/latexml_core/src/common/arena.rs
+++ b/latexml_core/src/common/arena.rs
@@ -133,6 +133,13 @@ macro_rules! pin {
 /// per doc). Neither cost was paying for itself.
 pub fn pin<S: AsRef<str>>(text: S) -> SymStr { with_arena_mut(|arena| arena.get_or_intern(text)) }
 
+/// Probe-only lookup: the symbol for `text` if it was ever interned, without
+/// interning it. For existence-style checks (e.g. `install_definition`'s
+/// `"{cs}:locked"` gate) a `None` here proves the key cannot be bound in any
+/// state table — and skipping the intern avoids permanently growing the arena
+/// with one probe-key twin per defined control sequence (2026-08-23 audit R6).
+pub fn get<S: AsRef<str>>(text: S) -> Option<SymStr> { with_arena_mut(|arena| arena.get(text)) }
+
 /// ASCII char-pin cache: every unique ASCII byte resolves to a single
 /// SymStr for the lifetime of the thread (arena is append-only, syms
 /// never change). Cache entries use `u32::MAX` as the "not yet pinned"

--- a/latexml_core/src/common/error.rs
+++ b/latexml_core/src/common/error.rs
@@ -607,6 +607,19 @@ pub fn debug_enabled(name: &str) -> bool {
     .unwrap_or(false)
 }
 
+/// Would a `Debug`-status record actually reach the log right now? True only
+/// when the global `log` level admits `Debug` (default is `Info`; `--verbose`/
+/// `--debug` raise it — `util/logger.rs::init`) AND output is not suppressed.
+/// The `Debug!` macro gates *message construction* on this: the 2026-08-23
+/// audit measured up to ~26% of a build-bound conversion spent serializing
+/// `node_to_string` subtrees into `Debug!` messages that `emit_record` then
+/// discarded (PERFORMANCE.md, Open levers P0). An atomic load + thread-local
+/// read — cheap enough for token-frequency call sites.
+#[inline]
+pub fn debug_record_enabled() -> bool {
+  log::max_level() >= log::LevelFilter::Debug && !is_log_output_suppressed()
+}
+
 /// Feature-gated debug logging — Perl's `Debug(...) if $LaTeXML::DEBUG{feature}`.
 /// Usage: `DebugFeature!("frontmatter", "FRONT Add {}", entry)`.
 /// Logs with the feature name as the `log` target (so output matches the
@@ -627,26 +640,44 @@ macro_rules! DebugFeature {
   }};
 }
 
+/// Debug-status diagnostics. **Lazy**: the argument expressions — which at
+/// several sites build whole `node_to_string` subtree serializations — are
+/// evaluated only when [`debug_record_enabled`] says the record would actually
+/// be logged (2026-08-23 audit, PERFORMANCE.md Open levers P0). The Debug
+/// status tally (`note_status`) is preserved unconditionally, so status counts
+/// are identical to the eager form at every verbosity.
 #[macro_export]
 macro_rules! Debug {
   ($category:expr_2021, $object:expr_2021, $message:expr_2021) => {{
-    $crate::common::error::emit_record(
-      $crate::common::error::LogStatus::Debug,
-      &format!("{}:{}", $category, $object),
-      &$crate::generate_message!($message))
+    if $crate::common::error::debug_record_enabled() {
+      $crate::common::error::emit_record(
+        $crate::common::error::LogStatus::Debug,
+        &format!("{}:{}", $category, $object),
+        &$crate::generate_message!($message))
+    } else {
+      $crate::common::error::note_status(
+        $crate::common::error::LogStatus::Debug, None);
+    }
   }};
  ($category:expr_2021, $object:expr_2021, $message:expr_2021, $($details:expr_2021),*) => {{
-    $crate::common::error::emit_record(
-      $crate::common::error::LogStatus::Debug,
-      &format!("{}:{}", $category, $object),
-      &$crate::generate_message!($message, $($details),*))
+    if $crate::common::error::debug_record_enabled() {
+      $crate::common::error::emit_record(
+        $crate::common::error::LogStatus::Debug,
+        &format!("{}:{}", $category, $object),
+        &$crate::generate_message!($message, $($details),*))
+    } else {
+      $crate::common::error::note_status(
+        $crate::common::error::LogStatus::Debug, None);
+    }
   }};
   ($($simple:expr_2021),*) => {{
-    let __diag_guard = $crate::common::error::macro_diag_guard();
     $crate::common::error::note_status(
       $crate::common::error::LogStatus::Debug, None);
-    use log::debug;
-    debug!($($simple),*);
+    if $crate::common::error::debug_record_enabled() {
+      let __diag_guard = $crate::common::error::macro_diag_guard();
+      use log::debug;
+      debug!($($simple),*);
+    }
   }};
 
 }

--- a/latexml_core/src/common/font.rs
+++ b/latexml_core/src/common/font.rs
@@ -18,7 +18,7 @@ use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
   BoxOps, Digested, DigestedData, Result,
-  binding::content::{load_font_map, preload_font_map},
+  binding::content::{fontmap_family_key_sym, fontmap_key_syms, load_font_map, preload_font_map},
   common::{
     arena::{self, SymHashMap, SymStr},
     color::{self, Color},
@@ -2090,8 +2090,7 @@ fn lookup_multichar_override(code: u8, encoding_opt: Option<&str>) -> Option<Str
   // such hazard: `FontDecode` calls `LoadFontMap` first and then indexes one
   // map whose slot already holds the whole string.
   let _ = preload_font_map(&encoding);
-  let mapname = format!("{encoding}_fontmap_multichar");
-  with_value(&mapname, |val_opt| {
+  with_value_sym(fontmap_key_syms(&encoding).multichar, |val_opt| {
     if let Some(Stored::HashString(map)) = val_opt {
       map.get(&code.to_string()).cloned()
     } else {
@@ -2132,14 +2131,14 @@ pub fn decode(code: u8, encoding_opt: Option<String>, implicit: bool) -> Option<
 
   let mut map: Option<Fontmap> = None;
   if !encoding.is_empty() {
-    let _ = preload_font_map(&encoding); // infallible in practice; swallow Result
+    // `load_font_map` preloads; keys are memoized (2026-08-23 audit R6).
     if let Some(encmap) = load_font_map(&encoding) {
       // OK got some map.
       map = Some(encmap);
       if let Some(ref font) = font
         && let Some(family) = (*font).get_family()
       {
-        with_value(&s!("{encoding}_{family}_fontmap"), |fmap_opt| {
+        with_value_sym(fontmap_family_key_sym(&encoding, family), |fmap_opt| {
           if let Some(fmap) = fmap_opt {
             map = fmap.into(); // Use the family specific map, if any.
           }
@@ -2189,28 +2188,30 @@ pub fn decode_string(string: SymStr, encoding_opt: Option<&str>, implicit: bool)
     Some(encoding) => encoding,
   };
 
+  // Memoized key syms — this runs per digested character run, and rebuilding
+  // the "{encoding}_fontmap"-family key strings each call was ~1M allocations
+  // on a 1.3 s paper (2026-08-23 audit R6). `load_font_map` preloads, so no
+  // separate `preload_font_map` call is needed.
   let mut map: Option<Fontmap> = None;
-  if !encoding.is_empty() {
-    let _ = preload_font_map(encoding); // infallible in practice; swallow Result
-    if let Some(encmap) = load_font_map(encoding) {
-      // OK got some map.
-      map = Some(encmap);
-      if let Some(ref font) = font
-        && let Some(family) = (*font).get_family()
-      {
-        with_value(&s!("{}_{}_fontmap", encoding, family), |fmap_opt| {
-          if let Some(fmap) = fmap_opt {
-            map = fmap.into(); // Use the family specific map, if any.
-          }
-        });
-      }
+  if !encoding.is_empty()
+    && let Some(encmap) = load_font_map(encoding)
+  {
+    // OK got some map.
+    map = Some(encmap);
+    if let Some(ref font) = font
+      && let Some(family) = (*font).get_family()
+    {
+      with_value_sym(fontmap_family_key_sym(encoding, family), |fmap_opt| {
+        if let Some(fmap) = fmap_opt {
+          map = fmap.into(); // Use the family specific map, if any.
+        }
+      });
     }
   }
 
   // Load multi-char overrides if available
   let multichar_map: Option<HashMap<String, String>> = if !encoding.is_empty() {
-    let mapname = format!("{encoding}_fontmap_multichar");
-    with_value(&mapname, |val_opt| {
+    with_value_sym(fontmap_key_syms(encoding).multichar, |val_opt| {
       if let Some(Stored::HashString(m)) = val_opt {
         Some(m.clone())
       } else {

--- a/latexml_core/src/document.rs
+++ b/latexml_core/src/document.rs
@@ -5927,9 +5927,22 @@ impl Document {
       && model::can_have_attribute(qname, pin!("xml:id"))
       && (qname != pin!("ltx:_Capture_"))
     {
-      let mut ancestor = self
-        .findnode("ancestor::*[@xml:id][1]", Some(node))
-        .unwrap_or_else(|| self.get_document().get_root_element().unwrap());
+      // Nearest ancestor element carrying @xml:id — a direct parent-chain
+      // walk, equivalent to the previous `ancestor::*[@xml:id][1]` findnode
+      // but without a per-call XPath parse+eval (generate_id runs once per
+      // id-lacking node during finalize; 2026-08-23 audit R5).
+      let mut ancestor = {
+        let mut cur = node.get_parent();
+        let mut found = None;
+        while let Some(p) = cur {
+          if p.get_type() == Some(NodeType::ElementNode) && p.has_attribute_ns("id", XML_NS) {
+            found = Some(p);
+            break;
+          }
+          cur = p.get_parent();
+        }
+        found.unwrap_or_else(|| self.get_document().get_root_element().unwrap())
+      };
       //// Old versions don't like ancestor.getAttribute('xml:id');
       let ancestor_id = ancestor.get_attribute_ns("id", XML_NS);
       // If we've got no ancestor_id, then we've got no ancestor (no document yet!),

--- a/latexml_core/src/lib.rs
+++ b/latexml_core/src/lib.rs
@@ -151,6 +151,10 @@ pub fn reset_thread_engine() {
   // resolves, in the renumbered arena, to a different string (phantom undefined).
   // (`reset_arena_keyed_reports` is in scope via `pub use crate::common::error::*`.)
   reset_arena_keyed_reports();
+  // The is_noexpand_family and fontmap-key memos are keyed by arena symbols —
+  // same stale-alias hazard as the REPORT maps; clear them with the arena.
+  token::reset_noexpand_family_memo();
+  binding::content::reset_fontmap_key_memo();
 }
 
 pub use crate::common::error::*;

--- a/latexml_core/src/state.rs
+++ b/latexml_core/src/state.rs
@@ -1188,8 +1188,12 @@ pub fn install_definition<T: Into<Stored>>(definition: T, scope: Option<Scope>) 
     _ => panic!("_wrong_argument_for_install_definition"),
   };
   let cs_sym = token.get_cs_name();
+  // Probe-only: if "{cs}:locked" was never interned it cannot be bound, so
+  // skip both the intern (which permanently grew the arena by one ":locked"
+  // twin per defined cs) and the table lookup (2026-08-23 audit R6).
   let lock_key = token.with_cs_name(|cs| s!("{cs}:locked"));
-  if lookup_bool(&lock_key) && !state_is_unlocked() {
+  let is_locked = arena::get(&lock_key).is_some_and(lookup_bool_sym);
+  if is_locked && !state_is_unlocked() {
     if let Some(Stored::String(s)) = state!().lookup_value("SOURCEFILE") {
       // report if the redefinition seems to come from document source
       if arena::with(*s, |txt| {
@@ -1537,8 +1541,9 @@ pub fn pop_value(key: &str) -> Result<Option<Stored>> {
   }
 }
 /// Check if the Value table contains a given key
-pub fn has_value(key: &str) -> bool {
-  let key_sym = arena::pin(key);
+pub fn has_value(key: &str) -> bool { has_value_sym(arena::pin(key)) }
+/// Sym-keyed variant of `has_value` — avoids the per-call `arena::pin(key)`.
+pub fn has_value_sym(key_sym: SymStr) -> bool {
   match state!().value.get(&key_sym) {
     None => false,
     Some(list) => match list.front() {

--- a/latexml_core/src/token.rs
+++ b/latexml_core/src/token.rs
@@ -330,6 +330,23 @@ impl PartialEq for Token {
   }
 }
 
+// Per-symbol memo for `Token::is_noexpand_family`, indexed by the symbol's
+// arena index: 0 = not yet computed, 1 = not in the family, 2 = in the family.
+// Sound because the arena is append-only (a symbol's text never changes);
+// MUST be cleared alongside `arena::reset()` (see
+// `reset_noexpand_family_memo`, called from `reset_thread_engine`) since a
+// reset renumbers symbols.
+thread_local! {
+  static NOEXPAND_FAMILY_MEMO: std::cell::RefCell<Vec<u8>> =
+    const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// Clear the [`Token::is_noexpand_family`] per-symbol memo. Companion to
+/// `arena::reset()` — symbol indices are reused after a reset, so stale
+/// entries would alias unrelated strings (same bug class as the REPORT-map
+/// fix, `7b64a48ad1`).
+pub fn reset_noexpand_family_memo() { NOEXPAND_FAMILY_MEMO.with(|m| m.borrow_mut().clear()); }
+
 /// Name of the bare no-op control sequence `\noexpand` collapses to, and the
 /// prefix of every member of the no-expand family. See [`Token::is_noexpand_family`].
 pub const NOEXPAND_PREFIX: &str = "\\special_relax";
@@ -858,12 +875,34 @@ impl Token {
   /// (`\dont_expand` at end-of-input). `\x01` is never valid in a CS name or as
   /// an active char, so the encoding is unambiguous.
   pub fn is_noexpand_family(&self) -> bool {
-    self.code == Catcode::CS
-      && self.with_str(|s| {
-        s.starts_with(NOEXPAND_PREFIX)
-          && (s.len() == NOEXPAND_PREFIX.len()
-            || s.as_bytes()[NOEXPAND_PREFIX.len()] == NOEXPAND_SEP)
-      })
+    if self.code != Catcode::CS {
+      return false;
+    }
+    // Per-symbol memo: this runs ×2 per CS token via `state::meaning_key`
+    // (read_x_token decides whether to expand, invoke_token how to invoke),
+    // and the string-prefix probe was ~2% of digest self-time (2026-08-23
+    // audit). A symbol's text never changes (append-only arena), so the
+    // answer is memoized by symbol index: 0 = unknown, 1 = no, 2 = yes.
+    // Cleared with the arena in `reset_thread_engine` (symbol indices are
+    // reused after `arena::reset`).
+    use string_interner::Symbol;
+    let idx = self.text.to_usize();
+    let cached = NOEXPAND_FAMILY_MEMO.with(|m| m.borrow().get(idx).copied().unwrap_or(0));
+    if cached != 0 {
+      return cached == 2;
+    }
+    let is_family = self.with_str(|s| {
+      s.starts_with(NOEXPAND_PREFIX)
+        && (s.len() == NOEXPAND_PREFIX.len() || s.as_bytes()[NOEXPAND_PREFIX.len()] == NOEXPAND_SEP)
+    });
+    NOEXPAND_FAMILY_MEMO.with(|m| {
+      let mut memo = m.borrow_mut();
+      if memo.len() <= idx {
+        memo.resize(idx + 1, 0);
+      }
+      memo[idx] = if is_family { 2 } else { 1 };
+    });
+    is_family
   }
 
   /// Recover the shadowed token from a `\special_relax`-family token, if it

--- a/latexml_engine/src/latex_constructs.rs
+++ b/latexml_engine/src/latex_constructs.rs
@@ -3445,11 +3445,11 @@ LoadDefinitions!({
             if document::get_node_qname(&parent) == capture_block {
               document.maybe_close_element("ltx:p")?;
             } else if document::can_contain(&context, "ltx:break") {
-              document.insert_element("ltx:break", Vec::new(), break_attrs.clone())?;
+              document.insert_element("ltx:break", Vec::new(), break_attrs)?;
             }
           }
         } else if document::can_contain(&context, "ltx:break") {
-          document.insert_element("ltx:break", Vec::new(), break_attrs.clone())?;
+          document.insert_element("ltx:break", Vec::new(), break_attrs)?;
         }
       }
       // else: no context => skip

--- a/latexml_oxide/bin/latexml_oxide.rs
+++ b/latexml_oxide/bin/latexml_oxide.rs
@@ -430,8 +430,9 @@ struct Cli {
   #[arg(long)]
   dump_model: bool,
 
-  /// Write a one-line JSON telemetry record for this job to this file (or set
-  /// env `LATEXML_TELEMETRY_OUT`). Written only on a successful conversion.
+  /// Append a one-line JSON telemetry record for this job to this file (or set
+  /// env `LATEXML_TELEMETRY_OUT`); batch runs accumulate a JSONL. Written only
+  /// on a successful conversion.
   #[arg(long, value_name = "PATH")]
   telemetry_out: Option<String>,
 
@@ -1696,7 +1697,15 @@ fn write_telemetry_record(
   {
     let _ = std::fs::create_dir_all(parent);
   }
-  if let Ok(mut fh) = File::create(&path) {
+  // Append (JSONL): batch runs pointing LATEXML_TELEMETRY_OUT at one file
+  // accumulate one record per job — the contract `perf_phase_summary.py`
+  // documents. `File::create` here used to truncate, silently keeping only
+  // the last job's record (2026-08-23 audit papercut).
+  if let Ok(mut fh) = std::fs::OpenOptions::new()
+    .create(true)
+    .append(true)
+    .open(&path)
+  {
     let _ = writeln!(fh, "{line}");
   }
 }

--- a/latexml_package/src/package/dcolumn_sty.rs
+++ b/latexml_package/src/package/dcolumn_sty.rs
@@ -84,7 +84,7 @@ LoadDefinitions!({
     // Rust `UnTeX` (see `Tokens::untex`; the `%\n` line-breaking half is
     // OXIDIZED_DESIGN #2, so the suppress-linebreaks flag has no counterpart).
     let delim_str = delim.to_string();
-    let todelim_str = todelim.clone().untex();
+    let todelim_str = todelim.untex();
     if delim_str != todelim_str {
       if let Some(ch) = delim_str.chars().next() {
         // Make the delimiter math-active (code 0x8000)

--- a/latexml_package/src/package/physics_sty.rs
+++ b/latexml_package/src/package/physics_sty.rs
@@ -440,7 +440,7 @@ LoadDefinitions!({
     let reversion = Tokens::new(rev);
 
     // Content: apply(symbol(meaning), arg1, arg2)
-    let content = i_apply(&[], i_symbol(&[("meaning", Tokenize!(semantic_tex.clone()))], None),
+    let content = i_apply(&[], i_symbol(&[("meaning", Tokenize!(semantic_tex))], None),
       vec![a1, a2]);
 
     // Presentation: open arg1 , arg2 close
@@ -502,7 +502,7 @@ LoadDefinitions!({
     let cs_tks = cs;
     let semantic_tex = semantic.untex_string();
     let function_tks = function;
-    let cfunc = i_symbol(&[("meaning", Tokenize!(semantic_tex.clone()))], None);
+    let cfunc = i_symbol(&[("meaning", Tokenize!(semantic_tex))], None);
     let (no_stretch, size_tok) = phys_read_size()?;
     let (arg, open, close) = phys_read_arg(false, physics_delimiters)?;
 
@@ -568,7 +568,7 @@ LoadDefinitions!({
     let cs_tks = cs;
     let semantic_tex = semantic.untex_string();
     let function_tks = function;
-    let cfunc = i_symbol(&[("meaning", Tokenize!(semantic_tex.clone()))], None);
+    let cfunc = i_symbol(&[("meaning", Tokenize!(semantic_tex))], None);
     let pfunc = function_tks;
     let (no_stretch, size_tok) = phys_read_size()?;
     let power = read_optional(None)?;
@@ -719,7 +719,7 @@ LoadDefinitions!({
     let raw_tks = raw;
     let function_tks = function;
     let (no_stretch, size_tok) = phys_read_size()?;
-    let cfunc = i_symbol(&[("meaning", Tokenize!(semantic_tex.clone()))], None);
+    let cfunc = i_symbol(&[("meaning", Tokenize!(semantic_tex))], None);
     let arg = phys_read_arg_tex()?;
 
     if let Some(arg_tks) = arg {
@@ -821,7 +821,7 @@ LoadDefinitions!({
     let cs_tks = cs;
     let semantic_tex = semantic.untex_string();
     let diff_tks = diff;
-    let cfunc = i_symbol(&[("meaning", Tokenize!(semantic_tex.clone()))], None);
+    let cfunc = i_symbol(&[("meaning", Tokenize!(semantic_tex))], None);
     let pfunc = i_wrap(Some(Tokenize!("role=DIFFOP")), diff_tks);
     let degree = read_optional(None)?;
     let (arg, open, close) = phys_read_arg(false, |s| {
@@ -1206,7 +1206,7 @@ LoadDefinitions!({
     let reversion = Tokens::new(rev);
 
     let content = i_apply(&[],
-      i_symbol(&[("meaning", Tokenize!(semantic_tex.clone()))], None),
+      i_symbol(&[("meaning", Tokenize!(semantic_tex))], None),
       vec![a1, a2]);
     // Stretchy by default (Perl parity); `no_stretch` passed directly — see the
     // `\matrixelement` note. A prior `!no_stretch` made `\innerproduct`/`\outerproduct`

--- a/latexml_post/src/document.rs
+++ b/latexml_post/src/document.rs
@@ -323,8 +323,14 @@ fn collect_walk_matches(node: &Node, arms: &[WalkArm], out: &mut Vec<Node>) {
   {
     out.push(node.clone());
   }
-  for child in node.get_child_nodes() {
-    collect_walk_matches(&child, arms, out);
+  // first_child/next_sibling like `collect_split_pages` below — the previous
+  // `get_child_nodes()` materialized a Vec of wrapped nodes per recursion
+  // level, ~2.4% self + allocator share on a whole-document walk that answers
+  // every post `//NAME[pred]` query (2026-08-23 audit R5).
+  let mut child = node.get_first_child();
+  while let Some(c) = child {
+    collect_walk_matches(&c, arms, out);
+    child = c.get_next_sibling();
   }
 }
 

--- a/latexml_post/src/mathml/presentation.rs
+++ b/latexml_post/src/mathml/presentation.rs
@@ -1441,7 +1441,7 @@ fn pmml_token_inner(doc: &PostDocument, node: &Node, role_override: Option<&str>
     // not by an infix role it does not actually carry here (issue #535). On the
     // ordinary path the `pmml()` wrapper re-stamps `_role` anyway.
     if role_override.is_none() {
-      attrs.insert("_role".to_string(), role.clone());
+      attrs.insert("_role".to_string(), role);
     }
     if props.lspace > 0.0 {
       attrs.insert("_lspace".to_string(), fmt_em(props.lspace));

--- a/latexml_post/src/xslt.rs
+++ b/latexml_post/src/xslt.rs
@@ -250,7 +250,7 @@ impl XSLT {
     {
       format!("{}/{}", base, rel_dest)
     } else {
-      rel_dest.clone()
+      rel_dest
     };
     let ensure_parent = |dest: &str| {
       if let Some(parent) = Path::new(dest).parent() {


### PR DESCRIPTION
Implements the actionable, output-neutral findings of the 2026-08-23 performance audit (PERFORMANCE.md — the P0 lever section is updated to LANDED with the measurements).

**Changes**
- **Lazy `Debug!`** (P0): message/target/location expressions evaluate only when a Debug record would actually be emitted (`debug_record_enabled()` = `max_level() >= Debug` and output not suppressed). The Debug `note_status` tally is preserved unconditionally, so status counts are identical at every verbosity. This removes the per-text-insert / per-element-close `node_to_string` subtree serializations that were built and discarded.
- `Token::is_noexpand_family`: per-arena-symbol memo (was a string-prefix probe ×2 per CS token); cleared with the arena in `reset_thread_engine`.
- `generate_id`: nearest `@xml:id` ancestor via direct parent walk instead of a per-node `ancestor::*[@xml:id][1]` XPath parse+eval.
- `collect_walk_matches`: `get_first_child`/`get_next_sibling` iteration (same idiom as `collect_split_pages`) instead of a child `Vec` per recursion level.
- Fontmap `"{encoding}_fontmap"`-family Value keys memoized per encoding (were rebuilt ~4× per decoded character run — ~1M allocations on a 1.3 s paper); new `has_value_sym`; the redundant double-preload dropped.
- `install_definition` `:locked` gate probes via new non-interning `arena::get` — no more permanently interned `:locked` twin per defined cs.
- `LATEXML_TELEMETRY_OUT` appends JSONL (was `File::create`-truncated to the last record).
- 13 clippy `redundant_clone` fixes; 2 sites kept as verified false positives (`latex_constructs.rs` `ctr` — documented 2026-07-02; `base_utilities.rs:917` — `content` is consumed by-value later).

**Verification**
- Suite: `cargo nextest run --workspace` **2175/2175 green**; clippy `-D warnings` clean.
- Output neutrality: HTML **byte-identical** vs the pre-branch baseline binary on all four A/B witnesses (2304.10050, 2405.14114, 2408.08292, 2402.14207).
- Same-conditions interleaved best-of-3: 2304.10050 (build/text-bound) **6.21 → 2.71 s (−56%)**; 2408.08292 (math) 8.66 → 7.74 s (−11%); 2405.14114 (200M-token digest runaway) 20.5 → 20.1 s (−2%).
- 82-paper regression-corpus sweep, same harness/box/day: **229.3 → 200.0 s (−12.8%)**, zero exit-status changes, sum max-RSS flat (+1.3%, noise).

**Deferred by design** (tracked in PERFORMANCE.md): typed `if_count` State slot (gated on dump-filter/`if_stack` review), libxml2 allocator routing (needs pinned-segmentation A/B), `get_search_paths` borrow refactor, `Table` inline-first-slot redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8XSPyPFsSdtVF7GG9isRR