### PR TITLE
chore(release): 0.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.7.6] (graphics & SVG figure fidelity; minted highlighting + overpic; author/frontmatter class sweep; Rhai runtime binding API; latexmlpost CLI parity; wider package & bibliography coverage)
+
   - **OmniBus fallback captures `\orcid` and no-ops the `\lefttitle`/`\righttitle`
     running heads.** Unbound bundled journal classes fall through to the generic
     OmniBus fallback, where Perl's `OmniBus.cls.ltxml` leaves these three undefined
@@ -70,8 +72,6 @@
     options are dropped as before, and calls without a leading optional are unchanged.
     Found in the sandbox-arxiv-2606 study; witness 2606.00555 (455→0 errors). Guard
     `cluster_newtcblisting_leading_optarg`.
-
-## [0.7.6] (graphics & SVG figure fidelity; minted highlighting + overpic; author/frontmatter class sweep; Rhai runtime binding API; latexmlpost CLI parity; wider package & bibliography coverage)
 
   - **`minted` code blocks render Pygments syntax colors, not just bold-black.** When the
     source ships a committed `_minted/` frozencache, `minted_frozencache.rs` content-matches

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/dginev/latexml-oxide/actions/workflows/CI.yml/badge.svg)](https://github.com/dginev/latexml-oxide/actions/workflows/CI.yml)
 [![release](https://img.shields.io/github/v/release/dginev/latexml-oxide?color=orange)](https://github.com/dginev/latexml-oxide/releases)
 [![license: CC0-1.0](https://img.shields.io/badge/license-CC0--1.0-blue.svg)](LICENSE)
-![ported tests](https://img.shields.io/badge/ported%20tests-1928-32a852?style=flat)
+![ported tests](https://img.shields.io/badge/ported%20tests-2177-32a852?style=flat)
 [![arXiv](https://img.shields.io/badge/arXiv-2605.16562-b31b1b.svg)](https://arxiv.org/abs/2605.16562)
 
 latexml-oxide turns LaTeX sources into accessible web documents.
@@ -52,7 +52,7 @@ A few external tools are called as subprocesses, mainly to convert graphics file
 
 The steps below use a version variable — set it to the release you want:
 ```
-$ VERSION=0.7.5
+$ VERSION=0.7.6
 ```
 
 ### Ubuntu / Debian
@@ -128,7 +128,7 @@ Homebrew's `texlive` or MacTeX/BasicTeX — just make sure the TeX binaries are 
 shipped in a `.zip`. In PowerShell run:
 
 ```
-> $VERSION = "0.7.5"
+> $VERSION = "0.7.6"
 > curl.exe -LO "https://github.com/dginev/latexml-oxide/releases/download/$VERSION/latexml-oxide-$VERSION-x86_64-pc-windows-msvc.zip"
 > Expand-Archive "latexml-oxide-$VERSION-x86_64-pc-windows-msvc.zip" -DestinationPath .
 > .\latexml-oxide-$VERSION-x86_64-pc-windows-msvc\latexml_oxide.exe --version

--- a/latexml_codegen/Cargo.toml
+++ b/latexml_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml_codegen"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 license = "CC0-1.0"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]

--- a/latexml_contrib/Cargo.toml
+++ b/latexml_contrib/Cargo.toml
@@ -32,7 +32,7 @@ runtime-bindings = ["dep:rhai", "dep:log"]
 
 [dependencies]
 latexml_core = {path = "../latexml_core", version = "0.6.0"}
-latexml_codegen = {path = "../latexml_codegen", version = "0.4.1"}
+latexml_codegen = {path = "../latexml_codegen", version = "0.4.2"}
 latexml_engine = {path = "../latexml_engine", version = "0.7.0"}
 latexml_package = {path = "../latexml_package", version = "0.7.0"}
 rustc-hash = "2.0.0"

--- a/latexml_engine/Cargo.toml
+++ b/latexml_engine/Cargo.toml
@@ -36,5 +36,5 @@ rustc-hash = "2.0.0"
 # Runtime gunzip of the embedded dumps from `build.rs` (DEP-12).
 # Same flate2 instance the binary already pulls via zip/tar.
 flate2 = "1"
-latexml_codegen = { path = "../latexml_codegen", version = "0.4.1" }
+latexml_codegen = { path = "../latexml_codegen", version = "0.4.2" }
 latexml_core = { path = "../latexml_core", version = "0.6.0" }

--- a/latexml_oxide/Cargo.toml
+++ b/latexml_oxide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latexml"
-version = "0.7.6-rc2"
+version = "0.7.6"
 edition = "2024"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>"]
 license = "CC0-1.0"
@@ -157,7 +157,7 @@ regex = { version = "1.7.1", default-features = false, features = ["std", "perf"
 glob = { version = "0.3", optional = true }
 phf = { version = "0.14.0", features = ["macros"], optional = true }
 rustc-hash = "2.0.0"
-latexml_codegen = {path = "../latexml_codegen", version = "0.4.1"}
+latexml_codegen = {path = "../latexml_codegen", version = "0.4.2"}
 latexml_core = {path = "../latexml_core", version = "0.6.0"}
 latexml_engine = {path = "../latexml_engine", version = "0.7.0"}
 latexml_package = {path = "../latexml_package", version = "0.7.0"}

--- a/latexml_package/Cargo.toml
+++ b/latexml_package/Cargo.toml
@@ -23,7 +23,7 @@ regex = { version = "1.7.1", default-features = false, features = ["std", "perf"
 libxml = "0.3.21"
 rustc-hash = "2.0.0"
 base64 = "0.23"
-latexml_codegen = { path = "../latexml_codegen", version = "0.4.1" }
+latexml_codegen = { path = "../latexml_codegen", version = "0.4.2" }
 latexml_core = { path = "../latexml_core", version = "0.6.0" }
 winnow = "1.0"
 latexml_engine = { path = "../latexml_engine", version = "0.7.0" }


### PR DESCRIPTION
Promotes **0.7.6-rc2 → 0.7.6** (final). Stops at the PR — no tag/publish yet.

## Changes
- `latexml_oxide` `0.7.6-rc2` → `0.7.6`.
- **CHANGELOG**: folded the `[Unreleased]` entries into `[0.7.6]` — OmniBus `\orcid` capture (#769), the output-neutral perf pass (#770), the `--quiet` log-floor fix (#764), and `\newtcblisting` leading `[init-options]` (#767).
- **`latexml_codegen` 0.4.1 → 0.4.2** (+ its four dependent pins): its `latexml_core` pin moved `0.5.0 → 0.6.0` since the 0.7.5 publish, so the crate has new bytes and can't republish at 0.4.1 (crates.io is immutable). The other subcrates were already bumped during the 0.7.6 cycle; `cargo metadata` resolves and all intra-workspace pins are consistent.
- **README**: `VERSION` `0.7.5 → 0.7.6`; ported-tests badge `1928 → 2177` (current `nextest` count).

## Not done here (awaiting go-ahead)
No tag, no `release.yml` run, no crates.io / ghcr / Homebrew publish. Merging this PR only lands the version/changelog; the bare `0.7.6` tag is a separate, deliberate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVYUo91xN1c9Bd7ziu1C5d